### PR TITLE
Refactor and move `Report` and its transitive dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,6 +1280,7 @@ dependencies = [
  "chrono",
  "hex",
  "hpke",
+ "hpke-dispatch",
  "num_enum",
  "prio",
  "rand",

--- a/janus/Cargo.toml
+++ b/janus/Cargo.toml
@@ -11,6 +11,7 @@ base64 = "0.13.0"
 chrono = "0.4"
 hex = "0.4.3"
 hpke = { version = "0.8.0", features = ["default", "std"] }
+hpke-dispatch = "0.2.0"
 num_enum = "0.5.6"
 prio = { git = "https://github.com/divviup/libprio-rs", rev = "229cd9c45924c7dae3ba754a6eb46b2a05ca8451" }  # TODO(brandon): use a numbered version, once a release is cut >0.7.0
 rand = "0.8"

--- a/janus/src/hpke.rs
+++ b/janus/src/hpke.rs
@@ -1,4 +1,5 @@
-use crate::message::HpkeConfig;
+use crate::message::{Extension, HpkeConfig, Nonce};
+use prio::codec::{encode_u16_items, Encode};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -22,4 +23,13 @@ impl TryFrom<&HpkeConfig> for hpke_dispatch::Config {
                 .map_err(|_| Self::Error::InvalidConfiguration("did not recognize kem"))?,
         })
     }
+}
+
+/// Construct the HPKE associated data for sealing or opening data enciphered for a report or report
+/// share, per §4.3.2 and 4.4.2.2 of draft-gpew-priv-ppm
+pub fn associated_data_for_report_share(nonce: Nonce, extensions: &[Extension]) -> Vec<u8> {
+    let mut associated_data = vec![];
+    nonce.encode(&mut associated_data);
+    encode_u16_items(&mut associated_data, &(), extensions);
+    associated_data
 }

--- a/janus/src/hpke.rs
+++ b/janus/src/hpke.rs
@@ -1,0 +1,25 @@
+use crate::message::HpkeConfig;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("invalid HPKE configuration: {0}")]
+    InvalidConfiguration(&'static str),
+}
+
+impl TryFrom<&HpkeConfig> for hpke_dispatch::Config {
+    type Error = Error;
+
+    fn try_from(config: &HpkeConfig) -> Result<Self, Self::Error> {
+        Ok(Self {
+            aead: (config.aead_id() as u16)
+                .try_into()
+                .map_err(|_| Self::Error::InvalidConfiguration("did not recognize aead"))?,
+            kdf: (config.kdf_id() as u16)
+                .try_into()
+                .map_err(|_| Self::Error::InvalidConfiguration("did not recognize kdf"))?,
+            kem: (config.kem_id() as u16)
+                .try_into()
+                .map_err(|_| Self::Error::InvalidConfiguration("did not recognize kem"))?,
+        })
+    }
+}

--- a/janus/src/lib.rs
+++ b/janus/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod hpke;
 pub mod message;
 pub mod time;

