### PR TITLE
Enable prometheus feature in container builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY janus_server /src/janus_server
 COPY monolithic_integration_test /src/monolithic_integration_test
 COPY test_util /src/test_util
 COPY db/schema.sql /src/db/schema.sql
-RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,target=/src/target cargo build --release --bin $BINARY && cp /src/target/release/$BINARY /$BINARY
+RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,target=/src/target cargo build --release --bin $BINARY --features=prometheus && cp /src/target/release/$BINARY /$BINARY
 
 FROM alpine:3.16.0
 ARG BINARY=aggregator


### PR DESCRIPTION
At this stage, it seems more likely that we will use Prometheus than Honeycomb Enterprise/Pro for metrics.