### PR TITLE
Upgrade libprio-rs to next release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1936,8 +1936,9 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "prio"
-version = "0.7.0"
-source = "git+https://github.com/divviup/libprio-rs?rev=229cd9c45924c7dae3ba754a6eb46b2a05ca8451#229cd9c45924c7dae3ba754a6eb46b2a05ca8451"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34dec6b842c17bb4ebff74907295c102f8790d47b8a914eade914efc6e2b1aa8"
 dependencies = [
  "aes 0.8.1",
  "aes-gcm",

--- a/janus/Cargo.toml
+++ b/janus/Cargo.toml
@@ -12,7 +12,7 @@ chrono = "0.4"
 hex = "0.4.3"
 hpke-dispatch = "0.3.0"
 num_enum = "0.5.6"
-prio = { git = "https://github.com/divviup/libprio-rs", rev = "229cd9c45924c7dae3ba754a6eb46b2a05ca8451" }  # TODO(brandon): use a numbered version, once a release is cut >0.7.0
+prio = "0.7.1"
 rand = "0.8"
 ring = "0.16.20"
 serde = { version = "1.0.137", features = ["derive"] }

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -34,7 +34,7 @@ opentelemetry-otlp = { version = "0.10.0", optional = true, features = ["metrics
 opentelemetry-prometheus = { version = "0.10.0", optional = true }
 opentelemetry-semantic-conventions = { version = "0.9.0", optional = true }
 postgres-types = { version = "0.2.3", features = ["derive", "array-impls"] }
-prio = { git = "https://github.com/divviup/libprio-rs", rev = "229cd9c45924c7dae3ba754a6eb46b2a05ca8451" }  # TODO(brandon): use a numbered version, once a release is cut >0.7.0
+prio = "0.7.1"
 prometheus = { version = "0.13.1", optional = true }
 rand = "0.8"
 reqwest = { version = "0.11.4", default-features = false, features = ["rustls-tls", "json"] }

--- a/monolithic_integration_test/Cargo.toml
+++ b/monolithic_integration_test/Cargo.toml
@@ -13,7 +13,7 @@ futures = "0.3.21"
 janus = { path = "../janus" }
 janus_server = { path = "../janus_server" }
 lazy_static = "1"
-prio = { git = "https://github.com/divviup/libprio-rs", rev = "229cd9c45924c7dae3ba754a6eb46b2a05ca8451" }  # TODO(brandon): use a numbered version, once a release is cut >0.7.0
+prio = "0.7.1"
 ring = "0.16.20"
 testcontainers = "0.14.0"
 janus_test_util = { path = "../test_util" }

--- a/test_util/Cargo.toml
+++ b/test_util/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 assert_matches = "1"
-prio = { git = "https://github.com/divviup/libprio-rs", rev = "229cd9c45924c7dae3ba754a6eb46b2a05ca8451" }  # TODO(brandon): use a numbered version, once a release is cut >0.7.0
+prio = "0.7.1"
 rand = "0.8"
 ring = "0.16.20"
 janus = { path = "../janus" }


### PR DESCRIPTION
Release 0.7.1 appears to have all the codec implementations and trait bounds we need.