### PR TITLE
Add caching to non-Docker CI build

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -14,6 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - name: cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: lint
       run: cargo fmt --message-format human -- --check
     - name: clippy


### PR DESCRIPTION
This invokes the cache action to cache cargo's repository index and our target directory. I'm going to force-push this in a bit and compare timing/outputs to see if it worked.