### PR TITLE
Implement SQL mapping for VDAF enum

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -3,7 +3,9 @@ CREATE EXTENSION pgcrypto; -- for gen_random_uuid()
 
 -- Identifies a particular VDAF.
 CREATE TYPE VDAF_IDENTIFIER AS ENUM(
-    'PRIO3',
+    'PRIO3_AES128_COUNT',
+    'PRIO3_AES128_SUM',
+    'PRIO3_AES128_HISTOGRAM',
     'POPLAR1'
 );
 

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -16,6 +16,7 @@ hpke = { version = "0.8.0", features = ["default", "std"] }
 http = "0.2.6"
 lazy_static = "1"
 num_enum = "0.5.6"
+postgres-types = { version = "0.2.2", features = ["derive"] }
 prio = "0.7.0"
 rand = "0.8"
 reqwest = { version = "0.11.4", default-features = false, features = ["rustls-tls", "json"] }

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     message::{Extension, HpkeCiphertext, Nonce, Report, TaskId, Time},
-    task::{TaskParameters, Vdaf},
+    task::TaskParameters,
 };
 use prio::codec::{decode_u16_items, encode_u16_items, CodecError, Decode, Encode};
 use std::{future::Future, io::Cursor, pin::Pin};
@@ -220,8 +220,8 @@ impl Transaction<'_> {
     /// This is a test-only method that is used to test round-tripping of values.
     /// TODO: remove this once the tasks table is finalized, and there's a method to retrieve an
     /// entire `TaskParameters` from the database.
-    #[allow(unused)]
-    async fn get_task_vdaf_by_id(&self, task_id: &TaskId) -> Result<Vdaf, Error> {
+    #[cfg(test)]
+    async fn get_task_vdaf_by_id(&self, task_id: &TaskId) -> Result<crate::task::Vdaf, Error> {
         let stmt = self
             .tx
             .prepare_cached("SELECT vdaf FROM tasks WHERE id=$1")
@@ -330,6 +330,7 @@ mod tests {
     use crate::datastore::test_util::ephemeral_datastore;
     use crate::hpke::{HpkeRecipient, Label};
     use crate::message::{Duration, ExtensionType, HpkeConfigId, Role};
+    use crate::task::Vdaf;
     use crate::trace::test_util::install_trace_subscriber;
 
     #[tokio::test]

--- a/janus_server/src/task.rs
+++ b/janus_server/src/task.rs
@@ -4,6 +4,7 @@ use crate::{
     hpke::{HpkeRecipient, Label},
     message::{Duration, HpkeConfig, Role, TaskId},
 };
+use postgres_types::{FromSql, ToSql};
 use url::Url;
 
 /// Errors that methods and functions in this module may return.
@@ -20,15 +21,20 @@ pub enum Error {
 /// [`prio::vdaf::prio3`].
 ///
 /// [1]: https://datatracker.ietf.org/doc/draft-patton-cfrg-vdaf/
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ToSql, FromSql)]
+#[postgres(name = "vdaf_identifier")]
 pub enum Vdaf {
     /// A `prio3` counter using the AES 128 pseudorandom generator.
+    #[postgres(name = "PRIO3_AES128_COUNT")]
     Prio3Aes128Count,
     /// A `prio3` sum using the AES 128 pseudorandom generator.
+    #[postgres(name = "PRIO3_AES128_SUM")]
     Prio3Aes128Sum,
     /// A `prio3` histogram using the AES 128 pseudorandom generator.
+    #[postgres(name = "PRIO3_AES128_HISTOGRAM")]
     Prio3Aes128Histogram,
     /// The `poplar1` VDAF. Support for this VDAF is experimental.
+    #[postgres(name = "POPLAR1")]
     Poplar1,
 }
 

--- a/janus_server/src/task.rs
+++ b/janus_server/src/task.rs
@@ -21,7 +21,7 @@ pub enum Error {
 /// [`prio::vdaf::prio3`].
 ///
 /// [1]: https://datatracker.ietf.org/doc/draft-patton-cfrg-vdaf/
-#[derive(Debug, Clone, ToSql, FromSql)]
+#[derive(Debug, Clone, PartialEq, Eq, ToSql, FromSql)]
 #[postgres(name = "vdaf_identifier")]
 pub enum Vdaf {
     /// A `prio3` counter using the AES 128 pseudorandom generator.
@@ -47,7 +47,7 @@ pub struct TaskParameters {
     /// entry is the leader's.
     pub(crate) aggregator_endpoints: Vec<Url>,
     /// The VDAF this task executes.
-    _vdaf: Vdaf,
+    pub(crate) vdaf: Vdaf,
     /// Secret verification parameter shared by the aggregators.
     _vdaf_verify_parameter: Vec<u8>,
     /// The maximum number of times a given batch may be collected.
@@ -79,7 +79,7 @@ impl TaskParameters {
         Self {
             id,
             aggregator_endpoints,
-            _vdaf: vdaf,
+            vdaf,
             _vdaf_verify_parameter: vdaf_verify_parameter,
             _max_batch_lifetime: max_batch_lifetime,
             _min_batch_size: min_batch_size,
@@ -96,7 +96,7 @@ impl TaskParameters {
         Self {
             id: task_id,
             aggregator_endpoints,
-            _vdaf: Vdaf::Prio3Aes128Count,
+            vdaf: Vdaf::Prio3Aes128Count,
             _vdaf_verify_parameter: vec![],
             _max_batch_lifetime: 0,
             _min_batch_size: 0,


### PR DESCRIPTION
This is a quick follow-up to #33 to implement `ToSql` and `FromSql` for our `Vdaf` enum. I added variants to the schema's enum to reflect the multiple instantiations of prio3.

Note that the attribute macro setting the database name of the enum uses lowercase, `"vdaf_identifier"`. This is what the derive macro insisted on, I take it that SQL enum names are case-insensitive like most other objects. The crate must normalize the name to lowercase, and then the generated implementations do their type checks against that.