### PR TITLE
Remove additional apk packages from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM rust:1.60.0-alpine as builder
-RUN apk add libc-dev protoc
+RUN apk add libc-dev
 
 WORKDIR /src
 COPY Cargo.toml /src/Cargo.toml
@@ -9,7 +9,6 @@ COPY db/schema.sql /src/db/schema.sql
 RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,target=/src/target cargo build --release --bin aggregator && cp /src/target/release/aggregator /aggregator
 
 FROM alpine:3.15.4
-RUN apk add libgcc
 COPY --from=builder /src/db/schema.sql /db/schema.sql
 COPY --from=builder /aggregator /aggregator
 ENTRYPOINT ["/aggregator"]


### PR DESCRIPTION
These are no longer needed by console-subscriber. (which is no longer built by default, in the first place)