### PR TITLE
Make members of TaskId/AggregationJobId private

### DIFF
--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -117,7 +117,7 @@ impl Transaction<'_> {
 
         let encrypted_vdaf_verify_param = self.crypter.encrypt(
             "tasks",
-            &task.id.0,
+            task.id.as_bytes(),
             "vdaf_verify_param",
             &task.vdaf_verify_parameter,
         )?;
@@ -136,7 +136,7 @@ impl Transaction<'_> {
             .execute(
                 &stmt,
                 &[
-                    &&task.id.0[..],                           // task_id
+                    &task.id.as_bytes(),                       // task_id
                     &aggregator_role,                          // aggregator_role
                     &endpoints,                                // aggregator_endpoints
                     &Json(&task.vdaf),                         // vdaf
@@ -157,7 +157,7 @@ impl Transaction<'_> {
             let ord = i64::try_from(ord)?;
 
             let mut row_id = [0u8; TaskId::ENCODED_LEN + size_of::<i64>()];
-            row_id[..TaskId::ENCODED_LEN].copy_from_slice(&task.id.0[..]);
+            row_id[..TaskId::ENCODED_LEN].copy_from_slice(task.id.as_bytes());
             row_id[TaskId::ENCODED_LEN..].copy_from_slice(&ord.to_be_bytes());
 
             let encrypted_agg_auth_key =
@@ -173,7 +173,7 @@ impl Transaction<'_> {
             )
             .await?;
         let auth_keys_params: &[&(dyn ToSql + Sync)] = &[
-            /* task_id */ &&task.id.0[..],
+            /* task_id */ &task.id.as_bytes(),
             /* ords */ &agg_auth_key_ords,
             /* keys */ &agg_auth_keys,
         ];
@@ -185,7 +185,7 @@ impl Transaction<'_> {
         let mut hpke_private_keys: Vec<Vec<u8>> = Vec::new();
         for (hpke_config, hpke_private_key) in task.hpke_keys.values() {
             let mut row_id = [0u8; TaskId::ENCODED_LEN + size_of::<u8>()];
-            row_id[..TaskId::ENCODED_LEN].copy_from_slice(&task.id.0);
+            row_id[..TaskId::ENCODED_LEN].copy_from_slice(task.id.as_bytes());
             row_id[TaskId::ENCODED_LEN..].copy_from_slice(&hpke_config.id.0.to_be_bytes());
 
             let encrypted_hpke_private_key = self.crypter.encrypt(
@@ -207,7 +207,7 @@ impl Transaction<'_> {
             )
             .await?;
         let hpke_configs_params: &[&(dyn ToSql + Sync)] = &[
-            /* task_id */ &&task.id.0[..],
+            /* task_id */ &task.id.as_bytes(),
             /* config_id */ &hpke_config_ids,
             /* configs */ &hpke_configs,
             /* private_keys */ &hpke_private_keys,
@@ -222,7 +222,7 @@ impl Transaction<'_> {
     /// Fetch the task parameters corresponing to the provided `task_id`.
     #[tracing::instrument(skip(self), err)]
     pub(crate) async fn get_task(&self, task_id: TaskId) -> Result<Option<Task>, Error> {
-        let params: &[&(dyn ToSql + Sync)] = &[&&task_id.0[..]];
+        let params: &[&(dyn ToSql + Sync)] = &[&task_id.as_bytes()];
         let stmt = self
             .tx
             .prepare_cached(
@@ -382,7 +382,7 @@ impl Transaction<'_> {
             let encrypted_agg_auth_key: Vec<u8> = row.get("key");
 
             let mut row_id = [0u8; TaskId::ENCODED_LEN + size_of::<i64>()];
-            row_id[..TaskId::ENCODED_LEN].copy_from_slice(&task_id.0[..]);
+            row_id[..TaskId::ENCODED_LEN].copy_from_slice(task_id.as_bytes());
             row_id[TaskId::ENCODED_LEN..].copy_from_slice(&ord.to_be_bytes());
 
             agg_auth_keys.push(AggregatorAuthKey::new(&self.crypter.decrypt(
@@ -401,7 +401,7 @@ impl Transaction<'_> {
             let encrypted_private_key: Vec<u8> = row.get("private_key");
 
             let mut row_id = [0u8; TaskId::ENCODED_LEN + size_of::<u8>()];
-            row_id[..TaskId::ENCODED_LEN].copy_from_slice(&task_id.0);
+            row_id[..TaskId::ENCODED_LEN].copy_from_slice(task_id.as_bytes());
             row_id[TaskId::ENCODED_LEN..].copy_from_slice(&config_id.to_be_bytes());
 
             let private_key = HpkePrivateKey::new(self.crypter.decrypt(
@@ -449,7 +449,7 @@ impl Transaction<'_> {
             .query_opt(
                 &stmt,
                 &[
-                    /* task_id */ &&task_id.0[..],
+                    /* task_id */ &task_id.as_bytes(),
                     /* nonce_time */ &nonce.time.as_naive_date_time(),
                     /* nonce_rand */ &&nonce.rand[..],
                 ],
@@ -566,8 +566,8 @@ impl Transaction<'_> {
             .query_opt(
                 &stmt,
                 &[
-                    /* task_id */ &&task_id.0[..],
-                    /* aggregation_job_id */ &&aggregation_job_id.0[..],
+                    /* task_id */ &task_id.as_bytes(),
+                    /* aggregation_job_id */ &aggregation_job_id.as_bytes(),
                 ],
             )
             .await?
@@ -603,8 +603,8 @@ impl Transaction<'_> {
             .execute(
                 &stmt,
                 &[
-                    /* aggregation_job_id */ &&aggregation_job.aggregation_job_id.0[..],
-                    /* task_id */ &&aggregation_job.task_id.0[..],
+                    /* aggregation_job_id */ &aggregation_job.aggregation_job_id.as_bytes(),
+                    /* task_id */ &aggregation_job.task_id.as_bytes(),
                     /* aggregation_param */ &aggregation_job.aggregation_param.get_encoded(),
                     /* state */ &aggregation_job.state,
                 ],
@@ -637,8 +637,9 @@ impl Transaction<'_> {
                         /* aggregation_param */
                         &aggregation_job.aggregation_param.get_encoded(),
                         /* state */ &aggregation_job.state,
-                        /* aggregation_job_id */ &&aggregation_job.aggregation_job_id.0[..],
-                        /* task_id */ &&aggregation_job.task_id.0[..],
+                        /* aggregation_job_id */
+                        &aggregation_job.aggregation_job_id.as_bytes(),
+                        /* task_id */ &aggregation_job.task_id.as_bytes(),
                     ],
                 )
                 .await?,
@@ -678,8 +679,8 @@ impl Transaction<'_> {
             .query_opt(
                 &stmt,
                 &[
-                    /* aggregation_job_id */ &&aggregation_job_id.0[..],
-                    /* task_id */ &&task_id.0[..],
+                    /* aggregation_job_id */ &aggregation_job_id.as_bytes(),
+                    /* task_id */ &task_id.as_bytes(),
                     /* nonce_time */ &nonce_time,
                     /* nonce_rand */ &nonce_rand,
                 ],
@@ -718,8 +719,8 @@ impl Transaction<'_> {
             .query(
                 &stmt,
                 &[
-                    /* aggregation_job_id */ &&aggregation_job_id.0[..],
-                    /* task_id */ &&task_id.0[..],
+                    /* aggregation_job_id */ &aggregation_job_id.as_bytes(),
+                    /* task_id */ &task_id.as_bytes(),
                 ],
             )
             .await?
@@ -763,8 +764,9 @@ impl Transaction<'_> {
             .execute(
                 &stmt,
                 &[
-                    /* aggregation_job_id */ &&report_aggregation.aggregation_job_id.0[..],
-                    /* task_id */ &&report_aggregation.task_id.0[..],
+                    /* aggregation_job_id */
+                    &report_aggregation.aggregation_job_id.as_bytes(),
+                    /* task_id */ &report_aggregation.task_id.as_bytes(),
                     /* nonce_time */ &nonce_time,
                     /* nonce_rand */ &nonce_rand,
                     /* ord */ &report_aggregation.ord,
@@ -818,8 +820,8 @@ impl Transaction<'_> {
                         /* vdaf_message */ &vdaf_message,
                         /* error_code */ &error_code,
                         /* aggregation_job_id */
-                        &&report_aggregation.aggregation_job_id.0[..],
-                        /* task_id */ &&report_aggregation.task_id.0[..],
+                        &report_aggregation.aggregation_job_id.as_bytes(),
+                        /* task_id */ &report_aggregation.task_id.as_bytes(),
                         /* nonce_time */ &nonce_time,
                         /* nonce_rand */ &nonce_rand,
                     ],
@@ -855,7 +857,7 @@ impl Transaction<'_> {
             .query_opt(
                 &stmt,
                 &[
-                    /* task_id */ &&task_id.0[..],
+                    /* task_id */ &task_id.as_bytes(),
                     &batch_interval_start,
                     &batch_interval_duration,
                     /* aggregation_param */ &encoded_aggregation_parameter,
@@ -893,7 +895,7 @@ impl Transaction<'_> {
                 &stmt,
                 &[
                     /* collect_job_id */ &collect_job_id,
-                    /* task_id */ &&task_id.0[..],
+                    /* task_id */ &task_id.as_bytes(),
                     &batch_interval_start,
                     &batch_interval_duration,
                     /* aggregation_param */ &encoded_aggregation_parameter,
@@ -933,7 +935,7 @@ impl Transaction<'_> {
             .execute(
                 &stmt,
                 &[
-                    /* task_id */ &&batch_aggregation.task_id.0[..],
+                    /* task_id */ &batch_aggregation.task_id.as_bytes(),
                     &unit_interval_start,
                     /* aggregation_param */ &encoded_aggregation_param,
                     /* aggregate_share */ &encoded_aggregate_share,
@@ -983,7 +985,7 @@ impl Transaction<'_> {
             .query(
                 &stmt,
                 &[
-                    /* task_id */ &&task_id.0[..],
+                    /* task_id */ &task_id.as_bytes(),
                     &unit_interval_start,
                     &unit_interval_end,
                     /* aggregation_param */ &encoded_aggregation_param,
@@ -1612,66 +1614,33 @@ mod tests {
         let (ds, _db_handle) = ephemeral_datastore().await;
 
         let values = [
+            (TaskId::random(), Vdaf::Prio3Aes128Count, Role::Leader),
             (
-                TaskId([
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 1,
-                ]),
-                Vdaf::Prio3Aes128Count,
-                Role::Leader,
-            ),
-            (
-                TaskId([
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 2,
-                ]),
+                TaskId::random(),
                 Vdaf::Prio3Aes128Sum { bits: 64 },
                 Role::Helper,
             ),
             (
-                TaskId([
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 3,
-                ]),
+                TaskId::random(),
                 Vdaf::Prio3Aes128Sum { bits: 32 },
                 Role::Helper,
             ),
             (
-                TaskId([
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 4,
-                ]),
+                TaskId::random(),
                 Vdaf::Prio3Aes128Histogram {
                     buckets: vec![0, 100, 200, 400],
                 },
                 Role::Leader,
             ),
             (
-                TaskId([
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 5,
-                ]),
+                TaskId::random(),
                 Vdaf::Prio3Aes128Histogram {
                     buckets: vec![0, 25, 50, 75, 100],
                 },
                 Role::Leader,
             ),
-            (
-                TaskId([
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 6,
-                ]),
-                Vdaf::Poplar1 { bits: 8 },
-                Role::Helper,
-            ),
-            (
-                TaskId([
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 7,
-                ]),
-                Vdaf::Poplar1 { bits: 64 },
-                Role::Helper,
-            ),
+            (TaskId::random(), Vdaf::Poplar1 { bits: 8 }, Role::Helper),
+            (TaskId::random(), Vdaf::Poplar1 { bits: 64 }, Role::Helper),
         ];
 
         // Insert tasks, check that they can be retrieved by ID.

--- a/janus_server/src/message.rs
+++ b/janus_server/src/message.rs
@@ -475,7 +475,7 @@ impl Decode for HpkeCiphertext {
 
 /// PPM protocol message representing an identifier for a PPM task.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct TaskId(pub(crate) [u8; Self::ENCODED_LEN]);
+pub struct TaskId([u8; Self::ENCODED_LEN]);
 
 impl Debug for TaskId {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -898,7 +898,13 @@ impl Decode for TransitionError {
 
 /// PPM protocol message representing an identifier for an aggregation job.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct AggregationJobId(pub(crate) [u8; Self::ENCODED_LEN]);
+pub struct AggregationJobId([u8; Self::ENCODED_LEN]);
+
+impl AggregationJobId {
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
 
 impl Encode for AggregationJobId {
     fn encode(&self, bytes: &mut Vec<u8>) {


### PR DESCRIPTION
This is a fairly mechanical change, just using `.as_bytes()` instead of accessing struct members directly. See also: #18.