### PR TITLE
tokio-console support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,30 @@ Janus is an experimental implementation of the
 [Privacy Preserving Measurement (PPM) specification](https://github.com/abetterinternet/ppm-specification).
 
 It is currently in active development.
+
+## Running janus\_server
+
+The aggregator server requires a connection to a PostgreSQL 14 database. Prepare the database by executing the script at `db/schema.sql`. Most server configuration is done via a YAML file, following the structure documented on `janus_server::config::AggregatorConfig`. Record the database's connection URL, the address the aggregator server should listen on for incoming HTTP requests, and other settings in a YAML file, and pass the file's path on the command line as follows.
+
+```bash
+aggregator --config-file <config-file> --role <role>
+```
+
+## Monitoring with `tokio-console`
+
+Optional support is included to monitor the server's async runtime using `tokio-console`. When enabled, a separate tracing subscriber will be installed to monitor when the async runtime polls tasks, and expose that information to diagnostic tools via a gRPC server. Currently, this requires both changes to the aggregator configuration and to the build flags used at compilation. Add a stanza similar to the following to the configuration file.
+
+```yaml
+logging_config:
+  tokio_console_config:
+    enabled: true
+    listen_address: 127.0.0.1:6669
+```
+
+Compile the server with the flag `--cfg tokio_unstable`, as follows. (If `tokio-console` support is enabled in the configuration, but the `tokio_unstable` flag was not present at compilation time, the server will panic upon startup)
+
+```bash
+RUSTFLAGS="--cfg tokio_unstable" CARGO_TARGET_DIR=target/tokio_unstable cargo build
+```
+
+Install `tokio-console`, run the server, and run `tokio-console http://127.0.0.1:6669` to connect to it and monitor tasks.

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -11,6 +11,7 @@ atty = "0.2"
 base64 = "0.13.0"
 bytes = "1.1.0"
 chrono = "0.4"
+console-subscriber = "0.1.3"
 deadpool-postgres = "0.10.1"
 derivative = "2"
 hex = "0.4.3"
@@ -29,7 +30,7 @@ serde_yaml = "0.8.23"
 structopt = "0.3.26"
 testcontainers = "0.12.0"
 thiserror = "1.0"
-tokio = { version = "^1.9", features = ["full"] }
+tokio = { version = "^1.9", features = ["full", "tracing"] }
 tokio-postgres = { version = "0.7.5", features = ["with-chrono-0_4"] }
 tracing = "0.1.32"
 tracing-log = "0.1.2"


### PR DESCRIPTION
This adds a configuration option to enable tokio-console support. Note that I didn't add `--cfg tokio_unstable` to RUSTFLAGS anywhere, so you'll need to rebuild with that, in addition to setting a variable in the configuration, to use it.

This PR will look funny because I am basing it off of #38, which was not merged into main. It appears there's a conflict as well.