### PR TITLE
/upload endpoint: store reports to a Datastore.

### DIFF
--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -10,14 +10,17 @@ anyhow = "1"
 bytes = "1.1.0"
 chrono = "0.4"
 deadpool-postgres = "0.10.1"
+derivative = "2"
 hex = "0.4.3"
 hpke = { version = "0.8.0", features = ["default", "std"] }
 http = "0.2.6"
+lazy_static = "1"
 num_enum = "0.5.6"
 prio = "0.7.0"
 rand = "0.8"
 reqwest = { version = "0.11.4", default-features = false, features = ["rustls-tls", "json"] }
 ring = "0.16.20"
+testcontainers = "0.12.0"
 thiserror = "1.0"
 tokio = { version = "^1.9", features = ["full"] }
 tokio-postgres = { version = "0.7.5", features = ["with-chrono-0_4"] }
@@ -29,5 +32,3 @@ warp = { version = "^0.3", features = ["tls"] }
 [dev-dependencies]
 assert_matches = "1"
 hyper = "0.14.17"
-lazy_static = "1"
-testcontainers = "0.12.0"

--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -1,5 +1,6 @@
 //! Common functionality for PPM aggregators
 use crate::{
+    datastore::{self, Datastore},
     hpke::HpkeRecipient,
     message::{HpkeConfigId, Nonce, Report, Role},
     time::Clock,
@@ -8,14 +9,7 @@ use bytes::Bytes;
 use chrono::Duration;
 use http::{header::CACHE_CONTROL, StatusCode};
 use prio::codec::{Decode, Encode};
-use std::{
-    collections::HashMap,
-    convert::Infallible,
-    future::Future,
-    net::SocketAddr,
-    ops::Sub,
-    sync::{Arc, Mutex},
-};
+use std::{convert::Infallible, future::Future, net::SocketAddr, ops::Sub, sync::Arc};
 use tracing::warn;
 use warp::{filters::BoxedFilter, reply, trace, Filter, Rejection, Reply};
 
@@ -23,53 +17,58 @@ use warp::{filters::BoxedFilter, reply, trace, Filter, Rejection, Reply};
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// An invalid configuration was passed.
-    #[error("Invalid configuration: {0}")]
+    #[error("invalid configuration: {0}")]
     InvalidConfiguration(&'static str),
     /// Error decoding an incoming message.
-    #[error("Message decoding failed: {0}")]
+    #[error("message decoding failed: {0}")]
     MessageDecode(#[from] prio::codec::CodecError),
     /// Corresponds to `staleReport`, §3.1
-    #[error("Stale report: {0}")]
+    #[error("stale report: {0}")]
     StaleReport(Nonce),
     /// Corresponds to `unrecognizedMessage`, §3.1
-    #[error("Unrecognized message: {0}")]
+    #[error("unrecognized message: {0}")]
     UnrecognizedMessage(&'static str),
     /// Corresponds to `outdatedHpkeConfig`, §3.1
-    #[error("Outdated HPKE config: {0}")]
+    #[error("outdated HPKE config: {0}")]
     OutdatedHpkeConfig(HpkeConfigId),
     /// A report was rejected becuase the timestamp is too far in the future,
     /// §4.3.4.
     // TODO(timg): define an error type in §3.1 and clarify language on
     // rejecting future reports
-    #[error("Report from the future: {0}")]
+    #[error("report from the future: {0}")]
     ReportFromTheFuture(Nonce),
+    #[error("datastore error: {0}")]
+    Datastore(#[from] datastore::Error),
 }
 
 // This impl allows use of [`Error`] in [`warp::reject::Rejection`]
 impl warp::reject::Reject for Error {}
 
 /// A PPM aggregator
-#[derive(Clone, Debug)]
+#[derive(Clone, derivative::Derivative)]
+#[derivative(Debug)]
 pub struct Aggregator<C> {
-    /// This aggregator's perception of what time it is
+    #[derivative(Debug = "ignore")]
+    /// The datstore used for durable storage.
+    datastore: Arc<Datastore>,
+    /// The clock to use to sample time.
     clock: C,
     /// How much clock skew to allow between client and aggregator. Reports from
     /// farther than this duration into the future will be rejected.
     tolerable_clock_skew: Duration,
-    /// Role of this aggregator
+    /// Role of this aggregator.
     role: Role,
-    /// Used to decrypt reports received by this aggregator
+    /// Used to decrypt reports received by this aggregator.
     // TODO: Aggregators should have multiple generations of HPKE config
     // available to decrypt tardy reports
     report_recipient: HpkeRecipient,
-    /// Reports received by this aggregator
-    stored_reports: Arc<Mutex<HashMap<Nonce, Report>>>,
 }
 
 impl<C: Clock> Aggregator<C> {
     /// Create a new aggregator. `report_recipient` is used to decrypt reports
     /// received by this aggregator.
     fn new(
+        datastore: Arc<Datastore>,
         clock: C,
         tolerable_clock_skew: Duration,
         role: Role,
@@ -82,25 +81,17 @@ impl<C: Clock> Aggregator<C> {
         }
 
         Ok(Self {
+            datastore,
             clock,
             tolerable_clock_skew,
             role,
             report_recipient,
-            stored_reports: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 
     /// Implements the `/upload` endpoint for the leader, described in §4.2 of
     /// draft-gpew-priv-ppm.
-    fn handle_upload(&self, report: &Report) -> Result<(), Error> {
-        let mut stored_reports = self.stored_reports.lock().unwrap();
-
-        // §4.2.2 and 4.3.2.2: reject reports whose nonce has been seen before
-        if stored_reports.contains_key(&report.nonce) {
-            warn!(?report.nonce, "report replayed");
-            return Err(Error::StaleReport(report.nonce));
-        }
-
+    async fn handle_upload(&self, report: &Report) -> Result<(), Error> {
         // §4.2.2 The leader's report is the first one
         if report.encrypted_input_shares.len() != 2 {
             warn!(
@@ -126,13 +117,9 @@ impl<C: Clock> Aggregator<C> {
 
         // §4.2.4: reject reports from too far in the future
         if report.nonce.time.as_naive_date_time().sub(now) > self.tolerable_clock_skew {
-            warn!(?report.nonce, "report timestamp exceeds tolerable clock skew");
+            warn!(?report.task_id, ?report.nonce, "report timestamp exceeds tolerable clock skew");
             return Err(Error::ReportFromTheFuture(report.nonce));
         }
-
-        // TODO: reject with `staleReport` reports whose timestamps fall in a
-        // batch interval that has already been collected (§4.3.2). We don't
-        // support collection so we can't implement this requirement yet.
 
         // Check that we can decrypt the report. This isn't required by the spec
         // but this exercises HPKE decryption and saves us the trouble of
@@ -142,15 +129,53 @@ impl<C: Clock> Aggregator<C> {
             leader_report,
             &Report::associated_data(report.nonce, &report.extensions),
         ) {
-            warn!(?report.nonce, ?error, "report decryption failed");
+            warn!(?report.task_id, ?report.nonce, ?error, "report decryption failed");
             return Ok(());
         }
 
-        // Store the report
-        // TODO: put this in real storage
-        stored_reports.insert(report.nonce, report.clone());
+        self.datastore
+            .run_tx(|tx| {
+                let report = report.clone();
+                Box::pin(async move {
+                    // §4.2.2 and 4.3.2.2: reject reports whose nonce has been seen before
+                    match tx
+                        .get_client_report_by_task_id_and_nonce(report.task_id, report.nonce)
+                        .await
+                    {
+                        Ok(_) => {
+                            warn!(?report.task_id, ?report.nonce, "report replayed");
+                            return Err(datastore::Error::User(
+                                Error::StaleReport(report.nonce).into(),
+                            ));
+                        }
 
+                        Err(datastore::Error::NotFound) => (), // happy path
+
+                        Err(err) => return Err(err),
+                    };
+
+                    // TODO: reject with `staleReport` reports whose timestamps fall in a
+                    // batch interval that has already been collected (§4.3.2). We don't
+                    // support collection so we can't implement this requirement yet.
+
+                    // Store the report.
+                    tx.put_client_report(&report).await?;
+                    Ok(())
+                })
+            })
+            .await
+            .map_err(downcast_to_aggregator_error)?;
         Ok(())
+    }
+}
+
+fn downcast_to_aggregator_error(err: datastore::Error) -> Error {
+    match err {
+        datastore::Error::User(err) => match err.downcast::<Error>() {
+            Ok(err) => *err,
+            Err(err) => Error::Datastore(datastore::Error::User(err)),
+        },
+        _ => Error::Datastore(err),
     }
 }
 
@@ -171,6 +196,7 @@ fn with_decoded_message<T: Decode + Send + Sync>(
 
 /// Constructs a Warp filter with endpoints common to all aggregators.
 fn aggregator_filter<C: 'static + Clock>(
+    datastore: Arc<Datastore>,
     clock: C,
     tolerable_clock_skew: Duration,
     role: Role,
@@ -182,7 +208,7 @@ fn aggregator_filter<C: 'static + Clock>(
 
     let hpke_config_encoded = hpke_recipient.config.get_encoded();
 
-    let aggregator = Aggregator::new(clock, tolerable_clock_skew, role, hpke_recipient)?;
+    let aggregator = Aggregator::new(datastore, clock, tolerable_clock_skew, role, hpke_recipient)?;
 
     let hpke_config_endpoint = warp::path("hpke_config")
         .and(warp::get())
@@ -207,6 +233,7 @@ fn aggregator_filter<C: 'static + Clock>(
 
             aggregator
                 .handle_upload(&report)
+                .await
                 .map_err(warp::reject::custom)?;
 
             Ok(reply::with_status(warp::reply(), StatusCode::OK)) as Result<_, Rejection>
@@ -221,13 +248,14 @@ fn aggregator_filter<C: 'static + Clock>(
 /// `SocketAddr` representing the address and port the server are listening on
 /// and a future that can be `await`ed to begin serving requests.
 pub fn aggregator_server<C: 'static + Clock>(
+    datastore: Arc<Datastore>,
     clock: C,
     tolerable_clock_skew: Duration,
     role: Role,
     hpke_recipient: HpkeRecipient,
     listen_address: SocketAddr,
 ) -> Result<(SocketAddr, impl Future<Output = ()> + 'static), Error> {
-    let routes = aggregator_filter(clock, tolerable_clock_skew, role, hpke_recipient)?;
+    let routes = aggregator_filter(datastore, clock, tolerable_clock_skew, role, hpke_recipient)?;
 
     Ok(warp::serve(routes).bind_ephemeral(listen_address))
 }
@@ -236,6 +264,7 @@ pub fn aggregator_server<C: 'static + Clock>(
 mod tests {
     use super::*;
     use crate::{
+        datastore::test_util::{ephemeral_datastore, DbHandle},
         hpke::{HpkeSender, Label},
         message::{HpkeConfig, TaskId, Time},
         time::tests::MockClock,
@@ -247,10 +276,12 @@ mod tests {
     use std::io::Cursor;
     use warp::reply::Reply;
 
-    #[test]
-    fn invalid_role() {
+    #[tokio::test]
+    async fn invalid_role() {
         install_trace_subscriber();
 
+        let (datastore, _db_handle) = ephemeral_datastore().await;
+        let datastore = Arc::new(datastore);
         let hpke_recipient = HpkeRecipient::generate(
             TaskId::random(),
             Label::InputShare,
@@ -261,6 +292,7 @@ mod tests {
         for invalid_role in [Role::Collector, Role::Client] {
             assert_matches!(
                 aggregator_filter(
+                    datastore.clone(),
                     MockClock::default(),
                     Duration::minutes(10),
                     invalid_role,
@@ -271,10 +303,11 @@ mod tests {
         }
     }
 
-    #[test]
-    fn invalid_clock_skew() {
+    #[tokio::test]
+    async fn invalid_clock_skew() {
         install_trace_subscriber();
 
+        let (datastore, _db_handle) = ephemeral_datastore().await;
         let hpke_recipient = HpkeRecipient::generate(
             TaskId::random(),
             Label::InputShare,
@@ -284,6 +317,7 @@ mod tests {
 
         assert_matches!(
             Aggregator::new(
+                Arc::new(datastore),
                 MockClock::default(),
                 Duration::minutes(-10),
                 Role::Leader,
@@ -298,7 +332,7 @@ mod tests {
         install_trace_subscriber();
 
         let task_id = TaskId::random();
-
+        let (datastore, _db_handle) = ephemeral_datastore().await;
         let hpke_recipient =
             HpkeRecipient::generate(task_id, Label::InputShare, Role::Client, Role::Leader);
 
@@ -307,6 +341,7 @@ mod tests {
             .method("GET")
             .filter(
                 &aggregator_filter(
+                    Arc::new(datastore),
                     MockClock::default(),
                     Duration::minutes(10),
                     Role::Leader,
@@ -343,8 +378,18 @@ mod tests {
         assert_eq!(&plaintext, message);
     }
 
-    fn setup_report(clock: &MockClock, skew: Duration) -> (HpkeRecipient, Report) {
+    async fn setup_report(
+        datastore: &Datastore,
+        clock: &MockClock,
+        skew: Duration,
+    ) -> (HpkeRecipient, Report) {
         let task_id = TaskId::random();
+
+        datastore
+            .run_tx(|tx| Box::pin(async move { tx.put_task(task_id).await }))
+            .await
+            .unwrap();
+
         let report_time = clock.now() - skew;
 
         let hpke_recipient =
@@ -390,11 +435,19 @@ mod tests {
     async fn upload_filter() {
         install_trace_subscriber();
 
+        let (datastore, _db_handle) = ephemeral_datastore().await;
         let clock = MockClock::default();
         let skew = Duration::minutes(10);
 
-        let (report_recipient, report) = setup_report(&clock, skew);
-        let filter = aggregator_filter(clock, skew, Role::Leader, report_recipient).unwrap();
+        let (report_recipient, report) = setup_report(&datastore, &clock, skew).await;
+        let filter = aggregator_filter(
+            Arc::new(datastore),
+            clock,
+            skew,
+            Role::Leader,
+            report_recipient,
+        )
+        .unwrap();
 
         let response = warp::test::request()
             .method("POST")
@@ -417,12 +470,20 @@ mod tests {
     async fn upload_filter_helper() {
         install_trace_subscriber();
 
+        let (datastore, _db_handle) = ephemeral_datastore().await;
         let clock = MockClock::default();
         let skew = Duration::minutes(10);
 
-        let (report_recipient, report) = setup_report(&clock, skew);
+        let (report_recipient, report) = setup_report(&datastore, &clock, skew).await;
 
-        let filter = aggregator_filter(clock, skew, Role::Helper, report_recipient).unwrap();
+        let filter = aggregator_filter(
+            Arc::new(datastore),
+            clock,
+            skew,
+            Role::Helper,
+            report_recipient,
+        )
+        .unwrap();
 
         let result = warp::test::request()
             .method("POST")
@@ -440,64 +501,77 @@ mod tests {
         }
     }
 
-    fn setup_upload_test(skew: Duration) -> (Aggregator<MockClock>, Report) {
+    async fn setup_upload_test(
+        skew: Duration,
+    ) -> (Aggregator<MockClock>, Report, Arc<Datastore>, DbHandle) {
+        let (datastore, db_handle) = ephemeral_datastore().await;
+        let datastore = Arc::new(datastore);
         let clock = MockClock::default();
-        let (report_recipient, report) = setup_report(&clock, skew);
-        let aggregator = Aggregator::new(clock, skew, Role::Leader, report_recipient).unwrap();
+        let (report_recipient, report) = setup_report(&datastore, &clock, skew).await;
 
-        (aggregator, report)
+        let aggregator = Aggregator::new(
+            datastore.clone(),
+            clock,
+            skew,
+            Role::Leader,
+            report_recipient,
+        )
+        .unwrap();
+
+        (aggregator, report, datastore, db_handle)
     }
 
-    #[test]
-    fn upload() {
+    #[tokio::test]
+    async fn upload() {
         install_trace_subscriber();
 
         let skew = Duration::minutes(10);
-        let (aggregator, report) = setup_upload_test(skew);
+        let (aggregator, report, datastore, _db_handle) = setup_upload_test(skew).await;
 
-        aggregator.handle_upload(&report).unwrap();
+        aggregator.handle_upload(&report).await.unwrap();
 
-        assert_eq!(
-            aggregator
-                .stored_reports
-                .lock()
-                .unwrap()
-                .get(&report.nonce)
-                .unwrap(),
-            &report
-        );
+        let got_report = datastore
+            .run_tx(|tx| {
+                Box::pin(async move {
+                    tx.get_client_report_by_task_id_and_nonce(report.task_id, report.nonce)
+                        .await
+                })
+            })
+            .await
+            .unwrap();
+        assert_eq!(report, got_report);
 
         // should reject duplicate reports
-        assert_matches!(aggregator.handle_upload(&report), Err(Error::StaleReport(stale_nonce)) => {
+        assert_matches!(aggregator.handle_upload(&report).await, Err(Error::StaleReport(stale_nonce)) => {
             assert_eq!(report.nonce, stale_nonce);
         });
     }
 
-    #[test]
-    fn upload_wrong_number_of_encrypted_shares() {
+    #[tokio::test]
+    async fn upload_wrong_number_of_encrypted_shares() {
         install_trace_subscriber();
 
         let skew = Duration::minutes(10);
-        let (aggregator, mut report) = setup_upload_test(skew);
+        let (aggregator, mut report, _, _db_handle) = setup_upload_test(skew).await;
 
         report.encrypted_input_shares = vec![report.encrypted_input_shares[0].clone()];
 
         assert_matches!(
-            aggregator.handle_upload(&report),
+            aggregator.handle_upload(&report).await,
             Err(Error::UnrecognizedMessage(_))
         );
     }
 
-    #[test]
-    fn upload_wrong_hpke_config_id() {
+    #[tokio::test]
+    async fn upload_wrong_hpke_config_id() {
         install_trace_subscriber();
 
         let skew = Duration::minutes(10);
-        let (aggregator, mut report) = setup_upload_test(skew);
+        let (aggregator, mut report, _, _db_handle) = setup_upload_test(skew).await;
 
         report.encrypted_input_shares[0].config_id = HpkeConfigId(101);
 
-        assert_matches!(aggregator.handle_upload(&report), Err(Error::OutdatedHpkeConfig(config_id)) => {
+        assert_matches!(aggregator.handle_upload(&report).await, Err(Error::OutdatedHpkeConfig(config_id)) => {
             assert_eq!(config_id, HpkeConfigId(101));
         });
     }
@@ -532,29 +606,34 @@ mod tests {
         }
     }
 
-    #[test]
-    fn report_in_the_future() {
+    #[tokio::test]
+    async fn report_in_the_future() {
         install_trace_subscriber();
 
         let skew = Duration::minutes(10);
-        let (aggregator, mut report) = setup_upload_test(skew);
+        let (aggregator, mut report, datastore, _db_handle) = setup_upload_test(skew).await;
 
         // Boundary condition
         report.nonce.time = Time::from_naive_date_time(aggregator.clock.now() + skew);
         let mut report = reencrypt_report(report, &aggregator.report_recipient);
-        aggregator.handle_upload(&report).unwrap();
+        aggregator.handle_upload(&report).await.unwrap();
 
-        assert!(aggregator
-            .stored_reports
-            .lock()
-            .unwrap()
-            .contains_key(&report.nonce));
+        let got_report = datastore
+            .run_tx(|tx| {
+                Box::pin(async move {
+                    tx.get_client_report_by_task_id_and_nonce(report.task_id, report.nonce)
+                        .await
+                })
+            })
+            .await
+            .unwrap();
+        assert_eq!(report, got_report);
 
         // Just past the clock skew
         report.nonce.time =
             Time::from_naive_date_time(aggregator.clock.now() + skew + Duration::seconds(1));
         let report = reencrypt_report(report, &aggregator.report_recipient);
-        assert_matches!(aggregator.handle_upload(&report), Err(Error::ReportFromTheFuture(nonce)) => {
+        assert_matches!(aggregator.handle_upload(&report).await, Err(Error::ReportFromTheFuture(nonce)) => {
             assert_eq!(report.nonce, nonce);
         });
     }

--- a/janus_server/src/bin/aggregator.rs
+++ b/janus_server/src/bin/aggregator.rs
@@ -1,7 +1,9 @@
 use anyhow::{anyhow, Context, Result};
 use chrono::Duration;
+use deadpool_postgres::{Manager, Pool};
 use janus_server::{
     aggregator::aggregator_server,
+    datastore::Datastore,
     hpke::{HpkeRecipient, Label},
     message::Role,
     message::TaskId,
@@ -12,7 +14,10 @@ use std::{
     env::args,
     iter::Iterator,
     net::{IpAddr, Ipv4Addr, SocketAddr},
+    str::FromStr,
+    sync::Arc,
 };
+use tokio_postgres::{Config, NoTls};
 use tracing::info;
 
 #[tokio::main]
@@ -27,14 +32,21 @@ async fn main() -> Result<()> {
 
     install_subscriber().context("failed to install tracing subscriber")?;
 
-    // TODO(issue #20): We should not hardcode the address we listen on and
-    // should not randomly generate task IDs.
+    // TODO(issue #20): We need to specify configuration parameters rather than hardcoding them.
     let task_id = TaskId::random();
+
+    let cfg = Config::from_str("postgres://postgres:postgres@localhost:5432/postgres")?;
+    let conn_mgr = Manager::new(cfg, NoTls);
+    let pool = Pool::builder(conn_mgr).build()?;
+    let datastore = Arc::new(Datastore::new(pool));
+
     let hpke_recipient =
         HpkeRecipient::generate(task_id, Label::InputShare, Role::Client, Role::Leader);
+
     let listen_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 8080);
 
     let (bound_address, server) = aggregator_server(
+        datastore,
         RealClock::default(),
         Duration::minutes(10),
         role,

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -254,9 +254,8 @@ impl Error {
     }
 }
 
-// debug_assertions allows this module to be used in integration tests.
-// XXX: if the debug_assertions strategy doesn't make it through code review, move things back to dev-dependencies
-#[cfg(any(test, debug_assertions))]
+// This is public to allow use in integration tests.
+#[doc(hidden)]
 pub mod test_util {
     use super::*;
     use deadpool_postgres::{Manager, Pool};

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -1,7 +1,7 @@
 //! Janus datastore (durable storage) implementation.
 
 use crate::message::{Extension, HpkeCiphertext, Nonce, Report, TaskId, Time};
-use prio::codec::{decode_u16_items, encode_u16_items, CodecError, Decode};
+use prio::codec::{decode_u16_items, encode_u16_items, CodecError, Decode, Encode};
 use std::{future::Future, io::Cursor, pin::Pin};
 use tokio_postgres::{error::SqlState, IsolationLevel, Row};
 
@@ -30,7 +30,8 @@ impl Datastore {
     /// "finalized" until the transaction is committed, i.e. after `run_tx` is run to completion.
     pub async fn run_tx<F, T>(&self, f: F) -> Result<T, Error>
     where
-        for<'a> F: Fn(&'a Transaction) -> Pin<Box<dyn Future<Output = Result<T, Error>> + 'a>>,
+        for<'a> F:
+            Fn(&'a Transaction) -> Pin<Box<dyn Future<Output = Result<T, Error>> + Send + 'a>>,
     {
         loop {
             let rslt = self.run_tx_once(&f).await;
@@ -45,7 +46,8 @@ impl Datastore {
 
     async fn run_tx_once<F, T>(&self, f: &F) -> Result<T, Error>
     where
-        for<'a> F: Fn(&'a Transaction) -> Pin<Box<dyn Future<Output = Result<T, Error>> + 'a>>,
+        for<'a> F:
+            Fn(&'a Transaction) -> Pin<Box<dyn Future<Output = Result<T, Error>> + Send + 'a>>,
     {
         // Open transaction.
         let mut client = self.pool.get().await?;
@@ -75,7 +77,7 @@ impl Transaction<'_> {
     // TODO(brandon): implement basic getters/putters for all types
 
     #[cfg(test)]
-    async fn put_task(&self, task_id: TaskId) -> Result<(), Error> {
+    pub async fn put_task(&self, task_id: TaskId) -> Result<(), Error> {
         let stmt = self
             .tx
             .prepare_cached(
@@ -120,6 +122,50 @@ impl Transaction<'_> {
                 time: nonce_time,
                 rand: nonce_rand as u64,
             },
+            extensions,
+            encrypted_input_shares: input_shares,
+        })
+    }
+
+    pub async fn get_client_report_by_task_id_and_nonce(
+        &self,
+        task_id: TaskId,
+        nonce: Nonce,
+    ) -> Result<Report, Error> {
+        let nonce_time = nonce.time.as_naive_date_time();
+        let nonce_rand = nonce.rand as i64;
+
+        let stmt = self
+            .tx
+            .prepare_cached(
+                "SELECT extensions, input_shares FROM client_reports
+            WHERE task_id = $1 AND nonce_time = $2 AND nonce_rand = $3",
+            )
+            .await?;
+        let row = single_row(
+            self.tx
+                .query(
+                    &stmt,
+                    &[
+                        /* task_id */ &task_id.get_encoded(),
+                        /* nonce_time */ &nonce_time,
+                        /* nonce_rand */ &nonce_rand,
+                    ],
+                )
+                .await?,
+        )?;
+
+        let encoded_extensions: Vec<u8> = row.get("extensions");
+        let extensions: Vec<Extension> =
+            decode_u16_items(&(), &mut Cursor::new(&encoded_extensions))?;
+
+        let encoded_input_shares: Vec<u8> = row.get("input_shares");
+        let input_shares: Vec<HpkeCiphertext> =
+            decode_u16_items(&(), &mut Cursor::new(&encoded_input_shares))?;
+
+        Ok(Report {
+            task_id,
+            nonce,
             extensions,
             encrypted_input_shares: input_shares,
         })
@@ -208,25 +254,35 @@ impl Error {
     }
 }
 
-#[cfg(test)]
-pub(crate) mod test_util {
+// debug_assertions allows this module to be used in integration tests.
+// XXX: if the debug_assertions strategy doesn't make it through code review, move things back to dev-dependencies
+#[cfg(any(test, debug_assertions))]
+pub mod test_util {
     use super::*;
     use deadpool_postgres::{Manager, Pool};
+    use lazy_static::lazy_static;
     use std::str::{self, FromStr};
-    use testcontainers::{images::postgres::Postgres, Container, Docker};
+    use testcontainers::{clients::Cli, images::postgres::Postgres, Container, Docker};
     use tokio_postgres::{Config, NoTls};
 
     const SCHEMA: &str = include_str!("../../db/schema.sql");
+
+    // TODO(brandon): use podman instead of docker for container management once testcontainers supports it
+    lazy_static! {
+        static ref DOCKER: Cli = Cli::default();
+    }
+
+    /// DbHandle represents a handle to a running (ephemeral) database. Dropping this value causes
+    /// the database to be shut down & cleaned up.
+    pub struct DbHandle(Container<'static, Cli, Postgres>);
 
     /// ephemeral_datastore creates a new Datastore instance backed by an ephemeral database which
     /// has the Janus schema applied but is otherwise empty.
     ///
     /// Dropping the second return value causes the database to be shut down & cleaned up.
-    pub(crate) async fn ephemeral_datastore<D: Docker>(
-        container_client: &D,
-    ) -> (Datastore, Container<'_, D, Postgres>) {
+    pub async fn ephemeral_datastore() -> (Datastore, DbHandle) {
         // Start an instance of Postgres running in a container.
-        let db_container = container_client.run(Postgres::default().with_version(14));
+        let db_container = DOCKER.run(Postgres::default().with_version(14));
 
         // Create a connection pool whose clients will talk to our newly-running instance of Postgres.
         const POSTGRES_DEFAULT_PORT: u16 = 5432;
@@ -241,25 +297,21 @@ pub(crate) mod test_util {
         // Connect to the database & run our schema.
         let client = pool.get().await.unwrap();
         client.batch_execute(SCHEMA).await.unwrap();
-        (Datastore::new(pool), db_container)
+        (Datastore::new(pool), DbHandle(db_container))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    // TODO(brandon): use podman instead of docker for container management once testcontainers supports this
-
     use super::*;
     use crate::datastore::test_util::ephemeral_datastore;
     use crate::message::{ExtensionType, HpkeConfigId};
     use crate::trace::test_util::install_trace_subscriber;
-    use testcontainers::clients;
 
     #[tokio::test]
     async fn roundtrip_report() {
         install_trace_subscriber();
-        let docker = clients::Cli::default();
-        let (ds, _db_container) = ephemeral_datastore(&docker).await;
+        let (ds, _db_handle) = ephemeral_datastore().await;
 
         let task_id = TaskId([
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
@@ -317,11 +369,99 @@ mod tests {
     #[tokio::test]
     async fn report_not_found() {
         install_trace_subscriber();
-        let docker = clients::Cli::default();
-        let (ds, _db_container) = ephemeral_datastore(&docker).await;
+        let (ds, _db_handle) = ephemeral_datastore().await;
 
         let rslt = ds
             .run_tx(|tx| Box::pin(async move { tx.get_client_report(12345).await }))
+            .await;
+
+        assert_matches::assert_matches!(rslt, Err(Error::NotFound));
+    }
+
+    #[tokio::test]
+    async fn roundtrip_report_by_task_id_and_nonce() {
+        install_trace_subscriber();
+        let (ds, _db_handle) = ephemeral_datastore().await;
+
+        let task_id = TaskId([
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31,
+        ]);
+        let nonce = Nonce {
+            time: Time(12345),
+            rand: 54321,
+        };
+        let report = Report {
+            task_id,
+            nonce,
+            extensions: vec![
+                Extension {
+                    extension_type: ExtensionType::Tbd,
+                    extension_data: Vec::from("extension_data_0"),
+                },
+                Extension {
+                    extension_type: ExtensionType::Tbd,
+                    extension_data: Vec::from("extension_data_1"),
+                },
+            ],
+            encrypted_input_shares: vec![
+                HpkeCiphertext {
+                    config_id: HpkeConfigId(12),
+                    encapsulated_context: Vec::from("encapsulated_context_0"),
+                    payload: Vec::from("payload_0"),
+                },
+                HpkeCiphertext {
+                    config_id: HpkeConfigId(13),
+                    encapsulated_context: Vec::from("encapsulated_context_1"),
+                    payload: Vec::from("payload_1"),
+                },
+            ],
+        };
+
+        ds.run_tx(|tx| {
+            let report = report.clone();
+            Box::pin(async move {
+                tx.put_task(task_id).await?;
+                tx.put_client_report(&report).await
+            })
+        })
+        .await
+        .unwrap();
+
+        let retrieved_report = ds
+            .run_tx(|tx| {
+                Box::pin(async move {
+                    tx.get_client_report_by_task_id_and_nonce(task_id, nonce)
+                        .await
+                })
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(report, retrieved_report);
+    }
+
+    #[tokio::test]
+    async fn report_not_found_by_task_id_and_nonce() {
+        install_trace_subscriber();
+        let (ds, _db_handle) = ephemeral_datastore().await;
+
+        let task_id = TaskId([
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31,
+        ]);
+        let nonce = Nonce {
+            time: Time(12345),
+            rand: 54321,
+        };
+
+        let rslt = ds
+            .run_tx(|tx| {
+                Box::pin(async move {
+                    tx.get_client_report_by_task_id_and_nonce(task_id, nonce)
+                        .await
+                })
+            })
             .await;
 
         assert_matches::assert_matches!(rslt, Err(Error::NotFound));


### PR DESCRIPTION
This replaces the previous temporary solution of storing them in-memory
only. This commit also includes some refactoring of the ephemeral
datastore test functionality to make it easier to use & ease later
refactorings.

I'm pretty unhappy about having to make the `datastore::test_util` module
compile under `debug_assertions`; this means I have to upgrade several
test-only dependencies from `dev-dependencies` to `depdendencies`.
Unfortunately, I think this is required because integration tests do not
run in `#[cfg(test)]`. (Better approaches very welcome.)