### PR TITLE
Update base64 format used in problem details

### DIFF
--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -1288,7 +1288,7 @@ fn build_problem_details_response(error_type: PpmProblemType, task_id: Option<Ta
                 // the instance member, thus ".." will always refer to the aggregator's endpoint,
                 // as required by §3.1.
                 "instance": "..",
-                "taskid": task_id.map(|tid| base64::encode(tid.as_bytes())),
+                "taskid": task_id.map(|tid| base64::encode_config(tid.as_bytes(), base64::URL_SAFE_NO_PAD)),
             })),
             http::header::CONTENT_TYPE,
             PROBLEM_DETAILS_JSON_MEDIA_TYPE,
@@ -1830,7 +1830,7 @@ mod tests {
                 "title": "Report could not be processed because it arrived too late.",
                 "detail": "Report could not be processed because it arrived too late.",
                 "instance": "..",
-                "taskid": base64::encode(report.task_id.as_bytes()),
+                "taskid": base64::encode_config(report.task_id.as_bytes(), base64::URL_SAFE_NO_PAD),
             })
         );
         assert_eq!(
@@ -1862,7 +1862,7 @@ mod tests {
                 "title": "The message type for a response was incorrect or the payload was malformed.",
                 "detail": "The message type for a response was incorrect or the payload was malformed.",
                 "instance": "..",
-                "taskid": base64::encode(report.task_id.as_bytes()),
+                "taskid": base64::encode_config(report.task_id.as_bytes(), base64::URL_SAFE_NO_PAD),
             })
         );
         assert_eq!(
@@ -1895,7 +1895,7 @@ mod tests {
                 "title": "The message was generated using an outdated configuration.",
                 "detail": "The message was generated using an outdated configuration.",
                 "instance": "..",
-                "taskid": base64::encode(report.task_id.as_bytes()),
+                "taskid": base64::encode_config(report.task_id.as_bytes(), base64::URL_SAFE_NO_PAD),
             })
         );
         assert_eq!(
@@ -1961,7 +1961,7 @@ mod tests {
                 "title": "An endpoint received a message with an unknown task ID.",
                 "detail": "An endpoint received a message with an unknown task ID.",
                 "instance": "..",
-                "taskid": base64::encode(task_id.as_bytes()),
+                "taskid": base64::encode_config(task_id.as_bytes(), base64::URL_SAFE_NO_PAD),
             })
         );
         assert_eq!(
@@ -2180,7 +2180,7 @@ mod tests {
                 "title": "An endpoint received a message with an unknown task ID.",
                 "detail": "An endpoint received a message with an unknown task ID.",
                 "instance": "..",
-                "taskid": base64::encode(task_id.as_bytes()),
+                "taskid": base64::encode_config(task_id.as_bytes(), base64::URL_SAFE_NO_PAD),
             })
         );
         assert_eq!(
@@ -2244,7 +2244,7 @@ mod tests {
                 "title": "The aggregate message's HMAC was not valid.",
                 "detail": "The aggregate message's HMAC was not valid.",
                 "instance": "..",
-                "taskid": base64::encode(task_id.as_bytes()),
+                "taskid": base64::encode_config(task_id.as_bytes(), base64::URL_SAFE_NO_PAD),
             })
         );
         assert_eq!(want_status, parts.status.as_u16());
@@ -2591,7 +2591,7 @@ mod tests {
                 "title": "The message type for a response was incorrect or the payload was malformed.",
                 "detail": "The message type for a response was incorrect or the payload was malformed.",
                 "instance": "..",
-                "taskid": base64::encode(task_id.as_bytes()),
+                "taskid": base64::encode_config(task_id.as_bytes(), base64::URL_SAFE_NO_PAD),
             })
         );
         assert_eq!(want_status, parts.status.as_u16());
@@ -2873,7 +2873,7 @@ mod tests {
                 "title": "The message type for a response was incorrect or the payload was malformed.",
                 "detail": "The message type for a response was incorrect or the payload was malformed.",
                 "instance": "..",
-                "taskid": base64::encode(task_id.as_bytes()),
+                "taskid": base64::encode_config(task_id.as_bytes(), base64::URL_SAFE_NO_PAD),
             })
         );
     }
@@ -3126,7 +3126,7 @@ mod tests {
                 "title": "The message type for a response was incorrect or the payload was malformed.",
                 "detail": "The message type for a response was incorrect or the payload was malformed.",
                 "instance": "..",
-                "taskid": base64::encode(task_id.as_bytes()),
+                "taskid": base64::encode_config(task_id.as_bytes(), base64::URL_SAFE_NO_PAD),
             })
         );
     }
