### PR TITLE
Initial split-out of common crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,6 +1265,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
+name = "janus"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "assert_matches",
+ "base64",
+ "chrono",
+ "hex",
+ "hpke",
+ "num_enum",
+ "prio",
+ "rand",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "janus_server"
 version = "0.1.0"
 dependencies = [
@@ -1284,6 +1301,7 @@ dependencies = [
  "http",
  "hyper",
  "itertools",
+ "janus",
  "lazy_static",
  "libc",
  "mockito",
@@ -1501,6 +1519,7 @@ dependencies = [
  "chrono",
  "deadpool-postgres",
  "futures",
+ "janus",
  "janus_server",
  "lazy_static",
  "prio",
@@ -2709,6 +2728,8 @@ dependencies = [
 name = "test_util"
 version = "0.1.0"
 dependencies = [
+ "chrono",
+ "janus",
  "rand",
  "ring",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["janus_server", "monolithic_integration_test", "test_util"]
+members = ["janus", "janus_server", "monolithic_integration_test", "test_util"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apk add libc-dev
 WORKDIR /src
 COPY Cargo.toml /src/Cargo.toml
 COPY Cargo.lock /src/Cargo.lock
+COPY janus /src/janus
 COPY janus_server /src/janus_server
 COPY monolithic_integration_test /src/monolithic_integration_test
 COPY test_util /src/test_util

--- a/janus/Cargo.toml
+++ b/janus/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "janus"
+version = "0.1.0"
+edition = "2021"
+license = "MPL-2.0"
+rust-version = "1.58"
+
+[dependencies]
+anyhow = "1"
+base64 = "0.13.0"
+chrono = "0.4"
+hex = "0.4.3"
+hpke = { version = "0.8.0", features = ["default", "std"] }
+num_enum = "0.5.6"
+prio = { git = "https://github.com/divviup/libprio-rs", rev = "229cd9c45924c7dae3ba754a6eb46b2a05ca8451" }  # TODO(brandon): use a numbered version, once a release is cut >0.7.0
+rand = "0.8"
+serde = { version = "1.0.137", features = ["derive"] }
+thiserror = "1.0"
+
+[dev-dependencies]
+assert_matches = "1"

--- a/janus/src/lib.rs
+++ b/janus/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod message;
+pub mod time;

--- a/janus/src/message.rs
+++ b/janus/src/message.rs
@@ -1,0 +1,517 @@
+//! PPM protocol message definitions with serialization/deserialization support.
+
+use crate::time::Clock;
+use anyhow::anyhow;
+use chrono::NaiveDateTime;
+use hpke::{
+    aead::{self, Aead},
+    kdf::{self, Kdf},
+    kem, Kem,
+};
+use num_enum::TryFromPrimitive;
+use prio::codec::{CodecError, Decode, Encode};
+use rand::{thread_rng, Rng};
+use serde::{Deserialize, Serialize};
+use std::{
+    fmt::{Debug, Display, Formatter},
+    io::{Cursor, Read},
+    str::FromStr,
+};
+
+/// Errors returned by functions and methods in this module
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// An illegal arithmetic operation on a [`Time`] or [`Duration`].
+    #[error("{0}")]
+    IllegalTimeArithmetic(&'static str),
+}
+
+/// PPM protocol message representing a duration with a resolution of seconds.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct Duration(u64);
+
+impl Duration {
+    /// Create a duration representing the provided number of seconds.
+    pub fn from_seconds(seconds: u64) -> Self {
+        Self(seconds)
+    }
+
+    /// Get the number of seconds this duration represents.
+    pub fn as_seconds(self) -> u64 {
+        self.0
+    }
+
+    /// Create a duration representing the provided number of minutes.
+    pub fn from_minutes(minutes: u64) -> Result<Self, Error> {
+        60u64
+            .checked_mul(minutes)
+            .map(Self::from_seconds)
+            .ok_or(Error::IllegalTimeArithmetic("operation would overflow"))
+    }
+
+    /// Create a duration representing the provided number of hours.
+    pub fn from_hours(hours: u64) -> Result<Self, Error> {
+        3600u64
+            .checked_mul(hours)
+            .map(Self::from_seconds)
+            .ok_or(Error::IllegalTimeArithmetic("operation would overflow"))
+    }
+}
+
+impl Encode for Duration {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        self.0.encode(bytes);
+    }
+}
+
+impl Decode for Duration {
+    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        Ok(Self(u64::decode(bytes)?))
+    }
+}
+
+impl Display for Duration {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} seconds", self.0)
+    }
+}
+
+/// PPM protocol message representing an instant in time with a resolution of seconds.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Time(u64);
+
+impl Time {
+    /// Convert this [`Time`] into a [`NaiveDateTime`], representing an instant in the UTC timezone.
+    pub fn as_naive_date_time(&self) -> NaiveDateTime {
+        NaiveDateTime::from_timestamp(self.0 as i64, 0)
+    }
+
+    /// Convert a [`NaiveDateTime`] representing an instant in the UTC timezone into a [`Time`].
+    pub fn from_naive_date_time(time: NaiveDateTime) -> Self {
+        Self(time.timestamp() as u64)
+    }
+
+    /// Get the number of seconds from January 1st, 1970, at 0:00:00 UTC to the instant represented
+    /// by this [`Time`] (i.e., the Unix timestamp for the instant it represents).
+    pub fn as_seconds_since_epoch(&self) -> u64 {
+        self.0
+    }
+
+    /// Construct a [`Time`] representing the instant that is a given number of seconds after
+    /// January 1st, 1970, at 0:00:00 UTC (i.e., the instant with the Unix timestamp of
+    /// `timestamp`).
+    pub fn from_seconds_since_epoch(timestamp: u64) -> Self {
+        Self(timestamp)
+    }
+
+    /// Add the provided duration to this time.
+    pub fn add(&self, duration: Duration) -> Result<Self, Error> {
+        self.0
+            .checked_add(duration.0)
+            .map(Self)
+            .ok_or(Error::IllegalTimeArithmetic("operation would overflow"))
+    }
+
+    /// Subtract the provided duration from this time.
+    pub fn sub(&self, duration: Duration) -> Result<Self, Error> {
+        self.0
+            .checked_sub(duration.0)
+            .map(Self)
+            .ok_or(Error::IllegalTimeArithmetic("operation would underflow"))
+    }
+
+    /// Compute the start of the batch interval containing this Time, given the batch unit duration.
+    pub fn to_batch_unit_interval_start(
+        &self,
+        min_batch_duration: Duration,
+    ) -> Result<Self, Error> {
+        let rem = self
+            .0
+            .checked_rem(min_batch_duration.0)
+            .ok_or(Error::IllegalTimeArithmetic(
+                "remainder would overflow/underflow",
+            ))?;
+        self.0
+            .checked_sub(rem)
+            .map(Self)
+            .ok_or(Error::IllegalTimeArithmetic("operation would underflow"))
+    }
+
+    /// Returns true if this [`Time`] occurs after `time`.
+    pub fn is_after(&self, time: Time) -> bool {
+        self.0 > time.0
+    }
+}
+
+impl Display for Time {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Encode for Time {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        self.0.encode(bytes);
+    }
+}
+
+impl Decode for Time {
+    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        Ok(Self(u64::decode(bytes)?))
+    }
+}
+
+/// PPM protocol message representing a nonce uniquely identifying a client report.
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Nonce {
+    /// The time at which the report was generated.
+    time: Time,
+    /// A randomly generated value.
+    rand: [u8; 8],
+}
+
+impl Nonce {
+    /// Construct a nonce with the given time and random parts.
+    pub fn new(time: Time, rand: [u8; 8]) -> Nonce {
+        Nonce { time, rand }
+    }
+
+    /// Generate a fresh nonce with the current time.
+    pub fn generate<C: Clock>(clock: C) -> Nonce {
+        Nonce {
+            time: clock.now(),
+            rand: rand::random(),
+        }
+    }
+
+    /// Get the time component of a nonce.
+    pub fn time(&self) -> Time {
+        self.time
+    }
+
+    /// Get the random component of a nonce.
+    pub fn rand(&self) -> [u8; 8] {
+        self.rand
+    }
+}
+
+impl Display for Nonce {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}", self.time, hex::encode(self.rand))
+    }
+}
+
+impl Encode for Nonce {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        self.time.encode(bytes);
+        bytes.extend_from_slice(&self.rand);
+    }
+}
+
+impl Decode for Nonce {
+    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        let time = Time::decode(bytes)?;
+        let mut rand = [0; 8];
+        bytes.read_exact(&mut rand)?;
+
+        Ok(Self { time, rand })
+    }
+}
+
+/// PPM protocol message representing the different roles that participants can adopt.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, TryFromPrimitive, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum Role {
+    Collector = 0,
+    Client = 1,
+    Leader = 2,
+    Helper = 3,
+}
+
+impl Role {
+    /// True if this [`Role`] is one of the aggregators.
+    pub fn is_aggregator(&self) -> bool {
+        matches!(self, Role::Leader | Role::Helper)
+    }
+
+    /// If this [`Role`] is one of the aggregators, returns the index at which
+    /// that aggregator's message or data can be found in various lists, or
+    /// `None` if the role is not an aggregator.
+    pub fn index(&self) -> Option<usize> {
+        match self {
+            // draft-gpew-priv-ppm §4.2: the leader's endpoint MUST be the first
+            Role::Leader => Some(0),
+            Role::Helper => Some(1),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Collector => "collector",
+            Self::Client => "client",
+            Self::Leader => "leader",
+            Self::Helper => "helper",
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("unknown role {0}")]
+pub struct RoleParseError(String);
+
+impl FromStr for Role {
+    type Err = RoleParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "collector" => Ok(Self::Collector),
+            "client" => Ok(Self::Client),
+            "leader" => Ok(Self::Leader),
+            "helper" => Ok(Self::Helper),
+            _ => Err(RoleParseError(s.to_owned())),
+        }
+    }
+}
+
+impl Encode for Role {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        (*self as u8).encode(bytes);
+    }
+}
+
+impl Decode for Role {
+    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        let val = u8::decode(bytes)?;
+        Self::try_from(val)
+            .map_err(|_| CodecError::Other(anyhow!("unexpected Role value {}", val).into()))
+    }
+}
+
+/// PPM protocol message representing an identifier for an HPKE config.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct HpkeConfigId(u8);
+
+impl Display for HpkeConfigId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Encode for HpkeConfigId {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        self.0.encode(bytes);
+    }
+}
+
+impl Decode for HpkeConfigId {
+    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        Ok(Self(u8::decode(bytes)?))
+    }
+}
+
+impl From<u8> for HpkeConfigId {
+    fn from(value: u8) -> HpkeConfigId {
+        HpkeConfigId(value)
+    }
+}
+
+impl From<HpkeConfigId> for u8 {
+    fn from(id: HpkeConfigId) -> u8 {
+        id.0
+    }
+}
+
+/// PPM protocol message representing an identifier for a PPM task.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct TaskId([u8; Self::ENCODED_LEN]);
+
+impl Debug for TaskId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "TaskId({})",
+            base64::display::Base64Display::with_config(&self.0, base64::URL_SAFE_NO_PAD)
+        )
+    }
+}
+
+impl Display for TaskId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            base64::display::Base64Display::with_config(&self.0, base64::URL_SAFE_NO_PAD)
+        )
+    }
+}
+
+impl Encode for TaskId {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        bytes.extend_from_slice(&self.0)
+    }
+}
+
+impl Decode for TaskId {
+    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        let mut decoded = [0u8; Self::ENCODED_LEN];
+        bytes.read_exact(&mut decoded)?;
+        Ok(Self(decoded))
+    }
+}
+
+impl TaskId {
+    /// ENCODED_LEN is the length of a task ID in bytes when encoded.
+    pub const ENCODED_LEN: usize = 32;
+
+    /// Get a reference to the task ID as a byte slice
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// Generate a random [`TaskId`]
+    pub fn random() -> Self {
+        let mut buf = [0u8; Self::ENCODED_LEN];
+        thread_rng().fill(&mut buf);
+        Self(buf)
+    }
+
+    /// Construct a [`TaskId`] from a byte array.
+    pub fn new(buf: [u8; Self::ENCODED_LEN]) -> Self {
+        Self(buf)
+    }
+}
+
+/// PPM protocol message representing an HPKE key encapsulation mechanism.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, TryFromPrimitive, Serialize, Deserialize)]
+#[repr(u16)]
+pub enum HpkeKemId {
+    /// NIST P-256 keys and HKDF-SHA256.
+    P256HkdfSha256 = kem::DhP256HkdfSha256::KEM_ID,
+    /// X25519 keys and HKDF-SHA256.
+    X25519HkdfSha256 = kem::X25519HkdfSha256::KEM_ID,
+}
+
+impl Encode for HpkeKemId {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        (*self as u16).encode(bytes);
+    }
+}
+
+impl Decode for HpkeKemId {
+    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        let val = u16::decode(bytes)?;
+        Self::try_from(val)
+            .map_err(|_| CodecError::Other(anyhow!("unexpected HpkeKemId value {}", val).into()))
+    }
+}
+
+/// PPM protocol message representing an HPKE key derivation function.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, TryFromPrimitive, Serialize, Deserialize)]
+#[repr(u16)]
+pub enum HpkeKdfId {
+    /// HMAC Key Derivation Function SHA256.
+    HkdfSha256 = kdf::HkdfSha256::KDF_ID,
+    /// HMAC Key Derivation Function SHA384.
+    HkdfSha384 = kdf::HkdfSha384::KDF_ID,
+    /// HMAC Key Derivation Function SHA512.
+    HkdfSha512 = kdf::HkdfSha512::KDF_ID,
+}
+
+impl Encode for HpkeKdfId {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        (*self as u16).encode(bytes);
+    }
+}
+
+impl Decode for HpkeKdfId {
+    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        let val = u16::decode(bytes)?;
+        Self::try_from(val)
+            .map_err(|_| CodecError::Other(anyhow!("unexpected HpkeKdfId value {}", val).into()))
+    }
+}
+
+/// PPM protocol message representing an HPKE AEAD.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, TryFromPrimitive, Serialize, Deserialize)]
+#[repr(u16)]
+pub enum HpkeAeadId {
+    /// AES-128-GCM.
+    Aes128Gcm = aead::AesGcm128::AEAD_ID,
+    /// AES-256-GCM.
+    Aes256Gcm = aead::AesGcm256::AEAD_ID,
+    /// ChaCha20Poly1305.
+    ChaCha20Poly1305 = aead::ChaCha20Poly1305::AEAD_ID,
+}
+
+impl Encode for HpkeAeadId {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        (*self as u16).encode(bytes);
+    }
+}
+
+impl Decode for HpkeAeadId {
+    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        let val = u16::decode(bytes)?;
+        Self::try_from(val)
+            .map_err(|_| CodecError::Other(anyhow!("unexpected HpkeAeadId value {}", val).into()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Duration, HpkeConfigId, Role, Time};
+    use prio::codec::{Decode, Encode};
+    use std::io::Cursor;
+
+    fn roundtrip_encoding<T>(vals_and_encodings: &[(T, &str)])
+    where
+        T: Encode + Decode + core::fmt::Debug + Eq,
+    {
+        for (val, hex_encoding) in vals_and_encodings {
+            let mut encoded_val = Vec::new();
+            val.encode(&mut encoded_val);
+            let encoding = hex::decode(hex_encoding).unwrap();
+            assert_eq!(encoding, encoded_val);
+            let decoded_val = T::decode(&mut Cursor::new(&encoded_val)).unwrap();
+            assert_eq!(val, &decoded_val);
+        }
+    }
+
+    #[test]
+    fn roundtrip_duration() {
+        roundtrip_encoding(&[
+            (Duration::from_seconds(u64::MIN), "0000000000000000"),
+            (Duration::from_seconds(12345), "0000000000003039"),
+            (Duration::from_seconds(u64::MAX), "FFFFFFFFFFFFFFFF"),
+        ])
+    }
+
+    #[test]
+    fn roundtrip_time() {
+        roundtrip_encoding(&[
+            (Time::from_seconds_since_epoch(u64::MIN), "0000000000000000"),
+            (Time::from_seconds_since_epoch(12345), "0000000000003039"),
+            (Time::from_seconds_since_epoch(u64::MAX), "FFFFFFFFFFFFFFFF"),
+        ])
+    }
+
+    #[test]
+    fn roundtrip_role() {
+        roundtrip_encoding(&[
+            (Role::Collector, "00"),
+            (Role::Client, "01"),
+            (Role::Leader, "02"),
+            (Role::Helper, "03"),
+        ]);
+    }
+
+    #[test]
+    fn roundtrip_hpke_config_id() {
+        roundtrip_encoding(&[
+            (HpkeConfigId(u8::MIN), "00"),
+            (HpkeConfigId(10), "0A"),
+            (HpkeConfigId(u8::MAX), "FF"),
+        ])
+    }
+}

--- a/janus/src/time.rs
+++ b/janus/src/time.rs
@@ -25,31 +25,3 @@ impl Debug for RealClock {
         write!(f, "{:?}", self.now())
     }
 }
