### PR TITLE
Hide primary keys from users of the datastore library.

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,6 +1,3 @@
--- TODO(brandon): remove pgcrypto extension once everyone is on Postgres 13+ w/ builtin gen_random_uuid
-CREATE EXTENSION pgcrypto; -- for gen_random_uuid()
-
 -- Identifies a particular VDAF.
 CREATE TYPE VDAF_IDENTIFIER AS ENUM(
     'PRIO3_AES128_COUNT',
@@ -11,7 +8,8 @@ CREATE TYPE VDAF_IDENTIFIER AS ENUM(
 
 -- Corresponds to a PPM task, containing static data associated with the task.
 CREATE TABLE tasks(
-    id                     BYTEA PRIMARY KEY,         -- 32-byte TaskID as defined by the PPM specification
+    id                     BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,  -- artificial ID, internal-only
+    task_id                BYTEA UNIQUE NOT NULL,     -- 32-byte TaskID as defined by the PPM specification
     ord                    BIGINT NOT NULL,           -- the order of this aggregator for this task; 0 is leader, 1 or larger is helper
     aggregator_endpoints   TEXT[] NOT NULL,           -- aggregator HTTPS endpoints, leader first
     vdaf                   VDAF_IDENTIFIER NOT NULL,  -- the VDAF in use for this task
@@ -27,7 +25,7 @@ CREATE TABLE tasks(
 -- Individual reports received from clients.
 CREATE TABLE client_reports(
     id            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY, -- artificial ID, internal-only
-    task_id       BYTEA NOT NULL,      -- task ID the report is associated with
+    task_id       BIGINT NOT NULL,     -- task ID the report is associated with
     nonce_time    TIMESTAMP NOT NULL,  -- timestamp from nonce
     nonce_rand    BIGINT NOT NULL,     -- random value from nonce
     extensions    BYTEA,               -- encoded sequence of Extension messages (populated for leader only)
@@ -48,7 +46,7 @@ CREATE TYPE AGGREGATION_JOB_STATE AS ENUM(
 CREATE TABLE aggregation_jobs(
     id                 BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY, -- artificial ID, internal-only
     aggregation_job_id BYTEA NOT NULL,                  -- aggregation job ID
-    task_id            BYTEA NOT NULL,                  -- ID of related task
+    task_id            BIGINT NOT NULL,                 -- ID of related task
     aggregation_param  BYTEA NOT NULL,                  -- encoded aggregation parameter (opaque VDAF message)
     state              AGGREGATION_JOB_STATE NOT NULL,  -- current state of the aggregation job
 
@@ -86,19 +84,22 @@ CREATE INDEX report_aggregations_aggregation_job_id_index ON report_aggregations
 -- Information on aggregation for a single batch. This information may be incremental if the VDAF
 -- supports incremental aggregation.
 CREATE TABLE batch_aggregations(
-    task_id               BYTEA NOT NULL,      -- the task ID
+    id                    BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,  -- artificial ID, internal-only
+    task_id               BIGINT NOT NULL,     -- the task ID
     batch_interval_start  TIMESTAMP NOT NULL,  -- the start of the batch interval
     aggregate_share       BYTEA NOT NULL,      -- the (possibly-incremental) aggregate share
     report_count          BIGINT NOT NULL,     -- the (possibly-incremental) client report count
     checksum              BYTEA NOT NULL,      -- the (possibly-incremental) checksum
 
-    PRIMARY KEY(task_id, batch_interval_start)
+    CONSTRAINT unique_task_id_interval UNIQUE(task_id, batch_interval_start),
+    CONSTRAINT fk_task_id FOREIGN KEY(task_id) REFERENCES tasks(id)
 );
 
 -- A collection request from the Collector.
 CREATE TABLE collect_jobs(
-    id                    UUID DEFAULT gen_random_uuid() PRIMARY KEY, -- UUID used by collector to refer to this job
-    task_id               BYTEA NOT NULL,      -- the task ID being collected
+    id                    BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,  -- artificial ID, internal-only
+    collect_job_id        UUID NOT NULL,       -- UUID used by collector to refer to this job
+    task_id               BIGINT NOT NULL,     -- the task ID being collected
     batch_interval_start  TIMESTAMP NOT NULL,  -- the start of the batch interval
     batch_interval_end    TIMESTAMP NOT NULL,  -- the end of the batch interval
     aggregation_param     BYTEA NOT NULL,      -- the aggregation parameter (opaque VDAF message)
@@ -109,10 +110,11 @@ CREATE INDEX collect_jobs_batch_interval_index ON collect_jobs(task_id, batch_in
 
 -- An encrypted aggregate share computed for a specific collection job.
 CREATE TABLE collect_job_encrypted_aggregate_shares(
-    collect_job_id             UUID,             -- the ID of the collect job this encrypted aggregate share is associated with
+    id                         BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,  -- artificial ID, internal-only
+    collect_job_id             BIGINT NOT NULL,  -- the ID of the collect job this encrypted aggregate share is associated with
     ord                        BIGINT NOT NULL,  -- the order of the aggregator associated with this encrypted_aggregate_share; 0 is leader, 1 or larger is helper
     encrypted_aggregate_share  BYTEA NOT NULL,   -- the encrypted aggregate share (an encoded HpkeCiphertext message)
 
-    CONSTRAINT fk_collect_job_id FOREIGN KEY(collect_job_id) REFERENCES collect_jobs(id),
-    PRIMARY KEY(collect_job_id, ord)
+    CONSTRAINT unique_collect_job_and_ord UNIQUE(collect_job_id, ord),
+    CONSTRAINT fk_collect_job_id FOREIGN KEY(collect_job_id) REFERENCES collect_jobs(id)
 );

--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -211,10 +211,7 @@ where
                 let report = report.clone();
                 Box::pin(async move {
                     // §4.2.2 and 4.3.2.2: reject reports whose nonce has been seen before
-                    match tx
-                        .get_client_report_by_task_id_and_nonce(report.task_id, report.nonce)
-                        .await
-                    {
+                    match tx.get_client_report(report.task_id, report.nonce).await {
                         Ok(_) => {
                             warn!(?report.task_id, ?report.nonce, "report replayed");
                             // TODO (issue #34): change this error type.
@@ -407,16 +404,16 @@ where
                 let report_share_data = report_share_data.clone();
                 Box::pin(async move {
                     // Write aggregation job.
-                    let aggregation_job_id = tx.put_aggregation_job(&aggregation_job).await?;
+                    tx.put_aggregation_job(&aggregation_job).await?;
 
                     for (ord, share_data) in report_share_data.as_ref().iter().enumerate() {
                         // Write client report & report aggregation.
-                        let client_report_id = tx
-                            .put_report_share(task_id, &share_data.report_share)
+                        tx.put_report_share(task_id, &share_data.report_share)
                             .await?;
                         tx.put_report_aggregation(&ReportAggregation::<A> {
-                            aggregation_job_id,
-                            client_report_id,
+                            aggregation_job_id: job_id,
+                            task_id,
+                            nonce: share_data.report_share.nonce,
                             ord: ord as i64,
                             state: share_data.agg_state.clone(),
                         })
@@ -1340,10 +1337,7 @@ mod tests {
 
         let got_report = datastore
             .run_tx(|tx| {
-                Box::pin(async move {
-                    tx.get_client_report_by_task_id_and_nonce(report.task_id, report.nonce)
-                        .await
-                })
+                Box::pin(async move { tx.get_client_report(report.task_id, report.nonce).await })
             })
             .await
             .unwrap();
@@ -1419,10 +1413,7 @@ mod tests {
 
         let got_report = datastore
             .run_tx(|tx| {
-                Box::pin(async move {
-                    tx.get_client_report_by_task_id_and_nonce(report.task_id, report.nonce)
-                        .await
-                })
+                Box::pin(async move { tx.get_client_report(report.task_id, report.nonce).await })
             })
             .await
             .unwrap();


### PR DESCRIPTION
As part of this, I refactor all tables to have an "artificial" primary
key, which is a BIGINT; internally the datastore code manages the
necessary joins. Code using the datastore uses the "natural" primary
keys--the BIGINT primary keys are not exposed at all.

This simplifies the client code, while keeping join indexes small (which
may help performance) and allowing flexibility in case the "natrual"
primary key for a given entity changes with future changes to the PPM
spec.