### PR TITLE
Helper `/aggregate_share` endpoint

### DIFF
--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -9,11 +9,12 @@ use crate::{
     message::{
         AggregateReq,
         AggregateReqBody::{AggregateContinueReq, AggregateInitReq},
-        AggregateResp, AggregationJobId, AuthenticatedDecodeError, AuthenticatedEncoder,
-        AuthenticatedRequestDecoder, CollectReq, HpkeConfig, HpkeConfigId, Interval, Nonce, Report,
-        ReportShare, Role, TaskId, Transition, TransitionError, TransitionTypeSpecificData,
+        AggregateResp, AggregateShareReq, AggregateShareResp, AggregationJobId,
+        AuthenticatedDecodeError, AuthenticatedEncoder, AuthenticatedRequestDecoder, CollectReq,
+        HpkeConfig, HpkeConfigId, Interval, Nonce, Report, ReportShare, Role, TaskId, Transition,
+        TransitionError, TransitionTypeSpecificData,
     },
-    task::{self, Task},
+    task::{self, AggregatorAuthKey, Task},
     time::Clock,
 };
 use bytes::Bytes;
@@ -24,10 +25,11 @@ use http::{
 };
 use prio::{
     codec::{Decode, Encode, ParameterizedDecode},
+    field::FieldError,
     vdaf::{
         self,
         prio3::{Prio3Aes128Count, Prio3Aes128Histogram, Prio3Aes128Sum},
-        PrepareTransition, Vdaf,
+        Aggregatable, PrepareTransition, Vdaf,
     },
 };
 use std::{
@@ -92,8 +94,30 @@ pub enum Error {
     /// A collect or aggregate share request was rejected because the interval is valid, per §4.6
     #[error("Invalid batch interval: {0} {1:?}")]
     InvalidBatchInterval(Interval, TaskId),
+    /// There are not enough reports in the batch interval to meet the task's minimum batch size.
+    #[error("Insufficient number of reports ({0}) for task {1:?}")]
+    InsufficientBatchSize(u64, TaskId),
     #[error("URL parse error: {0}")]
     Url(#[from] url::ParseError),
+    /// The checksum or report count in one aggregator's aggregate share does not match the other
+    /// aggregator's aggregate share, suggesting different sets of reports were aggregated.
+    #[error(
+        "Batch misalignment: own checksum: {own_checksum:?} own report count: {own_report_count} \
+peer checksum: {peer_checksum:?} peer report count: {peer_report_count}"
+    )]
+    BatchMisalignment {
+        task_id: TaskId,
+        own_checksum: [u8; 32],
+        own_report_count: u64,
+        peer_checksum: [u8; 32],
+        peer_report_count: u64,
+    },
+    /// Too many queries against a single batch.
+    #[error("Maxiumum batch lifetime for task {0:?} exceeded")]
+    BatchLifetimeExceeded(TaskId),
+    /// HPKE failure.
+    #[error("HPKE error: {0}")]
+    Hpke(#[from] crate::hpke::Error),
     /// An error representing a generic internal aggregation error; intended for "impossible"
     /// conditions.
     #[error("internal aggregator error: {0}")]
@@ -164,7 +188,7 @@ impl<C: Clock> Aggregator<C> {
         let resp = task_aggregator
             .handle_aggregate(&self.datastore, req)
             .await?;
-        let key = task_aggregator.task.agg_auth_keys.last().unwrap();
+        let key = task_aggregator.current_aggregator_auth_key();
         Ok(AuthenticatedEncoder::new(resp).encode(key.as_ref()))
     }
 
@@ -195,7 +219,7 @@ impl<C: Clock> Aggregator<C> {
 
         let task_aggregator = self.task_aggregator_for(collect_req.task_id).await?;
 
-        // Only the leader supports collect.
+        // Only the leader supports /collect.
         if task_aggregator.task.role != Role::Leader {
             // TODO (timg): We should make sure that a helper returns HTTP 404 or 403 when this
             // happens
@@ -205,6 +229,28 @@ impl<C: Clock> Aggregator<C> {
         task_aggregator
             .handle_collect(&self.datastore, collect_req)
             .await
+    }
+
+    /// Handle an aggregate share request. Only supported by the helper. `req_bytes` is an encoded,
+    /// authenticated [`AggregateShareReq`]. Returns an encoded, authenticated
+    /// [`AggregateShareResp`].
+    async fn handle_aggregate_share(&self, req_bytes: &[u8]) -> Result<Vec<u8>, Error> {
+        let (task_aggregator, req): (_, AggregateShareReq) = self
+            .authenticated_decode(req_bytes, Some(Role::Helper))
+            .await?;
+
+        // Only the helper supports /aggregate_share.
+        if task_aggregator.task.role != Role::Helper {
+            // TODO (timg): We should make sure that a leader returns HTTP 404 or 403 when this
+            // happens
+            return Err(Error::UnrecognizedTask(req.task_id));
+        }
+
+        let resp = task_aggregator
+            .handle_aggregate_share(&self.datastore, &req)
+            .await?;
+        Ok(AuthenticatedEncoder::new(resp)
+            .encode(task_aggregator.current_aggregator_auth_key().as_ref()))
     }
 
     async fn task_aggregator_for(&self, task_id: TaskId) -> Result<Arc<TaskAggregator>, Error> {
@@ -306,6 +352,12 @@ impl TaskAggregator {
         };
 
         Ok(Self { task, vdaf_ops })
+    }
+
+    /// Returns the [`AggregatorAuthKey`] currently used by this aggregator's task to authenticate
+    /// aggregate messages.
+    fn current_aggregator_auth_key(&self) -> &AggregatorAuthKey {
+        self.task.agg_auth_keys.last().unwrap()
     }
 
     fn handle_hpke_config(&self) -> HpkeConfig {
@@ -425,6 +477,7 @@ impl TaskAggregator {
     }
 
     async fn handle_collect(&self, datastore: &Datastore, req: CollectReq) -> Result<Url, Error> {
+        // §4.5: check that the batch interval meets the requirements from §4.6
         if !self.task.validate_batch_interval(req.batch_interval) {
             return Err(Error::InvalidBatchInterval(
                 req.batch_interval,
@@ -458,6 +511,24 @@ impl TaskAggregator {
         Ok(base_url
             .join("collect_jobs/")?
             .join(&collect_job_uuid.to_string())?)
+    }
+
+    async fn handle_aggregate_share(
+        &self,
+        datastore: &Datastore,
+        req: &AggregateShareReq,
+    ) -> Result<AggregateShareResp, Error> {
+        // §4.4.4.3: check that the batch interval meets the requirements from §4.6
+        if !self.task.validate_batch_interval(req.batch_interval) {
+            return Err(Error::InvalidBatchInterval(
+                req.batch_interval,
+                self.task.id,
+            ));
+        }
+
+        self.vdaf_ops
+            .handle_aggregate_share(datastore, &self.task, req)
+            .await
     }
 }
 
@@ -783,6 +854,9 @@ impl VdafOps {
 
         // TODO(brandon): don't hold DB transaction open while computing VDAF updates?
         // TODO(brandon): don't do O(n) network round-trips (where n is the number of transitions)
+        // TODO(timg): We have to reject reports in batches that have completed an aggregate-share
+        // request with `batch-collected` here as well as in the init case. Suppose that an
+        // AggregateShareReq arrives in between the AggregateInitReq and AggregateContinueReq.
         Ok(datastore
             .run_tx(|tx| {
                 let vdaf = vdaf.clone();
@@ -885,6 +959,9 @@ impl VdafOps {
                                     nonce: transition.nonce,
                                     trans_data: TransitionTypeSpecificData::Finished,
                                 });
+
+                                // TODO(timg): when a report's preparation is done, its value should
+                                // be accumulated into a batch_aggregations row
                             }
 
                             PrepareTransition::Fail(err) => {
@@ -933,6 +1010,167 @@ impl VdafOps {
             })
             .await?)
     }
+
+    /// Implements the `/aggregate_share` endpoint for the helper, described in §4.4.4.3
+    async fn handle_aggregate_share(
+        &self,
+        datastore: &Datastore,
+        task: &Task,
+        aggregate_share_req: &AggregateShareReq,
+    ) -> Result<AggregateShareResp, Error> {
+        match self {
+            VdafOps::Prio3Aes128Count(_, _) => {
+                Self::handle_aggregate_share_generic::<
+                    <Prio3Aes128Count as Vdaf>::AggregateShare,
+                    FieldError,
+                >(datastore, task, aggregate_share_req)
+                .await
+            }
+            VdafOps::Prio3Aes128Sum(_, _) => {
+                Self::handle_aggregate_share_generic::<
+                    <Prio3Aes128Sum as Vdaf>::AggregateShare,
+                    FieldError,
+                >(datastore, task, aggregate_share_req)
+                .await
+            }
+            VdafOps::Prio3Aes128Histogram(_, _) => {
+                Self::handle_aggregate_share_generic::<
+                    <Prio3Aes128Histogram as Vdaf>::AggregateShare,
+                    FieldError,
+                >(datastore, task, aggregate_share_req)
+                .await
+            }
+
+            #[cfg(test)]
+            VdafOps::Fake(_) => {
+                Self::handle_aggregate_share_generic::<
+                    <fake::Vdaf as Vdaf>::AggregateShare,
+                    Infallible,
+                >(datastore, task, aggregate_share_req)
+                .await
+            }
+        }
+    }
+
+    async fn handle_aggregate_share_generic<A, E>(
+        datastore: &Datastore,
+        task: &Task,
+        aggregate_share_req: &AggregateShareReq,
+    ) -> Result<AggregateShareResp, Error>
+    where
+        A: Aggregatable + Send + Sync,
+        E: std::fmt::Display,
+        Vec<u8>: for<'a> From<&'a A>,
+        for<'a> A: TryFrom<&'a [u8], Error = E>,
+    {
+        // TODO(timg): What should we do if any of the aggregation jobs handling reports relevant to
+        // the aggregate share request aren't finished yet? Helper could return an error like
+        // "EAGAIN" to leader, or could trust leader not to issue an AggregateShareReq until all of
+        // leader's aggregate jobs are done (which should imply that helper's are done).
+        // See issue #104.
+
+        let total_aggregate_share = datastore
+            .run_tx(move |tx| {
+                let task = task.clone();
+                let aggregate_share_req = aggregate_share_req.clone();
+                Box::pin(async move {
+                    // TODO(timg): this query should involve the aggregation parameter, since the
+                    // same (task_id, batch_interval) pair could be aggregated multiple times with
+                    // different parameters.
+                    let batch_aggregations = tx
+                        .get_batch_aggregations_for_task_in_interval::<A, E>(
+                            task.id,
+                            aggregate_share_req.batch_interval,
+                        )
+                        .await?;
+
+                    let mut total_report_count = 0;
+                    let mut total_checksum = [0u8; 32];
+                    let mut total_aggregate_share: Option<A> = None;
+
+                    for batch_aggregation in &batch_aggregations {
+                        // TODO(timg): enforce the max lifetime requirement from §4.6. We need to
+                        // make sure that this minimum batch interval's aggregate share has not
+                        // previously been included in a collect request with a different batch
+                        // interval. This requires the helper to store the aggregate share requests
+                        // it has serviced, perhaps in the collect_jobs table used by the leader.
+
+                        // §4.4.4.3: XOR this batch interval's checksum into the overall checksum
+                        total_checksum
+                            .iter_mut()
+                            .zip(batch_aggregation.checksum)
+                            .for_each(|(x, y)| *x ^= y);
+
+                        // §4.4.4.3: Sum all the report counts
+                        total_report_count += batch_aggregation.report_count;
+
+                        match &mut total_aggregate_share {
+                            Some(share) => {
+                                if let Err(err) = share.merge(&batch_aggregation.aggregate_share) {
+                                    return Ok(Err(Error::from(err)));
+                                }
+                            }
+                            None => {
+                                total_aggregate_share =
+                                    Some(batch_aggregation.aggregate_share.clone())
+                            }
+                        }
+                    }
+
+                    // §4.6: refuse to service aggregate share requests if there are too few reports
+                    // included.
+                    if total_report_count < task.min_batch_size {
+                        return Ok(Err(Error::InsufficientBatchSize(
+                            total_report_count,
+                            task.id,
+                        )));
+                    }
+
+                    let total_aggregate_share = match total_aggregate_share {
+                        Some(share) => share,
+                        None => return Ok(Err(Error::InsufficientBatchSize(0, task.id))),
+                    };
+
+                    // §4.4.4.3: verify total report count and the checksum we computed against
+                    // those reported by the leader.
+                    if total_report_count != aggregate_share_req.report_count
+                        || total_checksum != aggregate_share_req.checksum
+                    {
+                        return Ok(Err(Error::BatchMisalignment {
+                            task_id: task.id,
+                            own_checksum: total_checksum,
+                            own_report_count: total_report_count,
+                            peer_checksum: aggregate_share_req.checksum,
+                            peer_report_count: aggregate_share_req.report_count,
+                        }));
+                    }
+
+                    // TODO(timg): Once we are satisfied the request is serviceable, consume batch
+                    // lifetime by storing the aggregate share request parameters. Make sure to do
+                    // so in the same database txn where we queried the batch aggregations.
+
+                    Ok(Ok(total_aggregate_share))
+                })
+            })
+            .await??;
+
+        // §4.4.4.3: HPKE encrypt aggregate share to the collector.
+        let encrypted_aggregate_share = hpke::seal(
+            &task.collector_hpke_config,
+            &HpkeApplicationInfo::new(
+                task.id,
+                Label::AggregateShare,
+                Role::Helper,
+                Role::Collector,
+            ),
+            &<Vec<u8>>::from(&total_aggregate_share),
+            &aggregate_share_req.batch_interval.get_encoded(),
+        )?;
+
+        Ok(AggregateShareResp {
+            encrypted_aggregate_share,
+        })
+    }
 }
 
 /// Injects a clone of the provided value into the warp filter, making it
@@ -952,6 +1190,9 @@ enum PpmProblemType {
     StaleReport,
     InvalidHmac,
     InvalidBatchInterval,
+    InsufficientBatchSize,
+    BatchMisaligned,
+    BatchLifetimeExceeded,
 }
 
 impl PpmProblemType {
@@ -965,6 +1206,13 @@ impl PpmProblemType {
             PpmProblemType::InvalidHmac => "urn:ietf:params:ppm:error:invalidHmac",
             PpmProblemType::InvalidBatchInterval => {
                 "urn:ietf:params:ppm:error:invalidBatchInterval"
+            }
+            PpmProblemType::InsufficientBatchSize => {
+                "urn:ietf:params:ppm:error:insufficientBatchSize"
+            }
+            PpmProblemType::BatchMisaligned => "urn:ietf:params:ppm:error:batchMisaligned",
+            PpmProblemType::BatchLifetimeExceeded => {
+                "urn:ietf:params:ppm:error:batchLifetimeExceeded"
             }
         }
     }
@@ -985,7 +1233,18 @@ impl PpmProblemType {
                 "Report could not be processed because it arrived too late."
             }
             PpmProblemType::InvalidHmac => "The aggregate message's HMAC was not valid.",
-            PpmProblemType::InvalidBatchInterval => "The batch interval in the collect or aggregate share request is not valid for the task.",
+            PpmProblemType::InvalidBatchInterval => {
+                "The batch interval in the collect or aggregate share request is not valid for the task."
+            }
+            PpmProblemType::InsufficientBatchSize => {
+                "There are not enough reports in the batch interval."
+            }
+            PpmProblemType::BatchMisaligned => {
+                "The checksums or report counts in the two aggregator's aggregate shares do not match."
+            }
+            PpmProblemType::BatchLifetimeExceeded => {
+                "The batch lifetime has been exceeded for one or more reports included in the batch interval."
+            }
         }
     }
 }
@@ -1058,6 +1317,16 @@ fn error_handler<R: Reply>() -> impl Fn(Result<R, Error>) -> warp::reply::Respon
             Err(Error::InvalidBatchInterval(_, task_id)) => {
                 build_problem_details_response(PpmProblemType::InvalidBatchInterval, Some(task_id))
             }
+            Err(Error::InsufficientBatchSize(_, task_id)) => {
+                build_problem_details_response(PpmProblemType::InsufficientBatchSize, Some(task_id))
+            }
+            Err(Error::BatchMisalignment { task_id, .. }) => {
+                build_problem_details_response(PpmProblemType::BatchMisaligned, Some(task_id))
+            }
+            Err(Error::BatchLifetimeExceeded(task_id)) => {
+                build_problem_details_response(PpmProblemType::BatchLifetimeExceeded, Some(task_id))
+            }
+            Err(Error::Hpke(_)) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
             Err(Error::Datastore(_)) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
             Err(Error::Vdaf(_)) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
             Err(Error::Internal(_)) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
@@ -1121,7 +1390,7 @@ where
 
     let collect_endpoint = warp::path("collect")
         .and(warp::post())
-        .and(with_cloned_value(aggregator))
+        .and(with_cloned_value(aggregator.clone()))
         .and(warp::body::bytes())
         .then(|aggregator: Arc<Aggregator<C>>, body: Bytes| async move {
             let collect_uri = aggregator.handle_collect(&body).await?;
@@ -1135,10 +1404,24 @@ where
         .map(error_handler())
         .with(trace::named("collect"));
 
+    let aggregate_share_endpoint = warp::path("aggregate_share")
+        .and(warp::post())
+        .and(with_cloned_value(aggregator))
+        .and(warp::body::bytes())
+        .then(|aggregator: Arc<Aggregator<C>>, body: Bytes| async move {
+            let resp_bytes = aggregator.handle_aggregate_share(&body).await?;
+
+            // §4.4.4.3: Response is HTTP 200 OK
+            Ok(reply::with_status(resp_bytes, StatusCode::OK))
+        })
+        .map(error_handler())
+        .with(trace::named("aggregate_share"));
+
     Ok(hpke_config_endpoint
         .or(upload_endpoint)
         .or(aggregate_endpoint)
         .or(collect_endpoint)
+        .or(aggregate_share_endpoint)
         .boxed())
 }
 
@@ -1340,8 +1623,14 @@ mod tests {
     use super::*;
     use crate::{
         aggregator::test_util::fake,
-        datastore::test_util::{ephemeral_datastore, DbHandle},
-        hpke::{associated_data_for, HpkePrivateKey, Label},
+        datastore::{
+            models::BatchAggregation,
+            test_util::{ephemeral_datastore, DbHandle},
+        },
+        hpke::{
+            associated_data_for, test_util::generate_hpke_config_and_private_key, HpkePrivateKey,
+            Label,
+        },
         message::{self, AuthenticatedResponseDecoder, HpkeCiphertext, HpkeConfig, TaskId, Time},
         task::{test_util::new_dummy_task, Vdaf},
         time::tests::MockClock,
@@ -1352,7 +1641,8 @@ mod tests {
     use http::Method;
     use prio::{
         codec::Decode,
-        vdaf::prio3::Prio3Aes128Count,
+        field::Field64,
+        vdaf::{prio3::Prio3Aes128Count, AggregateShare},
         vdaf::{Vdaf as VdafTrait, VdafError},
     };
     use rand::{thread_rng, Rng};
@@ -3178,10 +3468,9 @@ mod tests {
 
         // Prepare parameters.
         let task_id = TaskId::random();
-
         let task = new_dummy_task(task_id, Vdaf::Fake, Role::Leader);
+
         let (datastore, _db_handle) = ephemeral_datastore().await;
-        let clock = MockClock::default();
 
         datastore
             .run_tx(|tx| {
@@ -3192,7 +3481,7 @@ mod tests {
             .await
             .unwrap();
 
-        let filter = aggregator_filter(Arc::new(datastore), clock).unwrap();
+        let filter = aggregator_filter(Arc::new(datastore), MockClock::default()).unwrap();
 
         let request = CollectReq {
             task_id,
@@ -3215,6 +3504,417 @@ mod tests {
         assert_eq!(response.status(), StatusCode::SEE_OTHER);
         // TODO(timg): validate collect URI
         assert!(response.headers().get(LOCATION).is_some());
+    }
+
+    #[tokio::test]
+    async fn aggregate_share_request_to_leader() {
+        install_test_trace_subscriber();
+
+        // Prepare parameters.
+        let task_id = TaskId::random();
+        let task = new_dummy_task(task_id, Vdaf::Fake, Role::Leader);
+        let hmac_key: &hmac::Key = task.agg_auth_keys.iter().last().unwrap().as_ref();
+
+        let (datastore, _db_handle) = ephemeral_datastore().await;
+
+        datastore
+            .run_tx(|tx| {
+                let task = task.clone();
+
+                Box::pin(async move { tx.put_task(&task).await })
+            })
+            .await
+            .unwrap();
+
+        let filter = aggregator_filter(Arc::new(datastore), MockClock::default()).unwrap();
+
+        let request = AggregateShareReq {
+            task_id,
+            batch_interval: Interval {
+                start: Time(0),
+                duration: message::Duration(task.min_batch_duration.num_seconds() as u64),
+            },
+            report_count: 0,
+            checksum: [0; 32],
+        };
+
+        let (parts, body) = warp::test::request()
+            .method("POST")
+            .path("/aggregate_share")
+            .body(AuthenticatedEncoder::new(request).encode(hmac_key))
+            .filter(&filter)
+            .await
+            .unwrap()
+            .into_response()
+            .into_parts();
+
+        assert_eq!(parts.status, StatusCode::BAD_REQUEST);
+        let problem_details: serde_json::Value =
+            serde_json::from_slice(&hyper::body::to_bytes(body).await.unwrap()).unwrap();
+        assert_eq!(
+            problem_details,
+            serde_json::json!({
+                "status": StatusCode::BAD_REQUEST.as_u16(),
+                "type": "urn:ietf:params:ppm:error:unrecognizedTask",
+                "title": "An endpoint received a message with an unknown task ID.",
+                "detail": "An endpoint received a message with an unknown task ID.",
+                "instance": "..",
+                "taskid": base64::encode(task_id.as_bytes()),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn aggregate_share_request_invalid_batch_interval() {
+        install_test_trace_subscriber();
+
+        // Prepare parameters.
+        let task_id = TaskId::random();
+        let task = new_dummy_task(task_id, Vdaf::Fake, Role::Helper);
+        let hmac_key: &hmac::Key = task.agg_auth_keys.iter().last().unwrap().as_ref();
+
+        let (datastore, _db_handle) = ephemeral_datastore().await;
+
+        datastore
+            .run_tx(|tx| {
+                let task = task.clone();
+
+                Box::pin(async move { tx.put_task(&task).await })
+            })
+            .await
+            .unwrap();
+
+        let filter = aggregator_filter(Arc::new(datastore), MockClock::default()).unwrap();
+
+        let request = AggregateShareReq {
+            task_id,
+            batch_interval: Interval {
+                start: Time(0),
+                // Collect request will be rejected because batch interval is too small
+                duration: message::Duration(task.min_batch_duration.num_seconds() as u64 - 1),
+            },
+            report_count: 0,
+            checksum: [0; 32],
+        };
+
+        let (parts, body) = warp::test::request()
+            .method("POST")
+            .path("/aggregate_share")
+            .body(AuthenticatedEncoder::new(request).encode(hmac_key))
+            .filter(&filter)
+            .await
+            .unwrap()
+            .into_response()
+            .into_parts();
+
+        assert_eq!(parts.status, StatusCode::BAD_REQUEST);
+        let problem_details: serde_json::Value =
+            serde_json::from_slice(&hyper::body::to_bytes(body).await.unwrap()).unwrap();
+        assert_eq!(
+            problem_details,
+            serde_json::json!({
+                "status": StatusCode::BAD_REQUEST.as_u16(),
+                "type": "urn:ietf:params:ppm:error:invalidBatchInterval",
+                "title": "The batch interval in the collect or aggregate share request is not valid for the task.",
+                "detail": "The batch interval in the collect or aggregate share request is not valid for the task.",
+                "instance": "..",
+                "taskid": base64::encode(task_id.as_bytes()),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn aggregate_share_request() {
+        install_test_trace_subscriber();
+
+        let task_id = TaskId::random();
+        let (collector_hpke_config, collector_hpke_recipient) =
+            generate_hpke_config_and_private_key();
+
+        let mut task = new_dummy_task(task_id, Vdaf::Prio3Aes128Count, Role::Helper);
+        task.max_batch_lifetime = 1;
+        task.min_batch_duration = chrono::Duration::seconds(500);
+        task.min_batch_size = 10;
+        task.collector_hpke_config = collector_hpke_config.clone();
+        let hmac_key: &hmac::Key = task.agg_auth_keys.iter().last().unwrap().as_ref();
+
+        let (datastore, _db_handle) = ephemeral_datastore().await;
+        let datastore = Arc::new(datastore);
+
+        datastore
+            .run_tx(|tx| {
+                let task = task.clone();
+
+                Box::pin(async move { tx.put_task(&task).await })
+            })
+            .await
+            .unwrap();
+
+        let filter = aggregator_filter(datastore.clone(), MockClock::default()).unwrap();
+
+        // There are no batch_aggregations in the datastore yet
+        let request = AggregateShareReq {
+            task_id,
+            batch_interval: Interval {
+                start: Time(0),
+                duration: message::Duration(task.min_batch_duration.num_seconds() as u64),
+            },
+            report_count: 0,
+            checksum: [0; 32],
+        };
+
+        let (parts, body) = warp::test::request()
+            .method("POST")
+            .path("/aggregate_share")
+            .body(AuthenticatedEncoder::new(request).encode(hmac_key))
+            .filter(&filter)
+            .await
+            .unwrap()
+            .into_response()
+            .into_parts();
+
+        assert_eq!(parts.status, StatusCode::BAD_REQUEST);
+        let problem_details: serde_json::Value =
+            serde_json::from_slice(&hyper::body::to_bytes(body).await.unwrap()).unwrap();
+        assert_eq!(
+            problem_details,
+            serde_json::json!({
+                "status": StatusCode::BAD_REQUEST.as_u16(),
+                "type": "urn:ietf:params:ppm:error:insufficientBatchSize",
+                "title": "There are not enough reports in the batch interval.",
+                "detail": "There are not enough reports in the batch interval.",
+                "instance": "..",
+                "taskid": base64::encode(task_id.as_bytes()),
+            })
+        );
+
+        // Put some batch aggregations in the DB
+        datastore
+            .run_tx(|tx| {
+                Box::pin(async move {
+                    tx.put_batch_aggregation(&BatchAggregation {
+                        task_id,
+                        batch_interval_start: Time(500),
+                        aggregate_share: AggregateShare::from(vec![Field64::from(64)]),
+                        report_count: 5,
+                        checksum: [3; 32],
+                    })
+                    .await?;
+
+                    tx.put_batch_aggregation(&BatchAggregation {
+                        task_id,
+                        batch_interval_start: Time(1500),
+                        aggregate_share: AggregateShare::from(vec![Field64::from(128)]),
+                        report_count: 5,
+                        checksum: [2; 32],
+                    })
+                    .await?;
+
+                    tx.put_batch_aggregation(&BatchAggregation {
+                        task_id,
+                        batch_interval_start: Time(2000),
+                        aggregate_share: AggregateShare::from(vec![Field64::from(256)]),
+                        report_count: 5,
+                        checksum: [2; 32],
+                    })
+                    .await?;
+
+                    Ok(())
+                })
+            })
+            .await
+            .unwrap();
+
+        // Specified interval includes too few reports
+        let request = AggregateShareReq {
+            task_id,
+            batch_interval: Interval {
+                start: Time(0),
+                duration: message::Duration(1000),
+            },
+            report_count: 5,
+            checksum: [0; 32],
+        };
+
+        let (parts, body) = warp::test::request()
+            .method("POST")
+            .path("/aggregate_share")
+            .body(AuthenticatedEncoder::new(request).encode(hmac_key))
+            .filter(&filter)
+            .await
+            .unwrap()
+            .into_response()
+            .into_parts();
+
+        assert_eq!(parts.status, StatusCode::BAD_REQUEST);
+        let problem_details: serde_json::Value =
+            serde_json::from_slice(&hyper::body::to_bytes(body).await.unwrap()).unwrap();
+        assert_eq!(
+            problem_details,
+            serde_json::json!({
+                "status": StatusCode::BAD_REQUEST.as_u16(),
+                "type": "urn:ietf:params:ppm:error:insufficientBatchSize",
+                "title": "There are not enough reports in the batch interval.",
+                "detail": "There are not enough reports in the batch interval.",
+                "instance": "..",
+                "taskid": base64::encode(task_id.as_bytes()),
+            })
+        );
+
+        // Interval is big enough, but checksum doesn't match
+        let request = AggregateShareReq {
+            task_id,
+            batch_interval: Interval {
+                start: Time(0),
+                duration: message::Duration(2500),
+            },
+            report_count: 10,
+            checksum: [3; 32],
+        };
+
+        let (parts, body) = warp::test::request()
+            .method("POST")
+            .path("/aggregate_share")
+            .body(AuthenticatedEncoder::new(request).encode(hmac_key))
+            .filter(&filter)
+            .await
+            .unwrap()
+            .into_response()
+            .into_parts();
+
+        assert_eq!(parts.status, StatusCode::BAD_REQUEST);
+        let problem_details: serde_json::Value =
+            serde_json::from_slice(&hyper::body::to_bytes(body).await.unwrap()).unwrap();
+        assert_eq!(
+            problem_details,
+            serde_json::json!({
+                "status": StatusCode::BAD_REQUEST.as_u16(),
+                "type": "urn:ietf:params:ppm:error:batchMisaligned",
+                "title": "The checksums or report counts in the two aggregator's aggregate shares do not match.",
+                "detail": "The checksums or report counts in the two aggregator's aggregate shares do not match.",
+                "instance": "..",
+                "taskid": base64::encode(task_id.as_bytes()),
+            })
+        );
+
+        // Interval is big enough, but report count doesn't match
+        let request = AggregateShareReq {
+            task_id,
+            batch_interval: Interval {
+                start: Time(0),
+                duration: message::Duration(2500),
+            },
+            report_count: 20,
+            checksum: [3 ^ 2; 32],
+        };
+
+        let (parts, body) = warp::test::request()
+            .method("POST")
+            .path("/aggregate_share")
+            .body(AuthenticatedEncoder::new(request).encode(hmac_key))
+            .filter(&filter)
+            .await
+            .unwrap()
+            .into_response()
+            .into_parts();
+
+        assert_eq!(parts.status, StatusCode::BAD_REQUEST);
+        let problem_details: serde_json::Value =
+            serde_json::from_slice(&hyper::body::to_bytes(body).await.unwrap()).unwrap();
+        assert_eq!(
+            problem_details,
+            serde_json::json!({
+                "status": StatusCode::BAD_REQUEST.as_u16(),
+                "type": "urn:ietf:params:ppm:error:batchMisaligned",
+                "title": "The checksums or report counts in the two aggregator's aggregate shares do not match.",
+                "detail": "The checksums or report counts in the two aggregator's aggregate shares do not match.",
+                "instance": "..",
+                "taskid": base64::encode(task_id.as_bytes()),
+            })
+        );
+
+        // Interval is big enough, checksum and report count are good
+        let batch_interval = Interval {
+            start: Time(0),
+            duration: message::Duration(2500),
+        };
+        let request = AggregateShareReq {
+            task_id,
+            batch_interval,
+            report_count: 10,
+            checksum: [3 ^ 2; 32],
+        };
+
+        let (parts, body) = warp::test::request()
+            .method("POST")
+            .path("/aggregate_share")
+            .body(AuthenticatedEncoder::new(request.clone()).encode(hmac_key))
+            .filter(&filter)
+            .await
+            .unwrap()
+            .into_response()
+            .into_parts();
+
+        assert_eq!(parts.status, StatusCode::OK);
+        let body_bytes = hyper::body::to_bytes(body).await.unwrap();
+
+        let aggregate_share_resp: AggregateShareResp =
+            AuthenticatedResponseDecoder::new(body_bytes.as_ref())
+                .unwrap()
+                .decode(hmac_key)
+                .unwrap();
+
+        let aggregate_share = hpke::open(
+            &collector_hpke_config,
+            &collector_hpke_recipient,
+            &HpkeApplicationInfo::new(
+                task_id,
+                Label::AggregateShare,
+                Role::Helper,
+                Role::Collector,
+            ),
+            &aggregate_share_resp.encrypted_aggregate_share,
+            &batch_interval.get_encoded(),
+        )
+        .unwrap();
+
+        // Should get the sum over the first and second aggregate shares
+        let decoded_aggregate_share =
+            <AggregateShare<Field64>>::try_from(aggregate_share.as_ref()).unwrap();
+        assert_eq!(
+            decoded_aggregate_share,
+            AggregateShare::from(vec![Field64::from(64 + 128)])
+        );
+
+        // TODO(timg): re-enable this test once handle_aggregate_share_generic handles
+        // max_batch_lifetime
+        #[cfg(disabled)]
+        {
+            // Attempt to collect the same interval again.
+            let (parts, body) = warp::test::request()
+                .method("POST")
+                .path("/aggregate_share")
+                .body(AuthenticatedEncoder::new(request).encode(hmac_key))
+                .filter(&filter)
+                .await
+                .unwrap()
+                .into_response()
+                .into_parts();
+            assert_eq!(parts.status, StatusCode::BAD_REQUEST);
+            let problem_details: serde_json::Value =
+                serde_json::from_slice(&hyper::body::to_bytes(body).await.unwrap()).unwrap();
+            assert_eq!(
+                problem_details,
+                serde_json::json!({
+                    "status": StatusCode::BAD_REQUEST.as_u16(),
+                    "type": "urn:ietf:params:ppm:error:batchLifetimeExceeded",
+                    "title": "The batch lifetime has been exceeded for one or more reports included in the batch interval.",
+                    "detail": "The batch lifetime has been exceeded for one or more reports included in the batch interval.",
+                    "instance": "..",
+                    "taskid": base64::encode(task_id.as_bytes()),
+                })
+            );
+        }
     }
 
     fn generate_nonce<C: Clock>(clock: &C) -> Nonce {

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -1,7 +1,7 @@
 //! Janus datastore (durable storage) implementation.
 
 use self::models::{
-    AggregationJob, AggregatorRole, ReportAggregation, ReportAggregationState,
+    AggregationJob, AggregatorRole, BatchAggregation, ReportAggregation, ReportAggregationState,
     ReportAggregationStateCode,
 };
 use crate::{
@@ -898,6 +898,115 @@ impl Transaction<'_> {
 
         Ok(collect_job_id)
     }
+
+    /// Store a new `batch_aggregations` row in the datastore.
+    #[cfg(test)]
+    #[tracing::instrument(skip(self), err)]
+    pub(crate) async fn put_batch_aggregation<A>(
+        &self,
+        batch_aggregation: &BatchAggregation<A>,
+    ) -> Result<(), Error>
+    where
+        A: std::fmt::Debug,
+        for<'a> &'a A: Into<Vec<u8>>,
+    {
+        let batch_interval_start = batch_aggregation.batch_interval_start.as_naive_date_time();
+        let encoded_aggregate_share: Vec<u8> = (&batch_aggregation.aggregate_share).into();
+        let report_count = i64::try_from(batch_aggregation.report_count)?;
+
+        let stmt = self
+            .tx
+            .prepare_cached(
+                "INSERT INTO batch_aggregations (task_id, batch_interval_start,
+                aggregate_share, report_count, checksum)
+                VALUES ((SELECT id FROM tasks WHERE task_id = $1), $2, $3, $4, $5)",
+            )
+            .await?;
+        self.tx
+            .execute(
+                &stmt,
+                &[
+                    /* task_id */ &&batch_aggregation.task_id.0[..],
+                    &batch_interval_start,
+                    /* aggregate_share */ &encoded_aggregate_share,
+                    &report_count,
+                    /* checksum */ &&batch_aggregation.checksum[..],
+                ],
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    /// Fetch all the `batch_aggregations` rows whose `batch_interval_start` describes an interval
+    /// that falls within the provided `interval`.
+    #[tracing::instrument(skip(self), err)]
+    pub(crate) async fn get_batch_aggregations_for_task_in_interval<A, E>(
+        &self,
+        task_id: TaskId,
+        interval: Interval,
+    ) -> Result<Vec<BatchAggregation<A>>, Error>
+    where
+        E: std::fmt::Display,
+        for<'a> A: TryFrom<&'a [u8], Error = E>,
+    {
+        let batch_interval_start = interval.start.as_naive_date_time();
+        let batch_interval_end = interval.end().as_naive_date_time();
+
+        let stmt = self
+            .tx
+            .prepare_cached(
+                "WITH tasks AS (SELECT id, min_batch_duration FROM tasks WHERE task_id = $1)
+                SELECT batch_interval_start, aggregate_share, report_count, checksum FROM batch_aggregations
+                WHERE
+                    task_id = (SELECT id FROM tasks)
+                    AND batch_interval_start >= $2
+                    AND (batch_interval_start + (SELECT min_batch_duration FROM tasks) * interval '1 second') < $3",
+            )
+            .await?;
+        let rows = self
+            .tx
+            .query(
+                &stmt,
+                &[
+                    /* task_id */ &&task_id.0[..],
+                    &batch_interval_start,
+                    &batch_interval_end,
+                ],
+            )
+            .await?
+            .iter()
+            .map(|row| {
+                let batch_interval_start =
+                    Time::from_naive_date_time(row.get("batch_interval_start"));
+                let aggregate_share_encoded: Vec<u8> = row.get("aggregate_share");
+                let aggregate_share = A::try_from(&aggregate_share_encoded).map_err(|e| {
+                    Error::DbState(format!(
+                        "aggregate share stored in database is invalid: {}",
+                        e
+                    ))
+                })?;
+                let report_count = row.get_bigint_as_u64("report_count")?;
+                let checksum: &[u8] = row.get("checksum");
+                let checksum: [u8; 32] = checksum.try_into().map_err(|e| {
+                    Error::DbState(format!(
+                        "checksum byte array in database has wrong length: {}",
+                        e
+                    ))
+                })?;
+
+                Ok(BatchAggregation {
+                    task_id,
+                    batch_interval_start,
+                    aggregate_share,
+                    report_count,
+                    checksum,
+                })
+            })
+            .collect::<Result<_, Error>>()?;
+
+        Ok(rows)
+    }
 }
 
 fn single_row(rows: Vec<Row>) -> Result<Row, Error> {
@@ -1205,7 +1314,7 @@ impl From<ring::error::Unspecified> for Error {
 pub mod models {
     use super::Error;
     use crate::{
-        message::{AggregationJobId, Nonce, Role, TaskId, TransitionError},
+        message::{AggregationJobId, Nonce, Role, TaskId, Time, TransitionError},
         task,
     };
     use postgres_types::{FromSql, ToSql};
@@ -1403,6 +1512,28 @@ pub mod models {
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
     }
+
+    /// BatchAggregation corresponds to a row in the `batch_aggregations` table and represents the
+    /// possibly-ongoing aggregation of the set of input shares. This is the finest-grained possible
+    /// aggregate share we can emit for this task. Servicing a collect request or an aggregate share
+    /// request may require summing together multiple rows.
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    pub(crate) struct BatchAggregation<A> {
+        /// The task ID for this aggregation result.
+        pub(crate) task_id: TaskId,
+        /// This is an aggregation over report shares whose timestamp falls within the interval
+        /// starting at this time and of duration equal to the corresponding task's
+        /// `min_batch_duration`. `batch_interval_start` is aligned to `min_batch_duration`.
+        pub(crate) batch_interval_start: Time,
+        /// The aggregate over all the input shares that have been prepared so far by this
+        /// aggregator. `A` is the `AggregateShare` associated type for some implementation of
+        /// [`prio::vdaf::Vdaf`].
+        pub(crate) aggregate_share: A,
+        /// The number of reports currently included in this aggregate sahre.
+        pub(crate) report_count: u64,
+        /// Checksum over the aggregated report shares, as described in §4.4.4.3.
+        pub(crate) checksum: [u8; 32],
+    }
 }
 
 #[cfg(test)]
@@ -1418,19 +1549,19 @@ mod tests {
     use crate::{
         aggregator::test_util::fake,
         datastore::{models::AggregationJobState, test_util::ephemeral_datastore},
-        message::{Duration, ExtensionType, HpkeConfigId, Role, Time, TransitionError},
+        message::{Duration, ExtensionType, HpkeConfigId, Interval, Role, Time, TransitionError},
         task::{test_util::new_dummy_task, Vdaf},
         trace::test_util::install_test_trace_subscriber,
     };
     use ::test_util::generate_aead_key;
     use assert_matches::assert_matches;
     use prio::{
-        field::Field128,
+        field::{Field128, Field64},
         vdaf::{
             poplar1::{IdpfInput, Poplar1, ToyIdpf},
             prg::PrgAes128,
             prio3::Prio3Aes128Count,
-            PrepareTransition,
+            AggregateShare, PrepareTransition,
         },
     };
     use std::collections::{BTreeSet, HashMap};
@@ -2167,6 +2298,122 @@ mod tests {
 
         // A new row should be present.
         assert!(rows.len() == 2);
+    }
+
+    #[tokio::test]
+    async fn roundtrip_batch_aggregation() {
+        install_test_trace_subscriber();
+
+        let task_id = TaskId::random();
+        let other_task_id = TaskId::random();
+        let aggregate_share = AggregateShare::from(vec![Field64::from(17)]);
+
+        let (ds, _db_handle) = ephemeral_datastore().await;
+
+        let batch_aggregations: Vec<BatchAggregation<AggregateShare<Field64>>> = ds
+            .run_tx(|tx| {
+                let aggregate_share = aggregate_share.clone();
+                Box::pin(async move {
+                    let mut task = new_dummy_task(task_id, Vdaf::Prio3Aes128Count, Role::Leader);
+                    task.min_batch_duration = chrono::Duration::seconds(100);
+                    tx.put_task(&task).await?;
+
+                    tx.put_task(&new_dummy_task(
+                        other_task_id,
+                        Vdaf::Prio3Aes128Count,
+                        Role::Leader,
+                    ))
+                    .await?;
+
+                    // Start of this aggregation's interval is before the interval passed to
+                    // get_batch_aggregations below.
+                    tx.put_batch_aggregation(&BatchAggregation {
+                        task_id,
+                        batch_interval_start: Time(25),
+                        aggregate_share: aggregate_share.clone(),
+                        report_count: 0,
+                        checksum: [0; 32],
+                    })
+                    .await?;
+
+                    tx.put_batch_aggregation(&BatchAggregation {
+                        task_id,
+                        batch_interval_start: Time(100),
+                        aggregate_share: aggregate_share.clone(),
+                        report_count: 0,
+                        checksum: [0; 32],
+                    })
+                    .await?;
+
+                    tx.put_batch_aggregation(&BatchAggregation {
+                        task_id,
+                        batch_interval_start: Time(150),
+                        aggregate_share: aggregate_share.clone(),
+                        report_count: 0,
+                        checksum: [0; 32],
+                    })
+                    .await?;
+
+                    // End of this aggregation's interval is after the interval passed to
+                    // get_batch_aggregations below.
+                    tx.put_batch_aggregation(&BatchAggregation {
+                        task_id,
+                        batch_interval_start: Time(200),
+                        aggregate_share: aggregate_share.clone(),
+                        report_count: 0,
+                        checksum: [0; 32],
+                    })
+                    .await?;
+
+                    // Start of this aggregation's interval is after the interval passed to
+                    // get_batch_aggregations below.
+                    tx.put_batch_aggregation(&BatchAggregation {
+                        task_id,
+                        batch_interval_start: Time(400),
+                        aggregate_share: aggregate_share.clone(),
+                        report_count: 0,
+                        checksum: [0; 32],
+                    })
+                    .await?;
+
+                    // Task ID differs from that passed to get_batch_aggregations below.
+                    tx.put_batch_aggregation(&BatchAggregation {
+                        task_id: other_task_id,
+                        batch_interval_start: Time(200),
+                        aggregate_share: aggregate_share.clone(),
+                        report_count: 0,
+                        checksum: [0; 32],
+                    })
+                    .await?;
+
+                    tx.get_batch_aggregations_for_task_in_interval(
+                        task_id,
+                        Interval {
+                            start: Time(50),
+                            duration: Duration(250),
+                        },
+                    )
+                    .await
+                })
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(batch_aggregations.len(), 2);
+        assert!(batch_aggregations.contains(&BatchAggregation {
+            task_id,
+            batch_interval_start: Time(100),
+            aggregate_share: aggregate_share.clone(),
+            report_count: 0,
+            checksum: [0u8; 32],
+        }));
+        assert!(batch_aggregations.contains(&BatchAggregation {
+            task_id,
+            batch_interval_start: Time(150),
+            aggregate_share: aggregate_share.clone(),
+            report_count: 0,
+            checksum: [0u8; 32],
+        }));
     }
 
     /// generate_vdaf_values generates some arbitrary VDAF values for use in testing. It is cribbed

--- a/janus_server/src/message.rs
+++ b/janus_server/src/message.rs
@@ -193,6 +193,11 @@ impl Time {
     pub(crate) fn from_naive_date_time(time: NaiveDateTime) -> Self {
         Self(time.timestamp() as u64)
     }
+
+    /// Add the provided duration to this time.
+    fn add(&self, duration: Duration) -> Time {
+        Time(self.0 + duration.0)
+    }
 }
 
 impl Display for Time {
@@ -221,6 +226,13 @@ pub struct Interval {
     pub(crate) start: Time,
     /// The length of the interval.
     pub(crate) duration: Duration,
+}
+
+impl Interval {
+    /// Returns a [`Time`] representing the excluded end of this interval.
+    pub(crate) fn end(&self) -> Time {
+        Time(self.start.add(self.duration).0)
+    }
 }
 
 impl Encode for Interval {

--- a/janus_server/src/task.rs
+++ b/janus_server/src/task.rs
@@ -64,7 +64,10 @@ pub enum Vdaf {
 // to get a `ring::hmac::Key` from a slice of bytes, we can't get the bytes
 // back out of the key.
 #[derive(Clone, Debug)]
-pub struct AggregatorAuthKey(Vec<u8>, hmac::Key);
+pub struct AggregatorAuthKey {
+    bytes: Vec<u8>,
+    hmac_key: hmac::Key,
+}
 
 // TODO(brandon): use a ring constant once one is exposed. This is the correct value per ring:
 //   https://docs.rs/ring/0.16.20/src/ring/digest.rs.html#339
@@ -76,10 +79,10 @@ impl AggregatorAuthKey {
         if key_bytes.len() < SHA256_OUTPUT_LEN || key_bytes.len() > SHA256_BLOCK_LEN {
             return Err(Error::AggregatorAuthKeySize);
         }
-        Ok(Self(
-            Vec::from(key_bytes),
-            hmac::Key::new(HMAC_SHA256, key_bytes),
-        ))
+        Ok(Self {
+            bytes: Vec::from(key_bytes),
+            hmac_key: hmac::Key::new(HMAC_SHA256, key_bytes),
+        })
     }
 
     /// Randomly generate an [`AggregatorAuthKey`].
@@ -94,13 +97,13 @@ impl AggregatorAuthKey {
 
 impl AsRef<[u8]> for AggregatorAuthKey {
     fn as_ref(&self) -> &[u8] {
-        &self.0
+        &self.bytes
     }
 }
 
 impl AsRef<hmac::Key> for AggregatorAuthKey {
     fn as_ref(&self) -> &hmac::Key {
-        &self.1
+        &self.hmac_key
     }
 }
 
@@ -108,7 +111,7 @@ impl PartialEq for AggregatorAuthKey {
     fn eq(&self, other: &Self) -> bool {
         // The key is ignored because it is derived from the key bytes.
         // (also, ring::hmac::Key doesn't implement PartialEq)
-        self.0 == other.0
+        self.bytes == other.bytes
     }
 }
 


### PR DESCRIPTION
Implements the helper's `aggregate_share` endpoint. The assumption is
that the process of preparing input shares into output shares will
create rows in `batch_aggregations` and update the `checksum` and
`aggregate_share` columns as individual reports are prepared. Then, all
the `/aggregate_share` handler has to do is sum the aggregate shares it
finds.

Note that this does not include support for the protocol changes in [1].

[1]: https://github.com/ietf-wg-ppm/ppm-specification/pull/224