-
-#[doc(hidden)]
-pub mod test_util {
-    use super::Clock;
-    use crate::message::Time;
-    use chrono::{NaiveDate, NaiveDateTime};
-
-    /// A mock clock for use in testing.
-    #[derive(Clone, Copy, Debug)]
-    pub struct MockClock {
-        /// The time that this clock will always return from [`Self::now`]
-        pub(crate) current_time: NaiveDateTime,
-    }
-
-    impl Clock for MockClock {
-        fn now(&self) -> Time {
-            Time::from_naive_date_time(self.current_time)
-        }
-    }
-
-    impl Default for MockClock {
-        fn default() -> Self {
-            Self {
-                current_time: NaiveDate::from_ymd(2001, 9, 9).and_hms(1, 46, 40),
-            }
-        }
-    }
-}

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -27,6 +27,7 @@ hpke-dispatch = "0.2.0"
 http = "0.2.7"
 hyper = "0.14.18"
 itertools = "0.10.3"
+janus = { path = "../janus" }
 num_enum = "0.5.6"
 opentelemetry = { version = "0.17.0", features = ["metrics", "rt-tokio"] }
 opentelemetry-jaeger = { version = "0.16.0", optional = true, features = ["rt-tokio"] }

--- a/janus_server/src/bin/aggregation_job_creator.rs
+++ b/janus_server/src/bin/aggregation_job_creator.rs
@@ -1,15 +1,16 @@
 use anyhow::Context;
 use futures::future::try_join_all;
 use itertools::Itertools;
