### PR TITLE
OpenTelemetry Metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,6 +596,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
+dependencies = [
+ "cfg-if",
+ "num_cpus",
+]
+
+[[package]]
 name = "dbl"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,9 +1253,11 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-jaeger",
  "opentelemetry-otlp",
+ "opentelemetry-prometheus",
  "opentelemetry-semantic-conventions",
  "postgres-types",
  "prio",
+ "prometheus",
  "rand",
  "reqwest",
  "ring",
@@ -1585,6 +1597,8 @@ checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
+ "dashmap",
+ "fnv",
  "futures-channel",
  "futures-executor",
  "futures-util",
@@ -1629,6 +1643,17 @@ dependencies = [
  "tokio",
  "tonic 0.6.2",
  "tonic-build",
+]
+
+[[package]]
+name = "opentelemetry-prometheus"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9328977e479cebe12ce0d3fcecdaea4721d234895a9440c5b5dfd113f0594ac6"
+dependencies = [
+ "opentelemetry",
+ "prometheus",
+ "protobuf",
 ]
 
 [[package]]
@@ -1925,6 +1950,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f64969ffd5dd8f39bd57a68ac53c163a095ed9d0fb707146da1b27025a3504"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot 0.11.2",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
 name = "prost"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2009,6 +2049,12 @@ dependencies = [
  "bytes",
  "prost 0.10.1",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96"
 
 [[package]]
 name = "quick-error"

--- a/README.md
+++ b/README.md
@@ -73,4 +73,33 @@ logging_config:
         x-honeycomb-team: "YOUR_API_KEY"
 ```
 
-The gRPC metadata can also be specified on the command line, with `--otlp-metadata x-honeycomb-team=YOUR_API_KEY`.
+The gRPC metadata can also be specified on the command line, with `--otlp-metadata x-honeycomb-team=YOUR_API_KEY`, or through the environment variable `OTLP_METADATA`.
+
+## OpenTelemetry Metrics
+
+Application-level metrics from the server can be exported to one of the following services.
+
+### Prometheus
+
+When the Prometheus exporter is enabled, a server will listen on port 9464 for metrics scrape requests. Prometheus must be configured to scrape the server, either manually or via an auto-discovery mechanism. Compile `janus_server` with the `prometheus` feature enabled, and add the following to the configuration file.
+```yaml
+metrics_config:
+  exporter:
+    prometheus:
+```
+
+### Honeycomb
+
+Honeycomb also supports OpenTelemetry-formatted metrics, though only on the Enterprise and Pro plans. Compile `janus_server` with the `otlp` feature enabled, and add the following section to the configuration file. Note that the OTLP/gRPC exporter will push metrics at regular intervals.
+
+```yaml
+metrics_config:
+  exporter:
+    otlp:
+      endpoint: "https://api.honeycomb.io:443"
+      metadata:
+        x-honeycomb-team: "YOUR_API_KEY"
+        x-honeycomb-dataset: "YOUR_METRICS_DATASET"
+```
+
+The command line flag `--otlp-metadata` or environment variable `OTLP_METADATA` may alternately be used to supply gRPC metadata for the metrics exporter, as with the tracing exporter above.

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -7,8 +7,9 @@ rust-version = "1.58"
 
 [features]
 tokio-console = ["console-subscriber"]
-jaeger = ["tracing-opentelemetry", "opentelemetry", "opentelemetry-jaeger"]
-otlp = ["tracing-opentelemetry", "opentelemetry", "opentelemetry-otlp", "opentelemetry-semantic-conventions", "tonic"]
+jaeger = ["tracing-opentelemetry", "opentelemetry-jaeger"]
+otlp = ["tracing-opentelemetry", "opentelemetry-otlp", "opentelemetry-semantic-conventions", "tonic"]
+prometheus = ["opentelemetry-prometheus", "dep:prometheus"]
 
 [dependencies]
 anyhow = "1"
@@ -22,13 +23,16 @@ futures = "0.3.21"
 hex = "0.4.3"
 hpke = { version = "0.8.0", features = ["default", "std"] }
 http = "0.2.6"
+hyper = "0.14.18"
 num_enum = "0.5.6"
-opentelemetry = { version = "0.17.0", optional = true, features = ["rt-tokio"] }
+opentelemetry = { version = "0.17.0", features = ["metrics", "rt-tokio"] }
 opentelemetry-jaeger = { version = "0.16.0", optional = true, features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.10.0", optional = true }
+opentelemetry-otlp = { version = "0.10.0", optional = true, features = ["metrics"] }
+opentelemetry-prometheus = { version = "0.10.0", optional = true }
 opentelemetry-semantic-conventions = { version = "0.9.0", optional = true }
 postgres-types = { version = "0.2.2", features = ["derive"] }
 prio = { git = "https://github.com/divviup/libprio-rs", rev = "229cd9c45924c7dae3ba754a6eb46b2a05ca8451" }  # TODO(brandon): use a numbered version, once a release is cut >0.7.0
+prometheus = { version = "0.13.0", optional = true }
 rand = "0.8"
 reqwest = { version = "0.11.4", default-features = false, features = ["rustls-tls", "json"] }
 ring = "0.16.20"

--- a/janus_server/src/config.rs
+++ b/janus_server/src/config.rs
@@ -1,6 +1,6 @@
 //! Configuration for various Janus actors.
 
-use crate::trace::TraceConfiguration;
+use crate::{metrics::MetricsConfiguration, trace::TraceConfiguration};
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use url::Url;
@@ -44,12 +44,24 @@ pub struct AggregatorConfig {
     /// Logging configuration
     #[serde(default)]
     pub logging_config: TraceConfiguration,
+    /// Application-level metrics configuration
+    #[serde(default)]
+    pub metrics_config: MetricsConfiguration,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::net::{IpAddr, Ipv4Addr};
+    use crate::{
+        metrics::{MetricsExporterConfiguration, OtlpExporterConfiguration},
+        trace::{
+            OpenTelemetryTraceConfiguration, OtlpTraceConfiguration, TokioConsoleConfiguration,
+        },
+    };
+    use std::{
+        collections::HashMap,
+        net::{IpAddr, Ipv4Addr},
+    };
 
     fn generate_db_config() -> DbConfig {
         DbConfig {
@@ -71,10 +83,133 @@ mod tests {
             listen_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 8080),
             database: generate_db_config(),
             logging_config: TraceConfiguration::default(),
+            metrics_config: MetricsConfiguration::default(),
         };
 
         let encoded = serde_yaml::to_string(&aggregator_config).unwrap();
         let decoded: AggregatorConfig = serde_yaml::from_str(&encoded).unwrap();
         assert_eq!(aggregator_config, decoded);
+    }
+
+    /// Check that configuration fragments in the README can be parsed correctly.
+    #[test]
+    fn readme_config_examples() {
+        assert_eq!(
+            serde_yaml::from_str::<AggregatorConfig>(
+                r#"---
+listen_address: "0.0.0.0:8080"
+database:
+    url: "postgres://postgres:postgres@localhost:5432/postgres"
+logging_config:
+    tokio_console_config:
+        enabled: true
+        listen_address: 127.0.0.1:6669
+"#
+            )
+            .unwrap()
+            .logging_config
+            .tokio_console_config,
+            TokioConsoleConfiguration {
+                enabled: true,
+                listen_address: Some(SocketAddr::new(
+                    IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                    6669,
+                )),
+            },
+        );
+
+        assert_eq!(
+            serde_yaml::from_str::<AggregatorConfig>(
+                r#"---
+listen_address: "0.0.0.0:8080"
+database:
+    url: "postgres://postgres:postgres@localhost:5432/postgres"
+logging_config:
+    open_telemetry_config:
+        jaeger:
+"#
+            )
+            .unwrap()
+            .logging_config
+            .open_telemetry_config,
+            Some(OpenTelemetryTraceConfiguration::Jaeger),
+        );
+
+        assert_eq!(
+            serde_yaml::from_str::<AggregatorConfig>(
+                r#"---
+listen_address: "0.0.0.0:8080"
+database:
+    url: "postgres://postgres:postgres@localhost:5432/postgres"
+logging_config:
+    open_telemetry_config:
+        otlp:
+            endpoint: "https://api.honeycomb.io:443"
+            metadata:
+                x-honeycomb-team: "YOUR_API_KEY"
+"#
+            )
+            .unwrap()
+            .logging_config
+            .open_telemetry_config,
+            Some(OpenTelemetryTraceConfiguration::Otlp(
+                OtlpTraceConfiguration {
+                    endpoint: "https://api.honeycomb.io:443".to_string(),
+                    metadata: HashMap::from([(
+                        "x-honeycomb-team".to_string(),
+                        "YOUR_API_KEY".to_string(),
+                    )]),
+                },
+            )),
+        );
+
+        assert_eq!(
+            serde_yaml::from_str::<AggregatorConfig>(
+                r#"---
+listen_address: "0.0.0.0:8080"
+database:
+    url: "postgres://postgres:postgres@localhost:5432/postgres"
+metrics_config:
+    exporter:
+        prometheus:
+"#
+            )
+            .unwrap()
+            .metrics_config
+            .exporter,
+            Some(MetricsExporterConfiguration::Prometheus),
+        );
+
+        assert_eq!(
+            serde_yaml::from_str::<AggregatorConfig>(
+                r#"---
+listen_address: "0.0.0.0:8080"
+database:
+    url: "postgres://postgres:postgres@localhost:5432/postgres"
+metrics_config:
+    exporter:
+        otlp:
+            endpoint: "https://api.honeycomb.io:443"
+            metadata:
+                x-honeycomb-team: "YOUR_API_KEY"
+                x-honeycomb-dataset: "YOUR_METRICS_DATASET"
+"#
+            )
+            .unwrap()
+            .metrics_config
+            .exporter,
+            Some(MetricsExporterConfiguration::Otlp(
+                OtlpExporterConfiguration {
+                    endpoint: "https://api.honeycomb.io:443".to_string(),
+                    metadata: HashMap::from([
+                        ("x-honeycomb-team".to_string(), "YOUR_API_KEY".to_string()),
+                        (
+                            "x-honeycomb-dataset".to_string(),
+                            "YOUR_METRICS_DATASET".to_string(),
+                        ),
+                    ]),
+                },
+            )),
+        );
     }
 }

--- a/janus_server/src/lib.rs
+++ b/janus_server/src/lib.rs
@@ -6,6 +6,7 @@ pub mod config;
 pub mod datastore;
 pub mod hpke;
 pub mod message;
+pub mod metrics;
 pub mod task;
 pub mod time;
 pub mod trace;

--- a/janus_server/src/metrics.rs
+++ b/janus_server/src/metrics.rs
@@ -1,0 +1,147 @@
+//! Collection and exporting of application-level metrics for Janus.
+
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, net::AddrParseError};
+
+/// Errors from initializing metrics provider, registry, and exporter.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("bad IP address: {0}")]
+    IpAddress(#[from] AddrParseError),
+    #[error(transparent)]
+    OpenTelemetry(#[from] opentelemetry::metrics::MetricsError),
+    #[cfg(feature = "otlp")]
+    #[error(transparent)]
+    TonicMetadataKey(#[from] tonic::metadata::errors::InvalidMetadataKey),
+    #[cfg(feature = "otlp")]
+    #[error(transparent)]
+    TonicMetadataValue(#[from] tonic::metadata::errors::InvalidMetadataValue),
+    #[error("{0}")]
+    Other(&'static str),
+}
+
+/// Configuration for collection/exporting of application-level metrics.
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct MetricsConfiguration {
+    /// Configuration for OpenTelemetry metrics, with a choice of exporters.
+    #[serde(default)]
+    pub exporter: Option<MetricsExporterConfiguration>,
+}
+
+/// Selection of an exporter for OpenTelemetry metrics.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MetricsExporterConfiguration {
+    #[serde(rename = "prometheus")]
+    Prometheus,
+    #[serde(rename = "otlp")]
+    Otlp(OtlpExporterConfiguration),
+}
+
+/// Configuration options specific to the OpenTelemetry OTLP metrics exporter.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OtlpExporterConfiguration {
+    /// gRPC endpoint for OTLP exporter.
+    pub endpoint: String,
+    /// Additional metadata/HTTP headers to be sent with OTLP requests.
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
+}
+
+/// Choice of OpenTelemetry metrics exporter implementation.
+pub enum MetricsExporterHandle {
+    #[cfg(feature = "prometheus")]
+    Prometheus(
+        opentelemetry_prometheus::PrometheusExporter,
+        tokio::task::JoinHandle<()>,
+    ),
+    #[cfg(feature = "otlp")]
+    Otlp(opentelemetry::sdk::metrics::controllers::PushController),
+    Noop,
+}
+
+/// Install a metrics provider and exporter, per the given configuration. The OpenTelemetry global
+/// API can be used to create and update meters, and they will be sent through this exporter. The
+/// returned handle should not be dropped until the application shuts down.
+pub fn install_metrics_exporter(
+    config: &MetricsConfiguration,
+) -> Result<MetricsExporterHandle, Error> {
+    match &config.exporter {
+        #[cfg(feature = "prometheus")]
+        Some(MetricsExporterConfiguration::Prometheus) => {
+            use http::StatusCode;
+            use hyper::Response;
+            use prometheus::{Encoder, TextEncoder};
+            use std::net::SocketAddr;
+            use warp::{Filter, Reply};
+
+            let exporter = opentelemetry_prometheus::exporter().try_init()?;
+
+            let filter = warp::path("metrics").and(warp::get()).map({
+                let exporter = exporter.clone();
+                move || {
+                    let mut buffer = Vec::new();
+                    let encoder = TextEncoder::new();
+                    match encoder.encode(&exporter.registry().gather(), &mut buffer) {
+                        Ok(()) => Response::builder()
+                            .header(hyper::header::CONTENT_TYPE, encoder.format_type())
+                            .body(buffer)
+                            // This unwrap is OK because the only possible source of errors is the
+                            // `header()` call, and its arguments are always valid.
+                            .unwrap()
+                            .into_response(),
+                        Err(err) => {
+                            tracing::error!(%err, "failed to encode Prometheus metrics");
+                            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+                        }
+                    }
+                }
+            });
+            let listen_address = SocketAddr::new(exporter.host().parse()?, exporter.port());
+            let handle = tokio::task::spawn(warp::serve(filter).bind(listen_address));
+
+            Ok(MetricsExporterHandle::Prometheus(exporter, handle))
+        }
+        #[cfg(not(feature = "prometheus"))]
+        Some(MetricsExporterConfiguration::Prometheus) => Err(Error::Other(
+            "The OpenTelemetry Prometheus metrics exporter was enabled in the \
+            configuration file, but support was not enabled at compile time. \
+            Rebuild with `--features prometheus`.",
+        )),
+
+        #[cfg(feature = "otlp")]
+        Some(MetricsExporterConfiguration::Otlp(otlp_config)) => {
+            use opentelemetry::{util::tokio_interval_stream, KeyValue};
+            use opentelemetry_otlp::WithExportConfig;
+            use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
+            use std::str::FromStr;
+            use tonic::metadata::{MetadataKey, MetadataMap, MetadataValue};
+
+            let mut map = MetadataMap::with_capacity(otlp_config.metadata.len());
+            for (key, value) in otlp_config.metadata.iter() {
+                map.insert(MetadataKey::from_str(key)?, MetadataValue::from_str(value)?);
+            }
+
+            let push_controller = opentelemetry_otlp::new_pipeline()
+                .metrics(tokio::spawn, tokio_interval_stream)
+                .with_resource([KeyValue::new(SERVICE_NAME, "janus_server")])
+                .with_exporter(
+                    opentelemetry_otlp::new_exporter()
+                        .tonic()
+                        .with_endpoint(otlp_config.endpoint.clone()),
+                )
+                .build()?;
+            // We can't drop the PushController, as that would stop pushes, so return it to the
+            // caller.
+            Ok(MetricsExporterHandle::Otlp(push_controller))
+        }
+        #[cfg(not(feature = "otlp"))]
+        Some(MetricsExporterConfiguration::Otlp(_)) => Err(Error::Other(
+            "The OpenTelemetry OTLP metrics exporter was enabled in the \
+            configuration file, but support was not enabled at compile time. \
+            Rebuild with `--features otlp`.",
+        )),
+
+        // If neither exporter is configured, leave the default NoopMeterProvider in place.
+        None => Ok(MetricsExporterHandle::Noop),
+    }
+}

--- a/janus_server/src/trace.rs
+++ b/janus_server/src/trace.rs
@@ -70,12 +70,12 @@ pub enum OpenTelemetryTraceConfiguration {
     #[serde(rename = "jaeger")]
     Jaeger,
     #[serde(rename = "otlp")]
-    Otlp(OtlpConfiguration),
+    Otlp(OtlpTraceConfiguration),
 }
 
 /// Configuration options specific to the OpenTelemetry OTLP exporter.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct OtlpConfiguration {
+pub struct OtlpTraceConfiguration {
     /// gRPC endpoint for OTLP exporter.
     pub endpoint: String,
     /// Additional metadata/HTTP headers to be sent with OTLP requests.

--- a/janus_server/tests/server_shutdown.rs
+++ b/janus_server/tests/server_shutdown.rs
@@ -62,6 +62,7 @@ async fn server_shutdown() {
             url: db_handle.connection_string().parse().unwrap(),
         },
         logging_config: Default::default(),
+        metrics_config: Default::default(),
     };
 
     let task_id = TaskId::random();


### PR DESCRIPTION
This adds metrics support, using the OpenTelemetry SDK. I included both a Prometheus exporter and an OTLP exporter. (Honeycomb supports metrics via OTLP, though only as a premium feature) I have included a couple metrics around HTTP request handling, as a start.

FWIW, due to changes in the OpenTelemetry metrics specification, future crate versions will remove the "ValueRecorder" layer of indirection, deprecating it and replacing it with histograms.

Here's a sample scrape, using the Prometheus exporter.

```
# HELP aggregator_response Success and failure responses to incoming requests.
# TYPE aggregator_response counter
aggregator_response{endpoint="hpke_config",status="error"} 1
# HELP aggregator_response_time Elapsed time handling incoming requests.
# TYPE aggregator_response_time histogram
aggregator_response_time_bucket{endpoint="hpke_config",le="0.005"} 1
aggregator_response_time_bucket{endpoint="hpke_config",le="0.01"} 1
aggregator_response_time_bucket{endpoint="hpke_config",le="0.025"} 1
aggregator_response_time_bucket{endpoint="hpke_config",le="0.05"} 1
aggregator_response_time_bucket{endpoint="hpke_config",le="0.1"} 1
aggregator_response_time_bucket{endpoint="hpke_config",le="0.25"} 1
aggregator_response_time_bucket{endpoint="hpke_config",le="0.5"} 1
aggregator_response_time_bucket{endpoint="hpke_config",le="1"} 1
aggregator_response_time_bucket{endpoint="hpke_config",le="2.5"} 1
aggregator_response_time_bucket{endpoint="hpke_config",le="5"} 1
aggregator_response_time_bucket{endpoint="hpke_config",le="10"} 1
aggregator_response_time_bucket{endpoint="hpke_config",le="+Inf"} 1
aggregator_response_time_sum{endpoint="hpke_config"} 0.000439081
aggregator_response_time_count{endpoint="hpke_config"} 1
```