### PR TITLE
require 'static + Copy on trait Clock

### DIFF
--- a/janus_server/src/client.rs
+++ b/janus_server/src/client.rs
@@ -161,7 +161,7 @@ where
             .shard(&self.vdaf_public_parameter, measurement)?;
         assert_eq!(input_shares.len(), 2); // PPM only supports VDAFs using two aggregators.
 
-        let nonce = Nonce::generate(&self.clock);
+        let nonce = Nonce::generate(self.clock);
         let extensions = vec![]; // No extensions supported yet
         let associated_data = associated_data_for_report_share(nonce, &extensions);
 

--- a/janus_server/src/message.rs
+++ b/janus_server/src/message.rs
@@ -370,7 +370,7 @@ impl Nonce {
     }
 
     /// Generate a fresh nonce with the current time.
-    pub fn generate<C: Clock>(clock: &C) -> Nonce {
+    pub fn generate<C: Clock>(clock: C) -> Nonce {
         Nonce {
             time: clock.now(),
             rand: rand::random(),

--- a/janus_server/src/time.rs
+++ b/janus_server/src/time.rs
@@ -5,13 +5,13 @@ use chrono::{naive::NaiveDateTime, Utc};
 use std::fmt::{Debug, Formatter};
 
 /// A clock knows what time it currently is.
-pub trait Clock: Clone + Debug + Sync + Send {
+pub trait Clock: 'static + Clone + Copy + Debug + Sync + Send {
     /// Get the current time.
     fn now(&self) -> Time;
 }
 
 /// A real clock returns the current time relative to the Unix epoch.
-#[derive(Clone, Default)]
+#[derive(Clone, Copy, Default)]
 pub struct RealClock {}
 
 impl Clock for RealClock {
@@ -33,7 +33,7 @@ pub mod test_util {
     use chrono::{NaiveDate, NaiveDateTime};
 
     /// A mock clock for use in testing.
-    #[derive(Clone, Debug)]
+    #[derive(Clone, Copy, Debug)]
     pub struct MockClock {
         /// The time that this clock will always return from [`Self::now`]
         pub(crate) current_time: NaiveDateTime,


### PR DESCRIPTION
Both of our implementations of trait `time::Clock` are teeny:
`RealClock` has no fields and `MockClock` only contains a single
`NaiveDateTime`. Therefore it's perfectly reasonable to pass them around
by value, and indeed most places they're used have to apply an extra
`'static` trait bound to safely use them. We now require `'static +
Copy` which lets us simplify generics in a couple of places.