### PR TITLE
JobDriver: remove all non-required parameters from callbacks.

### DIFF
--- a/janus_server/src/bin/collect_job_driver.rs
+++ b/janus_server/src/bin/collect_job_driver.rs
@@ -38,44 +38,56 @@ async fn main() -> anyhow::Result<()> {
     janus_main::<Options, _, _, _, _>(
         RealClock::default(),
         |clock, config: CollectJobDriverConfig, datastore| async move {
+            let datastore = Arc::new(datastore);
             let collect_job_driver = Arc::new(CollectJobDriver::new(
                 reqwest::Client::builder()
                     .user_agent(CLIENT_USER_AGENT)
                     .build()
                     .context("couldn't create HTTP client")?,
             ));
+            let lease_duration =
+                Duration::from_seconds(config.job_driver_config.worker_lease_duration_secs);
+
             // Start running.
             Arc::new(JobDriver::new(
-                Arc::new(datastore),
                 clock,
                 Duration::from_seconds(config.job_driver_config.min_job_discovery_delay_secs),
                 Duration::from_seconds(config.job_driver_config.max_job_discovery_delay_secs),
                 config.job_driver_config.max_concurrent_job_workers,
-                Duration::from_seconds(config.job_driver_config.worker_lease_duration_secs),
                 Duration::from_seconds(
                     config
                         .job_driver_config
                         .worker_lease_clock_skew_allowance_secs,
                 ),
-                |datastore, lease_duration, maximum_acquire_count| async move {
-                    datastore
-                        .run_tx(|tx| {
-                            Box::pin(async move {
-                                tx.acquire_incomplete_collect_jobs(
-                                    lease_duration,
-                                    maximum_acquire_count,
-                                )
+                {
+                    let datastore = Arc::clone(&datastore);
+                    move |maximum_acquire_count| {
+                        let datastore = Arc::clone(&datastore);
+                        async move {
+                            datastore
+                                .run_tx(|tx| {
+                                    Box::pin(async move {
+                                        tx.acquire_incomplete_collect_jobs(
+                                            lease_duration,
+                                            maximum_acquire_count,
+                                        )
+                                        .await
+                                    })
+                                })
                                 .await
-                            })
-                        })
-                        .await
+                        }
+                    }
                 },
-                move |datastore, acquired_collect_job| {
-                    let collect_job_driver = Arc::clone(&collect_job_driver);
-                    async move {
-                        collect_job_driver
-                            .step_collect_job(datastore, &acquired_collect_job)
-                            .await
+                {
+                    let datastore = Arc::clone(&datastore);
+                    move |acquired_collect_job| {
+                        let (datastore, collect_job_driver) =
+                            (Arc::clone(&datastore), Arc::clone(&collect_job_driver));
+                        async move {
+                            collect_job_driver
+                                .step_collect_job(datastore, &acquired_collect_job)
+                                .await
+                        }
                     }
                 },
             ))


### PR DESCRIPTION
The callbacks (job-acquirer, job-stepper) now only receive information
that is managed/computed by the JobDriver itself; data that is
effectively "constant" that the JobDriver was holding onto is now
expected to be owned by the callback itself.

This change may be controversial because it pushes more logic into the
application rather than keeping it in the "helper" JobDriver. I think
it's worthwhile not just from a cleanliness perspective but also because
it opens the door to later cleanups/optimizations--as a minor example,
we could now place the datastore into the {Aggregation,Collect}JobDriver
and no longer need to manage an Arc\<Datastore\>.