### PR TITLE
Avoid wrapping acquired job in `Arc`

### DIFF
--- a/janus_server/src/bin/collect_job_driver.rs
+++ b/janus_server/src/bin/collect_job_driver.rs
@@ -58,7 +58,7 @@ async fn main() -> anyhow::Result<()> {
                         })
                         .await
                 },
-                |_datastore, _acquired_job: Arc<Uuid>, _| async move {
+                |_datastore, _acquired_job: Uuid, _| async move {
                     // TODO(timg): step collect job
                     Ok(()) as Result<_, datastore::Error>
                 },


### PR DESCRIPTION
`tracing::info_span` doesn't take ownership of fields passed into it so
we can avoid some unnecessary `Arc::clone`s.