### PR TITLE
Make console-subscriber an optional dependency

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -21,6 +21,8 @@ jobs:
       run: cargo fmt --message-format human -- --check
     - name: clippy
       run: cargo clippy --all-targets -- -D warnings
+    - name: check, tokio-console feature
+      run: cargo check --features tokio-console
     - name: build
       run: cargo build --verbose
     - name: test

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ logging_config:
     listen_address: 127.0.0.1:6669
 ```
 
-Compile the server with the flag `--cfg tokio_unstable`, as follows. (If `tokio-console` support is enabled in the configuration, but the `tokio_unstable` flag was not present at compilation time, the server will panic upon startup)
+Compile the server with the `tokio-console` feature enabled, and provide the flag `--cfg tokio_unstable` to `rustc`, as follows. (If `tokio-console` support is enabled in a build without the `tokio_unstable` flag, the server will panic upon startup)
 
 ```bash
-RUSTFLAGS="--cfg tokio_unstable" CARGO_TARGET_DIR=target/tokio_unstable cargo build
+RUSTFLAGS="--cfg tokio_unstable" CARGO_TARGET_DIR=target/tokio_unstable cargo build --features tokio-console
 ```
 
 Install `tokio-console`, run the server, and run `tokio-console http://127.0.0.1:6669` to connect to it and monitor tasks.

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -5,13 +5,16 @@ edition = "2021"
 license = "MPL-2.0"
 rust-version = "1.58"
 
+[features]
+tokio-console = ["console-subscriber"]
+
 [dependencies]
 anyhow = "1"
 atty = "0.2"
 base64 = "0.13.0"
 bytes = "1.1.0"
 chrono = "0.4"
-console-subscriber = "0.1.3"
+console-subscriber = { version = "0.1.3", optional = true }
 deadpool-postgres = "0.10.1"
 derivative = "2"
 hex = "0.4.3"


### PR DESCRIPTION
`console-subscriber` and its dependents are responsible for a significant amount of compilation time, and yet they are only usable when compiling with a special RUSTFLAGS value. This puts support behind a non-default Cargo feature. I measured a time savings of 50 seconds (2:28 to 1:38) on a clean release build, so this should give us a noticeable win on CI job runtime.