### PR TITLE
Rename crate `test_util` to `janus_test_util`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,6 +1311,7 @@ dependencies = [
  "hyper",
  "itertools",
  "janus",
+ "janus_test_util",
  "lazy_static",
  "libc",
  "mockito",
@@ -1334,7 +1335,6 @@ dependencies = [
  "signal-hook-tokio",
  "structopt",
  "tempfile",
- "test_util",
  "testcontainers",
  "thiserror",
  "tokio",
@@ -1349,6 +1349,16 @@ dependencies = [
  "uuid",
  "wait-timeout",
  "warp",
+]
+
+[[package]]
+name = "janus_test_util"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "janus",
+ "rand",
+ "ring",
 ]
 
 [[package]]
@@ -1530,10 +1540,10 @@ dependencies = [
  "futures",
  "janus",
  "janus_server",
+ "janus_test_util",
  "lazy_static",
  "prio",
  "ring",
- "test_util",
  "testcontainers",
  "tokio",
  "tokio-postgres",
@@ -2732,16 +2742,6 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
-]
-
-[[package]]
-name = "test_util"
-version = "0.1.0"
-dependencies = [
- "chrono",
- "janus",
- "rand",
- "ring",
 ]
 
 [[package]]

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -68,7 +68,7 @@ mockito = "0.31.0"
 serde_test = "1.0.137"
 tempfile = "3.3.0"
 testcontainers = "0.13.0"
-test_util = { path = "../test_util" }
+janus_test_util = { path = "../test_util" }
 tokio = { version = "*", features = ["test-util"] }
 trycmd = "0.13.4"
 wait-timeout = "0.2.0"

--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -2104,7 +2104,7 @@ mod tests {
         task::{test_util::new_dummy_task, VdafInstance},
         trace::test_util::install_test_trace_subscriber,
     };
-    use ::test_util::MockClock;
+    use ::janus_test_util::MockClock;
     use assert_matches::assert_matches;
     use http::Method;
     use janus::{

--- a/janus_server/src/bin/aggregation_job_creator.rs
+++ b/janus_server/src/bin/aggregation_job_creator.rs
@@ -358,6 +358,7 @@ mod tests {
         task::{test_util::new_dummy_task, VdafInstance},
         trace::test_util::install_test_trace_subscriber,
     };
+    use janus_test_util::MockClock;
     use prio::vdaf::{prio3::Prio3Aes128Count, Vdaf as _};
     use std::{
         collections::{HashMap, HashSet},
@@ -365,10 +366,9 @@ mod tests {
         sync::Arc,
         time::Duration,
     };
-    use test_util::MockClock;
     use tokio::{task, time};
 
-    test_util::define_ephemeral_datastore!();
+    janus_test_util::define_ephemeral_datastore!();
 
     #[tokio::test]
     async fn aggregation_job_creator() {

--- a/janus_server/src/client.rs
+++ b/janus_server/src/client.rs
@@ -216,9 +216,9 @@ mod tests {
     use crate::trace::test_util::install_test_trace_subscriber;
     use assert_matches::assert_matches;
     use janus::{hpke::test_util::generate_hpke_config_and_private_key, message::TaskId};
+    use janus_test_util::MockClock;
     use mockito::mock;
     use prio::vdaf::prio3::{Prio3Aes128Count, Prio3Aes128Sum};
-    use test_util::MockClock;
     use url::Url;
 
     fn setup_client<V: vdaf::Client>(

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -2158,7 +2158,7 @@ pub mod models {
 pub mod test_util {
     use super::{Crypter, Datastore};
 
-    test_util::define_ephemeral_datastore!();
+    janus_test_util::define_ephemeral_datastore!();
 }
 
 #[cfg(test)]
@@ -2171,7 +2171,7 @@ mod tests {
         task::{test_util::new_dummy_task, VdafInstance},
         trace::test_util::install_test_trace_subscriber,
     };
-    use ::test_util::generate_aead_key;
+    use ::janus_test_util::generate_aead_key;
     use assert_matches::assert_matches;
     use janus::{
         hpke::{self, HpkeApplicationInfo, Label},

--- a/janus_server/tests/server_shutdown.rs
+++ b/janus_server/tests/server_shutdown.rs
@@ -18,7 +18,7 @@ use std::{
 };
 use wait_timeout::ChildExt;
 
-test_util::define_ephemeral_datastore!();
+janus_test_util::define_ephemeral_datastore!();
 
 /// Try to find an open port by binding to an ephemeral port, saving the port
 /// number, and closing the listening socket. This may still fail due to race

--- a/monolithic_integration_test/Cargo.toml
+++ b/monolithic_integration_test/Cargo.toml
@@ -16,7 +16,7 @@ lazy_static = "1"
 prio = { git = "https://github.com/divviup/libprio-rs", rev = "229cd9c45924c7dae3ba754a6eb46b2a05ca8451" }  # TODO(brandon): use a numbered version, once a release is cut >0.7.0
 ring = "0.16.20"
 testcontainers = "0.13.0"
-test_util = { path = "../test_util" }
+janus_test_util = { path = "../test_util" }
 tokio = { version = "^1.18", features = ["full", "tracing"] }
 tokio-postgres = { version = "0.7.6", features = ["with-chrono-0_4"] }
 tracing = "0.1.34"

--- a/monolithic_integration_test/tests/integration_test.rs
+++ b/monolithic_integration_test/tests/integration_test.rs
@@ -22,7 +22,7 @@ use std::{
 use tokio::task::JoinHandle;
 use url::Url;
 
-test_util::define_ephemeral_datastore!();
+janus_test_util::define_ephemeral_datastore!();
 
 fn endpoint_from_socket_addr(addr: &SocketAddr) -> Url {
     assert!(addr.ip().is_loopback());

--- a/test_util/Cargo.toml
+++ b/test_util/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "test_util"
+name = "janus_test_util"
 version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -68,14 +68,14 @@ macro_rules! define_ephemeral_datastore {
             let pool = ::deadpool_postgres::Pool::builder(conn_mgr).build().unwrap();
 
             // Create a crypter with a random (ephemeral) key.
-            let datastore_key_bytes = ::test_util::generate_aead_key_bytes();
+            let datastore_key_bytes = ::janus_test_util::generate_aead_key_bytes();
             let datastore_key =
                 ::ring::aead::LessSafeKey::new(::ring::aead::UnboundKey::new(&ring::aead::AES_128_GCM, &datastore_key_bytes).unwrap());
             let crypter = Crypter::new(vec![datastore_key]);
 
             // Connect to the database & run our schema.
             let client = pool.get().await.unwrap();
-            client.batch_execute(::test_util::SCHEMA).await.unwrap();
+            client.batch_execute(::janus_test_util::SCHEMA).await.unwrap();
 
             (
                 Datastore::new(pool, crypter),


### PR DESCRIPTION
I didn't rename the directory because I think `janus/test_util` is clear enough vs. `janus/janus_test_util` which stutters unnecessarily.

Closes #151.