### PR TITLE
Update HPKE usage to align with DAP-01.

### DIFF
--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -16,8 +16,7 @@ use crate::{
         AggregateReq,
         AggregateReqBody::{AggregateContinueReq, AggregateInitReq},
         AggregateResp, AggregateShareReq, AggregateShareResp, AggregationJobId, CollectReq,
-        CollectResp, Interval, ReportShare, Transition, TransitionError,
-        TransitionTypeSpecificData,
+        CollectResp, ReportShare, Transition, TransitionError, TransitionTypeSpecificData,
     },
     task::{Task, VdafInstance},
 };
@@ -29,7 +28,7 @@ use http::{
 };
 use janus::{
     hpke::{self, HpkeApplicationInfo, Label},
-    message::{HpkeConfig, HpkeConfigId, Nonce, NonceChecksum, Report, Role, TaskId},
+    message::{HpkeConfig, HpkeConfigId, Interval, Nonce, NonceChecksum, Report, Role, TaskId},
     time::Clock,
 };
 use opentelemetry::{
@@ -480,12 +479,7 @@ impl TaskAggregator {
         if let Err(err) = hpke::open(
             hpke_config,
             hpke_private_key,
-            &HpkeApplicationInfo::new(
-                report.task_id(),
-                Label::InputShare,
-                Role::Client,
-                self.task.role,
-            ),
+            &HpkeApplicationInfo::new(Label::InputShare, Role::Client, self.task.role),
             leader_report,
             &report.associated_data(),
         ) {
@@ -757,14 +751,9 @@ impl VdafOps {
                 hpke::open(
                     hpke_config,
                     hpke_private_key,
-                    &HpkeApplicationInfo::new(
-                        task_id,
-                        Label::InputShare,
-                        Role::Client,
-                        Role::Helper,
-                    ),
+                    &HpkeApplicationInfo::new(Label::InputShare, Role::Client, Role::Helper),
                     &report_share.encrypted_input_share,
-                    &report_share.associated_data(),
+                    &report_share.associated_data(task_id),
                 )
                 .map_err(|err| {
                     warn!(
@@ -1286,16 +1275,12 @@ impl VdafOps {
                 // TODO: consider fetching freshly encrypted helper aggregate share if it has been
                 // long enough since the encrypted helper share was cached -- tricky thing is
                 // deciding what "long enough" is.
+                let associated_data = job.associated_data_for_aggregate_share();
                 let encrypted_leader_aggregate_share = hpke::seal(
                     &task.collector_hpke_config,
-                    &HpkeApplicationInfo::new(
-                        task.id,
-                        Label::AggregateShare,
-                        Role::Leader,
-                        Role::Collector,
-                    ),
+                    &HpkeApplicationInfo::new(Label::AggregateShare, Role::Leader, Role::Collector),
                     &<Vec<u8>>::from(&job.leader_aggregate_share.unwrap()),
-                    &job.batch_interval.get_encoded(),
+                    &associated_data,
                 )?;
 
                 Ok(CollectResp {
@@ -1597,14 +1582,9 @@ impl VdafOps {
         // the time the aggregate share was first computed.
         let encrypted_aggregate_share = hpke::seal(
             &task.collector_hpke_config,
-            &HpkeApplicationInfo::new(
-                task.id,
-                Label::AggregateShare,
-                Role::Helper,
-                Role::Collector,
-            ),
+            &HpkeApplicationInfo::new(Label::AggregateShare, Role::Helper, Role::Collector),
             &<Vec<u8>>::from(&aggregate_share_job.helper_aggregate_share),
-            &aggregate_share_req.batch_interval.get_encoded(),
+            &aggregate_share_req.associated_data_for_aggregate_share(),
         )?;
 
         Ok(AggregateShareResp {
@@ -2188,7 +2168,10 @@ mod tests {
     use http::Method;
     use janus::{
         hpke::associated_data_for_report_share,
-        hpke::{test_util::generate_hpke_config_and_private_key, HpkePrivateKey, Label},
+        hpke::{
+            associated_data_for_aggregate_share, test_util::generate_hpke_config_and_private_key,
+            HpkePrivateKey, Label,
+        },
         message::{Duration, HpkeCiphertext, HpkeConfig, TaskId, Time},
     };
     use prio::{
@@ -2239,7 +2222,7 @@ mod tests {
         assert_eq!(hpke_config, want_hpke_key.0);
 
         let application_info =
-            HpkeApplicationInfo::new(task_id, Label::InputShare, Role::Client, Role::Leader);
+            HpkeApplicationInfo::new(Label::InputShare, Role::Client, Role::Leader);
         let message = b"this is a message";
         let associated_data = b"some associated data";
 
@@ -2276,18 +2259,18 @@ mod tests {
         );
         let extensions = vec![];
         let message = b"this is a message";
-        let associated_data = associated_data_for_report_share(nonce, &extensions);
+        let associated_data = associated_data_for_report_share(task.id, nonce, &extensions);
 
         let leader_ciphertext = hpke::seal(
             &hpke_key.0,
-            &HpkeApplicationInfo::new(task.id, Label::InputShare, Role::Client, Role::Leader),
+            &HpkeApplicationInfo::new(Label::InputShare, Role::Client, Role::Leader),
             message,
             &associated_data,
         )
         .unwrap();
         let helper_ciphertext = hpke::seal(
             &hpke_key.0,
-            &HpkeApplicationInfo::new(task.id, Label::InputShare, Role::Client, Role::Leader),
+            &HpkeApplicationInfo::new(Label::InputShare, Role::Client, Role::Leader),
             message,
             &associated_data,
         )
@@ -2627,16 +2610,11 @@ mod tests {
 
     fn reencrypt_report(report: Report, hpke_config: &HpkeConfig) -> Report {
         let message = b"this is a message";
-        let associated_data = associated_data_for_report_share(report.nonce(), report.extensions());
+        let associated_data = report.associated_data();
 
         let leader_ciphertext = hpke::seal(
             hpke_config,
-            &HpkeApplicationInfo::new(
-                report.task_id(),
-                Label::InputShare,
-                Role::Client,
-                Role::Leader,
-            ),
+            &HpkeApplicationInfo::new(Label::InputShare, Role::Client, Role::Leader),
             message,
             &associated_data,
         )
@@ -2644,12 +2622,7 @@ mod tests {
 
         let helper_ciphertext = hpke::seal(
             hpke_config,
-            &HpkeApplicationInfo::new(
-                report.task_id(),
-                Label::InputShare,
-                Role::Client,
-                Role::Helper,
-            ),
+            &HpkeApplicationInfo::new(Label::InputShare, Role::Client, Role::Helper),
             message,
             &associated_data,
         )
@@ -2934,13 +2907,11 @@ mod tests {
         let nonce_2 = Nonce::generate(&clock);
         let mut input_share_bytes = input_share.get_encoded();
         input_share_bytes.push(0); // can no longer be decoded.
-        let associated_data = associated_data_for_report_share(nonce_2, &[]);
         let report_share_2 = generate_helper_report_share_for_plaintext(
-            task_id,
             nonce_2,
             &hpke_key.0,
             &input_share_bytes,
-            &associated_data,
+            &associated_data_for_report_share(task_id, nonce_2, &[]),
         );
 
         // report_share_3 has an unknown HPKE config ID.
@@ -4673,13 +4644,12 @@ mod tests {
                     let encrypted_helper_aggregate_share = hpke::seal(
                         &collector_hpke_config,
                         &HpkeApplicationInfo::new(
-                            task.id,
                             Label::AggregateShare,
                             Role::Helper,
                             Role::Collector,
                         ),
                         &helper_aggregate_share_bytes,
-                        &batch_interval.get_encoded(),
+                        &associated_data_for_aggregate_share(task.id, batch_interval),
                     )
                     .unwrap();
 
@@ -4714,14 +4684,9 @@ mod tests {
         let decrypted_leader_aggregate_share = hpke::open(
             &task.collector_hpke_config,
             &collector_hpke_recipient,
-            &HpkeApplicationInfo::new(
-                task_id,
-                Label::AggregateShare,
-                Role::Leader,
-                Role::Collector,
-            ),
+            &HpkeApplicationInfo::new(Label::AggregateShare, Role::Leader, Role::Collector),
             &collect_resp.encrypted_agg_shares[0],
-            &batch_interval.get_encoded(),
+            &associated_data_for_aggregate_share(task_id, batch_interval),
         )
         .unwrap();
         assert_eq!(
@@ -4732,14 +4697,9 @@ mod tests {
         let decrypted_helper_aggregate_share = hpke::open(
             &task.collector_hpke_config,
             &collector_hpke_recipient,
-            &HpkeApplicationInfo::new(
-                task_id,
-                Label::AggregateShare,
-                Role::Helper,
-                Role::Collector,
-            ),
+            &HpkeApplicationInfo::new(Label::AggregateShare, Role::Helper, Role::Collector),
             &collect_resp.encrypted_agg_shares[1],
-            &batch_interval.get_encoded(),
+            &associated_data_for_aggregate_share(task_id, batch_interval),
         )
         .unwrap();
         assert_eq!(
@@ -5289,14 +5249,9 @@ mod tests {
                 let aggregate_share = hpke::open(
                     &collector_hpke_config,
                     &collector_hpke_recipient,
-                    &HpkeApplicationInfo::new(
-                        task_id,
-                        Label::AggregateShare,
-                        Role::Helper,
-                        Role::Collector,
-                    ),
+                    &HpkeApplicationInfo::new(Label::AggregateShare, Role::Helper, Role::Collector),
                     &aggregate_share_resp.encrypted_aggregate_share,
-                    &request.batch_interval.get_encoded(),
+                    &request.associated_data_for_aggregate_share(),
                 )
                 .unwrap();
 
@@ -5374,9 +5329,8 @@ mod tests {
     where
         for<'a> &'a V::AggregateShare: Into<Vec<u8>>,
     {
-        let associated_data = associated_data_for_report_share(nonce, &[]);
+        let associated_data = associated_data_for_report_share(task_id, nonce, &[]);
         generate_helper_report_share_for_plaintext(
-            task_id,
             nonce,
             cfg,
             &input_share.get_encoded(),
@@ -5385,7 +5339,6 @@ mod tests {
     }
 
     fn generate_helper_report_share_for_plaintext(
-        task_id: TaskId,
         nonce: Nonce,
         cfg: &HpkeConfig,
         plaintext: &[u8],
@@ -5396,7 +5349,7 @@ mod tests {
             extensions: Vec::new(),
             encrypted_input_share: hpke::seal(
                 cfg,
-                &HpkeApplicationInfo::new(task_id, Label::InputShare, Role::Client, Role::Helper),
+                &HpkeApplicationInfo::new(Label::InputShare, Role::Client, Role::Helper),
                 plaintext,
                 associated_data,
             )

--- a/janus_server/src/aggregator/accumulator.rs
+++ b/janus_server/src/aggregator/accumulator.rs
@@ -1,13 +1,10 @@
 //! In-memory accumulation of output shares.
 
 use super::Error;
-use crate::{
-    datastore::{self, models::BatchUnitAggregation, Transaction},
-    message::Interval,
-};
+use crate::datastore::{self, models::BatchUnitAggregation, Transaction};
 use derivative::Derivative;
 use janus::{
-    message::{Duration, Nonce, NonceChecksum, TaskId, Time},
+    message::{Duration, Interval, Nonce, NonceChecksum, TaskId, Time},
     time::Clock,
 };
 use prio::vdaf::{self, Aggregatable};

--- a/janus_server/src/bin/aggregation_job_driver.rs
+++ b/janus_server/src/bin/aggregation_job_driver.rs
@@ -450,9 +450,9 @@ impl<C: Clock> AggregationJobDriver<C> {
                 }
             };
             let hpke_application_info =
-                HpkeApplicationInfo::new(task.id, Label::InputShare, Role::Client, Role::Leader);
+                HpkeApplicationInfo::new(Label::InputShare, Role::Client, Role::Leader);
             let associated_data =
-                associated_data_for_report_share(report.nonce(), report.extensions());
+                associated_data_for_report_share(task.id, report.nonce(), report.extensions());
             let leader_input_share_bytes = match hpke::open(
                 hpke_config,
                 hpke_private_key,
@@ -1346,12 +1346,12 @@ mod tests {
             .map(|role| {
                 hpke::seal(
                     hpke_configs.get(role.index().unwrap()).unwrap(),
-                    &HpkeApplicationInfo::new(task_id, Label::InputShare, Role::Client, role),
+                    &HpkeApplicationInfo::new(Label::InputShare, Role::Client, role),
                     &input_shares
                         .get(role.index().unwrap())
                         .unwrap()
                         .get_encoded(),
-                    &associated_data_for_report_share(nonce, &[]),
+                    &associated_data_for_report_share(task_id, nonce, &[]),
                 )
             })
             .collect::<Result<_, _>>()

--- a/janus_server/src/client.rs
+++ b/janus_server/src/client.rs
@@ -164,7 +164,8 @@ where
 
         let nonce = Nonce::generate(&self.clock);
         let extensions = vec![]; // No extensions supported yet
-        let associated_data = associated_data_for_report_share(nonce, &extensions);
+        let associated_data =
+            associated_data_for_report_share(self.parameters.task_id, nonce, &extensions);
 
         let encrypted_input_shares: Vec<HpkeCiphertext> = [
             (&self.leader_hpke_config, Role::Leader),
@@ -175,12 +176,7 @@ where
         .map(|((hpke_config, receiver_role), input_share)| {
             Ok(hpke::seal(
                 hpke_config,
-                &HpkeApplicationInfo::new(
-                    self.parameters.task_id,
-                    Label::InputShare,
-                    Role::Client,
-                    receiver_role,
-                ),
+                &HpkeApplicationInfo::new(Label::InputShare, Role::Client, receiver_role),
                 &input_share.get_encoded(),
                 &associated_data,
             )?)

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -5,7 +5,7 @@ use self::models::{
     ReportAggregation, ReportAggregationState, ReportAggregationStateCode,
 };
 use crate::{
-    message::{AggregateShareReq, AggregationJobId, Interval, ReportShare},
+    message::{AggregateShareReq, AggregationJobId, ReportShare},
     task::{self, AggregatorAuthenticationToken, Task, VdafInstance},
 };
 use chrono::NaiveDateTime;
@@ -13,8 +13,8 @@ use futures::try_join;
 use janus::{
     hpke::HpkePrivateKey,
     message::{
-        Duration, Extension, HpkeCiphertext, HpkeConfig, Nonce, NonceChecksum, Report, Role,
-        TaskId, Time,
+        Duration, Extension, HpkeCiphertext, HpkeConfig, Interval, Nonce, NonceChecksum, Report,
+        Role, TaskId, Time,
     },
     time::Clock,
 };
@@ -1995,11 +1995,14 @@ impl From<ring::error::Unspecified> for Error {
 pub mod models {
     use super::Error;
     use crate::{
-        message::{AggregationJobId, Interval, TransitionError},
+        message::{AggregationJobId, TransitionError},
         task,
     };
     use derivative::Derivative;
-    use janus::message::{HpkeCiphertext, Nonce, NonceChecksum, Role, TaskId, Time};
+    use janus::{
+        hpke::associated_data_for_aggregate_share,
+        message::{HpkeCiphertext, Interval, Nonce, NonceChecksum, Role, TaskId, Time},
+    };
     use postgres_types::{FromSql, ToSql};
     use prio::{codec::Encode, vdaf};
     use uuid::Uuid;
@@ -2356,6 +2359,11 @@ pub mod models {
                 ))),
             }
         }
+
+        /// Returns the associated data for aggregate share encryptions related to this collect job.
+        pub(crate) fn associated_data_for_aggregate_share(&self) -> Vec<u8> {
+            associated_data_for_aggregate_share(self.task_id, self.batch_interval)
+        }
     }
 
     /// AggregateShareJob represents a row in the `aggregate_share_jobs` table, used by helpers to
@@ -2422,7 +2430,7 @@ mod tests {
     use crate::{
         aggregator::test_util::fake,
         datastore::{models::AggregationJobState, test_util::ephemeral_datastore},
-        message::{Interval, TransitionError},
+        message::TransitionError,
         task::{test_util::new_dummy_task, VdafInstance},
         trace::test_util::install_test_trace_subscriber,
     };
@@ -2430,7 +2438,7 @@ mod tests {
     use assert_matches::assert_matches;
     use futures::future::try_join_all;
     use janus::{
-        hpke::{self, HpkeApplicationInfo, Label},
+        hpke::{self, associated_data_for_aggregate_share, HpkeApplicationInfo, Label},
         message::{Duration, ExtensionType, HpkeConfigId, Role, Time},
     };
     use prio::{
@@ -3739,14 +3747,9 @@ mod tests {
 
                 let encrypted_helper_aggregate_share = hpke::seal(
                     &task.collector_hpke_config,
-                    &HpkeApplicationInfo::new(
-                        task.id,
-                        Label::AggregateShare,
-                        Role::Helper,
-                        Role::Collector,
-                    ),
+                    &HpkeApplicationInfo::new(Label::AggregateShare, Role::Helper, Role::Collector),
                     &[0, 1, 2, 3, 4, 5],
-                    &first_batch_interval.get_encoded(),
+                    &associated_data_for_aggregate_share(task.id, first_batch_interval),
                 )
                 .unwrap();
 

--- a/janus_server/src/task.rs
+++ b/janus_server/src/task.rs
@@ -1,10 +1,9 @@
 //! Shared parameters for a PPM task.
 
-use crate::message::Interval;
 use derivative::Derivative;
 use janus::{
     hpke::HpkePrivateKey,
-    message::{Duration, HpkeConfig, HpkeConfigId, Role, TaskId},
+    message::{Duration, HpkeConfig, HpkeConfigId, Interval, Role, TaskId},
 };
 use ring::constant_time;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
Specifically:
 * Domain separation parameters updated from "ppm" to "dap-01".
 * Task ID moved from application info to AAD for HPKE operations.

I believe this is the final set of changes required for Janus to implement what is specified in main on the DAP specification.

Closes #179. (@jbr, you may be interested in this PR.)