### PR TITLE
Get database password from env. var. if not in URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It is currently in active development.
 
 ## Running janus\_server
 
-The aggregator server requires a connection to a PostgreSQL 14 database. Prepare the database by executing the script at `db/schema.sql`. Most server configuration is done via a YAML file, following the structure documented on `janus_server::config::AggregatorConfig`. Record the database's connection URL, the address the aggregator server should listen on for incoming HTTP requests, and other settings in a YAML file, and pass the file's path on the command line as follows. (The database password can be passed through the `PGPASSWORD` environment variable rather than including it in the connection URL)
+The aggregator server requires a connection to a PostgreSQL 14 database. Prepare the database by executing the script at `db/schema.sql`. Most server configuration is done via a YAML file, following the structure documented on `janus_server::config::AggregatorConfig`. Record the database's connection URL, the address the aggregator server should listen on for incoming HTTP requests, and other settings in a YAML file, and pass the file's path on the command line as follows. (The database password can be passed through the command line or an environment variable rather than including it in the connection URL, see `aggregator --help`.)
 
 ```bash
 aggregator --config-file <config-file> --role <role>

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It is currently in active development.
 
 ## Running janus\_server
 
-The aggregator server requires a connection to a PostgreSQL 14 database. Prepare the database by executing the script at `db/schema.sql`. Most server configuration is done via a YAML file, following the structure documented on `janus_server::config::AggregatorConfig`. Record the database's connection URL, the address the aggregator server should listen on for incoming HTTP requests, and other settings in a YAML file, and pass the file's path on the command line as follows.
+The aggregator server requires a connection to a PostgreSQL 14 database. Prepare the database by executing the script at `db/schema.sql`. Most server configuration is done via a YAML file, following the structure documented on `janus_server::config::AggregatorConfig`. Record the database's connection URL, the address the aggregator server should listen on for incoming HTTP requests, and other settings in a YAML file, and pass the file's path on the command line as follows. (The database password can be passed through the `PGPASSWORD` environment variable rather than including it in the connection URL)
 
 ```bash
 aggregator --config-file <config-file> --role <role>

--- a/janus_server/src/bin/aggregator.rs
+++ b/janus_server/src/bin/aggregator.rs
@@ -90,13 +90,18 @@ async fn main() -> Result<()> {
     let vdaf = Prio3Aes128Count::new(2).unwrap();
     let verify_param = vdaf.setup().unwrap().1.first().unwrap().clone();
 
-    let database_config = tokio_postgres::Config::from_str(config.database.url.as_str())
+    let mut database_config = tokio_postgres::Config::from_str(config.database.url.as_str())
         .with_context(|| {
             format!(
                 "failed to parse database connect string: {:?}",
                 config.database.url
             )
         })?;
+    if database_config.get_password().is_none() {
+        if let Ok(password) = std::env::var("PGPASSWORD") {
+            database_config.password(password);
+        }
+    }
     let conn_mgr = Manager::new(database_config, NoTls);
     let pool = Pool::builder(conn_mgr)
         .build()

--- a/janus_server/src/bin/aggregator.rs
+++ b/janus_server/src/bin/aggregator.rs
@@ -58,6 +58,10 @@ struct Options {
         help = "role for this aggregator",
     )]
     role: Role,
+    /// Password for the PostgreSQL database connection. (if not included in the connection
+    /// string)
+    #[structopt(long, env = "PGPASSWORD", help = "PostgreSQL password")]
+    database_password: Option<String>,
 }
 
 impl Debug for Options {
@@ -98,7 +102,7 @@ async fn main() -> Result<()> {
             )
         })?;
     if database_config.get_password().is_none() {
-        if let Ok(password) = std::env::var("PGPASSWORD") {
+        if let Some(password) = options.database_password {
             database_config.password(password);
         }
     }


### PR DESCRIPTION
Currently, we read in a Postgres connection string from the configuration file, and pass that directly to the database library. This change will read a password from the environment variable `PGPASSWORD` if the connection string/URL does not include one, and use that. Splitting the password handling out in this way will make it easy to assemble everything but the password in Terraform, without having to worry about the secrecy of Terraform state files. The password can be plumbed via an environment variable from a Kubernetes secret, separate from the configuration.