### PR TITLE
Store aggregate share requests serviced by helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,6 +648,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,6 +1252,7 @@ dependencies = [
  "chrono",
  "console-subscriber",
  "deadpool-postgres",
+ "derivative",
  "futures",
  "hex",
  "hpke",

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -19,6 +19,7 @@ bytes = "1.1.0"
 chrono = "0.4"
 console-subscriber = { version = "0.1.4", optional = true }
 deadpool-postgres = "0.10.1"
+derivative = "2.2.0"
 futures = "0.3.21"
 hex = "0.4.3"
 hpke = { version = "0.8.0", features = ["default", "std"] }


### PR DESCRIPTION
Adds a new database table `aggregate_share_jobs`, used by helper to
store the results of successfully serviced `AggregateShareReq`s. This
allows leaders to retry an `AggregateShareReq` indefinitely, provided
the parameters don't change. The leader's `collect_jobs` table now also
has some nullable columns where it can cache the leader and helper's
aggregate shares, to similarly allow the collector to retry requests to
the collect job URI.

Part of #105