### PR TITLE
janus_server: rename subscriber installer fns

### DIFF
--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -398,7 +398,7 @@ mod tests {
         message::{HpkeConfig, TaskId, Time},
         task::TaskParameters,
         time::tests::MockClock,
-        trace::test_util::install_trace_subscriber,
+        trace::test_util::install_test_trace_subscriber,
     };
     use assert_matches::assert_matches;
     use http::Method;
@@ -410,7 +410,7 @@ mod tests {
 
     #[tokio::test]
     async fn invalid_role() {
-        install_trace_subscriber();
+        install_test_trace_subscriber();
 
         let (datastore, _db_handle) = ephemeral_datastore().await;
         let datastore = Arc::new(datastore);
@@ -437,7 +437,7 @@ mod tests {
 
     #[tokio::test]
     async fn invalid_clock_skew() {
-        install_trace_subscriber();
+        install_test_trace_subscriber();
 
         let (datastore, _db_handle) = ephemeral_datastore().await;
         let hpke_recipient = HpkeRecipient::generate(
@@ -461,7 +461,7 @@ mod tests {
 
     #[tokio::test]
     async fn hpke_config() {
-        install_trace_subscriber();
+        install_test_trace_subscriber();
 
         let task_id = TaskId::random();
         let (datastore, _db_handle) = ephemeral_datastore().await;
@@ -570,7 +570,7 @@ mod tests {
 
     #[tokio::test]
     async fn upload_filter() {
-        install_trace_subscriber();
+        install_test_trace_subscriber();
 
         let (datastore, _db_handle) = ephemeral_datastore().await;
         let clock = MockClock::default();
@@ -706,7 +706,7 @@ mod tests {
     // Helper should not expose /upload endpoint
     #[tokio::test]
     async fn upload_filter_helper() {
-        install_trace_subscriber();
+        install_test_trace_subscriber();
 
         let (datastore, _db_handle) = ephemeral_datastore().await;
         let clock = MockClock::default();
@@ -761,7 +761,7 @@ mod tests {
 
     #[tokio::test]
     async fn upload() {
-        install_trace_subscriber();
+        install_test_trace_subscriber();
 
         let skew = Duration::minutes(10);
         let (aggregator, report, datastore, _db_handle) = setup_upload_test(skew).await;
@@ -789,7 +789,7 @@ mod tests {
 
     #[tokio::test]
     async fn upload_wrong_number_of_encrypted_shares() {
-        install_trace_subscriber();
+        install_test_trace_subscriber();
 
         let skew = Duration::minutes(10);
         let (aggregator, mut report, _, _db_handle) = setup_upload_test(skew).await;
@@ -804,7 +804,7 @@ mod tests {
 
     #[tokio::test]
     async fn upload_wrong_hpke_config_id() {
-        install_trace_subscriber();
+        install_test_trace_subscriber();
 
         let skew = Duration::minutes(10);
         let (aggregator, mut report, _, _db_handle) = setup_upload_test(skew).await;
@@ -837,7 +837,7 @@ mod tests {
 
     #[tokio::test]
     async fn report_in_the_future() {
-        install_trace_subscriber();
+        install_test_trace_subscriber();
 
         let skew = Duration::minutes(10);
         let (aggregator, mut report, datastore, _db_handle) = setup_upload_test(skew).await;

--- a/janus_server/src/bin/aggregator.rs
+++ b/janus_server/src/bin/aggregator.rs
@@ -9,7 +9,7 @@ use janus_server::{
     message::Role,
     message::TaskId,
     time::RealClock,
-    trace::install_subscriber,
+    trace::install_trace_subscriber,
 };
 use std::{
     fmt::{self, Debug, Formatter},
@@ -77,7 +77,8 @@ async fn main() -> Result<()> {
     let config: AggregatorConfig = serde_yaml::from_reader(&config_file)
         .with_context(|| format!("failed to parse config file: {:?}", options.config_file))?;
 
-    install_subscriber(&config.logging_config).context("failed to install tracing subscriber")?;
+    install_trace_subscriber(&config.logging_config)
+        .context("failed to install tracing subscriber")?;
 
     info!(?options, ?config, "starting aggregator");
 

--- a/janus_server/src/client.rs
+++ b/janus_server/src/client.rs
@@ -169,7 +169,7 @@ mod tests {
     use super::*;
     use crate::{
         hpke::HpkeRecipient, message::TaskId, time::tests::MockClock,
-        trace::test_util::install_trace_subscriber,
+        trace::test_util::install_test_trace_subscriber,
     };
     use assert_matches::assert_matches;
     use mockito::mock;
@@ -208,7 +208,7 @@ mod tests {
 
     #[tokio::test]
     async fn upload_prio3_count() {
-        install_trace_subscriber();
+        install_test_trace_subscriber();
         let mocked_upload = mock("POST", "/upload").with_status(200).expect(1).create();
 
         let client = setup_client(Prio3Aes128Count::new(2).unwrap(), ());
@@ -220,7 +220,7 @@ mod tests {
 
     #[tokio::test]
     async fn upload_prio3_invalid_measurement() {
-        install_trace_subscriber();
+        install_test_trace_subscriber();
         let vdaf = Prio3Aes128Sum::new(2, 16).unwrap();
 
         let client = setup_client(vdaf, ());
@@ -232,7 +232,7 @@ mod tests {
 
     #[tokio::test]
     async fn upload_prio3_http_status_code() {
-        install_trace_subscriber();
+        install_test_trace_subscriber();
 
         let mocked_upload = mock("POST", "/upload").with_status(501).expect(1).create();
 

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -331,11 +331,11 @@ mod tests {
     use crate::hpke::{HpkeRecipient, Label};
     use crate::message::{Duration, ExtensionType, HpkeConfigId, Role};
     use crate::task::Vdaf;
-    use crate::trace::test_util::install_trace_subscriber;
+    use crate::trace::test_util::install_test_trace_subscriber;
 
     #[tokio::test]
     async fn roundtrip_report() {
-        install_trace_subscriber();
+        install_test_trace_subscriber();
         let (ds, _db_handle) = ephemeral_datastore().await;
 
         let task_id = TaskId([
@@ -394,7 +394,7 @@ mod tests {
 
     #[tokio::test]
     async fn report_not_found() {
-        install_trace_subscriber();
+        install_test_trace_subscriber();
         let (ds, _db_handle) = ephemeral_datastore().await;
 
         let rslt = ds
@@ -406,7 +406,7 @@ mod tests {
 
     #[tokio::test]
     async fn roundtrip_report_by_task_id_and_nonce() {
-        install_trace_subscriber();
+        install_test_trace_subscriber();
         let (ds, _db_handle) = ephemeral_datastore().await;
 
         let task_id = TaskId([
@@ -470,7 +470,7 @@ mod tests {
 
     #[tokio::test]
     async fn report_not_found_by_task_id_and_nonce() {
-        install_trace_subscriber();
+        install_test_trace_subscriber();
         let (ds, _db_handle) = ephemeral_datastore().await;
 
         let task_id = TaskId([
@@ -496,6 +496,7 @@ mod tests {
 
     #[tokio::test]
     async fn roundtrip_task() {
+        install_test_trace_subscriber();
         let (ds, _db_handle) = ephemeral_datastore().await;
 
         let task_ids = [

--- a/janus_server/src/hpke.rs
+++ b/janus_server/src/hpke.rs
@@ -357,9 +357,11 @@ fn open<Encrypt: Aead, Derive: Kdf, Encapsulate: Kem>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::trace::test_util::install_test_trace_subscriber;
 
     #[test]
     fn exchange_message() {
+        install_test_trace_subscriber();
         let task_id = TaskId::random();
         // Sender and receiver must agree on AAD for each message
         let associated_data = b"message associated data";
@@ -384,6 +386,7 @@ mod tests {
 
     #[test]
     fn wrong_private_key() {
+        install_test_trace_subscriber();
         let task_id = TaskId::random();
         // Sender and receiver must agree on AAD for each message
         let associated_data = b"message associated data";
@@ -413,6 +416,7 @@ mod tests {
 
     #[test]
     fn wrong_application_info() {
+        install_test_trace_subscriber();
         let task_id = TaskId::random();
         // Sender and receiver must agree on AAD for each message
         let associated_data = b"message associated data";
@@ -435,6 +439,7 @@ mod tests {
 
     #[test]
     fn wrong_associated_data() {
+        install_test_trace_subscriber();
         let task_id = TaskId::random();
         let message = b"a message that is secret";
 

--- a/janus_server/src/trace.rs
+++ b/janus_server/src/trace.rs
@@ -42,7 +42,7 @@ fn base_layer<S>() -> Layer<S> {
 /// Configures and installs a tracing subscriber, to capture events logged with
 /// [`tracing::info`] and the like. Captured events are written to stdout, with
 /// formatting affected by the provided [`TraceConfiguration`].
-pub fn install_subscriber(config: &TraceConfiguration) -> Result<(), Error> {
+pub fn install_trace_subscriber(config: &TraceConfiguration) -> Result<(), Error> {
     // If stdout is not a tty or if forced by config, output logs as JSON
     // structures
     let output_json = atty::isnt(Stream::Stdout) || config.force_json_output;
@@ -74,12 +74,13 @@ pub(crate) mod test_util {
     use super::*;
     use std::sync::Once;
 
-    /// install_trace_subscriber installs a tracing subscriber suitable for tests. It should be
-    /// called at the beginning of any test that requires a tracing subscriber.
-    pub(crate) fn install_trace_subscriber() {
+    /// install_test_trace_subscriber installs a tracing subscriber suitable for
+    /// tests. It should be called at the beginning of any test that requires a
+    /// tracing subscriber.
+    pub(crate) fn install_test_trace_subscriber() {
         static INSTALL_TRACE_SUBSCRIBER: Once = Once::new();
         INSTALL_TRACE_SUBSCRIBER.call_once(|| {
-            super::install_subscriber(&TraceConfiguration {
+            install_trace_subscriber(&TraceConfiguration {
                 use_test_writer: true,
                 ..Default::default()
             })

--- a/janus_server/tests/integration_test.rs
+++ b/janus_server/tests/integration_test.rs
@@ -7,7 +7,7 @@ use janus_server::{
     message::{Role, TaskId},
     task::TaskParameters,
     time::RealClock,
-    trace::{install_subscriber, TraceConfiguration},
+    trace::{install_trace_subscriber, TraceConfiguration},
 };
 use prio::vdaf::prio3::Prio3Aes128Count;
 use std::{
@@ -34,7 +34,7 @@ struct TestCase {
 }
 
 async fn setup_test() -> TestCase {
-    install_subscriber(&TraceConfiguration {
+    install_trace_subscriber(&TraceConfiguration {
         use_test_writer: true,
         ..Default::default()
     })


### PR DESCRIPTION
`trace::install_subscriber` is now `install_trace_subscriber` to make it
more obvious what the subscriber subscribes to, and
`trace::test_util::install_trace_subscriber` is now
`install_test_trace_subscriber` to make it easier to distinguish between
it and the subscriber intended for non-test cases.

Also installs a test subscriber in a few tests that failed to do so.