### PR TITLE
janus_server: implement upload in client

### DIFF
--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -32,3 +32,4 @@ warp = { version = "^0.3", features = ["tls"] }
 [dev-dependencies]
 assert_matches = "1"
 hyper = "0.14.17"
+mockito = "0.31.0"

--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -367,13 +367,8 @@ mod tests {
 
         let bytes = to_bytes(response.into_body()).await.unwrap();
         let hpke_config = HpkeConfig::decode(&mut Cursor::new(&bytes)).unwrap();
-        let sender = HpkeSender {
-            task_id,
-            recipient_config: hpke_config,
-            label: Label::InputShare,
-            sender_role: Role::Client,
-            recipient_role: Role::Leader,
-        };
+        assert_eq!(hpke_config, hpke_recipient.config);
+        let sender = HpkeSender::from_recipient(&hpke_recipient);
 
         let message = b"this is a message";
         let associated_data = b"some associated data";
@@ -409,22 +404,10 @@ mod tests {
         let associated_data = Report::associated_data(nonce, &extensions);
         let message = b"this is a message";
 
-        let leader_sender = HpkeSender {
-            task_id,
-            recipient_config: hpke_recipient.config.clone(),
-            label: Label::InputShare,
-            sender_role: Role::Client,
-            recipient_role: Role::Leader,
-        };
+        let leader_sender = HpkeSender::from_recipient(&hpke_recipient);
         let leader_ciphertext = leader_sender.seal(message, &associated_data).unwrap();
 
-        let helper_sender = HpkeSender {
-            task_id,
-            recipient_config: hpke_recipient.config.clone(),
-            label: Label::InputShare,
-            sender_role: Role::Client,
-            recipient_role: Role::Helper,
-        };
+        let helper_sender = HpkeSender::from_recipient(&hpke_recipient);
         let helper_ciphertext = helper_sender.seal(message, &associated_data).unwrap();
 
         let report = Report {
@@ -586,22 +569,10 @@ mod tests {
         let associated_data = Report::associated_data(report.nonce, &report.extensions);
         let message = b"this is a message";
 
-        let leader_sender = HpkeSender {
-            task_id: report.task_id,
-            recipient_config: hpke_recipient.config.clone(),
-            label: Label::InputShare,
-            sender_role: Role::Client,
-            recipient_role: Role::Leader,
-        };
+        let leader_sender = HpkeSender::from_recipient(hpke_recipient);
         let leader_ciphertext = leader_sender.seal(message, &associated_data).unwrap();
 
-        let helper_sender = HpkeSender {
-            task_id: report.task_id,
-            recipient_config: hpke_recipient.config.clone(),
-            label: Label::InputShare,
-            sender_role: Role::Client,
-            recipient_role: Role::Helper,
-        };
+        let helper_sender = HpkeSender::from_recipient(hpke_recipient);
         let helper_ciphertext = helper_sender.seal(message, &associated_data).unwrap();
 
         Report {

--- a/janus_server/src/client.rs
+++ b/janus_server/src/client.rs
@@ -2,10 +2,14 @@
 
 use crate::{
     hpke::{HpkeSender, Label},
-    message::{HpkeConfig, Role, TaskId},
+    message::{HpkeCiphertext, HpkeConfig, Nonce, Report, Role, TaskId, Time},
+    time::Clock,
 };
 use http::StatusCode;
-use prio::codec::Decode;
+use prio::{
+    codec::{Decode, Encode},
+    vdaf::Client as VdafClient,
+};
 use std::io::Cursor;
 use url::Url;
 
@@ -13,12 +17,16 @@ use url::Url;
 pub enum Error {
     #[error("HTTP client error: {0}")]
     HttpClient(#[from] reqwest::Error),
-    #[error("Codec error")]
+    #[error("Codec error: {0}")]
     Codec(#[from] prio::codec::CodecError),
     #[error("HTTP response status {0}")]
     Http(StatusCode),
     #[error("URL parse: {0}")]
     Url(#[from] url::ParseError),
+    #[error("VDAF error: {0}")]
+    Vdaf(#[from] prio::vdaf::VdafError),
+    #[error("HPKE error: {0}")]
+    Hpke(#[from] crate::hpke::Error),
 }
 
 static CLIENT_USER_AGENT: &str = concat!(
@@ -29,63 +37,205 @@ static CLIENT_USER_AGENT: &str = concat!(
     "client"
 );
 
+pub async fn aggregator_hpke_sender(
+    http_client: &reqwest::Client,
+    task_id: TaskId,
+    aggregator_endpoint: Url,
+) -> Result<HpkeSender, Error> {
+    let hpke_config_response = http_client
+        .get(aggregator_endpoint.join("hpke_config")?)
+        .send()
+        .await?;
+    let status = hpke_config_response.status();
+    if !status.is_success() {
+        return Err(Error::Http(status));
+    }
+
+    let hpke_config = HpkeConfig::decode(&mut Cursor::new(
+        hpke_config_response.bytes().await?.as_ref(),
+    ))?;
+
+    Ok(HpkeSender::new(
+        task_id,
+        hpke_config,
+        Label::InputShare,
+        Role::Client,
+        Role::Leader,
+    ))
+}
+
+/// Construct a [`reqwest::Client`] suitable for use in a PPM [`Client`].
+pub fn default_http_client() -> Result<reqwest::Client, Error> {
+    Ok(reqwest::Client::builder()
+        .user_agent(CLIENT_USER_AGENT)
+        .build()?)
+}
+
 /// A PPM client.
 #[derive(Debug)]
-pub struct Client {
+pub struct Client<V, P, C> {
+    task_id: TaskId,
+    vdaf_client: V,
+    vdaf_public_parameter: P,
+    leader_url: Url,
+    clock: C,
     http_client: reqwest::Client,
     leader_report_sender: HpkeSender,
     helper_report_sender: HpkeSender,
 }
 
-impl Client {
+impl<V: VdafClient, C: Clock> Client<V, V::PublicParam, C> {
     pub fn new(
+        task_id: TaskId,
+        vdaf_client: V,
+        vdaf_public_parameter: V::PublicParam,
+        leader_url: Url,
+        clock: C,
         http_client: &reqwest::Client,
         leader_report_sender: HpkeSender,
         helper_report_sender: HpkeSender,
     ) -> Self {
         Self {
+            task_id,
+            vdaf_client,
+            vdaf_public_parameter,
+            leader_url,
+            clock,
             http_client: http_client.clone(),
             leader_report_sender,
             helper_report_sender,
         }
     }
 
-    /// Construct a [`reqwest::Client`] suitable for use in a PPM [`Client`].
-    //
-    // TODO: To be particularly useful, this function should return
-    // `Box<dyn JanusHttpClient>`, where `JanusHttpClient` is a trait we define
-    // that captures exactly what our client needs (e.g., GET). Then tests could
-    // provide an alternate implementation of it.
-    pub fn default_http_client() -> Result<reqwest::Client, Error> {
-        Ok(reqwest::Client::builder()
-            .user_agent(CLIENT_USER_AGENT)
-            .build()?)
-    }
+    /// Upload a [`crate::message::Report`] to the leader, per §4.3.2 of
+    /// draft-gpew-priv-ppm. The provided measurement is sharded into one input
+    /// share plus one proof share for each aggregator and then uploaded to the
+    /// leader.
+    pub async fn upload(&self, measurement: &V::Measurement) -> Result<(), Error> {
+        let input_shares = self
+            .vdaf_client
+            .shard(&self.vdaf_public_parameter, measurement)?;
 
-    pub async fn aggregator_hpke_sender(
-        http_client: &reqwest::Client,
-        task_id: TaskId,
-        aggregator_endpoint: Url,
-    ) -> Result<HpkeSender, Error> {
-        let hpke_config_response = http_client
-            .get(aggregator_endpoint.join("hpke_config")?)
+        // All supported VDAFs use two aggregators
+        assert_eq!(input_shares.len(), 2);
+
+        let nonce = Nonce {
+            time: Time::from_naive_date_time(self.clock.now()),
+            rand: rand::random(),
+        };
+
+        // No extensions supported yet
+        let extensions = vec![];
+
+        let associated_data = Report::associated_data(nonce, &extensions);
+
+        // Leader's share MUST be the first in the report. We assume/guess that
+        // the first element in input_shares is the leader's. This is true for
+        // all prio3 VDAFs, but not guaranteed generically.
+        // https://github.com/cjpatton/vdaf/issues/40
+        let encrypted_input_shares: Vec<HpkeCiphertext> =
+            [&self.leader_report_sender, &self.helper_report_sender]
+                .into_iter()
+                .zip(input_shares)
+                .map(|(hpke_sender, input_share)| {
+                    Ok(hpke_sender.seal(&input_share.get_encoded(), &associated_data)?)
+                })
+                .collect::<Result<_, Error>>()?;
+
+        let report = Report {
+            task_id: self.task_id,
+            nonce,
+            extensions,
+            encrypted_input_shares,
+        };
+
+        let upload_response = self
+            .http_client
+            .post(self.leader_url.join("upload")?)
+            .body(report.get_encoded())
             .send()
             .await?;
-        let status = hpke_config_response.status();
+        let status = upload_response.status();
         if !status.is_success() {
+            // TODO: decode an RFC 7807 problem document once #25 / #31 land
             return Err(Error::Http(status));
         }
 
-        let hpke_config = HpkeConfig::decode(&mut Cursor::new(
-            hpke_config_response.bytes().await?.as_ref(),
-        ))?;
+        Ok(())
+    }
+}
 
-        Ok(HpkeSender {
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        hpke::HpkeRecipient, time::tests::MockClock, trace::test_util::install_trace_subscriber,
+    };
+    use assert_matches::assert_matches;
+    use mockito::mock;
+    use prio::vdaf::prio3::{Prio3Aes128Count, Prio3Aes128Sum};
+
+    fn setup_client<V: VdafClient>(
+        vdaf_client: V,
+        public_parameter: V::PublicParam,
+    ) -> Client<V, V::PublicParam, MockClock> {
+        let task_id = TaskId::random();
+        let clock = MockClock::default();
+        let leader_hpke_recipient =
+            HpkeRecipient::generate(task_id, Label::InputShare, Role::Client, Role::Leader);
+        let leader_hpke_sender = HpkeSender::from_recipient(&leader_hpke_recipient);
+        let helper_hpke_recipient =
+            HpkeRecipient::generate(task_id, Label::InputShare, Role::Client, Role::Helper);
+        let helper_hpke_sender = HpkeSender::from_recipient(&helper_hpke_recipient);
+
+        Client::new(
             task_id,
-            recipient_config: hpke_config,
-            label: Label::InputShare,
-            sender_role: Role::Client,
-            recipient_role: Role::Leader,
-        })
+            vdaf_client,
+            public_parameter,
+            Url::parse(&mockito::server_url()).unwrap(),
+            clock,
+            &default_http_client().unwrap(),
+            leader_hpke_sender,
+            helper_hpke_sender,
+        )
+    }
+
+    #[tokio::test]
+    async fn upload_prio3_count() {
+        install_trace_subscriber();
+        let mocked_upload = mock("POST", "/upload").with_status(200).expect(1).create();
+
+        let client = setup_client(Prio3Aes128Count::new(2).unwrap(), ());
+
+        client.upload(&1).await.unwrap();
+
+        mocked_upload.assert();
+    }
+
+    #[tokio::test]
+    async fn upload_prio3_invalid_measurement() {
+        install_trace_subscriber();
+        let vdaf = Prio3Aes128Sum::new(2, 16).unwrap();
+
+        let client = setup_client(vdaf, ());
+        // 65536 is too big for a 16 bit sum and will be rejected by the VDAF.
+        // Make sure we get the right error variant but otherwise we aren't
+        // picky about its contents.
+        assert_matches!(client.upload(&65536).await, Err(Error::Vdaf(_)));
+    }
+
+    #[tokio::test]
+    async fn upload_prio3_http_status_code() {
+        install_trace_subscriber();
+
+        let mocked_upload = mock("POST", "/upload").with_status(501).expect(1).create();
+
+        let client = setup_client(Prio3Aes128Count::new(2).unwrap(), ());
+        assert_matches!(
+            client.upload(&1).await,
+            Err(Error::Http(StatusCode::NOT_IMPLEMENTED))
+        );
+
+        mocked_upload.assert();
     }
 }

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -76,7 +76,8 @@ pub struct Transaction<'a> {
 impl Transaction<'_> {
     // TODO(brandon): implement basic getters/putters for all types
 
-    #[cfg(test)]
+    // This is pub to be used in integration tests
+    #[doc(hidden)]
     pub async fn put_task(&self, task_id: TaskId) -> Result<(), Error> {
         let stmt = self
             .tx

--- a/janus_server/src/hpke.rs
+++ b/janus_server/src/hpke.rs
@@ -10,7 +10,7 @@ use hpke::{
 use rand::thread_rng;
 
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum Error {
+pub enum Error {
     /// Wrapper around errors from crate hpke. See [`hpke::HpkeError`] for more
     /// details on possible variants.
     #[error("HPKE error")]
@@ -87,14 +87,44 @@ impl HpkeApplicationInfo {
 // doesn't "leak" the generic type parameters into the caller.
 #[derive(Clone, Debug)]
 pub struct HpkeSender {
-    pub(crate) task_id: TaskId,
-    pub recipient_config: HpkeConfig,
-    pub(crate) label: Label,
-    pub(crate) sender_role: Role,
-    pub(crate) recipient_role: Role,
+    task_id: TaskId,
+    recipient_config: HpkeConfig,
+    label: Label,
+    sender_role: Role,
+    recipient_role: Role,
 }
 
 impl HpkeSender {
+    /// Create an [`HpkeSender`] with the provided parameters.
+    pub fn new(
+        task_id: TaskId,
+        recipient_config: HpkeConfig,
+        label: Label,
+        sender_role: Role,
+        recipient_role: Role,
+    ) -> Self {
+        Self {
+            task_id,
+            recipient_config,
+            label,
+            sender_role,
+            recipient_role,
+        }
+    }
+
+    /// Create an [`HpkeSender`] configured to encrypt messages to the provided
+    /// [`HpkeRecipient`].
+    #[cfg(test)]
+    pub(crate) fn from_recipient(recipient: &HpkeRecipient) -> Self {
+        Self {
+            task_id: recipient.task_id,
+            recipient_config: recipient.config.clone(),
+            label: recipient.label,
+            sender_role: recipient.sender_role,
+            recipient_role: recipient.recipient_role,
+        }
+    }
+
     /// Encrypt `plaintext` and return the HPKE ciphertext.
     ///
     /// In PPM, an HPKE context can only be used once (we have no means of

--- a/janus_server/src/lib.rs
+++ b/janus_server/src/lib.rs
@@ -1,12 +1,8 @@
 #![allow(clippy::too_many_arguments)]
 
 pub mod aggregator;
-#[allow(dead_code)]
 pub mod client;
 pub mod datastore;
-// TODO(timg) delete this once items in the hpke module are actually used
-// anywhere
-#[allow(dead_code)]
 pub mod hpke;
 pub mod message;
 pub mod time;


### PR DESCRIPTION
Adds an implementation of `upload` to `client::Client`, which is now
generic over `prio::vdaf::Client`.