### PR TITLE
Point Dependabot at the Cargo workspace root

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 
 updates:
   - package-ecosystem: "cargo"
-    directory: "/janus_server"
+    directory: "/"
     schedule:
       interval: "weekly"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Dependabot should be pointed at the workspace root now, as that's where our lockfile is, and it will be able to discover our crate from there.