### PR TITLE
Move EnvFilter to be per-layer, use Vec<Layer>

### DIFF
--- a/janus_server/src/trace.rs
+++ b/janus_server/src/trace.rs
@@ -4,11 +4,7 @@ use atty::{self, Stream};
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use tracing_log::LogTracer;
-use tracing_subscriber::{
-    filter::{FilterExt, Targets},
-    layer::SubscriberExt,
-    EnvFilter, Layer, Registry,
-};
+use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Layer, Registry};
 
 /// Errors from initializing trace subscriber.
 #[derive(Debug, thiserror::Error)]
@@ -64,16 +60,6 @@ fn base_layer<S>() -> tracing_subscriber::fmt::Layer<S> {
         .with_line_number(true)
 }
 
-/// Filter factory to create per-layer filters for stdout layers. The returned
-/// filter will prevent verbose runtime-related events from being printed to
-/// stdout.
-fn runtime_tracing_filter<S>() -> tracing_subscriber::filter::combinator::Not<Targets, S> {
-    Targets::new()
-        .with_target("tokio", tracing::Level::TRACE)
-        .with_target("runtime", tracing::Level::TRACE)
-        .not()
-}
-
 /// Configures and installs a tracing subscriber, to capture events logged with
 /// [`tracing::info`] and the like. Captured events are written to stdout, with
 /// formatting affected by the provided [`TraceConfiguration`].
@@ -82,72 +68,48 @@ pub fn install_trace_subscriber(config: &TraceConfiguration) -> Result<(), Error
     // structures
     let output_json = atty::isnt(Stream::Stdout) || config.force_json_output;
 
-    let (pretty_layer, json_layer, test_layer) = match (output_json, config.use_test_writer) {
-        (true, false) => (
-            None,
-            Some(base_layer().json().with_filter(runtime_tracing_filter())),
-            None,
-        ),
-        (false, false) => (
-            Some(base_layer().pretty().with_filter(runtime_tracing_filter())),
-            None,
-            None,
-        ),
-        (_, true) => (
-            None,
-            None,
-            Some(
-                base_layer()
-                    .pretty()
-                    .with_test_writer()
-                    .with_filter(runtime_tracing_filter()),
-            ),
-        ),
-    };
-
     // Configure filters with RUST_LOG env var. Format discussed at
     // https://docs.rs/tracing-subscriber/latest/tracing_subscriber/struct.EnvFilter.html
-    #[allow(unused_mut)]
-    let mut global_filter = EnvFilter::from_default_env();
+    let stdout_filter = EnvFilter::from_default_env();
+
+    let mut layers = Vec::new();
+    match (output_json, config.use_test_writer) {
+        (true, false) => layers.push(base_layer().json().with_filter(stdout_filter).boxed()),
+        (false, false) => layers.push(base_layer().pretty().with_filter(stdout_filter).boxed()),
+        (_, true) => layers.push(
+            base_layer()
+                .pretty()
+                .with_test_writer()
+                .with_filter(stdout_filter)
+                .boxed(),
+        ),
+    }
 
     #[cfg(feature = "tokio-console")]
-    let console_layer = match &config.tokio_console_config.enabled {
-        true => {
-            global_filter = global_filter.add_directive("tokio=trace".parse().unwrap());
-            global_filter = global_filter.add_directive("runtime=trace".parse().unwrap());
+    if config.tokio_console_config.enabled {
+        let console_filter = tracing_subscriber::filter::Targets::new()
+            .with_target("tokio", tracing::Level::TRACE)
+            .with_target("runtime", tracing::Level::TRACE);
 
-            let mut builder = console_subscriber::ConsoleLayer::builder();
-            builder = builder.with_default_env();
-            if let Some(listen_address) = &config.tokio_console_config.listen_address {
-                builder = builder.server_addr(*listen_address);
-            }
-            let layer = builder.spawn();
-            Some(layer)
+        let mut builder = console_subscriber::ConsoleLayer::builder();
+        builder = builder.with_default_env();
+        if let Some(listen_address) = &config.tokio_console_config.listen_address {
+            builder = builder.server_addr(*listen_address);
         }
-        false => None,
-    };
+        layers.push(builder.spawn().with_filter(console_filter).boxed());
+    }
 
     #[cfg(not(feature = "tokio-console"))]
-    let console_layer = {
-        if config.tokio_console_config.enabled {
-            eprintln!(
-                "Warning: the tokio-console subscriber was enabled in the \
-                configuration file, but support was not enabled at compile \
-                time. Rebuild with `RUSTFLAGS=\"--cfg tokio_unstable\"` and \
-                `--features tokio-console`."
-            );
-        }
+    if config.tokio_console_config.enabled {
+        eprintln!(
+            "Warning: the tokio-console subscriber was enabled in the \
+            configuration file, but support was not enabled at compile \
+            time. Rebuild with `RUSTFLAGS=\"--cfg tokio_unstable\"` and \
+            `--features tokio-console`."
+        );
+    }
 
-        // Always return a no-op layer.
-        None::<EnvFilter>
-    };
-
-    let subscriber = Registry::default()
-        .with(pretty_layer)
-        .with(test_layer)
-        .with(json_layer)
-        .with(console_layer)
-        .with(global_filter);
+    let subscriber = Registry::default().with(layers);
 
     tracing::subscriber::set_global_default(subscriber)?;
 


### PR DESCRIPTION
The upgrade to tracing-subscriber 0.3.10 brings with it some new features for better ergonomics. First, EnvFilter can now be used as a per-layer Filter, rather than only as a Layer. By using it as a Filter on our stdout layers, we can now avoid modifying a global filter when using console-subscriber. Instead, we put EnvFilter on the stdout layer, and Targets on the console-subscriber layer, and the two do not interfere with each other. Additionally, Vec<L: Layer> now implements Layer, so we can create a vector of one or two boxed layers, rather than handling four different Option variables. This will also greatly simplify adding additional subscribers. (such as tracing-opentelemetry)