### PR TITLE
Workaround: connect to ephemeral db on 127.0.0.1

### DIFF
--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -51,8 +51,12 @@ macro_rules! define_ephemeral_datastore {
 
             // Create a connection pool whose clients will talk to our newly-running instance of Postgres.
             const POSTGRES_DEFAULT_PORT: u16 = 5432;
+            // Workaround: `get_host_port` does not specify what host IP address the port is
+            // associated with, but empirically we see it is the port for 127.0.0.1, and not
+            // [::1]. We will hardcode 127.0.0.1 (instead of localhost) until a host IP is
+            // exposed via the API.
             let connection_string = format!(
-                "postgres://postgres:postgres@localhost:{}/postgres",
+                "postgres://postgres:postgres@127.0.0.1:{}/postgres",
                 db_container.get_host_port(POSTGRES_DEFAULT_PORT)
             );
             ::tracing::trace!("Postgres container is up with URL {}", connection_string);

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -51,7 +51,7 @@ macro_rules! define_ephemeral_datastore {
 
             // Create a connection pool whose clients will talk to our newly-running instance of Postgres.
             const POSTGRES_DEFAULT_PORT: u16 = 5432;
-            // Workaround: `get_host_port` does not specify what host IP address the port is
+            // TODO (issue #109): `get_host_port` does not specify what host IP address the port is
             // associated with, but empirically we see it is the port for 127.0.0.1, and not
             // [::1]. We will hardcode 127.0.0.1 (instead of localhost) until a host IP is
             // exposed via the API.


### PR DESCRIPTION
The `testcontainers` crate makes use of `docker run` with the `--publish-all` flag to expose our Postgres database for connections. In certain situations, Docker's port allocation assigns different port numbers to the same container via the host's IPv4 and IPv6 addresses. The `get_host_port()` method does not provide which host IP address a
port corresponds to, nor specify which address's port will be returned.

Empirically, it appears that Docker will return port bindings for 0.0.0.0 before ::, and `testcontainers` will select the first port
binding in the list. Thus, as a workaround, we use 127.0.0.1 in the connection string, instead of "localhost", to keep the database client from trying both socket addresses, and possibly connecting to the wrong container.