### PR TITLE
Initial implementation of aggregation job creator.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,6 +1245,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-postgres",
+ "tokio-stream",
  "tracing",
  "tracing-log",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,6 +1224,7 @@ dependencies = [
  "hpke",
  "http",
  "hyper",
+ "itertools",
  "lazy_static",
  "libc",
  "mockito",

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -110,6 +110,7 @@ CREATE TABLE report_aggregations(
     CONSTRAINT fk_client_report_id FOREIGN KEY(client_report_id) REFERENCES client_reports(id)
 );
 CREATE INDEX report_aggregations_aggregation_job_id_index ON report_aggregations(aggregation_job_id);
+CREATE INDEX report_aggregations_client_report_id_index ON report_aggregations(client_report_id);
 
 -- Information on aggregation for a single batch. This information may be incremental if the VDAF
 -- supports incremental aggregation.

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -35,6 +35,7 @@ structopt = "0.3.26"
 thiserror = "1.0"
 tokio = { version = "^1.9", features = ["full", "tracing"] }
 tokio-postgres = { version = "0.7.5", features = ["with-chrono-0_4"] }
+tokio-stream = "0.1.8"
 tracing = "0.1.34"
 tracing-log = "0.1.2"
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt", "json"] }

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -20,6 +20,7 @@ futures = "0.3.21"
 hex = "0.4.3"
 hpke = { version = "0.8.0", features = ["default", "std"] }
 http = "0.2.6"
+itertools = "0.10.3"
 num_enum = "0.5.6"
 postgres-types = { version = "0.2.2", features = ["derive"] }
 prio = { git = "https://github.com/divviup/libprio-rs", rev = "229cd9c45924c7dae3ba754a6eb46b2a05ca8451" }  # TODO(brandon): use a numbered version, once a release is cut >0.7.0

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -65,5 +65,6 @@ serde_test = "1.0.136"
 tempfile = "3.3.0"
 testcontainers = "0.13.0"
 test_util = { path = "../test_util" }
+tokio = { version = "*", features = ["test-util"] }
 trycmd = "0.13.3"
 wait-timeout = "0.2.0"

--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -1653,7 +1653,7 @@ mod tests {
             AuthenticatedResponseDecoder, Duration, HpkeCiphertext, HpkeConfig, TaskId, Time,
         },
         task::{test_util::new_dummy_task, Vdaf},
-        time::tests::MockClock,
+        time::test_util::MockClock,
         trace::test_util::install_test_trace_subscriber,
     };
     use assert_matches::assert_matches;

--- a/janus_server/src/bin/aggregation_job_creator.rs
+++ b/janus_server/src/bin/aggregation_job_creator.rs
@@ -367,13 +367,6 @@ mod tests {
 
     test_util::define_ephemeral_datastore!();
 
-    #[test]
-    fn cli_tests() {
-        trycmd::TestCases::new()
-            .case("tests/cmd/aggregation_job_creator.trycmd")
-            .run();
-    }
-
     #[tokio::test]
     async fn aggregation_job_creator() {
         // This is a minimal test that AggregationJobCreator::run() will successfully find tasks &

--- a/janus_server/src/bin/aggregation_job_creator.rs
+++ b/janus_server/src/bin/aggregation_job_creator.rs
@@ -1,0 +1,195 @@
+use anyhow::{Context, Result};
+use futures::future::Fuse;
+use futures::stream::{FuturesUnordered, StreamExt};
+use futures::FutureExt;
+use janus_server::binary_utils::datastore;
+use janus_server::config::AggregationJobCreatorConfig;
+use janus_server::datastore::Datastore;
+use janus_server::task::Task;
+use janus_server::trace::install_trace_subscriber;
+use rand::{thread_rng, Rng};
+use std::collections::HashMap;
+use std::fmt::Formatter;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+use std::{fmt, fmt::Debug, fs};
+use structopt::StructOpt;
+use tokio::task::JoinHandle;
+use tokio::time::{Instant, MissedTickBehavior};
+use tokio::{select, time};
+use tracing::info;
+
+#[derive(StructOpt)]
+#[structopt(
+    name = "janus-aggregator",
+    about = "PPM aggregator server",
+    rename_all = "kebab-case",
+    version = env!("CARGO_PKG_VERSION"),
+)]
+struct Options {
+    /// Path to configuration YAML.
+    #[structopt(
+        long,
+        env = "CONFIG_FILE",
+        parse(from_os_str),
+        takes_value = true,
+        required(true),
+        help = "path to configuration file"
+    )]
+    config_file: PathBuf,
+
+    /// Password for the PostgreSQL database connection. (if not included in the connection
+    /// string)
+    #[structopt(long, env = "PGPASSWORD", help = "PostgreSQL password")]
+    database_password: Option<String>,
+
+    /// Datastore encryption keys.
+    #[structopt(
+        long,
+        env = "DATASTORE_KEYS",
+        takes_value = true,
+        use_delimiter = true,
+        required(true),
+        help = "datastore encryption keys, encoded in base64 then comma-separated"
+    )]
+    datastore_keys: Vec<String>,
+}
+
+impl Debug for Options {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Options")
+            .field("config_file", &self.config_file)
+            .finish()
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Read arguments, read & parse config.
+    let options = Options::from_args();
+    let config: AggregationJobCreatorConfig = {
+        let config_content = fs::read_to_string(&options.config_file)
+            .with_context(|| format!("couldn't read config file {:?}", options.config_file))?;
+        serde_yaml::from_str(&config_content)
+            .with_context(|| format!("couldn't parse config file {:?}", options.config_file))?
+    };
+    install_trace_subscriber(&config.logging_config)
+        .context("couldn't install tracing subscriber")?;
+
+    info!(?options, ?config, "Starting aggregation job creator");
+
+    // Connect to database.
+    let datastore = datastore(
+        config.database,
+        options.database_password,
+        options.datastore_keys,
+    )
+    .context("couldn't connect to database")?;
+
+    run_aggregation_job_creator(Arc::new(datastore)).await
+}
+
+async fn run_aggregation_job_creator(datastore: Arc<Datastore>) -> Result<()> {
+    // TODO(brandon): add support for handling only a subset of tasks in a single job (i.e. sharding).
+
+    // XXX: throw all of this away, and just loop finding all tasks -> generate future per task to generate new agg jobs -> joining all futures? *sigh*
+
+    // Set up an interval to occasionally update our view of tasks in the DB.
+    // (This will fire immediately, so we'll immediately load tasks from the DB once we enter the
+    // select loop.)
+    const TASKS_UPDATE_FREQUENCY: Duration = Duration::from_secs(600); // XXX: make configurable
+    let mut tasks_update_interval = time::interval(TASKS_UPDATE_FREQUENCY);
+    tasks_update_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+    let mut job_creation_tasks: HashMap<_, Fuse<JoinHandle<_>>> = HashMap::new();
+
+    loop {
+        let mut job_creation_tasks_future: FuturesUnordered<_> =
+            job_creation_tasks.values_mut().collect();
+
+        select! {
+            // Update set of tasks we are creating aggregation jobs for every now & then.
+            _ = tasks_update_interval.tick() => {
+                drop(job_creation_tasks_future);
+                info!("Updating tasks");
+                let tasks = datastore.run_tx(|tx| Box::pin(async move{ tx.get_tasks().await })).await?.into_iter().map(|task| (task.id, task)).collect::<HashMap<_, _>>();
+
+                // Trim job creation tasks for nonexistent tasks.
+                job_creation_tasks.retain(|task_id, task| {
+                    if !tasks.contains_key(task_id) {
+                        info!("Stopping job creation task for task {:?}", task_id);
+                        // task.abort(); // XXX: can't abort because wrapped in Fuse, Fuse doesn't let us get a reference to the inner future :-(
+                        return false;
+                    }
+                    return true;
+                });
+
+                // Create job creation tasks for new tasks.
+                for (task_id, task) in tasks {
+                    if job_creation_tasks.contains_key(&task_id) {
+                        continue;
+                    }
+                    info!("Starting job creation task for task {:?}", task_id);
+                    job_creation_tasks.insert(task_id, tokio::task::spawn({
+                        let datastore = datastore.clone();
+                        async move {
+                            run_aggregation_job_creator_for_task(datastore, task).await.with_context(|| format!("couldn't create aggregation jobs for task {:?}", task_id))
+                        }
+                    }).fuse());
+                }
+            }
+
+            // If one of the single-task job creation tasks finishes, error out if it was in error.
+            // XXX: this doesn't quite work. we need to figure out how to remove the finished future
+            // from job_creation_tasks in order to avoid polling it again in future iterations of
+            // the loop.
+            rslt = job_creation_tasks_future.next(), if !job_creation_tasks_future.is_empty() => {
+                if let Some(rslt) = rslt {
+                    rslt??;
+                }
+            }
+        }
+    }
+}
+
+async fn run_aggregation_job_creator_for_task(datastore: Arc<Datastore>, task: Task) -> Result<()> {
+    // Create a ticker to allow us to periodically create new aggregation jobs for the given task.
+    // We randomize when in the update period we start in order to avoid a thundering herd problem
+    // on startup.
+    const TASK_UPDATE_FREQUENCY: Duration = Duration::from_secs(60); // XXX: make configurable
+    let first_tick_instant = Instant::now()
+        + Duration::from_secs(thread_rng().gen_range(0..=TASK_UPDATE_FREQUENCY.as_secs()));
+    let mut task_update_interval = time::interval_at(first_tick_instant, TASK_UPDATE_FREQUENCY);
+
+    loop {
+        task_update_interval.tick().await;
+        run_aggregation_job_creator_for_task_once(&datastore, &task).await?;
+    }
+}
+
+async fn run_aggregation_job_creator_for_task_once(
+    datastore: &Datastore,
+    task: &Task,
+) -> Result<()> {
+    if task.vdaf.has_aggregation_param() {
+        create_aggregation_jobs_no_collect_job(datastore, task).await
+    } else {
+        panic!("VDAF {:?} is not yet supported", task.vdaf)
+    }
+}
+
+async fn create_aggregation_jobs_no_collect_job(datastore: &Datastore, task: &Task) -> Result<()> {
+    let task_id = task.id;
+    Ok(datastore
+        .run_tx(|tx| {
+            Box::pin(async move {
+                // Find some unaggregated client reports, and partition them by their batch unit.
+                let reports = tx.get_unaggregated_client_reports_for_task(task_id).await?;
+
+                // XXX
+                Ok(())
+            })
+        })
+        .await?)
+}

