### PR TITLE
client: remove type param, add concrete upload fns

### DIFF
--- a/monolithic_integration_test/tests/integration_test.rs
+++ b/monolithic_integration_test/tests/integration_test.rs
@@ -33,7 +33,7 @@ fn endpoint_from_socket_addr(addr: &SocketAddr) -> Url {
 }
 
 struct TestCase {
-    client: Client<Prio3Aes128Count, RealClock>,
+    client: Client<RealClock>,
     _leader_db_handle: DbHandle,
     _helper_db_handle: DbHandle,
     leader_shutdown_sender: Sender<()>,
@@ -164,12 +164,10 @@ async fn setup_test() -> TestCase {
             .await
             .unwrap();
 
-    let vdaf = Prio3Aes128Count::new(2).unwrap();
-
     let client = Client::new(
         client_parameters,
-        vdaf,
-        (), // no public parameter for prio3
+        Vdaf::Prio3Aes128Count,
+        vec![], // no public parameter for prio3
         RealClock::default(),
         &http_client,
         leader_report_config,
@@ -198,6 +196,6 @@ async fn teardown_test(test_case: TestCase) {
 #[tokio::test]
 async fn upload() {
     let test_case = setup_test().await;
-    test_case.client.upload(&1).await.unwrap();
+    test_case.client.upload_boolean(true).await.unwrap();
     teardown_test(test_case).await
 }


### PR DESCRIPTION
This removes the type parameter on `Client` that specified a `vdaf::Client`, instead using our `crate::task::Vdaf` enum to specify a VDAF instantiation. Separate `upload_boolean()` and `upload_integer_u128()` methods are added, which take a measurement of a concrete type as an input, and perform dispatching based on the enum to the correct implementation. (Adding an `upload_byte_string()` method for Poplar1 is left as future work, for once the Poplar1 VDAF is better specified and implemented)

This fixes #152.