### PR TITLE
Make testcontainers a dev-dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,6 +1240,7 @@ dependencies = [
  "signal-hook-tokio",
  "structopt",
  "tempfile",
+ "test_util",
  "testcontainers",
  "thiserror",
  "tokio",
@@ -1431,10 +1432,16 @@ name = "monolithic_integration_test"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "deadpool-postgres",
  "futures",
  "janus_server",
+ "lazy_static",
  "prio",
+ "ring",
+ "test_util",
+ "testcontainers",
  "tokio",
+ "tokio-postgres",
  "url",
 ]
 
@@ -2441,6 +2448,14 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "test_util"
+version = "0.1.0"
+dependencies = [
+ "rand",
+ "ring",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["janus_server", "monolithic_integration_test"]
+members = ["janus_server", "monolithic_integration_test", "test_util"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY Cargo.toml /src/Cargo.toml
 COPY Cargo.lock /src/Cargo.lock
 COPY janus_server /src/janus_server
 COPY monolithic_integration_test /src/monolithic_integration_test
+COPY test_util /src/test_util
 COPY db/schema.sql /src/db/schema.sql
 RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,target=/src/target cargo build --release --bin aggregator && cp /src/target/release/aggregator /aggregator
 

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -20,7 +20,6 @@ futures = "0.3.21"
 hex = "0.4.3"
 hpke = { version = "0.8.0", features = ["default", "std"] }
 http = "0.2.6"
-lazy_static = "1"
 num_enum = "0.5.6"
 postgres-types = { version = "0.2.2", features = ["derive"] }
 prio = { git = "https://github.com/divviup/libprio-rs", rev = "229cd9c45924c7dae3ba754a6eb46b2a05ca8451" }  # TODO(brandon): use a numbered version, once a release is cut >0.7.0
@@ -33,7 +32,6 @@ serde_yaml = "0.8.23"
 signal-hook = "0.3.13"
 signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
 structopt = "0.3.26"
-testcontainers = "0.13.0"
 thiserror = "1.0"
 tokio = { version = "^1.9", features = ["full", "tracing"] }
 tokio-postgres = { version = "0.7.5", features = ["with-chrono-0_4"] }
@@ -47,8 +45,11 @@ warp = { version = "^0.3", features = ["tls"] }
 assert_matches = "1"
 hex = { version = "0.4.3", features = ["serde"] }
 hyper = "0.14.17"
+lazy_static = "1"
 libc = "0.2.123"
 mockito = "0.31.0"
 tempfile = "3.3.0"
+testcontainers = "0.13.0"
+test_util = { path = "../test_util" }
 trycmd = "0.13.3"
 wait-timeout = "0.2.0"

--- a/janus_server/tests/server_shutdown.rs
+++ b/janus_server/tests/server_shutdown.rs
@@ -5,7 +5,7 @@
 
 use janus_server::{
     config::{AggregatorConfig, DbConfig},
-    datastore::test_util::ephemeral_datastore,
+    datastore::{Crypter, Datastore},
     message::{Role, TaskId},
     task::{test_util::new_dummy_task, Vdaf},
     trace::{install_trace_subscriber, TraceConfiguration},
@@ -16,6 +16,8 @@ use std::{
     process::Command,
 };
 use wait_timeout::ChildExt;
+
+test_util::define_ephemeral_datastore!(false);
 
 /// Try to find an open port by binding to an ephemeral port, saving the port
 /// number, and closing the listening socket. This may still fail due to race

--- a/monolithic_integration_test/Cargo.toml
+++ b/monolithic_integration_test/Cargo.toml
@@ -5,8 +5,14 @@ edition = "2021"
 
 [dev-dependencies]
 chrono = "0.4.19"
+deadpool-postgres = "0.10.1"
 futures = "0.3.21"
 janus_server = { path = "../janus_server" }
+lazy_static = "1"
 prio = { git = "https://github.com/divviup/libprio-rs", rev = "229cd9c45924c7dae3ba754a6eb46b2a05ca8451" }  # TODO(brandon): use a numbered version, once a release is cut >0.7.0
+ring = "0.16.20"
+testcontainers = "0.13.0"
+test_util = { path = "../test_util" }
 tokio = { version = "^1.9", features = ["full", "tracing"] }
+tokio-postgres = { version = "0.7.5", features = ["with-chrono-0_4"] }
 url = { version = "2.2.2", features = ["serde"] }

--- a/monolithic_integration_test/tests/integration_test.rs
+++ b/monolithic_integration_test/tests/integration_test.rs
@@ -3,7 +3,7 @@ use futures::channel::oneshot::Sender;
 use janus_server::{
     aggregator::aggregator_server,
     client::{self, Client, ClientParameters},
-    datastore::test_util::{ephemeral_datastore, DbHandle},
+    datastore::{Crypter, Datastore},
     hpke::test_util::generate_hpke_config_and_private_key,
     message::{Role, TaskId},
     task::{AggregatorAuthKey, Task, Vdaf},
@@ -20,6 +20,8 @@ use std::{
 };
 use tokio::task::JoinHandle;
 use url::Url;
+
+test_util::define_ephemeral_datastore!(false);
 
 fn endpoint_from_socket_addr(addr: &SocketAddr) -> Url {
     assert!(addr.ip().is_loopback());

--- a/test_util/Cargo.toml
+++ b/test_util/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "test_util"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rand = "0.8"
+ring = "0.16.20"

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -1,0 +1,103 @@
+use rand::{thread_rng, Rng};
+use ring::aead::{LessSafeKey, UnboundKey, AES_128_GCM};
+
+/// This macro injects definitions of `DbHandle` and `ephemeral_datastore()`, for use in tests.
+/// It should be invoked once per binary target, and then `ephemeral_datastore()` can be called
+/// to set up a database for test purposes. This depends on `janus_server::datastore::Datastore`
+/// and `janus_server::datastore::Crypter` already being imported into scope, and it expects the
+/// following crates to be available: `deadpool_postgres`, `lazy_static`, `ring`, `testcontainers`,
+/// and `tokio_postgres`.
+///
+/// If invoking from within `janus_server`, with `--cfg=test`, use
+/// `define_ephemeral_datastore!(true)`, and the VDAF enum in Postgres will be updated with
+/// unit test-only variants. Otherwise, use `define_ephemeral_datastore!(false)`.
+#[macro_export]
+macro_rules! define_ephemeral_datastore {
+    ($with_fake_vdaf:literal) => {
+        const SCHEMA: &str = include_str!("../../db/schema.sql");
+
+        ::lazy_static::lazy_static! {
+            static ref CONTAINER_CLIENT: ::testcontainers::clients::Cli = ::testcontainers::clients::Cli::default();
+        }
+
+        /// DbHandle represents a handle to a running (ephemeral) database. Dropping this value
+        /// causes the database to be shut down & cleaned up.
+        pub struct DbHandle {
+            _db_container: ::testcontainers::Container<'static, ::testcontainers::images::postgres::Postgres>,
+            connection_string: String,
+            datastore_key_bytes: Vec<u8>,
+        }
+
+        impl DbHandle {
+            pub fn connection_string(&self) -> &str {
+                &self.connection_string
+            }
+
+            pub fn datastore_key_bytes(&self) -> &[u8] {
+                &self.datastore_key_bytes
+            }
+        }
+
+        /// ephemeral_datastore creates a new Datastore instance backed by an ephemeral database which
+        /// has the Janus schema applied but is otherwise empty.
+        ///
+        /// Dropping the second return value causes the database to be shut down & cleaned up.
+        pub async fn ephemeral_datastore() -> (Datastore, DbHandle) {
+            // Start an instance of Postgres running in a container.
+            let db_container =
+                CONTAINER_CLIENT.run(::testcontainers::RunnableImage::from(::testcontainers::images::postgres::Postgres::default()).with_tag("14-alpine"));
+
+            // Create a connection pool whose clients will talk to our newly-running instance of Postgres.
+            const POSTGRES_DEFAULT_PORT: u16 = 5432;
+            let connection_string = format!(
+                "postgres://postgres:postgres@localhost:{}/postgres",
+                db_container.get_host_port(POSTGRES_DEFAULT_PORT)
+            );
+            let cfg = <::tokio_postgres::Config as std::str::FromStr>::from_str(&connection_string).unwrap();
+            let conn_mgr = ::deadpool_postgres::Manager::new(cfg, ::tokio_postgres::NoTls);
+            let pool = ::deadpool_postgres::Pool::builder(conn_mgr).build().unwrap();
+
+            // Create a crypter with a random (ephemeral) key.
+            let datastore_key_bytes = ::test_util::generate_aead_key_bytes();
+            let datastore_key =
+                ::ring::aead::LessSafeKey::new(::ring::aead::UnboundKey::new(&ring::aead::AES_128_GCM, &datastore_key_bytes).unwrap());
+            let crypter = Crypter::new(vec![datastore_key]);
+
+            // Connect to the database & run our schema.
+            let client = pool.get().await.unwrap();
+            client.batch_execute(SCHEMA).await.unwrap();
+
+            // Test-only DB schema modifications.
+            if $with_fake_vdaf {
+                client
+                    .batch_execute(
+                        "ALTER TYPE VDAF_IDENTIFIER ADD VALUE 'FAKE';
+                        ALTER TYPE VDAF_IDENTIFIER ADD VALUE 'FAKE_FAILS_PREP_INIT';
+                        ALTER TYPE VDAF_IDENTIFIER ADD VALUE 'FAKE_FAILS_PREP_STEP';",
+                    )
+                    .await
+                    .unwrap();
+            }
+
+            (
+                Datastore::new(pool, crypter),
+                DbHandle {
+                    _db_container: db_container,
+                    connection_string,
+                    datastore_key_bytes,
+                },
+            )
+        }
+    };
+}
+
+pub fn generate_aead_key_bytes() -> Vec<u8> {
+    let mut key_bytes = vec![0u8; AES_128_GCM.key_len()];
+    thread_rng().fill(&mut key_bytes[..]);
+    key_bytes
+}
+
+pub fn generate_aead_key() -> LessSafeKey {
+    let unbound_key = UnboundKey::new(&AES_128_GCM, &generate_aead_key_bytes()).unwrap();
+    LessSafeKey::new(unbound_key)
+}


### PR DESCRIPTION
This is stacked on top of #94.

This moves the declaration of items necessary for an ephemeral datastore into a macro in a new crate, `test_util`. This macro is then invoked inside `janus_server` only in its unit tests, as well as separately in each integration test. As a result, `testcontainers` can be removed from `janus_server`'s runtime dependencies.

I'm using a macro tactic here to enable code reuse while keeping `ephemeral_datastore()` out of `janus_server`'s exposed API, and to be able to use it within `janus_server`'s unit tests without setting up a dev-dependency cycle.