--- a/janus_server/src/bin/aggregation_job_creator.rs
+++ b/janus_server/src/bin/aggregation_job_creator.rs
@@ -1,7 +1,5 @@
-use anyhow::{anyhow, Context};
-use futures::future::Fuse;
-use futures::stream::{FuturesUnordered, StreamExt};
-use futures::FutureExt;
+use anyhow::Context;
+use futures::future::try_join_all;
 use itertools::Itertools;
 use janus_server::binary_utils::datastore;
 use janus_server::config::AggregationJobCreatorConfig;
@@ -9,9 +7,11 @@ use janus_server::datastore::models::{
     AggregationJob, AggregationJobState, ReportAggregation, ReportAggregationState,
 };
 use janus_server::datastore::{self, Datastore};
-use janus_server::message::{AggregationJobId, Nonce, Report, Time};
+use janus_server::message::{AggregationJobId, Nonce, Role, TaskId, Time};
 use janus_server::task::Task;
+use janus_server::time::{Clock, RealClock};
 use janus_server::trace::install_trace_subscriber;
+use prio::codec::Encode;
 use prio::vdaf;
 use prio::vdaf::prio3::{Prio3Aes128Count, Prio3Aes128Histogram, Prio3Aes128Sum};
 use rand::{thread_rng, Rng};
@@ -22,15 +22,15 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::{fmt, fmt::Debug, fs};
 use structopt::StructOpt;
-use tokio::task::JoinHandle;
+use tokio::sync::oneshot::{self, Receiver, Sender};
 use tokio::time::{Instant, MissedTickBehavior};
 use tokio::{select, time};
-use tracing::info;
+use tracing::{debug, error, info};
 
 #[derive(StructOpt)]
 #[structopt(
-    name = "janus-aggregator",
-    about = "PPM aggregator server",
+    name = "janus-aggregation-job-creator",
+    about = "Janus aggregation job creator",
     rename_all = "kebab-case",
     version = env!("CARGO_PKG_VERSION"),
 )]
@@ -46,8 +46,8 @@ struct Options {
     )]
     config_file: PathBuf,
 
-    /// Password for the PostgreSQL database connection. (if not included in the connection
-    /// string)
+    /// Password for the PostgreSQL database connection. If specified, must not be specified in the
+    /// connection string.
     #[structopt(long, env = "PGPASSWORD", help = "PostgreSQL password")]
     database_password: Option<String>,
 
@@ -94,174 +94,619 @@ async fn main() -> anyhow::Result<()> {
     )
     .context("couldn't connect to database")?;
 
-    run_aggregation_job_creator(Arc::new(datastore)).await
+    // Start creating aggregation jobs.
+    Arc::new(AggregationJobCreator {
+        datastore,
+        clock: RealClock {},
+        tasks_update_frequency: Duration::from_secs(config.tasks_update_frequency_secs),
+        aggregation_job_creation_interval: Duration::from_secs(
+            config.aggregation_job_creation_interval_secs,
+        ),
+        min_aggregation_job_size: config.min_aggregation_job_size,
+        max_aggregation_job_size: config.max_aggregation_job_size,
+    })
+    .run()
+    .await
 }
 
