### PR TITLE
`janus_server`: storage of task parameters

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -23,6 +23,7 @@ CREATE TABLE tasks(
     max_batch_lifetime     BIGINT NOT NULL,           -- the maximum number of times a given batch may be collected
     min_batch_size         BIGINT NOT NULL,           -- the minimum number of reports in a batch to allow it to be collected
     min_batch_duration     BIGINT NOT NULL,           -- the minimum duration in seconds of a single batch interval
+    tolerable_clock_skew   BIGINT NOT NULL,           -- the maximum acceptable clock skew to allow between client and aggregator, in seconds
     collector_hpke_config  BYTEA NOT NULL,            -- the HPKE config of the collector (encoded HpkeConfig message)
     agg_auth_key           BYTEA NOT NULL,            -- HMAC key used by this aggregator to authenticate messages to/from the other aggregator
     hpke_config            BYTEA NOT NULL,            -- the HPKE config of this aggregator (encoded HpkeConfig message)

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -108,14 +108,16 @@ impl Transaction<'_> {
         let max_batch_lifetime = i64::try_from(task.max_batch_lifetime)?;
         let min_batch_size = i64::try_from(task.min_batch_size)?;
         let min_batch_duration = i64::try_from(task.min_batch_duration.0)?;
+        let tolerable_clock_skew = i64::try_from(task.tolerable_clock_skew.0)?;
 
         let stmt = self
             .tx
             .prepare_cached(
-                "INSERT INTO tasks (task_id, aggregator_role, aggregator_endpoints, vdaf, vdaf_verify_param,
-                max_batch_lifetime, min_batch_size, min_batch_duration, collector_hpke_config,
-                agg_auth_key, hpke_config, hpke_private_key)
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
+                "INSERT INTO tasks (task_id, aggregator_role, aggregator_endpoints, vdaf,
+                vdaf_verify_param, max_batch_lifetime, min_batch_size, min_batch_duration,
+                tolerable_clock_skew, collector_hpke_config, agg_auth_key, hpke_config,
+                hpke_private_key)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)",
             )
             .await?;
         self.tx
@@ -130,6 +132,7 @@ impl Transaction<'_> {
                     &max_batch_lifetime,                         // max batch lifetime
                     &min_batch_size,                             // min batch size
                     &min_batch_duration,                         // min batch duration
+                    &tolerable_clock_skew,                       // tolerable clock skew
                     &task.collector_hpke_config.get_encoded(),   // collector hpke config
                     &task.agg_auth_key.as_slice(),               // agg_auth_key
                     &task.hpke_recipient.config().get_encoded(), // hpke_config
@@ -150,9 +153,9 @@ impl Transaction<'_> {
             .tx
             .prepare_cached(
                 "SELECT aggregator_role, aggregator_endpoints, vdaf, vdaf_verify_param,
-                max_batch_lifetime, min_batch_size, min_batch_duration, collector_hpke_config,
-                agg_auth_key, hpke_config, hpke_private_key
-                FROM tasks WHERE task_id = $1",
+                max_batch_lifetime, min_batch_size, min_batch_duration, tolerable_clock_skew,
+                collector_hpke_config, agg_auth_key, hpke_config, hpke_private_key
+                FROM tasks WHERE task_id=$1",
             )
             .await?;
         let row = single_row(self.tx.query(&stmt, &[&&task_id.0[..]]).await?)?;
@@ -168,6 +171,7 @@ impl Transaction<'_> {
         let max_batch_lifetime = row.get_bigint_as_u64("max_batch_lifetime")?;
         let min_batch_size = row.get_bigint_as_u64("min_batch_size")?;
         let min_batch_duration = Duration(row.get_bigint_as_u64("min_batch_duration")?);
+        let tolerable_clock_skew = Duration(row.get_bigint_as_u64("tolerable_clock_skew")?);
         let collector_hpke_config = HpkeConfig::get_decoded(row.get("collector_hpke_config"))?;
         let agg_auth_key = AggregatorAuthKey::from_bytes(row.get("agg_auth_key"))?;
         let hpke_config = HpkeConfig::get_decoded(row.get("hpke_config"))?;
@@ -190,6 +194,7 @@ impl Transaction<'_> {
             max_batch_lifetime,
             min_batch_size,
             min_batch_duration,
+            tolerable_clock_skew,
             &collector_hpke_config,
             agg_auth_key,
             &hpke_recipient,

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -143,22 +143,21 @@ impl Transaction<'_> {
         Ok(())
     }
 
-    /// Fetch the task parameters corresponing to the provided `task_id`.
-    //
-    // Only available in test configs for now, but will soon be used by
-    // aggregators to discover tasks from the database.
+    /// Construct a [`TaskParameters`] from the contents of the provided `Row`.
+    /// If `task_id` is not `None`, it is used. Otherwise the task ID is read
+    /// from the row.
     #[cfg(test)]
-    pub(crate) async fn get_task_by_id(&self, task_id: TaskId) -> Result<TaskParameters, Error> {
-        let stmt = self
-            .tx
-            .prepare_cached(
-                "SELECT aggregator_role, aggregator_endpoints, vdaf, vdaf_verify_param,
-                max_batch_lifetime, min_batch_size, min_batch_duration, tolerable_clock_skew,
-                collector_hpke_config, agg_auth_key, hpke_config, hpke_private_key
-                FROM tasks WHERE task_id=$1",
-            )
-            .await?;
-        let row = single_row(self.tx.query(&stmt, &[&&task_id.0[..]]).await?)?;
+    fn task_parameters_from_row(
+        task_id: Option<TaskId>,
+        row: &Row,
+    ) -> Result<TaskParameters, Error> {
+        let task_id = task_id.map_or_else(
+            || {
+                let encoded_task_id: Vec<u8> = row.get("task_id");
+                TaskId::get_decoded(&encoded_task_id)
+            },
+            Ok,
+        )?;
 
         let aggregator_role: AggregatorRole = row.get("aggregator_role");
         let endpoints: Vec<String> = row.get("aggregator_endpoints");
@@ -199,6 +198,46 @@ impl Transaction<'_> {
             agg_auth_key,
             &hpke_recipient,
         ))
