### PR TITLE
Introduce `janus_main`

### DIFF
--- a/janus_server/src/bin/aggregator.rs
+++ b/janus_server/src/bin/aggregator.rs
@@ -1,25 +1,16 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use futures::StreamExt;
 use janus::time::RealClock;
 use janus_server::{
     aggregator::aggregator_server,
-    binary_utils::datastore,
+    binary_utils::{janus_main, BinaryOptions, CommonBinaryOptions},
     config::AggregatorConfig,
-    metrics::{install_metrics_exporter, MetricsExporterConfiguration},
-    trace::{cleanup_trace_subscriber, install_trace_subscriber, OpenTelemetryTraceConfiguration},
 };
-use std::{
-    fmt::{self, Debug, Formatter},
-    fs::File,
-    future::Future,
-    iter::Iterator,
-    path::PathBuf,
-    sync::Arc,
-};
+use std::{future::Future, iter::Iterator, sync::Arc};
 use structopt::StructOpt;
 use tracing::info;
 
-#[derive(StructOpt)]
+#[derive(Debug, StructOpt)]
 #[structopt(
     name = "janus-aggregator",
     about = "PPM aggregator server",
@@ -27,75 +18,13 @@ use tracing::info;
     version = env!("CARGO_PKG_VERSION"),
 )]
 struct Options {
-    /// Path to configuration YAML.
-    #[structopt(
-        long,
-        env = "CONFIG_FILE",
-        parse(from_os_str),
-        takes_value = true,
-        required(true),
-        help = "path to configuration file"
-    )]
-    config_file: PathBuf,
-
-    /// Password for the PostgreSQL database connection. If specified, must not be specified in the
-    /// connection string.
-    #[structopt(long, env = "PGPASSWORD", help = "PostgreSQL password")]
-    database_password: Option<String>,
-
-    /// Datastore encryption keys.
-    #[structopt(
-        long,
-        env = "DATASTORE_KEYS",
-        takes_value = true,
-        use_delimiter = true,
-        required(true),
-        help = "datastore encryption keys, encoded in base64 then comma-separated"
-    )]
-    datastore_keys: Vec<String>,
-
-    /// Additional OTLP/gRPC metadata key/value pairs. (concatenated with those in the logging
-    /// configuration sections)
-    #[structopt(
-        long,
-        env = "OTLP_TRACING_METADATA",
-        parse(try_from_str = parse_metadata_entry),
-        help = "additional OTLP/gRPC metadata key/value pairs for the tracing exporter",
-        value_name = "KEY=value",
-        use_delimiter = true,
-    )]
-    otlp_tracing_metadata: Vec<(String, String)>,
-
-    /// Additional OTLP/gRPC metadata key/value pairs. (concatenated with those in the metrics
-    /// configuration sections)
-    #[structopt(
-        long,
-        env = "OTLP_METRICS_METADATA",
-        parse(try_from_str = parse_metadata_entry),
-        help = "additional OTLP/gRPC metadata key/value pairs for the metrics exporter",
-        value_name = "KEY=value",
-        use_delimiter = true,
-    )]
-    otlp_metrics_metadata: Vec<(String, String)>,
+    #[structopt(flatten)]
+    common: CommonBinaryOptions,
 }
 
