### PR TITLE
Rewrite Dockerfile to use BuildKit cache mounts

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -28,4 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - run: docker build .
+    - env:
+        DOCKER_BUILDKIT: 1
+      run: docker build .

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ COPY Cargo.toml /src/Cargo.toml
 COPY Cargo.lock /src/Cargo.lock
 COPY janus_server /src/janus_server
 COPY db/schema.sql /src/db/schema.sql
-RUN cargo build --release --bin aggregator
+RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,target=/src/target cargo build --release --bin aggregator && cp /src/target/release/aggregator /aggregator
 
 FROM alpine:3.15.4
 RUN apk add libgcc
 COPY --from=builder /src/db/schema.sql /db/schema.sql
-COPY --from=builder /src/target/release/aggregator /aggregator
+COPY --from=builder /aggregator /aggregator
 ENTRYPOINT ["/aggregator"]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ The aggregator server requires a connection to a PostgreSQL 14 database. Prepare
 aggregator --config-file <config-file> --role <role>
 ```
 
+## Container image
+
+To build a container image, run the following command.
+
+```bash
+DOCKER_BUILDKIT=1 docker build --tag=janus_server .
+```
+
 ## Monitoring with `tokio-console`
 
 Optional support is included to monitor the server's async runtime using `tokio-console`. When enabled, a separate tracing subscriber will be installed to monitor when the async runtime polls tasks, and expose that information to diagnostic tools via a gRPC server. Currently, this requires both changes to the aggregator configuration and to the build flags used at compilation. Add a stanza similar to the following to the configuration file.


### PR DESCRIPTION
This adds caching to the Dockerfile build through the use of BuildKit, and its cache mounts. The target directory and Cargo registry are both mounted out to persistent cache directories. As `target` is no longer part of image layers, we also copy the final binary out to a different directory. Using cache mounts will give us better caching granularity (including rustc incremental compilation) than we could get by breaking the build into multiple layers.