### PR TITLE
Make Nonce members private, add methods

### DIFF
--- a/janus_server/src/bin/aggregation_job_creator.rs
+++ b/janus_server/src/bin/aggregation_job_creator.rs
@@ -275,7 +275,7 @@ impl<C: Clock> AggregationJobCreator<C> {
                         .into_iter()
                         .map(|nonce| {
                             nonce
-                                .time
+                                .time()
                                 .to_batch_unit_interval_start(min_batch_duration)
                                 .map(|s| (s, nonce))
                                 .map_err(datastore::Error::from)
@@ -554,7 +554,7 @@ mod tests {
                 .iter()
                 .map(|nonce| {
                     nonce
-                        .time
+                        .time()
                         .to_batch_unit_interval_start(task.min_batch_duration)
                         .unwrap()
                 })

--- a/janus_server/src/client.rs
+++ b/janus_server/src/client.rs
@@ -161,10 +161,7 @@ where
             .shard(&self.vdaf_public_parameter, measurement)?;
         assert_eq!(input_shares.len(), 2); // PPM only supports VDAFs using two aggregators.
 
-        let nonce = Nonce {
-            time: self.clock.now(),
-            rand: rand::random(),
-        };
+        let nonce = Nonce::generate(&self.clock);
         let extensions = vec![]; // No extensions supported yet
         let associated_data = associated_data_for_report_share(nonce, &extensions);
 

--- a/janus_server/src/message.rs
+++ b/janus_server/src/message.rs
@@ -24,7 +24,7 @@ use std::{
     str::FromStr,
 };
 
-use crate::hpke::associated_data_for_report_share;
+use crate::{hpke::associated_data_for_report_share, time::Clock};
 
 /// Errors returned by functions and methods in this module
 #[derive(Debug, thiserror::Error)]
@@ -358,9 +358,34 @@ impl Display for Interval {
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Nonce {
     /// The time at which the report was generated.
-    pub time: Time,
+    time: Time,
     /// A randomly generated value.
-    pub(crate) rand: [u8; 8],
+    rand: [u8; 8],
+}
+
+impl Nonce {
+    /// Construct a nonce with the given time and random parts.
+    pub fn new(time: Time, rand: [u8; 8]) -> Nonce {
+        Nonce { time, rand }
+    }
+
+    /// Generate a fresh nonce with the current time.
+    pub fn generate<C: Clock>(clock: &C) -> Nonce {
+        Nonce {
+            time: clock.now(),
+            rand: rand::random(),
+        }
+    }
+
+    /// Get the time component of a nonce.
+    pub fn time(&self) -> Time {
+        self.time
+    }
+
+    /// Get the random component of a nonce.
+    pub fn rand(&self) -> [u8; 8] {
+        self.rand
+    }
 }
 
 impl Display for Nonce {


### PR DESCRIPTION
This is part of #18. One item of note: I promoted the test-only function `generate_nonce()` to `Nonce::generate()`, since the client needs to do this too.