-fn parse_metadata_entry(input: &str) -> Result<(String, String)> {
-    if let Some(equals) = input.find('=') {
-        let (key, rest) = input.split_at(equals);
-        let value = &rest[1..];
-        Ok((key.to_string(), value.to_string()))
-    } else {
-        Err(anyhow!(
-            "`--otlp-tracing-metadata` and `--otlp-metrics-metadata` must be provided a key and value, joined with an `=`"
-        ))
-    }
-}
-
-impl Debug for Options {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Options")
-            .field("config_file", &self.config_file)
-            .finish()
+impl BinaryOptions for Options {
+    fn common_options(&self) -> &CommonBinaryOptions {
+        &self.common
     }
 }
 
@@ -130,62 +59,24 @@ fn setup_signal_handler() -> Result<impl Future<Output = ()>, std::io::Error> {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // The configuration file path and any secret values are provided through
-    // command line options or environment variables.
-    let options = Options::from_args();
+    janus_main::<Options, _, _, _, _>(
+        RealClock::default(),
+        |clock, config: AggregatorConfig, datastore| async move {
+            let shutdown_signal =
+                setup_signal_handler().context("failed to register SIGTERM signal handler")?;
 
-    // The bulk of configuration options are in the config file.
-    let config_file = File::open(&options.config_file)
-        .with_context(|| format!("failed to open config file: {:?}", options.config_file))?;
-
-    let mut config: AggregatorConfig = serde_yaml::from_reader(&config_file)
-        .with_context(|| format!("failed to parse config file: {:?}", options.config_file))?;
-
-    if let Some(OpenTelemetryTraceConfiguration::Otlp(otlp_config)) =
-        &mut config.logging_config.open_telemetry_config
-    {
-        otlp_config
-            .metadata
-            .extend(options.otlp_tracing_metadata.iter().cloned());
-    }
-    if let Some(MetricsExporterConfiguration::Otlp(otlp_config)) =
-        &mut config.metrics_config.exporter
-    {
-        otlp_config
-            .metadata
-            .extend(options.otlp_metrics_metadata.iter().cloned());
-    }
-
-    install_trace_subscriber(&config.logging_config)
-        .context("failed to install tracing subscriber")?;
-    let _metrics_exporter = install_metrics_exporter(&config.metrics_config)
-        .context("failed to install metrics exporter")?;
-
-    info!(?options, ?config, "starting aggregator");
-
-    // Connect to database.
-    let clock = RealClock::default();
-    let datastore = Arc::new(
-        datastore(
-            clock,
-            config.database,
-            options.database_password,
-            options.datastore_keys,
-        )
-        .context("couldn't connect to database")?,
-    );
-
-    let shutdown_signal =
-        setup_signal_handler().context("failed to register SIGTERM signal handler")?;
-
-    let (bound_address, server) =
-        aggregator_server(datastore, clock, config.listen_address, shutdown_signal)
+            let (bound_address, server) = aggregator_server(
+                Arc::new(datastore),
+                clock,
+                config.listen_address,
+                shutdown_signal,
+            )
             .context("failed to create aggregator server")?;
-    info!(?bound_address, "running aggregator");
+            info!(?bound_address, "running aggregator");
 
-    server.await;
-
-    cleanup_trace_subscriber(&config.logging_config);
-
-    Ok(())
+            server.await;
+            Ok(())
+        },
+    )
+    .await
 }

--- a/janus_server/src/binary_utils.rs
+++ b/janus_server/src/binary_utils.rs
@@ -1,15 +1,25 @@
 //! Utilities for Janus binaries.
 
 use crate::{
-    config::DbConfig,
+    config::{BinaryConfig, DbConfig},
     datastore::{Crypter, Datastore},
+    metrics::{install_metrics_exporter, MetricsExporterConfiguration},
+    trace::{cleanup_trace_subscriber, install_trace_subscriber, OpenTelemetryTraceConfiguration},
 };
 use anyhow::{anyhow, Context, Result};
 use deadpool_postgres::{Manager, Pool};
 use janus::time::Clock;
 use ring::aead::{LessSafeKey, UnboundKey, AES_128_GCM};
-use std::str::FromStr;
+use std::{
+    fmt::{self, Debug, Formatter},
+    fs,
+    future::Future,
+    path::PathBuf,
+    str::FromStr,
+};
+use structopt::StructOpt;
 use tokio_postgres::NoTls;
+use tracing::info;
 
 /// Connects to a datastore, given a config for the underlying database. `db_password` is mutually
 /// exclusive with the database password specified in the connection URL in `db_config`. `ds_keys`
@@ -17,9 +27,9 @@ use tokio_postgres::NoTls;
 /// stored in the datastore; it must not be empty.
 pub fn datastore<C: Clock>(
     clock: C,
-    db_config: DbConfig,
-    db_password: Option<String>,
-    ds_keys: Vec<String>,
+    db_config: &DbConfig,
+    db_password: &Option<String>,
+    ds_keys: &[String],
 ) -> Result<Datastore<C>> {
     let mut database_config = tokio_postgres::Config::from_str(db_config.url.as_str())
         .with_context(|| {
@@ -42,7 +52,7 @@ pub fn datastore<C: Clock>(
         .build()
         .context("failed to create database connection pool")?;
     let ds_keys = ds_keys
-        .into_iter()
+        .iter()
         .filter(|k| !k.is_empty())
         .map(|k| {
             base64::decode_config(k, base64::STANDARD_NO_PAD)
@@ -59,4 +69,150 @@ pub fn datastore<C: Clock>(
         return Err(anyhow!("ds_keys is empty"));
     }
     Ok(Datastore::new(pool, Crypter::new(ds_keys), clock))
+}
+
+/// Options for Janus binaries.
+pub trait BinaryOptions: StructOpt + Debug {
+    /// Returns the common options.
+    fn common_options(&self) -> &CommonBinaryOptions;
+}
+
+#[cfg_attr(doc, doc = "Common options that are used by all Janus binaries.")]
+#[derive(StructOpt)]
+pub struct CommonBinaryOptions {
+    /// Path to configuration YAML.
+    #[structopt(
+        long,
+        env = "CONFIG_FILE",
+        parse(from_os_str),
+        takes_value = true,
+        required(true),
+        help = "path to configuration file"
+    )]
+    config_file: PathBuf,
+
+    /// Password for the PostgreSQL database connection. If specified, must not be specified in the
+    /// connection string.
+    #[structopt(long, env = "PGPASSWORD", help = "PostgreSQL password")]
+    database_password: Option<String>,
+
+    /// Datastore encryption keys.
+    #[structopt(
+        long,
+        env = "DATASTORE_KEYS",
+        takes_value = true,
+        use_delimiter = true,
+        required(true),
+        help = "datastore encryption keys, encoded in base64 then comma-separated"
+    )]
+    datastore_keys: Vec<String>,
+
+    /// Additional OTLP/gRPC metadata key/value pairs. (concatenated with those in the logging
+    /// configuration sections)
+    #[structopt(
+        long,
+        env = "OTLP_TRACING_METADATA",
+        parse(try_from_str = parse_metadata_entry),
+        help = "additional OTLP/gRPC metadata key/value pairs for the tracing exporter",
+        value_name = "KEY=value",
+        use_delimiter = true,
+    )]
+    otlp_tracing_metadata: Vec<(String, String)>,
+
+    /// Additional OTLP/gRPC metadata key/value pairs. (concatenated with those in the metrics
+    /// configuration sections)
+    #[structopt(
+        long,
+        env = "OTLP_METRICS_METADATA",
+        parse(try_from_str = parse_metadata_entry),
+        help = "additional OTLP/gRPC metadata key/value pairs for the metrics exporter",
+        value_name = "KEY=value",
+        use_delimiter = true,
+    )]
+    otlp_metrics_metadata: Vec<(String, String)>,
+}
+
+impl Debug for CommonBinaryOptions {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Options")
+            .field("config_file", &self.config_file)
+            .finish()
+    }
+}
+
+fn parse_metadata_entry(input: &str) -> Result<(String, String)> {
+    if let Some(equals) = input.find('=') {
+        let (key, rest) = input.split_at(equals);
+        let value = &rest[1..];
+        Ok((key.to_string(), value.to_string()))
+    } else {
+        Err(anyhow!(
+            "`--otlp-tracing-metadata` and `--otlp-metrics-metadata` must be provided a key and value, joined with an `=`"
+        ))
+    }
+}
+
+pub async fn janus_main<O, C, Config, F, Fut>(clock: C, f: F) -> anyhow::Result<()>
+where
+    O: BinaryOptions,
+    C: Clock,
+    Config: BinaryConfig,
+    F: FnOnce(C, Config, Datastore<C>) -> Fut,
+    Fut: Future<Output = anyhow::Result<()>>,
+{
+    // Read arguments, read & parse config.
+    let options = O::from_args();
+    let common_options = options.common_options();
+    let mut config = {
+        let config_content =
+            fs::read_to_string(&common_options.config_file).with_context(|| {
+                format!("couldn't read config file {:?}", common_options.config_file)
+            })?;
+        let mut config: Config = serde_yaml::from_str(&config_content).with_context(|| {
+            format!(
+                "couldn't parse config file {:?}",
+                common_options.config_file
+            )
+        })?;
+
+        if let Some(OpenTelemetryTraceConfiguration::Otlp(otlp_config)) =
+            &mut config.logging_config().open_telemetry_config
+        {
+            otlp_config
+                .metadata
+                .extend(common_options.otlp_tracing_metadata.iter().cloned());
+        }
+        if let Some(MetricsExporterConfiguration::Otlp(otlp_config)) =
+            &mut config.metrics_config().exporter
+        {
+            otlp_config
+                .metadata
+                .extend(common_options.otlp_metrics_metadata.iter().cloned());
+        }
+
+        config
+    };
+    install_trace_subscriber(config.logging_config())
+        .context("couldn't install tracing subscriber")?;
+    let _metrics_exporter = install_metrics_exporter(config.metrics_config())
+        .context("failed to install metrics exporter")?;
+
+    info!(?common_options, ?config, "Starting up");
+
+    // Connect to database.
+    let datastore = datastore(
+        clock.clone(),
+        config.database_config(),
+        &common_options.database_password,
+        &common_options.datastore_keys,
+    )
+    .context("couldn't connect to database")?;
+
+    let logging_config = config.logging_config().clone();
+
+    f(clock, config, datastore).await?;
+
+    cleanup_trace_subscriber(&logging_config);
+
+    Ok(())
 }

