### PR TITLE
Store public VDAF params with type in JSON column

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1235,6 +1235,7 @@ dependencies = [
  "ring",
  "serde",
  "serde_json",
+ "serde_test",
  "serde_yaml",
  "signal-hook",
  "signal-hook-tokio",
@@ -1743,6 +1744,8 @@ dependencies = [
  "fallible-iterator",
  "postgres-derive",
  "postgres-protocol",
+ "serde",
+ "serde_json",
  "uuid",
 ]
 
@@ -2141,6 +2144,15 @@ checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_test"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21675ba6f9d97711cc00eee79d8dd7d0a31e571c350fb4d8a7c78f70c0e7b0e9"
+dependencies = [
  "serde",
 ]
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,11 +1,3 @@
--- Identifies a particular VDAF.
-CREATE TYPE VDAF_IDENTIFIER AS ENUM(
-    'PRIO3_AES128_COUNT',
-    'PRIO3_AES128_SUM',
-    'PRIO3_AES128_HISTOGRAM',
-    'POPLAR1'
-);
-
 -- Identifies which aggregator role is being played for this task.
 CREATE TYPE AGGREGATOR_ROLE AS ENUM(
     'LEADER',
@@ -18,7 +10,7 @@ CREATE TABLE tasks(
     task_id                BYTEA UNIQUE NOT NULL,     -- 32-byte TaskID as defined by the PPM specification
     aggregator_role        AGGREGATOR_ROLE NOT NULL,  -- the role of this aggregator for this task
     aggregator_endpoints   TEXT[] NOT NULL,           -- aggregator HTTPS endpoints, leader first
-    vdaf                   VDAF_IDENTIFIER NOT NULL,  -- the VDAF in use for this task
+    vdaf                   JSON NOT NULL,             -- the VDAF instance in use for this task, along with its parameters
     vdaf_verify_param      BYTEA NOT NULL,            -- the VDAF verify parameter (opaque VDAF message, encrypted)
     max_batch_lifetime     BIGINT NOT NULL,           -- the maximum number of times a given batch may be collected
     min_batch_size         BIGINT NOT NULL,           -- the minimum number of reports in a batch to allow it to be collected

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -34,7 +34,7 @@ signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
 structopt = "0.3.26"
 thiserror = "1.0"
 tokio = { version = "^1.9", features = ["full", "tracing"] }
-tokio-postgres = { version = "0.7.5", features = ["with-chrono-0_4", "with-uuid-0_8"] }
+tokio-postgres = { version = "0.7.5", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-0_8"] }
 tracing = "0.1.34"
 tracing-log = "0.1.2"
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt", "json"] }
@@ -51,6 +51,7 @@ hyper = "0.14.17"
 lazy_static = "1"
 libc = "0.2.123"
 mockito = "0.31.0"
+serde_test = "1.0.136"
 tempfile = "3.3.0"
 testcontainers = "0.13.0"
 test_util = { path = "../test_util" }

--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -251,8 +251,7 @@ impl TaskAggregator {
     /// Create a new aggregator. `report_recipient` is used to decrypt reports received by this
     /// aggregator.
     fn new(task: Task) -> Result<Self, Error> {
-        // TODO(brandon): include VDAF-specific configuration (like bit-length for sums, buckets for histograms) in Task
-        let vdaf_ops = match task.vdaf {
+        let vdaf_ops = match &task.vdaf {
             task::Vdaf::Prio3Aes128Count => {
                 let vdaf = Prio3Aes128Count::new(2)?;
                 let verify_param = <Prio3Aes128Count as Vdaf>::VerifyParam::get_decoded_with_param(
@@ -262,8 +261,8 @@ impl TaskAggregator {
                 VdafOps::Prio3Aes128Count(vdaf, verify_param)
             }
 
-            task::Vdaf::Prio3Aes128Sum => {
-                let vdaf = Prio3Aes128Sum::new(2, 64)?;
+            task::Vdaf::Prio3Aes128Sum { bits } => {
+                let vdaf = Prio3Aes128Sum::new(2, *bits)?;
                 let verify_param = <Prio3Aes128Sum as Vdaf>::VerifyParam::get_decoded_with_param(
                     &vdaf,
                     &task.vdaf_verify_parameter,
@@ -271,8 +270,8 @@ impl TaskAggregator {
                 VdafOps::Prio3Aes128Sum(vdaf, verify_param)
             }
 
-            task::Vdaf::Prio3Aes128Histogram => {
-                let vdaf = Prio3Aes128Histogram::new(2, &[0, 100, 200, 400])?;
+            task::Vdaf::Prio3Aes128Histogram { buckets } => {
+                let vdaf = Prio3Aes128Histogram::new(2, &*buckets)?;
                 let verify_param =
                     <Prio3Aes128Histogram as Vdaf>::VerifyParam::get_decoded_with_param(
                         &vdaf,

--- a/janus_server/tests/server_shutdown.rs
+++ b/janus_server/tests/server_shutdown.rs
@@ -17,7 +17,7 @@ use std::{
 };
 use wait_timeout::ChildExt;
 
-test_util::define_ephemeral_datastore!(false);
+test_util::define_ephemeral_datastore!();
 
 /// Try to find an open port by binding to an ephemeral port, saving the port
 /// number, and closing the listening socket. This may still fail due to race

--- a/monolithic_integration_test/tests/integration_test.rs
+++ b/monolithic_integration_test/tests/integration_test.rs
@@ -21,7 +21,7 @@ use std::{
 use tokio::task::JoinHandle;
 use url::Url;
 
-test_util::define_ephemeral_datastore!(false);
+test_util::define_ephemeral_datastore!();
 
 fn endpoint_from_socket_addr(addr: &SocketAddr) -> Url {
     assert!(addr.ip().is_loopback());


### PR DESCRIPTION
This changes the `vdaf` column in `tasks` from being an enum of the different VDAF instantiations to being a JSON object. This JSON object represents the `Vdaf` Rust enum, which now has value-carrying variants, for instances that require parameters, like Prio3Aes128Sum, etc.