### PR TITLE
Graceful shutdown of warp server upon SIGTERM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,6 +1206,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "signal-hook",
+ "signal-hook-tokio",
  "structopt",
  "tempfile",
  "testcontainers",
@@ -2232,12 +2234,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "647c97df271007dcea485bb74ffdb57f2e683f1306c854f468a0c244badabf2d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signal-hook-tokio"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213241f76fb1e37e27de3b6aa1b068a2c333233b59cca6634f634b80a27ecf1e"
+dependencies = [
+ "futures-core",
+ "libc",
+ "signal-hook",
+ "tokio",
 ]
 
 [[package]]

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -31,6 +31,8 @@ ring = "0.16.20"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 serde_yaml = "0.8.23"
+signal-hook = "0.3.13"
+signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
 structopt = "0.3.26"
 testcontainers = "0.13.0"
 thiserror = "1.0"

--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -923,6 +923,7 @@ pub fn aggregator_server<A, C>(
     agg_auth_keys: Vec<hmac::Key>,
     hpke_keys: HashMap<HpkeConfigId, (HpkeConfig, HpkePrivateKey)>,
     listen_address: SocketAddr,
+    shutdown_signal: impl Future<Output = ()> + Send + 'static,
 ) -> Result<(SocketAddr, impl Future<Output = ()> + 'static), Error>
 where
     A: 'static + vdaf::Aggregator + Send + Sync,
@@ -945,7 +946,7 @@ where
         agg_auth_keys,
         hpke_keys,
     )?)
-    .bind_ephemeral(listen_address))
+    .bind_with_graceful_shutdown(listen_address, shutdown_signal))
 }
 
 #[cfg(test)]

--- a/janus_server/src/bin/aggregator.rs
+++ b/janus_server/src/bin/aggregator.rs
@@ -167,6 +167,7 @@ async fn main() -> Result<()> {
         vec![agg_auth_key],
         hpke_keys,
         config.listen_address,
+        std::future::pending(),
     )
     .context("failed to create aggregator server")?;
     info!(?task_id, ?bound_address, "running aggregator");


### PR DESCRIPTION
This registers a SIGTERM handler, and plumbs it through to warp's `bind_with_graceful_shutdown()`. In the integration test, one-shot channels are used to shut down the servers instead of aborting their tasks.

Closes #40.