### PR TITLE
Remove AggregateContinueRequest::task_id.

### DIFF
--- a/janus_server/src/bin/aggregation_job_driver.rs
+++ b/janus_server/src/bin/aggregation_job_driver.rs
@@ -541,7 +541,6 @@ impl AggregationJobDriver {
         // TODO(brandon): what HTTP errors should cause us to abort/stop retrying the aggregation job?
         // TODO(brandon): should we care about the response's content type?
         let req = AggregateContinueReq {
-            task_id: task.id,
             job_id: aggregation_job.aggregation_job_id,
             prepare_steps,
         };
@@ -1199,7 +1198,6 @@ mod tests {
         // then do our own parsing & verification -- but mockito does not yet expose this
         // functionality.
         let leader_request = AggregateContinueReq {
-            task_id,
             job_id: aggregation_job_id,
             prepare_steps: vec![PrepareStep {
                 nonce,

--- a/janus_server/src/message.rs
+++ b/janus_server/src/message.rs
@@ -267,7 +267,6 @@ impl Decode for AggregateInitializeResp {
 /// DAP protocol message representing an aggregation continuation request from leader to helper.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AggregateContinueReq {
-    pub task_id: TaskId,
     pub job_id: AggregationJobId,
     pub prepare_steps: Vec<PrepareStep>,
 }
@@ -279,7 +278,6 @@ impl AggregateContinueReq {
 
 impl Encode for AggregateContinueReq {
     fn encode(&self, bytes: &mut Vec<u8>) {
-        self.task_id.encode(bytes);
         self.job_id.encode(bytes);
         encode_u16_items(bytes, &(), &self.prepare_steps);
     }
@@ -287,11 +285,9 @@ impl Encode for AggregateContinueReq {
 
 impl Decode for AggregateContinueReq {
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
-        let task_id = TaskId::decode(bytes)?;
         let job_id = AggregationJobId::decode(bytes)?;
         let prepare_steps = decode_u16_items(&(), bytes)?;
         Ok(Self {
-            task_id,
             job_id,
             prepare_steps,
         })
@@ -783,7 +779,6 @@ mod tests {
     fn roundtrip_aggregate_continue_req() {
         roundtrip_encoding(&[(
             AggregateContinueReq {
-                task_id: TaskId::new([u8::MIN; 32]),
                 job_id: AggregationJobId([u8::MAX; 32]),
                 prepare_steps: vec![
                     PrepareStep {
@@ -803,7 +798,6 @@ mod tests {
                 ],
             },
             concat!(
-                "0000000000000000000000000000000000000000000000000000000000000000", // task_id
                 "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", // job_id
                 concat!(
                     // prepare_steps


### PR DESCRIPTION
This brings Janus' messages fully in-line with the current DAP
specification.

#187 was merged with `task_id` in place, in the optimistic hope that https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/263 would be merged fairly quickly. I'm no longer as optimistic, and if it comes to pass that the DAP change is not merged by the time we are ready to begin end-to-end testing with CF's implementation, I don't want this difference to hold up testing.

I don't plan to merge this until https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/263 is resolved one way or another, unless/until this would become a blocker for interop testing.