### PR TITLE
Leases: add tokens, on-release sanity checking, acquire counts.

### DIFF
--- a/janus_server/src/bin/aggregation_job_driver.rs
+++ b/janus_server/src/bin/aggregation_job_driver.rs
@@ -6,7 +6,7 @@ use futures::{
 use http::header::CONTENT_TYPE;
 use janus::{
     hpke::{self, associated_data_for_report_share, HpkeApplicationInfo, Label},
-    message::{Duration, Report, Role, TaskId},
+    message::{Duration, Report, Role},
     time::{Clock, RealClock},
 };
 use janus_server::{
@@ -15,15 +15,14 @@ use janus_server::{
     datastore::{
         self,
         models::{
-            AcquiredAggregationJob, AggregationJob, AggregationJobState, ReportAggregation,
+            AcquiredAggregationJob, AggregationJob, AggregationJobState, Lease, ReportAggregation,
             ReportAggregationState,
         },
         Datastore,
     },
     message::{
         AggregateContinueReq, AggregateContinueResp, AggregateInitializeReq,
-        AggregateInitializeResp, AggregationJobId, PrepareStep, PrepareStepResult, ReportShare,
-        ReportShareError,
+        AggregateInitializeResp, PrepareStep, PrepareStepResult, ReportShare, ReportShareError,
     },
     task::{Task, VdafInstance, DAP_AUTH_HEADER},
 };
@@ -75,6 +74,7 @@ async fn main() -> anyhow::Result<()> {
                     .build()
                     .context("couldn't create HTTP client")?,
             });
+
             // Start running.
             Arc::new(JobDriver::new(
                 Arc::new(datastore),
@@ -104,9 +104,9 @@ async fn main() -> anyhow::Result<()> {
                         })
                         .await
                 },
-                |datastore, acquired_aggregation_job, aggregation_job_driver| async move {
+                |datastore, aggregation_job_lease, aggregation_job_driver| async move {
                     aggregation_job_driver
-                        .step_aggregation_job(datastore, &acquired_aggregation_job)
+                        .step_aggregation_job(datastore, aggregation_job_lease)
                         .await
                 },
                 aggregation_job_driver,
@@ -129,46 +129,28 @@ impl AggregationJobDriver {
     async fn step_aggregation_job<C: Clock>(
         &self,
         datastore: Arc<Datastore<C>>,
-        acquired_aggregation_job: &AcquiredAggregationJob,
+        lease: Lease<AcquiredAggregationJob>,
     ) -> Result<()> {
-        match acquired_aggregation_job.vdaf {
+        match lease.leased().vdaf {
             VdafInstance::Prio3Aes128Count => {
                 let vdaf = Prio3Aes128Count::new(2)?;
-                self.step_aggregation_job_generic(
-                    datastore,
-                    vdaf,
-                    acquired_aggregation_job.task_id,
-                    acquired_aggregation_job.aggregation_job_id,
-                )
-                .await
+                self.step_aggregation_job_generic(datastore, vdaf, lease)
+                    .await
             }
 
             VdafInstance::Prio3Aes128Sum { bits } => {
                 let vdaf = Prio3Aes128Sum::new(2, bits)?;
-                self.step_aggregation_job_generic(
-                    datastore,
-                    vdaf,
-                    acquired_aggregation_job.task_id,
-                    acquired_aggregation_job.aggregation_job_id,
-                )
-                .await
+                self.step_aggregation_job_generic(datastore, vdaf, lease)
+                    .await
             }
 
             VdafInstance::Prio3Aes128Histogram { ref buckets } => {
                 let vdaf = Prio3Aes128Histogram::new(2, buckets)?;
-                self.step_aggregation_job_generic(
-                    datastore,
-                    vdaf,
-                    acquired_aggregation_job.task_id,
-                    acquired_aggregation_job.aggregation_job_id,
-                )
-                .await
+                self.step_aggregation_job_generic(datastore, vdaf, lease)
+                    .await
             }
 
-            _ => panic!(
-                "VDAF {:?} is not yet supported",
-                acquired_aggregation_job.vdaf
-            ),
+            _ => panic!("VDAF {:?} is not yet supported", lease.leased().vdaf),
         }
     }
 
@@ -176,8 +158,7 @@ impl AggregationJobDriver {
         &self,
         datastore: Arc<Datastore<C>>,
         vdaf: A,
-        task_id: TaskId,
-        aggregation_job_id: AggregationJobId,
+        lease: Lease<AcquiredAggregationJob>,
     ) -> Result<()>
     where
         C: Clock,
@@ -192,6 +173,8 @@ impl AggregationJobDriver {
     {
         // Read all information about the aggregation job.
         let vdaf = Arc::new(vdaf);
+        let task_id = lease.leased().task_id;
+        let aggregation_job_id = lease.leased().aggregation_job_id;
         let (task, aggregation_job, report_aggregations, client_reports, verify_param) = datastore
             .run_tx(|tx| {
                 let vdaf = Arc::clone(&vdaf);
@@ -282,11 +265,11 @@ impl AggregationJobDriver {
         match (saw_start, saw_waiting, saw_finished) {
             // Only saw report aggregations in state "start" (or failed or invalid).
             (true, false, false) => self.step_aggregation_job_aggregate_init(
-                &datastore, vdaf.as_ref(), task, aggregation_job, report_aggregations, client_reports, verify_param).await,
+                &datastore, vdaf.as_ref(), lease, task, aggregation_job, report_aggregations, client_reports, verify_param).await,
 
             // Only saw report aggregations in state "waiting" (or failed or invalid).
             (false, true, false) => self.step_aggregation_job_aggregate_continue(
-                &datastore, vdaf.as_ref(), task, aggregation_job, report_aggregations).await,
+                &datastore, vdaf.as_ref(), lease, task, aggregation_job, report_aggregations).await,
 
             _ => return Err(anyhow!("unexpected combination of report aggregation states (saw_start = {}, saw_waiting = {}, saw_finished = {})", saw_start, saw_waiting, saw_finished)),
         }
@@ -297,6 +280,7 @@ impl AggregationJobDriver {
         &self,
         datastore: &Datastore<C>,
         vdaf: &A,
+        lease: Lease<AcquiredAggregationJob>,
         task: Task,
         aggregation_job: AggregationJob<A>,
         report_aggregations: Vec<ReportAggregation<A>>,
@@ -474,7 +458,7 @@ impl AggregationJobDriver {
         self.process_response_from_helper(
             datastore,
             vdaf,
-            task,
+            lease,
             aggregation_job,
             stepped_aggregations,
             report_aggregations_to_write,
@@ -487,6 +471,7 @@ impl AggregationJobDriver {
         &self,
         datastore: &Datastore<C>,
         vdaf: &A,
+        lease: Lease<AcquiredAggregationJob>,
         task: Task,
         aggregation_job: AggregationJob<A>,
         report_aggregations: Vec<ReportAggregation<A>>,
@@ -560,7 +545,7 @@ impl AggregationJobDriver {
         self.process_response_from_helper(
             datastore,
             vdaf,
-            task,
+            lease,
             aggregation_job,
             stepped_aggregations,
             report_aggregations_to_write,
@@ -574,7 +559,7 @@ impl AggregationJobDriver {
         &self,
         datastore: &Datastore<C>,
         vdaf: &A,
-        task: Task,
+        lease: Lease<AcquiredAggregationJob>,
         aggregation_job: AggregationJob<A>,
         stepped_aggregations: Vec<SteppedAggregation<A>>,
         mut report_aggregations_to_write: Vec<ReportAggregation<A>>,
@@ -665,7 +650,6 @@ impl AggregationJobDriver {
 
         // Determine if we've finished the aggregation job (i.e. if all report aggregations are in
         // a terminal state), then write everything back to storage.
-        let aggregation_job_id = aggregation_job.aggregation_job_id;
         let aggregation_job_is_finished = report_aggregations_to_write
             .iter()
             .all(|ra| !matches!(ra.state, ReportAggregationState::Waiting(_, _)));
@@ -678,11 +662,13 @@ impl AggregationJobDriver {
         };
         let report_aggregations_to_write = Arc::new(report_aggregations_to_write);
         let aggregation_job_to_write = Arc::new(aggregation_job_to_write);
+        let lease = Arc::new(lease);
         datastore
             .run_tx(|tx| {
-                let (report_aggregations_to_write, aggregation_job_to_write) = (
+                let (report_aggregations_to_write, aggregation_job_to_write, lease) = (
                     Arc::clone(&report_aggregations_to_write),
                     Arc::clone(&aggregation_job_to_write),
+                    Arc::clone(&lease),
                 );
                 Box::pin(async move {
                     let report_aggregations_future =
@@ -696,7 +682,7 @@ impl AggregationJobDriver {
                     );
 
                     try_join!(
-                        tx.release_aggregation_job(task.id, aggregation_job_id),
+                        tx.release_aggregation_job(&lease),
                         report_aggregations_future,
                         aggregation_job_future
                     )?;
@@ -735,8 +721,7 @@ mod tests {
         binary_utils::job_driver::JobDriver,
         datastore::{
             models::{
-                AcquiredAggregationJob, AggregationJob, AggregationJobState, ReportAggregation,
-                ReportAggregationState,
+                AggregationJob, AggregationJobState, ReportAggregation, ReportAggregationState,
             },
             Crypter, Datastore,
         },
@@ -897,9 +882,9 @@ mod tests {
                     })
                     .await
             },
-            |datastore, acquired_aggregation_job, aggregation_job_driver| async move {
+            |datastore, aggregation_job_lease, aggregation_job_driver| async move {
                 aggregation_job_driver
-                    .step_aggregation_job(datastore, &acquired_aggregation_job)
+                    .step_aggregation_job(datastore, aggregation_job_lease)
                     .await
             },
             aggregation_job_driver,
@@ -997,31 +982,39 @@ mod tests {
         );
         let aggregation_job_id = AggregationJobId::random();
 
-        ds.run_tx(|tx| {
-            let (task, report) = (task.clone(), report.clone());
-            Box::pin(async move {
-                tx.put_task(&task).await?;
-                tx.put_client_report(&report).await?;
+        let lease = ds
+            .run_tx(|tx| {
+                let (task, report) = (task.clone(), report.clone());
+                Box::pin(async move {
+                    tx.put_task(&task).await?;
+                    tx.put_client_report(&report).await?;
 
-                tx.put_aggregation_job(&AggregationJob::<Prio3Aes128Count> {
-                    aggregation_job_id,
-                    task_id,
-                    aggregation_param: (),
-                    state: AggregationJobState::InProgress,
+                    tx.put_aggregation_job(&AggregationJob::<Prio3Aes128Count> {
+                        aggregation_job_id,
+                        task_id,
+                        aggregation_param: (),
+                        state: AggregationJobState::InProgress,
+                    })
+                    .await?;
+                    tx.put_report_aggregation(&ReportAggregation::<Prio3Aes128Count> {
+                        aggregation_job_id,
+                        task_id,
+                        nonce: report.nonce(),
+                        ord: 0,
+                        state: ReportAggregationState::Start,
+                    })
+                    .await?;
+
+                    Ok(tx
+                        .acquire_incomplete_aggregation_jobs(Duration::from_seconds(60), 1)
+                        .await?
+                        .remove(0))
                 })
-                .await?;
-                tx.put_report_aggregation(&ReportAggregation::<Prio3Aes128Count> {
-                    aggregation_job_id,
-                    task_id,
-                    nonce: report.nonce(),
-                    ord: 0,
-                    state: ReportAggregationState::Start,
-                })
-                .await
             })
-        })
-        .await
-        .unwrap();
+            .await
+            .unwrap();
+        assert_eq!(lease.leased().task_id, task_id);
+        assert_eq!(lease.leased().aggregation_job_id, aggregation_job_id);
 
         // Setup: prepare mocked HTTP response.
         // TODO(brandon): this is fragile in that it expects the leader request to be
@@ -1067,14 +1060,7 @@ mod tests {
             http_client: reqwest::Client::builder().build().unwrap(),
         };
         aggregation_job_driver
-            .step_aggregation_job(
-                ds.clone(),
-                &AcquiredAggregationJob {
-                    vdaf: VdafInstance::Prio3Aes128Count,
-                    task_id,
-                    aggregation_job_id,
-                },
-            )
+            .step_aggregation_job(ds.clone(), lease)
             .await
             .unwrap();
 
@@ -1160,36 +1146,47 @@ mod tests {
         let leader_prep_state = assert_matches!(&transcript.transitions[Role::Leader.index().unwrap()][0], PrepareTransition::Continue(prep_state, _) => prep_state);
         let combined_msg = &transcript.combined_messages[0];
 
-        ds.run_tx(|tx| {
-            let (task, report, leader_prep_state, combined_msg) = (
-                task.clone(),
-                report.clone(),
-                leader_prep_state.clone(),
-                combined_msg.clone(),
-            );
-            Box::pin(async move {
-                tx.put_task(&task).await?;
-                tx.put_client_report(&report).await?;
+        let lease = ds
+            .run_tx(|tx| {
+                let (task, report, leader_prep_state, combined_msg) = (
+                    task.clone(),
+                    report.clone(),
+                    leader_prep_state.clone(),
+                    combined_msg.clone(),
+                );
+                Box::pin(async move {
+                    tx.put_task(&task).await?;
+                    tx.put_client_report(&report).await?;
 
-                tx.put_aggregation_job(&AggregationJob::<Prio3Aes128Count> {
-                    aggregation_job_id,
-                    task_id,
-                    aggregation_param: (),
-                    state: AggregationJobState::InProgress,
+                    tx.put_aggregation_job(&AggregationJob::<Prio3Aes128Count> {
+                        aggregation_job_id,
+                        task_id,
+                        aggregation_param: (),
+                        state: AggregationJobState::InProgress,
+                    })
+                    .await?;
+                    tx.put_report_aggregation(&ReportAggregation::<Prio3Aes128Count> {
+                        aggregation_job_id,
+                        task_id,
+                        nonce: report.nonce(),
+                        ord: 0,
+                        state: ReportAggregationState::Waiting(
+                            leader_prep_state,
+                            Some(combined_msg),
+                        ),
+                    })
+                    .await?;
+
+                    Ok(tx
+                        .acquire_incomplete_aggregation_jobs(Duration::from_seconds(60), 1)
+                        .await?
+                        .remove(0))
                 })
-                .await?;
-                tx.put_report_aggregation(&ReportAggregation::<Prio3Aes128Count> {
-                    aggregation_job_id,
-                    task_id,
-                    nonce: report.nonce(),
-                    ord: 0,
-                    state: ReportAggregationState::Waiting(leader_prep_state, Some(combined_msg)),
-                })
-                .await
             })
-        })
-        .await
-        .unwrap();
+            .await
+            .unwrap();
+        assert_eq!(lease.leased().task_id, task_id);
+        assert_eq!(lease.leased().aggregation_job_id, aggregation_job_id);
 
         // Setup: prepare mocked HTTP response.
         // TODO(brandon): this is fragile in that it expects the leader request to be
@@ -1228,14 +1225,7 @@ mod tests {
             http_client: reqwest::Client::builder().build().unwrap(),
         };
         aggregation_job_driver
-            .step_aggregation_job(
-                ds.clone(),
-                &AcquiredAggregationJob {
-                    vdaf: VdafInstance::Prio3Aes128Count,
-                    task_id,
-                    aggregation_job_id,
-                },
-            )
+            .step_aggregation_job(ds.clone(), lease)
             .await
             .unwrap();
 

--- a/janus_server/src/bin/collect_job_driver.rs
+++ b/janus_server/src/bin/collect_job_driver.rs
@@ -70,9 +70,9 @@ async fn main() -> anyhow::Result<()> {
                         })
                         .await
                 },
-                |datastore, acquired_collect_job, collect_job_driver| async move {
+                |datastore, collect_job_lease, collect_job_driver| async move {
                     collect_job_driver
-                        .step_collect_job(datastore, &acquired_collect_job)
+                        .step_collect_job(datastore, collect_job_lease)
                         .await
                 },
                 collect_job_driver,

--- a/janus_server/src/binary_utils/job_driver.rs
+++ b/janus_server/src/binary_utils/job_driver.rs
@@ -1,6 +1,6 @@
 //! Discovery and driving of jobs scheduled elsewhere.
 
-use crate::datastore::{self, Datastore};
+use crate::datastore::{self, models::Lease, Datastore};
 use janus::{
     message::{Duration, Time},
     time::Clock,
@@ -53,9 +53,9 @@ where
     JobStepperError: Debug + Send + Sync + 'static,
     JobAcquirer:
         Fn(Arc<Datastore<C>>, Duration, usize) -> JobAcquirerFuture + Send + Sync + 'static,
-    JobAcquirerFuture: Future<Output = Result<Vec<(AcquiredJob, Time)>, datastore::Error>> + Send,
+    JobAcquirerFuture: Future<Output = Result<Vec<Lease<AcquiredJob>>, datastore::Error>> + Send,
     JobStepperContext: Clone + Debug + Send + Sync + 'static,
-    JobStepper: Fn(Arc<Datastore<C>>, AcquiredJob, JobStepperContext) -> JobStepperFuture
+    JobStepper: Fn(Arc<Datastore<C>>, Lease<AcquiredJob>, JobStepperContext) -> JobStepperFuture
         + Send
         + Sync
         + 'static,
@@ -119,14 +119,14 @@ where
             // TODO(brandon): only acquire jobs whose batch units have not already been collected (probably by modifying acquire_incomplete_aggregation_jobs)
             let max_acquire_count = sem.available_permits();
             info!(max_acquire_count, "Acquiring jobs");
-            let acquired_jobs = (self.incomplete_job_acquirer)(
+            let leases = (self.incomplete_job_acquirer)(
                 self.datastore.clone(),
                 self.worker_lease_duration,
                 max_acquire_count,
             )
             .await;
-            let acquired_jobs = match acquired_jobs {
-                Ok(acquired_jobs) => acquired_jobs,
+            let leases = match leases {
+                Ok(leases) => leases,
                 Err(err) => {
                     error!(?err, "Couldn't acquire jobs");
                     // Go ahead and step job discovery delay in this error case to ensure we don't
@@ -135,22 +135,22 @@ where
                     continue;
                 }
             };
-            if acquired_jobs.is_empty() {
+            if leases.is_empty() {
                 debug!("No jobs available");
                 job_discovery_delay = self.step_job_discovery_delay(job_discovery_delay);
                 continue;
             }
             assert!(
-                acquired_jobs.len() <= max_acquire_count,
+                leases.len() <= max_acquire_count,
                 "Acquired {} jobs exceeding maximum of {}",
-                acquired_jobs.len(),
+                leases.len(),
                 max_acquire_count
             );
-            info!(acquired_job_count = acquired_jobs.len(), "Acquired jobs");
+            info!(acquired_job_count = leases.len(), "Acquired jobs");
 
             // Start up tasks for each acquired job.
             job_discovery_delay = Duration::ZERO;
-            for (acquired_job, lease_expiry) in acquired_jobs {
+            for lease in leases {
                 task::spawn({
                     // We acquire a semaphore in the job-discovery task rather than inside the new
                     // job-stepper task to ensure that acquiring a permit does not race with
@@ -162,15 +162,15 @@ where
                     // available, and this task is the only task that acquires permits.
                     let permit = Arc::clone(&sem).try_acquire_owned().unwrap();
                     let this = Arc::clone(&self);
-                    let span = info_span!("Job stepper", ?acquired_job);
+                    let span = info_span!("Job stepper", acquired_job = ?lease.leased());
 
                     async move {
-                        info!(?lease_expiry, "Stepping job");
+                        info!(lease_expiry = ?lease.lease_expiry_time(), "Stepping job");
                         match time::timeout(
-                            this.effective_lease_duration(lease_expiry),
+                            this.effective_lease_duration(lease.lease_expiry_time()),
                             (this.job_stepper)(
                                 this.datastore.clone(),
-                                acquired_job,
+                                lease,
                                 this.job_stepper_context.clone(),
                             ),
                         )
@@ -235,7 +235,6 @@ mod tests {
     };
     use janus::{message::TaskId, time::Clock};
     use janus_test_util::MockClock;
-    use lazy_static::lazy_static;
     use tokio::{sync::Mutex, task, time};
 
     janus_test_util::define_ephemeral_datastore!();
@@ -277,45 +276,43 @@ mod tests {
             stepped_jobs: Vec<SteppedJob>,
         }
 
-        lazy_static! {
-            static ref TEST_STATE: Mutex<TestState> = Mutex::const_new(TestState {
-                job_acquire_counter: 0,
-                stepped_jobs: vec![],
-            });
-            // View of incomplete jobs acquired from datastore fed to job finder closure
-            static ref INCOMPLETE_JOBS: Vec<Vec<IncompleteJob>> = vec![
-                // First job finder call: acquire some jobs.
-                vec![
-                    IncompleteJob {
-                     task_id:   TaskId::random(),
-                        job_id: AggregationJobId::random(),
-                        lease_expiry: Time::from_seconds_since_epoch(100),
-                    },
-                    IncompleteJob {
-                     task_id:   TaskId::random(),
-                        job_id: AggregationJobId::random(),
-                        lease_expiry: Time::from_seconds_since_epoch(200),
-                    },
-                ],
-                // Second job finder call will be immediately after the first: no more jobs
-                // available yet. Should cause a minimum delay before job finder runs again.
-                vec![],
-                // Third job finder call: return some new jobs to simulate lease being released and
-                // re-acquired (it doesn't matter if the task and job IDs change).
-                vec![
-                    IncompleteJob {
-                     task_id:   TaskId::random(),
-                        job_id: AggregationJobId::random(),
-                        lease_expiry: Time::from_seconds_since_epoch(300),
-                    },
-                    IncompleteJob {
-                     task_id:   TaskId::random(),
-                        job_id: AggregationJobId::random(),
-                        lease_expiry: Time::from_seconds_since_epoch(400),
-                    },
-                ],
-            ];
-        };
+        let test_state = Arc::new(Mutex::new(TestState {
+            job_acquire_counter: 0,
+            stepped_jobs: vec![],
+        }));
+        // View of incomplete jobs acquired from datastore fed to job finder closure
+        let incomplete_jobs = Arc::new(vec![
+            // First job finder call: acquire some jobs.
+            vec![
+                IncompleteJob {
+                    task_id: TaskId::random(),
+                    job_id: AggregationJobId::random(),
+                    lease_expiry: Time::from_seconds_since_epoch(100),
+                },
+                IncompleteJob {
+                    task_id: TaskId::random(),
+                    job_id: AggregationJobId::random(),
+                    lease_expiry: Time::from_seconds_since_epoch(200),
+                },
+            ],
+            // Second job finder call will be immediately after the first: no more jobs
+            // available yet. Should cause a minimum delay before job finder runs again.
+            vec![],
+            // Third job finder call: return some new jobs to simulate lease being released and
+            // re-acquired (it doesn't matter if the task and job IDs change).
+            vec![
+                IncompleteJob {
+                    task_id: TaskId::random(),
+                    job_id: AggregationJobId::random(),
+                    lease_expiry: Time::from_seconds_since_epoch(300),
+                },
+                IncompleteJob {
+                    task_id: TaskId::random(),
+                    job_id: AggregationJobId::random(),
+                    lease_expiry: Time::from_seconds_since_epoch(400),
+                },
+            ],
+        ]);
 
         // Run. Give the aggregation job driver enough time to step aggregation jobs, then kill it.
         let job_driver = Arc::new(JobDriver::new(
@@ -326,48 +323,62 @@ mod tests {
             10,
             Duration::from_seconds(600),
             Duration::from_seconds(60),
-            move |_datastore, lease_duration, max_acquire_count| async move {
-                let mut test_state = TEST_STATE.lock().await;
+            {
+                let (test_state, incomplete_jobs) =
+                    (Arc::clone(&test_state), Arc::clone(&incomplete_jobs));
+                move |_datastore, lease_duration, max_acquire_count| {
+                    let (test_state, incomplete_jobs) =
+                        (Arc::clone(&test_state), Arc::clone(&incomplete_jobs));
+                    async move {
+                        let mut test_state = test_state.lock().await;
 
-                assert_eq!(lease_duration, Duration::from_seconds(600));
-                assert_eq!(max_acquire_count, 10);
+                        assert_eq!(lease_duration, Duration::from_seconds(600));
+                        assert_eq!(max_acquire_count, 10);
 
-                let incomplete_jobs = INCOMPLETE_JOBS
-                    .get(test_state.job_acquire_counter)
-                    // Clone here so that incomplete_jobs will be Vec<_> and not &Vec<_>, which
-                    // would be impossible to return from Option::unwrap_or_default.
-                    .cloned()
-                    .unwrap_or_default();
+                        let incomplete_jobs = incomplete_jobs
+                            .get(test_state.job_acquire_counter)
+                            // Clone here so that incomplete_jobs will be Vec<_> and not &Vec<_>, which
+                            // would be impossible to return from Option::unwrap_or_default.
+                            .cloned()
+                            .unwrap_or_default();
 
-                let acquired_jobs = incomplete_jobs
-                    .iter()
-                    .map(|job| {
-                        (
-                            (job.task_id, VdafInstance::Fake, job.job_id),
-                            job.lease_expiry,
-                        )
-                    })
-                    .collect();
+                        let leases = incomplete_jobs
+                            .iter()
+                            .map(|job| {
+                                Lease::new(
+                                    (job.task_id, VdafInstance::Fake, job.job_id),
+                                    job.lease_expiry,
+                                )
+                            })
+                            .collect();
 
-                test_state.job_acquire_counter += 1;
+                        test_state.job_acquire_counter += 1;
 
-                // Create some fake incomplete jobs
-                Ok(acquired_jobs)
+                        // Create some fake incomplete jobs
+                        Ok(leases)
+                    }
+                }
             },
-            move |_datastore, acquired_job, context| async move {
-                let mut test_state = TEST_STATE.lock().await;
-                let job_acquire_counter = test_state.job_acquire_counter;
+            {
+                let test_state = Arc::clone(&test_state);
+                move |_datastore, lease, context| {
+                    let test_state = Arc::clone(&test_state);
+                    async move {
+                        let mut test_state = test_state.lock().await;
+                        let job_acquire_counter = test_state.job_acquire_counter;
 
-                assert_eq!(acquired_job.1, VdafInstance::Fake);
-                assert_eq!(context, "context");
+                        assert_eq!(lease.leased().1, VdafInstance::Fake);
+                        assert_eq!(context, "context");
 
-                test_state.stepped_jobs.push(SteppedJob {
-                    observed_jobs_acquire_counter: job_acquire_counter,
-                    task_id: acquired_job.0,
-                    job_id: acquired_job.2,
-                });
+                        test_state.stepped_jobs.push(SteppedJob {
+                            observed_jobs_acquire_counter: job_acquire_counter,
+                            task_id: lease.leased().0,
+                            job_id: lease.leased().2,
+                        });
 
-                Ok(()) as Result<(), datastore::Error>
+                        Ok(()) as Result<(), datastore::Error>
+                    }
+                }
             },
             "context",
         ));
@@ -382,9 +393,9 @@ mod tests {
         task_handle.abort();
 
         // Verify that we got the expected calls to closures.
-        let final_test_state = TEST_STATE.lock().await;
+        let final_test_state = test_state.lock().await;
 
-        // We expect the job acquirer to run at least three times in the 5s we sleep,, but we can't
+        // We expect the job acquirer to run at least three times in the 5s we sleep, but we can't
         // prove it won't run once more.
         assert!(final_test_state.job_acquire_counter >= 3);
         assert_eq!(
@@ -393,25 +404,25 @@ mod tests {
                 // First acquirer run should have caused INCOMPLETE_JOBS[0] to be stepped.
                 SteppedJob {
                     observed_jobs_acquire_counter: 1,
-                    task_id: INCOMPLETE_JOBS[0][0].task_id,
-                    job_id: INCOMPLETE_JOBS[0][0].job_id,
+                    task_id: incomplete_jobs[0][0].task_id,
+                    job_id: incomplete_jobs[0][0].job_id,
                 },
                 SteppedJob {
                     observed_jobs_acquire_counter: 1,
-                    task_id: INCOMPLETE_JOBS[0][1].task_id,
-                    job_id: INCOMPLETE_JOBS[0][1].job_id,
+                    task_id: incomplete_jobs[0][1].task_id,
+                    job_id: incomplete_jobs[0][1].job_id,
                 },
                 // Second acquirer run should step no jobs
                 // Third acquirer run should have caused INCOMPLETE_JOBS[2] to be stepped.
                 SteppedJob {
                     observed_jobs_acquire_counter: 3,
-                    task_id: INCOMPLETE_JOBS[2][0].task_id,
-                    job_id: INCOMPLETE_JOBS[2][0].job_id,
+                    task_id: incomplete_jobs[2][0].task_id,
+                    job_id: incomplete_jobs[2][0].job_id,
                 },
                 SteppedJob {
                     observed_jobs_acquire_counter: 3,
-                    task_id: INCOMPLETE_JOBS[2][1].task_id,
-                    job_id: INCOMPLETE_JOBS[2][1].job_id,
+                    task_id: incomplete_jobs[2][1].task_id,
+                    job_id: incomplete_jobs[2][1].job_id,
                 },
             ]
         );


### PR DESCRIPTION
  * The tokens are a (probably-)unique opaque value associated with each
    lease, intended to ensure that a release operation affects the same
    lease that was acquired.
  * On-release sanity checking is implemented by checking that the lease
    timeout & token match what is recorded in the in-memory lease. If
    they don't, someone else has taken the lease out from under us & we
    must fail. Note that we might still be able to release if the lease
    expiry time is in the past--the lease expiry time is the first time
    someone else _can_ take the lease, if no one else has taken the
    lease we can still release it.
  * Tracking of acquire counts (since last successful release) will
    allow lease users to decide when to permanently fail. (to be
    implemented in a pair of upcoming PRs)

I also adapt the JobDriver abstraction to work with leases; I suppose
this isn't strictly necessary, and it enforces that all users of the
JobDriver need to work with leases in the future. I think that's OK.

Note that I don't implement exponential backoff. I think we need to tune
our batch jobs to be non-overloading even when running at maximum
throughput; we might choose to implement exponential backoff on the helper
request retries, once we have retries in place, since we don't have control
over how overloaded the helper is.

Closes #193.