--- a/janus/src/message.rs
+++ b/janus/src/message.rs
@@ -710,7 +710,7 @@ impl Decode for HpkeConfig {
 mod tests {
     use super::{
         Duration, Extension, ExtensionType, HpkeAeadId, HpkeCiphertext, HpkeConfig, HpkeConfigId,
-        HpkeKdfId, HpkeKemId, HpkePublicKey, Role, Time,
+        HpkeKdfId, HpkeKemId, HpkePublicKey, Role, TaskId, Time,
     };
     use prio::codec::{Decode, Encode};
     use std::io::Cursor;
@@ -763,6 +763,53 @@ mod tests {
             (HpkeConfigId(u8::MIN), "00"),
             (HpkeConfigId(10), "0A"),
             (HpkeConfigId(u8::MAX), "FF"),
+        ])
+    }
+
+    #[test]
+    fn roundtrip_task_id() {
+        roundtrip_encoding(&[
+            (
+                TaskId::new([u8::MIN; 32]),
+                "0000000000000000000000000000000000000000000000000000000000000000",
+            ),
+            (
+                TaskId::new([
+                    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+                    22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+                ]),
+                "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F",
+            ),
+            (
+                TaskId::new([u8::MAX; 32]),
+                "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+            ),
+        ])
+    }
+
+    #[test]
+    fn roundtrip_hpke_kem_id() {
+        roundtrip_encoding(&[
+            (HpkeKemId::P256HkdfSha256, "0010"),
+            (HpkeKemId::X25519HkdfSha256, "0020"),
+        ])
+    }
+
+    #[test]
+    fn roundtrip_hpke_kdf_id() {
+        roundtrip_encoding(&[
+            (HpkeKdfId::HkdfSha256, "0001"),
+            (HpkeKdfId::HkdfSha384, "0002"),
+            (HpkeKdfId::HkdfSha512, "0003"),
+        ])
+    }
+
+    #[test]
+    fn roundtrip_hpke_aead_id() {
+        roundtrip_encoding(&[
+            (HpkeAeadId::Aes128Gcm, "0001"),
+            (HpkeAeadId::Aes256Gcm, "0002"),
+            (HpkeAeadId::ChaCha20Poly1305, "0003"),
         ])
     }
 

--- a/janus/src/message.rs
+++ b/janus/src/message.rs
@@ -1,6 +1,6 @@
 //! PPM protocol message definitions with serialization/deserialization support.
 
-use crate::time::Clock;
+use crate::{hpke::associated_data_for_report_share, time::Clock};
 use anyhow::anyhow;
 use chrono::NaiveDateTime;
 use hpke::{
@@ -706,11 +706,87 @@ impl Decode for HpkeConfig {
     }
 }
 
+/// PPM protocol message representing a client report.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Report {
+    task_id: TaskId,
+    nonce: Nonce,
+    extensions: Vec<Extension>,
+    encrypted_input_shares: Vec<HpkeCiphertext>,
+}
+
+impl Report {
+    /// Construct a report from its components.
+    pub fn new(
+        task_id: TaskId,
+        nonce: Nonce,
+        extensions: Vec<Extension>,
+        encrypted_input_shares: Vec<HpkeCiphertext>,
+    ) -> Report {
+        Report {
+            task_id,
+            nonce,
+            extensions,
+            encrypted_input_shares,
+        }
+    }
+
+    /// Retrieve the task identifier from this report.
+    pub fn task_id(&self) -> TaskId {
+        self.task_id
+    }
+
+    /// Get this report's nonce.
+    pub fn nonce(&self) -> Nonce {
+        self.nonce
+    }
+
+    /// Get this report's extensions.
+    pub fn extensions(&self) -> &[Extension] {
+        &self.extensions
+    }
+
+    /// Get this report's encrypted input shares.
+    pub fn encrypted_input_shares(&self) -> &[HpkeCiphertext] {
+        &self.encrypted_input_shares
+    }
+
+    /// Get the authenticated additional data associated with this report.
+    pub fn associated_data(&self) -> Vec<u8> {
+        associated_data_for_report_share(self.nonce, &self.extensions)
+    }
+}
+
+impl Encode for Report {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        self.task_id.encode(bytes);
+        self.nonce.encode(bytes);
+        encode_u16_items(bytes, &(), &self.extensions);
+        encode_u16_items(bytes, &(), &self.encrypted_input_shares);
+    }
+}
+
+impl Decode for Report {
+    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        let task_id = TaskId::decode(bytes)?;
+        let timestamp = Nonce::decode(bytes)?;
+        let extensions = decode_u16_items(&(), bytes)?;
+        let encrypted_input_shares = decode_u16_items(&(), bytes)?;
+
+        Ok(Self {
+            task_id,
+            nonce: timestamp,
+            extensions,
+            encrypted_input_shares,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         Duration, Extension, ExtensionType, HpkeAeadId, HpkeCiphertext, HpkeConfig, HpkeConfigId,
-        HpkeKdfId, HpkeKemId, HpkePublicKey, Role, TaskId, Time,
+        HpkeKdfId, HpkeKemId, HpkePublicKey, Nonce, Report, Role, TaskId, Time,
     };
     use prio::codec::{Decode, Encode};
     use std::io::Cursor;
@@ -945,6 +1021,110 @@ mod tests {
                         "0010",                             // length
                         "30313233343536373839616263646566", // opaque data
                     )
+                ),
+            ),
+        ])
+    }
+
+    #[test]
+    fn roundtrip_report() {
+        roundtrip_encoding(&[
+            (
+                Report::new(
+                    TaskId::new([u8::MIN; 32]),
+                    Nonce::new(
+                        Time::from_seconds_since_epoch(12345),
+                        [1, 2, 3, 4, 5, 6, 7, 8],
+                    ),
+                    vec![],
+                    vec![],
+                ),
+                concat!(
+                    "0000000000000000000000000000000000000000000000000000000000000000", // task_id
+                    concat!(
+                        // nonce
+                        "0000000000003039", // time
+                        "0102030405060708", // rand
+                    ),
+                    concat!(
+                        // extensions
+                        "0000", // length
+                    ),
+                    concat!(
+                        // encrypted_input_shares
+                        "0000", // length
+                    )
+                ),
+            ),
+            (
+                Report::new(
+                    TaskId::new([u8::MAX; 32]),
+                    Nonce::new(
+                        Time::from_seconds_since_epoch(54321),
+                        [8, 7, 6, 5, 4, 3, 2, 1],
+                    ),
+                    vec![Extension::new(ExtensionType::Tbd, Vec::from("0123"))],
+                    vec![
+                        HpkeCiphertext::new(
+                            HpkeConfigId::from(42),
+                            Vec::from("012345"),
+                            Vec::from("543210"),
+                        ),
+                        HpkeCiphertext::new(
+                            HpkeConfigId::from(13),
+                            Vec::from("abce"),
+                            Vec::from("abfd"),
+                        ),
+                    ],
+                ),
+                concat!(
+                    "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", // task_id
+                    concat!(
+                        "000000000000D431", // time
+                        "0807060504030201", // rand
+                    ),
+                    concat!(
+                        // extensions
+                        "0008", // length
+                        concat!(
+                            "0000", // extension_type
+                            concat!(
+                                // extension_data
+                                "0004",     // length
+                                "30313233", // opaque data
+                            ),
+                        )
+                    ),
+                    concat!(
+                        // encrypted_input_shares
+                        "001E", // length
+                        concat!(
+                            "2A", // config_id
+                            concat!(
+                                // encapsulated_context
+                                "0006",         // length
+                                "303132333435"  // opaque data
+                            ),
+                            concat!(
+                                // payload
+                                "0006",         // length
+                                "353433323130", // opaque data
+                            ),
+                        ),
+                        concat!(
+                            "0D", // config_id
+                            concat!(
+                                // encapsulated_context
+                                "0004",     // length
+                                "61626365", // opaque data
+                            ),
+                            concat!(
+                                // payload
+                                "0004",     // length
+                                "61626664", // opaque data
+                            ),
+                        ),
+                    ),
                 ),
             ),
         ])

--- a/janus_server/src/bin/aggregation_job_creator.rs
+++ b/janus_server/src/bin/aggregation_job_creator.rs
@@ -349,12 +349,12 @@ mod tests {
     use chrono::NaiveDateTime;
     use futures::{future::try_join_all, TryFutureExt};
     use janus::{
-        message::{Nonce, Role, TaskId, Time},
+        message::{Nonce, Report, Role, TaskId, Time},
         time::Clock,
     };
     use janus_server::{
         datastore::{Crypter, Datastore, Transaction},
-        message::{test_util::new_dummy_report, AggregationJobId, Report},
+        message::{test_util::new_dummy_report, AggregationJobId},
         task::{test_util::new_dummy_task, Vdaf},
         trace::test_util::install_test_trace_subscriber,
     };
@@ -445,7 +445,7 @@ mod tests {
         assert!(helper_agg_jobs.is_empty());
         assert_eq!(leader_agg_jobs.len(), 1);
         let nonces = leader_agg_jobs.into_iter().next().unwrap().1;
-        assert_eq!(nonces, HashSet::from([leader_report.nonce]));
+        assert_eq!(nonces, HashSet::from([leader_report.nonce()]));
     }
 
     #[tokio::test]
@@ -501,7 +501,7 @@ mod tests {
             .iter()
             .chain(&small_batch_unit_reports)
             .chain(&big_batch_unit_reports)
-            .map(|report| report.nonce)
+            .map(|report| report.nonce())
             .collect();
 
         ds.run_tx(|tx| {
@@ -659,7 +659,7 @@ mod tests {
         let nonces = agg_jobs.into_iter().next().unwrap().1;
         assert_eq!(
             nonces,
-            HashSet::from([first_report.nonce, second_report.nonce])
+            HashSet::from([first_report.nonce(), second_report.nonce()])
         );
     }
 

--- a/janus_server/src/client.rs
+++ b/janus_server/src/client.rs
@@ -2,11 +2,11 @@
 
 use crate::{
     hpke::{self, associated_data_for_report_share, HpkeApplicationInfo, Label},
-    message::{HpkeCiphertext, HpkeConfig, Report},
+    message::{HpkeConfig, Report},
 };
 use http::StatusCode;
 use janus::{
-    message::{Nonce, Role, TaskId},
+    message::{HpkeCiphertext, Nonce, Role, TaskId},
     time::Clock,
 };
 use prio::{

--- a/janus_server/src/client.rs
+++ b/janus_server/src/client.rs
@@ -2,11 +2,11 @@
 
 use crate::{
     hpke::{self, associated_data_for_report_share, HpkeApplicationInfo, Label},
-    message::{HpkeConfig, Report},
+    message::Report,
 };
 use http::StatusCode;
 use janus::{
-    message::{HpkeCiphertext, Nonce, Role, TaskId},
+    message::{HpkeCiphertext, HpkeConfig, Nonce, Role, TaskId},
     time::Clock,
 };
 use prio::{

--- a/janus_server/src/client.rs
+++ b/janus_server/src/client.rs
@@ -1,12 +1,10 @@
 //! PPM protocol client
 
-use crate::{
-    hpke::{self, associated_data_for_report_share, HpkeApplicationInfo, Label},
-    message::Report,
-};
+use crate::hpke::{self, HpkeApplicationInfo, Label};
 use http::StatusCode;
 use janus::{
-    message::{HpkeCiphertext, HpkeConfig, Nonce, Role, TaskId},
+    hpke::associated_data_for_report_share,
+    message::{HpkeCiphertext, HpkeConfig, Nonce, Report, Role, TaskId},
     time::Clock,
 };
 use prio::{
@@ -189,12 +187,12 @@ where
         })
         .collect::<Result<_, Error>>()?;
 
-        let report = Report {
-            task_id: self.parameters.task_id,
+        let report = Report::new(
+            self.parameters.task_id,
             nonce,
             extensions,
             encrypted_input_shares,
-        };
+        );
 
         let upload_response = self
             .http_client

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -6,12 +6,14 @@ use self::models::{
 };
 use crate::{
     hpke::HpkePrivateKey,
-    message::{AggregateShareReq, AggregationJobId, Interval, Report, ReportShare},
+    message::{AggregateShareReq, AggregationJobId, Interval, ReportShare},
     task::{self, AggregatorAuthKey, Task, Vdaf},
 };
 use chrono::NaiveDateTime;
 use futures::try_join;
-use janus::message::{Duration, Extension, HpkeCiphertext, HpkeConfig, Nonce, TaskId, Time};
+use janus::message::{
+    Duration, Extension, HpkeCiphertext, HpkeConfig, Nonce, Report, TaskId, Time,
+};
 use postgres_types::{Json, ToSql};
 use prio::{
     codec::{decode_u16_items, encode_u16_items, CodecError, Decode, Encode, ParameterizedDecode},
@@ -466,12 +468,7 @@ impl Transaction<'_> {
                 let input_shares: Vec<HpkeCiphertext> =
                     decode_u16_items(&(), &mut Cursor::new(&encoded_input_shares))?;
 
-                Ok(Report {
-                    task_id,
-                    nonce,
-                    extensions,
-                    encrypted_input_shares: input_shares,
-                })
+                Ok(Report::new(task_id, nonce, extensions, input_shares))
             })
             .transpose()
     }
@@ -520,17 +517,17 @@ impl Transaction<'_> {
     /// put_client_report stores a client report.
     #[tracing::instrument(skip(self), err)]
     pub async fn put_client_report(&self, report: &Report) -> Result<(), Error> {
-        let nonce_time = report.nonce.time().as_naive_date_time();
-        let nonce_rand = report.nonce.rand();
+        let nonce_time = report.nonce().time().as_naive_date_time();
+        let nonce_rand = report.nonce().rand();
 
         let mut encoded_extensions = Vec::new();
-        encode_u16_items(&mut encoded_extensions, &(), &report.extensions);
+        encode_u16_items(&mut encoded_extensions, &(), report.extensions());
 
         let mut encoded_input_shares = Vec::new();
         encode_u16_items(
             &mut encoded_input_shares,
             &(),
-            &report.encrypted_input_shares,
+            report.encrypted_input_shares(),
         );
 
         let stmt = self.tx.prepare_cached(
@@ -541,7 +538,7 @@ impl Transaction<'_> {
             .execute(
                 &stmt,
                 &[
-                    /* task_id */ &&report.task_id.get_encoded(),
+                    /* task_id */ &&report.task_id().get_encoded(),
                     /* nonce_time */ &nonce_time,
                     /* nonce_rand */ &&nonce_rand[..],
                     /* extensions */ &encoded_extensions,
@@ -1995,17 +1992,17 @@ mod tests {
         install_test_trace_subscriber();
         let (ds, _db_handle) = ephemeral_datastore().await;
 
-        let report = Report {
-            task_id: TaskId::random(),
-            nonce: Nonce::new(
+        let report = Report::new(
+            TaskId::random(),
+            Nonce::new(
                 Time::from_seconds_since_epoch(12345),
                 [1, 2, 3, 4, 5, 6, 7, 8],
             ),
-            extensions: vec![
+            vec![
                 Extension::new(ExtensionType::Tbd, Vec::from("extension_data_0")),
                 Extension::new(ExtensionType::Tbd, Vec::from("extension_data_1")),
             ],
-            encrypted_input_shares: vec![
+            vec![
                 HpkeCiphertext::new(
                     HpkeConfigId::from(12),
                     Vec::from("encapsulated_context_0"),
@@ -2017,13 +2014,13 @@ mod tests {
                     Vec::from("payload_1"),
                 ),
             ],
-        };
+        );
 
         ds.run_tx(|tx| {
             let report = report.clone();
             Box::pin(async move {
                 tx.put_task(&new_dummy_task(
-                    report.task_id,
+                    report.task_id(),
                     Vdaf::Prio3Aes128Count,
                     Role::Leader,
                 ))
@@ -2036,7 +2033,9 @@ mod tests {
 
         let retrieved_report = ds
             .run_tx(|tx| {
-                Box::pin(async move { tx.get_client_report(report.task_id, report.nonce).await })
+                let task_id = report.task_id();
+                let nonce = report.nonce();
+                Box::pin(async move { tx.get_client_report(task_id, nonce).await })
             })
             .await
             .unwrap();
@@ -2076,42 +2075,42 @@ mod tests {
         let task_id = TaskId::random();
         let unrelated_task_id = TaskId::random();
 
-        let first_unaggregated_report = Report {
+        let first_unaggregated_report = Report::new(
             task_id,
-            nonce: Nonce::new(
+            Nonce::new(
                 Time::from_seconds_since_epoch(12345),
                 [1, 2, 3, 4, 5, 6, 7, 8],
             ),
-            extensions: vec![],
-            encrypted_input_shares: vec![],
-        };
-        let second_unaggregated_report = Report {
+            vec![],
+            vec![],
+        );
+        let second_unaggregated_report = Report::new(
             task_id,
-            nonce: Nonce::new(
+            Nonce::new(
                 Time::from_seconds_since_epoch(12346),
                 [1, 2, 3, 4, 5, 6, 7, 8],
             ),
-            extensions: vec![],
-            encrypted_input_shares: vec![],
-        };
-        let aggregated_report = Report {
+            vec![],
+            vec![],
+        );
+        let aggregated_report = Report::new(
             task_id,
-            nonce: Nonce::new(
+            Nonce::new(
                 Time::from_seconds_since_epoch(12347),
                 [1, 2, 3, 4, 5, 6, 7, 8],
             ),
-            extensions: vec![],
-            encrypted_input_shares: vec![],
-        };
-        let unrelated_report = Report {
-            task_id: unrelated_task_id,
-            nonce: Nonce::new(
+            vec![],
+            vec![],
+        );
+        let unrelated_report = Report::new(
+            unrelated_task_id,
+            Nonce::new(
                 Time::from_seconds_since_epoch(12348),
                 [1, 2, 3, 4, 5, 6, 7, 8],
             ),
-            extensions: vec![],
-            encrypted_input_shares: vec![],
-        };
+            vec![],
+            vec![],
+        );
 
         // Set up state.
         ds.run_tx(|tx| {
@@ -2157,7 +2156,7 @@ mod tests {
                 tx.put_report_aggregation(&ReportAggregation {
                     aggregation_job_id,
                     task_id,
-                    nonce: aggregated_report.nonce,
+                    nonce: aggregated_report.nonce(),
                     ord: 0,
                     state: ReportAggregationState::<Prio3Aes128Count>::Start,
                 })
@@ -2182,8 +2181,8 @@ mod tests {
         assert_eq!(
             got_reports,
             HashSet::from([
-                first_unaggregated_report.nonce,
-                second_unaggregated_report.nonce
+                first_unaggregated_report.nonce(),
+                second_unaggregated_report.nonce()
             ]),
         );
     }

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -6,15 +6,12 @@ use self::models::{
 };
 use crate::{
     hpke::HpkePrivateKey,
-    message::{
-        AggregateShareReq, AggregationJobId, HpkeCiphertext, HpkeConfig, Interval, Report,
-        ReportShare,
-    },
+    message::{AggregateShareReq, AggregationJobId, HpkeConfig, Interval, Report, ReportShare},
     task::{self, AggregatorAuthKey, Task, Vdaf},
 };
 use chrono::NaiveDateTime;
 use futures::try_join;
-use janus::message::{Duration, Extension, Nonce, TaskId, Time};
+use janus::message::{Duration, Extension, HpkeCiphertext, Nonce, TaskId, Time};
 use postgres_types::{Json, ToSql};
 use prio::{
     codec::{decode_u16_items, encode_u16_items, CodecError, Decode, Encode, ParameterizedDecode},
@@ -2008,16 +2005,16 @@ mod tests {
                 Extension::new(ExtensionType::Tbd, Vec::from("extension_data_1")),
             ],
             encrypted_input_shares: vec![
-                HpkeCiphertext {
-                    config_id: HpkeConfigId::from(12),
-                    encapsulated_context: Vec::from("encapsulated_context_0"),
-                    payload: Vec::from("payload_0"),
-                },
-                HpkeCiphertext {
-                    config_id: HpkeConfigId::from(13),
-                    encapsulated_context: Vec::from("encapsulated_context_1"),
-                    payload: Vec::from("payload_1"),
-                },
+                HpkeCiphertext::new(
+                    HpkeConfigId::from(12),
+                    Vec::from("encapsulated_context_0"),
+                    Vec::from("payload_0"),
+                ),
+                HpkeCiphertext::new(
+                    HpkeConfigId::from(13),
+                    Vec::from("encapsulated_context_1"),
+                    Vec::from("payload_1"),
+                ),
             ],
         };
 
@@ -2205,11 +2202,11 @@ mod tests {
                 Extension::new(ExtensionType::Tbd, Vec::from("extension_data_0")),
                 Extension::new(ExtensionType::Tbd, Vec::from("extension_data_1")),
             ],
-            encrypted_input_share: HpkeCiphertext {
-                config_id: HpkeConfigId::from(12),
-                encapsulated_context: Vec::from("encapsulated_context_0"),
-                payload: Vec::from("payload_0"),
-            },
+            encrypted_input_share: HpkeCiphertext::new(
+                HpkeConfigId::from(12),
+                Vec::from("encapsulated_context_0"),
+                Vec::from("payload_0"),
+            ),
         };
 
         ds.run_tx(|tx| {
@@ -2494,11 +2491,11 @@ mod tests {
                             &ReportShare {
                                 nonce,
                                 extensions: Vec::new(),
-                                encrypted_input_share: HpkeCiphertext {
-                                    config_id: HpkeConfigId::from(12),
-                                    encapsulated_context: Vec::from("encapsulated_context_0"),
-                                    payload: Vec::from("payload_0"),
-                                },
+                                encrypted_input_share: HpkeCiphertext::new(
+                                    HpkeConfigId::from(12),
+                                    Vec::from("encapsulated_context_0"),
+                                    Vec::from("payload_0"),
+                                ),
                             },
                         )
                         .await?;
@@ -2657,11 +2654,11 @@ mod tests {
                             &ReportShare {
                                 nonce,
                                 extensions: Vec::new(),
-                                encrypted_input_share: HpkeCiphertext {
-                                    config_id: HpkeConfigId::from(12),
-                                    encapsulated_context: Vec::from("encapsulated_context_0"),
-                                    payload: Vec::from("payload_0"),
-                                },
+                                encrypted_input_share: HpkeCiphertext::new(
+                                    HpkeConfigId::from(12),
+                                    Vec::from("encapsulated_context_0"),
+                                    Vec::from("payload_0"),
+                                ),
                             },
                         )
                         .await?;

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -7,14 +7,14 @@ use self::models::{
 use crate::{
     hpke::HpkePrivateKey,
     message::{
-        AggregateShareReq, AggregationJobId, Extension, HpkeCiphertext, HpkeConfig, Interval,
-        Report, ReportShare,
+        AggregateShareReq, AggregationJobId, HpkeCiphertext, HpkeConfig, Interval, Report,
+        ReportShare,
     },
     task::{self, AggregatorAuthKey, Task, Vdaf},
 };
 use chrono::NaiveDateTime;
 use futures::try_join;
-use janus::message::{Duration, Nonce, TaskId, Time};
+use janus::message::{Duration, Extension, Nonce, TaskId, Time};
 use postgres_types::{Json, ToSql};
 use prio::{
     codec::{decode_u16_items, encode_u16_items, CodecError, Decode, Encode, ParameterizedDecode},
@@ -1909,13 +1909,13 @@ mod tests {
     use crate::{
         aggregator::test_util::fake,
         datastore::{models::AggregationJobState, test_util::ephemeral_datastore},
-        message::{ExtensionType, Interval, TransitionError},
+        message::{Interval, TransitionError},
         task::{test_util::new_dummy_task, Vdaf},
         trace::test_util::install_test_trace_subscriber,
     };
     use ::test_util::generate_aead_key;
     use assert_matches::assert_matches;
-    use janus::message::{Duration, HpkeConfigId, Role, Time};
+    use janus::message::{Duration, ExtensionType, HpkeConfigId, Role, Time};
     use prio::{
         field::{Field128, Field64},
         vdaf::{
@@ -2004,14 +2004,8 @@ mod tests {
                 [1, 2, 3, 4, 5, 6, 7, 8],
             ),
             extensions: vec![
-                Extension {
-                    extension_type: ExtensionType::Tbd,
-                    extension_data: Vec::from("extension_data_0"),
-                },
-                Extension {
-                    extension_type: ExtensionType::Tbd,
-                    extension_data: Vec::from("extension_data_1"),
-                },
+                Extension::new(ExtensionType::Tbd, Vec::from("extension_data_0")),
+                Extension::new(ExtensionType::Tbd, Vec::from("extension_data_1")),
             ],
             encrypted_input_shares: vec![
                 HpkeCiphertext {
@@ -2208,14 +2202,8 @@ mod tests {
                 [1, 2, 3, 4, 5, 6, 7, 8],
             ),
             extensions: vec![
-                Extension {
-                    extension_type: ExtensionType::Tbd,
-                    extension_data: Vec::from("extension_data_0"),
-                },
-                Extension {
-                    extension_type: ExtensionType::Tbd,
-                    extension_data: Vec::from("extension_data_1"),
-                },
+                Extension::new(ExtensionType::Tbd, Vec::from("extension_data_0")),
+                Extension::new(ExtensionType::Tbd, Vec::from("extension_data_1")),
             ],
             encrypted_input_share: HpkeCiphertext {
                 config_id: HpkeConfigId::from(12),

--- a/janus_server/src/hpke.rs
+++ b/janus_server/src/hpke.rs
@@ -1,8 +1,8 @@
 //! Encryption and decryption of messages using HPKE (RFC 9180).
 
-use crate::message::{Extension, HpkeCiphertext, HpkeConfig};
+use crate::message::{HpkeCiphertext, HpkeConfig};
 use hpke::HpkeError;
-use janus::message::{Nonce, Role, TaskId};
+use janus::message::{Extension, Nonce, Role, TaskId};
 use prio::codec::{encode_u16_items, Encode};
 use std::str::FromStr;
 

--- a/janus_server/src/hpke.rs
+++ b/janus_server/src/hpke.rs
@@ -1,8 +1,7 @@
 //! Encryption and decryption of messages using HPKE (RFC 9180).
 
 use hpke::HpkeError;
-use janus::message::{Extension, HpkeCiphertext, HpkeConfig, Nonce, Role, TaskId};
-use prio::codec::{encode_u16_items, Encode};
+use janus::message::{HpkeCiphertext, HpkeConfig, Role, TaskId};
 use std::str::FromStr;
 
 #[derive(Debug, thiserror::Error)]
@@ -83,15 +82,6 @@ impl HpkeApplicationInfo {
             .concat(),
         )
     }
-}
-
-/// Construct the HPKE associated data for sealing or opening data enciphered for a report or report
-/// share, per §4.3.2 and 4.4.2.2 of draft-gpew-priv-ppm
-pub fn associated_data_for_report_share(nonce: Nonce, extensions: &[Extension]) -> Vec<u8> {
-    let mut associated_data = vec![];
-    nonce.encode(&mut associated_data);
-    encode_u16_items(&mut associated_data, &(), extensions);
-    associated_data
 }
 
 /// Encrypt `plaintext` using the provided `recipient_config` and return the HPKE ciphertext. The

--- a/janus_server/src/message.rs
+++ b/janus_server/src/message.rs
@@ -647,9 +647,7 @@ pub mod test_util {
 mod tests {
     use super::*;
     use assert_matches::assert_matches;
-    use janus::message::{
-        Duration, ExtensionType, HpkeAeadId, HpkeConfigId, HpkeKdfId, HpkeKemId, Time,
-    };
+    use janus::message::{Duration, ExtensionType, HpkeConfigId, Time};
     use lazy_static::lazy_static;
 
     lazy_static! {
@@ -860,53 +858,6 @@ mod tests {
                     "0000000000000000", // duration
                 ),
             ),
-        ])
-    }
-
-    #[test]
-    fn roundtrip_task_id() {
-        roundtrip_encoding(&[
-            (
-                TaskId::new([u8::MIN; 32]),
-                "0000000000000000000000000000000000000000000000000000000000000000",
-            ),
-            (
-                TaskId::new([
-                    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-                    22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
-                ]),
-                "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F",
-            ),
-            (
-                TaskId::new([u8::MAX; 32]),
-                "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
-            ),
-        ])
-    }
-
-    #[test]
-    fn roundtrip_hpke_kem_id() {
-        roundtrip_encoding(&[
-            (HpkeKemId::P256HkdfSha256, "0010"),
-            (HpkeKemId::X25519HkdfSha256, "0020"),
-        ])
-    }
-
-    #[test]
-    fn roundtrip_hpke_kdf_id() {
-        roundtrip_encoding(&[
-            (HpkeKdfId::HkdfSha256, "0001"),
-            (HpkeKdfId::HkdfSha384, "0002"),
-            (HpkeKdfId::HkdfSha512, "0003"),
-        ])
-    }
-
-    #[test]
-    fn roundtrip_hpke_aead_id() {
-        roundtrip_encoding(&[
-            (HpkeAeadId::Aes128Gcm, "0001"),
-            (HpkeAeadId::Aes256Gcm, "0002"),
-            (HpkeAeadId::ChaCha20Poly1305, "0003"),
         ])
     }
 


### PR DESCRIPTION
This adds constructors and accessors for the remaining message structs the client will use, and moves them into the common crate. This is part of #18.