### PR TITLE
Fix Dockerfile entrypoint, pass args and use exec

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -42,7 +42,9 @@ jobs:
     - uses: actions/checkout@v3
     - env:
         DOCKER_BUILDKIT: 1
-      run: docker build .
+      run: docker build --tag janus_server .
     - env:
         DOCKER_BUILDKIT: 1
-      run: docker build --build-arg BINARY=aggregation_job_creator .
+      run: docker build --tag janus_aggregation_job_creator --build-arg BINARY=aggregation_job_creator .
+    - run: docker run --rm janus_server --help
+    - run: docker run --rm janus_aggregation_job_creator --help

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ COPY --from=builder /$BINARY /$BINARY
 # Store the build argument in an environment variable so we can reference it
 # from the ENTRYPOINT at runtime.
 ENV BINARY=$BINARY
-ENTRYPOINT ["/bin/sh", "-c", "/$BINARY"]
+ENTRYPOINT ["/bin/sh", "-c", "exec /$BINARY \"$0\" \"$@\""]


### PR DESCRIPTION
This change to the ENTRYPOINT line fixes two problems. First, by using exec, it makes the server PID 1 again, so that it can receive signals. Second, it propagates command line arguments passed to the container onward to the server. It also adds a simple CI test that the container images can be run successfully.