### PR TITLE
Add sleep and interval APIs to the Clock trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,6 +1276,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "async-trait",
  "base64",
  "chrono",
  "hex",
@@ -1288,6 +1289,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -1356,11 +1358,15 @@ name = "janus_test_util"
 version = "0.1.0"
 dependencies = [
  "assert_matches",
+ "async-trait",
  "chrono",
+ "futures",
  "janus",
+ "pin-project",
  "prio",
  "rand",
  "ring",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1362,7 +1362,6 @@ dependencies = [
  "chrono",
  "futures",
  "janus",
- "pin-project",
  "prio",
  "rand",
  "ring",

--- a/janus/Cargo.toml
+++ b/janus/Cargo.toml
@@ -7,6 +7,7 @@ rust-version = "1.58"
 
 [dependencies]
 anyhow = "1"
+async-trait = "0.1.53"
 base64 = "0.13.0"
 chrono = "0.4"
 hex = "0.4.3"
@@ -18,6 +19,7 @@ rand = "0.8"
 ring = "0.16.20"
 serde = { version = "1.0.137", features = ["derive"] }
 thiserror = "1.0"
+tokio = { version = "^1.18", default-features = false, features = ["time"] }
 
 [dev-dependencies]
 assert_matches = "1"

--- a/janus/src/time.rs
+++ b/janus/src/time.rs
@@ -1,13 +1,56 @@
 //! Utilities for timestamps and durations.
 
 use crate::message::Time;
+use async_trait::async_trait;
 use chrono::Utc;
-use std::fmt::{Debug, Formatter};
+use std::{
+    fmt::{Debug, Formatter},
+    future::Future,
+    time::{Duration, Instant},
+};
+use tokio::time::{interval_at, sleep, timeout, Interval, MissedTickBehavior};
+
+/// Error type indicating that a timeout elapsed.
+#[derive(Debug)]
+pub struct Elapsed;
 
 /// A clock knows what time it currently is.
+#[async_trait]
 pub trait Clock: 'static + Clone + Debug + Sync + Send {
-    /// Get the current time.
+    /// Return type of `interval` and `interval_at`. This produces a series of ticks with a given
+    /// amount of time between each tick.
+    type Interval: ClockInterval;
+
+    /// Get the current wall clock time.
     fn now(&self) -> Time;
+
+    /// Get the current time from a monotonic clock, for use with timers.
+    fn now_monotonic(&self) -> Instant;
+
+    /// Wraps a future in a timeout, either returning the future's output or cancelling the future
+    /// and returning an error.
+    async fn timeout<O, F>(&self, duration: Duration, future: F) -> Result<O, Elapsed>
+    where
+        F: Future<Output = O> + Send;
+
+    /// Create a [`Self::Interval`] that will produce ticks at a regular interval, with the first tick
+    /// happening at `start`.
+    fn interval_at(&self, start: Instant, period: Duration) -> Self::Interval;
+
+    /// Create a [`Self::Interval`] that will produce ticks at a regular interval.
+    fn interval(&self, period: Duration) -> Self::Interval {
+        self.interval_at(self.now_monotonic(), period)
+    }
+
+    /// Wait for `duration`.
+    async fn sleep(&self, duration: Duration);
+}
+
+/// Produces a series of ticks with a given amount of time between each tick.
+#[async_trait]
+pub trait ClockInterval: 'static + Debug + Send + Sync {
+    async fn tick(&mut self);
+    fn set_missed_tick_behavior(&mut self, behavior: MissedTickBehavior);
 }
 
 /// A real clock returns the current time relative to the Unix epoch.
@@ -15,7 +58,10 @@ pub trait Clock: 'static + Clone + Debug + Sync + Send {
 #[non_exhaustive]
 pub struct RealClock {}
 
