### PR TITLE
Run rustdoc in CI

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -36,6 +36,10 @@ jobs:
       env:
         RUST_LOG: trace
       run: cargo test --verbose
+    - name: document
+      env:
+        RUSTDOCFLAGS: "-Dwarnings"
+      run: cargo doc
   janus_server_docker:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
We should check for documentation warnings in CI to catch them earlier.