### PR TITLE
testcontainers: 0.12.0 -> 0.13.0.

### DIFF
--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 serde_yaml = "0.8.23"
 structopt = "0.3.26"
-testcontainers = "0.12.0"
+testcontainers = "0.13.0"
 thiserror = "1.0"
 tokio = { version = "^1.9", features = ["full", "tracing"] }
 tokio-postgres = { version = "0.7.5", features = ["with-chrono-0_4"] }

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -817,7 +817,7 @@ pub mod test_util {
     use deadpool_postgres::{Manager, Pool};
     use lazy_static::lazy_static;
     use std::str::{self, FromStr};
-    use testcontainers::{clients::Cli, images::postgres::Postgres, Container};
+    use testcontainers::{clients::Cli, images::postgres::Postgres, Container, RunnableImage};
     use tokio_postgres::{Config, NoTls};
 
     const SCHEMA: &str = include_str!("../../db/schema.sql");
@@ -837,7 +837,8 @@ pub mod test_util {
     /// Dropping the second return value causes the database to be shut down & cleaned up.
     pub async fn ephemeral_datastore() -> (Datastore, DbHandle) {
         // Start an instance of Postgres running in a container.
-        let db_container = CONTAINER_CLIENT.run(Postgres::default());
+        let db_container =
+            CONTAINER_CLIENT.run(RunnableImage::from(Postgres::default()).with_tag("14-alpine"));
 
         // Create a connection pool whose clients will talk to our newly-running instance of Postgres.
         const POSTGRES_DEFAULT_PORT: u16 = 5432;


### PR DESCRIPTION
A few notes:
 * Unfortunately, we can't use podman yet; attempting to start the
   Postgres container fails.
 * The testcontainers library apparently removed the ability to request
   a specific Postgres version, but fortunately the default version is
   high enough to have all of the features we care about.

Example error when using podman:
```
thread 'datastore::tests::roundtrip_task' panicked at 'called `Result::unwrap()` on an `Err` value: Error("invalid type: string \"docker-entrypoint.sh\", expected a sequence", line: 180, column: 48)', /home/bran/.cargo/registry/src/github.com-1ecc6299db9ec823/testcontainers-0.13.0/src/clients/cli.rs:323:88
```