### PR TITLE
Split VdafInstance out into the common crate

### DIFF
--- a/janus/src/lib.rs
+++ b/janus/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod hpke;
 pub mod message;
+pub mod task;
 pub mod time;

--- a/janus/src/task.rs
+++ b/janus/src/task.rs
@@ -1,0 +1,15 @@
+/// Identifiers for supported VDAFs, corresponding to definitions in
+/// [draft-irtf-cfrg-vdaf-00][1] and implementations in [`prio::vdaf::prio3`].
+///
+/// [1]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/00/
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum VdafInstance {
+    /// A `prio3` counter using the AES 128 pseudorandom generator.
+    Prio3Aes128Count,
+    /// A `prio3` sum using the AES 128 pseudorandom generator.
+    Prio3Aes128Sum { bits: u32 },
+    /// A `prio3` histogram using the AES 128 pseudorandom generator.
+    Prio3Aes128Histogram { buckets: Vec<u64> },
+    /// The `poplar1` VDAF. Support for this VDAF is experimental.
+    Poplar1 { bits: usize },
+}

--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -396,7 +396,7 @@ impl TaskAggregator {
     fn new(task: Task) -> Result<Self, Error> {
         let current_vdaf_verify_parameter = task.vdaf_verify_parameters.last().unwrap();
         let vdaf_ops = match &task.vdaf {
-            VdafInstance::Prio3Aes128Count => {
+            VdafInstance::Real(janus::task::VdafInstance::Prio3Aes128Count) => {
                 let vdaf = Prio3Aes128Count::new(2)?;
                 let verify_param = <Prio3Aes128Count as Vdaf>::VerifyParam::get_decoded_with_param(
                     &vdaf,
@@ -405,7 +405,7 @@ impl TaskAggregator {
                 VdafOps::Prio3Aes128Count(vdaf, verify_param)
             }
 
-            VdafInstance::Prio3Aes128Sum { bits } => {
+            VdafInstance::Real(janus::task::VdafInstance::Prio3Aes128Sum { bits }) => {
                 let vdaf = Prio3Aes128Sum::new(2, *bits)?;
                 let verify_param = <Prio3Aes128Sum as Vdaf>::VerifyParam::get_decoded_with_param(
                     &vdaf,
@@ -414,7 +414,7 @@ impl TaskAggregator {
                 VdafOps::Prio3Aes128Sum(vdaf, verify_param)
             }
 
-            VdafInstance::Prio3Aes128Histogram { buckets } => {
+            VdafInstance::Real(janus::task::VdafInstance::Prio3Aes128Histogram { buckets }) => {
                 let vdaf = Prio3Aes128Histogram::new(2, &*buckets)?;
                 let verify_param =
                     <Prio3Aes128Histogram as Vdaf>::VerifyParam::get_decoded_with_param(
@@ -2046,7 +2046,11 @@ mod tests {
         install_test_trace_subscriber();
 
         let task_id = TaskId::random();
-        let task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count, Role::Leader);
+        let task = new_dummy_task(
+            task_id,
+            janus::task::VdafInstance::Prio3Aes128Count.into(),
+            Role::Leader,
+        );
         let clock = MockClock::default();
         let (datastore, _db_handle) = ephemeral_datastore(clock.clone()).await;
 
@@ -2207,7 +2211,7 @@ mod tests {
 
         let task = new_dummy_task(
             TaskId::random(),
-            VdafInstance::Prio3Aes128Count,
+            janus::task::VdafInstance::Prio3Aes128Count.into(),
             Role::Leader,
         );
         let clock = MockClock::default();
@@ -2418,7 +2422,11 @@ mod tests {
         install_test_trace_subscriber();
 
         let task_id = TaskId::random();
-        let task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count, Role::Helper);
+        let task = new_dummy_task(
+            task_id,
+            janus::task::VdafInstance::Prio3Aes128Count.into(),
+            Role::Helper,
+        );
         let clock = MockClock::default();
         let (datastore, _db_handle) = ephemeral_datastore(clock.clone()).await;
 
@@ -2472,7 +2480,7 @@ mod tests {
     ) {
         let task = new_dummy_task(
             TaskId::random(),
-            VdafInstance::Prio3Aes128Count,
+            janus::task::VdafInstance::Prio3Aes128Count.into(),
             Role::Leader,
         );
         let clock = MockClock::default();
@@ -2659,7 +2667,11 @@ mod tests {
         install_test_trace_subscriber();
 
         let task_id = TaskId::random();
-        let task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count, Role::Leader);
+        let task = new_dummy_task(
+            task_id,
+            janus::task::VdafInstance::Prio3Aes128Count.into(),
+            Role::Leader,
+        );
         let clock = MockClock::default();
         let (datastore, _db_handle) = ephemeral_datastore(clock.clone()).await;
 
@@ -2741,7 +2753,11 @@ mod tests {
         install_test_trace_subscriber();
 
         let task_id = TaskId::random();
-        let task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count, Role::Helper);
+        let task = new_dummy_task(
+            task_id,
+            janus::task::VdafInstance::Prio3Aes128Count.into(),
+            Role::Helper,
+        );
         let clock = MockClock::default();
         let (datastore, _db_handle) = ephemeral_datastore(clock.clone()).await;
 
@@ -2827,7 +2843,11 @@ mod tests {
         install_test_trace_subscriber();
 
         let task_id = TaskId::random();
-        let mut task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count, Role::Helper);
+        let mut task = new_dummy_task(
+            task_id,
+            janus::task::VdafInstance::Prio3Aes128Count.into(),
+            Role::Helper,
+        );
         let clock = MockClock::default();
         let (datastore, _db_handle) = ephemeral_datastore(clock.clone()).await;
 
@@ -3175,7 +3195,11 @@ mod tests {
 
         let task_id = TaskId::random();
         let aggregation_job_id = AggregationJobId::random();
-        let mut task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count, Role::Helper);
+        let mut task = new_dummy_task(
+            task_id,
+            janus::task::VdafInstance::Prio3Aes128Count.into(),
+            Role::Helper,
+        );
         let clock = MockClock::default();
         let (datastore, _db_handle) = ephemeral_datastore(clock.clone()).await;
         let datastore = Arc::new(datastore);
@@ -3358,7 +3382,11 @@ mod tests {
         let task_id = TaskId::random();
         let aggregation_job_id_0 = AggregationJobId::random();
         let aggregation_job_id_1 = AggregationJobId::random();
-        let mut task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count, Role::Helper);
+        let mut task = new_dummy_task(
+            task_id,
+            janus::task::VdafInstance::Prio3Aes128Count.into(),
+            Role::Helper,
+        );
         let (datastore, _db_handle) = ephemeral_datastore(MockClock::default()).await;
         let datastore = Arc::new(datastore);
         let first_batch_unit_interval_clock = MockClock::default();
@@ -4490,7 +4518,11 @@ mod tests {
 
         // Prepare parameters.
         let task_id = TaskId::random();
-        let mut task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count, Role::Leader);
+        let mut task = new_dummy_task(
+            task_id,
+            janus::task::VdafInstance::Prio3Aes128Count.into(),
+            Role::Leader,
+        );
         task.aggregator_endpoints = vec![
             "https://leader.endpoint".parse().unwrap(),
             "https://helper.endpoint".parse().unwrap(),
@@ -4880,7 +4912,11 @@ mod tests {
         let (collector_hpke_config, collector_hpke_recipient) =
             generate_hpke_config_and_private_key();
 
-        let mut task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count, Role::Helper);
+        let mut task = new_dummy_task(
+            task_id,
+            janus::task::VdafInstance::Prio3Aes128Count.into(),
+            Role::Helper,
+        );
         task.max_batch_lifetime = 3;
         task.min_batch_duration = Duration::from_seconds(500);
         task.min_batch_size = 10;

--- a/janus_server/src/aggregator/aggregate_share.rs
+++ b/janus_server/src/aggregator/aggregate_share.rs
@@ -58,7 +58,7 @@ impl CollectJobDriver {
         lease: Lease<AcquiredCollectJob>,
     ) -> Result<(), Error> {
         match lease.leased().vdaf {
-            VdafInstance::Prio3Aes128Count => {
+            VdafInstance::Real(janus::task::VdafInstance::Prio3Aes128Count) => {
                 self.step_collect_job_generic::<C, Prio3Aes128Count>(
                     datastore,
                     lease
@@ -66,7 +66,7 @@ impl CollectJobDriver {
                 .await
             }
 
-            VdafInstance::Prio3Aes128Sum { .. } => {
+            VdafInstance::Real(janus::task::VdafInstance::Prio3Aes128Sum { .. }) => {
                 self.step_collect_job_generic::<C, Prio3Aes128Sum>(
                     datastore,
                     lease
@@ -74,7 +74,7 @@ impl CollectJobDriver {
                 .await
             }
 
-            VdafInstance::Prio3Aes128Histogram { .. } => {
+            VdafInstance::Real(janus::task::VdafInstance::Prio3Aes128Histogram { .. }) => {
                 self.step_collect_job_generic::<C, Prio3Aes128Histogram>(
                     datastore,
                     lease,

--- a/janus_server/src/bin/aggregation_job_creator.rs
+++ b/janus_server/src/bin/aggregation_job_creator.rs
@@ -182,17 +182,21 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
     #[tracing::instrument(skip(self), err)]
     async fn create_aggregation_jobs_for_task(&self, task: &Task) -> anyhow::Result<()> {
         match task.vdaf {
-            janus_server::task::VdafInstance::Prio3Aes128Count => {
+            janus_server::task::VdafInstance::Real(janus::task::VdafInstance::Prio3Aes128Count) => {
                 self.create_aggregation_jobs_for_task_no_param::<Prio3Aes128Count>(task)
                     .await
             }
 
-            janus_server::task::VdafInstance::Prio3Aes128Sum { .. } => {
+            janus_server::task::VdafInstance::Real(janus::task::VdafInstance::Prio3Aes128Sum {
+                ..
+            }) => {
                 self.create_aggregation_jobs_for_task_no_param::<Prio3Aes128Sum>(task)
                     .await
             }
 
-            janus_server::task::VdafInstance::Prio3Aes128Histogram { .. } => {
+            janus_server::task::VdafInstance::Real(
+                janus::task::VdafInstance::Prio3Aes128Histogram { .. },
+            ) => {
                 self.create_aggregation_jobs_for_task_no_param::<Prio3Aes128Histogram>(task)
                     .await
             }
@@ -310,12 +314,13 @@ mod tests {
     use futures::{future::try_join_all, TryFutureExt};
     use janus::{
         message::{Nonce, Report, Role, TaskId, Time},
+        task::VdafInstance,
         time::Clock,
     };
     use janus_server::{
         datastore::{Crypter, Datastore, Transaction},
         message::{test_util::new_dummy_report, AggregationJobId},
-        task::{test_util::new_dummy_task, VdafInstance},
+        task::test_util::new_dummy_task,
         trace::test_util::install_test_trace_subscriber,
     };
     use janus_test_util::MockClock;
@@ -350,13 +355,19 @@ mod tests {
         let report_time = Time::from_seconds_since_epoch(0);
 
         let leader_task_id = TaskId::random();
-        let leader_task =
-            new_dummy_task(leader_task_id, VdafInstance::Prio3Aes128Count, Role::Leader);
+        let leader_task = new_dummy_task(
+            leader_task_id,
+            VdafInstance::Prio3Aes128Count.into(),
+            Role::Leader,
+        );
         let leader_report = new_dummy_report(leader_task_id, report_time);
 
         let helper_task_id = TaskId::random();
-        let helper_task =
-            new_dummy_task(helper_task_id, VdafInstance::Prio3Aes128Count, Role::Helper);
+        let helper_task = new_dummy_task(
+            helper_task_id,
+            VdafInstance::Prio3Aes128Count.into(),
+            Role::Helper,
+        );
         let helper_report = new_dummy_report(helper_task_id, report_time);
 
         ds.run_tx(|tx| {
@@ -429,7 +440,7 @@ mod tests {
         }
 
         let task_id = TaskId::random();
-        let task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count, Role::Leader);
+        let task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count.into(), Role::Leader);
         let current_batch_unit = clock
             .now()
             .to_batch_unit_interval_start(task.min_batch_duration)
@@ -552,7 +563,7 @@ mod tests {
         let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
 
         let task_id = TaskId::random();
-        let task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count, Role::Leader);
+        let task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count.into(), Role::Leader);
         let first_report = new_dummy_report(task_id, clock.now());
         let second_report = new_dummy_report(task_id, clock.now());
 

--- a/janus_server/src/bin/aggregation_job_driver.rs
+++ b/janus_server/src/bin/aggregation_job_driver.rs
@@ -156,17 +156,17 @@ impl AggregationJobDriver {
         lease: Lease<AcquiredAggregationJob>,
     ) -> Result<()> {
         match lease.leased().vdaf {
-            VdafInstance::Prio3Aes128Count => {
+            VdafInstance::Real(janus::task::VdafInstance::Prio3Aes128Count) => {
                 let vdaf = Prio3Aes128Count::new(2)?;
                 self.step_aggregation_job_generic(datastore, vdaf, lease)
                     .await
             }
-            VdafInstance::Prio3Aes128Sum { bits } => {
+            VdafInstance::Real(janus::task::VdafInstance::Prio3Aes128Sum { bits }) => {
                 let vdaf = Prio3Aes128Sum::new(2, bits)?;
                 self.step_aggregation_job_generic(datastore, vdaf, lease)
                     .await
             }
-            VdafInstance::Prio3Aes128Histogram { ref buckets } => {
+            VdafInstance::Real(janus::task::VdafInstance::Prio3Aes128Histogram { ref buckets }) => {
                 let vdaf = Prio3Aes128Histogram::new(2, buckets)?;
                 self.step_aggregation_job_generic(datastore, vdaf, lease)
                     .await
@@ -721,15 +721,15 @@ impl AggregationJobDriver {
         lease: Lease<AcquiredAggregationJob>,
     ) -> Result<()> {
         match &lease.leased().vdaf {
-            VdafInstance::Prio3Aes128Count => {
+            VdafInstance::Real(janus::task::VdafInstance::Prio3Aes128Count) => {
                 self.cancel_aggregation_job_generic::<C, Prio3Aes128Count>(datastore, lease)
                     .await
             }
-            VdafInstance::Prio3Aes128Sum { .. } => {
+            VdafInstance::Real(janus::task::VdafInstance::Prio3Aes128Sum { .. }) => {
                 self.cancel_aggregation_job_generic::<C, Prio3Aes128Sum>(datastore, lease)
                     .await
             }
-            VdafInstance::Prio3Aes128Histogram { .. } => {
+            VdafInstance::Real(janus::task::VdafInstance::Prio3Aes128Histogram { .. }) => {
                 self.cancel_aggregation_job_generic::<C, Prio3Aes128Histogram>(datastore, lease)
                     .await
             }
@@ -806,6 +806,7 @@ mod tests {
             test_util::generate_hpke_config_and_private_key, HpkeApplicationInfo, Label,
         },
         message::{Duration, HpkeConfig, Nonce, Report, Role, TaskId},
+        task::VdafInstance,
         time::Clock,
     };
     use janus_server::{
@@ -820,7 +821,7 @@ mod tests {
             AggregateContinueReq, AggregateContinueResp, AggregateInitializeReq,
             AggregateInitializeResp, AggregationJobId, PrepareStep, PrepareStepResult, ReportShare,
         },
-        task::{test_util::new_dummy_task, VdafInstance},
+        task::test_util::new_dummy_task,
         trace::test_util::install_test_trace_subscriber,
     };
     use janus_test_util::{run_vdaf, MockClock};
@@ -855,7 +856,7 @@ mod tests {
         let transcript = run_vdaf(&vdaf, &public_param, &verify_params, &(), nonce, &0);
 
         let task_id = TaskId::random();
-        let mut task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count, Role::Leader);
+        let mut task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count.into(), Role::Leader);
         task.aggregator_endpoints = vec![
             Url::parse("http://irrelevant").unwrap(), // leader URL doesn't matter
             Url::parse(&mockito::server_url()).unwrap(),
@@ -1065,7 +1066,7 @@ mod tests {
         let transcript = run_vdaf(&vdaf, &public_param, &verify_params, &(), nonce, &0);
 
         let task_id = TaskId::random();
-        let mut task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count, Role::Leader);
+        let mut task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count.into(), Role::Leader);
         task.aggregator_endpoints = vec![
             Url::parse("http://irrelevant").unwrap(), // leader URL doesn't matter
             Url::parse(&mockito::server_url()).unwrap(),
@@ -1225,7 +1226,7 @@ mod tests {
         let transcript = run_vdaf(&vdaf, &public_param, &verify_params, &(), nonce, &0);
 
         let task_id = TaskId::random();
-        let mut task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count, Role::Leader);
+        let mut task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count.into(), Role::Leader);
         task.aggregator_endpoints = vec![
             Url::parse("http://irrelevant").unwrap(), // leader URL doesn't matter
             Url::parse(&mockito::server_url()).unwrap(),
@@ -1388,7 +1389,7 @@ mod tests {
             run_vdaf(&vdaf, &public_param, &verify_params, &(), nonce, &0).input_shares;
 
         let task_id = TaskId::random();
-        let mut task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count, Role::Leader);
+        let mut task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count.into(), Role::Leader);
         task.aggregator_endpoints = vec![
             Url::parse("http://irrelevant").unwrap(), // leader URL doesn't matter
             Url::parse(&mockito::server_url()).unwrap(),

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -2669,41 +2669,41 @@ mod tests {
         let values = [
             (
                 TaskId::random(),
-                VdafInstance::Prio3Aes128Count,
+                janus::task::VdafInstance::Prio3Aes128Count,
                 Role::Leader,
             ),
             (
                 TaskId::random(),
-                VdafInstance::Prio3Aes128Sum { bits: 64 },
+                janus::task::VdafInstance::Prio3Aes128Sum { bits: 64 },
                 Role::Helper,
             ),
             (
                 TaskId::random(),
-                VdafInstance::Prio3Aes128Sum { bits: 32 },
+                janus::task::VdafInstance::Prio3Aes128Sum { bits: 32 },
                 Role::Helper,
             ),
             (
                 TaskId::random(),
-                VdafInstance::Prio3Aes128Histogram {
+                janus::task::VdafInstance::Prio3Aes128Histogram {
                     buckets: vec![0, 100, 200, 400],
                 },
                 Role::Leader,
             ),
             (
                 TaskId::random(),
-                VdafInstance::Prio3Aes128Histogram {
+                janus::task::VdafInstance::Prio3Aes128Histogram {
                     buckets: vec![0, 25, 50, 75, 100],
                 },
                 Role::Leader,
             ),
             (
                 TaskId::random(),
-                VdafInstance::Poplar1 { bits: 8 },
+                janus::task::VdafInstance::Poplar1 { bits: 8 },
                 Role::Helper,
             ),
             (
                 TaskId::random(),
-                VdafInstance::Poplar1 { bits: 64 },
+                janus::task::VdafInstance::Poplar1 { bits: 64 },
                 Role::Helper,
             ),
         ];
@@ -2711,7 +2711,7 @@ mod tests {
         // Insert tasks, check that they can be retrieved by ID.
         let mut want_tasks = HashMap::new();
         for (task_id, vdaf, role) in values {
-            let task = new_dummy_task(task_id, vdaf, role);
+            let task = new_dummy_task(task_id, vdaf.into(), role);
 
             ds.run_tx(|tx| {
                 let task = task.clone();
@@ -2772,7 +2772,7 @@ mod tests {
             Box::pin(async move {
                 tx.put_task(&new_dummy_task(
                     report.task_id(),
-                    VdafInstance::Prio3Aes128Count,
+                    janus::task::VdafInstance::Prio3Aes128Count.into(),
                     Role::Leader,
                 ))
                 .await?;
@@ -2880,13 +2880,13 @@ mod tests {
             Box::pin(async move {
                 tx.put_task(&new_dummy_task(
                     task_id,
-                    VdafInstance::Prio3Aes128Count,
+                    janus::task::VdafInstance::Prio3Aes128Count.into(),
                     Role::Leader,
                 ))
                 .await?;
                 tx.put_task(&new_dummy_task(
                     unrelated_task_id,
-                    VdafInstance::Prio3Aes128Count,
+                    janus::task::VdafInstance::Prio3Aes128Count.into(),
                     Role::Leader,
                 ))
                 .await?;
@@ -2965,7 +2965,7 @@ mod tests {
             Box::pin(async move {
                 tx.put_task(&new_dummy_task(
                     task_id,
-                    VdafInstance::Prio3Aes128Count,
+                    janus::task::VdafInstance::Prio3Aes128Count.into(),
                     Role::Leader,
                 ))
                 .await?;
@@ -3029,7 +3029,7 @@ mod tests {
             Box::pin(async move {
                 tx.put_task(&new_dummy_task(
                     aggregation_job.task_id,
-                    VdafInstance::Poplar1 { bits: 64 },
+                    janus::task::VdafInstance::Poplar1 { bits: 64 }.into(),
                     Role::Leader,
                 ))
                 .await?;
@@ -3098,7 +3098,7 @@ mod tests {
                 // acquire_incomplete_aggregation_jobs().
                 tx.put_task(&new_dummy_task(
                     task_id,
-                    VdafInstance::Prio3Aes128Count,
+                    janus::task::VdafInstance::Prio3Aes128Count.into(),
                     Role::Leader,
                 ))
                 .await?;
@@ -3126,7 +3126,7 @@ mod tests {
                 let helper_task_id = TaskId::random();
                 tx.put_task(&new_dummy_task(
                     helper_task_id,
-                    VdafInstance::Prio3Aes128Count,
+                    janus::task::VdafInstance::Prio3Aes128Count.into(),
                     Role::Helper,
                 ))
                 .await?;
@@ -3184,7 +3184,7 @@ mod tests {
                 (
                     AcquiredAggregationJob {
                         task_id,
-                        vdaf: VdafInstance::Prio3Aes128Count,
+                        vdaf: janus::task::VdafInstance::Prio3Aes128Count.into(),
                         aggregation_job_id: agg_job_id,
                     },
                     want_expiry_time,
@@ -3266,7 +3266,7 @@ mod tests {
                 (
                     AcquiredAggregationJob {
                         task_id,
-                        vdaf: VdafInstance::Prio3Aes128Count,
+                        vdaf: janus::task::VdafInstance::Prio3Aes128Count.into(),
                         aggregation_job_id: job_id,
                     },
                     want_expiry_time,
@@ -3404,7 +3404,7 @@ mod tests {
             Box::pin(async move {
                 tx.put_task(&new_dummy_task(
                     task_id,
-                    VdafInstance::Poplar1 { bits: 64 },
+                    janus::task::VdafInstance::Poplar1 { bits: 64 }.into(),
                     Role::Leader,
                 ))
                 .await?;
@@ -3416,7 +3416,7 @@ mod tests {
                 let unrelated_task_id = TaskId::random();
                 tx.put_task(&new_dummy_task(
                     unrelated_task_id,
-                    VdafInstance::Poplar1 { bits: 64 },
+                    janus::task::VdafInstance::Poplar1 { bits: 64 }.into(),
                     Role::Leader,
                 ))
                 .await?;
@@ -3482,7 +3482,7 @@ mod tests {
                     Box::pin(async move {
                         tx.put_task(&new_dummy_task(
                             task_id,
-                            VdafInstance::Prio3Aes128Count,
+                            janus::task::VdafInstance::Prio3Aes128Count.into(),
                             Role::Leader,
                         ))
                         .await?;
@@ -3630,7 +3630,7 @@ mod tests {
                 Box::pin(async move {
                     tx.put_task(&new_dummy_task(
                         task_id,
-                        VdafInstance::Prio3Aes128Count,
+                        janus::task::VdafInstance::Prio3Aes128Count.into(),
                         Role::Leader,
                     ))
                     .await?;
@@ -3763,7 +3763,7 @@ mod tests {
             Box::pin(async move {
                 tx.put_task(&new_dummy_task(
                     task_id,
-                    VdafInstance::Prio3Aes128Count,
+                    janus::task::VdafInstance::Prio3Aes128Count.into(),
                     Role::Leader,
                 ))
                 .await
@@ -3876,7 +3876,7 @@ mod tests {
             Box::pin(async move {
                 tx.put_task(&new_dummy_task(
                     first_task_id,
-                    VdafInstance::Prio3Aes128Count,
+                    janus::task::VdafInstance::Prio3Aes128Count.into(),
                     Role::Leader,
                 ))
                 .await
@@ -3884,7 +3884,7 @@ mod tests {
 
                 tx.put_task(&new_dummy_task(
                     second_task_id,
-                    VdafInstance::Prio3Aes128Count,
+                    janus::task::VdafInstance::Prio3Aes128Count.into(),
                     Role::Leader,
                 ))
                 .await
@@ -3944,7 +3944,11 @@ mod tests {
 
         ds.run_tx(|tx| {
             Box::pin(async move {
-                let task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count, Role::Leader);
+                let task = new_dummy_task(
+                    task_id,
+                    janus::task::VdafInstance::Prio3Aes128Count.into(),
+                    Role::Leader,
+                );
                 tx.put_task(&task).await.unwrap();
 
                 let first_collect_job_id = tx
@@ -4669,14 +4673,17 @@ mod tests {
             let (aggregate_share, aggregation_param) =
                 (aggregate_share.clone(), aggregation_param.clone());
             Box::pin(async move {
-                let mut task =
-                    new_dummy_task(task_id, VdafInstance::Prio3Aes128Count, Role::Leader);
+                let mut task = new_dummy_task(
+                    task_id,
+                    janus::task::VdafInstance::Prio3Aes128Count.into(),
+                    Role::Leader,
+                );
                 task.min_batch_duration = Duration::from_seconds(100);
                 tx.put_task(&task).await?;
 
                 tx.put_task(&new_dummy_task(
                     other_task_id,
-                    VdafInstance::Prio3Aes128Count,
+                    janus::task::VdafInstance::Prio3Aes128Count.into(),
                     Role::Leader,
                 ))
                 .await?;
@@ -4861,7 +4868,11 @@ mod tests {
         ds.run_tx(|tx| {
             Box::pin(async move {
                 let task_id = TaskId::random();
-                let task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count, Role::Helper);
+                let task = new_dummy_task(
+                    task_id,
+                    janus::task::VdafInstance::Prio3Aes128Count.into(),
+                    Role::Helper,
+                );
                 tx.put_task(&task).await?;
 
                 let aggregate_share = AggregateShare::from(vec![Field64::from(17)]);
@@ -4933,15 +4944,21 @@ mod tests {
         ds.run_tx(|tx| {
             Box::pin(async move {
                 let first_task_id = TaskId::random();
-                let mut task =
-                    new_dummy_task(first_task_id, VdafInstance::Prio3Aes128Count, Role::Helper);
+                let mut task = new_dummy_task(
+                    first_task_id,
+                    janus::task::VdafInstance::Prio3Aes128Count.into(),
+                    Role::Helper,
+                );
                 task.max_batch_lifetime = 2;
                 task.min_batch_duration = Duration::from_seconds(100);
                 tx.put_task(&task).await?;
 
                 let second_task_id = TaskId::random();
-                let other_task =
-                    new_dummy_task(second_task_id, VdafInstance::Prio3Aes128Count, Role::Helper);
+                let other_task = new_dummy_task(
+                    second_task_id,
+                    janus::task::VdafInstance::Prio3Aes128Count.into(),
+                    Role::Helper,
+                );
                 tx.put_task(&other_task).await?;
 
                 let aggregate_share = AggregateShare::from(vec![Field64::from(17)]);

--- a/janus_server/src/task.rs
+++ b/janus_server/src/task.rs
@@ -25,13 +25,96 @@ pub enum Error {
 }
 
 /// Identifiers for VDAFs supported by this aggregator, corresponding to
-/// definitions in [draft-patton-cfrg-vdaf][1] and implementations in
+/// definitions in [draft-irtf-cfrg-vdaf-00][1] and implementations in
 /// [`prio::vdaf::prio3`].
 ///
-/// [1]: https://datatracker.ietf.org/doc/draft-patton-cfrg-vdaf/
+/// [1]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/00/
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum VdafInstance {
+    Real(janus::task::VdafInstance),
+
+    #[cfg(test)]
+    Fake,
+    #[cfg(test)]
+    FakeFailsPrepInit,
+    #[cfg(test)]
+    FakeFailsPrepStep,
+}
+
+impl From<janus::task::VdafInstance> for VdafInstance {
+    fn from(vdaf: janus::task::VdafInstance) -> Self {
+        VdafInstance::Real(vdaf)
+    }
+}
+
+impl Serialize for VdafInstance {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let flattened = match self {
+            VdafInstance::Real(janus::task::VdafInstance::Prio3Aes128Count) => {
+                VdafSerialization::Prio3Aes128Count
+            }
+            VdafInstance::Real(janus::task::VdafInstance::Prio3Aes128Sum { bits }) => {
+                VdafSerialization::Prio3Aes128Sum { bits: *bits }
+            }
+            VdafInstance::Real(janus::task::VdafInstance::Prio3Aes128Histogram { buckets }) => {
+                VdafSerialization::Prio3Aes128Histogram {
+                    buckets: buckets.clone(),
+                }
+            }
+            VdafInstance::Real(janus::task::VdafInstance::Poplar1 { bits }) => {
+                VdafSerialization::Poplar1 { bits: *bits }
+            }
+            #[cfg(test)]
+            VdafInstance::Fake => VdafSerialization::Fake,
+            #[cfg(test)]
+            VdafInstance::FakeFailsPrepInit => VdafSerialization::FakeFailsPrepInit,
+            #[cfg(test)]
+            VdafInstance::FakeFailsPrepStep => VdafSerialization::FakeFailsPrepStep,
+        };
+        flattened.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for VdafInstance {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let flattened = <VdafSerialization as Deserialize<'de>>::deserialize(deserializer)?;
+        match flattened {
+            VdafSerialization::Prio3Aes128Count => Ok(VdafInstance::Real(
+                janus::task::VdafInstance::Prio3Aes128Count,
+            )),
+            VdafSerialization::Prio3Aes128Sum { bits } => Ok(VdafInstance::Real(
+                janus::task::VdafInstance::Prio3Aes128Sum { bits },
+            )),
+            VdafSerialization::Prio3Aes128Histogram { buckets } => Ok(VdafInstance::Real(
+                janus::task::VdafInstance::Prio3Aes128Histogram { buckets },
+            )),
+            VdafSerialization::Poplar1 { bits } => {
+                Ok(VdafInstance::Real(janus::task::VdafInstance::Poplar1 {
+                    bits,
+                }))
+            }
+            #[cfg(test)]
+            VdafSerialization::Fake => Ok(VdafInstance::Fake),
+            #[cfg(test)]
+            VdafSerialization::FakeFailsPrepInit => Ok(VdafInstance::FakeFailsPrepInit),
+            #[cfg(test)]
+            VdafSerialization::FakeFailsPrepStep => Ok(VdafInstance::FakeFailsPrepStep),
+        }
+    }
+}
+
+/// An internal helper enum to allow representing [`VdafInstance`] flattened as a
+/// single JSON object, without having to implement [`Serialize`] and
+/// [`Deserialize`] by hand.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename = "Vdaf")]
-pub enum VdafInstance {
+enum VdafSerialization {
     /// A `prio3` counter using the AES 128 pseudorandom generator.
     Prio3Aes128Count,
     /// A `prio3` sum using the AES 128 pseudorandom generator.
@@ -276,14 +359,16 @@ pub mod test_util {
 
     fn verify_param_dispatch(vdaf: &VdafInstance, role: Role) -> Vec<u8> {
         match &vdaf {
-            VdafInstance::Prio3Aes128Count => verify_param(Prio3Aes128Count::new(2).unwrap(), role),
-            VdafInstance::Prio3Aes128Sum { bits } => {
+            VdafInstance::Real(janus::task::VdafInstance::Prio3Aes128Count) => {
+                verify_param(Prio3Aes128Count::new(2).unwrap(), role)
+            }
+            VdafInstance::Real(janus::task::VdafInstance::Prio3Aes128Sum { bits }) => {
                 verify_param(Prio3Aes128Sum::new(2, *bits).unwrap(), role)
             }
-            VdafInstance::Prio3Aes128Histogram { buckets } => {
+            VdafInstance::Real(janus::task::VdafInstance::Prio3Aes128Histogram { buckets }) => {
                 verify_param(Prio3Aes128Histogram::new(2, &*buckets).unwrap(), role)
             }
-            VdafInstance::Poplar1 { bits } => verify_param(
+            VdafInstance::Real(janus::task::VdafInstance::Poplar1 { bits }) => verify_param(
                 Poplar1::<ToyIdpf<Field128>, PrgAes128, 16>::new(*bits),
                 role,
             ),
@@ -390,14 +475,14 @@ mod tests {
         // The `Vdaf` type must have a stable serialization, as it gets stored in a JSON database
         // column.
         assert_tokens(
-            &VdafInstance::Prio3Aes128Count,
+            &VdafInstance::Real(janus::task::VdafInstance::Prio3Aes128Count),
             &[Token::UnitVariant {
                 name: "Vdaf",
                 variant: "Prio3Aes128Count",
             }],
         );
         assert_tokens(
-            &VdafInstance::Prio3Aes128Sum { bits: 64 },
+            &VdafInstance::Real(janus::task::VdafInstance::Prio3Aes128Sum { bits: 64 }),
             &[
                 Token::StructVariant {
                     name: "Vdaf",
@@ -410,9 +495,9 @@ mod tests {
             ],
         );
         assert_tokens(
-            &VdafInstance::Prio3Aes128Histogram {
+            &VdafInstance::Real(janus::task::VdafInstance::Prio3Aes128Histogram {
                 buckets: vec![0, 100, 200, 400],
-            },
+            }),
             &[
                 Token::StructVariant {
                     name: "Vdaf",
@@ -430,7 +515,7 @@ mod tests {
             ],
         );
         assert_tokens(
-            &VdafInstance::Poplar1 { bits: 64 },
+            &VdafInstance::Real(janus::task::VdafInstance::Poplar1 { bits: 64 }),
             &[
                 Token::StructVariant {
                     name: "Vdaf",

--- a/janus_server/tests/server_shutdown.rs
+++ b/janus_server/tests/server_shutdown.rs
@@ -5,12 +5,13 @@
 
 use janus::{
     message::{Role, TaskId},
+    task::VdafInstance,
     time::{Clock, RealClock},
 };
 use janus_server::{
     config::{AggregatorConfig, CommonConfig, DbConfig},
     datastore::{Crypter, Datastore},
-    task::{test_util::new_dummy_task, VdafInstance},
+    task::test_util::new_dummy_task,
     trace::{install_trace_subscriber, TraceConfiguration},
 };
 use reqwest::{Client, Url};
@@ -71,7 +72,7 @@ async fn server_shutdown() {
     };
 
     let task_id = TaskId::random();
-    let task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count, Role::Leader);
+    let task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count.into(), Role::Leader);
     datastore
         .run_tx(|tx| {
             let task = task.clone();

--- a/monolithic_integration_test/tests/integration_test.rs
+++ b/monolithic_integration_test/tests/integration_test.rs
@@ -2,13 +2,14 @@ use futures::channel::oneshot::Sender;
 use janus::{
     hpke::test_util::generate_hpke_config_and_private_key,
     message::{Duration, Role, TaskId},
+    task::VdafInstance,
     time::{Clock, RealClock},
 };
 use janus_server::{
     aggregator::aggregator_server,
     client::{self, Client, ClientParameters},
     datastore::{Crypter, Datastore},
-    task::{test_util::generate_aggregator_auth_token, Task, VdafInstance},
+    task::{test_util::generate_aggregator_auth_token, Task},
     trace::{install_trace_subscriber, TraceConfiguration},
 };
 use prio::{
@@ -82,7 +83,7 @@ async fn setup_test() -> TestCase {
             Url::parse("http://leader_endpoint").unwrap(),
             Url::parse("http://helper_endpoint").unwrap(),
         ],
-        VdafInstance::Prio3Aes128Count,
+        VdafInstance::Prio3Aes128Count.into(),
         Role::Leader,
         vec![leader_verify_param.get_encoded()],
         1,
@@ -115,7 +116,7 @@ async fn setup_test() -> TestCase {
             Url::parse("http://leader_endpoint").unwrap(),
             Url::parse("http://helper_endpoint").unwrap(),
         ],
-        VdafInstance::Prio3Aes128Count,
+        VdafInstance::Prio3Aes128Count.into(),
         Role::Helper,
         vec![helper_verify_param.get_encoded()],
         1,


### PR DESCRIPTION
This splits out `VdafInstance` into two enums, keeping the "fake" variants in `janus_server`. This is part of #18.