### PR TITLE
Miscellaneous test logging improvements

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -33,6 +33,8 @@ jobs:
     - name: build
       run: cargo build --verbose
     - name: test
+      env:
+        RUST_LOG: trace
       run: cargo test --verbose
   janus_server_docker:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,6 +1444,7 @@ dependencies = [
  "testcontainers",
  "tokio",
  "tokio-postgres",
+ "tracing",
  "url",
 ]
 

--- a/janus_server/tests/server_shutdown.rs
+++ b/janus_server/tests/server_shutdown.rs
@@ -12,8 +12,9 @@ use janus_server::{
 };
 use reqwest::{Client, Url};
 use std::{
+    io::Read,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4, TcpListener, TcpStream},
-    process::Command,
+    process::{Command, Stdio},
 };
 use wait_timeout::ChildExt;
 
@@ -60,10 +61,7 @@ async fn server_shutdown() {
         database: DbConfig {
             url: db_handle.connection_string().parse().unwrap(),
         },
-        logging_config: TraceConfiguration {
-            use_test_writer: true,
-            ..Default::default()
-        },
+        logging_config: Default::default(),
     };
 
     let task_id = TaskId::random();
@@ -89,8 +87,28 @@ async fn server_shutdown() {
             "DATASTORE_KEYS",
             base64::encode_config(&db_handle.datastore_key_bytes(), base64::STANDARD_NO_PAD),
         )
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .spawn()
         .unwrap();
+
+    // Kick off tasks to read from piped stdout/stderr
+    let stdout_join_handle = tokio::task::spawn_blocking({
+        let mut stdout = child.stdout.take().unwrap();
+        move || {
+            let mut output = String::new();
+            stdout.read_to_string(&mut output).unwrap();
+            output
+        }
+    });
+    let stderr_join_handle = tokio::task::spawn_blocking({
+        let mut stderr = child.stderr.take().unwrap();
+        move || {
+            let mut output = String::new();
+            stderr.read_to_string(&mut output).unwrap();
+            output
+        }
+    });
 
     // Try to connect to the server in a loop, until it's ready.
     wait_for_server(config.listen_address).expect("could not connect to server after starting it");
@@ -120,6 +138,11 @@ async fn server_shutdown() {
         // We timed out waiting after sending a SIGTERM. Send a SIGKILL to clean up.
         child.kill().unwrap();
         child.wait().unwrap();
+        println!("===== child process stdout =====");
+        println!("{}", stdout_join_handle.await.unwrap());
+        println!("===== child process stderr =====");
+        println!("{}", stderr_join_handle.await.unwrap());
+        println!("===== end =====");
     }
     child_exit_status_opt.unwrap();
 }

--- a/monolithic_integration_test/Cargo.toml
+++ b/monolithic_integration_test/Cargo.toml
@@ -15,4 +15,5 @@ testcontainers = "0.13.0"
 test_util = { path = "../test_util" }
 tokio = { version = "^1.9", features = ["full", "tracing"] }
 tokio-postgres = { version = "0.7.5", features = ["with-chrono-0_4"] }
+tracing = "0.1.34"
 url = { version = "2.2.2", features = ["serde"] }


### PR DESCRIPTION
This includes a few semi-related changes to help diagnose our flaky testcontainers error and clean up the test suite output.

- Turn on logging when running the test suite in CI.
- Log our database connection string after creating a `testcontainers::core::Container` and before dropping it.
- Capture child process output in `server_shutdown`, and only print it on failure.