-async fn run_aggregation_job_creator(datastore: Arc<Datastore>) -> anyhow::Result<()> {
-    // TODO(brandon): add support for handling only a subset of tasks in a single job (i.e. sharding).
-
-    // XXX: throw all of this away, and just loop finding all tasks -> generate future per task to generate new agg jobs -> joining all futures? *sigh*
-
-    // Set up an interval to occasionally update our view of tasks in the DB.
-    // (This will fire immediately, so we'll immediately load tasks from the DB once we enter the
-    // select loop.)
-    const TASKS_UPDATE_FREQUENCY: Duration = Duration::from_secs(600); // XXX: make configurable
-    let mut tasks_update_interval = time::interval(TASKS_UPDATE_FREQUENCY);
-    tasks_update_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
-
-    let mut job_creation_tasks: HashMap<_, Fuse<JoinHandle<_>>> = HashMap::new();
-
-    loop {
-        let mut job_creation_tasks_future: FuturesUnordered<_> =
-            job_creation_tasks.values_mut().collect();
-
-        select! {
-            // Update set of tasks we are creating aggregation jobs for every now & then.
-            _ = tasks_update_interval.tick() => {
-                drop(job_creation_tasks_future);
-                info!("Updating tasks");
-                let tasks = datastore.run_tx(|tx| Box::pin(async move{ tx.get_tasks().await })).await?.into_iter().map(|task| (task.id, task)).collect::<HashMap<_, _>>();
-
-                // Trim job creation tasks for nonexistent tasks.
-                job_creation_tasks.retain(|task_id, task| {
-                    if !tasks.contains_key(task_id) {
-                        info!("Stopping job creation task for task {:?}", task_id);
-                        // task.abort(); // XXX: can't abort because wrapped in Fuse, Fuse doesn't let us get a reference to the inner future :-(
-                        return false;
-                    }
-                    return true;
-                });
-
-                // Create job creation tasks for new tasks.
-                for (task_id, task) in tasks {
-                    if job_creation_tasks.contains_key(&task_id) {
-                        continue;
-                    }
-                    info!("Starting job creation task for task {:?}", task_id);
-                    job_creation_tasks.insert(task_id, tokio::task::spawn({
-                        let datastore = datastore.clone();
-                        async move {
-                            run_aggregation_job_creator_for_task(datastore, task).await.with_context(|| format!("couldn't create aggregation jobs for task {:?}", task_id))
-                        }
-                    }).fuse());
-                }
-            }
-
-            // If one of the single-task job creation tasks finishes, error out if it was in error.
-            // XXX: this doesn't quite work. we need to figure out how to remove the finished future
-            // from job_creation_tasks in order to avoid polling it again in future iterations of
-            // the loop.
-            rslt = job_creation_tasks_future.next(), if !job_creation_tasks_future.is_empty() => {
-                if let Some(rslt) = rslt {
-                    rslt??;
-                }
-            }
-        }
-    }
-}
-
-async fn run_aggregation_job_creator_for_task(
-    datastore: Arc<Datastore>,
-    task: Task,
-) -> anyhow::Result<()> {
-    // Create a ticker to allow us to periodically create new aggregation jobs for the given task.
-    // We randomize when in the update period we start in order to avoid a thundering herd problem
-    // on startup.
-    const TASK_UPDATE_FREQUENCY: Duration = Duration::from_secs(60); // XXX: make configurable
-    let first_tick_instant = Instant::now()
-        + Duration::from_secs(thread_rng().gen_range(0..=TASK_UPDATE_FREQUENCY.as_secs()));
-    let mut task_update_interval = time::interval_at(first_tick_instant, TASK_UPDATE_FREQUENCY);
-
-    loop {
-        task_update_interval.tick().await;
-        run_aggregation_job_creator_for_task_once(&datastore, &task).await?;
-    }
-}
-
-async fn run_aggregation_job_creator_for_task_once(
-    datastore: &Datastore,
-    task: &Task,
-) -> anyhow::Result<()> {
-    match task.vdaf {
-        janus_server::task::Vdaf::Prio3Aes128Count => {
-            create_aggregation_jobs_no_param::<Prio3Aes128Count>(datastore, task).await
-        }
-
-        janus_server::task::Vdaf::Prio3Aes128Sum { .. } => {
-            create_aggregation_jobs_no_param::<Prio3Aes128Sum>(datastore, task).await
-        }
-
-        janus_server::task::Vdaf::Prio3Aes128Histogram { .. } => {
-            create_aggregation_jobs_no_param::<Prio3Aes128Histogram>(datastore, task).await
-        }
-
-        _ => panic!("VDAF {:?} is not yet supported", task.vdaf),
-    }
-}
-
-async fn create_aggregation_jobs_no_param<A: vdaf::Aggregator>(
-    datastore: &Datastore,
-    task: &Task,
-) -> anyhow::Result<()>
+struct AggregationJobCreator<C: Clock>
 where
-    for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
-    A::AggregationParam: Default,
+    C: 'static,
 {
-    let task_id = task.id;
-    let min_batch_duration = task.min_batch_duration;
+    // Dependencies.
+    datastore: Datastore,
+    clock: C,
 
-    // XXX: make configurable
-    const MIN_BATCH_SIZE: usize = 100; // only for "current" batch unit
-    const MAX_BATCH_SIZE: usize = 1000;
+    // Configuration values.
+    /// How frequently we look for new tasks to start creating aggregation jobs for.
+    tasks_update_frequency: Duration,
+    /// How frequently we attempt to create new aggregation jobs for each task.
+    aggregation_job_creation_interval: Duration,
+    /// The minimum number of client reports to include in an aggregation job. Applies to the
+    /// "current" batch unit only; historical batch units will create aggregation jobs of any size,
+    /// on the theory that almost all reports will have be received for these batch units already.
+    min_aggregation_job_size: usize,
+    /// The maximum number of client reports to include in an aggregation job.
+    max_aggregation_job_size: usize,
+}
 
