### PR TITLE
Fix a test failure re. leader-filtered reports

### DIFF
--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -2306,7 +2306,7 @@ mod tests {
                     task_id,
                     nonce: nonce_1,
                     ord: 1,
-                    state: ReportAggregationState::Invalid,
+                    state: ReportAggregationState::Failed(TransitionError::ReportDropped),
                 }
             ]
         );


### PR DESCRIPTION
This is a quick follow-up to #57, there's one test failure related to a late change.