### PR TITLE
Monitor completion of some async tasks in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,6 +1293,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -1361,10 +1362,12 @@ version = "0.1.0"
 dependencies = [
  "assert_matches",
  "chrono",
+ "futures",
  "janus",
  "prio",
  "rand",
  "ring",
+ "tokio",
 ]
 
 [[package]]

--- a/janus/Cargo.toml
+++ b/janus/Cargo.toml
@@ -23,6 +23,7 @@ rand = "0.8"
 ring = "0.16.20"
 serde = { version = "1.0.137", features = ["derive"] }
 thiserror = "1.0"
+tokio = { version = "^1.19", features = ["rt"] }
 
 [dev-dependencies]
 assert_matches = "1"

--- a/janus/src/lib.rs
+++ b/janus/src/lib.rs
@@ -1,4 +1,30 @@
+use std::future::Future;
+use tokio::task::JoinHandle;
+
 pub mod hpke;
 pub mod message;
 pub mod task;
 pub mod time;
+
+/// This trait provides a mockable facade for [`tokio::task::spawn`].
+pub trait Runtime {
+    /// Spawn a future on a new task managed by an asynchronous runtime, and
+    /// return a handle that can be used to await completion of that task.
+    fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static;
+}
+
+/// This type implements [`Runtime`] by directly calling [`tokio::task::spawn`].
+pub struct TokioRuntime;
+
+impl Runtime for TokioRuntime {
+    fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        tokio::task::spawn(future)
+    }
+}