-    Ok(datastore
-        .run_tx(|tx| {
-            Box::pin(async move {
-                // Find some unaggregated client reports, and group them by their batch unit.
-                let nonces_by_batch_unit = tx
-                    .get_unaggregated_client_report_nonces_for_task(task_id)
-                    .await?
+impl<C: Clock> AggregationJobCreator<C> {
+    #[tracing::instrument(skip(self))]
+    async fn run(self: Arc<Self>) -> ! {
+        // TODO(brandon): add support for handling only a subset of tasks in a single job (i.e. sharding).
+
+        // Set up an interval to occasionally update our view of tasks in the DB.
+        // (This will fire immediately, so we'll immediately load tasks from the DB when we enter
+        // the loop.)
+        let mut tasks_update_ticker = time::interval(self.tasks_update_frequency);
+        tasks_update_ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+        // This tracks the "shutdown handle" (i.e. oneshot sender) used to shut down the per-task
+        // worker by task ID.
+        let mut job_creation_task_shutdown_handles: HashMap<TaskId, Sender<()>> = HashMap::new();
+
+        loop {
+            tasks_update_ticker.tick().await;
+            info!("Updating tasks");
+            let tasks = self
+                .datastore
+                .run_tx(|tx| Box::pin(async move { tx.get_tasks().await }))
+                .await;
+            let tasks = match tasks {
+                Ok(tasks) => tasks
                     .into_iter()
-                    .map(|nonce| {
-                        nonce
-                            .time
-                            .to_batch_unit_interval_start(min_batch_duration)
-                            .map(|s| (s, nonce))
-                            .map_err(datastore::Error::from)
+                    .filter_map(|task| match task.role {
+                        Role::Leader => Some((task.id, task)),
+                        _ => None,
                     })
-                    .collect::<Result<Vec<(Time, Nonce)>, _>>()?
-                    .into_iter()
-                    .into_group_map();
+                    .collect::<HashMap<_, _>>(),
 
-                let mut agg_jobs = Vec::new();
-                let mut report_aggs = Vec::new();
-                for (unit_interval_start, nonces) in nonces_by_batch_unit {
-                    for agg_job_nonces in nonces.chunks(MAX_BATCH_SIZE) {
-                        // XXX: don't create job if we're in the "current" batch unit & there are too few nonces
+                Err(err) => {
+                    error!(?err, "Couldn't update tasks");
+                    continue;
+                }
+            };
 
-                        let aggregation_job_id = AggregationJobId::random();
-                        agg_jobs.push(AggregationJob::<A> {
-                            aggregation_job_id,
-                            task_id,
-                            aggregation_param: A::AggregationParam::default(),
-                            state: AggregationJobState::InProgress,
-                        });
+            // Stop job creation tasks for no-longer-existing tasks.
+            job_creation_task_shutdown_handles.retain(|task_id, _| {
+                if tasks.contains_key(task_id) {
+                    return true;
+                }
+                // We don't need to send on the channel: dropping the sender is enough to cause the
+                // receiver future to resolve with a RecvError, which will trigger shutdown.
+                info!(?task_id, "Stopping job creation worker");
+                false
+            });
 
-                        for (ord, nonce) in agg_job_nonces.iter().enumerate() {
-                            report_aggs.push(ReportAggregation::<A> {
+            // Start job creation tasks for newly-discovered tasks.
+            for (task_id, task) in tasks {
+                if job_creation_task_shutdown_handles.contains_key(&task_id) {
+                    continue;
+                }
+                info!(?task_id, "Starting job creation worker");
+                let (tx, rx) = oneshot::channel();
+                job_creation_task_shutdown_handles.insert(task_id, tx);
+                tokio::task::spawn({
+                    let this = self.clone();
+                    async move { this.run_for_task(rx, task).await }
+                });
+            }
+        }
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn run_for_task(&self, mut shutdown: Receiver<()>, task: Task) {
+        debug!(task_id = ?task.id, "Job creation worker started");
+        let first_tick_instant = Instant::now()
+            + Duration::from_secs(
+                thread_rng().gen_range(0..self.aggregation_job_creation_interval.as_secs()),
+            );
+        let mut aggregation_job_creation_ticker =
+            time::interval_at(first_tick_instant, self.aggregation_job_creation_interval);
+
+        loop {
+            select! {
+                _ = aggregation_job_creation_ticker.tick() => {
+                    info!(task_id = ?task.id, "Creating aggregation jobs for task");
+                    if let Err(err) = self.create_aggregation_jobs_for_task(&task).await {
+                        error!(task_id = ?task.id, ?err, "Couldn't create aggregation jobs for task")
+                    }
+                }
+
+                _ = &mut shutdown => {
+                    debug!(task_id = ?task.id, "Job creation worker stopped");
+                    return;
+                }
+            }
+        }
+    }
+
+    #[tracing::instrument(skip(self), err)]
+    async fn create_aggregation_jobs_for_task(&self, task: &Task) -> anyhow::Result<()> {
+        match task.vdaf {
+            janus_server::task::Vdaf::Prio3Aes128Count => {
+                self.create_aggregation_jobs_for_task_no_param::<Prio3Aes128Count>(task)
+                    .await
+            }
+
+            janus_server::task::Vdaf::Prio3Aes128Sum { .. } => {
+                self.create_aggregation_jobs_for_task_no_param::<Prio3Aes128Sum>(task)
+                    .await
+            }
+
+            janus_server::task::Vdaf::Prio3Aes128Histogram { .. } => {
+                self.create_aggregation_jobs_for_task_no_param::<Prio3Aes128Histogram>(task)
+                    .await
+            }
+
+            _ => panic!("VDAF {:?} is not yet supported", task.vdaf),
+        }
+    }
+
+    #[tracing::instrument(skip(self), err)]
+    async fn create_aggregation_jobs_for_task_no_param<A: vdaf::Aggregator<AggregationParam = ()>>(
+        &self,
+        task: &Task,
+    ) -> anyhow::Result<()>
+    where
+        for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
+        A::PrepareStep: Send + Sync + Encode,
+        A::OutputShare: Send + Sync,
+        for<'a> &'a A::OutputShare: Into<Vec<u8>>,
+    {
+        let task_id = task.id;
+        let min_batch_duration = task.min_batch_duration;
+        let current_batch_unit_start = self
+            .clock
+            .now()
+            .to_batch_unit_interval_start(min_batch_duration)?;
+
+        let min_aggregation_job_size = self.min_aggregation_job_size;
+        let max_aggregation_job_size = self.max_aggregation_job_size;
+
+        Ok(self
+            .datastore
+            .run_tx(|tx| {
+                Box::pin(async move {
+                    // Find some unaggregated client reports, and group them by their batch unit.
+                    let nonces_by_batch_unit = tx
+                        .get_unaggregated_client_report_nonces_for_task(task_id)
+                        .await?
+                        .into_iter()
+                        .map(|nonce| {
+                            nonce
+                                .time
+                                .to_batch_unit_interval_start(min_batch_duration)
+                                .map(|s| (s, nonce))
+                                .map_err(datastore::Error::from)
+                        })
+                        .collect::<Result<Vec<(Time, Nonce)>, _>>()?
+                        .into_iter()
+                        .into_group_map();
+
+                    // Generate aggregation jobs & report aggregations based on the reports we read.
+                    let mut agg_jobs = Vec::new();
+                    let mut report_aggs = Vec::new();
+                    for (batch_unit_start, nonces) in nonces_by_batch_unit {
+                        for agg_job_nonces in nonces.chunks(max_aggregation_job_size) {
+                            if batch_unit_start >= current_batch_unit_start
+                                && agg_job_nonces.len() < min_aggregation_job_size
+                            {
+                                continue;
+                            }
+
+                            let aggregation_job_id = AggregationJobId::random();
+                            debug!(
+                                ?task_id,
+                                ?aggregation_job_id,
+                                report_count = agg_job_nonces.len(),
+                                "Creating aggregation job"
+                            );
+                            agg_jobs.push(AggregationJob::<A> {
                                 aggregation_job_id,
                                 task_id,
-                                nonce: *nonce,
-                                ord: i64::try_from(ord)?,
-                                state: ReportAggregationState::Start,
+                                aggregation_param: (),
+                                state: AggregationJobState::InProgress,
                             });
+
+                            for (ord, nonce) in agg_job_nonces.iter().enumerate() {
+                                report_aggs.push(ReportAggregation::<A> {
+                                    aggregation_job_id,
+                                    task_id,
+                                    nonce: *nonce,
+                                    ord: i64::try_from(ord)?,
+                                    state: ReportAggregationState::Start,
+                                });
+                            }
                         }
                     }
-                }
 
-                // XXX
+                    // Write the aggregation jobs & report aggregations we created.
+                    try_join_all(
+                        agg_jobs
+                            .iter()
+                            .map(|agg_job| tx.put_aggregation_job(agg_job)),
+                    )
+                    .await?;
+                    try_join_all(
+                        report_aggs
+                            .iter()
+                            .map(|report_agg| tx.put_report_aggregation(report_agg)),
+                    )
+                    .await?;
+
+                    Ok(())
+                })
+            })
+            .await?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::AggregationJobCreator;
+    use chrono::NaiveDateTime;
+    use futures::{future::try_join_all, TryFutureExt};
+    use janus_server::{
+        datastore::{Crypter, Datastore, Transaction},
+        message::{
+            test_util::new_dummy_report, AggregationJobId, Nonce, Report, Role, TaskId, Time,
+        },
+        task::{test_util::new_dummy_task, Vdaf},
+        time::{test_util::MockClock, Clock},
+        trace::test_util::install_test_trace_subscriber,
+    };
+    use prio::vdaf::{prio3::Prio3Aes128Count, Vdaf as _};
+    use std::{
+        collections::{HashMap, HashSet},
+        iter,
+        sync::Arc,
+        time::Duration,
+    };
+    use tokio::{task, time};
+
+    test_util::define_ephemeral_datastore!();
+
+    #[test]
+    fn cli_tests() {
+        trycmd::TestCases::new()
+            .case("tests/cmd/aggregation_job_creator.trycmd")
+            .run();
+    }
+
+    #[tokio::test]
+    async fn aggregation_job_creator() {
+        // This is a minimal test that AggregationJobCreator::run() will successfully find tasks &
+        // trigger creation of aggregation jobs. More detailed tests of the aggregation job creation
+        // logic are contained in other tests which do not exercise the task-lookup code.
+
+        // Setup.
+        install_test_trace_subscriber();
+        let (ds, _db_handle) = ephemeral_datastore().await;
+
+        // TODO(brandon): consider using tokio::time::pause() to make time deterministic, and allow
+        // this test to run without the need for a (racy, wallclock-consuming) real sleep.
+        // Unfortunately, at time of writing this TODO, calling time::pause() breaks interaction
+        // with the database -- the task-loader transaction deadlocks on attempting to start a
+        // transaction, even if the main test loops on calling yield_now().
+
+        let report_time = Time::from_naive_date_time(NaiveDateTime::from_timestamp(0, 0));
+
+        let leader_task_id = TaskId::random();
+        let leader_task = new_dummy_task(leader_task_id, Vdaf::Prio3Aes128Count, Role::Leader);
+        let leader_report = new_dummy_report(leader_task_id, report_time);
+
+        let helper_task_id = TaskId::random();
+        let helper_task = new_dummy_task(helper_task_id, Vdaf::Prio3Aes128Count, Role::Helper);
+        let helper_report = new_dummy_report(helper_task_id, report_time);
+
+        ds.run_tx(|tx| {
+            let (leader_task, helper_task) = (leader_task.clone(), helper_task.clone());
+            let (leader_report, helper_report) = (leader_report.clone(), helper_report.clone());
+            Box::pin(async move {
+                tx.put_task(&leader_task).await?;
+                tx.put_task(&helper_task).await?;
+
+                tx.put_client_report(&leader_report).await?;
+                tx.put_client_report(&helper_report).await
+            })
+        })
+        .await
+        .unwrap();
+
+        // Create & run the aggregation job creator, give it long enough to create tasks, and then
+        // kill it.
+        const AGGREGATION_JOB_CREATION_INTERVAL: Duration = Duration::from_secs(1);
+        let job_creator = Arc::new(AggregationJobCreator {
+            datastore: ds,
+            clock: MockClock::default(),
+            tasks_update_frequency: Duration::from_secs(3600),
+            aggregation_job_creation_interval: AGGREGATION_JOB_CREATION_INTERVAL,
+            min_aggregation_job_size: 0,
+            max_aggregation_job_size: 100,
+        });
+        let task_handle = task::spawn({
+            let job_creator = job_creator.clone();
+            async move { job_creator.run().await }
+        });
+        time::sleep(5 * AGGREGATION_JOB_CREATION_INTERVAL).await;
+        task_handle.abort();
+
+        // Inspect database state to verify that the expected aggregation jobs were created.
+        let (leader_agg_jobs, helper_agg_jobs) = job_creator
+            .datastore
+            .run_tx(|tx| {
+                Box::pin(async move {
+                    let leader_agg_jobs =
+                        read_aggregate_jobs_for_task::<HashSet<_>>(tx, leader_task_id).await;
+                    let helper_agg_jobs =
+                        read_aggregate_jobs_for_task::<HashSet<_>>(tx, helper_task_id).await;
+                    Ok((leader_agg_jobs, helper_agg_jobs))
+                })
+            })
+            .await
+            .unwrap();
+        assert!(helper_agg_jobs.is_empty());
+        assert_eq!(leader_agg_jobs.len(), 1);
+        let nonces = leader_agg_jobs.into_iter().next().unwrap().1;
+        assert_eq!(nonces, HashSet::from([leader_report.nonce]));
+    }
+
+    #[tokio::test]
+    async fn create_aggregation_jobs_for_task() {
+        // Setup.
+        let (ds, _db_handle) = ephemeral_datastore().await;
+        let clock = MockClock::default();
+
+        const MIN_AGGREGATION_JOB_SIZE: usize = 50;
+        const MAX_AGGREGATION_JOB_SIZE: usize = 60;
+
+        // Sanity check the constant values provided.
+        #[allow(clippy::assertions_on_constants)]
+        {
+            assert!(1 < MIN_AGGREGATION_JOB_SIZE); // we can subtract 1 safely
+            assert!(MIN_AGGREGATION_JOB_SIZE < MAX_AGGREGATION_JOB_SIZE);
+            assert!(MAX_AGGREGATION_JOB_SIZE < usize::MAX); // we can add 1 safely
+        }
+
+        let task_id = TaskId::random();
+        let task = new_dummy_task(task_id, Vdaf::Prio3Aes128Count, Role::Leader);
+        let current_batch_unit = clock
+            .now()
+            .to_batch_unit_interval_start(task.min_batch_duration)
+            .unwrap();
+
+        // In the current batch unit, create MIN_AGGREGATION_JOB_SIZE reports. We expect an
+        // aggregation job to be created containing these reports.
+        let report_time = clock.now();
+        let cur_batch_unit_reports: Vec<Report> =
+            iter::repeat_with(|| new_dummy_report(task_id, report_time))
+                .take(MIN_AGGREGATION_JOB_SIZE)
+                .collect();
+
+        // In a previous "small" batch unit, create fewer than MIN_AGGREGATION_JOB_SIZE reports.
+        // Since the minimum aggregation job size applies only to the current batch window, we
+        // expect an aggregation job to be created for these reports.
+        let report_time = report_time.sub(task.min_batch_duration).unwrap();
+        let small_batch_unit_reports: Vec<Report> =
+            iter::repeat_with(|| new_dummy_report(task_id, report_time))
+                .take(MIN_AGGREGATION_JOB_SIZE - 1)
+                .collect();
+
+        // In a (separate) previous "big" batch unit, create more than MAX_AGGREGATION_JOB_SIZE
+        // reports. We expect these reports will be split into more than one aggregation job.
+        let report_time = report_time.sub(task.min_batch_duration).unwrap();
+        let big_batch_unit_reports: Vec<Report> =
+            iter::repeat_with(|| new_dummy_report(task_id, report_time))
+                .take(MAX_AGGREGATION_JOB_SIZE + 1)
+                .collect();
+
+        let all_nonces: HashSet<Nonce> = cur_batch_unit_reports
+            .iter()
+            .chain(&small_batch_unit_reports)
+            .chain(&big_batch_unit_reports)
+            .map(|report| report.nonce)
+            .collect();
+
+        ds.run_tx(|tx| {
+            let task = task.clone();
+            let (cur_batch_unit_reports, small_batch_unit_reports, big_batch_unit_reports) = (
+                cur_batch_unit_reports.clone(),
+                small_batch_unit_reports.clone(),
+                big_batch_unit_reports.clone(),
+            );
+            Box::pin(async move {
+                tx.put_task(&task).await?;
+                for report in cur_batch_unit_reports
+                    .iter()
+                    .chain(&small_batch_unit_reports)
+                    .chain(&big_batch_unit_reports)
+                {
+                    tx.put_client_report(report).await?;
+                }
                 Ok(())
             })
         })
-        .await?)
+        .await
+        .unwrap();
+
+        // Run.
+        let job_creator = AggregationJobCreator {
+            datastore: ds,
+            clock,
+            tasks_update_frequency: Duration::from_secs(3600),
+            aggregation_job_creation_interval: Duration::from_secs(1),
+            min_aggregation_job_size: MIN_AGGREGATION_JOB_SIZE,
+            max_aggregation_job_size: MAX_AGGREGATION_JOB_SIZE,
+        };
+        job_creator
+            .create_aggregation_jobs_for_task(&task)
+            .await
+            .unwrap();
+
+        // Verify.
+        let agg_jobs = job_creator
+            .datastore
+            .run_tx(|tx| {
+                Box::pin(
+                    async move { Ok(read_aggregate_jobs_for_task::<Vec<_>>(tx, task_id).await) },
+                )
+            })
+            .await
+            .unwrap();
+        let mut seen_nonces = HashSet::new();
+        for (_, nonces) in agg_jobs {
+            // All nonces for aggregation job are in the same batch unit.
+            let batch_units: HashSet<Time> = nonces
+                .iter()
+                .map(|nonce| {
+                    nonce
+                        .time
+                        .to_batch_unit_interval_start(task.min_batch_duration)
+                        .unwrap()
+                })
+                .collect();
+            assert_eq!(batch_units.len(), 1);
+            let batch_unit = batch_units.into_iter().next().unwrap();
+
+            // The batch is at most MAX_AGGREGATION_JOB_SIZE in size.
+            assert!(nonces.len() <= MAX_AGGREGATION_JOB_SIZE);
+
+            // If we are in the current batch unit, the batch is at least MIN_AGGREGATION_JOB_SIZE in size.
+            assert!(batch_unit < current_batch_unit || nonces.len() >= MIN_AGGREGATION_JOB_SIZE);
+
+            // Nonces are non-repeated across or inside aggregation jobs.
+            for nonce in nonces {
+                assert!(!seen_nonces.contains(&nonce));
+                seen_nonces.insert(nonce);
+            }
+        }
+
+        // Every client report was added to some aggregation job.
+        assert_eq!(all_nonces, seen_nonces);
+    }
+
+    #[tokio::test]
+    async fn create_aggregation_jobs_for_task_not_enough_reports() {
+        // Setup.
+        let (ds, _db_handle) = ephemeral_datastore().await;
+        let clock = MockClock::default();
+
+        let task_id = TaskId::random();
+        let task = new_dummy_task(task_id, Vdaf::Prio3Aes128Count, Role::Leader);
+        let first_report = new_dummy_report(task_id, clock.now());
+        let second_report = new_dummy_report(task_id, clock.now());
+
+        ds.run_tx(|tx| {
+            let (task, first_report) = (task.clone(), first_report.clone());
+            Box::pin(async move {
+                tx.put_task(&task).await?;
+                tx.put_client_report(&first_report).await
+            })
+        })
+        .await
+        .unwrap();
+
+        // Run.
+        let job_creator = AggregationJobCreator {
+            datastore: ds,
+            clock,
+            tasks_update_frequency: Duration::from_secs(3600),
+            aggregation_job_creation_interval: Duration::from_secs(1),
+            min_aggregation_job_size: 2,
+            max_aggregation_job_size: 100,
+        };
+        job_creator
+            .create_aggregation_jobs_for_task(&task)
+            .await
+            .unwrap();
+
+        // Verify -- we haven't received enough reports yet, so we don't create anything.
+        let agg_jobs = job_creator
+            .datastore
+            .run_tx(|tx| {
+                Box::pin(async move {
+                    Ok(read_aggregate_jobs_for_task::<HashSet<_>>(tx, task_id).await)
+                })
+            })
+            .await
+            .unwrap();
+        assert!(agg_jobs.is_empty());
+
+        // Setup again -- add another report.
+        job_creator
+            .datastore
+            .run_tx(|tx| {
+                let second_report = second_report.clone();
+                Box::pin(async move { tx.put_client_report(&second_report).await })
+            })
+            .await
+            .unwrap();
+
+        // Run.
+        job_creator
+            .create_aggregation_jobs_for_task(&task)
+            .await
+            .unwrap();
+
+        // Verify -- the additional report we wrote allows an aggregation job to be created.
+        let agg_jobs = job_creator
+            .datastore
+            .run_tx(|tx| {
+                Box::pin(async move {
+                    Ok(read_aggregate_jobs_for_task::<HashSet<_>>(tx, task_id).await)
+                })
+            })
+            .await
+            .unwrap();
+        assert_eq!(agg_jobs.len(), 1);
+        let nonces = agg_jobs.into_iter().next().unwrap().1;
+        assert_eq!(
+            nonces,
+            HashSet::from([first_report.nonce, second_report.nonce])
+        );
+    }
+
+    // Test helper function that reads all aggregation jobs for a given task ID, returning a map
+    // from aggregation job ID to the report nonces included in the aggregation job. The container
+    // used to store the nonces is up to the caller; ordered containers will store nonces in the
+    // order they are included in the aggregate job.
+    async fn read_aggregate_jobs_for_task<T: FromIterator<Nonce>>(
+        tx: &Transaction<'_>,
+        task_id: TaskId,
+    ) -> HashMap<AggregationJobId, T> {
+        // For this test, all of the report aggregations will be in the Start state, so the verify
+        // parameter effectively does not matter.
+        let verify_param = Prio3Aes128Count::new(2)
+            .unwrap()
+            .setup()
+            .unwrap()
+            .1
+            .remove(0);
+
+        try_join_all(
+            tx.get_aggregation_jobs_for_task_id::<Prio3Aes128Count>(task_id)
+                .await
+                .unwrap()
+                .into_iter()
+                .map(|agg_job| {
+                    tx.get_report_aggregations_for_aggregation_job::<Prio3Aes128Count>(
+                        &verify_param,
+                        task_id,
+                        agg_job.aggregation_job_id,
+                    )
+                    .map_ok(move |report_aggs| (agg_job.aggregation_job_id, report_aggs))
+                }),
+        )
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|(agg_job_id, report_aggs)| {
+            (
+                agg_job_id,
+                report_aggs.into_iter().map(|ra| ra.nonce).collect::<T>(),
+            )
+        })
+        .collect()
+    }
 }

--- a/janus_server/src/bin/aggregator.rs
+++ b/janus_server/src/bin/aggregator.rs
@@ -37,8 +37,8 @@ struct Options {
     )]
     config_file: PathBuf,
 
-    /// Password for the PostgreSQL database connection. (if not included in the connection
-    /// string)
+    /// Password for the PostgreSQL database connection. If specified, must not be specified in the
+    /// connection string.
     #[structopt(long, env = "PGPASSWORD", help = "PostgreSQL password")]
     database_password: Option<String>,
 

--- a/janus_server/src/bin/aggregator.rs
+++ b/janus_server/src/bin/aggregator.rs
@@ -169,13 +169,3 @@ async fn main() -> Result<()> {
 
     Ok(())
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn cli_tests() {
-        trycmd::TestCases::new()
-            .case("tests/cmd/aggregator.trycmd")
-            .run();
-    }
-}

--- a/janus_server/src/binary_utils.rs
+++ b/janus_server/src/binary_utils.rs
@@ -1,0 +1,56 @@
+//! Utilities for Janus binaries.
+
+use crate::{
+    config::DbConfig,
+    datastore::{Crypter, Datastore},
+};
+use anyhow::{anyhow, Context, Result};
+use deadpool_postgres::{Manager, Pool};
+use ring::aead::{LessSafeKey, UnboundKey, AES_128_GCM};
+use std::str::FromStr;
+use tokio_postgres::NoTls;
+
+pub fn datastore(
+    db_config: DbConfig,
+    db_password: Option<String>,
+    ds_keys: Vec<String>,
+) -> Result<Datastore> {
+    let mut database_config = tokio_postgres::Config::from_str(db_config.url.as_str())
+        .with_context(|| {
+            format!(
+                "couldn't parse database connect string: {:?}",
+                db_config.url
+            )
+        })?;
+    if database_config.get_password().is_some() && db_password.is_some() {
+        return Err(anyhow!(
+            "Database config & password override are both specified"
+        ));
+    }
+    if let Some(pass) = db_password {
+        database_config.password(pass);
+    }
+
+    let conn_mgr = Manager::new(database_config, NoTls);
+    let pool = Pool::builder(conn_mgr)
+        .build()
+        .context("failed to create database connection pool")?;
+    let ds_keys = ds_keys
+        .into_iter()
+        .filter(|k| !k.is_empty())
+        .map(|k| {
+            base64::decode_config(k, base64::STANDARD_NO_PAD)
+                .context("couldn't base64-decode datastore keys")
+                .and_then(|k| {
+                    Ok(LessSafeKey::new(
+                        UnboundKey::new(&AES_128_GCM, &k)
+                            .map_err(|_| anyhow!("coulnd't parse datastore keys as keys"))?,
+                    ))
+                })
+        })
+        .collect::<Result<Vec<LessSafeKey>>>()?;
+    if ds_keys.is_empty() {
+        return Err(anyhow!("ds_keys is empty"));
+    }
+    Ok(Datastore::new(pool, Crypter::new(ds_keys)))
+}

--- a/janus_server/src/client.rs
+++ b/janus_server/src/client.rs
@@ -220,7 +220,7 @@ mod tests {
     use super::*;
     use crate::{
         hpke::test_util::generate_hpke_config_and_private_key, message::TaskId,
-        time::tests::MockClock, trace::test_util::install_test_trace_subscriber,
+        time::test_util::MockClock, trace::test_util::install_test_trace_subscriber,
     };
     use assert_matches::assert_matches;
     use mockito::mock;

--- a/janus_server/src/config.rs
+++ b/janus_server/src/config.rs
@@ -59,6 +59,10 @@ pub struct AggregatorConfig {
 ///   url: "postgres://postgres:postgres@localhost:5432/postgres"
 /// logging_config: # logging_config is optional
 ///   force_json_output: true
+/// tasks_update_frequency_secs: 3600
+/// aggregation_job_creation_interval_secs: 60
+/// min_aggregation_job_size: 100
+/// max_aggregation_job_size: 1000
 /// "#;
 ///
 /// let _decoded: AggregationJobCreatorConfig = serde_yaml::from_str(yaml_config).unwrap();
@@ -70,6 +74,16 @@ pub struct AggregationJobCreatorConfig {
     /// Logging configuration.
     #[serde(default)]
     pub logging_config: TraceConfiguration,
+    /// How frequently we look for new tasks to start creating aggregation jobs for, in seconds.
+    pub tasks_update_frequency_secs: u64,
+    /// How frequently we attempt to create new aggregation jobs for each task, in seconds.
+    pub aggregation_job_creation_interval_secs: u64,
+    /// The minimum number of client reports to include in an aggregation job. Applies to the
+    /// "current" batch unit only; historical batch units will create aggregation jobs of any size,
+    /// on the theory that almost all reports will have be received for these batch units already.
+    pub min_aggregation_job_size: usize,
+    /// The maximum number of client reports to include in an aggregation job.
+    pub max_aggregation_job_size: usize,
 }
 
 #[cfg(test)]
@@ -109,6 +123,10 @@ mod tests {
         let config = AggregationJobCreatorConfig {
             database: generate_db_config(),
             logging_config: TraceConfiguration::default(),
+            tasks_update_frequency_secs: 3600,
+            aggregation_job_creation_interval_secs: 60,
+            min_aggregation_job_size: 100,
+            max_aggregation_job_size: 1000,
         };
 
         let encoded = serde_yaml::to_string(&config).unwrap();

--- a/janus_server/src/config.rs
+++ b/janus_server/src/config.rs
@@ -126,7 +126,7 @@ mod tests {
             tasks_update_frequency_secs: 3600,
             aggregation_job_creation_interval_secs: 60,
             min_aggregation_job_size: 100,
-            max_aggregation_job_size: 1000,
+            max_aggregation_job_size: 500,
         };
 
         let encoded = serde_yaml::to_string(&config).unwrap();

--- a/janus_server/src/config.rs
+++ b/janus_server/src/config.rs
@@ -41,7 +41,33 @@ pub struct AggregatorConfig {
     pub listen_address: SocketAddr,
     /// The aggregator's database configuration.
     pub database: DbConfig,
-    /// Logging configuration
+    /// Logging configuration.
+    #[serde(default)]
+    pub logging_config: TraceConfiguration,
+}
+
+/// Non-secret configuration options for the Janus Aggregation Job Creator job.
+///
+/// # Examples
+///
+/// ```
+/// use janus_server::config::AggregationJobCreatorConfig;
+///
+/// let yaml_config = r#"
+/// ---
+/// database:
+///   url: "postgres://postgres:postgres@localhost:5432/postgres"
+/// logging_config: # logging_config is optional
+///   force_json_output: true
+/// "#;
+///
+/// let _decoded: AggregationJobCreatorConfig = serde_yaml::from_str(yaml_config).unwrap();
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AggregationJobCreatorConfig {
+    /// Configuration for the database backend to connect to.
+    pub database: DbConfig,
+    /// Logging configuration.
     #[serde(default)]
     pub logging_config: TraceConfiguration,
 }
@@ -76,5 +102,17 @@ mod tests {
         let encoded = serde_yaml::to_string(&aggregator_config).unwrap();
         let decoded: AggregatorConfig = serde_yaml::from_str(&encoded).unwrap();
         assert_eq!(aggregator_config, decoded);
+    }
+
+    #[test]
+    fn roundtrip_aggregation_job_creator_config() {
+        let config = AggregationJobCreatorConfig {
+            database: generate_db_config(),
+            logging_config: TraceConfiguration::default(),
+        };
+
+        let encoded = serde_yaml::to_string(&config).unwrap();
+        let decoded_config: AggregationJobCreatorConfig = serde_yaml::from_str(&encoded).unwrap();
+        assert_eq!(config, decoded_config);
     }
 }

--- a/janus_server/src/config.rs
+++ b/janus_server/src/config.rs
@@ -62,7 +62,7 @@ pub struct AggregatorConfig {
 /// tasks_update_frequency_secs: 3600
 /// aggregation_job_creation_interval_secs: 60
 /// min_aggregation_job_size: 100
-/// max_aggregation_job_size: 1000
+/// max_aggregation_job_size: 500
 /// "#;
 ///
 /// let _decoded: AggregationJobCreatorConfig = serde_yaml::from_str(yaml_config).unwrap();

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -480,7 +480,7 @@ impl Transaction<'_> {
         &self,
         task_id: TaskId,
     ) -> Result<Vec<Nonce>, Error> {
-        // We choose to return the newest client reports first (LIFO). The goal is to maintiain
+        // We choose to return the newest client reports first (LIFO). The goal is to maintain
         // throughput even if we begin to fall behind enough that reports are too old to be
         // aggregated.
         //

--- a/janus_server/src/lib.rs
+++ b/janus_server/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::too_many_arguments)]
 
 pub mod aggregator;
+pub mod binary_utils;
 pub mod client;
 pub mod config;
 pub mod datastore;

--- a/janus_server/src/message.rs
+++ b/janus_server/src/message.rs
@@ -215,7 +215,7 @@ impl Time {
         NaiveDateTime::from_timestamp(self.0 as i64, 0)
     }
 
-    pub(crate) fn from_naive_date_time(time: NaiveDateTime) -> Self {
+    pub fn from_naive_date_time(time: NaiveDateTime) -> Self {
         Self(time.timestamp() as u64)
     }
 
@@ -228,8 +228,7 @@ impl Time {
     }
 
     /// Subtract the provided duration from this time.
-    #[cfg(test)]
-    pub(crate) fn sub(&self, duration: Duration) -> Result<Self, Error> {
+    pub fn sub(&self, duration: Duration) -> Result<Self, Error> {
         self.0
             .checked_sub(duration.0)
             .map(Self)
@@ -899,8 +898,14 @@ impl Decode for TransitionError {
 }
 
 /// PPM protocol message representing an identifier for an aggregation job.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AggregationJobId(pub(crate) [u8; Self::ENCODED_LEN]);
+
+impl Debug for AggregationJobId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", hex::encode(self.0))
+    }
+}
 
 impl Encode for AggregationJobId {
     fn encode(&self, bytes: &mut Vec<u8>) {
@@ -1133,6 +1138,24 @@ impl Decode for CollectResp {
         Ok(Self {
             encrypted_agg_shares,
         })
+    }
+}
+
+#[doc(hidden)]
+pub mod test_util {
+    use super::{Nonce, Report, TaskId, Time};
+    use rand::{thread_rng, Rng};
+
+    pub fn new_dummy_report(task_id: TaskId, when: Time) -> Report {
+        Report {
+            task_id,
+            nonce: Nonce {
+                time: when,
+                rand: thread_rng().gen(),
+            },
+            extensions: Vec::new(),
+            encrypted_input_shares: Vec::new(),
+        }
     }
 }
 

--- a/janus_server/src/task.rs
+++ b/janus_server/src/task.rs
@@ -49,16 +49,6 @@ pub enum Vdaf {
     FakeFailsPrepStep,
 }
 
-impl Vdaf {
-    /// Determines whether the VDAF has a non-empty aggregation parameter.
-    pub fn has_aggregation_param(&self) -> bool {
-        match self {
-            Vdaf::Poplar1 { .. } => true,
-            _ => false,
-        }
-    }
-}
-
 /// An HMAC-SHA-256 key used to authenticate messages exchanged between
 /// aggregators. See `agg_auth_key` in draft-gpew-priv-ppm §4.2.
 // We define the type this way because while we can use `ring::hmac::Key::new`
@@ -138,7 +128,7 @@ pub struct Task {
     pub(crate) min_batch_size: u64,
     /// The minimum batch interval for a collect request. Batch intervals must
     /// be multiples of this duration.
-    pub(crate) min_batch_duration: Duration,
+    pub min_batch_duration: Duration,
     /// How much clock skew to allow between client and aggregator. Reports from
     /// farther than this duration into the future will be rejected.
     pub(crate) tolerable_clock_skew: Duration,

--- a/janus_server/src/task.rs
+++ b/janus_server/src/task.rs
@@ -58,6 +58,16 @@ pub enum Vdaf {
     FakeFailsPrepStep,
 }
 
+impl Vdaf {
+    /// Determines whether the VDAF has a non-empty aggregation parameter.
+    pub fn has_aggregation_param(&self) -> bool {
+        match self {
+            Vdaf::Poplar1 => true,
+            _ => false,
+        }
+    }
+}
+
 /// An HMAC-SHA-256 key used to authenticate messages exchanged between
 /// aggregators. See `agg_auth_key` in draft-gpew-priv-ppm §4.2.
 // We define the type this way because while we can use `ring::hmac::Key::new`
@@ -117,13 +127,13 @@ impl Eq for AggregatorAuthKey {}
 /// The parameters for a PPM task, corresponding to draft-gpew-priv-ppm §4.2.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Task {
-    /// Unique identifier for the task
-    pub(crate) id: TaskId,
+    /// Unique identifier for the task.
+    pub id: TaskId,
     /// URLs relative to which aggregator API endpoints are found. The first
     /// entry is the leader's.
     pub(crate) aggregator_endpoints: Vec<Url>,
     /// The VDAF this task executes.
-    pub(crate) vdaf: Vdaf,
+    pub vdaf: Vdaf,
     /// The role performed by the aggregator.
     pub(crate) role: Role,
     /// Secret verification parameter shared by the aggregators.

--- a/janus_server/src/task.rs
+++ b/janus_server/src/task.rs
@@ -119,7 +119,7 @@ pub struct Task {
     /// The VDAF this task executes.
     pub vdaf: Vdaf,
     /// The role performed by the aggregator.
-    pub(crate) role: Role,
+    pub role: Role,
     /// Secret verification parameter shared by the aggregators.
     pub(crate) vdaf_verify_parameter: Vec<u8>,
     /// The maximum number of times a given batch may be collected.

--- a/janus_server/src/time.rs
+++ b/janus_server/src/time.rs
@@ -26,15 +26,16 @@ impl Debug for RealClock {
     }
 }
 
-#[cfg(test)]
-pub(crate) mod tests {
-    use super::*;
-    use chrono::naive::NaiveDate;
+#[doc(hidden)]
+pub mod test_util {
+    use super::Clock;
+    use crate::message::Time;
+    use chrono::{NaiveDate, NaiveDateTime};
 
     /// A mock clock for use in testing.
     #[derive(Clone, Debug)]
-    pub(crate) struct MockClock {
-        /// The fake time that this clock will always return from [`Self::now`]
+    pub struct MockClock {
+        /// The time that this clock will always return from [`Self::now`]
         pub(crate) current_time: NaiveDateTime,
     }
 

--- a/janus_server/src/trace.rs
+++ b/janus_server/src/trace.rs
@@ -233,15 +233,17 @@ pub fn cleanup_trace_subscriber(_config: &TraceConfiguration) {
     }
 }
 
-#[cfg(test)]
-pub(crate) mod test_util {
+#[doc(hidden)]
+pub mod test_util {
     use super::*;
     use std::sync::Once;
 
-    /// install_test_trace_subscriber installs a tracing subscriber suitable for
-    /// tests. It should be called at the beginning of any test that requires a
-    /// tracing subscriber.
-    pub(crate) fn install_test_trace_subscriber() {
+    /// install_test_trace_subscriber installs a tracing subscriber suitable for tests. It should be
+    /// called at the beginning of any test that requires a tracing subscriber.
+    ///
+    /// To see output, you will need to set the RUST_LOG environment variable appropriately.
+    /// See https://docs.rs/tracing-subscriber/latest/tracing_subscriber/struct.EnvFilter.html.
+    pub fn install_test_trace_subscriber() {
         static INSTALL_TRACE_SUBSCRIBER: Once = Once::new();
         INSTALL_TRACE_SUBSCRIBER.call_once(|| {
             install_trace_subscriber(&TraceConfiguration {

--- a/janus_server/tests/cmd/aggregation_job_creator.trycmd
+++ b/janus_server/tests/cmd/aggregation_job_creator.trycmd
@@ -1,0 +1,20 @@
+```
+$ aggregation_job_creator --help
+janus-aggregation-job-creator 0.1.0
+Janus aggregation job creator
+
+USAGE:
+    aggregation_job_creator [OPTIONS] --config-file <config-file> --datastore-keys <datastore-keys>...
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+        --config-file <config-file>                path to configuration file [env: CONFIG_FILE=]
+        --database-password <database-password>    PostgreSQL password [env: PGPASSWORD=]
+        --datastore-keys <datastore-keys>...
+            datastore encryption keys, encoded in base64 then comma-separated [env: DATASTORE_KEYS=]
+
+
+```

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -2,7 +2,7 @@ use rand::{thread_rng, Rng};
 use ring::aead::{LessSafeKey, UnboundKey, AES_128_GCM};
 
 /// The Janus database schema.
-pub const SCHEMA: &str = include_str!("../../db/schema.sql");
+pub static SCHEMA: &str = include_str!("../../db/schema.sql");
 
 /// This macro injects definitions of `DbHandle` and `ephemeral_datastore()`, for use in tests.
 /// It should be invoked once per binary target, and then `ephemeral_datastore()` can be called

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -1,6 +1,9 @@
 use rand::{thread_rng, Rng};
 use ring::aead::{LessSafeKey, UnboundKey, AES_128_GCM};
 
+/// The Janus database schema.
+pub const SCHEMA: &str = include_str!("../../db/schema.sql");
+
 /// This macro injects definitions of `DbHandle` and `ephemeral_datastore()`, for use in tests.
 /// It should be invoked once per binary target, and then `ephemeral_datastore()` can be called
 /// to set up a database for test purposes. This depends on `janus_server::datastore::Datastore`
@@ -10,8 +13,6 @@ use ring::aead::{LessSafeKey, UnboundKey, AES_128_GCM};
 #[macro_export]
 macro_rules! define_ephemeral_datastore {
     () => {
-        const SCHEMA: &str = include_str!("../../db/schema.sql");
-
         ::lazy_static::lazy_static! {
             static ref CONTAINER_CLIENT: ::testcontainers::clients::Cli = ::testcontainers::clients::Cli::default();
         }
@@ -36,7 +37,7 @@ macro_rules! define_ephemeral_datastore {
 
         impl Drop for DbHandle {
             fn drop(&mut self) {
-                ::tracing::trace!("dropping Postgres container with URL {}", self.connection_string);
+                ::tracing::trace!(connection_string = %self.connection_string, "Dropping ephemeral Postgres container");
             }
         }
 
@@ -72,7 +73,7 @@ macro_rules! define_ephemeral_datastore {
 
             // Connect to the database & run our schema.
             let client = pool.get().await.unwrap();
-            client.batch_execute(SCHEMA).await.unwrap();
+            client.batch_execute(::test_util::SCHEMA).await.unwrap();
 
             (
                 Datastore::new(pool, crypter),


### PR DESCRIPTION
The concurrency part was the most challenging piece: I would have liked
to have the task-creation worker (i.e. AggregationJobCreator::run()) be
"tightly linked" to the job-creation workers (i.e.
AggregationJobCreator::run_for_task()) in the sense that a
task-discovery worker shutting down would be noticed & cleaned up
immediately (in a select loop). Sadly, the lifetime/ownership issues
involved made this very challenging. Instead, I settled for a strategy
where the task-discovery worker owns a oneshot sender for each
job-creation worker, and is responsible to notice when a task is no
longer relevant; actual shutdown of the job-creation worker is loosely
coupled and may happen later. This approach is hypothetically racy and
definitely slower to notice a lingering no-longer-existent task, but I
think those issues are marginal enough that this is an acceptable
strategy -- I think the worst outcome we'll see is, if we delete a task,
we'll see its job-creation worker produce errors until the next time the
task-creation worker updates its view of existing tasks.