@@ -3266,7 +3266,7 @@ mod tests {
                 "title": "The message type for a response was incorrect or the payload was malformed.",
                 "detail": "The message type for a response was incorrect or the payload was malformed.",
                 "instance": "..",
-                "taskid": base64::encode(task_id.as_bytes()),
+                "taskid": base64::encode_config(task_id.as_bytes(), base64::URL_SAFE_NO_PAD),
             })
         );
     }
@@ -3372,7 +3372,7 @@ mod tests {
                 "title": "The message type for a response was incorrect or the payload was malformed.",
                 "detail": "The message type for a response was incorrect or the payload was malformed.",
                 "instance": "..",
-                "taskid": base64::encode(task_id.as_bytes()),
+                "taskid": base64::encode_config(task_id.as_bytes(), base64::URL_SAFE_NO_PAD),
             })
         );
     }
@@ -3426,7 +3426,7 @@ mod tests {
                 "title": "An endpoint received a message with an unknown task ID.",
                 "detail": "An endpoint received a message with an unknown task ID.",
                 "instance": "..",
-                "taskid": base64::encode(task_id.as_bytes()),
+                "taskid": base64::encode_config(task_id.as_bytes(), base64::URL_SAFE_NO_PAD),
             })
         );
     }
@@ -3485,7 +3485,7 @@ mod tests {
                 "title": "The batch interval in the collect or aggregate share request is not valid for the task.",
                 "detail": "The batch interval in the collect or aggregate share request is not valid for the task.",
                 "instance": "..",
-                "taskid": base64::encode(task_id.as_bytes()),
+                "taskid": base64::encode_config(task_id.as_bytes(), base64::URL_SAFE_NO_PAD),
             })
         );
     }
@@ -3582,7 +3582,7 @@ mod tests {
                 "title": "An endpoint received a message with an unknown task ID.",
                 "detail": "An endpoint received a message with an unknown task ID.",
                 "instance": "..",
-                "taskid": base64::encode(task_id.as_bytes()),
+                "taskid": base64::encode_config(task_id.as_bytes(), base64::URL_SAFE_NO_PAD),
             })
         );
     }
@@ -3643,7 +3643,7 @@ mod tests {
                 "title": "The batch interval in the collect or aggregate share request is not valid for the task.",
                 "detail": "The batch interval in the collect or aggregate share request is not valid for the task.",
                 "instance": "..",
-                "taskid": base64::encode(task_id.as_bytes()),
+                "taskid": base64::encode_config(task_id.as_bytes(), base64::URL_SAFE_NO_PAD),
             })
         );
     }
@@ -3708,7 +3708,7 @@ mod tests {
                 "title": "There are not enough reports in the batch interval.",
                 "detail": "There are not enough reports in the batch interval.",
                 "instance": "..",
-                "taskid": base64::encode(task_id.as_bytes()),
+                "taskid": base64::encode_config(task_id.as_bytes(), base64::URL_SAFE_NO_PAD),
             })
         );
 
@@ -3782,7 +3782,7 @@ mod tests {
                 "title": "There are not enough reports in the batch interval.",
                 "detail": "There are not enough reports in the batch interval.",
                 "instance": "..",
-                "taskid": base64::encode(task_id.as_bytes()),
+                "taskid": base64::encode_config(task_id.as_bytes(), base64::URL_SAFE_NO_PAD),
             })
         );
 
@@ -3816,7 +3816,7 @@ mod tests {
                 "title": "The checksums or report counts in the two aggregator's aggregate shares do not match.",
                 "detail": "The checksums or report counts in the two aggregator's aggregate shares do not match.",
                 "instance": "..",
-                "taskid": base64::encode(task_id.as_bytes()),
+                "taskid": base64::encode_config(task_id.as_bytes(), base64::URL_SAFE_NO_PAD),
             })
         );
 
@@ -3850,7 +3850,7 @@ mod tests {
                 "title": "The checksums or report counts in the two aggregator's aggregate shares do not match.",
                 "detail": "The checksums or report counts in the two aggregator's aggregate shares do not match.",
                 "instance": "..",
-                "taskid": base64::encode(task_id.as_bytes()),
+                "taskid": base64::encode_config(task_id.as_bytes(), base64::URL_SAFE_NO_PAD),
             })
         );
 
@@ -3930,7 +3930,7 @@ mod tests {
                     "title": "The batch lifetime has been exceeded for one or more reports included in the batch interval.",
                     "detail": "The batch lifetime has been exceeded for one or more reports included in the batch interval.",
                     "instance": "..",
-                    "taskid": base64::encode(task_id.as_bytes()),
+                    "taskid": base64::encode_config(task_id.as_bytes(), base64::URL_SAFE_NO_PAD),
                 })
             );
         }


### PR DESCRIPTION
Earlier this month, the interop branch was updated to require that the task ID in problem details documents be encoded with base64url, with no padding. This updates our implementation to match.