### PR TITLE
Miscellaneous cleanups

### DIFF
--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -256,8 +256,6 @@ static PROBLEM_DETAILS_JSON_MEDIA_TYPE: &str = "application/problem+json";
 
 /// Construct an error response in accordance with §3.1.
 //
-// TODO (PR abetterinternet/ppm-specification#208): base64-encoding the TaskID has not yet been
-// adopted in the specification, and may change.
 // TODO (issue abetterinternet/ppm-specification#209): The handling of the instance, title,
 // detail, and taskid fields are subject to change.
 fn build_problem_details_response(error_type: PpmProblemType, task_id: TaskId) -> Response {

--- a/janus_server/tests/integration_test.rs
+++ b/janus_server/tests/integration_test.rs
@@ -124,16 +124,16 @@ async fn teardown_test(test_case: TestCase) {
     test_case.leader_task_handle.abort();
     test_case.helper_task_handle.abort();
 
-    test_case
+    assert!(test_case
         .leader_task_handle
         .await
         .unwrap_err()
-        .is_cancelled();
-    test_case
+        .is_cancelled());
+    assert!(test_case
         .helper_task_handle
         .await
         .unwrap_err()
-        .is_cancelled();
+        .is_cancelled());
 }
 
 #[tokio::test]


### PR DESCRIPTION
This takes out a now-obsolete TODO comment and uses a couple of unused values in a test case.