--- a/janus_server/src/bin/collect_job_driver.rs
+++ b/janus_server/src/bin/collect_job_driver.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use janus::{message::Duration, time::RealClock};
+use janus::{message::Duration, time::RealClock, TokioRuntime};
 use janus_server::{
     aggregator::aggregate_share::CollectJobDriver,
     binary_utils::{janus_main, job_driver::JobDriver, BinaryOptions, CommonBinaryOptions},
@@ -53,6 +53,7 @@ async fn main() -> anyhow::Result<()> {
             // Start running.
             Arc::new(JobDriver::new(
                 clock,
+                TokioRuntime,
                 Duration::from_seconds(config.job_driver_config.min_job_discovery_delay_secs),
                 Duration::from_seconds(config.job_driver_config.max_job_discovery_delay_secs),
                 config.job_driver_config.max_concurrent_job_workers,

--- a/test_util/Cargo.toml
+++ b/test_util/Cargo.toml
@@ -8,8 +8,13 @@ publish = false
 
 [dependencies]
 assert_matches = "1"
+chrono = "0.4"
+futures = "0.3.21"
+janus = { path = "../janus" }
 prio = "0.8.0"
 rand = "0.8"
 ring = "0.16.20"
-janus = { path = "../janus" }
-chrono = "0.4"
+tokio = { version = "^1.19", features = ["rt", "sync"] }
+
+[dev-dependencies]
+tokio = { version = "*", features = ["macros"] }

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -12,6 +12,7 @@ use ring::aead::{LessSafeKey, UnboundKey, AES_128_GCM};
 use std::sync::{Arc, Mutex};
 
 pub mod dummy_vdaf;
+pub mod runtime;
 
 /// The Janus database schema.
 pub static SCHEMA: &str = include_str!("../../db/schema.sql");

--- a/test_util/src/runtime.rs
+++ b/test_util/src/runtime.rs
@@ -1,0 +1,204 @@
+use futures::FutureExt;
+use janus::Runtime;
+use std::{
+    collections::HashMap,
+    future::Future,
+    hash::Hash,
+    panic::{panic_any, AssertUnwindSafe},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
+use tokio::{
+    sync::watch::{self, Sender},
+    task::JoinHandle,
+};
+
+/// Tracks multiple instrumented [`Runtime`] objects, for use in tests. Each
+/// [`TestRuntime`] keeps track of how many of its tasks have been completed,
+/// and tests can wait until a given number of tasks finish. If any task
+/// panics, this manager object will panic on drop, to ensure that the
+/// relevant test fails and the task panics do not go unnoticed.
+pub struct TestRuntimeManager<L> {
+    map: HashMap<L, TestRuntime>,
+}
+
+impl<L> TestRuntimeManager<L> {
+    pub fn new() -> TestRuntimeManager<L> {
+        TestRuntimeManager {
+            map: HashMap::new(),
+        }
+    }
+}
+
+impl<L> TestRuntimeManager<L>
+where
+    L: Eq + Hash,
+{
+    /// Construct or retrieve a [`TestRuntime`] with a given label.
+    pub fn with_label(&mut self, label: L) -> TestRuntime {
+        self.map.entry(label).or_default().clone()
+    }
+
+    /// Wait for the runtime with the given label to reach some number of
+    /// completed tasks. Note that tasks that have already completed before
+    /// this method is called are included in the count.
+    pub async fn wait_for_completed_tasks(&mut self, label: L, target_count: usize) {
+        let labeled_runtime = self.with_label(label);
+        let mut receiver = labeled_runtime.inner.sender.subscribe();
+        if *receiver.borrow_and_update() >= target_count {
+            return;
+        }
+        loop {
+            receiver.changed().await.expect(
+                "The channel sender should not be dropped before waits have \
+                finished, this likely indicates an issue with a test.",
+            );
+            if *receiver.borrow() >= target_count {
+                break;
+            }
+        }
+    }
+}
+
+impl<L> Default for TestRuntimeManager<L> {
+    fn default() -> TestRuntimeManager<L> {
+        TestRuntimeManager::new()
+    }
+}
+
+impl<L> Drop for TestRuntimeManager<L> {
+    fn drop(&mut self) {
+        // Check if any panicking tasks were observed. By default, an error
+        // message and backtrace will be printed, but we would like this to be
+        // noisier in tests, and cause the main test thread to panic.
+        for labeled_runtime in self.map.values() {
+            if labeled_runtime.inner.any_panic.load(Ordering::Acquire) {
+                panic!("An async task panicked");
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct TestRuntime {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    any_panic: AtomicBool,
+    sender: Sender<usize>,
+}
+
+impl TestRuntime {
+    fn new() -> TestRuntime {
+        let (channel, _) = watch::channel(0);
+        TestRuntime {
+            inner: Arc::new(Inner {
+                any_panic: AtomicBool::new(false),
+                sender: channel,
+            }),
+        }
+    }
+}
+
+impl Default for TestRuntime {
+    fn default() -> TestRuntime {
+        TestRuntime::new()
+    }
+}
+
+impl Runtime for TestRuntime {
+    fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        let labeled_runtime = self.clone();
+        tokio::task::spawn(async move {
+            // If there is any non-UnwindSafe behavior in this future, it
+            // won't be an issue because we will re-raise the panic after
+            // making note of it. Nothing will have a chance to observe any
+            // broken logical invariants.
+            let res = AssertUnwindSafe(future).catch_unwind().await;
+            labeled_runtime
+                .inner
+                .sender
+                .send_modify(|counter| *counter += 1);
+            match res {
+                Ok(output) => output,
+                Err(e) => {
+                    labeled_runtime
+                        .inner
+                        .any_panic
+                        .fetch_or(true, Ordering::Release);
+                    panic_any(e);
+                }
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tokio::sync::Barrier;
+
+    use super::{Runtime, TestRuntimeManager};
+
+    #[tokio::test]
+    async fn mock_runtime() {
+        #[derive(PartialEq, Eq, Hash)]
+        enum Label {
+            A,
+            B,
+        }
+
+        let mut runtime = TestRuntimeManager::<Label>::new();
+        let runtime_a = runtime.with_label(Label::A);
+        let runtime_b = runtime.with_label(Label::B);
+
+        let barrier = Arc::new(Barrier::new(2));
+
+        let handle_a_1 = runtime_a.spawn(std::future::ready(()));
+        let handle_b_1 = runtime_b.spawn(std::future::ready(()));
+
+        runtime.wait_for_completed_tasks(Label::A, 1).await;
+        runtime.wait_for_completed_tasks(Label::B, 1).await;
+        assert_eq!(*runtime_a.inner.sender.borrow(), 1);
+        assert_eq!(*runtime_b.inner.sender.borrow(), 1);
+
+        let handle_a_2 = runtime_a.spawn({
+            let handle_a_3 = runtime_a.spawn(std::future::ready(()));
+            let barrier = Arc::clone(&barrier);
+            async move {
+                barrier.wait().await;
+                handle_a_3
+            }
+        });
+
+        assert_eq!(*runtime_a.inner.sender.borrow(), 1);
+        barrier.wait().await;
+        runtime.wait_for_completed_tasks(Label::A, 2).await;
+        runtime.wait_for_completed_tasks(Label::A, 3).await;
+        runtime.wait_for_completed_tasks(Label::A, 2).await;
+
+        handle_a_1.await.unwrap();
+        let handle_a_3 = handle_a_2.await.unwrap();
+        handle_a_3.await.unwrap();
+        handle_b_1.await.unwrap();
+        assert_eq!(*runtime_a.inner.sender.borrow(), 3);
+        assert_eq!(*runtime_b.inner.sender.borrow(), 1);
+    }
+
+    #[tokio::test]
+    #[should_panic]
+    async fn noisy_task_panic() {
+        let mut runtime = TestRuntimeManager::<()>::new();
+        let handle = runtime.with_label(()).spawn(async { &[0u8][..2] });
+        let _ = handle.await;
+        drop(runtime);
+    }
+}

--- a/test_util/src/runtime.rs
+++ b/test_util/src/runtime.rs
@@ -47,17 +47,11 @@ where
     pub async fn wait_for_completed_tasks(&mut self, label: L, target_count: usize) {
         let labeled_runtime = self.with_label(label);
         let mut receiver = labeled_runtime.inner.sender.subscribe();
-        if *receiver.borrow_and_update() >= target_count {
-            return;
-        }
-        loop {
+        while *receiver.borrow_and_update() < target_count {
             receiver.changed().await.expect(
                 "The channel sender should not be dropped before waits have \
                 finished, this likely indicates an issue with a test.",
             );
-            if *receiver.borrow() >= target_count {
-                break;
-            }
         }
     }
 }


### PR DESCRIPTION
This adds a new trait that abstracts over `tokio::task::spawn()`, and adds a test-only implementor that monitors when spawned async tasks complete. Tests can create multiple such `TestRuntime`s with different labels, and wait for some number of tasks to be completed before continuing. This addresses one of the two reasons we needed sleeps in tests for. Those tests are rewritten with this new functionality.

`TestRuntime` provides one additional feature: if a task spawned through it panics, then this will be detected, and the test's main task will panic when a related object drops.

This unblocks #253 and partially addresses #234.