### PR TITLE
AggregatorAuthKey: a few miscellaneous updates.

### DIFF
--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -113,6 +113,7 @@ impl Transaction<'_> {
         let min_batch_size = i64::try_from(task.min_batch_size)?;
         let min_batch_duration = i64::try_from(task.min_batch_duration.0)?;
         let tolerable_clock_skew = i64::try_from(task.tolerable_clock_skew.0)?;
+        let agg_auth_key: &[u8] = task.agg_auth_key.as_ref();
 
         let stmt = self
             .tx
@@ -138,7 +139,7 @@ impl Transaction<'_> {
                     &min_batch_duration,                         // min batch duration
                     &tolerable_clock_skew,                       // tolerable clock skew
                     &task.collector_hpke_config.get_encoded(),   // collector hpke config
-                    &task.agg_auth_key.as_slice(),               // agg_auth_key
+                    &agg_auth_key,                               // agg_auth_key
                     &task.hpke_recipient.config().get_encoded(), // hpke_config
                     &task.hpke_recipient.private_key().as_ref(), // hpke_private_key
                 ],
@@ -176,7 +177,7 @@ impl Transaction<'_> {
         let min_batch_duration = Duration(row.get_bigint_as_u64("min_batch_duration")?);
         let tolerable_clock_skew = Duration(row.get_bigint_as_u64("tolerable_clock_skew")?);
         let collector_hpke_config = HpkeConfig::get_decoded(row.get("collector_hpke_config"))?;
-        let agg_auth_key = AggregatorAuthKey::from_bytes(row.get("agg_auth_key"))?;
+        let agg_auth_key = AggregatorAuthKey::new(row.get("agg_auth_key"))?;
         let hpke_config = HpkeConfig::get_decoded(row.get("hpke_config"))?;
         let hpke_private_key = HpkePrivateKey::new(row.get("hpke_private_key"));
         let hpke_recipient = HpkeRecipient::new(


### PR DESCRIPTION
I'm working on supporting multiple aggregator auth keys per task (for
rotation), and I noticed a few changes I'd like to make.

  * Generate HMAC keys that are sized to the SHA256 block size (64
    bytes) rather than output size (32 bytes). This is the largest
    useful key size & is sometimes recommended as a best-practice. It
    doesn't incur a performance penalty as smaller values are padded out
    to 64 bytes anyway before use in the HMAC algorithm.
  * Make generate() infallible. This is done by using thread_rng() (a
    thread-local CSPRNG, initially seeded & occasionally reseeded by OS
    randomness) instead of SystemRandom (which reads OS randomness
    every time), and by carefully sizing the key that is generated.
  * Cache the hmac::Key inside the type, rather than recreating it
    every time it is requested. This may be useful because
    hmac::Key::new precomputes the ipad/opad-xor'ed values internal to
    the HMAC algorithm, so we'd prefer to not create the key multiple
    times (especially not once-per-usage).
  * Switch from bespoke as_slice/as_hmac_key methods to more-standard
    AsRef<[u8]>/AsRef<hmac::Key>. I'm not so sure about this change:
    Rust isn't as smart as I expected about inferring which is desired
    when calling as_ref(), leading to some awkward code. I can switch
    back to bespoke methods if desirable, but the important bit is that
    the API now exposes a reference to the hmac::Key rather than the
    hmac::Key itself -- not all of the consumers are yet smart enough
    to be able to effectively use a reference, but I'll leave that for
    a later PR.