### PR TITLE
Represent nonce randomness as opaque byte string.

### DIFF
--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -2548,7 +2548,7 @@ mod tests {
         let report_share = ReportShare {
             nonce: Nonce {
                 time: Time(54321),
-                rand: 314,
+                rand: [1, 2, 3, 4, 5, 6, 7, 8],
             },
             extensions: Vec::new(),
             encrypted_input_share: HpkeCiphertext {
@@ -2787,7 +2787,7 @@ mod tests {
         let aggregation_job_id = AggregationJobId::random();
         let nonce = Nonce {
             time: Time(54321),
-            rand: 314,
+            rand: [1, 2, 3, 4, 5, 6, 7, 8],
         };
         let task = new_dummy_task(task_id, Vdaf::Fake, Role::Helper);
         let (datastore, _db_handle) = ephemeral_datastore().await;
@@ -2888,7 +2888,7 @@ mod tests {
         let aggregation_job_id = AggregationJobId::random();
         let nonce = Nonce {
             time: Time(54321),
-            rand: 314,
+            rand: [1, 2, 3, 4, 5, 6, 7, 8],
         };
         let task = new_dummy_task(task_id, Vdaf::FakeFailsPrepStep, Role::Helper);
         let (datastore, _db_handle) = ephemeral_datastore().await;
@@ -3036,7 +3036,7 @@ mod tests {
         let aggregation_job_id = AggregationJobId::random();
         let nonce = Nonce {
             time: Time(54321),
-            rand: 314,
+            rand: [1, 2, 3, 4, 5, 6, 7, 8],
         };
         let task = new_dummy_task(task_id, Vdaf::Fake, Role::Helper);
         let (datastore, _db_handle) = ephemeral_datastore().await;
@@ -3093,7 +3093,7 @@ mod tests {
                 seq: vec![Transition {
                     nonce: Nonce {
                         time: Time(54321),
-                        rand: 315, // not the same as above
+                        rand: [8, 7, 6, 5, 4, 3, 2, 1], // not the same as above
                     },
                     trans_data: TransitionTypeSpecificData::Continued {
                         payload: Vec::new(),
@@ -3141,11 +3141,11 @@ mod tests {
         let aggregation_job_id = AggregationJobId::random();
         let nonce_0 = Nonce {
             time: Time(54321),
-            rand: 314,
+            rand: [1, 2, 3, 4, 5, 6, 7, 8],
         };
         let nonce_1 = Nonce {
             time: Time(54321),
-            rand: 315,
+            rand: [8, 7, 6, 5, 4, 3, 2, 1],
         };
 
         let task = new_dummy_task(task_id, Vdaf::Fake, Role::Helper);
@@ -3281,7 +3281,7 @@ mod tests {
         let aggregation_job_id = AggregationJobId::random();
         let nonce = Nonce {
             time: Time(54321),
-            rand: 314,
+            rand: [1, 2, 3, 4, 5, 6, 7, 8],
         };
 
         let task = new_dummy_task(task_id, Vdaf::Fake, Role::Helper);
@@ -3339,7 +3339,7 @@ mod tests {
                 seq: vec![Transition {
                     nonce: Nonce {
                         time: Time(54321),
-                        rand: 314,
+                        rand: [1, 2, 3, 4, 5, 6, 7, 8],
                     },
                     trans_data: TransitionTypeSpecificData::Continued {
                         payload: Vec::new(),

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -446,7 +446,7 @@ impl Transaction<'_> {
                     &[
                         /* task_id */ &&task_id.0[..],
                         /* nonce_time */ &nonce.time.as_naive_date_time(),
-                        /* nonce_rand */ &&nonce.rand.to_be_bytes()[..],
+                        /* nonce_rand */ &&nonce.rand[..],
                     ],
                 )
                 .await?,
@@ -472,7 +472,7 @@ impl Transaction<'_> {
     #[tracing::instrument(skip(self), err)]
     pub async fn put_client_report(&self, report: &Report) -> Result<(), Error> {
         let nonce_time = report.nonce.time.as_naive_date_time();
-        let nonce_rand = report.nonce.rand.to_be_bytes();
+        let nonce_rand = report.nonce.rand;
 
         let mut encoded_extensions = Vec::new();
         encode_u16_items(&mut encoded_extensions, &(), &report.extensions);
@@ -516,7 +516,7 @@ impl Transaction<'_> {
         report_share: &ReportShare,
     ) -> Result<(), Error> {
         let nonce_time = report_share.nonce.time.as_naive_date_time();
-        let nonce_rand = report_share.nonce.rand.to_be_bytes();
+        let nonce_rand = report_share.nonce.rand;
 
         let stmt = self
             .tx
@@ -653,7 +653,7 @@ impl Transaction<'_> {
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
         let nonce_time = nonce.time.as_naive_date_time();
-        let nonce_rand = &nonce.rand.to_be_bytes()[..];
+        let nonce_rand = &nonce.rand[..];
 
         let stmt = self
             .tx
@@ -736,7 +736,7 @@ impl Transaction<'_> {
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
         let nonce_time = report_aggregation.nonce.time.as_naive_date_time();
-        let nonce_rand = &report_aggregation.nonce.rand.to_be_bytes()[..];
+        let nonce_rand = &report_aggregation.nonce.rand[..];
         let state_code = report_aggregation.state.state_code();
         let (vdaf_message, error_code) = match &report_aggregation.state {
             ReportAggregationState::Start => (None, None),
@@ -784,7 +784,7 @@ impl Transaction<'_> {
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
         let nonce_time = report_aggregation.nonce.time.as_naive_date_time();
-        let nonce_rand = &report_aggregation.nonce.rand.to_be_bytes()[..];
+        let nonce_rand = &report_aggregation.nonce.rand[..];
         let state_code = report_aggregation.state.state_code();
         let (vdaf_message, error_code) = match &report_aggregation.state {
             ReportAggregationState::Start => (None, None),
@@ -1050,9 +1050,12 @@ where
     A::OutputShare: for<'a> TryFrom<&'a [u8]>,
     for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
 {
+    let nonce_rand: Vec<u8> = row.get("nonce_rand");
     let nonce = Nonce {
         time: Time::from_naive_date_time(row.get("nonce_time")),
-        rand: row.get_bytea_as_u64("nonce_rand")?,
+        rand: nonce_rand.try_into().map_err(|err| {
+            Error::DbState(format!("couldn't convert nonce_rand value: {0:?}", err))
+        })?,
     };
     let ord: i64 = row.get("ord");
     let state: ReportAggregationStateCode = row.get("state");
@@ -1689,7 +1692,7 @@ mod tests {
             task_id: TaskId::random(),
             nonce: Nonce {
                 time: Time(12345),
-                rand: 54321,
+                rand: [1, 2, 3, 4, 5, 6, 7, 8],
             },
             extensions: vec![
                 Extension {
@@ -1752,7 +1755,7 @@ mod tests {
                         TaskId::random(),
                         Nonce {
                             time: Time(12345),
-                            rand: 54321,
+                            rand: [1, 2, 3, 4, 5, 6, 7, 8],
                         },
                     )
                     .await
@@ -1772,7 +1775,7 @@ mod tests {
         let report_share = ReportShare {
             nonce: Nonce {
                 time: Time(12345),
-                rand: 54321,
+                rand: [1, 2, 3, 4, 5, 6, 7, 8],
             },
             extensions: vec![
                 Extension {
@@ -1810,7 +1813,7 @@ mod tests {
             .run_tx(|tx| {
                 Box::pin(async move {
                     let nonce_time = report_share.nonce.time.as_naive_date_time();
-                    let nonce_rand = report_share.nonce.rand.to_be_bytes();
+                    let nonce_rand = report_share.nonce.rand;
                     let row = tx
                         .tx
                         .query_one(
@@ -1964,7 +1967,7 @@ mod tests {
             let aggregation_job_id = AggregationJobId::random();
             let nonce = Nonce {
                 time: Time(12345),
-                rand: 54321,
+                rand: [1, 2, 3, 4, 5, 6, 7, 8],
             };
 
             let report_aggregation = ds
@@ -2071,7 +2074,7 @@ mod tests {
                         AggregationJobId::random(),
                         Nonce {
                             time: Time(12345),
-                            rand: 54321,
+                            rand: [1, 2, 3, 4, 5, 6, 7, 8],
                         },
                     )
                     .await
@@ -2088,7 +2091,7 @@ mod tests {
                         task_id: TaskId::random(),
                         nonce: Nonce {
                             time: Time(12345),
-                            rand: 54321,
+                            rand: [1, 2, 3, 4, 5, 6, 7, 8],
                         },
                         ord: 0,
                         state: ReportAggregationState::Invalid,
@@ -2144,7 +2147,7 @@ mod tests {
                     {
                         let nonce = Nonce {
                             time: Time(12345),
-                            rand: ord as u64,
+                            rand: (ord as u64).to_be_bytes(),
                         };
                         tx.put_report_share(
                             task_id,

--- a/janus_server/src/message.rs
+++ b/janus_server/src/message.rs
@@ -322,26 +322,27 @@ pub struct Nonce {
     /// The time at which the report was generated.
     pub(crate) time: Time,
     /// A randomly generated value.
-    pub(crate) rand: u64,
+    pub(crate) rand: [u8; 8],
 }
 
 impl Display for Nonce {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}.{}", self.time, self.rand)
+        write!(f, "{}.{}", self.time, hex::encode(self.rand))
     }
 }
 
 impl Encode for Nonce {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.time.encode(bytes);
-        self.rand.encode(bytes);
+        bytes.extend_from_slice(&self.rand);
     }
 }
 
 impl Decode for Nonce {
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
         let time = Time::decode(bytes)?;
-        let rand = u64::decode(bytes)?;
+        let mut rand = [0; 8];
+        bytes.read_exact(&mut rand)?;
 
         Ok(Self { time, rand })
     }
@@ -1163,7 +1164,7 @@ mod tests {
                     ReportShare {
                         nonce: Nonce {
                             time: Time(54321),
-                            rand: 314,
+                            rand: [0u8; 8],
                         },
                         extensions: vec![Extension {
                             extension_type: ExtensionType::Tbd,
@@ -1178,7 +1179,7 @@ mod tests {
                     ReportShare {
                         nonce: Nonce {
                             time: Time(73542),
-                            rand: 515,
+                            rand: [1u8; 8],
                         },
                         extensions: vec![Extension {
                             extension_type: ExtensionType::Tbd,
@@ -1243,7 +1244,7 @@ mod tests {
                 Transition {
                     nonce: Nonce {
                         time: Time(54372),
-                        rand: 53,
+                        rand: [0u8; 8],
                     },
                     trans_data: TransitionTypeSpecificData::Continued {
                         payload: Vec::from("012345"),
@@ -1252,7 +1253,7 @@ mod tests {
                 Transition {
                     nonce: Nonce {
                         time: Time(12345),
-                        rand: 413,
+                        rand: [1u8; 8],
                     },
                     trans_data: TransitionTypeSpecificData::Finished,
                 },
@@ -1554,7 +1555,7 @@ mod tests {
                     task_id: TaskId([u8::MIN; 32]),
                     nonce: Nonce {
                         time: Time(12345),
-                        rand: 413,
+                        rand: [1, 2, 3, 4, 5, 6, 7, 8],
                     },
                     extensions: vec![],
                     encrypted_input_shares: vec![],
@@ -1564,7 +1565,7 @@ mod tests {
                     concat!(
                         // nonce
                         "0000000000003039", // time
-                        "000000000000019D", // rand
+                        "0102030405060708", // rand
                     ),
                     concat!(
                         // extensions
@@ -1581,7 +1582,7 @@ mod tests {
                     task_id: TaskId([u8::MAX; 32]),
                     nonce: Nonce {
                         time: Time(54321),
-                        rand: 314,
+                        rand: [8, 7, 6, 5, 4, 3, 2, 1],
                     },
                     extensions: vec![Extension {
                         extension_type: ExtensionType::Tbd,
@@ -1604,7 +1605,7 @@ mod tests {
                     "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", // task_id
                     concat!(
                         "000000000000D431", // time
-                        "000000000000013A", // rand
+                        "0807060504030201", // rand
                     ),
                     concat!(
                         // extensions
@@ -1699,7 +1700,7 @@ mod tests {
                 Transition {
                     nonce: Nonce {
                         time: Time(54372),
-                        rand: 53,
+                        rand: [1, 2, 3, 4, 5, 6, 7, 8],
                     },
                     trans_data: TransitionTypeSpecificData::Continued {
                         payload: Vec::from("012345"),
@@ -1709,7 +1710,7 @@ mod tests {
                     concat!(
                         // nonce
                         "000000000000D464", // time
-                        "0000000000000035", // rand
+                        "0102030405060708", // rand
                     ),
                     "00", // trans_type
                     concat!(
@@ -1723,7 +1724,7 @@ mod tests {
                 Transition {
                     nonce: Nonce {
                         time: Time(12345),
-                        rand: 413,
+                        rand: [8, 7, 6, 5, 4, 3, 2, 1],
                     },
                     trans_data: TransitionTypeSpecificData::Finished,
                 },
@@ -1731,7 +1732,7 @@ mod tests {
                     concat!(
                         // nonce
                         "0000000000003039", // time
-                        "000000000000019D", // rand
+                        "0807060504030201", // rand
                     ),
                     "01", // trans_type
                 ),
@@ -1740,7 +1741,7 @@ mod tests {
                 Transition {
                     nonce: Nonce {
                         time: Time(345078),
-                        rand: 98345,
+                        rand: [255; 8],
                     },
                     trans_data: TransitionTypeSpecificData::Failed {
                         error: TransitionError::UnrecognizedNonce,
@@ -1750,7 +1751,7 @@ mod tests {
                     concat!(
                         // nonce
                         "00000000000543F6", // time
-                        "0000000000018029", // rand
+                        "FFFFFFFFFFFFFFFF", // rand
                     ),
                     "02", // trans_type
                     "06", // trans_error
@@ -1806,7 +1807,7 @@ mod tests {
                             ReportShare {
                                 nonce: Nonce {
                                     time: Time(54321),
-                                    rand: 314,
+                                    rand: [1, 2, 3, 4, 5, 6, 7, 8],
                                 },
                                 extensions: vec![Extension {
                                     extension_type: ExtensionType::Tbd,
@@ -1821,7 +1822,7 @@ mod tests {
                             ReportShare {
                                 nonce: Nonce {
                                     time: Time(73542),
-                                    rand: 515,
+                                    rand: [8, 7, 6, 5, 4, 3, 2, 1],
                                 },
                                 extensions: vec![Extension {
                                     extension_type: ExtensionType::Tbd,
@@ -1854,7 +1855,7 @@ mod tests {
                                 concat!(
                                     // nonce
                                     "000000000000D431", // time
-                                    "000000000000013A", // rand
+                                    "0102030405060708", // rand
                                 ),
                                 concat!(
                                     // extensions
@@ -1887,7 +1888,7 @@ mod tests {
                                 concat!(
                                     // nonce
                                     "0000000000011F46", // time
-                                    "0000000000000203", // rand
+                                    "0807060504030201", // rand
                                 ),
                                 concat!(
                                     // extensions
@@ -1928,7 +1929,7 @@ mod tests {
                             Transition {
                                 nonce: Nonce {
                                     time: Time(54372),
-                                    rand: 53,
+                                    rand: [1, 2, 3, 4, 5, 6, 7, 8],
                                 },
                                 trans_data: TransitionTypeSpecificData::Continued {
                                     payload: Vec::from("012345"),
@@ -1937,7 +1938,7 @@ mod tests {
                             Transition {
                                 nonce: Nonce {
                                     time: Time(12345),
-                                    rand: 413,
+                                    rand: [8, 7, 6, 5, 4, 3, 2, 1],
                                 },
                                 trans_data: TransitionTypeSpecificData::Finished,
                             },
@@ -1957,7 +1958,7 @@ mod tests {
                                 concat!(
                                     // nonce
                                     "000000000000D464", // time
-                                    "0000000000000035", // rand
+                                    "0102030405060708", // rand
                                 ),
                                 "00", // trans_type
                                 concat!(
@@ -1970,7 +1971,7 @@ mod tests {
                                 concat!(
                                     // nonce
                                     "0000000000003039", // time
-                                    "000000000000019D", // rand
+                                    "0807060504030201", // rand
                                 ),
                                 "01", // trans_type
                             )
@@ -1997,7 +1998,7 @@ mod tests {
                         Transition {
                             nonce: Nonce {
                                 time: Time(54372),
-                                rand: 53,
+                                rand: [1, 2, 3, 4, 5, 6, 7, 8],
                             },
                             trans_data: TransitionTypeSpecificData::Continued {
                                 payload: Vec::from("012345"),
@@ -2006,7 +2007,7 @@ mod tests {
                         Transition {
                             nonce: Nonce {
                                 time: Time(12345),
-                                rand: 413,
+                                rand: [8, 7, 6, 5, 4, 3, 2, 1],
                             },
                             trans_data: TransitionTypeSpecificData::Finished,
                         },
@@ -2019,7 +2020,7 @@ mod tests {
                         concat!(
                             // nonce
                             "000000000000D464", // time
-                            "0000000000000035", // rand
+                            "0102030405060708", // rand
                         ),
                         "00", // trans_type
                         concat!(
@@ -2032,7 +2033,7 @@ mod tests {
                         concat!(
                             // nonce
                             "0000000000003039", // time
-                            "000000000000019D", // rand
+                            "0807060504030201", // rand
                         ),
                         "01", // trans_type
                     ),


### PR DESCRIPTION
Previously, we represented it as a u64. 43f68e38 updated the database
representation to be a byte string; this commit updates the codebase
similarly.