### PR TITLE
Parameterize BatchUnitAggregation by vdaf::Aggregator.

### DIFF
--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -1063,7 +1063,7 @@ impl VdafOps {
         aggregate_share_req: &AggregateShareReq,
     ) -> Result<AggregateShareResp, Error>
     where
-        A: vdaf::Vdaf,
+        A: vdaf::Aggregator,
         A::AggregationParam: Send + Sync,
         A::AggregateShare: Send + Sync,
         Vec<u8>: for<'a> From<&'a A::AggregateShare>,
@@ -1092,7 +1092,7 @@ impl VdafOps {
                     let aggregation_param =
                         A::AggregationParam::get_decoded(&aggregate_share_req.aggregation_param)?;
                     let batch_unit_aggregations = tx
-                        .get_batch_unit_aggregations_for_task_in_interval::<_, A::AggregateShare, E>(
+                        .get_batch_unit_aggregations_for_task_in_interval::<A>(
                             task.id,
                             aggregate_share_req.batch_interval,
                             &aggregation_param,
@@ -3716,7 +3716,7 @@ mod tests {
         datastore
             .run_tx(|tx| {
                 Box::pin(async move {
-                    tx.put_batch_unit_aggregation(&BatchUnitAggregation {
+                    tx.put_batch_unit_aggregation(&BatchUnitAggregation::<Prio3Aes128Count> {
                         task_id,
                         unit_interval_start: Time(500),
                         aggregation_param,
@@ -3726,7 +3726,7 @@ mod tests {
                     })
                     .await?;
 
-                    tx.put_batch_unit_aggregation(&BatchUnitAggregation {
+                    tx.put_batch_unit_aggregation(&BatchUnitAggregation::<Prio3Aes128Count> {
                         task_id,
                         unit_interval_start: Time(1500),
                         aggregation_param,
@@ -3736,7 +3736,7 @@ mod tests {
                     })
                     .await?;
 
-                    tx.put_batch_unit_aggregation(&BatchUnitAggregation {
+                    tx.put_batch_unit_aggregation(&BatchUnitAggregation::<Prio3Aes128Count> {
                         task_id,
                         unit_interval_start: Time(2000),
                         aggregation_param,


### PR DESCRIPTION
Previously, it was parameterized by various messages, which was
unnecessarily flexible & somewhat confusing. I modified some tests to
work with Poplar1, to allow testing with a non-unit aggregation
parameter.

While working on this I noticed that
get_batch_unit_aggregations_for_task_in_interval assumes a deterministic
encoding for aggregation params, since it does an index lookup based on
the encoded aggregation parameter. I think this is true for all
aggregation parameters today (prio3 uses the unit type which certainly
qualifies; poplar1 uses BTreeSet which has a deterministic iteration
order). We'll need to ensure this remains true in the future to avoid
the potential for weird bugs -- I can't think of a (performant) way to
do better.