+use janus::message::{Nonce, Role, TaskId, Time};
+use janus::time::{Clock, RealClock};
 use janus_server::binary_utils::datastore;
 use janus_server::config::AggregationJobCreatorConfig;
 use janus_server::datastore::models::{
     AggregationJob, AggregationJobState, ReportAggregation, ReportAggregationState,
 };
 use janus_server::datastore::{self, Datastore};
-use janus_server::message::{AggregationJobId, Nonce, Role, TaskId, Time};
+use janus_server::message::AggregationJobId;
 use janus_server::task::Task;
-use janus_server::time::{Clock, RealClock};
 use janus_server::trace::install_trace_subscriber;
 use prio::codec::Encode;
 use prio::vdaf;
@@ -347,13 +348,14 @@ mod tests {
     use crate::AggregationJobCreator;
     use chrono::NaiveDateTime;
     use futures::{future::try_join_all, TryFutureExt};
+    use janus::{
+        message::{Nonce, Role, TaskId, Time},
+        time::Clock,
+    };
     use janus_server::{
         datastore::{Crypter, Datastore, Transaction},
-        message::{
-            test_util::new_dummy_report, AggregationJobId, Nonce, Report, Role, TaskId, Time,
-        },
+        message::{test_util::new_dummy_report, AggregationJobId, Report},
         task::{test_util::new_dummy_task, Vdaf},
-        time::{test_util::MockClock, Clock},
         trace::test_util::install_test_trace_subscriber,
     };
     use prio::vdaf::{prio3::Prio3Aes128Count, Vdaf as _};
@@ -363,6 +365,7 @@ mod tests {
         sync::Arc,
         time::Duration,
     };
+    use test_util::MockClock;
     use tokio::{task, time};
 
     test_util::define_ephemeral_datastore!();

--- a/janus_server/src/bin/aggregator.rs
+++ b/janus_server/src/bin/aggregator.rs
@@ -1,11 +1,11 @@
 use anyhow::{anyhow, Context, Result};
 use futures::StreamExt;
+use janus::time::RealClock;
 use janus_server::{
     aggregator::aggregator_server,
     binary_utils::datastore,
     config::AggregatorConfig,
     metrics::{install_metrics_exporter, MetricsExporterConfiguration},
-    time::RealClock,
     trace::{cleanup_trace_subscriber, install_trace_subscriber, OpenTelemetryTraceConfiguration},
 };
 use std::{

--- a/janus_server/src/client.rs
+++ b/janus_server/src/client.rs
@@ -2,10 +2,13 @@
 
 use crate::{
     hpke::{self, associated_data_for_report_share, HpkeApplicationInfo, Label},
-    message::{HpkeCiphertext, HpkeConfig, Nonce, Report, Role, TaskId},
-    time::Clock,
+    message::{HpkeCiphertext, HpkeConfig, Report},
 };
 use http::StatusCode;
+use janus::{
+    message::{Nonce, Role, TaskId},
+    time::Clock,
+};
 use prio::{
     codec::{Decode, Encode},
     vdaf,
@@ -213,12 +216,14 @@ where
 mod tests {
     use super::*;
     use crate::{
-        hpke::test_util::generate_hpke_config_and_private_key, message::TaskId,
-        time::test_util::MockClock, trace::test_util::install_test_trace_subscriber,
+        hpke::test_util::generate_hpke_config_and_private_key,
+        trace::test_util::install_test_trace_subscriber,
     };
     use assert_matches::assert_matches;
+    use janus::message::TaskId;
     use mockito::mock;
     use prio::vdaf::prio3::{Prio3Aes128Count, Prio3Aes128Sum};
+    use test_util::MockClock;
     use url::Url;
 
     fn setup_client<V: vdaf::Client>(

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -7,12 +7,13 @@ use self::models::{
 use crate::{
     hpke::HpkePrivateKey,
     message::{
-        self, AggregateShareReq, AggregationJobId, Duration, Extension, HpkeCiphertext, HpkeConfig,
-        Interval, Nonce, Report, ReportShare, TaskId, Time,
+        AggregateShareReq, AggregationJobId, Extension, HpkeCiphertext, HpkeConfig, Interval,
+        Report, ReportShare,
     },
     task::{self, AggregatorAuthKey, Task, Vdaf},
 };
 use futures::try_join;
+use janus::message::{Duration, Nonce, TaskId, Time};
 use postgres_types::{Json, ToSql};
 use prio::{
     codec::{decode_u16_items, encode_u16_items, CodecError, Decode, Encode, ParameterizedDecode},
@@ -1496,7 +1497,7 @@ pub enum Error {
     #[error("integer conversion failed: {0}")]
     TryFromInt(#[from] std::num::TryFromIntError),
     #[error(transparent)]
-    Message(#[from] message::Error),
+    Message(#[from] janus::message::Error),
 }
 
 impl Error {
@@ -1525,10 +1526,11 @@ impl From<ring::error::Unspecified> for Error {
 pub mod models {
     use super::Error;
     use crate::{
-        message::{AggregationJobId, Interval, Nonce, Role, TaskId, Time, TransitionError},
+        message::{AggregationJobId, Interval, TransitionError},
         task,
     };
     use derivative::Derivative;
+    use janus::message::{Nonce, Role, TaskId, Time};
     use postgres_types::{FromSql, ToSql};
     use prio::vdaf;
 
@@ -1844,12 +1846,13 @@ mod tests {
     use crate::{
         aggregator::test_util::fake,
         datastore::{models::AggregationJobState, test_util::ephemeral_datastore},
-        message::{Duration, ExtensionType, HpkeConfigId, Interval, Role, Time, TransitionError},
+        message::{ExtensionType, Interval, TransitionError},
         task::{test_util::new_dummy_task, Vdaf},
         trace::test_util::install_test_trace_subscriber,
     };
     use ::test_util::generate_aead_key;
     use assert_matches::assert_matches;
+    use janus::message::{Duration, HpkeConfigId, Role, Time};
     use prio::{
         field::{Field128, Field64},
         vdaf::{

--- a/janus_server/src/hpke.rs
+++ b/janus_server/src/hpke.rs
@@ -1,7 +1,8 @@
 //! Encryption and decryption of messages using HPKE (RFC 9180).
 
-use crate::message::{Extension, HpkeCiphertext, HpkeConfig, Nonce, Role, TaskId};
+use crate::message::{Extension, HpkeCiphertext, HpkeConfig};
 use hpke::HpkeError;
+use janus::message::{Nonce, Role, TaskId};
 use prio::codec::{encode_u16_items, Encode};
 use std::str::FromStr;
 
@@ -163,10 +164,9 @@ pub fn open(
 #[doc(hidden)]
 pub mod test_util {
     use super::HpkePrivateKey;
-    use crate::message::{
-        HpkeAeadId, HpkeConfig, HpkeConfigId, HpkeKdfId, HpkeKemId, HpkePublicKey,
-    };
+    use crate::message::{HpkeConfig, HpkePublicKey};
     use hpke::{kem::X25519HkdfSha256, Kem, Serializable};
+    use janus::message::{HpkeAeadId, HpkeConfigId, HpkeKdfId, HpkeKemId};
     use rand::thread_rng;
 
     /// Generate a new HPKE keypair and return it as an HpkeConfig (public portion) and
@@ -189,11 +189,9 @@ pub mod test_util {
 #[cfg(test)]
 mod tests {
     use super::{test_util::generate_hpke_config_and_private_key, *};
-    use crate::{
-        message::{HpkeConfigId, HpkePublicKey},
-        trace::test_util::install_test_trace_subscriber,
-    };
+    use crate::{message::HpkePublicKey, trace::test_util::install_test_trace_subscriber};
     use hpke::{aead::*, kdf::*, kem::*, Serializable};
+    use janus::message::HpkeConfigId;
     use serde::Deserialize;
     use std::collections::HashSet;
 

--- a/janus_server/src/lib.rs
+++ b/janus_server/src/lib.rs
@@ -9,5 +9,4 @@ pub mod hpke;
 pub mod message;
 pub mod metrics;
 pub mod task;
-pub mod time;
 pub mod trace;

--- a/janus_server/src/task.rs
+++ b/janus_server/src/task.rs
@@ -4,9 +4,10 @@ use std::collections::HashMap;
 
 use crate::{
     hpke::HpkePrivateKey,
-    message::{Duration, HpkeConfig, HpkeConfigId, Interval, Role, TaskId},
+    message::{HpkeConfig, Interval},
 };
 use ::rand::{thread_rng, Rng};
+use janus::message::{Duration, HpkeConfigId, Role, TaskId};
 use ring::{
     digest::SHA256_OUTPUT_LEN,
     hmac::{self, HMAC_SHA256},
@@ -208,11 +209,8 @@ impl Task {
 #[doc(hidden)]
 pub mod test_util {
     use super::{Task, Vdaf};
-    use crate::{
-        hpke::test_util::generate_hpke_config_and_private_key,
-        message::{Duration, HpkeConfigId, Role, TaskId},
-        task::AggregatorAuthKey,
-    };
+    use crate::{hpke::test_util::generate_hpke_config_and_private_key, task::AggregatorAuthKey};
+    use janus::message::{Duration, HpkeConfigId, Role, TaskId};
     use prio::{
         codec::Encode,
         field::Field128,
@@ -290,11 +288,10 @@ pub mod test_util {
 
 #[cfg(test)]
 mod tests {
-    use serde_test::{assert_tokens, Token};
-
     use super::test_util::new_dummy_task;
     use super::*;
-    use crate::message::{Duration, TaskId, Time};
+    use janus::message::{Duration, TaskId, Time};
+    use serde_test::{assert_tokens, Token};
 
     #[test]
     fn validate_batch_interval() {

--- a/janus_server/tests/server_shutdown.rs
+++ b/janus_server/tests/server_shutdown.rs
@@ -3,10 +3,10 @@
 //! The server should promptly shut down, and this test will fail if it times
 //! out waiting for the server to do so.
 
+use janus::message::{Role, TaskId};
 use janus_server::{
     config::{AggregatorConfig, DbConfig},
     datastore::{Crypter, Datastore},
-    message::{Role, TaskId},
     task::{test_util::new_dummy_task, Vdaf},
     trace::{install_trace_subscriber, TraceConfiguration},
 };

--- a/monolithic_integration_test/Cargo.toml
+++ b/monolithic_integration_test/Cargo.toml
@@ -2,11 +2,15 @@
 name = "monolithic_integration_test"
 version = "0.1.0"
 edition = "2021"
+license = "MPL-2.0"
+rust-version = "1.58"
+publish = false
 
 [dev-dependencies]
 chrono = "0.4.19"
 deadpool-postgres = "0.10.1"
 futures = "0.3.21"
+janus = { path = "../janus" }
 janus_server = { path = "../janus_server" }
 lazy_static = "1"
 prio = { git = "https://github.com/divviup/libprio-rs", rev = "229cd9c45924c7dae3ba754a6eb46b2a05ca8451" }  # TODO(brandon): use a numbered version, once a release is cut >0.7.0

--- a/monolithic_integration_test/tests/integration_test.rs
+++ b/monolithic_integration_test/tests/integration_test.rs
@@ -1,12 +1,14 @@
 use futures::channel::oneshot::Sender;
+use janus::{
+    message::{Duration, Role, TaskId},
+    time::RealClock,
+};
 use janus_server::{
     aggregator::aggregator_server,
     client::{self, Client, ClientParameters},
     datastore::{Crypter, Datastore},
     hpke::test_util::generate_hpke_config_and_private_key,
-    message::{Duration, Role, TaskId},
     task::{AggregatorAuthKey, Task, Vdaf},
-    time::RealClock,
     trace::{install_trace_subscriber, TraceConfiguration},
 };
 use prio::{

--- a/test_util/Cargo.toml
+++ b/test_util/Cargo.toml
@@ -2,7 +2,12 @@
 name = "test_util"
 version = "0.1.0"
 edition = "2021"
+license = "MPL-2.0"
+rust-version = "1.58"
+publish = false
 
 [dependencies]
 rand = "0.8"
 ring = "0.16.20"
+janus = { path = "../janus" }
+chrono = "0.4"

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -1,3 +1,5 @@
+use chrono::{NaiveDate, NaiveDateTime};
+use janus::{message::Time, time::Clock};
 use rand::{thread_rng, Rng};
 use ring::aead::{LessSafeKey, UnboundKey, AES_128_GCM};
 
@@ -96,4 +98,25 @@ pub fn generate_aead_key_bytes() -> Vec<u8> {
 pub fn generate_aead_key() -> LessSafeKey {
     let unbound_key = UnboundKey::new(&AES_128_GCM, &generate_aead_key_bytes()).unwrap();
     LessSafeKey::new(unbound_key)
+}
+
+/// A mock clock for use in testing.
+#[derive(Clone, Copy, Debug)]
+pub struct MockClock {
+    /// The time that this clock will always return from [`Self::now`]
+    pub(crate) current_time: NaiveDateTime,
+}
+
+impl Clock for MockClock {
+    fn now(&self) -> Time {
+        Time::from_naive_date_time(self.current_time)
+    }
+}
+
+impl Default for MockClock {
+    fn default() -> Self {
+        Self {
+            current_time: NaiveDate::from_ymd(2001, 9, 9).and_hms(1, 46, 40),
+        }
+    }
 }


### PR DESCRIPTION
This moves some of the most primitive types into a common `janus` crate. In the future, this will be reused from separate client and server crates. (with the possible addition of a collector crate as well) Additionally, the methods of `Role` were made public, `MockClock` was moved to the `test_util` crate, and a constructor was added to `TaskId`.

This is part of #18. Next steps: clean up the APIs of `HpkeCiphertext`, `HpkePublicKey`, `HpkeConfig`, `Extension`, `ExtensionType`, and `Report`, move those, and move the `hpke` module.