### PR TITLE
Accumulate prepared output shares in helper

### DIFF
--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -1,5 +1,9 @@
 //! Common functionality for PPM aggregators
+
+mod accumulator;
+
 use crate::{
+    aggregator::accumulator::Accumulator,
     datastore::{
         self,
         models::{
@@ -562,7 +566,7 @@ impl VdafOps {
         }
     }
 
-    async fn handle_aggregate_generic<A: vdaf::Aggregator>(
+    async fn handle_aggregate_generic<A: vdaf::Aggregator, E>(
         datastore: &Datastore,
         vdaf: &A,
         task: &Task,
@@ -572,12 +576,14 @@ impl VdafOps {
     where
         A: 'static + Send + Sync,
         A::AggregationParam: Send + Sync,
+        A::AggregateShare: Send + Sync + for<'a> TryFrom<&'a [u8], Error = E>,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
         A::PrepareStep: Send + Sync + Encode + ParameterizedDecode<A::VerifyParam>,
         A::PrepareMessage: Send + Sync,
         A::OutputShare: Send + Sync + for<'a> TryFrom<&'a [u8]>,
         for<'a> &'a A::OutputShare: Into<Vec<u8>>,
         A::VerifyParam: Send + Sync,
+        E: std::fmt::Display,
     {
         match req.body {
             AggregateInitReq { agg_param, seq } => {
@@ -608,7 +614,7 @@ impl VdafOps {
 
     /// Implements the aggregate initialization request portion of the `/aggregate` endpoint for the
     /// helper, described in §4.4.4.1 of draft-gpew-priv-ppm.
-    async fn handle_aggregate_init_generic<A: vdaf::Aggregator>(
+    async fn handle_aggregate_init_generic<A: vdaf::Aggregator, E>(
         datastore: &Datastore,
         vdaf: &A,
         task: &Task,
@@ -620,12 +626,15 @@ impl VdafOps {
     where
         A: 'static + Send + Sync,
         A::AggregationParam: Send + Sync,
+        A::AggregateShare: Send + Sync + for<'a> TryFrom<&'a [u8], Error = E>,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
         A::PrepareStep: Send + Sync + Encode,
         A::OutputShare: Send + Sync,
         for<'a> &'a A::OutputShare: Into<Vec<u8>>,
+        E: std::fmt::Display,
     {
         let task_id = task.id;
+        let min_batch_duration = task.min_batch_duration;
 
         // If two ReportShare messages have the same nonce, then the helper MUST abort with
         // error "unrecognizedMessage". (§4.4.4.1)
@@ -783,9 +792,16 @@ impl VdafOps {
             .run_tx(|tx| {
                 let aggregation_job = aggregation_job.clone();
                 let report_share_data = report_share_data.clone();
+
                 Box::pin(async move {
                     // Write aggregation job.
                     tx.put_aggregation_job(&aggregation_job).await?;
+
+                    let mut accumulator = Accumulator::<A>::new(
+                        task_id,
+                        min_batch_duration,
+                        &aggregation_job.aggregation_param,
+                    );
 
                     for (ord, share_data) in report_share_data.as_ref().iter().enumerate() {
                         // Write client report & report aggregation.
@@ -799,7 +815,16 @@ impl VdafOps {
                             state: share_data.agg_state.clone(),
                         })
                         .await?;
+
+                        if let ReportAggregationState::<A>::Finished(ref output_share) =
+                            share_data.agg_state
+                        {
+                            accumulator.update(output_share, share_data.report_share.nonce)?;
+                        }
                     }
+
+                    accumulator.flush_to_datastore(tx).await?;
+
                     Ok(())
                 })
             })
@@ -818,7 +843,7 @@ impl VdafOps {
         })
     }
 
-    async fn handle_aggregate_continue_generic<A: vdaf::Aggregator>(
+    async fn handle_aggregate_continue_generic<A: vdaf::Aggregator, E>(
         datastore: &Datastore,
         vdaf: &A,
         task: &Task,
@@ -829,6 +854,8 @@ impl VdafOps {
     where
         A: 'static + Send + Sync,
         A::AggregationParam: Send + Sync,
+        E: std::fmt::Display,
+        A::AggregateShare: Send + Sync + for<'a> TryFrom<&'a [u8], Error = E>,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
         A::PrepareStep: Send + Sync + Encode + ParameterizedDecode<A::VerifyParam>,
         A::PrepareMessage: Send + Sync,
@@ -837,6 +864,7 @@ impl VdafOps {
         A::VerifyParam: Send + Sync,
     {
         let task_id = task.id;
+        let min_batch_duration = task.min_batch_duration;
         let vdaf = Arc::new(vdaf.clone());
         let verify_param = Arc::new(verify_param.clone());
         let transitions = Arc::new(transitions);
@@ -868,6 +896,9 @@ impl VdafOps {
                     let mut report_aggregations = report_aggregations.into_iter();
                     let (mut saw_continue, mut saw_finish) = (false, false);
                     let mut response_transitions = Vec::new();
+
+                    let mut accumulator = Accumulator::<A>::new(task_id, min_batch_duration, &aggregation_job.aggregation_param);
+
                     for transition in transitions.iter() {
                         // Match transition received from leader to stored report aggregation, and
                         // extract the stored preparation step.
@@ -942,15 +973,15 @@ impl VdafOps {
 
                             PrepareTransition::Finish(output_share) => {
                                 saw_finish = true;
+
+                                accumulator.update(&output_share, transition.nonce)?;
+
                                 report_aggregation.state =
                                     ReportAggregationState::Finished(output_share);
                                 response_transitions.push(Transition {
                                     nonce: transition.nonce,
                                     trans_data: TransitionTypeSpecificData::Finished,
                                 });
-
-                                // TODO(timg): when a report's preparation is done, its value should
-                                // be accumulated into a batch_unit_aggregations row
                             }
 
                             PrepareTransition::Fail(err) => {
@@ -991,6 +1022,8 @@ impl VdafOps {
                         }
                     };
                     tx.update_aggregation_job(&aggregation_job).await?;
+
+                    accumulator.flush_to_datastore(tx).await?;
 
                     Ok(AggregateResp {
                         seq: response_transitions,
@@ -1949,7 +1982,7 @@ mod tests {
         codec::Decode,
         field::Field64,
         vdaf::{prio3::Prio3Aes128Count, AggregateShare},
-        vdaf::{Vdaf as VdafTrait, VdafError},
+        vdaf::{Aggregator as AggregatorTrait, Vdaf as VdafTrait, VdafError},
     };
     use rand::{thread_rng, Rng};
     use ring::{
@@ -3042,7 +3075,9 @@ mod tests {
                         ord: 1,
                         state: ReportAggregationState::Waiting(prep_step_1),
                     })
-                    .await
+                    .await?;
+
+                    Ok(())
                 })
             })
             .await
@@ -3107,6 +3142,7 @@ mod tests {
                             aggregation_job_id,
                         )
                         .await?;
+
                     Ok((aggregation_job, report_aggregations))
                 })
             })
@@ -3130,7 +3166,7 @@ mod tests {
                     task_id,
                     nonce: nonce_0,
                     ord: 0,
-                    state: ReportAggregationState::Finished(out_share_0),
+                    state: ReportAggregationState::Finished(out_share_0.clone()),
                 },
                 ReportAggregation {
                     aggregation_job_id,
@@ -3138,6 +3174,430 @@ mod tests {
                     nonce: nonce_1,
                     ord: 1,
                     state: ReportAggregationState::Failed(TransitionError::ReportDropped),
+                },
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn aggregate_continue_accumulate_batch_unit_aggregation() {
+        install_test_trace_subscriber();
+
+        let task_id = TaskId::random();
+        let aggregation_job_id_0 = AggregationJobId::random();
+        let aggregation_job_id_1 = AggregationJobId::random();
+        let mut task = new_dummy_task(task_id, Vdaf::Prio3Aes128Count, Role::Helper);
+        let (datastore, _db_handle) = ephemeral_datastore().await;
+        let datastore = Arc::new(datastore);
+        let first_batch_unit_interval_clock = MockClock::default();
+        let second_batch_unit_interval_clock = MockClock::new(
+            first_batch_unit_interval_clock
+                .now()
+                .add(task.min_batch_duration)
+                .unwrap(),
+        );
+
+        let vdaf = Prio3Aes128Count::new(2).unwrap();
+        let (_, verify_params) = vdaf.setup().unwrap();
+        task.vdaf_verify_parameter = verify_params.iter().last().unwrap().get_encoded();
+        let hpke_key = current_hpke_key(&task.hpke_keys);
+        let hmac_key: &hmac::Key = task.agg_auth_keys.iter().last().unwrap().as_ref();
+        let hmac_key = hmac_key.clone();
+
+        // report_share_0 is a "happy path" report.
+        let nonce_0 = Nonce::generate(first_batch_unit_interval_clock);
+        let transcript_0 = run_vdaf(&vdaf, &(), &verify_params, &(), nonce_0, &0);
+        let prep_step_0 = assert_matches!(&transcript_0.transitions[1][0], PrepareTransition::<Prio3Aes128Count>::Continue(prep_step, _) => prep_step.clone());
+        let out_share_0 = assert_matches!(&transcript_0.transitions[1][1], PrepareTransition::<Prio3Aes128Count>::Finish(out_share) => out_share.clone());
+        let prep_msg_0 = transcript_0.messages[0].clone();
+        let report_share_0 = generate_helper_report_share::<Prio3Aes128Count>(
+            task_id,
+            nonce_0,
+            &hpke_key.0,
+            &transcript_0.input_shares[1],
+        );
+
+        // report_share_1 is another "happy path" report to exercise in-memory accumulation of
+        // output shares
+        let nonce_1 = Nonce::generate(first_batch_unit_interval_clock);
+        let transcript_1 = run_vdaf(&vdaf, &(), &verify_params, &(), nonce_1, &0);
+        let prep_step_1 = assert_matches!(&transcript_1.transitions[1][0], PrepareTransition::<Prio3Aes128Count>::Continue(prep_step, _) => prep_step.clone());
+        let out_share_1 = assert_matches!(&transcript_1.transitions[1][1], PrepareTransition::<Prio3Aes128Count>::Finish(out_share) => out_share.clone());
+        let prep_msg_1 = transcript_1.messages[0].clone();
+        let report_share_1 = generate_helper_report_share::<Prio3Aes128Count>(
+            task_id,
+            nonce_1,
+            &hpke_key.0,
+            &transcript_1.input_shares[1],
+        );
+
+        // report share 2 aggregates successfully, but into a distinct batch unit aggregation.
+        let nonce_2 = Nonce::generate(second_batch_unit_interval_clock);
+        let transcript_2 = run_vdaf(&vdaf, &(), &verify_params, &(), nonce_2, &0);
+        let prep_step_2 = assert_matches!(&transcript_2.transitions[1][0], PrepareTransition::<Prio3Aes128Count>::Continue(prep_step, _) => prep_step.clone());
+        let out_share_2 = assert_matches!(&transcript_2.transitions[1][1], PrepareTransition::<Prio3Aes128Count>::Finish(out_share) => out_share.clone());
+        let prep_msg_2 = transcript_2.messages[0].clone();
+        let report_share_2 = generate_helper_report_share::<Prio3Aes128Count>(
+            task_id,
+            nonce_2,
+            &hpke_key.0,
+            &transcript_2.input_shares[1],
+        );
+
+        datastore
+            .run_tx(|tx| {
+                let task = task.clone();
+                let (report_share_0, report_share_1, report_share_2) = (
+                    report_share_0.clone(),
+                    report_share_1.clone(),
+                    report_share_2.clone(),
+                );
+                let (prep_step_0, prep_step_1, prep_step_2) = (
+                    prep_step_0.clone(),
+                    prep_step_1.clone(),
+                    prep_step_2.clone(),
+                );
+
+                Box::pin(async move {
+                    tx.put_task(&task).await?;
+
+                    tx.put_report_share(task_id, &report_share_0).await?;
+                    tx.put_report_share(task_id, &report_share_1).await?;
+                    tx.put_report_share(task_id, &report_share_2).await?;
+
+                    tx.put_aggregation_job(&AggregationJob::<Prio3Aes128Count> {
+                        aggregation_job_id: aggregation_job_id_0,
+                        task_id,
+                        aggregation_param: (),
+                        state: AggregationJobState::InProgress,
+                    })
+                    .await?;
+
+                    tx.put_report_aggregation(&ReportAggregation::<Prio3Aes128Count> {
+                        aggregation_job_id: aggregation_job_id_0,
+                        task_id,
+                        nonce: nonce_0,
+                        ord: 0,
+                        state: ReportAggregationState::Waiting(prep_step_0),
+                    })
+                    .await?;
+                    tx.put_report_aggregation(&ReportAggregation::<Prio3Aes128Count> {
+                        aggregation_job_id: aggregation_job_id_0,
+                        task_id,
+                        nonce: nonce_1,
+                        ord: 1,
+                        state: ReportAggregationState::Waiting(prep_step_1),
+                    })
+                    .await?;
+                    tx.put_report_aggregation(&ReportAggregation::<Prio3Aes128Count> {
+                        aggregation_job_id: aggregation_job_id_0,
+                        task_id,
+                        nonce: nonce_2,
+                        ord: 2,
+                        state: ReportAggregationState::Waiting(prep_step_2),
+                    })
+                    .await?;
+
+                    Ok(())
+                })
+            })
+            .await
+            .unwrap();
+
+        let request = AggregateReq {
+            task_id,
+            job_id: aggregation_job_id_0,
+            body: AggregateContinueReq {
+                seq: vec![
+                    Transition {
+                        nonce: nonce_0,
+                        trans_data: TransitionTypeSpecificData::Continued {
+                            payload: prep_msg_0.get_encoded(),
+                        },
+                    },
+                    Transition {
+                        nonce: nonce_1,
+                        trans_data: TransitionTypeSpecificData::Continued {
+                            payload: prep_msg_1.get_encoded(),
+                        },
+                    },
+                    Transition {
+                        nonce: nonce_2,
+                        trans_data: TransitionTypeSpecificData::Continued {
+                            payload: prep_msg_2.get_encoded(),
+                        },
+                    },
+                ],
+            },
+        };
+
+        // Create aggregator filter, send request, and parse response.
+        let filter = aggregator_filter(datastore.clone(), first_batch_unit_interval_clock).unwrap();
+
+        let response = warp::test::request()
+            .method("POST")
+            .path("/aggregate")
+            .body(AuthenticatedEncoder::new(request).encode(&hmac_key))
+            .filter(&filter)
+            .await
+            .unwrap()
+            .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let batch_unit_aggregations = datastore
+            .run_tx(|tx| {
+                Box::pin(async move {
+                    tx.get_batch_unit_aggregations_for_task_in_interval::<Prio3Aes128Count, _>(
+                        task_id,
+                        Interval::new(
+                            nonce_0
+                                .time()
+                                .to_batch_unit_interval_start(task.min_batch_duration)
+                                .unwrap(),
+                            // Make interval big enough to capture both batch unit aggregations
+                            Duration::from_seconds(task.min_batch_duration.as_seconds() * 2),
+                        )
+                        .unwrap(),
+                        &(),
+                    )
+                    .await
+                })
+            })
+            .await
+            .unwrap();
+
+        let aggregate_share = vdaf
+            .aggregate(&(), [out_share_0.clone(), out_share_1.clone()])
+            .unwrap();
+        let mut checksum = NonceChecksum::from_nonce(nonce_0);
+        checksum.update(nonce_1);
+
+        assert_eq!(
+            batch_unit_aggregations,
+            vec![
+                BatchUnitAggregation::<Prio3Aes128Count> {
+                    task_id,
+                    unit_interval_start: nonce_0
+                        .time()
+                        .to_batch_unit_interval_start(task.min_batch_duration)
+                        .unwrap(),
+                    aggregation_param: (),
+                    aggregate_share,
+                    report_count: 2,
+                    checksum,
+                },
+                BatchUnitAggregation::<Prio3Aes128Count> {
+                    task_id,
+                    unit_interval_start: nonce_2
+                        .time()
+                        .to_batch_unit_interval_start(task.min_batch_duration)
+                        .unwrap(),
+                    aggregation_param: (),
+                    aggregate_share: AggregateShare::from(out_share_2.clone()),
+                    report_count: 1,
+                    checksum: NonceChecksum::from_nonce(nonce_2),
+                }
+            ]
+        );
+
+        // Aggregate some more reports, which should get accumulated into the
+        // batch_unit_aggregations rows created earlier.
+        // report_share_3 gets aggreated into the first batch unit interval.
+        let nonce_3 = Nonce::generate(first_batch_unit_interval_clock);
+        let transcript_3 = run_vdaf(&vdaf, &(), &verify_params, &(), nonce_3, &0);
+        let prep_step_3 = assert_matches!(&transcript_3.transitions[1][0], PrepareTransition::<Prio3Aes128Count>::Continue(prep_step, _) => prep_step.clone());
+        let out_share_3 = assert_matches!(&transcript_3.transitions[1][1], PrepareTransition::<Prio3Aes128Count>::Finish(out_share) => out_share.clone());
+        let prep_msg_3 = transcript_3.messages[0].clone();
+        let report_share_3 = generate_helper_report_share::<Prio3Aes128Count>(
+            task_id,
+            nonce_3,
+            &hpke_key.0,
+            &transcript_3.input_shares[1],
+        );
+
+        // report_share_4 gets aggregated into the second batch unit interval
+        let nonce_4 = Nonce::generate(second_batch_unit_interval_clock);
+        let transcript_4 = run_vdaf(&vdaf, &(), &verify_params, &(), nonce_4, &0);
+        let prep_step_4 = assert_matches!(&transcript_4.transitions[1][0], PrepareTransition::<Prio3Aes128Count>::Continue(prep_step, _) => prep_step.clone());
+        let out_share_4 = assert_matches!(&transcript_4.transitions[1][1], PrepareTransition::<Prio3Aes128Count>::Finish(out_share) => out_share.clone());
+        let prep_msg_4 = transcript_4.messages[0].clone();
+        let report_share_4 = generate_helper_report_share::<Prio3Aes128Count>(
+            task_id,
+            nonce_4,
+            &hpke_key.0,
+            &transcript_4.input_shares[1],
+        );
+
+        // report share 5 also gets aggregated into the second batch unit interval
+        let nonce_5 = Nonce::generate(second_batch_unit_interval_clock);
+        let transcript_5 = run_vdaf(&vdaf, &(), &verify_params, &(), nonce_5, &0);
+        let prep_step_5 = assert_matches!(&transcript_5.transitions[1][0], PrepareTransition::<Prio3Aes128Count>::Continue(prep_step, _) => prep_step.clone());
+        let out_share_5 = assert_matches!(&transcript_5.transitions[1][1], PrepareTransition::<Prio3Aes128Count>::Finish(out_share) => out_share.clone());
+        let prep_msg_5 = transcript_5.messages[0].clone();
+        let report_share_5 = generate_helper_report_share::<Prio3Aes128Count>(
+            task_id,
+            nonce_5,
+            &hpke_key.0,
+            &transcript_5.input_shares[1],
+        );
+
+        datastore
+            .run_tx(|tx| {
+                let (report_share_3, report_share_4, report_share_5) = (
+                    report_share_3.clone(),
+                    report_share_4.clone(),
+                    report_share_5.clone(),
+                );
+                let (prep_step_3, prep_step_4, prep_step_5) = (
+                    prep_step_3.clone(),
+                    prep_step_4.clone(),
+                    prep_step_5.clone(),
+                );
+
+                Box::pin(async move {
+                    tx.put_report_share(task_id, &report_share_3).await?;
+                    tx.put_report_share(task_id, &report_share_4).await?;
+                    tx.put_report_share(task_id, &report_share_5).await?;
+
+                    tx.put_aggregation_job(&AggregationJob::<Prio3Aes128Count> {
+                        aggregation_job_id: aggregation_job_id_1,
+                        task_id,
+                        aggregation_param: (),
+                        state: AggregationJobState::InProgress,
+                    })
+                    .await?;
+
+                    tx.put_report_aggregation(&ReportAggregation::<Prio3Aes128Count> {
+                        aggregation_job_id: aggregation_job_id_1,
+                        task_id,
+                        nonce: nonce_3,
+                        ord: 3,
+                        state: ReportAggregationState::Waiting(prep_step_3),
+                    })
+                    .await?;
+                    tx.put_report_aggregation(&ReportAggregation::<Prio3Aes128Count> {
+                        aggregation_job_id: aggregation_job_id_1,
+                        task_id,
+                        nonce: nonce_4,
+                        ord: 4,
+                        state: ReportAggregationState::Waiting(prep_step_4),
+                    })
+                    .await?;
+                    tx.put_report_aggregation(&ReportAggregation::<Prio3Aes128Count> {
+                        aggregation_job_id: aggregation_job_id_1,
+                        task_id,
+                        nonce: nonce_5,
+                        ord: 5,
+                        state: ReportAggregationState::Waiting(prep_step_5),
+                    })
+                    .await?;
+
+                    Ok(())
+                })
+            })
+            .await
+            .unwrap();
+
+        let request = AggregateReq {
+            task_id,
+            job_id: aggregation_job_id_1,
+            body: AggregateContinueReq {
+                seq: vec![
+                    Transition {
+                        nonce: nonce_3,
+                        trans_data: TransitionTypeSpecificData::Continued {
+                            payload: prep_msg_3.get_encoded(),
+                        },
+                    },
+                    Transition {
+                        nonce: nonce_4,
+                        trans_data: TransitionTypeSpecificData::Continued {
+                            payload: prep_msg_4.get_encoded(),
+                        },
+                    },
+                    Transition {
+                        nonce: nonce_5,
+                        trans_data: TransitionTypeSpecificData::Continued {
+                            payload: prep_msg_5.get_encoded(),
+                        },
+                    },
+                ],
+            },
+        };
+
+        // Create aggregator filter, send request, and parse response.
+        let filter = aggregator_filter(datastore.clone(), first_batch_unit_interval_clock).unwrap();
+
+        let response = warp::test::request()
+            .method("POST")
+            .path("/aggregate")
+            .body(AuthenticatedEncoder::new(request).encode(&hmac_key))
+            .filter(&filter)
+            .await
+            .unwrap()
+            .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let batch_unit_aggregations = datastore
+            .run_tx(|tx| {
+                Box::pin(async move {
+                    tx.get_batch_unit_aggregations_for_task_in_interval::<Prio3Aes128Count, _>(
+                        task_id,
+                        Interval::new(
+                            nonce_0
+                                .time()
+                                .to_batch_unit_interval_start(task.min_batch_duration)
+                                .unwrap(),
+                            // Make interval big enough to capture both batch unit aggregations
+                            Duration::from_seconds(task.min_batch_duration.as_seconds() * 2),
+                        )
+                        .unwrap(),
+                        &(),
+                    )
+                    .await
+                })
+            })
+            .await
+            .unwrap();
+
+        let first_aggregate_share = vdaf
+            .aggregate(&(), [out_share_0, out_share_1, out_share_3])
+            .unwrap();
+        let mut first_checksum = NonceChecksum::from_nonce(nonce_0);
+        first_checksum.update(nonce_1);
+        first_checksum.update(nonce_3);
+
+        let second_aggregate_share = vdaf
+            .aggregate(&(), [out_share_2, out_share_4, out_share_5])
+            .unwrap();
+        let mut second_checksum = NonceChecksum::from_nonce(nonce_2);
+        second_checksum.update(nonce_4);
+        second_checksum.update(nonce_5);
+
+        assert_eq!(
+            batch_unit_aggregations,
+            vec![
+                BatchUnitAggregation::<Prio3Aes128Count> {
+                    task_id,
+                    unit_interval_start: nonce_0
+                        .time()
+                        .to_batch_unit_interval_start(task.min_batch_duration)
+                        .unwrap(),
+                    aggregation_param: (),
+                    aggregate_share: first_aggregate_share,
+                    report_count: 3,
+                    checksum: first_checksum,
+                },
+                BatchUnitAggregation::<Prio3Aes128Count> {
+                    task_id,
+                    unit_interval_start: nonce_2
+                        .time()
+                        .to_batch_unit_interval_start(task.min_batch_duration)
+                        .unwrap(),
+                    aggregation_param: (),
+                    aggregate_share: second_aggregate_share,
+                    report_count: 3,
+                    checksum: second_checksum,
                 }
             ]
         );

--- a/janus_server/src/aggregator/accumulator.rs
+++ b/janus_server/src/aggregator/accumulator.rs
@@ -1,0 +1,165 @@
+//! In-memory accumulation of output shares.
+
+use super::Error;
+use crate::{
+    datastore::{self, models::BatchUnitAggregation, Transaction},
+    message::Interval,
+};
+use derivative::Derivative;
+use janus::message::{Duration, Nonce, NonceChecksum, TaskId, Time};
+use prio::vdaf::{self, Aggregatable};
+use std::collections::HashMap;
+use tracing::debug;
+
+#[derive(Debug)]
+struct Accumulation<A: vdaf::Aggregator>
+where
+    for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
+{
+    aggregate_share: A::AggregateShare,
+    report_count: u64,
+    checksum: NonceChecksum,
+}
+
+impl<A: vdaf::Aggregator> Accumulation<A>
+where
+    for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
+{
+    fn update(&mut self, output_share: &A::OutputShare, nonce: Nonce) -> Result<(), Error> {
+        self.aggregate_share.accumulate(output_share)?;
+        self.report_count += 1;
+        self.checksum.update(nonce);
+
+        Ok(())
+    }
+}
+
+/// Accumulates output shares in memory and eventually flushes accumulations to a datastore. Janus'
+/// leader aligns aggregate jobs with batch unit intervals, but this is not generally required for
+/// DAP implementations, so we accumulate output shares into a HashMap mapping the Time at which the
+/// batch unit interval begins to the accumulated aggregate share, report count and checksum.
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub(super) struct Accumulator<A: vdaf::Aggregator>
+where
+    for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
+{
+    task_id: TaskId,
+    min_batch_duration: Duration,
+    #[derivative(Debug = "ignore")]
+    aggregation_param: A::AggregationParam,
+    accumulations: HashMap<Time, Accumulation<A>>,
+}
+
+impl<A: vdaf::Aggregator> Accumulator<A>
+where
+    for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
+{
+    /// Create a new accumulator
+    pub(super) fn new(
+        task_id: TaskId,
+        min_batch_duration: Duration,
+        aggregation_param: &A::AggregationParam,
+    ) -> Self {
+        Self {
+            task_id,
+            min_batch_duration,
+            aggregation_param: aggregation_param.clone(),
+            accumulations: HashMap::new(),
+        }
+    }
+
+    /// Update the in-memory accumulators with the provided output share and report nonce.
+    pub(super) fn update(
+        &mut self,
+        output_share: &A::OutputShare,
+        nonce: Nonce,
+    ) -> Result<(), datastore::Error> {
+        let key = nonce
+            .time()
+            .to_batch_unit_interval_start(self.min_batch_duration)
+            .map_err(|e| datastore::Error::User(e.into()))?;
+        if let Some(accumulate) = self.accumulations.get_mut(&key) {
+            accumulate
+                .update(output_share, nonce)
+                .map_err(|e| datastore::Error::User(e.into()))?;
+        } else {
+            self.accumulations.insert(
+                key,
+                Accumulation {
+                    aggregate_share: A::AggregateShare::from(output_share.clone()),
+                    report_count: 1,
+                    checksum: NonceChecksum::from_nonce(nonce),
+                },
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Write the accumulated aggregate shares, report counts and checksums to the datastore. If a
+    /// batch unit aggregation already exists for some accumulator, it is updated. If no batch unit
+    /// aggregation exists, one is created and initialized with the accumulated values.
+    #[tracing::instrument(skip(self, tx), err)]
+    pub(super) async fn flush_to_datastore<E>(
+        self,
+        tx: &Transaction<'_>,
+    ) -> Result<(), datastore::Error>
+    where
+        for<'a> A::AggregateShare: TryFrom<&'a [u8], Error = E>,
+        E: std::fmt::Display,
+    {
+        for (unit_interval_start, accumulate) in self.accumulations {
+            let unit_interval = Interval::new(unit_interval_start, self.min_batch_duration)?;
+
+            let mut batch_unit_aggregations = tx
+                .get_batch_unit_aggregations_for_task_in_interval::<A, _>(
+                    self.task_id,
+                    unit_interval,
+                    &self.aggregation_param,
+                )
+                .await?;
+
+            if batch_unit_aggregations.len() > 1 {
+                return Err(datastore::Error::DbState(format!(
+                    "found {} batch unit aggregation rows for task {}, interval {unit_interval}, agg parameter {:?}",
+                    batch_unit_aggregations.len(),
+                    self.task_id,
+                    self.aggregation_param,
+                )));
+            }
+
+            if let Some(batch_unit_aggregation) = batch_unit_aggregations.first_mut() {
+                debug!(
+                    unit_interval_start = ?unit_interval.start(),
+                    "accumulating into existing batch_unit_aggregation_row",
+                );
+                batch_unit_aggregation
+                    .aggregate_share
+                    .merge(&accumulate.aggregate_share)
+                    .map_err(|e| datastore::Error::User(e.into()))?;
+                batch_unit_aggregation.report_count += accumulate.report_count;
+                batch_unit_aggregation.checksum.combine(accumulate.checksum);
+
+                tx.update_batch_unit_aggregation(&batch_unit_aggregations[0])
+                    .await?;
+            } else {
+                debug!(
+                    unit_interval_start = ?unit_interval.start(),
+                    "inserting new batch_unit_aggregation row",
+                );
+                tx.put_batch_unit_aggregation::<A>(&BatchUnitAggregation {
+                    task_id: self.task_id,
+                    unit_interval_start: unit_interval.start(),
+                    aggregation_param: self.aggregation_param.clone(),
+                    aggregate_share: accumulate.aggregate_share,
+                    report_count: accumulate.report_count,
+                    checksum: accumulate.checksum,
+                })
+                .await?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -989,7 +989,6 @@ impl Transaction<'_> {
     }
 
     /// Store a new `batch_unit_aggregations` row in the datastore.
-    #[cfg(test)]
     #[tracing::instrument(skip(self), err)]
     pub(crate) async fn put_batch_unit_aggregation<A>(
         &self,
@@ -1029,6 +1028,57 @@ impl Transaction<'_> {
                 ],
             )
             .await?;
+
+        Ok(())
+    }
+
+    /// Update an existing `batch_unit_aggregations` row with the `aggregate_share`, `checksum` and
+    /// `report_count` values in `batch_unit_aggregation`.
+    #[tracing::instrument(skip(self), err)]
+    pub(crate) async fn update_batch_unit_aggregation<A>(
+        &self,
+        batch_unit_aggregation: &BatchUnitAggregation<A>,
+    ) -> Result<(), Error>
+    where
+        A: vdaf::Aggregator,
+        A::AggregationParam: Encode + std::fmt::Debug,
+        A::AggregateShare: std::fmt::Debug,
+        for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
+    {
+        let encoded_aggregate_share: Vec<u8> = (&batch_unit_aggregation.aggregate_share).into();
+        let report_count = i64::try_from(batch_unit_aggregation.report_count)?;
+        let encoded_checksum = batch_unit_aggregation.checksum.get_encoded();
+        let unit_interval_start = batch_unit_aggregation
+            .unit_interval_start
+            .as_naive_date_time();
+        let encoded_aggregation_param = batch_unit_aggregation.aggregation_param.get_encoded();
+
+        let stmt = self
+            .tx
+            .prepare_cached(
+                "UPDATE batch_unit_aggregations
+                SET aggregate_share = $1, report_count = $2, checksum = $3
+                WHERE
+                    task_id = (SELECT id from TASKS WHERE task_id = $4)
+                    AND unit_interval_start = $5
+                    AND aggregation_param = $6",
+            )
+            .await?;
+        check_update(
+            self.tx
+                .execute(
+                    &stmt,
+                    &[
+                        /* aggregate_share */ &encoded_aggregate_share,
+                        &report_count,
+                        /* checksum */ &encoded_checksum,
+                        /* task_id */ &batch_unit_aggregation.task_id.as_bytes(),
+                        &unit_interval_start,
+                        /* aggregation_param */ &encoded_aggregation_param,
+                    ],
+                )
+                .await?,
+        )?;
 
         Ok(())
     }
@@ -2869,113 +2919,117 @@ mod tests {
 
         let (ds, _db_handle) = ephemeral_datastore().await;
 
-        let batch_unit_aggregations: Vec<BatchUnitAggregation<ToyPoplar1>> = ds
-            .run_tx(|tx| {
-                let (aggregate_share, aggregation_param) =
-                    (aggregate_share.clone(), aggregation_param.clone());
-                Box::pin(async move {
-                    let mut task = new_dummy_task(task_id, Vdaf::Prio3Aes128Count, Role::Leader);
-                    task.min_batch_duration = Duration::from_seconds(100);
-                    tx.put_task(&task).await?;
+        ds.run_tx(|tx| {
+            let (aggregate_share, aggregation_param) =
+                (aggregate_share.clone(), aggregation_param.clone());
+            Box::pin(async move {
+                let mut task = new_dummy_task(task_id, Vdaf::Prio3Aes128Count, Role::Leader);
+                task.min_batch_duration = Duration::from_seconds(100);
+                tx.put_task(&task).await?;
 
-                    tx.put_task(&new_dummy_task(
-                        other_task_id,
-                        Vdaf::Prio3Aes128Count,
-                        Role::Leader,
-                    ))
+                tx.put_task(&new_dummy_task(
+                    other_task_id,
+                    Vdaf::Prio3Aes128Count,
+                    Role::Leader,
+                ))
+                .await?;
+
+                let first_batch_unit_aggregation = BatchUnitAggregation::<ToyPoplar1> {
+                    task_id,
+                    unit_interval_start: Time::from_seconds_since_epoch(100),
+                    aggregation_param: aggregation_param.clone(),
+                    aggregate_share: aggregate_share.clone(),
+                    report_count: 0,
+                    checksum: NonceChecksum::default(),
+                };
+
+                let second_batch_unit_aggregation = BatchUnitAggregation::<ToyPoplar1> {
+                    task_id,
+                    unit_interval_start: Time::from_seconds_since_epoch(150),
+                    aggregation_param: aggregation_param.clone(),
+                    aggregate_share: aggregate_share.clone(),
+                    report_count: 0,
+                    checksum: NonceChecksum::default(),
+                };
+
+                let third_batch_unit_aggregation = BatchUnitAggregation::<ToyPoplar1> {
+                    task_id,
+                    unit_interval_start: Time::from_seconds_since_epoch(200),
+                    aggregation_param: aggregation_param.clone(),
+                    aggregate_share: aggregate_share.clone(),
+                    report_count: 0,
+                    checksum: NonceChecksum::default(),
+                };
+
+                // Start of this aggregation's interval is before the interval queried below.
+                tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
+                    task_id,
+                    unit_interval_start: Time::from_seconds_since_epoch(25),
+                    aggregation_param: aggregation_param.clone(),
+                    aggregate_share: aggregate_share.clone(),
+                    report_count: 0,
+                    checksum: NonceChecksum::default(),
+                })
+                .await?;
+
+                // Following three batch units are within the interval queried below.
+                tx.put_batch_unit_aggregation(&first_batch_unit_aggregation)
+                    .await?;
+                tx.put_batch_unit_aggregation(&second_batch_unit_aggregation)
                     .await?;
 
-                    // Start of this aggregation's interval is before the interval queried below.
-                    tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
-                        task_id,
-                        unit_interval_start: Time::from_seconds_since_epoch(25),
-                        aggregation_param: aggregation_param.clone(),
-                        aggregate_share: aggregate_share.clone(),
-                        report_count: 0,
-                        checksum: NonceChecksum::default(),
-                    })
+                // The end of this batch unit is exactly the end of the interval queried below.
+                tx.put_batch_unit_aggregation(&third_batch_unit_aggregation)
                     .await?;
+                // Aggregation parameter differs from the one queried below.
+                tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
+                    task_id,
+                    unit_interval_start: Time::from_seconds_since_epoch(100),
+                    aggregation_param: BTreeSet::from([
+                        IdpfInput::new("gh".as_bytes(), 2).unwrap(),
+                        IdpfInput::new("jk".as_bytes(), 3).unwrap(),
+                    ]),
+                    aggregate_share: aggregate_share.clone(),
+                    report_count: 0,
+                    checksum: NonceChecksum::default(),
+                })
+                .await?;
 
-                    // Following three batch units are within the interval queried below.
-                    tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
-                        task_id,
-                        unit_interval_start: Time::from_seconds_since_epoch(100),
-                        aggregation_param: aggregation_param.clone(),
-                        aggregate_share: aggregate_share.clone(),
-                        report_count: 0,
-                        checksum: NonceChecksum::default(),
-                    })
-                    .await?;
+                // End of this aggregation's interval is after the interval queried below.
+                tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
+                    task_id,
+                    unit_interval_start: Time::from_seconds_since_epoch(250),
+                    aggregation_param: aggregation_param.clone(),
+                    aggregate_share: aggregate_share.clone(),
+                    report_count: 0,
+                    checksum: NonceChecksum::default(),
+                })
+                .await?;
 
-                    tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
-                        task_id,
-                        unit_interval_start: Time::from_seconds_since_epoch(150),
-                        aggregation_param: aggregation_param.clone(),
-                        aggregate_share: aggregate_share.clone(),
-                        report_count: 0,
-                        checksum: NonceChecksum::default(),
-                    })
-                    .await?;
+                // Start of this aggregation's interval is after the interval queried below.
+                tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
+                    task_id,
+                    unit_interval_start: Time::from_seconds_since_epoch(400),
+                    aggregation_param: aggregation_param.clone(),
+                    aggregate_share: aggregate_share.clone(),
+                    report_count: 0,
+                    checksum: NonceChecksum::default(),
+                })
+                .await?;
 
-                    // The end of this batch unit is exactly the end of the interval queried below.
-                    tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
-                        task_id,
-                        unit_interval_start: Time::from_seconds_since_epoch(200),
-                        aggregation_param: aggregation_param.clone(),
-                        aggregate_share: aggregate_share.clone(),
-                        report_count: 0,
-                        checksum: NonceChecksum::default(),
-                    })
-                    .await?;
+                // Task ID differs from that queried below.
+                tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
+                    task_id: other_task_id,
+                    unit_interval_start: Time::from_seconds_since_epoch(200),
+                    aggregation_param: aggregation_param.clone(),
+                    aggregate_share: aggregate_share.clone(),
+                    report_count: 0,
+                    checksum: NonceChecksum::default(),
+                })
+                .await?;
 
-                    // Aggregation parameter differs from the one queried below.
-                    tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
-                        task_id,
-                        unit_interval_start: Time::from_seconds_since_epoch(100),
-                        aggregation_param: BTreeSet::from([
-                            IdpfInput::new("gh".as_bytes(), 2).unwrap(),
-                            IdpfInput::new("jk".as_bytes(), 3).unwrap(),
-                        ]),
-                        aggregate_share: aggregate_share.clone(),
-                        report_count: 0,
-                        checksum: NonceChecksum::default(),
-                    })
-                    .await?;
-
-                    // End of this aggregation's interval is after the interval queried below.
-                    tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
-                        task_id,
-                        unit_interval_start: Time::from_seconds_since_epoch(250),
-                        aggregation_param: aggregation_param.clone(),
-                        aggregate_share: aggregate_share.clone(),
-                        report_count: 0,
-                        checksum: NonceChecksum::default(),
-                    })
-                    .await?;
-
-                    // Start of this aggregation's interval is after the interval queried below.
-                    tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
-                        task_id,
-                        unit_interval_start: Time::from_seconds_since_epoch(400),
-                        aggregation_param: aggregation_param.clone(),
-                        aggregate_share: aggregate_share.clone(),
-                        report_count: 0,
-                        checksum: NonceChecksum::default(),
-                    })
-                    .await?;
-
-                    // Task ID differs from that queried below.
-                    tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
-                        task_id: other_task_id,
-                        unit_interval_start: Time::from_seconds_since_epoch(200),
-                        aggregation_param: aggregation_param.clone(),
-                        aggregate_share: aggregate_share.clone(),
-                        report_count: 0,
-                        checksum: NonceChecksum::default(),
-                    })
-                    .await?;
-
-                    tx.get_batch_unit_aggregations_for_task_in_interval::<ToyPoplar1, _>(
+                let batch_unit_aggregations = tx
+                    .get_batch_unit_aggregations_for_task_in_interval::<ToyPoplar1, _>(
                         task_id,
                         Interval::new(
                             Time::from_seconds_since_epoch(50),
@@ -2984,42 +3038,71 @@ mod tests {
                         .unwrap(),
                         &aggregation_param,
                     )
-                    .await
-                })
-            })
-            .await
-            .unwrap();
+                    .await?;
 
-        assert_eq!(
-            batch_unit_aggregations.len(),
-            3,
-            "{:#?}",
-            batch_unit_aggregations,
-        );
-        assert!(
-            batch_unit_aggregations.contains(&BatchUnitAggregation {
-                task_id,
-                unit_interval_start: Time::from_seconds_since_epoch(100),
-                aggregation_param: aggregation_param.clone(),
-                aggregate_share: aggregate_share.clone(),
-                report_count: 0,
-                checksum: NonceChecksum::default(),
-            }),
-            "{:#?}",
-            batch_unit_aggregations,
-        );
-        assert!(
-            batch_unit_aggregations.contains(&BatchUnitAggregation {
-                task_id,
-                unit_interval_start: Time::from_seconds_since_epoch(150),
-                aggregation_param: aggregation_param.clone(),
-                aggregate_share: aggregate_share.clone(),
-                report_count: 0,
-                checksum: NonceChecksum::default(),
-            }),
-            "{:#?}",
-            batch_unit_aggregations,
-        );
+                assert_eq!(
+                    batch_unit_aggregations.len(),
+                    3,
+                    "{:#?}",
+                    batch_unit_aggregations,
+                );
+                assert!(
+                    batch_unit_aggregations.contains(&first_batch_unit_aggregation),
+                    "{:#?}",
+                    batch_unit_aggregations,
+                );
+                assert!(
+                    batch_unit_aggregations.contains(&second_batch_unit_aggregation),
+                    "{:#?}",
+                    batch_unit_aggregations,
+                );
+                assert!(batch_unit_aggregations.contains(&third_batch_unit_aggregation));
+
+                let updated_first_batch_unit_aggregation = BatchUnitAggregation::<ToyPoplar1> {
+                    aggregate_share: AggregateShare::from(vec![Field64::from(25)]),
+                    report_count: 1,
+                    checksum: NonceChecksum::get_decoded(&[1; 32]).unwrap(),
+                    ..first_batch_unit_aggregation
+                };
+
+                tx.update_batch_unit_aggregation(&updated_first_batch_unit_aggregation)
+                    .await?;
+
+                let batch_unit_aggregations = tx
+                    .get_batch_unit_aggregations_for_task_in_interval::<ToyPoplar1, _>(
+                        task_id,
+                        Interval::new(
+                            Time::from_seconds_since_epoch(50),
+                            Duration::from_seconds(250),
+                        )
+                        .unwrap(),
+                        &aggregation_param,
+                    )
+                    .await?;
+
+                assert_eq!(
+                    batch_unit_aggregations.len(),
+                    3,
+                    "{:#?}",
+                    batch_unit_aggregations,
+                );
+                assert!(
+                    batch_unit_aggregations.contains(&updated_first_batch_unit_aggregation),
+                    "{:#?}",
+                    batch_unit_aggregations,
+                );
+                assert!(
+                    batch_unit_aggregations.contains(&second_batch_unit_aggregation),
+                    "{:#?}",
+                    batch_unit_aggregations,
+                );
+                assert!(batch_unit_aggregations.contains(&third_batch_unit_aggregation));
+
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
As the helper prepares inputs and obtains output shares, accumulate the
values into rows in `batch_unit_aggregations` (also updating checksum
and report count). These rows will later be used by the
`/aggregate_share` handler to service `AggregateShareReq` messages.

Resolves #164