--- a/janus_server/src/trace.rs
+++ b/janus_server/src/trace.rs
@@ -227,7 +227,7 @@ pub fn install_trace_subscriber(config: &TraceConfiguration) -> Result<(), Error
     Ok(())
 }
 
-pub fn cleanup_trace_subscriber(_config: &TraceConfiguration) {
+pub(crate) fn cleanup_trace_subscriber(_config: &TraceConfiguration) {
     #[cfg(any(feature = "jaeger", feature = "otlp"))]
     if _config.open_telemetry_config.is_some() {
         // Flush buffered traces in the OpenTelemetry pipeline.

--- a/janus_server/tests/cmd/aggregation_job_creator.trycmd
+++ b/janus_server/tests/cmd/aggregation_job_creator.trycmd
@@ -16,5 +16,11 @@ OPTIONS:
         --datastore-keys <datastore-keys>...
             datastore encryption keys, encoded in base64 then comma-separated [env: DATASTORE_KEYS=]
 
+        --otlp-metrics-metadata <KEY=value>...
+            additional OTLP/gRPC metadata key/value pairs for the metrics exporter [env: OTLP_METRICS_METADATA=]
+
+        --otlp-tracing-metadata <KEY=value>...
+            additional OTLP/gRPC metadata key/value pairs for the tracing exporter [env: OTLP_TRACING_METADATA=]
+
 
 ```

--- a/janus_server/tests/cmd/aggregation_job_driver.trycmd
+++ b/janus_server/tests/cmd/aggregation_job_driver.trycmd
@@ -16,5 +16,11 @@ OPTIONS:
         --datastore-keys <datastore-keys>...
             datastore encryption keys, encoded in base64 then comma-separated [env: DATASTORE_KEYS=]
 
+        --otlp-metrics-metadata <KEY=value>...
+            additional OTLP/gRPC metadata key/value pairs for the metrics exporter [env: OTLP_METRICS_METADATA=]
+
+        --otlp-tracing-metadata <KEY=value>...
+            additional OTLP/gRPC metadata key/value pairs for the tracing exporter [env: OTLP_TRACING_METADATA=]
+
 
 ```


### PR DESCRIPTION
Factors out common binary startup work like parsing options and config,
setting up metrics and logging and setting up a datastore connection
into a function `binary_utils::janus_main`.