+#[async_trait]
 impl Clock for RealClock {
+    type Interval = Interval;
+
     fn now(&self) -> Time {
         Time::from_seconds_since_epoch(
             Utc::now()
@@ -24,10 +70,40 @@ impl Clock for RealClock {
                 .expect("invalid or out-of-range timestamp"),
         )
     }
+
+    fn now_monotonic(&self) -> Instant {
+        Instant::now()
+    }
+
+    async fn timeout<O, F>(&self, duration: Duration, future: F) -> Result<O, Elapsed>
+    where
+        F: Future<Output = O> + Send,
+    {
+        timeout(duration, future).await.map_err(|_| Elapsed)
+    }
+
+    fn interval_at(&self, start: Instant, period: Duration) -> Self::Interval {
+        interval_at(start.into(), period)
+    }
+
+    async fn sleep(&self, duration: Duration) {
+        sleep(duration).await
+    }
 }
 
 impl Debug for RealClock {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self.now())
+    }
+}
+
+#[async_trait]
+impl ClockInterval for Interval {
+    async fn tick(&mut self) {
+        self.tick().await;
+    }
+
+    fn set_missed_tick_behavior(&mut self, behavior: MissedTickBehavior) {
+        self.set_missed_tick_behavior(behavior);
     }
 }

--- a/janus_server/src/client.rs
+++ b/janus_server/src/client.rs
@@ -152,7 +152,7 @@ where
         }
     }
 
-    /// Upload a [`crate::message::Report`] to the leader, per §4.3.2 of
+    /// Upload a [`janus::message::Report`] to the leader, per §4.3.2 of
     /// draft-gpew-priv-ppm. The provided measurement is sharded into one input
     /// share plus one proof share for each aggregator and then uploaded to the
     /// leader.

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -4153,7 +4153,7 @@ mod tests {
             .unwrap();
 
         // Advance time by the lease duration
-        clock.advance(Duration::from_seconds(100));
+        clock.advance(Duration::from_seconds(100)).await;
 
         ds.run_tx(|tx| {
             let reacquired_jobs = reacquired_jobs.clone();

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -3058,7 +3058,7 @@ mod tests {
 
         // Run: advance time by the lease duration (which implicitly releases the jobs), and attempt
         // to acquire aggregation jobs again.
-        clock.advance(LEASE_DURATION);
+        clock.advance(LEASE_DURATION).await;
         let want_expiry_time = clock.now().add(LEASE_DURATION).unwrap();
         let want_aggregation_jobs: Vec<_> = aggregation_job_ids
             .iter()

--- a/test_util/Cargo.toml
+++ b/test_util/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 [dependencies]
 assert_matches = "1"
 async-trait = "0.1.53"
-pin-project = "1.0.10"
 prio = { git = "https://github.com/divviup/libprio-rs", rev = "229cd9c45924c7dae3ba754a6eb46b2a05ca8451" }  # TODO(brandon): use a numbered version, once a release is cut >0.7.0
 rand = "0.8"
 ring = "0.16.20"

--- a/test_util/Cargo.toml
+++ b/test_util/Cargo.toml
@@ -8,8 +8,15 @@ publish = false
 
 [dependencies]
 assert_matches = "1"
+async-trait = "0.1.53"
+pin-project = "1.0.10"
 prio = { git = "https://github.com/divviup/libprio-rs", rev = "229cd9c45924c7dae3ba754a6eb46b2a05ca8451" }  # TODO(brandon): use a numbered version, once a release is cut >0.7.0
 rand = "0.8"
 ring = "0.16.20"
 janus = { path = "../janus" }
 chrono = "0.4"
+tokio = { version = "^1.18", default-features = false, features = ["sync"] }
+
+[dev-dependencies]
+futures = "0.3.21"
+tokio = { version = "^1.18", default-features = false, features = ["macros", "rt", "sync"] }


### PR DESCRIPTION
This adds some additional time-related methods to the `Clock` trait and both of its implementations.

Tomorrow, I'll cut over the worker binaries to use these new methods instead of `tokio::time` APIs, and then rewrite tests with them to better check the time-based control flow. This will give us the control we wanted from `tokio::time::pause()` without the side-effects on other async libraries.