### PR TITLE
Update libprio-rs dependency to version 0.8.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1546,6 +1546,7 @@ dependencies = [
  "janus_test_util",
  "lazy_static",
  "prio",
+ "rand",
  "ring",
  "testcontainers",
  "tokio",
@@ -1936,9 +1937,9 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "prio"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34dec6b842c17bb4ebff74907295c102f8790d47b8a914eade914efc6e2b1aa8"
+checksum = "6e58420a9eed730ff64632a63d8f01becd86367999562978c2ac891582ebb720"
 dependencies = [
  "aes 0.8.1",
  "aes-gcm",

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -43,14 +43,14 @@ CREATE TABLE task_hpke_keys(
     CONSTRAINT fk_task_id FOREIGN KEY(task_id) REFERENCES tasks(id)
 );
 
--- The VDAF verification parameters used by a given task.
+-- The VDAF verification keys used by a given task.
 -- TODO(#229): support multiple verification parameters per task
-CREATE TABLE task_vdaf_verify_params(
+CREATE TABLE task_vdaf_verify_keys(
     id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,  -- artificial ID, internal-only
-    task_id BIGINT NOT NULL,           -- task ID the verification parameter is associated with
-    vdaf_verify_param BYTEA NOT NULL,  -- the VDAF verification parameter (opaque VDAF message, encrypted)
+    task_id BIGINT NOT NULL,         -- task ID the verification key is associated with
+    vdaf_verify_key BYTEA NOT NULL,  -- the VDAF verification key (encrypted)
 
-    CONSTRAINT vdaf_verify_param_unique_task_id UNIQUE(task_id),
+    CONSTRAINT vdaf_verify_key_unique_task_id UNIQUE(task_id),
     CONSTRAINT fk_task_id FOREIGN KEY(task_id) REFERENCES tasks(id)
 );
 

--- a/janus/Cargo.toml
+++ b/janus/Cargo.toml
@@ -12,7 +12,7 @@ chrono = "0.4"
 hex = "0.4.3"
 hpke-dispatch = "0.3.0"
 num_enum = "0.5.6"
-prio = "0.7.1"
+prio = "0.8.0"
 rand = "0.8"
 ring = "0.16.20"
 serde = { version = "1.0.137", features = ["derive"] }

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -34,7 +34,7 @@ opentelemetry-otlp = { version = "0.10.0", optional = true, features = ["metrics
 opentelemetry-prometheus = { version = "0.10.0", optional = true }
 opentelemetry-semantic-conventions = { version = "0.9.0", optional = true }
 postgres-types = { version = "0.2.3", features = ["derive", "array-impls"] }
-prio = "0.7.1"
+prio = "0.8.0"
 prometheus = { version = "0.13.1", optional = true }
 rand = "0.8"
 reqwest = { version = "0.11.4", default-features = false, features = ["rustls-tls", "json"] }

--- a/janus_server/src/bin/aggregation_job_creator.rs
+++ b/janus_server/src/bin/aggregation_job_creator.rs
@@ -11,7 +11,7 @@ use janus_server::datastore::models::{
 };
 use janus_server::datastore::{self, Datastore};
 use janus_server::message::AggregationJobId;
-use janus_server::task::Task;
+use janus_server::task::{Task, PRIO3_AES128_VERIFY_KEY_LENGTH};
 use prio::codec::Encode;
 use prio::vdaf;
 use prio::vdaf::prio3::{Prio3Aes128Count, Prio3Aes128Histogram, Prio3Aes128Sum};
@@ -183,17 +183,17 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
     async fn create_aggregation_jobs_for_task(&self, task: &Task) -> anyhow::Result<()> {
         match task.vdaf {
             janus_server::task::VdafInstance::Prio3Aes128Count => {
-                self.create_aggregation_jobs_for_task_no_param::<Prio3Aes128Count>(task)
+                self.create_aggregation_jobs_for_task_no_param::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(task)
                     .await
             }
 
             janus_server::task::VdafInstance::Prio3Aes128Sum { .. } => {
-                self.create_aggregation_jobs_for_task_no_param::<Prio3Aes128Sum>(task)
+                self.create_aggregation_jobs_for_task_no_param::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Sum>(task)
                     .await
             }
 
             janus_server::task::VdafInstance::Prio3Aes128Histogram { .. } => {
-                self.create_aggregation_jobs_for_task_no_param::<Prio3Aes128Histogram>(task)
+                self.create_aggregation_jobs_for_task_no_param::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Histogram>(task)
                     .await
             }
 
@@ -205,14 +205,17 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
     }
 
     #[tracing::instrument(skip(self), err)]
-    async fn create_aggregation_jobs_for_task_no_param<A: vdaf::Aggregator<AggregationParam = ()>>(
+    async fn create_aggregation_jobs_for_task_no_param<
+        const L: usize,
+        A: vdaf::Aggregator<L, AggregationParam = ()>,
+    >(
         &self,
         task: &Task,
     ) -> anyhow::Result<()>
     where
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
         A::PrepareMessage: Send + Sync,
-        A::PrepareStep: Send + Sync + Encode,
+        A::PrepareState: Send + Sync + Encode,
         A::OutputShare: Send + Sync,
         for<'a> &'a A::OutputShare: Into<Vec<u8>>,
     {
@@ -264,7 +267,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                                 report_count = agg_job_nonces.len(),
                                 "Creating aggregation job"
                             );
-                            agg_jobs.push(AggregationJob::<A> {
+                            agg_jobs.push(AggregationJob::<L, A> {
                                 aggregation_job_id,
                                 task_id,
                                 aggregation_param: (),
@@ -272,7 +275,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                             });
 
                             for (ord, nonce) in agg_job_nonces.iter().enumerate() {
-                                report_aggs.push(ReportAggregation::<A> {
+                                report_aggs.push(ReportAggregation::<L, A> {
                                     aggregation_job_id,
                                     task_id,
                                     nonce: *nonce,
@@ -315,11 +318,11 @@ mod tests {
     use janus_server::{
         datastore::{Crypter, Datastore, Transaction},
         message::{test_util::new_dummy_report, AggregationJobId},
-        task::{test_util::new_dummy_task, VdafInstance},
+        task::{test_util::new_dummy_task, VdafInstance, PRIO3_AES128_VERIFY_KEY_LENGTH},
         trace::test_util::install_test_trace_subscriber,
     };
     use janus_test_util::MockClock;
-    use prio::vdaf::{prio3::Prio3Aes128Count, Vdaf as _};
+    use prio::vdaf::prio3::{Prio3, Prio3Aes128Count};
     use std::{
         collections::{HashMap, HashSet},
         iter,
@@ -634,23 +637,17 @@ mod tests {
         tx: &Transaction<'_, C>,
         task_id: TaskId,
     ) -> HashMap<AggregationJobId, T> {
-        // For this test, all of the report aggregations will be in the Start state, so the verify
-        // parameter effectively does not matter.
-        let verify_param = Prio3Aes128Count::new(2)
-            .unwrap()
-            .setup()
-            .unwrap()
-            .1
-            .remove(0);
+        let vdaf = Prio3::new_aes128_count(2).unwrap();
 
         try_join_all(
-            tx.get_aggregation_jobs_for_task_id::<Prio3Aes128Count>(task_id)
+            tx.get_aggregation_jobs_for_task_id::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(task_id)
                 .await
                 .unwrap()
                 .into_iter()
                 .map(|agg_job| {
-                    tx.get_report_aggregations_for_aggregation_job::<Prio3Aes128Count>(
-                        &verify_param,
+                    tx.get_report_aggregations_for_aggregation_job(
+                        &vdaf,
+                        Role::Leader,
                         task_id,
                         agg_job.aggregation_job_id,
                     )

--- a/janus_server/src/bin/aggregation_job_driver.rs
+++ b/janus_server/src/bin/aggregation_job_driver.rs
@@ -24,13 +24,13 @@ use janus_server::{
         AggregateContinueReq, AggregateContinueResp, AggregateInitializeReq,
         AggregateInitializeResp, PrepareStep, PrepareStepResult, ReportShare, ReportShareError,
     },
-    task::{Task, VdafInstance, DAP_AUTH_HEADER},
+    task::{Task, VdafInstance, DAP_AUTH_HEADER, PRIO3_AES128_VERIFY_KEY_LENGTH},
 };
 use prio::{
     codec::{Decode, Encode, ParameterizedDecode},
     vdaf::{
         self,
-        prio3::{Prio3Aes128Count, Prio3Aes128Histogram, Prio3Aes128Sum},
+        prio3::{Prio3, Prio3Aes128Count, Prio3Aes128Histogram, Prio3Aes128Sum},
         PrepareTransition,
     },
 };
@@ -157,17 +157,17 @@ impl AggregationJobDriver {
     ) -> Result<()> {
         match lease.leased().vdaf {
             VdafInstance::Prio3Aes128Count => {
-                let vdaf = Prio3Aes128Count::new(2)?;
+                let vdaf = Prio3::new_aes128_count(2)?;
                 self.step_aggregation_job_generic(datastore, vdaf, lease)
                     .await
             }
             VdafInstance::Prio3Aes128Sum { bits } => {
-                let vdaf = Prio3Aes128Sum::new(2, bits)?;
+                let vdaf = Prio3::new_aes128_sum(2, bits)?;
                 self.step_aggregation_job_generic(datastore, vdaf, lease)
                     .await
             }
             VdafInstance::Prio3Aes128Histogram { ref buckets } => {
-                let vdaf = Prio3Aes128Histogram::new(2, buckets)?;
+                let vdaf = Prio3::new_aes128_histogram(2, buckets)?;
                 self.step_aggregation_job_generic(datastore, vdaf, lease)
                     .await
             }
@@ -176,44 +176,51 @@ impl AggregationJobDriver {
         }
     }
 
-    async fn step_aggregation_job_generic<C, A>(
+    async fn step_aggregation_job_generic<const L: usize, C: Clock, A: vdaf::Aggregator<L>>(
         &self,
         datastore: Arc<Datastore<C>>,
         vdaf: A,
         lease: Lease<AcquiredAggregationJob>,
     ) -> Result<()>
     where
-        C: Clock,
-        A: vdaf::Aggregator + 'static + Send + Sync,
+        A: 'static + Send + Sync,
         A::AggregationParam: Send + Sync,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
         A::OutputShare: PartialEq + Eq + Send + Sync + for<'a> TryFrom<&'a [u8]>,
         for<'a> &'a A::OutputShare: Into<Vec<u8>>,
-        A::PrepareStep: PartialEq + Eq + Send + Sync + Encode + ParameterizedDecode<A::VerifyParam>,
+        for<'a> A::PrepareState:
+            PartialEq + Eq + Send + Sync + Encode + ParameterizedDecode<(&'a A, usize)>,
         A::PrepareMessage: PartialEq + Eq + Send + Sync,
-        A::VerifyParam: Send + Sync + ParameterizedDecode<A>,
     {
         // Read all information about the aggregation job.
         let vdaf = Arc::new(vdaf);
         let task_id = lease.leased().task_id;
         let aggregation_job_id = lease.leased().aggregation_job_id;
-        let (task, aggregation_job, report_aggregations, client_reports, verify_param) = datastore
+        let (task, aggregation_job, report_aggregations, client_reports, verify_key) = datastore
             .run_tx(|tx| {
                 let vdaf = Arc::clone(&vdaf);
                 Box::pin(async move {
                     let task = tx.get_task(task_id).await?.ok_or_else(|| {
                         datastore::Error::User(anyhow!("couldn't find task {}", task_id).into())
                     })?;
-                    let verify_param = A::VerifyParam::get_decoded_with_param(
-                        &vdaf,
-                        task.vdaf_verify_parameters.get(0).unwrap(),
-                    )?;
+                    let verify_key = task
+                        .vdaf_verify_keys
+                        .get(0)
+                        .unwrap()
+                        .clone()
+                        .try_into()
+                        .map_err(|_| {
+                            datastore::Error::User(
+                                anyhow!("VDAF verification key has wrong length").into(),
+                            )
+                        })?;
 
                     let aggregation_job_future =
-                        tx.get_aggregation_job::<A>(task_id, aggregation_job_id);
+                        tx.get_aggregation_job::<L, A>(task_id, aggregation_job_id);
                     let report_aggregations_future = tx
-                        .get_report_aggregations_for_aggregation_job::<A>(
-                            &verify_param,
+                        .get_report_aggregations_for_aggregation_job(
+                            vdaf.as_ref(),
+                            Role::Leader,
                             task_id,
                             aggregation_job_id,
                         );
@@ -268,7 +275,7 @@ impl AggregationJobDriver {
                         aggregation_job,
                         report_aggregations,
                         client_reports,
-                        verify_param,
+                        verify_key,
                     ))
                 })
             })
@@ -287,7 +294,7 @@ impl AggregationJobDriver {
         match (saw_start, saw_waiting, saw_finished) {
             // Only saw report aggregations in state "start" (or failed or invalid).
             (true, false, false) => self.step_aggregation_job_aggregate_init(
-                &datastore, vdaf.as_ref(), lease, task, aggregation_job, report_aggregations, client_reports, verify_param).await,
+                &datastore, vdaf.as_ref(), lease, task, aggregation_job, report_aggregations, client_reports, verify_key).await,
 
             // Only saw report aggregations in state "waiting" (or failed or invalid).
             (false, true, false) => self.step_aggregation_job_aggregate_continue(
@@ -298,25 +305,24 @@ impl AggregationJobDriver {
     }
 
     #[allow(clippy::too_many_arguments)]
-    async fn step_aggregation_job_aggregate_init<C, A>(
+    async fn step_aggregation_job_aggregate_init<const L: usize, C: Clock, A: vdaf::Aggregator<L>>(
         &self,
         datastore: &Datastore<C>,
         vdaf: &A,
         lease: Lease<AcquiredAggregationJob>,
         task: Task,
-        aggregation_job: AggregationJob<A>,
-        report_aggregations: Vec<ReportAggregation<A>>,
+        aggregation_job: AggregationJob<L, A>,
+        report_aggregations: Vec<ReportAggregation<L, A>>,
         client_reports: Vec<Report>,
-        verify_param: A::VerifyParam,
+        verify_key: [u8; L],
     ) -> Result<()>
     where
-        C: Clock,
-        A: vdaf::Aggregator + 'static,
+        A: 'static,
         A::AggregationParam: Send + Sync,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
         A::OutputShare: PartialEq + Eq + Send + Sync,
         for<'a> &'a A::OutputShare: Into<Vec<u8>>,
-        A::PrepareStep: PartialEq + Eq + Send + Sync + Encode,
+        A::PrepareState: PartialEq + Eq + Send + Sync + Encode,
         A::PrepareMessage: PartialEq + Eq + Send + Sync,
     {
         // Zip the report aggregations at start with the client reports, verifying that their nonces
@@ -404,7 +410,7 @@ impl AggregationJobDriver {
                 }
             };
             let leader_input_share = match A::InputShare::get_decoded_with_param(
-                &verify_param,
+                &(vdaf, Role::Leader.index().unwrap()),
                 &leader_input_share_bytes,
             ) {
                 Ok(leader_input_share) => leader_input_share,
@@ -418,13 +424,14 @@ impl AggregationJobDriver {
             };
 
             // Initialize the leader's preparation state from the input share.
-            let prep_state = match vdaf.prepare_init(
-                &verify_param,
+            let (prep_state, prep_share) = match vdaf.prepare_init(
+                &verify_key,
+                Role::Leader.index().unwrap(),
                 &aggregation_job.aggregation_param,
                 &report.nonce().get_encoded(),
                 &leader_input_share,
             ) {
-                Ok(prep_state) => prep_state,
+                Ok(prep_state_and_share) => prep_state_and_share,
                 Err(err) => {
                     error!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't initialize leader's preparation state");
                     report_aggregation.state =
@@ -432,14 +439,6 @@ impl AggregationJobDriver {
                     report_aggregations_to_write.push(report_aggregation);
                     continue;
                 }
-            };
-            let leader_transition = vdaf.prepare_step(prep_state, None);
-            if let PrepareTransition::Fail(err) = leader_transition {
-                error!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't step leader's initial preparation state");
-                report_aggregation.state =
-                    ReportAggregationState::Failed(ReportShareError::VdafPrepError);
-                report_aggregations_to_write.push(report_aggregation);
-                continue;
             };
 
             report_shares.push(ReportShare {
@@ -449,7 +448,7 @@ impl AggregationJobDriver {
             });
             stepped_aggregations.push(SteppedAggregation {
                 report_aggregation,
-                leader_transition,
+                leader_transition: PrepareTransition::Continue(prep_state, prep_share),
             });
         }
 
@@ -488,23 +487,26 @@ impl AggregationJobDriver {
         .await
     }
 
-    async fn step_aggregation_job_aggregate_continue<C, A>(
+    async fn step_aggregation_job_aggregate_continue<
+        const L: usize,
+        C: Clock,
+        A: vdaf::Aggregator<L>,
+    >(
         &self,
         datastore: &Datastore<C>,
         vdaf: &A,
         lease: Lease<AcquiredAggregationJob>,
         task: Task,
-        aggregation_job: AggregationJob<A>,
-        report_aggregations: Vec<ReportAggregation<A>>,
+        aggregation_job: AggregationJob<L, A>,
+        report_aggregations: Vec<ReportAggregation<L, A>>,
     ) -> Result<()>
     where
-        C: Clock,
-        A: vdaf::Aggregator + 'static,
+        A: 'static,
         A::AggregationParam: Send + Sync,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
         A::OutputShare: Send + Sync,
         for<'a> &'a A::OutputShare: Into<Vec<u8>>,
-        A::PrepareStep: Send + Sync + Encode,
+        A::PrepareState: Send + Sync + Encode,
         A::PrepareMessage: Send + Sync,
     {
         // Visit the report aggregations, ignoring any that have already failed; compute our own
@@ -520,15 +522,18 @@ impl AggregationJobDriver {
                     .ok_or_else(|| anyhow!("report aggregation missing prepare message"))?;
 
                 // Step our own state.
-                let leader_transition =
-                    vdaf.prepare_step(prep_state.clone(), Some(prep_msg.clone()));
-                if let PrepareTransition::Fail(err) = leader_transition {
-                    error!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't step report aggregation");
-                    report_aggregation.state =
-                        ReportAggregationState::Failed(ReportShareError::VdafPrepError);
-                    report_aggregations_to_write.push(report_aggregation);
-                    continue;
-                }
+                let leader_transition = match vdaf
+                    .prepare_step(prep_state.clone(), prep_msg.clone())
+                {
+                    Ok(leader_transition) => leader_transition,
+                    Err(err) => {
+                        error!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't step report aggregation");
+                        report_aggregation.state =
+                            ReportAggregationState::Failed(ReportShareError::VdafPrepError);
+                        report_aggregations_to_write.push(report_aggregation);
+                        continue;
+                    }
+                };
 
                 prepare_steps.push(PrepareStep {
                     nonce: report_aggregation.nonce,
@@ -576,25 +581,24 @@ impl AggregationJobDriver {
     }
 
     #[allow(clippy::too_many_arguments)]
-    async fn process_response_from_helper<C, A>(
+    async fn process_response_from_helper<const L: usize, C: Clock, A: vdaf::Aggregator<L>>(
         &self,
         datastore: &Datastore<C>,
         vdaf: &A,
         lease: Lease<AcquiredAggregationJob>,
-        aggregation_job: AggregationJob<A>,
-        stepped_aggregations: Vec<SteppedAggregation<A>>,
-        mut report_aggregations_to_write: Vec<ReportAggregation<A>>,
+        aggregation_job: AggregationJob<L, A>,
+        stepped_aggregations: Vec<SteppedAggregation<L, A>>,
+        mut report_aggregations_to_write: Vec<ReportAggregation<L, A>>,
         prep_steps: Vec<PrepareStep>,
     ) -> Result<()>
     where
-        C: Clock,
-        A: vdaf::Aggregator + 'static,
+        A: 'static,
         A::AggregationParam: Send + Sync,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
         A::OutputShare: Send + Sync,
         for<'a> &'a A::OutputShare: Into<Vec<u8>>,
         A::PrepareMessage: Send + Sync,
-        A::PrepareStep: Send + Sync + Encode,
+        A::PrepareState: Send + Sync + Encode,
     {
         // Handle response, computing the new report aggregations to be stored.
         if stepped_aggregations.len() != prep_steps.len() {
@@ -616,29 +620,26 @@ impl AggregationJobDriver {
             }
             match helper_prep_step.result {
                 PrepareStepResult::Continued(payload) => {
-                    // If the leader continued too, combine the leader's message with the helper's
-                    // and prepare to store the leader's new state & the combined message for the
-                    // next round. If the leader didn't continue, transition to INVALID.
-                    if let PrepareTransition::Continue(leader_prep_state, leader_prep_msg) =
+                    // If the leader continued too, combine the leader's prepare share with the
+                    // helper's to compute next round's prepare message. Prepare to store the
+                    // leader's new state & the prepare message. If the leader didn't continue,
+                    // transition to INVALID.
+                    if let PrepareTransition::Continue(leader_prep_state, leader_prep_share) =
                         leader_transition
                     {
-                        // TODO(https://github.com/divviup/libprio-rs/issues/245): is it OK to match
-                        // prep state w/ prep message decoding in this way? It works for the existing
-                        // VDAFs, but I'm not sure if this is expected to be generally true.
-                        let helper_prep_msg =
-                            A::PrepareMessage::get_decoded_with_param(&leader_prep_state, &payload)
+                        let helper_prep_share =
+                            A::PrepareShare::get_decoded_with_param(&leader_prep_state, &payload)
                                 .context("couldn't decode helper's prepare message");
-                        let combined_prep_msg = helper_prep_msg.and_then(|helper_prep_msg| {
-                            vdaf.prepare_preprocess([leader_prep_msg, helper_prep_msg])
-                                .context("couldn't combine leader & helper prepare messages")
+                        let prep_msg = helper_prep_share.and_then(|helper_prep_share| {
+                            vdaf.prepare_preprocess([leader_prep_share, helper_prep_share])
+                                .context("couldn't preprocess leader & helper prepare shares into prepare message")
                         });
-                        report_aggregation.state = match combined_prep_msg {
-                            Ok(combined_prep_msg) => ReportAggregationState::Waiting(
-                                leader_prep_state,
-                                Some(combined_prep_msg),
-                            ),
+                        report_aggregation.state = match prep_msg {
+                            Ok(prep_msg) => {
+                                ReportAggregationState::Waiting(leader_prep_state, Some(prep_msg))
+                            }
                             Err(err) => {
-                                error!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't compute combined prepare message");
+                                error!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't compute prepare message");
                                 ReportAggregationState::Failed(ReportShareError::VdafPrepError)
                             }
                         }
@@ -722,15 +723,15 @@ impl AggregationJobDriver {
     ) -> Result<()> {
         match &lease.leased().vdaf {
             VdafInstance::Prio3Aes128Count => {
-                self.cancel_aggregation_job_generic::<C, Prio3Aes128Count>(datastore, lease)
+                self.cancel_aggregation_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, Prio3Aes128Count>(datastore, lease)
                     .await
             }
             VdafInstance::Prio3Aes128Sum { .. } => {
-                self.cancel_aggregation_job_generic::<C, Prio3Aes128Sum>(datastore, lease)
+                self.cancel_aggregation_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, Prio3Aes128Sum>(datastore, lease)
                     .await
             }
             VdafInstance::Prio3Aes128Histogram { .. } => {
-                self.cancel_aggregation_job_generic::<C, Prio3Aes128Histogram>(datastore, lease)
+                self.cancel_aggregation_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, Prio3Aes128Histogram>(datastore, lease)
                     .await
             }
 
@@ -738,16 +739,15 @@ impl AggregationJobDriver {
         }
     }
 
-    async fn cancel_aggregation_job_generic<C, A>(
+    async fn cancel_aggregation_job_generic<const L: usize, C: Clock, A: vdaf::Aggregator<L>>(
         &self,
         datastore: Arc<Datastore<C>>,
         lease: Lease<AcquiredAggregationJob>,
     ) -> Result<()>
     where
-        A: vdaf::Aggregator + Send + Sync + 'static,
+        A: Send + Sync + 'static,
         A::AggregationParam: Send + Sync,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
-        C: Clock,
     {
         let lease = Arc::new(lease);
         let (task_id, aggregation_job_id) =
@@ -757,7 +757,7 @@ impl AggregationJobDriver {
                 let lease = Arc::clone(&lease);
                 Box::pin(async move {
                     let mut aggregation_job = tx
-                        .get_aggregation_job::<A>(task_id, aggregation_job_id)
+                        .get_aggregation_job::<L, A>(task_id, aggregation_job_id)
                         .await?
                         .ok_or_else(|| {
                             datastore::Error::User(
@@ -787,12 +787,12 @@ impl AggregationJobDriver {
 
 /// SteppedAggregation represents a report aggregation along with the associated preparation-state
 /// transition representing the next step for the leader.
-struct SteppedAggregation<A: vdaf::Aggregator>
+struct SteppedAggregation<const L: usize, A: vdaf::Aggregator<L>>
 where
     for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
 {
-    report_aggregation: ReportAggregation<A>,
-    leader_transition: PrepareTransition<A::PrepareStep, A::PrepareMessage, A::OutputShare>,
+    report_aggregation: ReportAggregation<L, A>,
+    leader_transition: PrepareTransition<A, L>,
 }
 
 #[cfg(test)]
@@ -820,14 +820,17 @@ mod tests {
             AggregateContinueReq, AggregateContinueResp, AggregateInitializeReq,
             AggregateInitializeResp, AggregationJobId, PrepareStep, PrepareStepResult, ReportShare,
         },
-        task::{test_util::new_dummy_task, VdafInstance},
+        task::{test_util::new_dummy_task, VdafInstance, PRIO3_AES128_VERIFY_KEY_LENGTH},
         trace::test_util::install_test_trace_subscriber,
     };
     use janus_test_util::{run_vdaf, MockClock};
     use mockito::mock;
     use prio::{
         codec::Encode,
-        vdaf::{prio3::Prio3Aes128Count, PrepareTransition, Vdaf},
+        vdaf::{
+            prio3::{Prio3, Prio3Aes128Count},
+            PrepareTransition,
+        },
     };
     use reqwest::Url;
     use std::{str, sync::Arc};
@@ -848,11 +851,8 @@ mod tests {
         let clock = MockClock::default();
         let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
         let ds = Arc::new(ds);
-        let vdaf = Prio3Aes128Count::new(2).unwrap();
-        let (public_param, verify_params) = vdaf.setup().unwrap();
-        let leader_verify_param = verify_params.get(Role::Leader.index().unwrap()).unwrap();
+        let vdaf = Arc::new(Prio3::new_aes128_count(2).unwrap());
         let nonce = Nonce::generate(&clock);
-        let transcript = run_vdaf(&vdaf, &public_param, &verify_params, &(), nonce, &0);
 
         let task_id = TaskId::random();
         let mut task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count, Role::Leader);
@@ -860,10 +860,15 @@ mod tests {
             Url::parse("http://irrelevant").unwrap(), // leader URL doesn't matter
             Url::parse(&mockito::server_url()).unwrap(),
         ];
-        task.vdaf_verify_parameters = vec![verify_params
-            .get(Role::Leader.index().unwrap())
+        let verify_key = task
+            .vdaf_verify_keys
+            .get(0)
             .unwrap()
-            .get_encoded()];
+            .clone()
+            .try_into()
+            .unwrap();
+
+        let transcript = run_vdaf(vdaf.as_ref(), &verify_key, &(), nonce, &0);
 
         let agg_auth_token = task.primary_aggregator_auth_token().clone();
         let (leader_hpke_config, _) = task.hpke_keys.iter().next().unwrap().1;
@@ -882,14 +887,20 @@ mod tests {
                 tx.put_task(&task).await?;
                 tx.put_client_report(&report).await?;
 
-                tx.put_aggregation_job(&AggregationJob::<Prio3Aes128Count> {
+                tx.put_aggregation_job(&AggregationJob::<
+                    PRIO3_AES128_VERIFY_KEY_LENGTH,
+                    Prio3Aes128Count,
+                > {
                     aggregation_job_id,
                     task_id,
                     aggregation_param: (),
                     state: AggregationJobState::InProgress,
                 })
                 .await?;
-                tx.put_report_aggregation(&ReportAggregation::<Prio3Aes128Count> {
+                tx.put_report_aggregation(&ReportAggregation::<
+                    PRIO3_AES128_VERIFY_KEY_LENGTH,
+                    Prio3Aes128Count,
+                > {
                     aggregation_job_id,
                     task_id,
                     nonce: report.nonce(),
@@ -903,7 +914,7 @@ mod tests {
         .unwrap();
 
         // Setup: prepare mocked HTTP responses.
-        let helper_vdaf_msg = assert_matches!(&transcript.transitions[Role::Helper.index().unwrap()][0], PrepareTransition::Continue(_, prep_msg) => prep_msg);
+        let helper_vdaf_msg = assert_matches!(&transcript.prepare_transitions[Role::Helper.index().unwrap()][0], PrepareTransition::Continue(_, prep_share) => prep_share);
         let helper_responses = vec![
             (
                 AggregateInitializeReq::MEDIA_TYPE,
@@ -951,6 +962,7 @@ mod tests {
                 .build()
                 .unwrap(),
         });
+
         // Run. Give the aggregation job driver enough time to step aggregation jobs, then kill it.
         let aggregation_job_driver = Arc::new(JobDriver::new(
             clock,
@@ -1009,32 +1021,38 @@ mod tests {
             mocked_aggregate.assert();
         }
 
-        let want_aggregation_job = AggregationJob::<Prio3Aes128Count> {
-            aggregation_job_id,
-            task_id,
-            aggregation_param: (),
-            state: AggregationJobState::Finished,
-        };
-        let leader_output_share = assert_matches!(&transcript.transitions[Role::Leader.index().unwrap()][1], PrepareTransition::Finish(leader_output_share) => leader_output_share.clone());
-        let want_report_aggregation = ReportAggregation::<Prio3Aes128Count> {
-            aggregation_job_id,
-            task_id,
-            nonce,
-            ord: 0,
-            state: ReportAggregationState::Finished(leader_output_share),
-        };
+        let want_aggregation_job =
+            AggregationJob::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count> {
+                aggregation_job_id,
+                task_id,
+                aggregation_param: (),
+                state: AggregationJobState::Finished,
+            };
+        let leader_output_share = assert_matches!(&transcript.prepare_transitions[Role::Leader.index().unwrap()][1], PrepareTransition::Finish(leader_output_share) => leader_output_share.clone());
+        let want_report_aggregation =
+            ReportAggregation::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count> {
+                aggregation_job_id,
+                task_id,
+                nonce,
+                ord: 0,
+                state: ReportAggregationState::Finished(leader_output_share),
+            };
 
         let (got_aggregation_job, got_report_aggregation) = ds
             .run_tx(|tx| {
-                let leader_verify_param = leader_verify_param.clone();
+                let vdaf = Arc::clone(&vdaf);
                 Box::pin(async move {
                     let aggregation_job = tx
-                        .get_aggregation_job::<Prio3Aes128Count>(task_id, aggregation_job_id)
+                        .get_aggregation_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                            task_id,
+                            aggregation_job_id,
+                        )
                         .await?
                         .unwrap();
                     let report_aggregation = tx
-                        .get_report_aggregation::<Prio3Aes128Count>(
-                            &leader_verify_param,
+                        .get_report_aggregation(
+                            vdaf.as_ref(),
+                            Role::Leader,
                             task_id,
                             aggregation_job_id,
                             nonce,
@@ -1058,11 +1076,8 @@ mod tests {
         let clock = MockClock::default();
         let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
         let ds = Arc::new(ds);
-        let vdaf = Prio3Aes128Count::new(2).unwrap();
-        let (public_param, verify_params) = vdaf.setup().unwrap();
-        let leader_verify_param = verify_params.get(Role::Leader.index().unwrap()).unwrap();
+        let vdaf = Arc::new(Prio3::new_aes128_count(2).unwrap());
         let nonce = Nonce::generate(&clock);
-        let transcript = run_vdaf(&vdaf, &public_param, &verify_params, &(), nonce, &0);
 
         let task_id = TaskId::random();
         let mut task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count, Role::Leader);
@@ -1070,7 +1085,15 @@ mod tests {
             Url::parse("http://irrelevant").unwrap(), // leader URL doesn't matter
             Url::parse(&mockito::server_url()).unwrap(),
         ];
-        task.vdaf_verify_parameters = vec![leader_verify_param.get_encoded()];
+        let verify_key = task
+            .vdaf_verify_keys
+            .get(0)
+            .unwrap()
+            .clone()
+            .try_into()
+            .unwrap();
+
+        let transcript = run_vdaf(vdaf.as_ref(), &verify_key, &(), nonce, &0);
 
         let agg_auth_token = task.primary_aggregator_auth_token();
         let (leader_hpke_config, _) = task.hpke_keys.iter().next().unwrap().1;
@@ -1090,14 +1113,20 @@ mod tests {
                     tx.put_task(&task).await?;
                     tx.put_client_report(&report).await?;
 
-                    tx.put_aggregation_job(&AggregationJob::<Prio3Aes128Count> {
+                    tx.put_aggregation_job(&AggregationJob::<
+                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        Prio3Aes128Count,
+                    > {
                         aggregation_job_id,
                         task_id,
                         aggregation_param: (),
                         state: AggregationJobState::InProgress,
                     })
                     .await?;
-                    tx.put_report_aggregation(&ReportAggregation::<Prio3Aes128Count> {
+                    tx.put_report_aggregation(&ReportAggregation::<
+                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        Prio3Aes128Count,
+                    > {
                         aggregation_job_id,
                         task_id,
                         nonce: report.nonce(),
@@ -1135,7 +1164,7 @@ mod tests {
                     .clone(),
             }],
         };
-        let helper_vdaf_msg = assert_matches!(&transcript.transitions[Role::Helper.index().unwrap()][0], PrepareTransition::Continue(_, prep_msg) => prep_msg);
+        let helper_vdaf_msg = assert_matches!(&transcript.prepare_transitions[Role::Helper.index().unwrap()][0], PrepareTransition::Continue(_, prep_share) => prep_share);
         let helper_response = AggregateInitializeResp {
             job_id: aggregation_job_id,
             prepare_steps: vec![PrepareStep {
@@ -1167,33 +1196,39 @@ mod tests {
         // Verify.
         mocked_aggregate.assert();
 
-        let want_aggregation_job = AggregationJob::<Prio3Aes128Count> {
-            aggregation_job_id,
-            task_id,
-            aggregation_param: (),
-            state: AggregationJobState::InProgress,
-        };
-        let leader_prep_state = assert_matches!(&transcript.transitions[Role::Leader.index().unwrap()][0], PrepareTransition::Continue(prep_state, _) => prep_state.clone());
-        let combined_prep_msg = transcript.combined_messages[0].clone();
-        let want_report_aggregation = ReportAggregation::<Prio3Aes128Count> {
-            aggregation_job_id,
-            task_id,
-            nonce,
-            ord: 0,
-            state: ReportAggregationState::Waiting(leader_prep_state, Some(combined_prep_msg)),
-        };
+        let want_aggregation_job =
+            AggregationJob::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count> {
+                aggregation_job_id,
+                task_id,
+                aggregation_param: (),
+                state: AggregationJobState::InProgress,
+            };
+        let leader_prep_state = assert_matches!(&transcript.prepare_transitions[Role::Leader.index().unwrap()][0], PrepareTransition::Continue(prep_state, _) => prep_state.clone());
+        let prep_msg = transcript.prepare_messages[0].clone();
+        let want_report_aggregation =
+            ReportAggregation::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count> {
+                aggregation_job_id,
+                task_id,
+                nonce,
+                ord: 0,
+                state: ReportAggregationState::Waiting(leader_prep_state, Some(prep_msg)),
+            };
 
         let (got_aggregation_job, got_report_aggregation) = ds
             .run_tx(|tx| {
-                let leader_verify_param = leader_verify_param.clone();
+                let vdaf = Arc::clone(&vdaf);
                 Box::pin(async move {
                     let aggregation_job = tx
-                        .get_aggregation_job::<Prio3Aes128Count>(task_id, aggregation_job_id)
+                        .get_aggregation_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                            task_id,
+                            aggregation_job_id,
+                        )
                         .await?
                         .unwrap();
                     let report_aggregation = tx
-                        .get_report_aggregation::<Prio3Aes128Count>(
-                            &leader_verify_param,
+                        .get_report_aggregation(
+                            vdaf.as_ref(),
+                            Role::Leader,
                             task_id,
                             aggregation_job_id,
                             nonce,
@@ -1218,11 +1253,8 @@ mod tests {
         let clock = MockClock::default();
         let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
         let ds = Arc::new(ds);
-        let vdaf = Prio3Aes128Count::new(2).unwrap();
-        let (public_param, verify_params) = vdaf.setup().unwrap();
-        let leader_verify_param = verify_params.get(Role::Leader.index().unwrap()).unwrap();
+        let vdaf = Arc::new(Prio3::new_aes128_count(2).unwrap());
         let nonce = Nonce::generate(&clock);
-        let transcript = run_vdaf(&vdaf, &public_param, &verify_params, &(), nonce, &0);
 
         let task_id = TaskId::random();
         let mut task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count, Role::Leader);
@@ -1230,7 +1262,15 @@ mod tests {
             Url::parse("http://irrelevant").unwrap(), // leader URL doesn't matter
             Url::parse(&mockito::server_url()).unwrap(),
         ];
-        task.vdaf_verify_parameters = vec![leader_verify_param.get_encoded()];
+        let verify_key = task
+            .vdaf_verify_keys
+            .get(0)
+            .unwrap()
+            .clone()
+            .try_into()
+            .unwrap();
+
+        let transcript = run_vdaf(vdaf.as_ref(), &verify_key, &(), nonce, &0);
 
         let agg_auth_token = task.primary_aggregator_auth_token();
         let (leader_hpke_config, _) = task.hpke_keys.iter().next().unwrap().1;
@@ -1243,37 +1283,40 @@ mod tests {
         );
         let aggregation_job_id = AggregationJobId::random();
 
-        let leader_prep_state = assert_matches!(&transcript.transitions[Role::Leader.index().unwrap()][0], PrepareTransition::Continue(prep_state, _) => prep_state);
-        let combined_msg = &transcript.combined_messages[0];
+        let leader_prep_state = assert_matches!(&transcript.prepare_transitions[Role::Leader.index().unwrap()][0], PrepareTransition::Continue(prep_state, _) => prep_state);
+        let prep_msg = &transcript.prepare_messages[0];
 
         let lease = ds
             .run_tx(|tx| {
-                let (task, report, leader_prep_state, combined_msg) = (
+                let (task, report, leader_prep_state, prep_msg) = (
                     task.clone(),
                     report.clone(),
                     leader_prep_state.clone(),
-                    combined_msg.clone(),
+                    prep_msg.clone(),
                 );
                 Box::pin(async move {
                     tx.put_task(&task).await?;
                     tx.put_client_report(&report).await?;
 
-                    tx.put_aggregation_job(&AggregationJob::<Prio3Aes128Count> {
+                    tx.put_aggregation_job(&AggregationJob::<
+                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        Prio3Aes128Count,
+                    > {
                         aggregation_job_id,
                         task_id,
                         aggregation_param: (),
                         state: AggregationJobState::InProgress,
                     })
                     .await?;
-                    tx.put_report_aggregation(&ReportAggregation::<Prio3Aes128Count> {
+                    tx.put_report_aggregation(&ReportAggregation::<
+                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        Prio3Aes128Count,
+                    > {
                         aggregation_job_id,
                         task_id,
                         nonce: report.nonce(),
                         ord: 0,
-                        state: ReportAggregationState::Waiting(
-                            leader_prep_state,
-                            Some(combined_msg),
-                        ),
+                        state: ReportAggregationState::Waiting(leader_prep_state, Some(prep_msg)),
                     })
                     .await?;
 
@@ -1297,7 +1340,7 @@ mod tests {
             job_id: aggregation_job_id,
             prepare_steps: vec![PrepareStep {
                 nonce,
-                result: PrepareStepResult::Continued(combined_msg.get_encoded()),
+                result: PrepareStepResult::Continued(prep_msg.get_encoded()),
             }],
         };
         let helper_response = AggregateContinueResp {
@@ -1331,32 +1374,38 @@ mod tests {
         // Verify.
         mocked_aggregate.assert();
 
-        let want_aggregation_job = AggregationJob::<Prio3Aes128Count> {
-            aggregation_job_id,
-            task_id,
-            aggregation_param: (),
-            state: AggregationJobState::Finished,
-        };
-        let leader_output_share = assert_matches!(&transcript.transitions[Role::Leader.index().unwrap()][1], PrepareTransition::Finish(leader_output_share) => leader_output_share.clone());
-        let want_report_aggregation = ReportAggregation::<Prio3Aes128Count> {
-            aggregation_job_id,
-            task_id,
-            nonce,
-            ord: 0,
-            state: ReportAggregationState::Finished(leader_output_share),
-        };
+        let want_aggregation_job =
+            AggregationJob::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count> {
+                aggregation_job_id,
+                task_id,
+                aggregation_param: (),
+                state: AggregationJobState::Finished,
+            };
+        let leader_output_share = assert_matches!(&transcript.prepare_transitions[Role::Leader.index().unwrap()][1], PrepareTransition::Finish(leader_output_share) => leader_output_share.clone());
+        let want_report_aggregation =
+            ReportAggregation::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count> {
+                aggregation_job_id,
+                task_id,
+                nonce,
+                ord: 0,
+                state: ReportAggregationState::Finished(leader_output_share),
+            };
 
         let (got_aggregation_job, got_report_aggregation) = ds
             .run_tx(|tx| {
-                let leader_verify_param = leader_verify_param.clone();
+                let vdaf = Arc::clone(&vdaf);
                 Box::pin(async move {
                     let aggregation_job = tx
-                        .get_aggregation_job::<Prio3Aes128Count>(task_id, aggregation_job_id)
+                        .get_aggregation_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                            task_id,
+                            aggregation_job_id,
+                        )
                         .await?
                         .unwrap();
                     let report_aggregation = tx
-                        .get_report_aggregation::<Prio3Aes128Count>(
-                            &leader_verify_param,
+                        .get_report_aggregation(
+                            vdaf.as_ref(),
+                            Role::Leader,
                             task_id,
                             aggregation_job_id,
                             nonce,
@@ -1380,12 +1429,8 @@ mod tests {
         let clock = MockClock::default();
         let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
         let ds = Arc::new(ds);
-        let vdaf = Prio3Aes128Count::new(2).unwrap();
-        let (public_param, verify_params) = vdaf.setup().unwrap();
-        let leader_verify_param = verify_params.get(Role::Leader.index().unwrap()).unwrap();
+        let vdaf = Arc::new(Prio3::new_aes128_count(2).unwrap());
         let nonce = Nonce::generate(&clock);
-        let input_shares =
-            run_vdaf(&vdaf, &public_param, &verify_params, &(), nonce, &0).input_shares;
 
         let task_id = TaskId::random();
         let mut task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count, Role::Leader);
@@ -1393,7 +1438,15 @@ mod tests {
             Url::parse("http://irrelevant").unwrap(), // leader URL doesn't matter
             Url::parse(&mockito::server_url()).unwrap(),
         ];
-        task.vdaf_verify_parameters = vec![leader_verify_param.get_encoded()];
+        let verify_key = task
+            .vdaf_verify_keys
+            .get(0)
+            .unwrap()
+            .clone()
+            .try_into()
+            .unwrap();
+
+        let input_shares = run_vdaf(vdaf.as_ref(), &verify_key, &(), nonce, &0).input_shares;
 
         let (leader_hpke_config, _) = task.hpke_keys.iter().next().unwrap().1;
         let (helper_hpke_config, _) = generate_hpke_config_and_private_key();
@@ -1405,19 +1458,20 @@ mod tests {
         );
         let aggregation_job_id = AggregationJobId::random();
 
-        let aggregation_job = AggregationJob::<Prio3Aes128Count> {
+        let aggregation_job = AggregationJob::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count> {
             aggregation_job_id,
             task_id,
             aggregation_param: (),
             state: AggregationJobState::InProgress,
         };
-        let report_aggregation = ReportAggregation::<Prio3Aes128Count> {
-            aggregation_job_id,
-            task_id,
-            nonce,
-            ord: 0,
-            state: ReportAggregationState::Start,
-        };
+        let report_aggregation =
+            ReportAggregation::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count> {
+                aggregation_job_id,
+                task_id,
+                nonce,
+                ord: 0,
+                state: ReportAggregationState::Start,
+            };
 
         let lease = ds
             .run_tx(|tx| {
@@ -1464,15 +1518,19 @@ mod tests {
 
         let (got_aggregation_job, got_report_aggregation, got_leases) = ds
             .run_tx(|tx| {
-                let leader_verify_param = leader_verify_param.clone();
+                let vdaf = Arc::clone(&vdaf);
                 Box::pin(async move {
                     let aggregation_job = tx
-                        .get_aggregation_job::<Prio3Aes128Count>(task_id, aggregation_job_id)
+                        .get_aggregation_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                            task_id,
+                            aggregation_job_id,
+                        )
                         .await?
                         .unwrap();
                     let report_aggregation = tx
-                        .get_report_aggregation::<Prio3Aes128Count>(
-                            &leader_verify_param,
+                        .get_report_aggregation(
+                            vdaf.as_ref(),
+                            Role::Leader,
                             task_id,
                             aggregation_job_id,
                             nonce,

--- a/janus_server/src/client.rs
+++ b/janus_server/src/client.rs
@@ -16,11 +16,11 @@ use url::Url;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("Invalid parameter {0}")]
+    #[error("invalid parameter {0}")]
     InvalidParameter(&'static str),
     #[error("HTTP client error: {0}")]
     HttpClient(#[from] reqwest::Error),
-    #[error("Codec error: {0}")]
+    #[error("codec error: {0}")]
     Codec(#[from] prio::codec::CodecError),
     #[error("HTTP response status {0}")]
     Http(StatusCode),
@@ -118,7 +118,6 @@ where
 {
     parameters: ClientParameters,
     vdaf_client: V,
-    vdaf_public_parameter: V::PublicParam,
     clock: C,
     http_client: reqwest::Client,
     leader_hpke_config: HpkeConfig,
@@ -132,7 +131,6 @@ where
     pub fn new(
         parameters: ClientParameters,
         vdaf_client: V,
-        vdaf_public_parameter: V::PublicParam,
         clock: C,
         http_client: &reqwest::Client,
         leader_hpke_config: HpkeConfig,
@@ -144,7 +142,6 @@ where
         Self {
             parameters,
             vdaf_client,
-            vdaf_public_parameter,
             clock,
             http_client: http_client.clone(),
             leader_hpke_config,
@@ -157,9 +154,7 @@ where
     /// share plus one proof share for each aggregator and then uploaded to the
     /// leader.
     pub async fn upload(&self, measurement: &V::Measurement) -> Result<(), Error> {
-        let input_shares = self
-            .vdaf_client
-            .shard(&self.vdaf_public_parameter, measurement)?;
+        let input_shares = self.vdaf_client.shard(measurement)?;
         assert_eq!(input_shares.len(), 2); // PPM only supports VDAFs using two aggregators.
 
         let nonce = Nonce::generate(&self.clock);
@@ -215,13 +210,10 @@ mod tests {
     use janus::{hpke::test_util::generate_hpke_config_and_private_key, message::TaskId};
     use janus_test_util::MockClock;
     use mockito::mock;
-    use prio::vdaf::prio3::{Prio3Aes128Count, Prio3Aes128Sum};
+    use prio::vdaf::prio3::Prio3;
     use url::Url;
 
-    fn setup_client<V: vdaf::Client>(
-        vdaf_client: V,
-        public_parameter: V::PublicParam,
-    ) -> Client<V, MockClock>
+    fn setup_client<V: vdaf::Client>(vdaf_client: V) -> Client<V, MockClock>
     where
         for<'a> &'a V::AggregateShare: Into<Vec<u8>>,
     {
@@ -241,7 +233,6 @@ mod tests {
         Client::new(
             client_parameters,
             vdaf_client,
-            public_parameter,
             clock,
             &default_http_client().unwrap(),
             leader_hpke_config,
@@ -258,8 +249,7 @@ mod tests {
             .expect(1)
             .create();
 
-        let client = setup_client(Prio3Aes128Count::new(2).unwrap(), ());
-
+        let client = setup_client(Prio3::new_aes128_count(2).unwrap());
         client.upload(&1).await.unwrap();
 
         mocked_upload.assert();
@@ -268,9 +258,9 @@ mod tests {
     #[tokio::test]
     async fn upload_prio3_invalid_measurement() {
         install_test_trace_subscriber();
-        let vdaf = Prio3Aes128Sum::new(2, 16).unwrap();
+        let vdaf = Prio3::new_aes128_sum(2, 16).unwrap();
 
-        let client = setup_client(vdaf, ());
+        let client = setup_client(vdaf);
         // 65536 is too big for a 16 bit sum and will be rejected by the VDAF.
         // Make sure we get the right error variant but otherwise we aren't
         // picky about its contents.
@@ -287,7 +277,7 @@ mod tests {
             .expect(1)
             .create();
 
-        let client = setup_client(Prio3Aes128Count::new(2).unwrap(), ());
+        let client = setup_client(Prio3::new_aes128_count(2).unwrap());
         assert_matches!(
             client.upload(&1).await,
             Err(Error::Http(StatusCode::NOT_IMPLEMENTED))

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -9,6 +9,7 @@ use crate::{
     message::{AggregateShareReq, AggregationJobId, ReportShare},
     task::{self, AggregatorAuthenticationToken, Task, VdafInstance},
 };
+use anyhow::anyhow;
 use chrono::NaiveDateTime;
 use futures::try_join;
 use janus::{
@@ -248,34 +249,34 @@ impl<C: Clock> Transaction<'_, C> {
         ];
         let hpke_configs_future = self.tx.execute(&stmt, hpke_configs_params);
 
-        // VDAF verification parameters.
-        let mut vdaf_verify_params: Vec<Vec<u8>> = Vec::new();
-        for vdaf_verify_param in task.vdaf_verify_parameters.iter() {
-            let encrypted_vdaf_verify_param = self.crypter.encrypt(
-                "task_vdaf_verify_params",
+        // VDAF verification keys.
+        let mut vdaf_verify_keys: Vec<Vec<u8>> = Vec::new();
+        for vdaf_verify_key in task.vdaf_verify_keys.iter() {
+            let encrypted_vdaf_verify_key = self.crypter.encrypt(
+                "task_vdaf_verify_keys",
                 task.id.as_bytes(),
-                "vdaf_verify_param",
-                vdaf_verify_param.as_ref(),
+                "vdaf_verify_key",
+                vdaf_verify_key.as_ref(),
             )?;
-            vdaf_verify_params.push(encrypted_vdaf_verify_param);
+            vdaf_verify_keys.push(encrypted_vdaf_verify_key);
         }
         let stmt = self
             .tx
             .prepare_cached(
-                "INSERT INTO task_vdaf_verify_params (task_id, vdaf_verify_param)
+                "INSERT INTO task_vdaf_verify_keys (task_id, vdaf_verify_key)
                 SELECT (SELECT id FROM tasks WHERE task_id = $1), * FROM UNNEST($2::BYTEA[])",
             )
             .await?;
-        let vdaf_verify_params_params: &[&(dyn ToSql + Sync)] = &[
+        let vdaf_verify_keys_params: &[&(dyn ToSql + Sync)] = &[
             /* task_id */ &task.id.as_bytes(),
-            /* vdaf_verify_params */ &vdaf_verify_params,
+            /* vdaf_verify_keys */ &vdaf_verify_keys,
         ];
-        let vdaf_verify_params_future = self.tx.execute(&stmt, vdaf_verify_params_params);
+        let vdaf_verify_keys_future = self.tx.execute(&stmt, vdaf_verify_keys_params);
 
         try_join!(
             auth_tokens_future,
             hpke_configs_future,
-            vdaf_verify_params_future
+            vdaf_verify_keys_future
         )?;
 
         Ok(())
@@ -316,17 +317,17 @@ impl<C: Clock> Transaction<'_, C> {
         let stmt = self
             .tx
             .prepare_cached(
-                "SELECT vdaf_verify_param FROM task_vdaf_verify_params
+                "SELECT vdaf_verify_key FROM task_vdaf_verify_keys
                 WHERE task_id = (SELECT id FROM tasks WHERE task_id = $1)",
             )
             .await?;
-        let vdaf_verify_param_rows = self.tx.query(&stmt, params);
+        let vdaf_verify_key_rows = self.tx.query(&stmt, params);
 
-        let (task_row, agg_auth_token_rows, hpke_key_rows, vdaf_verify_param_rows) = try_join!(
+        let (task_row, agg_auth_token_rows, hpke_key_rows, vdaf_verify_key_rows) = try_join!(
             task_row,
             agg_auth_token_rows,
             hpke_key_rows,
-            vdaf_verify_param_rows,
+            vdaf_verify_key_rows,
         )?;
         task_row
             .map(|task_row| {
@@ -335,7 +336,7 @@ impl<C: Clock> Transaction<'_, C> {
                     task_row,
                     agg_auth_token_rows,
                     hpke_key_rows,
-                    vdaf_verify_param_rows,
+                    vdaf_verify_key_rows,
                 )
             })
             .transpose()
@@ -376,16 +377,16 @@ impl<C: Clock> Transaction<'_, C> {
         let hpke_config_rows = self.tx.query(&stmt, &[]);
 
         let stmt = self.tx.prepare_cached(
-            "SELECT (SELECT tasks.task_id FROM tasks WHERE tasks.id = task_vdaf_verify_params.task_id),
-            vdaf_verify_param FROM task_vdaf_verify_params"
+            "SELECT (SELECT tasks.task_id FROM tasks WHERE tasks.id = task_vdaf_verify_keys.task_id),
+            vdaf_verify_key FROM task_vdaf_verify_keys"
         ).await?;
-        let vdaf_verify_param_rows = self.tx.query(&stmt, &[]);
+        let vdaf_verify_key_rows = self.tx.query(&stmt, &[]);
 
-        let (task_rows, agg_auth_token_rows, hpke_config_rows, vdaf_verify_param_rows) = try_join!(
+        let (task_rows, agg_auth_token_rows, hpke_config_rows, vdaf_verify_key_rows) = try_join!(
             task_rows,
             agg_auth_token_rows,
             hpke_config_rows,
-            vdaf_verify_param_rows
+            vdaf_verify_key_rows
         )?;
 
         let mut task_row_by_id = Vec::new();
@@ -412,10 +413,10 @@ impl<C: Clock> Transaction<'_, C> {
                 .push(row);
         }
 
-        let mut vdaf_verify_param_rows_by_task_id: HashMap<TaskId, Vec<Row>> = HashMap::new();
-        for row in vdaf_verify_param_rows {
+        let mut vdaf_verify_key_rows_by_task_id: HashMap<TaskId, Vec<Row>> = HashMap::new();
+        for row in vdaf_verify_key_rows {
             let task_id = TaskId::get_decoded(row.get("task_id"))?;
-            vdaf_verify_param_rows_by_task_id
+            vdaf_verify_key_rows_by_task_id
                 .entry(task_id)
                 .or_default()
                 .push(row);
@@ -433,7 +434,7 @@ impl<C: Clock> Transaction<'_, C> {
                     hpke_config_rows_by_task_id
                         .remove(&task_id)
                         .unwrap_or_default(),
-                    vdaf_verify_param_rows_by_task_id
+                    vdaf_verify_key_rows_by_task_id
                         .remove(&task_id)
                         .unwrap_or_default(),
                 )
@@ -451,7 +452,7 @@ impl<C: Clock> Transaction<'_, C> {
         row: Row,
         agg_auth_token_rows: Vec<Row>,
         hpke_key_rows: Vec<Row>,
-        vdaf_verify_param_rows: Vec<Row>,
+        vdaf_verify_key_rows: Vec<Row>,
     ) -> Result<Task, Error> {
         // Scalar task parameters.
         let aggregator_role: AggregatorRole = row.get("aggregator_role");
@@ -508,15 +509,14 @@ impl<C: Clock> Transaction<'_, C> {
             hpke_configs.push((config, private_key));
         }
 
-        let mut vdaf_verify_params = Vec::new();
-        for row in vdaf_verify_param_rows {
-            let encrypted_vdaf_verify_param: Vec<u8> = row.get("vdaf_verify_param");
-
-            vdaf_verify_params.push(self.crypter.decrypt(
-                "task_vdaf_verify_params",
+        let mut vdaf_verify_keys = Vec::new();
+        for row in vdaf_verify_key_rows {
+            let encrypted_vdaf_verify_key: Vec<u8> = row.get("vdaf_verify_key");
+            vdaf_verify_keys.push(self.crypter.decrypt(
+                "task_vdaf_verify_keys",
                 task_id.as_bytes(),
-                "vdaf_verify_param",
-                &encrypted_vdaf_verify_param,
+                "vdaf_verify_key",
+                &encrypted_vdaf_verify_key,
             )?);
         }
 
@@ -525,7 +525,7 @@ impl<C: Clock> Transaction<'_, C> {
             endpoints,
             vdaf,
             aggregator_role.as_role(),
-            vdaf_verify_params,
+            vdaf_verify_keys,
             max_batch_lifetime,
             min_batch_size,
             min_batch_duration,
@@ -688,11 +688,11 @@ impl<C: Clock> Transaction<'_, C> {
 
     /// get_aggregation_job retrieves an aggregation job by ID.
     #[tracing::instrument(skip(self), err)]
-    pub async fn get_aggregation_job<A: vdaf::Aggregator>(
+    pub async fn get_aggregation_job<const L: usize, A: vdaf::Aggregator<L>>(
         &self,
         task_id: TaskId,
         aggregation_job_id: AggregationJobId,
-    ) -> Result<Option<AggregationJob<A>>, Error>
+    ) -> Result<Option<AggregationJob<L, A>>, Error>
     where
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
@@ -721,10 +721,10 @@ impl<C: Clock> Transaction<'_, C> {
     /// intended for use in tests.
     #[tracing::instrument(skip(self), err)]
     #[doc(hidden)]
-    pub async fn get_aggregation_jobs_for_task_id<A: vdaf::Aggregator>(
+    pub async fn get_aggregation_jobs_for_task_id<const L: usize, A: vdaf::Aggregator<L>>(
         &self,
         task_id: TaskId,
-    ) -> Result<Vec<AggregationJob<A>>, Error>
+    ) -> Result<Vec<AggregationJob<L, A>>, Error>
     where
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
@@ -748,11 +748,11 @@ impl<C: Clock> Transaction<'_, C> {
             .collect()
     }
 
-    fn aggregation_job_from_row<A: vdaf::Aggregator>(
+    fn aggregation_job_from_row<const L: usize, A: vdaf::Aggregator<L>>(
         task_id: TaskId,
         aggregation_job_id: AggregationJobId,
         row: Row,
-    ) -> Result<AggregationJob<A>, Error>
+    ) -> Result<AggregationJob<L, A>, Error>
     where
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
@@ -873,9 +873,9 @@ impl<C: Clock> Transaction<'_, C> {
 
     /// put_aggregation_job stores an aggregation job.
     #[tracing::instrument(skip(self), err)]
-    pub async fn put_aggregation_job<A: vdaf::Aggregator>(
+    pub async fn put_aggregation_job<const L: usize, A: vdaf::Aggregator<L>>(
         &self,
-        aggregation_job: &AggregationJob<A>,
+        aggregation_job: &AggregationJob<L, A>,
     ) -> Result<(), Error>
     where
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
@@ -900,9 +900,9 @@ impl<C: Clock> Transaction<'_, C> {
 
     /// update_aggregation_job updates a stored aggregation job.
     #[tracing::instrument(skip(self), err)]
-    pub async fn update_aggregation_job<A: vdaf::Aggregator>(
+    pub async fn update_aggregation_job<const L: usize, A: vdaf::Aggregator<L>>(
         &self,
-        aggregation_job: &AggregationJob<A>,
+        aggregation_job: &AggregationJob<L, A>,
     ) -> Result<(), Error>
     where
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
@@ -933,15 +933,16 @@ impl<C: Clock> Transaction<'_, C> {
 
     /// get_report_aggregation gets a report aggregation by ID.
     #[tracing::instrument(skip(self), err)]
-    pub async fn get_report_aggregation<A: vdaf::Aggregator>(
+    pub async fn get_report_aggregation<const L: usize, A: vdaf::Aggregator<L>>(
         &self,
-        verify_param: &A::VerifyParam,
+        vdaf: &A,
+        role: Role,
         task_id: TaskId,
         aggregation_job_id: AggregationJobId,
         nonce: Nonce,
-    ) -> Result<Option<ReportAggregation<A>>, Error>
+    ) -> Result<Option<ReportAggregation<L, A>>, Error>
     where
-        A::PrepareStep: ParameterizedDecode<A::VerifyParam>,
+        for<'a> A::PrepareState: ParameterizedDecode<(&'a A, usize)>,
         A::OutputShare: for<'a> TryFrom<&'a [u8]>,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
@@ -973,21 +974,25 @@ impl<C: Clock> Transaction<'_, C> {
                 ],
             )
             .await?
-            .map(|row| report_aggregation_from_row(verify_param, task_id, aggregation_job_id, row))
+            .map(|row| report_aggregation_from_row(vdaf, role, task_id, aggregation_job_id, row))
             .transpose()
     }
 
     /// get_report_aggregations_for_aggregation_job retrieves all report aggregations associated
     /// with a given aggregation job, ordered by their natural ordering.
     #[tracing::instrument(skip(self), err)]
-    pub async fn get_report_aggregations_for_aggregation_job<A: vdaf::Aggregator>(
+    pub async fn get_report_aggregations_for_aggregation_job<
+        const L: usize,
+        A: vdaf::Aggregator<L>,
+    >(
         &self,
-        verify_param: &A::VerifyParam,
+        vdaf: &A,
+        role: Role,
         task_id: TaskId,
         aggregation_job_id: AggregationJobId,
-    ) -> Result<Vec<ReportAggregation<A>>, Error>
+    ) -> Result<Vec<ReportAggregation<L, A>>, Error>
     where
-        A::PrepareStep: ParameterizedDecode<A::VerifyParam>,
+        for<'a> A::PrepareState: ParameterizedDecode<(&'a A, usize)>,
         A::OutputShare: for<'a> TryFrom<&'a [u8]>,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
@@ -1014,18 +1019,18 @@ impl<C: Clock> Transaction<'_, C> {
             )
             .await?
             .into_iter()
-            .map(|row| report_aggregation_from_row(verify_param, task_id, aggregation_job_id, row))
+            .map(|row| report_aggregation_from_row(vdaf, role, task_id, aggregation_job_id, row))
             .collect()
     }
 
     /// put_report_aggregation stores aggregation data for a single report.
     #[tracing::instrument(skip(self), err)]
-    pub async fn put_report_aggregation<A: vdaf::Aggregator>(
+    pub async fn put_report_aggregation<const L: usize, A: vdaf::Aggregator<L>>(
         &self,
-        report_aggregation: &ReportAggregation<A>,
+        report_aggregation: &ReportAggregation<L, A>,
     ) -> Result<(), Error>
     where
-        A::PrepareStep: Encode,
+        A::PrepareState: Encode,
         for<'a> &'a A::OutputShare: Into<Vec<u8>>,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
@@ -1065,12 +1070,12 @@ impl<C: Clock> Transaction<'_, C> {
     }
 
     #[tracing::instrument(skip(self), err)]
-    pub async fn update_report_aggregation<A: vdaf::Aggregator>(
+    pub async fn update_report_aggregation<const L: usize, A: vdaf::Aggregator<L>>(
         &self,
-        report_aggregation: &ReportAggregation<A>,
+        report_aggregation: &ReportAggregation<L, A>,
     ) -> Result<(), Error>
     where
-        A::PrepareStep: Encode,
+        A::PrepareState: Encode,
         for<'a> &'a A::OutputShare: Into<Vec<u8>>,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
@@ -1134,12 +1139,11 @@ impl<C: Clock> Transaction<'_, C> {
 
     /// Returns the collect job for the provided UUID, or `None` if no such collect job exists.
     #[tracing::instrument(skip(self), err)]
-    pub(crate) async fn get_collect_job<A: vdaf::Aggregator>(
+    pub(crate) async fn get_collect_job<const L: usize, A: vdaf::Aggregator<L>>(
         &self,
         collect_job_id: Uuid,
-    ) -> Result<Option<CollectJob<A>>, Error>
+    ) -> Result<Option<CollectJob<L, A>>, Error>
     where
-        A: vdaf::Aggregator,
         for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Display,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
@@ -1404,14 +1408,13 @@ ORDER BY id DESC
     /// Updates an existing collect job with the provided aggregate shares.
     // TODO(#242): update this function to take a CollectJob.
     #[tracing::instrument(skip(self), err)]
-    pub(crate) async fn update_collect_job<A: vdaf::Aggregator>(
+    pub(crate) async fn update_collect_job<const L: usize, A: vdaf::Aggregator<L>>(
         &self,
         collect_job_id: Uuid,
         leader_aggregate_share: &A::AggregateShare,
         helper_aggregate_share: &HpkeCiphertext,
     ) -> Result<(), Error>
     where
-        A: vdaf::Aggregator,
         for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Display,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
@@ -1446,12 +1449,11 @@ ORDER BY id DESC
 
     /// Store a new `batch_unit_aggregations` row in the datastore.
     #[tracing::instrument(skip(self), err)]
-    pub(crate) async fn put_batch_unit_aggregation<A>(
+    pub(crate) async fn put_batch_unit_aggregation<const L: usize, A: vdaf::Aggregator<L>>(
         &self,
-        batch_unit_aggregation: &BatchUnitAggregation<A>,
+        batch_unit_aggregation: &BatchUnitAggregation<L, A>,
     ) -> Result<(), Error>
     where
-        A: vdaf::Aggregator,
         A::AggregationParam: Encode + std::fmt::Debug,
         A::AggregateShare: std::fmt::Debug,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
@@ -1491,12 +1493,11 @@ ORDER BY id DESC
     /// Update an existing `batch_unit_aggregations` row with the `aggregate_share`, `checksum` and
     /// `report_count` values in `batch_unit_aggregation`.
     #[tracing::instrument(skip(self), err)]
-    pub(crate) async fn update_batch_unit_aggregation<A>(
+    pub(crate) async fn update_batch_unit_aggregation<const L: usize, A: vdaf::Aggregator<L>>(
         &self,
-        batch_unit_aggregation: &BatchUnitAggregation<A>,
+        batch_unit_aggregation: &BatchUnitAggregation<L, A>,
     ) -> Result<(), Error>
     where
-        A: vdaf::Aggregator,
         A::AggregationParam: Encode + std::fmt::Debug,
         A::AggregateShare: std::fmt::Debug,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
@@ -1542,14 +1543,16 @@ ORDER BY id DESC
     /// Fetch all the `batch_unit_aggregations` rows whose `unit_interval_start` describes an
     /// interval that falls within the provided `interval` and whose `aggregation_param` matches.
     #[tracing::instrument(skip(self, aggregation_param), err)]
-    pub(crate) async fn get_batch_unit_aggregations_for_task_in_interval<A>(
+    pub(crate) async fn get_batch_unit_aggregations_for_task_in_interval<
+        const L: usize,
+        A: vdaf::Aggregator<L>,
+    >(
         &self,
         task_id: TaskId,
         interval: Interval,
         aggregation_param: &A::AggregationParam,
-    ) -> Result<Vec<BatchUnitAggregation<A>>, Error>
+    ) -> Result<Vec<BatchUnitAggregation<L, A>>, Error>
     where
-        A: vdaf::Aggregator,
         A::AggregationParam: Encode + Clone,
         for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Display,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
@@ -1608,12 +1611,11 @@ ORDER BY id DESC
     /// Fetch an `aggregate_share_jobs` row from the datastore corresponding to the provided
     /// [`AggregateShareRequest`], or `None` if no such job exists.
     #[tracing::instrument(skip(self), err)]
-    pub(crate) async fn get_aggregate_share_job_by_request<A>(
+    pub(crate) async fn get_aggregate_share_job_by_request<const L: usize, A: vdaf::Aggregator<L>>(
         &self,
         request: &AggregateShareReq,
-    ) -> Result<Option<AggregateShareJob<A>>, Error>
+    ) -> Result<Option<AggregateShareJob<L, A>>, Error>
     where
-        A: vdaf::Aggregator,
         for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Display,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
@@ -1730,12 +1732,11 @@ ORDER BY id DESC
 
     /// Put an `aggregate_share_job` row into the datastore.
     #[tracing::instrument(skip(self), err)]
-    pub(crate) async fn put_aggregate_share_job<A>(
+    pub(crate) async fn put_aggregate_share_job<const L: usize, A: vdaf::Aggregator<L>>(
         &self,
-        job: &AggregateShareJob<A>,
+        job: &AggregateShareJob<L, A>,
     ) -> Result<(), Error>
     where
-        A: vdaf::Aggregator,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
         for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Display,
     {
@@ -1785,14 +1786,15 @@ fn check_update(row_count: u64) -> Result<(), Error> {
     }
 }
 
-fn report_aggregation_from_row<A: vdaf::Aggregator>(
-    verify_param: &A::VerifyParam,
+fn report_aggregation_from_row<const L: usize, A: vdaf::Aggregator<L>>(
+    vdaf: &A,
+    role: Role,
     task_id: TaskId,
     aggregation_job_id: AggregationJobId,
     row: Row,
-) -> Result<ReportAggregation<A>, Error>
+) -> Result<ReportAggregation<L, A>, Error>
 where
-    A::PrepareStep: ParameterizedDecode<A::VerifyParam>,
+    for<'a> A::PrepareState: ParameterizedDecode<(&'a A, usize)>,
     A::OutputShare: for<'a> TryFrom<&'a [u8]>,
     for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
 {
@@ -1825,8 +1827,11 @@ where
     let agg_state = match state {
         ReportAggregationStateCode::Start => ReportAggregationState::Start,
         ReportAggregationStateCode::Waiting => {
-            let prep_state = A::PrepareStep::get_decoded_with_param(
-                verify_param,
+            let agg_index = role
+                .index()
+                .ok_or_else(|| Error::User(anyhow!("unexpected role: {}", role.as_str()).into()))?;
+            let prep_state = A::PrepareState::get_decoded_with_param(
+                &(vdaf, agg_index),
                 &prep_state_bytes.ok_or_else(|| {
                     Error::DbState(
                         "report aggregation in state WAITING but prep_state is NULL".to_string(),
@@ -2158,7 +2163,7 @@ pub mod models {
 
     /// AggregationJob represents an aggregation job from the PPM specification.
     #[derive(Clone, Debug)]
-    pub struct AggregationJob<A: vdaf::Aggregator>
+    pub struct AggregationJob<const L: usize, A: vdaf::Aggregator<L>>
     where
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
@@ -2168,7 +2173,7 @@ pub mod models {
         pub state: AggregationJobState,
     }
 
-    impl<A: vdaf::Aggregator> PartialEq for AggregationJob<A>
+    impl<const L: usize, A: vdaf::Aggregator<L>> PartialEq for AggregationJob<L, A>
     where
         A::AggregationParam: PartialEq,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
@@ -2181,7 +2186,7 @@ pub mod models {
         }
     }
 
-    impl<A: vdaf::Aggregator> Eq for AggregationJob<A>
+    impl<const L: usize, A: vdaf::Aggregator<L>> Eq for AggregationJob<L, A>
     where
         A::AggregationParam: Eq,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
@@ -2278,7 +2283,7 @@ pub mod models {
 
     /// ReportAggregation represents a the state of a single client report's ongoing aggregation.
     #[derive(Clone, Debug)]
-    pub struct ReportAggregation<A: vdaf::Aggregator>
+    pub struct ReportAggregation<const L: usize, A: vdaf::Aggregator<L>>
     where
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
@@ -2286,12 +2291,12 @@ pub mod models {
         pub task_id: TaskId,
         pub nonce: Nonce,
         pub ord: i64,
-        pub state: ReportAggregationState<A>,
+        pub state: ReportAggregationState<L, A>,
     }
 
-    impl<A: vdaf::Aggregator> PartialEq for ReportAggregation<A>
+    impl<const L: usize, A: vdaf::Aggregator<L>> PartialEq for ReportAggregation<L, A>
     where
-        A::PrepareStep: PartialEq,
+        A::PrepareState: PartialEq,
         A::PrepareMessage: PartialEq,
         A::OutputShare: PartialEq,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
@@ -2305,9 +2310,9 @@ pub mod models {
         }
     }
 
-    impl<A: vdaf::Aggregator> Eq for ReportAggregation<A>
+    impl<const L: usize, A: vdaf::Aggregator<L>> Eq for ReportAggregation<L, A>
     where
-        A::PrepareStep: Eq,
+        A::PrepareState: Eq,
         A::PrepareMessage: Eq,
         A::OutputShare: Eq,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
@@ -2317,18 +2322,18 @@ pub mod models {
     /// ReportAggregationState represents the state of a single report aggregation. It corresponds
     /// to the REPORT_AGGREGATION_STATE enum in the schema, along with the state-specific data.
     #[derive(Clone, Debug)]
-    pub enum ReportAggregationState<A: vdaf::Aggregator>
+    pub enum ReportAggregationState<const L: usize, A: vdaf::Aggregator<L>>
     where
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
         Start,
-        Waiting(A::PrepareStep, Option<A::PrepareMessage>),
+        Waiting(A::PrepareState, Option<A::PrepareMessage>),
         Finished(A::OutputShare),
         Failed(ReportShareError),
         Invalid,
     }
 
-    impl<A: vdaf::Aggregator> ReportAggregationState<A>
+    impl<const L: usize, A: vdaf::Aggregator<L>> ReportAggregationState<L, A>
     where
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
@@ -2347,14 +2352,14 @@ pub mod models {
         /// message, output share, transition error.
         pub(super) fn encoded_values_from_state(&self) -> EncodedReportAggregationStateValues
         where
-            A::PrepareStep: Encode,
+            A::PrepareState: Encode,
             for<'a> &'a A::OutputShare: Into<Vec<u8>>,
             for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
         {
             let (prep_state, prep_msg, output_share, report_share_err) = match self {
                 ReportAggregationState::Start => (None, None, None, None),
-                ReportAggregationState::Waiting(prep_step, prep_msg) => (
-                    Some(prep_step.get_encoded()),
+                ReportAggregationState::Waiting(prep_state, prep_msg) => (
+                    Some(prep_state.get_encoded()),
                     prep_msg.as_ref().map(|msg| msg.get_encoded()),
                     None,
                     None,
@@ -2402,9 +2407,9 @@ pub mod models {
         Invalid,
     }
 
-    impl<A: vdaf::Aggregator> PartialEq for ReportAggregationState<A>
+    impl<const L: usize, A: vdaf::Aggregator<L>> PartialEq for ReportAggregationState<L, A>
     where
-        A::PrepareStep: PartialEq,
+        A::PrepareState: PartialEq,
         A::PrepareMessage: PartialEq,
         A::OutputShare: PartialEq,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
@@ -2412,9 +2417,9 @@ pub mod models {
         fn eq(&self, other: &Self) -> bool {
             match (self, other) {
                 (
-                    Self::Waiting(lhs_prep_step, lhs_prep_msg),
-                    Self::Waiting(rhs_prep_step, rhs_prep_msg),
-                ) => lhs_prep_step == rhs_prep_step && lhs_prep_msg == rhs_prep_msg,
+                    Self::Waiting(lhs_prep_state, lhs_prep_msg),
+                    Self::Waiting(rhs_prep_state, rhs_prep_msg),
+                ) => lhs_prep_state == rhs_prep_state && lhs_prep_msg == rhs_prep_msg,
                 (Self::Finished(lhs_out_share), Self::Finished(rhs_out_share)) => {
                     lhs_out_share == rhs_out_share
                 }
@@ -2426,9 +2431,9 @@ pub mod models {
         }
     }
 
-    impl<A: vdaf::Aggregator> Eq for ReportAggregationState<A>
+    impl<const L: usize, A: vdaf::Aggregator<L>> Eq for ReportAggregationState<L, A>
     where
-        A::PrepareStep: Eq,
+        A::PrepareState: Eq,
         A::PrepareMessage: Eq,
         A::OutputShare: Eq,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
@@ -2443,7 +2448,7 @@ pub mod models {
     /// consists of one or more `BatchUnitAggregation`s merged together.
     #[derive(Clone, Derivative)]
     #[derivative(Debug)]
-    pub(crate) struct BatchUnitAggregation<A: vdaf::Aggregator>
+    pub(crate) struct BatchUnitAggregation<const L: usize, A: vdaf::Aggregator<L>>
     where
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
@@ -2467,7 +2472,7 @@ pub mod models {
         pub(crate) checksum: NonceChecksum,
     }
 
-    impl<A: vdaf::Aggregator> PartialEq for BatchUnitAggregation<A>
+    impl<const L: usize, A: vdaf::Aggregator<L>> PartialEq for BatchUnitAggregation<L, A>
     where
         A::AggregationParam: PartialEq,
         A::AggregateShare: PartialEq,
@@ -2483,7 +2488,7 @@ pub mod models {
         }
     }
 
-    impl<A: vdaf::Aggregator> Eq for BatchUnitAggregation<A>
+    impl<const L: usize, A: vdaf::Aggregator<L>> Eq for BatchUnitAggregation<L, A>
     where
         A::AggregationParam: Eq,
         A::AggregateShare: Eq,
@@ -2495,7 +2500,7 @@ pub mod models {
     /// running collect jobs and store the results of completed ones.
     #[derive(Clone, Derivative)]
     #[derivative(Debug)]
-    pub(crate) struct CollectJob<A: vdaf::Aggregator>
+    pub(crate) struct CollectJob<const L: usize, A: vdaf::Aggregator<L>>
     where
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
@@ -2509,12 +2514,12 @@ pub mod models {
         #[derivative(Debug = "ignore")]
         pub(crate) aggregation_param: A::AggregationParam,
         /// The current state of the collect job.
-        pub(crate) state: CollectJobState<A>,
+        pub(crate) state: CollectJobState<L, A>,
     }
 
     #[derive(Clone, Derivative)]
     #[derivative(Debug)]
-    pub(crate) enum CollectJobState<A: vdaf::Aggregator>
+    pub(crate) enum CollectJobState<const L: usize, A: vdaf::Aggregator<L>>
     where
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
@@ -2529,7 +2534,7 @@ pub mod models {
         },
     }
 
-    impl<A: vdaf::Aggregator> PartialEq for CollectJobState<A>
+    impl<const L: usize, A: vdaf::Aggregator<L>> PartialEq for CollectJobState<L, A>
     where
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
         A::AggregateShare: PartialEq,
@@ -2554,7 +2559,7 @@ pub mod models {
         }
     }
 
-    impl<A: vdaf::Aggregator> Eq for CollectJobState<A>
+    impl<const L: usize, A: vdaf::Aggregator<L>> Eq for CollectJobState<L, A>
     where
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
         A::AggregateShare: Eq,
@@ -2574,7 +2579,7 @@ pub mod models {
     /// store the results of handling an AggregateShareReq from the leader.
     #[derive(Clone, Derivative)]
     #[derivative(Debug)]
-    pub(crate) struct AggregateShareJob<A: vdaf::Aggregator>
+    pub(crate) struct AggregateShareJob<const L: usize, A: vdaf::Aggregator<L>>
     where
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
@@ -2595,7 +2600,7 @@ pub mod models {
         pub(crate) checksum: NonceChecksum,
     }
 
-    impl<A: vdaf::Aggregator> PartialEq for AggregateShareJob<A>
+    impl<const L: usize, A: vdaf::Aggregator<L>> PartialEq for AggregateShareJob<L, A>
     where
         A::AggregationParam: PartialEq,
         A::AggregateShare: PartialEq,
@@ -2611,7 +2616,7 @@ pub mod models {
         }
     }
 
-    impl<A: vdaf::Aggregator> Eq for AggregateShareJob<A>
+    impl<const L: usize, A: vdaf::Aggregator<L>> Eq for AggregateShareJob<L, A>
     where
         A::AggregationParam: Eq,
         A::AggregateShare: Eq,
@@ -2637,7 +2642,7 @@ mod tests {
             test_util::ephemeral_datastore,
         },
         message::{test_util::new_dummy_report, ReportShareError},
-        task::{test_util::new_dummy_task, VdafInstance},
+        task::{test_util::new_dummy_task, VdafInstance, PRIO3_AES128_VERIFY_KEY_LENGTH},
         trace::test_util::install_test_trace_subscriber,
     };
     use ::janus_test_util::{dummy_vdaf, generate_aead_key, MockClock};
@@ -2652,13 +2657,14 @@ mod tests {
         vdaf::{
             poplar1::{IdpfInput, Poplar1, ToyIdpf},
             prg::PrgAes128,
-            prio3::Prio3Aes128Count,
+            prio3::{Prio3, Prio3Aes128Count},
             AggregateShare, PrepareTransition,
         },
     };
     use std::{
         collections::{BTreeSet, HashMap, HashSet},
         iter, mem,
+        sync::Arc,
     };
 
     #[tokio::test]
@@ -2897,20 +2903,28 @@ mod tests {
                 tx.put_client_report(&unrelated_report).await?;
 
                 let aggregation_job_id = AggregationJobId::random();
-                tx.put_aggregation_job(&AggregationJob::<Prio3Aes128Count> {
+                tx.put_aggregation_job(&AggregationJob::<
+                    PRIO3_AES128_VERIFY_KEY_LENGTH,
+                    Prio3Aes128Count,
+                > {
                     aggregation_job_id,
                     task_id: unrelated_task_id,
                     aggregation_param: (),
                     state: AggregationJobState::InProgress,
                 })
                 .await?;
-                tx.put_report_aggregation(&ReportAggregation {
-                    aggregation_job_id,
-                    task_id,
-                    nonce: aggregated_report.nonce(),
-                    ord: 0,
-                    state: ReportAggregationState::<Prio3Aes128Count>::Start,
-                })
+                tx.put_report_aggregation(
+                    &ReportAggregation {
+                        aggregation_job_id,
+                        task_id,
+                        nonce: aggregated_report.nonce(),
+                        ord: 0,
+                        state: ReportAggregationState::<
+                            PRIO3_AES128_VERIFY_KEY_LENGTH,
+                            Prio3Aes128Count,
+                        >::Start,
+                    },
+                )
                 .await
             })
         })
@@ -3013,8 +3027,9 @@ mod tests {
 
         // We use Poplar1 for this test as it has a non-trivial aggregation parameter, to allow
         // better exercising the serialization/deserialization roundtrip of the aggregation_param.
-        type ToyPoplar1 = Poplar1<ToyIdpf<Field128>, PrgAes128, 16>;
-        let aggregation_job = AggregationJob::<ToyPoplar1> {
+        const PRG_SEED_SIZE: usize = 16;
+        type ToyPoplar1 = Poplar1<ToyIdpf<Field128>, PrgAes128, PRG_SEED_SIZE>;
+        let aggregation_job = AggregationJob::<PRG_SEED_SIZE, ToyPoplar1> {
             aggregation_job_id: AggregationJobId::random(),
             task_id: TaskId::random(),
             aggregation_param: BTreeSet::from([
@@ -3103,7 +3118,10 @@ mod tests {
                 ))
                 .await?;
                 for aggregation_job_id in aggregation_job_ids {
-                    tx.put_aggregation_job(&AggregationJob::<Prio3Aes128Count> {
+                    tx.put_aggregation_job(&AggregationJob::<
+                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        Prio3Aes128Count,
+                    > {
                         aggregation_job_id,
                         task_id,
                         aggregation_param: (),
@@ -3113,7 +3131,10 @@ mod tests {
                 }
 
                 // Write an aggregation job that is finished. We don't want to retrieve this one.
-                tx.put_aggregation_job(&AggregationJob::<Prio3Aes128Count> {
+                tx.put_aggregation_job(&AggregationJob::<
+                    PRIO3_AES128_VERIFY_KEY_LENGTH,
+                    Prio3Aes128Count,
+                > {
                     aggregation_job_id: AggregationJobId::random(),
                     task_id,
                     aggregation_param: (),
@@ -3130,7 +3151,10 @@ mod tests {
                     Role::Helper,
                 ))
                 .await?;
-                tx.put_aggregation_job(&AggregationJob::<Prio3Aes128Count> {
+                tx.put_aggregation_job(&AggregationJob::<
+                    PRIO3_AES128_VERIFY_KEY_LENGTH,
+                    Prio3Aes128Count,
+                > {
                     aggregation_job_id: AggregationJobId::random(),
                     task_id: helper_task_id,
                     aggregation_param: (),
@@ -3340,7 +3364,7 @@ mod tests {
         let rslt = ds
             .run_tx(|tx| {
                 Box::pin(async move {
-                    tx.get_aggregation_job::<Prio3Aes128Count>(
+                    tx.get_aggregation_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
                         TaskId::random(),
                         AggregationJobId::random(),
                     )
@@ -3354,12 +3378,14 @@ mod tests {
         let rslt = ds
             .run_tx(|tx| {
                 Box::pin(async move {
-                    tx.update_aggregation_job::<Prio3Aes128Count>(&AggregationJob {
-                        aggregation_job_id: AggregationJobId::random(),
-                        task_id: TaskId::random(),
-                        aggregation_param: (),
-                        state: AggregationJobState::InProgress,
-                    })
+                    tx.update_aggregation_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                        &AggregationJob {
+                            aggregation_job_id: AggregationJobId::random(),
+                            task_id: TaskId::random(),
+                            aggregation_param: (),
+                            state: AggregationJobState::InProgress,
+                        },
+                    )
                     .await
                 })
             })
@@ -3375,9 +3401,10 @@ mod tests {
 
         // We use Poplar1 for this test as it has a non-trivial aggregation parameter, to allow
         // better exercising the serialization/deserialization roundtrip of the aggregation_param.
-        type ToyPoplar1 = Poplar1<ToyIdpf<Field128>, PrgAes128, 16>;
+        const PRG_SEED_SIZE: usize = 16;
+        type ToyPoplar1 = Poplar1<ToyIdpf<Field128>, PrgAes128, PRG_SEED_SIZE>;
         let task_id = TaskId::random();
-        let first_aggregation_job = AggregationJob::<ToyPoplar1> {
+        let first_aggregation_job = AggregationJob::<PRG_SEED_SIZE, ToyPoplar1> {
             aggregation_job_id: AggregationJobId::random(),
             task_id,
             aggregation_param: BTreeSet::from([
@@ -3386,7 +3413,7 @@ mod tests {
             ]),
             state: AggregationJobState::InProgress,
         };
-        let second_aggregation_job = AggregationJob::<ToyPoplar1> {
+        let second_aggregation_job = AggregationJob::<PRG_SEED_SIZE, ToyPoplar1> {
             aggregation_job_id: AggregationJobId::random(),
             task_id,
             aggregation_param: BTreeSet::from([
@@ -3420,7 +3447,7 @@ mod tests {
                     Role::Leader,
                 ))
                 .await?;
-                tx.put_aggregation_job(&AggregationJob::<ToyPoplar1> {
+                tx.put_aggregation_job(&AggregationJob::<PRG_SEED_SIZE, ToyPoplar1> {
                     aggregation_job_id: AggregationJobId::random(),
                     task_id: unrelated_task_id,
                     aggregation_param: BTreeSet::from([
@@ -3455,13 +3482,13 @@ mod tests {
         install_test_trace_subscriber();
         let (ds, _db_handle) = ephemeral_datastore(MockClock::default()).await;
 
-        let vdaf = Prio3Aes128Count::new(2).unwrap();
-        let (verify_param, prep_step, prep_msg, output_share) = generate_vdaf_values(vdaf, (), 0);
+        let vdaf = Arc::new(Prio3::new_aes128_count(2).unwrap());
+        let (prep_state, prep_msg, output_share) = generate_vdaf_values(vdaf.as_ref(), (), 0);
 
         for (ord, state) in [
-            ReportAggregationState::<Prio3Aes128Count>::Start,
-            ReportAggregationState::Waiting(prep_step.clone(), None),
-            ReportAggregationState::Waiting(prep_step, Some(prep_msg)),
+            ReportAggregationState::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>::Start,
+            ReportAggregationState::Waiting(prep_state.clone(), None),
+            ReportAggregationState::Waiting(prep_state, Some(prep_msg)),
             ReportAggregationState::Finished(output_share),
             ReportAggregationState::Failed(ReportShareError::VdafPrepError),
             ReportAggregationState::Invalid,
@@ -3486,7 +3513,10 @@ mod tests {
                             Role::Leader,
                         ))
                         .await?;
-                        tx.put_aggregation_job(&AggregationJob::<Prio3Aes128Count> {
+                        tx.put_aggregation_job(&AggregationJob::<
+                            PRIO3_AES128_VERIFY_KEY_LENGTH,
+                            Prio3Aes128Count,
+                        > {
                             aggregation_job_id,
                             task_id,
                             aggregation_param: (),
@@ -3523,10 +3553,11 @@ mod tests {
 
             let got_report_aggregation = ds
                 .run_tx(|tx| {
-                    let verify_param = verify_param.clone();
+                    let vdaf = Arc::clone(&vdaf);
                     Box::pin(async move {
-                        tx.get_report_aggregation::<Prio3Aes128Count>(
-                            &verify_param,
+                        tx.get_report_aggregation(
+                            vdaf.as_ref(),
+                            Role::Leader,
                             task_id,
                             aggregation_job_id,
                             nonce,
@@ -3549,10 +3580,11 @@ mod tests {
 
             let got_report_aggregation = ds
                 .run_tx(|tx| {
-                    let verify_param = verify_param.clone();
+                    let vdaf = Arc::clone(&vdaf);
                     Box::pin(async move {
-                        tx.get_report_aggregation::<Prio3Aes128Count>(
-                            &verify_param,
+                        tx.get_report_aggregation(
+                            vdaf.as_ref(),
+                            Role::Leader,
                             task_id,
                             aggregation_job_id,
                             nonce,
@@ -3571,11 +3603,16 @@ mod tests {
         install_test_trace_subscriber();
         let (ds, _db_handle) = ephemeral_datastore(MockClock::default()).await;
 
+        const VERIFY_KEY_LENGTH: usize = FakeVdaf::VERIFY_KEY_LENGTH;
+        let vdaf = Arc::new(FakeVdaf::default());
+
         let rslt = ds
             .run_tx(|tx| {
+                let vdaf = Arc::clone(&vdaf);
                 Box::pin(async move {
-                    tx.get_report_aggregation::<dummy_vdaf::Vdaf>(
-                        &(),
+                    tx.get_report_aggregation(
+                        vdaf.as_ref(),
+                        Role::Leader,
                         TaskId::random(),
                         AggregationJobId::random(),
                         Nonce::new(
@@ -3593,16 +3630,18 @@ mod tests {
         let rslt = ds
             .run_tx(|tx| {
                 Box::pin(async move {
-                    tx.update_report_aggregation::<dummy_vdaf::Vdaf>(&ReportAggregation {
-                        aggregation_job_id: AggregationJobId::random(),
-                        task_id: TaskId::random(),
-                        nonce: Nonce::new(
-                            Time::from_seconds_since_epoch(12345),
-                            [1, 2, 3, 4, 5, 6, 7, 8],
-                        ),
-                        ord: 0,
-                        state: ReportAggregationState::Invalid,
-                    })
+                    tx.update_report_aggregation::<VERIFY_KEY_LENGTH, FakeVdaf>(
+                        &ReportAggregation {
+                            aggregation_job_id: AggregationJobId::random(),
+                            task_id: TaskId::random(),
+                            nonce: Nonce::new(
+                                Time::from_seconds_since_epoch(12345),
+                                [1, 2, 3, 4, 5, 6, 7, 8],
+                            ),
+                            ord: 0,
+                            state: ReportAggregationState::Invalid,
+                        },
+                    )
                     .await
                 })
             })
@@ -3615,8 +3654,8 @@ mod tests {
         install_test_trace_subscriber();
         let (ds, _db_handle) = ephemeral_datastore(MockClock::default()).await;
 
-        let vdaf = Prio3Aes128Count::new(2).unwrap();
-        let (verify_param, prep_step, prep_msg, output_share) = generate_vdaf_values(vdaf, (), 0);
+        let vdaf = Arc::new(Prio3::new_aes128_count(2).unwrap());
+        let (prep_state, prep_msg, output_share) = generate_vdaf_values(vdaf.as_ref(), (), 0);
 
         let task_id = TaskId::random();
         let aggregation_job_id = AggregationJobId::random();
@@ -3624,7 +3663,7 @@ mod tests {
         let report_aggregations = ds
             .run_tx(|tx| {
                 let prep_msg = prep_msg.clone();
-                let prep_step = prep_step.clone();
+                let prep_state = prep_state.clone();
                 let output_share = output_share.clone();
 
                 Box::pin(async move {
@@ -3634,7 +3673,10 @@ mod tests {
                         Role::Leader,
                     ))
                     .await?;
-                    tx.put_aggregation_job(&AggregationJob::<Prio3Aes128Count> {
+                    tx.put_aggregation_job(&AggregationJob::<
+                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        Prio3Aes128Count,
+                    > {
                         aggregation_job_id,
                         task_id,
                         aggregation_param: (),
@@ -3643,16 +3685,20 @@ mod tests {
                     .await?;
 
                     let mut report_aggregations = Vec::new();
-                    for (ord, state) in [
-                        ReportAggregationState::<Prio3Aes128Count>::Start,
-                        ReportAggregationState::Waiting(prep_step.clone(), None),
-                        ReportAggregationState::Waiting(prep_step, Some(prep_msg)),
-                        ReportAggregationState::Finished(output_share),
-                        ReportAggregationState::Failed(ReportShareError::VdafPrepError),
-                        ReportAggregationState::Invalid,
-                    ]
-                    .iter()
-                    .enumerate()
+                    for (ord, state) in
+                        [
+                            ReportAggregationState::<
+                                PRIO3_AES128_VERIFY_KEY_LENGTH,
+                                Prio3Aes128Count,
+                            >::Start,
+                            ReportAggregationState::Waiting(prep_state.clone(), None),
+                            ReportAggregationState::Waiting(prep_state, Some(prep_msg)),
+                            ReportAggregationState::Finished(output_share),
+                            ReportAggregationState::Failed(ReportShareError::VdafPrepError),
+                            ReportAggregationState::Invalid,
+                        ]
+                        .iter()
+                        .enumerate()
                     {
                         let nonce = Nonce::new(
                             Time::from_seconds_since_epoch(12345),
@@ -3690,11 +3736,11 @@ mod tests {
 
         let got_report_aggregations = ds
             .run_tx(|tx| {
-                let verify_param = verify_param.clone();
-
+                let vdaf = Arc::clone(&vdaf);
                 Box::pin(async move {
                     tx.get_report_aggregations_for_aggregation_job(
-                        &verify_param,
+                        vdaf.as_ref(),
+                        Role::Leader,
                         task_id,
                         aggregation_job_id,
                     )
@@ -3957,7 +4003,9 @@ mod tests {
                     .unwrap();
 
                 let first_collect_job = tx
-                    .get_collect_job::<Prio3Aes128Count>(first_collect_job_id)
+                    .get_collect_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                        first_collect_job_id,
+                    )
                     .await
                     .unwrap()
                     .unwrap();
@@ -3967,7 +4015,9 @@ mod tests {
                 assert_eq!(first_collect_job.state, CollectJobState::Start);
 
                 let second_collect_job = tx
-                    .get_collect_job::<Prio3Aes128Count>(second_collect_job_id)
+                    .get_collect_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                        second_collect_job_id,
+                    )
                     .await
                     .unwrap()
                     .unwrap();
@@ -3986,7 +4036,7 @@ mod tests {
                 )
                 .unwrap();
 
-                tx.update_collect_job::<Prio3Aes128Count>(
+                tx.update_collect_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
                     first_collect_job_id,
                     &leader_aggregate_share,
                     &encrypted_helper_aggregate_share,
@@ -3995,7 +4045,9 @@ mod tests {
                 .unwrap();
 
                 let first_collect_job = tx
-                    .get_collect_job::<Prio3Aes128Count>(first_collect_job_id)
+                    .get_collect_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                        first_collect_job_id,
+                    )
                     .await
                     .unwrap()
                     .unwrap();
@@ -4033,8 +4085,8 @@ mod tests {
     struct CollectJobAcquireTestCase {
         task_ids: Vec<TaskId>,
         reports: Vec<Report>,
-        aggregation_jobs: Vec<AggregationJob<FakeVdaf>>,
-        report_aggregations: Vec<ReportAggregation<FakeVdaf>>,
+        aggregation_jobs: Vec<AggregationJob<0, FakeVdaf>>,
+        report_aggregations: Vec<ReportAggregation<0, FakeVdaf>>,
         collect_job_test_cases: Vec<CollectJobTestCase>,
     }
 
@@ -4042,6 +4094,7 @@ mod tests {
         ds: &Datastore<MockClock>,
         test_case: CollectJobAcquireTestCase,
     ) -> CollectJobAcquireTestCase {
+        const VERIFY_KEY_LENGTH: usize = FakeVdaf::VERIFY_KEY_LENGTH;
         ds.run_tx(|tx| {
             let mut test_case = test_case.clone();
             Box::pin(async move {
@@ -4072,7 +4125,7 @@ mod tests {
                         .await?;
 
                     if test_case.set_aggregate_shares {
-                        tx.update_collect_job::<FakeVdaf>(
+                        tx.update_collect_job::<VERIFY_KEY_LENGTH, FakeVdaf>(
                             collect_job_id,
                             &dummy_vdaf::AggregateShare(),
                             &HpkeCiphertext::new(HpkeConfigId::from(0), vec![], vec![]),
@@ -4143,16 +4196,18 @@ mod tests {
         let clock = MockClock::default();
         let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
 
+        const VERIFY_KEY_LENGTH: usize = FakeVdaf::VERIFY_KEY_LENGTH;
+
         let task_id = TaskId::random();
         let reports = vec![new_dummy_report(task_id, Time::from_seconds_since_epoch(0))];
         let aggregation_job_id = AggregationJobId::random();
-        let aggregation_jobs = vec![AggregationJob::<FakeVdaf> {
+        let aggregation_jobs = vec![AggregationJob::<VERIFY_KEY_LENGTH, FakeVdaf> {
             aggregation_job_id,
             aggregation_param: 0u8,
             task_id,
             state: AggregationJobState::Finished,
         }];
-        let report_aggregations = vec![ReportAggregation::<FakeVdaf> {
+        let report_aggregations = vec![ReportAggregation::<VERIFY_KEY_LENGTH, FakeVdaf> {
             aggregation_job_id,
             task_id,
             nonce: reports[0].nonce(),
@@ -4262,10 +4317,12 @@ mod tests {
         let clock = MockClock::default();
         let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
 
+        const VERIFY_KEY_LENGTH: usize = FakeVdaf::VERIFY_KEY_LENGTH;
+
         let task_id = TaskId::random();
         let other_task_id = TaskId::random();
 
-        let aggregation_jobs = vec![AggregationJob::<FakeVdaf> {
+        let aggregation_jobs = vec![AggregationJob::<VERIFY_KEY_LENGTH, FakeVdaf> {
             aggregation_job_id: AggregationJobId::random(),
             aggregation_param: 0u8,
             // Aggregation job task ID does not match collect job task ID
@@ -4305,10 +4362,12 @@ mod tests {
         let clock = MockClock::default();
         let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
 
+        const VERIFY_KEY_LENGTH: usize = FakeVdaf::VERIFY_KEY_LENGTH;
+
         let task_id = TaskId::random();
         let reports = vec![new_dummy_report(task_id, Time::from_seconds_since_epoch(0))];
 
-        let aggregation_jobs = vec![AggregationJob::<FakeVdaf> {
+        let aggregation_jobs = vec![AggregationJob::<VERIFY_KEY_LENGTH, FakeVdaf> {
             aggregation_job_id: AggregationJobId::random(),
             // Aggregation job agg param does not match collect job agg param
             aggregation_param: 1u8,
@@ -4348,6 +4407,8 @@ mod tests {
         let clock = MockClock::default();
         let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
 
+        const VERIFY_KEY_LENGTH: usize = FakeVdaf::VERIFY_KEY_LENGTH;
+
         let task_id = TaskId::random();
         let reports = vec![new_dummy_report(
             task_id,
@@ -4356,13 +4417,13 @@ mod tests {
             Time::from_seconds_since_epoch(200),
         )];
         let aggregation_job_id = AggregationJobId::random();
-        let aggregation_jobs = vec![AggregationJob::<FakeVdaf> {
+        let aggregation_jobs = vec![AggregationJob::<VERIFY_KEY_LENGTH, FakeVdaf> {
             aggregation_job_id,
             aggregation_param: 0u8,
             task_id,
             state: AggregationJobState::Finished,
         }];
-        let report_aggregations = vec![ReportAggregation::<FakeVdaf> {
+        let report_aggregations = vec![ReportAggregation::<VERIFY_KEY_LENGTH, FakeVdaf> {
             aggregation_job_id,
             task_id,
             nonce: reports[0].nonce(),
@@ -4403,17 +4464,19 @@ mod tests {
         let clock = MockClock::default();
         let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
 
+        const VERIFY_KEY_LENGTH: usize = FakeVdaf::VERIFY_KEY_LENGTH;
+
         let task_id = TaskId::random();
         let reports = vec![new_dummy_report(task_id, Time::from_seconds_since_epoch(0))];
         let aggregation_job_id = AggregationJobId::random();
-        let aggregation_jobs = vec![AggregationJob::<FakeVdaf> {
+        let aggregation_jobs = vec![AggregationJob::<VERIFY_KEY_LENGTH, FakeVdaf> {
             aggregation_job_id,
             aggregation_param: 0u8,
             task_id,
             state: AggregationJobState::Finished,
         }];
 
-        let report_aggregations = vec![ReportAggregation::<FakeVdaf> {
+        let report_aggregations = vec![ReportAggregation::<VERIFY_KEY_LENGTH, FakeVdaf> {
             aggregation_job_id,
             task_id,
             nonce: reports[0].nonce(),
@@ -4454,6 +4517,8 @@ mod tests {
         let clock = MockClock::default();
         let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
 
+        const VERIFY_KEY_LENGTH: usize = FakeVdaf::VERIFY_KEY_LENGTH;
+
         let task_id = TaskId::random();
         let reports = vec![
             new_dummy_report(task_id, Time::from_seconds_since_epoch(0)),
@@ -4462,13 +4527,13 @@ mod tests {
 
         let aggregation_job_ids = [AggregationJobId::random(), AggregationJobId::random()];
         let aggregation_jobs = vec![
-            AggregationJob::<FakeVdaf> {
+            AggregationJob::<VERIFY_KEY_LENGTH, FakeVdaf> {
                 aggregation_job_id: aggregation_job_ids[0],
                 aggregation_param: 0u8,
                 task_id,
                 state: AggregationJobState::Finished,
             },
-            AggregationJob::<FakeVdaf> {
+            AggregationJob::<VERIFY_KEY_LENGTH, FakeVdaf> {
                 aggregation_job_id: aggregation_job_ids[1],
                 aggregation_param: 0u8,
                 task_id,
@@ -4478,14 +4543,14 @@ mod tests {
         ];
 
         let report_aggregations = vec![
-            ReportAggregation::<FakeVdaf> {
+            ReportAggregation::<VERIFY_KEY_LENGTH, FakeVdaf> {
                 aggregation_job_id: aggregation_job_ids[0],
                 task_id,
                 nonce: reports[0].nonce(),
                 ord: 0,
                 state: ReportAggregationState::Start,
             },
-            ReportAggregation::<FakeVdaf> {
+            ReportAggregation::<VERIFY_KEY_LENGTH, FakeVdaf> {
                 aggregation_job_id: aggregation_job_ids[1],
                 task_id,
                 nonce: reports[1].nonce(),
@@ -4526,17 +4591,19 @@ mod tests {
         let clock = MockClock::default();
         let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
 
+        const VERIFY_KEY_LENGTH: usize = FakeVdaf::VERIFY_KEY_LENGTH;
+
         let task_id = TaskId::random();
         let reports = vec![new_dummy_report(task_id, Time::from_seconds_since_epoch(0))];
         let aggregation_job_ids = [AggregationJobId::random(), AggregationJobId::random()];
         let aggregation_jobs = vec![
-            AggregationJob::<FakeVdaf> {
+            AggregationJob::<VERIFY_KEY_LENGTH, FakeVdaf> {
                 aggregation_job_id: aggregation_job_ids[0],
                 aggregation_param: 0u8,
                 task_id,
                 state: AggregationJobState::Finished,
             },
-            AggregationJob::<FakeVdaf> {
+            AggregationJob::<VERIFY_KEY_LENGTH, FakeVdaf> {
                 aggregation_job_id: aggregation_job_ids[1],
                 aggregation_param: 1u8,
                 task_id,
@@ -4544,14 +4611,14 @@ mod tests {
             },
         ];
         let report_aggregations = vec![
-            ReportAggregation::<FakeVdaf> {
+            ReportAggregation::<VERIFY_KEY_LENGTH, FakeVdaf> {
                 aggregation_job_id: aggregation_job_ids[0],
                 task_id,
                 nonce: reports[0].nonce(),
                 ord: 0,
                 state: ReportAggregationState::Start,
             },
-            ReportAggregation::<FakeVdaf> {
+            ReportAggregation::<VERIFY_KEY_LENGTH, FakeVdaf> {
                 aggregation_job_id: aggregation_job_ids[1],
                 task_id,
                 nonce: reports[0].nonce(),
@@ -4653,7 +4720,8 @@ mod tests {
     async fn roundtrip_batch_unit_aggregation() {
         install_test_trace_subscriber();
 
-        type ToyPoplar1 = Poplar1<ToyIdpf<Field64>, PrgAes128, 16>;
+        const PRG_SEED_SIZE: usize = 16;
+        type ToyPoplar1 = Poplar1<ToyIdpf<Field64>, PrgAes128, PRG_SEED_SIZE>;
 
         let task_id = TaskId::random();
         let other_task_id = TaskId::random();
@@ -4681,35 +4749,38 @@ mod tests {
                 ))
                 .await?;
 
-                let first_batch_unit_aggregation = BatchUnitAggregation::<ToyPoplar1> {
-                    task_id,
-                    unit_interval_start: Time::from_seconds_since_epoch(100),
-                    aggregation_param: aggregation_param.clone(),
-                    aggregate_share: aggregate_share.clone(),
-                    report_count: 0,
-                    checksum: NonceChecksum::default(),
-                };
+                let first_batch_unit_aggregation =
+                    BatchUnitAggregation::<PRG_SEED_SIZE, ToyPoplar1> {
+                        task_id,
+                        unit_interval_start: Time::from_seconds_since_epoch(100),
+                        aggregation_param: aggregation_param.clone(),
+                        aggregate_share: aggregate_share.clone(),
+                        report_count: 0,
+                        checksum: NonceChecksum::default(),
+                    };
 
-                let second_batch_unit_aggregation = BatchUnitAggregation::<ToyPoplar1> {
-                    task_id,
-                    unit_interval_start: Time::from_seconds_since_epoch(150),
-                    aggregation_param: aggregation_param.clone(),
-                    aggregate_share: aggregate_share.clone(),
-                    report_count: 0,
-                    checksum: NonceChecksum::default(),
-                };
+                let second_batch_unit_aggregation =
+                    BatchUnitAggregation::<PRG_SEED_SIZE, ToyPoplar1> {
+                        task_id,
+                        unit_interval_start: Time::from_seconds_since_epoch(150),
+                        aggregation_param: aggregation_param.clone(),
+                        aggregate_share: aggregate_share.clone(),
+                        report_count: 0,
+                        checksum: NonceChecksum::default(),
+                    };
 
-                let third_batch_unit_aggregation = BatchUnitAggregation::<ToyPoplar1> {
-                    task_id,
-                    unit_interval_start: Time::from_seconds_since_epoch(200),
-                    aggregation_param: aggregation_param.clone(),
-                    aggregate_share: aggregate_share.clone(),
-                    report_count: 0,
-                    checksum: NonceChecksum::default(),
-                };
+                let third_batch_unit_aggregation =
+                    BatchUnitAggregation::<PRG_SEED_SIZE, ToyPoplar1> {
+                        task_id,
+                        unit_interval_start: Time::from_seconds_since_epoch(200),
+                        aggregation_param: aggregation_param.clone(),
+                        aggregate_share: aggregate_share.clone(),
+                        report_count: 0,
+                        checksum: NonceChecksum::default(),
+                    };
 
                 // Start of this aggregation's interval is before the interval queried below.
-                tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
+                tx.put_batch_unit_aggregation(&BatchUnitAggregation::<PRG_SEED_SIZE, ToyPoplar1> {
                     task_id,
                     unit_interval_start: Time::from_seconds_since_epoch(25),
                     aggregation_param: aggregation_param.clone(),
@@ -4729,7 +4800,7 @@ mod tests {
                 tx.put_batch_unit_aggregation(&third_batch_unit_aggregation)
                     .await?;
                 // Aggregation parameter differs from the one queried below.
-                tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
+                tx.put_batch_unit_aggregation(&BatchUnitAggregation::<PRG_SEED_SIZE, ToyPoplar1> {
                     task_id,
                     unit_interval_start: Time::from_seconds_since_epoch(100),
                     aggregation_param: BTreeSet::from([
@@ -4743,7 +4814,7 @@ mod tests {
                 .await?;
 
                 // End of this aggregation's interval is after the interval queried below.
-                tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
+                tx.put_batch_unit_aggregation(&BatchUnitAggregation::<PRG_SEED_SIZE, ToyPoplar1> {
                     task_id,
                     unit_interval_start: Time::from_seconds_since_epoch(250),
                     aggregation_param: aggregation_param.clone(),
@@ -4754,7 +4825,7 @@ mod tests {
                 .await?;
 
                 // Start of this aggregation's interval is after the interval queried below.
-                tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
+                tx.put_batch_unit_aggregation(&BatchUnitAggregation::<PRG_SEED_SIZE, ToyPoplar1> {
                     task_id,
                     unit_interval_start: Time::from_seconds_since_epoch(400),
                     aggregation_param: aggregation_param.clone(),
@@ -4765,7 +4836,7 @@ mod tests {
                 .await?;
 
                 // Task ID differs from that queried below.
-                tx.put_batch_unit_aggregation(&BatchUnitAggregation::<ToyPoplar1> {
+                tx.put_batch_unit_aggregation(&BatchUnitAggregation::<PRG_SEED_SIZE, ToyPoplar1> {
                     task_id: other_task_id,
                     unit_interval_start: Time::from_seconds_since_epoch(200),
                     aggregation_param: aggregation_param.clone(),
@@ -4776,7 +4847,7 @@ mod tests {
                 .await?;
 
                 let batch_unit_aggregations = tx
-                    .get_batch_unit_aggregations_for_task_in_interval::<ToyPoplar1>(
+                    .get_batch_unit_aggregations_for_task_in_interval::<PRG_SEED_SIZE, ToyPoplar1>(
                         task_id,
                         Interval::new(
                             Time::from_seconds_since_epoch(50),
@@ -4805,18 +4876,19 @@ mod tests {
                 );
                 assert!(batch_unit_aggregations.contains(&third_batch_unit_aggregation));
 
-                let updated_first_batch_unit_aggregation = BatchUnitAggregation::<ToyPoplar1> {
-                    aggregate_share: AggregateShare::from(vec![Field64::from(25)]),
-                    report_count: 1,
-                    checksum: NonceChecksum::get_decoded(&[1; 32]).unwrap(),
-                    ..first_batch_unit_aggregation
-                };
+                let updated_first_batch_unit_aggregation =
+                    BatchUnitAggregation::<PRG_SEED_SIZE, ToyPoplar1> {
+                        aggregate_share: AggregateShare::from(vec![Field64::from(25)]),
+                        report_count: 1,
+                        checksum: NonceChecksum::get_decoded(&[1; 32]).unwrap(),
+                        ..first_batch_unit_aggregation
+                    };
 
                 tx.update_batch_unit_aggregation(&updated_first_batch_unit_aggregation)
                     .await?;
 
                 let batch_unit_aggregations = tx
-                    .get_batch_unit_aggregations_for_task_in_interval::<ToyPoplar1>(
+                    .get_batch_unit_aggregations_for_task_in_interval::<PRG_SEED_SIZE, ToyPoplar1>(
                         task_id,
                         Interval::new(
                             Time::from_seconds_since_epoch(50),
@@ -4887,18 +4959,22 @@ mod tests {
                     checksum,
                 };
 
-                tx.put_aggregate_share_job::<Prio3Aes128Count>(&aggregate_share_job)
-                    .await
-                    .unwrap();
+                tx.put_aggregate_share_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                    &aggregate_share_job,
+                )
+                .await
+                .unwrap();
 
                 let aggregate_share_job_again = tx
-                    .get_aggregate_share_job_by_request::<Prio3Aes128Count>(&AggregateShareReq {
-                        task_id,
-                        batch_interval,
-                        aggregation_param: ().get_encoded(),
-                        report_count,
-                        checksum,
-                    })
+                    .get_aggregate_share_job_by_request::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                        &AggregateShareReq {
+                            task_id,
+                            batch_interval,
+                            aggregation_param: ().get_encoded(),
+                            report_count,
+                            checksum,
+                        },
+                    )
                     .await
                     .unwrap()
                     .unwrap();
@@ -4906,13 +4982,15 @@ mod tests {
                 assert_eq!(aggregate_share_job, aggregate_share_job_again);
 
                 assert!(tx
-                    .get_aggregate_share_job_by_request::<Prio3Aes128Count>(&AggregateShareReq {
-                        task_id,
-                        batch_interval: other_batch_interval,
-                        aggregation_param: ().get_encoded(),
-                        report_count,
-                        checksum,
-                    },)
+                    .get_aggregate_share_job_by_request::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                        &AggregateShareReq {
+                            task_id,
+                            batch_interval: other_batch_interval,
+                            aggregation_param: ().get_encoded(),
+                            report_count,
+                            checksum,
+                        },
+                    )
                     .await
                     .unwrap()
                     .is_none());
@@ -4979,14 +5057,16 @@ mod tests {
                 ];
 
                 for (task_id, interval) in aggregate_share_jobs {
-                    tx.put_aggregate_share_job::<Prio3Aes128Count>(&AggregateShareJob {
-                        task_id,
-                        batch_interval: interval,
-                        aggregation_param: (),
-                        helper_aggregate_share: aggregate_share.clone(),
-                        report_count: 10,
-                        checksum: NonceChecksum::get_decoded(&[1; 32]).unwrap(),
-                    })
+                    tx.put_aggregate_share_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                        &AggregateShareJob {
+                            task_id,
+                            batch_interval: interval,
+                            aggregation_param: (),
+                            helper_aggregate_share: aggregate_share.clone(),
+                            report_count: 10,
+                            checksum: NonceChecksum::get_decoded(&[1; 32]).unwrap(),
+                        },
+                    )
                     .await
                     .unwrap();
                 }
@@ -5095,49 +5175,33 @@ mod tests {
     /// with the same aggregator.
     ///
     /// generate_vdaf_values assumes that the VDAF in use is one-round.
-    fn generate_vdaf_values<A: vdaf::Aggregator + vdaf::Client>(
-        vdaf: A,
+    fn generate_vdaf_values<const L: usize, A: vdaf::Aggregator<L> + vdaf::Client>(
+        vdaf: &A,
         agg_param: A::AggregationParam,
         measurement: A::Measurement,
-    ) -> (
-        A::VerifyParam,
-        A::PrepareStep,
-        A::PrepareMessage,
-        A::OutputShare,
-    )
+    ) -> (A::PrepareState, A::PrepareMessage, A::OutputShare)
     where
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
-        let (public_param, mut verify_params) = vdaf.setup().unwrap();
+        let input_shares = vdaf.shard(&measurement).unwrap();
+        let mut verify_key = [0u8; L];
+        thread_rng().fill(&mut verify_key[..]);
 
-        let input_shares = vdaf.shard(&public_param, &measurement).unwrap();
-        let prep_states: Vec<A::PrepareStep> = verify_params
+        let (mut prep_states, prep_shares): (Vec<_>, Vec<_>) = input_shares
             .iter()
-            .zip(input_shares)
-            .map(|(verify_param, input_share)| {
-                vdaf.prepare_init(verify_param, &agg_param, b"nonce", &input_share)
+            .enumerate()
+            .map(|(agg_id, input_share)| {
+                vdaf.prepare_init(&verify_key, agg_id, &agg_param, b"nonce", input_share)
                     .unwrap()
             })
-            .collect();
-        let (mut prep_states, prep_msgs): (Vec<A::PrepareStep>, Vec<A::PrepareMessage>) =
-            prep_states
-                .iter()
-                .map(|prep_state| {
-                    if let PrepareTransition::Continue(prep_state, prep_msg) =
-                        vdaf.prepare_step(prep_state.clone(), None)
-                    {
-                        (prep_state, prep_msg)
-                    } else {
-                        panic!("generate_vdaf_values: VDAF returned something other than Continue")
-                    }
-                })
-                .unzip();
-        let prep_msg = vdaf.prepare_preprocess(prep_msgs).unwrap();
+            .unzip();
+        let prep_msg = vdaf.prepare_preprocess(prep_shares).unwrap();
         let mut output_shares: Vec<A::OutputShare> = prep_states
             .iter()
             .map(|prep_state| {
-                if let PrepareTransition::Finish(output_share) =
-                    vdaf.prepare_step(prep_state.clone(), Some(prep_msg.clone()))
+                if let PrepareTransition::Finish(output_share) = vdaf
+                    .prepare_step(prep_state.clone(), prep_msg.clone())
+                    .unwrap()
                 {
                     output_share
                 } else {
@@ -5146,11 +5210,6 @@ mod tests {
             })
             .collect();
 
-        (
-            verify_params.remove(0),
-            prep_states.remove(0),
-            prep_msg,
-            output_shares.remove(0),
-        )
+        (prep_states.remove(0), prep_msg, output_shares.remove(0))
     }
 }

--- a/janus_server/src/message.rs
+++ b/janus_server/src/message.rs
@@ -88,9 +88,9 @@ impl Encode for PrepareStepResult {
         // The encoding includes an implicit discriminator byte, called PrepareStepResult in the
         // DAP spec.
         match self {
-            Self::Continued(prep_msg) => {
+            Self::Continued(vdaf_msg) => {
                 0u8.encode(bytes);
-                encode_u16_items(bytes, &(), prep_msg);
+                encode_u16_items(bytes, &(), vdaf_msg);
             }
             Self::Finished => 1u8.encode(bytes),
             Self::Failed(error) => {
@@ -522,7 +522,7 @@ mod tests {
                     ),
                     "00", // prepare_step_result
                     concat!(
-                        // prep_msg
+                        // vdaf_msg
                         "0006",         // length
                         "303132333435", // opaque data
                     ),

--- a/monolithic_integration_test/Cargo.toml
+++ b/monolithic_integration_test/Cargo.toml
@@ -13,7 +13,8 @@ futures = "0.3.21"
 janus = { path = "../janus" }
 janus_server = { path = "../janus_server" }
 lazy_static = "1"
-prio = "0.7.1"
+prio = "0.8.0"
+rand = "0.8"
 ring = "0.16.20"
 testcontainers = "0.14.0"
 janus_test_util = { path = "../test_util" }

--- a/test_util/Cargo.toml
+++ b/test_util/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 assert_matches = "1"
-prio = "0.7.1"
+prio = "0.8.0"
 rand = "0.8"
 ring = "0.16.20"
 janus = { path = "../janus" }


### PR DESCRIPTION
This version of libprio-rs implements draft-irtf-cfrg-vdaf-01, which is
the version we are targeting for interop tests.

This change is large but mostly-mechanical. A large number of line
changes are due to the new `L` const generic parameter to the VDAF
Aggregator trait.  This parameter is effectively the underlying PRG's
seed size.  Unfortunately, Rust currently doesn't allow const generic
parameters to be inferred; there is an open issue to resolve this, but
it doesn't appear to have received much attention thus far[1].

[1] https://github.com/rust-lang/rust/issues/80528