+    }
+
+    /// Fetch the task parameters corresponing to the provided `task_id`.
+    //
+    // Only available in test configs for now, but will soon be used by
+    // aggregators to discover tasks from the database.
+    #[cfg(test)]
+    pub(crate) async fn get_task_by_id(&self, task_id: TaskId) -> Result<TaskParameters, Error> {
+        let stmt = self
+            .tx
+            .prepare_cached(
+                "SELECT aggregator_role, aggregator_endpoints, vdaf, vdaf_verify_param,
+                max_batch_lifetime, min_batch_size, min_batch_duration, tolerable_clock_skew,
+                collector_hpke_config, agg_auth_key, hpke_config, hpke_private_key
+                FROM tasks WHERE task_id=$1",
+            )
+            .await?;
+        let row = single_row(self.tx.query(&stmt, &[&&task_id.0[..]]).await?)?;
+
+        Self::task_parameters_from_row(Some(task_id), &row)
+    }
+
+    /// Fetch all the tasks in the database.
+    #[cfg(test)]
+    pub(crate) async fn get_tasks(&self) -> Result<Vec<TaskParameters>, Error> {
+        let stmt = self
+            .tx
+            .prepare_cached(
+                "SELECT task_id, aggregator_role, aggregator_endpoints, vdaf,
+                vdaf_verify_param, max_batch_lifetime, min_batch_size, min_batch_duration,
+                tolerable_clock_skew, collector_hpke_config, agg_auth_key, hpke_config,
+                hpke_private_key
+                FROM tasks",
+            )
+            .await?;
+        let rows = self.tx.query(&stmt, &[]).await?;
+
+        rows.iter()
+            .map(|row| Self::task_parameters_from_row(None, row))
+            .collect::<Result<_, _>>()
     }
 
     /// get_client_report retrieves a client report by ID.
@@ -944,6 +983,23 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(task_params, retrieved_task);
+        }
+
+        let retrieved_tasks = ds
+            .run_tx(|tx| Box::pin(async move { tx.get_tasks().await }))
+            .await
+            .unwrap();
+        assert_eq!(retrieved_tasks.len(), values.len());
+        let mut saw_tasks = vec![false; values.len()];
+        for task in retrieved_tasks {
+            for (idx, value) in values.iter().enumerate() {
+                if value.0 == task.id {
+                    saw_tasks[idx] = true;
+                }
+            }
+        }
+        for (idx, saw_task) in saw_tasks.iter().enumerate() {
+            assert!(saw_task, "never saw task {} in datastore", idx);
         }
     }
 

--- a/janus_server/src/task.rs
+++ b/janus_server/src/task.rs
@@ -100,6 +100,9 @@ pub struct TaskParameters {
     /// The minimum batch interval for a collect request. Batch intervals must
     /// be multiples of this duration.
     pub(crate) min_batch_duration: Duration,
+    /// How much clock skew to allow between client and aggregator. Reports from
+    /// farther than this duration into the future will be rejected.
+    pub(crate) tolerable_clock_skew: Duration,
     /// HPKE configuration for the collector.
     pub(crate) collector_hpke_config: HpkeConfig,
     /// Key used to authenticate messages sent to or received from the other
@@ -120,6 +123,7 @@ impl TaskParameters {
         max_batch_lifetime: u64,
         min_batch_size: u64,
         min_batch_duration: Duration,
+        tolerable_clock_skew: Duration,
         collector_hpke_config: &HpkeConfig,
         agg_auth_key: AggregatorAuthKey,
         hpke_recipient: &HpkeRecipient,
@@ -136,6 +140,7 @@ impl TaskParameters {
             max_batch_lifetime,
             min_batch_size,
             min_batch_duration,
+            tolerable_clock_skew,
             collector_hpke_config: collector_hpke_config.clone(),
             agg_auth_key,
             hpke_recipient: hpke_recipient.clone(),
@@ -161,6 +166,7 @@ impl TaskParameters {
             max_batch_lifetime: 0,
             min_batch_size: 0,
             min_batch_duration: Duration(1),
+            tolerable_clock_skew: Duration(1),
             collector_hpke_config: HpkeRecipient::generate(
                 task_id,
                 Label::AggregateShare,

--- a/janus_server/tests/integration_test.rs
+++ b/janus_server/tests/integration_test.rs
@@ -102,6 +102,7 @@ async fn setup_test() -> TestCase {
         0,                                  // max_batch_lifetime
         0,                                  // min_batch_size
         message::Duration::from_seconds(1), // min_batch_duration,
+        message::Duration::from_seconds(1), // tolerable_clock_skew,
         collector_hpke_recipient.config(),
         agg_auth_key,
         &leader_hpke_recipient,


### PR DESCRIPTION
With these changes we now store the tolerable clock skew in the tasks table and add functions for fetching task parameters from the database, to be used by aggregators to dynamically discover the defined tasks.