### PR TITLE
Adjust privacy of Time, Duration, and Interval

### DIFF
--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -2553,7 +2553,7 @@ mod tests {
 
         let report_share = ReportShare {
             nonce: Nonce {
-                time: Time(54321),
+                time: Time::from_timestamp(54321),
                 rand: [1, 2, 3, 4, 5, 6, 7, 8],
             },
             extensions: Vec::new(),
@@ -2792,7 +2792,7 @@ mod tests {
         let task_id = TaskId::random();
         let aggregation_job_id = AggregationJobId::random();
         let nonce = Nonce {
-            time: Time(54321),
+            time: Time::from_timestamp(54321),
             rand: [1, 2, 3, 4, 5, 6, 7, 8],
         };
         let task = new_dummy_task(task_id, Vdaf::Fake, Role::Helper);
@@ -2893,7 +2893,7 @@ mod tests {
         let task_id = TaskId::random();
         let aggregation_job_id = AggregationJobId::random();
         let nonce = Nonce {
-            time: Time(54321),
+            time: Time::from_timestamp(54321),
             rand: [1, 2, 3, 4, 5, 6, 7, 8],
         };
         let task = new_dummy_task(task_id, Vdaf::FakeFailsPrepStep, Role::Helper);
@@ -3041,7 +3041,7 @@ mod tests {
         let task_id = TaskId::random();
         let aggregation_job_id = AggregationJobId::random();
         let nonce = Nonce {
-            time: Time(54321),
+            time: Time::from_timestamp(54321),
             rand: [1, 2, 3, 4, 5, 6, 7, 8],
         };
         let task = new_dummy_task(task_id, Vdaf::Fake, Role::Helper);
@@ -3098,7 +3098,7 @@ mod tests {
             body: AggregateContinueReq {
                 seq: vec![Transition {
                     nonce: Nonce {
-                        time: Time(54321),
+                        time: Time::from_timestamp(54321),
                         rand: [8, 7, 6, 5, 4, 3, 2, 1], // not the same as above
                     },
                     trans_data: TransitionTypeSpecificData::Continued {
@@ -3146,11 +3146,11 @@ mod tests {
         let task_id = TaskId::random();
         let aggregation_job_id = AggregationJobId::random();
         let nonce_0 = Nonce {
-            time: Time(54321),
+            time: Time::from_timestamp(54321),
             rand: [1, 2, 3, 4, 5, 6, 7, 8],
         };
         let nonce_1 = Nonce {
-            time: Time(54321),
+            time: Time::from_timestamp(54321),
             rand: [8, 7, 6, 5, 4, 3, 2, 1],
         };
 
@@ -3286,7 +3286,7 @@ mod tests {
         let task_id = TaskId::random();
         let aggregation_job_id = AggregationJobId::random();
         let nonce = Nonce {
-            time: Time(54321),
+            time: Time::from_timestamp(54321),
             rand: [1, 2, 3, 4, 5, 6, 7, 8],
         };
 
@@ -3344,7 +3344,7 @@ mod tests {
             body: AggregateContinueReq {
                 seq: vec![Transition {
                     nonce: Nonce {
-                        time: Time(54321),
+                        time: Time::from_timestamp(54321),
                         rand: [1, 2, 3, 4, 5, 6, 7, 8],
                     },
                     trans_data: TransitionTypeSpecificData::Continued {
@@ -3407,7 +3407,8 @@ mod tests {
 
         let request = CollectReq {
             task_id,
-            batch_interval: Interval::new(Time(0), task.min_batch_duration).unwrap(),
+            batch_interval: Interval::new(Time::from_timestamp(0), task.min_batch_duration)
+                .unwrap(),
             agg_param: vec![],
         };
 
@@ -3462,9 +3463,9 @@ mod tests {
         let request = CollectReq {
             task_id,
             batch_interval: Interval::new(
-                Time(0),
+                Time::from_timestamp(0),
                 // Collect request will be rejected because batch interval is too small
-                Duration(task.min_batch_duration.0 - 1),
+                Duration::from_seconds(task.min_batch_duration.as_seconds() - 1),
             )
             .unwrap(),
             agg_param: vec![],
@@ -3519,7 +3520,8 @@ mod tests {
 
         let request = CollectReq {
             task_id,
-            batch_interval: Interval::new(Time(0), task.min_batch_duration).unwrap(),
+            batch_interval: Interval::new(Time::from_timestamp(0), task.min_batch_duration)
+                .unwrap(),
             agg_param: vec![],
         };
 
@@ -3561,7 +3563,8 @@ mod tests {
 
         let request = AggregateShareReq {
             task_id,
-            batch_interval: Interval::new(Time(0), task.min_batch_duration).unwrap(),
+            batch_interval: Interval::new(Time::from_timestamp(0), task.min_batch_duration)
+                .unwrap(),
             aggregation_param: vec![],
             report_count: 0,
             checksum: [0; 32],
@@ -3618,9 +3621,9 @@ mod tests {
         let request = AggregateShareReq {
             task_id,
             batch_interval: Interval::new(
-                Time(0),
+                Time::from_timestamp(0),
                 // Collect request will be rejected because batch interval is too small
-                Duration(task.min_batch_duration.0 - 1),
+                Duration::from_seconds(task.min_batch_duration.as_seconds() - 1),
             )
             .unwrap(),
             aggregation_param: vec![],
@@ -3687,7 +3690,8 @@ mod tests {
         // There are no batch unit_aggregations in the datastore yet
         let request = AggregateShareReq {
             task_id,
-            batch_interval: Interval::new(Time(0), task.min_batch_duration).unwrap(),
+            batch_interval: Interval::new(Time::from_timestamp(0), task.min_batch_duration)
+                .unwrap(),
             aggregation_param: vec![],
             report_count: 0,
             checksum: [0; 32],
@@ -3724,7 +3728,7 @@ mod tests {
                 Box::pin(async move {
                     tx.put_batch_unit_aggregation(&BatchUnitAggregation::<Prio3Aes128Count> {
                         task_id,
-                        unit_interval_start: Time(500),
+                        unit_interval_start: Time::from_timestamp(500),
                         aggregation_param,
                         aggregate_share: AggregateShare::from(vec![Field64::from(64)]),
                         report_count: 5,
@@ -3734,7 +3738,7 @@ mod tests {
 
                     tx.put_batch_unit_aggregation(&BatchUnitAggregation::<Prio3Aes128Count> {
                         task_id,
-                        unit_interval_start: Time(1500),
+                        unit_interval_start: Time::from_timestamp(1500),
                         aggregation_param,
                         aggregate_share: AggregateShare::from(vec![Field64::from(128)]),
                         report_count: 5,
@@ -3744,7 +3748,7 @@ mod tests {
 
                     tx.put_batch_unit_aggregation(&BatchUnitAggregation::<Prio3Aes128Count> {
                         task_id,
-                        unit_interval_start: Time(2000),
+                        unit_interval_start: Time::from_timestamp(2000),
                         aggregation_param,
                         aggregate_share: AggregateShare::from(vec![Field64::from(256)]),
                         report_count: 5,
@@ -3761,7 +3765,8 @@ mod tests {
         // Specified interval includes too few reports
         let request = AggregateShareReq {
             task_id,
-            batch_interval: Interval::new(Time(0), Duration(1000)).unwrap(),
+            batch_interval: Interval::new(Time::from_timestamp(0), Duration::from_seconds(1000))
+                .unwrap(),
             aggregation_param: vec![],
             report_count: 5,
             checksum: [0; 32],
@@ -3795,7 +3800,8 @@ mod tests {
         // Interval is big enough, but checksum doesn't match
         let request = AggregateShareReq {
             task_id,
-            batch_interval: Interval::new(Time(0), Duration(2500)).unwrap(),
+            batch_interval: Interval::new(Time::from_timestamp(0), Duration::from_seconds(2500))
+                .unwrap(),
             aggregation_param: vec![],
             report_count: 10,
             checksum: [3; 32],
@@ -3829,7 +3835,8 @@ mod tests {
         // Interval is big enough, but report count doesn't match
         let request = AggregateShareReq {
             task_id,
-            batch_interval: Interval::new(Time(0), Duration(2500)).unwrap(),
+            batch_interval: Interval::new(Time::from_timestamp(0), Duration::from_seconds(2500))
+                .unwrap(),
             aggregation_param: vec![],
             report_count: 20,
             checksum: [3 ^ 2; 32],
@@ -3861,7 +3868,8 @@ mod tests {
         );
 
         // Interval is big enough, checksum and report count are good
-        let batch_interval = Interval::new(Time(0), Duration(2500)).unwrap();
+        let batch_interval =
+            Interval::new(Time::from_timestamp(0), Duration::from_seconds(2500)).unwrap();
         let request = AggregateShareReq {
             task_id,
             batch_interval,

--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -2553,7 +2553,7 @@ mod tests {
 
         let report_share = ReportShare {
             nonce: Nonce {
-                time: Time::from_timestamp(54321),
+                time: Time::from_seconds_since_epoch(54321),
                 rand: [1, 2, 3, 4, 5, 6, 7, 8],
             },
             extensions: Vec::new(),
@@ -2792,7 +2792,7 @@ mod tests {
         let task_id = TaskId::random();
         let aggregation_job_id = AggregationJobId::random();
         let nonce = Nonce {
-            time: Time::from_timestamp(54321),
+            time: Time::from_seconds_since_epoch(54321),
             rand: [1, 2, 3, 4, 5, 6, 7, 8],
         };
         let task = new_dummy_task(task_id, Vdaf::Fake, Role::Helper);
@@ -2893,7 +2893,7 @@ mod tests {
         let task_id = TaskId::random();
         let aggregation_job_id = AggregationJobId::random();
         let nonce = Nonce {
-            time: Time::from_timestamp(54321),
+            time: Time::from_seconds_since_epoch(54321),
             rand: [1, 2, 3, 4, 5, 6, 7, 8],
         };
         let task = new_dummy_task(task_id, Vdaf::FakeFailsPrepStep, Role::Helper);
@@ -3041,7 +3041,7 @@ mod tests {
         let task_id = TaskId::random();
         let aggregation_job_id = AggregationJobId::random();
         let nonce = Nonce {
-            time: Time::from_timestamp(54321),
+            time: Time::from_seconds_since_epoch(54321),
             rand: [1, 2, 3, 4, 5, 6, 7, 8],
         };
         let task = new_dummy_task(task_id, Vdaf::Fake, Role::Helper);
@@ -3098,7 +3098,7 @@ mod tests {
             body: AggregateContinueReq {
                 seq: vec![Transition {
                     nonce: Nonce {
-                        time: Time::from_timestamp(54321),
+                        time: Time::from_seconds_since_epoch(54321),
                         rand: [8, 7, 6, 5, 4, 3, 2, 1], // not the same as above
                     },
                     trans_data: TransitionTypeSpecificData::Continued {
@@ -3146,11 +3146,11 @@ mod tests {
         let task_id = TaskId::random();
         let aggregation_job_id = AggregationJobId::random();
         let nonce_0 = Nonce {
-            time: Time::from_timestamp(54321),
+            time: Time::from_seconds_since_epoch(54321),
             rand: [1, 2, 3, 4, 5, 6, 7, 8],
         };
         let nonce_1 = Nonce {
-            time: Time::from_timestamp(54321),
+            time: Time::from_seconds_since_epoch(54321),
             rand: [8, 7, 6, 5, 4, 3, 2, 1],
         };
 
@@ -3286,7 +3286,7 @@ mod tests {
         let task_id = TaskId::random();
         let aggregation_job_id = AggregationJobId::random();
         let nonce = Nonce {
-            time: Time::from_timestamp(54321),
+            time: Time::from_seconds_since_epoch(54321),
             rand: [1, 2, 3, 4, 5, 6, 7, 8],
         };
 
@@ -3344,7 +3344,7 @@ mod tests {
             body: AggregateContinueReq {
                 seq: vec![Transition {
                     nonce: Nonce {
-                        time: Time::from_timestamp(54321),
+                        time: Time::from_seconds_since_epoch(54321),
                         rand: [1, 2, 3, 4, 5, 6, 7, 8],
                     },
                     trans_data: TransitionTypeSpecificData::Continued {
@@ -3407,8 +3407,11 @@ mod tests {
 
         let request = CollectReq {
             task_id,
-            batch_interval: Interval::new(Time::from_timestamp(0), task.min_batch_duration)
-                .unwrap(),
+            batch_interval: Interval::new(
+                Time::from_seconds_since_epoch(0),
+                task.min_batch_duration,
+            )
+            .unwrap(),
             agg_param: vec![],
         };
 
@@ -3463,7 +3466,7 @@ mod tests {
         let request = CollectReq {
             task_id,
             batch_interval: Interval::new(
-                Time::from_timestamp(0),
+                Time::from_seconds_since_epoch(0),
                 // Collect request will be rejected because batch interval is too small
                 Duration::from_seconds(task.min_batch_duration.as_seconds() - 1),
             )
@@ -3520,8 +3523,11 @@ mod tests {
 
         let request = CollectReq {
             task_id,
-            batch_interval: Interval::new(Time::from_timestamp(0), task.min_batch_duration)
-                .unwrap(),
+            batch_interval: Interval::new(
+                Time::from_seconds_since_epoch(0),
+                task.min_batch_duration,
+            )
+            .unwrap(),
             agg_param: vec![],
         };
 
@@ -3563,8 +3569,11 @@ mod tests {
 
         let request = AggregateShareReq {
             task_id,
-            batch_interval: Interval::new(Time::from_timestamp(0), task.min_batch_duration)
-                .unwrap(),
+            batch_interval: Interval::new(
+                Time::from_seconds_since_epoch(0),
+                task.min_batch_duration,
+            )
+            .unwrap(),
             aggregation_param: vec![],
             report_count: 0,
             checksum: [0; 32],
@@ -3621,7 +3630,7 @@ mod tests {
         let request = AggregateShareReq {
             task_id,
             batch_interval: Interval::new(
-                Time::from_timestamp(0),
+                Time::from_seconds_since_epoch(0),
                 // Collect request will be rejected because batch interval is too small
                 Duration::from_seconds(task.min_batch_duration.as_seconds() - 1),
             )
@@ -3690,8 +3699,11 @@ mod tests {
         // There are no batch unit_aggregations in the datastore yet
         let request = AggregateShareReq {
             task_id,
-            batch_interval: Interval::new(Time::from_timestamp(0), task.min_batch_duration)
-                .unwrap(),
+            batch_interval: Interval::new(
+                Time::from_seconds_since_epoch(0),
+                task.min_batch_duration,
+            )
+            .unwrap(),
             aggregation_param: vec![],
             report_count: 0,
             checksum: [0; 32],
@@ -3728,7 +3740,7 @@ mod tests {
                 Box::pin(async move {
                     tx.put_batch_unit_aggregation(&BatchUnitAggregation::<Prio3Aes128Count> {
                         task_id,
-                        unit_interval_start: Time::from_timestamp(500),
+                        unit_interval_start: Time::from_seconds_since_epoch(500),
                         aggregation_param,
                         aggregate_share: AggregateShare::from(vec![Field64::from(64)]),
                         report_count: 5,
@@ -3738,7 +3750,7 @@ mod tests {
 
                     tx.put_batch_unit_aggregation(&BatchUnitAggregation::<Prio3Aes128Count> {
                         task_id,
-                        unit_interval_start: Time::from_timestamp(1500),
+                        unit_interval_start: Time::from_seconds_since_epoch(1500),
                         aggregation_param,
                         aggregate_share: AggregateShare::from(vec![Field64::from(128)]),
                         report_count: 5,
@@ -3748,7 +3760,7 @@ mod tests {
 
                     tx.put_batch_unit_aggregation(&BatchUnitAggregation::<Prio3Aes128Count> {
                         task_id,
-                        unit_interval_start: Time::from_timestamp(2000),
+                        unit_interval_start: Time::from_seconds_since_epoch(2000),
                         aggregation_param,
                         aggregate_share: AggregateShare::from(vec![Field64::from(256)]),
                         report_count: 5,
@@ -3765,8 +3777,11 @@ mod tests {
         // Specified interval includes too few reports
         let request = AggregateShareReq {
             task_id,
-            batch_interval: Interval::new(Time::from_timestamp(0), Duration::from_seconds(1000))
-                .unwrap(),
+            batch_interval: Interval::new(
+                Time::from_seconds_since_epoch(0),
+                Duration::from_seconds(1000),
+            )
+            .unwrap(),
             aggregation_param: vec![],
             report_count: 5,
             checksum: [0; 32],
@@ -3800,8 +3815,11 @@ mod tests {
         // Interval is big enough, but checksum doesn't match
         let request = AggregateShareReq {
             task_id,
-            batch_interval: Interval::new(Time::from_timestamp(0), Duration::from_seconds(2500))
-                .unwrap(),
+            batch_interval: Interval::new(
+                Time::from_seconds_since_epoch(0),
+                Duration::from_seconds(2500),
+            )
+            .unwrap(),
             aggregation_param: vec![],
             report_count: 10,
             checksum: [3; 32],
@@ -3835,8 +3853,11 @@ mod tests {
         // Interval is big enough, but report count doesn't match
         let request = AggregateShareReq {
             task_id,
-            batch_interval: Interval::new(Time::from_timestamp(0), Duration::from_seconds(2500))
-                .unwrap(),
+            batch_interval: Interval::new(
+                Time::from_seconds_since_epoch(0),
+                Duration::from_seconds(2500),
+            )
+            .unwrap(),
             aggregation_param: vec![],
             report_count: 20,
             checksum: [3 ^ 2; 32],
@@ -3868,8 +3889,11 @@ mod tests {
         );
 
         // Interval is big enough, checksum and report count are good
-        let batch_interval =
-            Interval::new(Time::from_timestamp(0), Duration::from_seconds(2500)).unwrap();
+        let batch_interval = Interval::new(
+            Time::from_seconds_since_epoch(0),
+            Duration::from_seconds(2500),
+        )
+        .unwrap();
         let request = AggregateShareReq {
             task_id,
             batch_interval,

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -1762,7 +1762,7 @@ mod tests {
         let report = Report {
             task_id: TaskId::random(),
             nonce: Nonce {
-                time: Time::from_timestamp(12345),
+                time: Time::from_seconds_since_epoch(12345),
                 rand: [1, 2, 3, 4, 5, 6, 7, 8],
             },
             extensions: vec![
@@ -1825,7 +1825,7 @@ mod tests {
                     tx.get_client_report(
                         TaskId::random(),
                         Nonce {
-                            time: Time::from_timestamp(12345),
+                            time: Time::from_seconds_since_epoch(12345),
                             rand: [1, 2, 3, 4, 5, 6, 7, 8],
                         },
                     )
@@ -1849,7 +1849,7 @@ mod tests {
         let first_unaggregated_report = Report {
             task_id,
             nonce: Nonce {
-                time: Time::from_timestamp(12345),
+                time: Time::from_seconds_since_epoch(12345),
                 rand: [1, 2, 3, 4, 5, 6, 7, 8],
             },
             extensions: vec![],
@@ -1858,7 +1858,7 @@ mod tests {
         let second_unaggregated_report = Report {
             task_id,
             nonce: Nonce {
-                time: Time::from_timestamp(12346),
+                time: Time::from_seconds_since_epoch(12346),
                 rand: [1, 2, 3, 4, 5, 6, 7, 8],
             },
             extensions: vec![],
@@ -1867,7 +1867,7 @@ mod tests {
         let aggregated_report = Report {
             task_id,
             nonce: Nonce {
-                time: Time::from_timestamp(12347),
+                time: Time::from_seconds_since_epoch(12347),
                 rand: [1, 2, 3, 4, 5, 6, 7, 8],
             },
             extensions: vec![],
@@ -1876,7 +1876,7 @@ mod tests {
         let unrelated_report = Report {
             task_id: unrelated_task_id,
             nonce: Nonce {
-                time: Time::from_timestamp(12348),
+                time: Time::from_seconds_since_epoch(12348),
                 rand: [1, 2, 3, 4, 5, 6, 7, 8],
             },
             extensions: vec![],
@@ -1966,7 +1966,7 @@ mod tests {
         let task_id = TaskId::random();
         let report_share = ReportShare {
             nonce: Nonce {
-                time: Time::from_timestamp(12345),
+                time: Time::from_seconds_since_epoch(12345),
                 rand: [1, 2, 3, 4, 5, 6, 7, 8],
             },
             extensions: vec![
@@ -2242,7 +2242,7 @@ mod tests {
             let task_id = TaskId::random();
             let aggregation_job_id = AggregationJobId::random();
             let nonce = Nonce {
-                time: Time::from_timestamp(12345),
+                time: Time::from_seconds_since_epoch(12345),
                 rand: [1, 2, 3, 4, 5, 6, 7, 8],
             };
 
@@ -2349,7 +2349,7 @@ mod tests {
                         TaskId::random(),
                         AggregationJobId::random(),
                         Nonce {
-                            time: Time::from_timestamp(12345),
+                            time: Time::from_seconds_since_epoch(12345),
                             rand: [1, 2, 3, 4, 5, 6, 7, 8],
                         },
                     )
@@ -2367,7 +2367,7 @@ mod tests {
                         aggregation_job_id: AggregationJobId::random(),
                         task_id: TaskId::random(),
                         nonce: Nonce {
-                            time: Time::from_timestamp(12345),
+                            time: Time::from_seconds_since_epoch(12345),
                             rand: [1, 2, 3, 4, 5, 6, 7, 8],
                         },
                         ord: 0,
@@ -2423,7 +2423,7 @@ mod tests {
                     .enumerate()
                     {
                         let nonce = Nonce {
-                            time: Time::from_timestamp(12345),
+                            time: Time::from_seconds_since_epoch(12345),
                             rand: (ord as u64).to_be_bytes(),
                         };
                         tx.put_report_share(
@@ -2519,8 +2519,11 @@ mod tests {
         install_test_trace_subscriber();
 
         let task_id = TaskId::random();
-        let batch_interval =
-            Interval::new(Time::from_timestamp(100), Duration::from_seconds(100)).unwrap();
+        let batch_interval = Interval::new(
+            Time::from_seconds_since_epoch(100),
+            Duration::from_seconds(100),
+        )
+        .unwrap();
 
         let (ds, _db_handle) = ephemeral_datastore().await;
 
@@ -2591,8 +2594,11 @@ mod tests {
                 Box::pin(async move {
                     tx.put_collect_job(
                         task_id,
-                        Interval::new(Time::from_timestamp(101), Duration::from_seconds(100))
-                            .unwrap(),
+                        Interval::new(
+                            Time::from_seconds_since_epoch(101),
+                            Duration::from_seconds(100),
+                        )
+                        .unwrap(),
                         &[0, 1, 2, 3, 4],
                     )
                     .await
@@ -2655,7 +2661,7 @@ mod tests {
                     // Start of this aggregation's interval is before the interval queried below.
                     tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
                         task_id,
-                        unit_interval_start: Time::from_timestamp(25),
+                        unit_interval_start: Time::from_seconds_since_epoch(25),
                         aggregation_param: aggregation_param.clone(),
                         aggregate_share: aggregate_share.clone(),
                         report_count: 0,
@@ -2665,7 +2671,7 @@ mod tests {
 
                     tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
                         task_id,
-                        unit_interval_start: Time::from_timestamp(100),
+                        unit_interval_start: Time::from_seconds_since_epoch(100),
                         aggregation_param: aggregation_param.clone(),
                         aggregate_share: aggregate_share.clone(),
                         report_count: 0,
@@ -2675,7 +2681,7 @@ mod tests {
 
                     tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
                         task_id,
-                        unit_interval_start: Time::from_timestamp(150),
+                        unit_interval_start: Time::from_seconds_since_epoch(150),
                         aggregation_param: aggregation_param.clone(),
                         aggregate_share: aggregate_share.clone(),
                         report_count: 0,
@@ -2686,7 +2692,7 @@ mod tests {
                     // Aggregation parameter differs from the one queried below.
                     tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
                         task_id,
-                        unit_interval_start: Time::from_timestamp(100),
+                        unit_interval_start: Time::from_seconds_since_epoch(100),
                         aggregation_param: BTreeSet::from([
                             IdpfInput::new("gh".as_bytes(), 2).unwrap(),
                             IdpfInput::new("jk".as_bytes(), 3).unwrap(),
@@ -2700,7 +2706,7 @@ mod tests {
                     // End of this aggregation's interval is after the interval queried below.
                     tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
                         task_id,
-                        unit_interval_start: Time::from_timestamp(200),
+                        unit_interval_start: Time::from_seconds_since_epoch(200),
                         aggregation_param: aggregation_param.clone(),
                         aggregate_share: aggregate_share.clone(),
                         report_count: 0,
@@ -2711,7 +2717,7 @@ mod tests {
                     // Start of this aggregation's interval is after the interval queried below.
                     tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
                         task_id,
-                        unit_interval_start: Time::from_timestamp(400),
+                        unit_interval_start: Time::from_seconds_since_epoch(400),
                         aggregation_param: aggregation_param.clone(),
                         aggregate_share: aggregate_share.clone(),
                         report_count: 0,
@@ -2722,7 +2728,7 @@ mod tests {
                     // Task ID differs from that queried below.
                     tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
                         task_id: other_task_id,
-                        unit_interval_start: Time::from_timestamp(200),
+                        unit_interval_start: Time::from_seconds_since_epoch(200),
                         aggregation_param: aggregation_param.clone(),
                         aggregate_share: aggregate_share.clone(),
                         report_count: 0,
@@ -2732,8 +2738,11 @@ mod tests {
 
                     tx.get_batch_unit_aggregations_for_task_in_interval::<ToyPoplar1>(
                         task_id,
-                        Interval::new(Time::from_timestamp(50), Duration::from_seconds(250))
-                            .unwrap(),
+                        Interval::new(
+                            Time::from_seconds_since_epoch(50),
+                            Duration::from_seconds(250),
+                        )
+                        .unwrap(),
                         &aggregation_param,
                     )
                     .await
@@ -2745,7 +2754,7 @@ mod tests {
         assert_eq!(batch_unit_aggregations.len(), 2);
         assert!(batch_unit_aggregations.contains(&BatchUnitAggregation {
             task_id,
-            unit_interval_start: Time::from_timestamp(100),
+            unit_interval_start: Time::from_seconds_since_epoch(100),
             aggregation_param: aggregation_param.clone(),
             aggregate_share: aggregate_share.clone(),
             report_count: 0,
@@ -2753,7 +2762,7 @@ mod tests {
         }));
         assert!(batch_unit_aggregations.contains(&BatchUnitAggregation {
             task_id,
-            unit_interval_start: Time::from_timestamp(150),
+            unit_interval_start: Time::from_seconds_since_epoch(150),
             aggregation_param: aggregation_param.clone(),
             aggregate_share: aggregate_share.clone(),
             report_count: 0,

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -112,8 +112,8 @@ impl Transaction<'_> {
 
         let max_batch_lifetime = i64::try_from(task.max_batch_lifetime)?;
         let min_batch_size = i64::try_from(task.min_batch_size)?;
-        let min_batch_duration = i64::try_from(task.min_batch_duration.0)?;
-        let tolerable_clock_skew = i64::try_from(task.tolerable_clock_skew.0)?;
+        let min_batch_duration = i64::try_from(task.min_batch_duration.as_seconds())?;
+        let tolerable_clock_skew = i64::try_from(task.tolerable_clock_skew.as_seconds())?;
 
         let encrypted_vdaf_verify_param = self.crypter.encrypt(
             "tasks",
@@ -920,7 +920,7 @@ impl Transaction<'_> {
         encoded_aggregation_parameter: &[u8],
     ) -> Result<Option<Uuid>, Error> {
         let batch_interval_start = batch_interval.start().as_naive_date_time();
-        let batch_interval_duration = i64::try_from(batch_interval.duration().0)?;
+        let batch_interval_duration = i64::try_from(batch_interval.duration().as_seconds())?;
 
         let stmt = self
             .tx
@@ -957,7 +957,7 @@ impl Transaction<'_> {
         encoded_aggregation_parameter: &[u8],
     ) -> Result<Uuid, Error> {
         let batch_interval_start = batch_interval.start().as_naive_date_time();
-        let batch_interval_duration = i64::try_from(batch_interval.duration().0)?;
+        let batch_interval_duration = i64::try_from(batch_interval.duration().as_seconds())?;
 
         let collect_job_id = Uuid::new_v4();
 
@@ -1762,7 +1762,7 @@ mod tests {
         let report = Report {
             task_id: TaskId::random(),
             nonce: Nonce {
-                time: Time(12345),
+                time: Time::from_timestamp(12345),
                 rand: [1, 2, 3, 4, 5, 6, 7, 8],
             },
             extensions: vec![
@@ -1825,7 +1825,7 @@ mod tests {
                     tx.get_client_report(
                         TaskId::random(),
                         Nonce {
-                            time: Time(12345),
+                            time: Time::from_timestamp(12345),
                             rand: [1, 2, 3, 4, 5, 6, 7, 8],
                         },
                     )
@@ -1849,7 +1849,7 @@ mod tests {
         let first_unaggregated_report = Report {
             task_id,
             nonce: Nonce {
-                time: Time(12345),
+                time: Time::from_timestamp(12345),
                 rand: [1, 2, 3, 4, 5, 6, 7, 8],
             },
             extensions: vec![],
@@ -1858,7 +1858,7 @@ mod tests {
         let second_unaggregated_report = Report {
             task_id,
             nonce: Nonce {
-                time: Time(12346),
+                time: Time::from_timestamp(12346),
                 rand: [1, 2, 3, 4, 5, 6, 7, 8],
             },
             extensions: vec![],
@@ -1867,7 +1867,7 @@ mod tests {
         let aggregated_report = Report {
             task_id,
             nonce: Nonce {
-                time: Time(12347),
+                time: Time::from_timestamp(12347),
                 rand: [1, 2, 3, 4, 5, 6, 7, 8],
             },
             extensions: vec![],
@@ -1876,7 +1876,7 @@ mod tests {
         let unrelated_report = Report {
             task_id: unrelated_task_id,
             nonce: Nonce {
-                time: Time(12348),
+                time: Time::from_timestamp(12348),
                 rand: [1, 2, 3, 4, 5, 6, 7, 8],
             },
             extensions: vec![],
@@ -1966,7 +1966,7 @@ mod tests {
         let task_id = TaskId::random();
         let report_share = ReportShare {
             nonce: Nonce {
-                time: Time(12345),
+                time: Time::from_timestamp(12345),
                 rand: [1, 2, 3, 4, 5, 6, 7, 8],
             },
             extensions: vec![
@@ -2242,7 +2242,7 @@ mod tests {
             let task_id = TaskId::random();
             let aggregation_job_id = AggregationJobId::random();
             let nonce = Nonce {
-                time: Time(12345),
+                time: Time::from_timestamp(12345),
                 rand: [1, 2, 3, 4, 5, 6, 7, 8],
             };
 
@@ -2349,7 +2349,7 @@ mod tests {
                         TaskId::random(),
                         AggregationJobId::random(),
                         Nonce {
-                            time: Time(12345),
+                            time: Time::from_timestamp(12345),
                             rand: [1, 2, 3, 4, 5, 6, 7, 8],
                         },
                     )
@@ -2367,7 +2367,7 @@ mod tests {
                         aggregation_job_id: AggregationJobId::random(),
                         task_id: TaskId::random(),
                         nonce: Nonce {
-                            time: Time(12345),
+                            time: Time::from_timestamp(12345),
                             rand: [1, 2, 3, 4, 5, 6, 7, 8],
                         },
                         ord: 0,
@@ -2423,7 +2423,7 @@ mod tests {
                     .enumerate()
                     {
                         let nonce = Nonce {
-                            time: Time(12345),
+                            time: Time::from_timestamp(12345),
                             rand: (ord as u64).to_be_bytes(),
                         };
                         tx.put_report_share(
@@ -2519,7 +2519,8 @@ mod tests {
         install_test_trace_subscriber();
 
         let task_id = TaskId::random();
-        let batch_interval = Interval::new(Time(100), Duration(100)).unwrap();
+        let batch_interval =
+            Interval::new(Time::from_timestamp(100), Duration::from_seconds(100)).unwrap();
 
         let (ds, _db_handle) = ephemeral_datastore().await;
 
@@ -2590,7 +2591,8 @@ mod tests {
                 Box::pin(async move {
                     tx.put_collect_job(
                         task_id,
-                        Interval::new(Time(101), Duration(100)).unwrap(),
+                        Interval::new(Time::from_timestamp(101), Duration::from_seconds(100))
+                            .unwrap(),
                         &[0, 1, 2, 3, 4],
                     )
                     .await
@@ -2653,7 +2655,7 @@ mod tests {
                     // Start of this aggregation's interval is before the interval queried below.
                     tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
                         task_id,
-                        unit_interval_start: Time(25),
+                        unit_interval_start: Time::from_timestamp(25),
                         aggregation_param: aggregation_param.clone(),
                         aggregate_share: aggregate_share.clone(),
                         report_count: 0,
@@ -2663,7 +2665,7 @@ mod tests {
 
                     tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
                         task_id,
-                        unit_interval_start: Time(100),
+                        unit_interval_start: Time::from_timestamp(100),
                         aggregation_param: aggregation_param.clone(),
                         aggregate_share: aggregate_share.clone(),
                         report_count: 0,
@@ -2673,7 +2675,7 @@ mod tests {
 
                     tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
                         task_id,
-                        unit_interval_start: Time(150),
+                        unit_interval_start: Time::from_timestamp(150),
                         aggregation_param: aggregation_param.clone(),
                         aggregate_share: aggregate_share.clone(),
                         report_count: 0,
@@ -2684,7 +2686,7 @@ mod tests {
                     // Aggregation parameter differs from the one queried below.
                     tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
                         task_id,
-                        unit_interval_start: Time(100),
+                        unit_interval_start: Time::from_timestamp(100),
                         aggregation_param: BTreeSet::from([
                             IdpfInput::new("gh".as_bytes(), 2).unwrap(),
                             IdpfInput::new("jk".as_bytes(), 3).unwrap(),
@@ -2698,7 +2700,7 @@ mod tests {
                     // End of this aggregation's interval is after the interval queried below.
                     tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
                         task_id,
-                        unit_interval_start: Time(200),
+                        unit_interval_start: Time::from_timestamp(200),
                         aggregation_param: aggregation_param.clone(),
                         aggregate_share: aggregate_share.clone(),
                         report_count: 0,
@@ -2709,7 +2711,7 @@ mod tests {
                     // Start of this aggregation's interval is after the interval queried below.
                     tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
                         task_id,
-                        unit_interval_start: Time(400),
+                        unit_interval_start: Time::from_timestamp(400),
                         aggregation_param: aggregation_param.clone(),
                         aggregate_share: aggregate_share.clone(),
                         report_count: 0,
@@ -2720,7 +2722,7 @@ mod tests {
                     // Task ID differs from that queried below.
                     tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
                         task_id: other_task_id,
-                        unit_interval_start: Time(200),
+                        unit_interval_start: Time::from_timestamp(200),
                         aggregation_param: aggregation_param.clone(),
                         aggregate_share: aggregate_share.clone(),
                         report_count: 0,
@@ -2730,7 +2732,8 @@ mod tests {
 
                     tx.get_batch_unit_aggregations_for_task_in_interval::<ToyPoplar1>(
                         task_id,
-                        Interval::new(Time(50), Duration(250)).unwrap(),
+                        Interval::new(Time::from_timestamp(50), Duration::from_seconds(250))
+                            .unwrap(),
                         &aggregation_param,
                     )
                     .await
@@ -2742,7 +2745,7 @@ mod tests {
         assert_eq!(batch_unit_aggregations.len(), 2);
         assert!(batch_unit_aggregations.contains(&BatchUnitAggregation {
             task_id,
-            unit_interval_start: Time(100),
+            unit_interval_start: Time::from_timestamp(100),
             aggregation_param: aggregation_param.clone(),
             aggregate_share: aggregate_share.clone(),
             report_count: 0,
@@ -2750,7 +2753,7 @@ mod tests {
         }));
         assert!(batch_unit_aggregations.contains(&BatchUnitAggregation {
             task_id,
-            unit_interval_start: Time(150),
+            unit_interval_start: Time::from_timestamp(150),
             aggregation_param: aggregation_param.clone(),
             aggregate_share: aggregate_share.clone(),
             report_count: 0,

--- a/janus_server/src/message.rs
+++ b/janus_server/src/message.rs
@@ -226,13 +226,16 @@ impl Time {
         Self(time.timestamp() as u64)
     }
 
-    /// Get the Unix timestamp represented by this [`Time`] (in seconds).
-    pub fn as_timestamp(&self) -> u64 {
+    /// Get the number of seconds from January 1st, 1970, at 0:00:00 UTC to the instant represented
+    /// by this [`Time`] (i.e., the Unix timestamp for the instant it represents).
+    pub fn as_seconds_since_epoch(&self) -> u64 {
         self.0
     }
 
-    /// Construct a [`Time`] from a Unix timestamp (in seconds).
-    pub fn from_timestamp(timestamp: u64) -> Self {
+    /// Construct a [`Time`] representing the instant that is a given number of seconds after
+    /// January 1st, 1970, at 0:00:00 UTC (i.e., the instant with the Unix timestamp of
+    /// `timestamp`).
+    pub fn from_seconds_since_epoch(timestamp: u64) -> Self {
         Self(timestamp)
     }
 

--- a/janus_server/src/task.rs
+++ b/janus_server/src/task.rs
@@ -196,11 +196,11 @@ impl Task {
     /// Returns true if `batch_interval` is valid, per §4.6 of draft-gpew-priv-ppm.
     pub(crate) fn validate_batch_interval(&self, batch_interval: Interval) -> bool {
         // Batch interval should be greater than task's minimum batch duration
-        batch_interval.duration().0 >= self.min_batch_duration.0
+        batch_interval.duration().as_seconds() >= self.min_batch_duration.as_seconds()
             // Batch interval start must be a multiple of minimum batch duration
-            && batch_interval.start().0 % self.min_batch_duration.0 == 0
+            && batch_interval.start().as_timestamp() % self.min_batch_duration.as_seconds() == 0
             // Batch interval duration must be a multiple of minimum batch duration
-            && batch_interval.duration().0 % self.min_batch_duration.0 == 0
+            && batch_interval.duration().as_seconds() % self.min_batch_duration.as_seconds() == 0
     }
 }
 
@@ -312,7 +312,7 @@ mod tests {
             TestCase {
                 name: "same duration as minimum",
                 input: Interval::new(
-                    Time(min_batch_duration_secs),
+                    Time::from_timestamp(min_batch_duration_secs),
                     Duration::from_seconds(min_batch_duration_secs),
                 )
                 .unwrap(),
@@ -321,7 +321,7 @@ mod tests {
             TestCase {
                 name: "interval too short",
                 input: Interval::new(
-                    Time(min_batch_duration_secs),
+                    Time::from_timestamp(min_batch_duration_secs),
                     Duration::from_seconds(min_batch_duration_secs - 1),
                 )
                 .unwrap(),
@@ -330,7 +330,7 @@ mod tests {
             TestCase {
                 name: "interval larger than minimum",
                 input: Interval::new(
-                    Time(min_batch_duration_secs),
+                    Time::from_timestamp(min_batch_duration_secs),
                     Duration::from_seconds(min_batch_duration_secs * 2),
                 )
                 .unwrap(),
@@ -339,7 +339,7 @@ mod tests {
             TestCase {
                 name: "interval duration not aligned with minimum",
                 input: Interval::new(
-                    Time(min_batch_duration_secs),
+                    Time::from_timestamp(min_batch_duration_secs),
                     Duration::from_seconds(min_batch_duration_secs + 1800),
                 )
                 .unwrap(),
@@ -347,8 +347,11 @@ mod tests {
             },
             TestCase {
                 name: "interval start not aligned with minimum",
-                input: Interval::new(Time(1800), Duration::from_seconds(min_batch_duration_secs))
-                    .unwrap(),
+                input: Interval::new(
+                    Time::from_timestamp(1800),
+                    Duration::from_seconds(min_batch_duration_secs),
+                )
+                .unwrap(),
                 expected: false,
             },
         ];

--- a/janus_server/src/task.rs
+++ b/janus_server/src/task.rs
@@ -198,7 +198,7 @@ impl Task {
         // Batch interval should be greater than task's minimum batch duration
         batch_interval.duration().as_seconds() >= self.min_batch_duration.as_seconds()
             // Batch interval start must be a multiple of minimum batch duration
-            && batch_interval.start().as_timestamp() % self.min_batch_duration.as_seconds() == 0
+            && batch_interval.start().as_seconds_since_epoch() % self.min_batch_duration.as_seconds() == 0
             // Batch interval duration must be a multiple of minimum batch duration
             && batch_interval.duration().as_seconds() % self.min_batch_duration.as_seconds() == 0
     }
@@ -312,7 +312,7 @@ mod tests {
             TestCase {
                 name: "same duration as minimum",
                 input: Interval::new(
-                    Time::from_timestamp(min_batch_duration_secs),
+                    Time::from_seconds_since_epoch(min_batch_duration_secs),
                     Duration::from_seconds(min_batch_duration_secs),
                 )
                 .unwrap(),
@@ -321,7 +321,7 @@ mod tests {
             TestCase {
                 name: "interval too short",
                 input: Interval::new(
-                    Time::from_timestamp(min_batch_duration_secs),
+                    Time::from_seconds_since_epoch(min_batch_duration_secs),
                     Duration::from_seconds(min_batch_duration_secs - 1),
                 )
                 .unwrap(),
@@ -330,7 +330,7 @@ mod tests {
             TestCase {
                 name: "interval larger than minimum",
                 input: Interval::new(
-                    Time::from_timestamp(min_batch_duration_secs),
+                    Time::from_seconds_since_epoch(min_batch_duration_secs),
                     Duration::from_seconds(min_batch_duration_secs * 2),
                 )
                 .unwrap(),
@@ -339,7 +339,7 @@ mod tests {
             TestCase {
                 name: "interval duration not aligned with minimum",
                 input: Interval::new(
-                    Time::from_timestamp(min_batch_duration_secs),
+                    Time::from_seconds_since_epoch(min_batch_duration_secs),
                     Duration::from_seconds(min_batch_duration_secs + 1800),
                 )
                 .unwrap(),
@@ -348,7 +348,7 @@ mod tests {
             TestCase {
                 name: "interval start not aligned with minimum",
                 input: Interval::new(
-                    Time::from_timestamp(1800),
+                    Time::from_seconds_since_epoch(1800),
                     Duration::from_seconds(min_batch_duration_secs),
                 )
                 .unwrap(),

--- a/janus_server/src/trace.rs
+++ b/janus_server/src/trace.rs
@@ -242,7 +242,7 @@ pub mod test_util {
     /// called at the beginning of any test that requires a tracing subscriber.
     ///
     /// To see output, you will need to set the RUST_LOG environment variable appropriately.
-    /// See https://docs.rs/tracing-subscriber/latest/tracing_subscriber/struct.EnvFilter.html.
+    /// See <https://docs.rs/tracing-subscriber/latest/tracing_subscriber/struct.EnvFilter.html>.
     pub fn install_test_trace_subscriber() {
         static INSTALL_TRACE_SUBSCRIBER: Once = Once::new();
         INSTALL_TRACE_SUBSCRIBER.call_once(|| {


### PR DESCRIPTION
Make fields private, and expose some additional methods as public.

This is part of #18. I also fixed one rustdoc warning I noticed.