### PR TITLE
Use 415 Unsupported Media Type in /aggregate

### DIFF
--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -1863,7 +1863,7 @@ fn aggregator_filter<C: Clock>(
                                 .await?,
                         ),
                     _ => http::Response::builder()
-                        .status(StatusCode::NOT_FOUND)
+                        .status(StatusCode::UNSUPPORTED_MEDIA_TYPE)
                         .body(Vec::new()),
                 }
                 .map_err(|err| Error::Internal(format!("couldn't produce response: {}", err)))


### PR DESCRIPTION
If the request to `/aggregate` has the wrong media type, return status code 415 instead of 404.

For reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/415. This should be a more intuitive error for this situation.

CC @cjpatton FYI