### PR TITLE
Remove stale TODOs.

### DIFF
--- a/janus_server/src/aggregator/aggregation_job_driver.rs
+++ b/janus_server/src/aggregator/aggregation_job_driver.rs
@@ -726,9 +726,6 @@ impl AggregationJobDriver {
                 datastore
                     .run_tx(|tx| {
                         Box::pin(async move {
-                            // TODO(#193): only acquire jobs whose batch units
-                            // have not already been collected (probably by
-                            // modifying acquire_incomplete_aggregation_jobs)
                             tx.acquire_incomplete_aggregation_jobs(
                                 lease_duration,
                                 max_acquire_count,

--- a/janus_server/src/bin/collect_job_driver.rs
+++ b/janus_server/src/bin/collect_job_driver.rs
@@ -33,7 +33,6 @@ const CLIENT_USER_AGENT: &str = concat!(
     "/collect_job_driver",
 );
 
-// TODO(#193): make CollectJobDriver repsect JobDriverConfig::maximum_retries_before_failure.
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     janus_main::<Options, _, _, _, _>(


### PR DESCRIPTION
The removed TODO in aggregation_job_driver.rs is stale because it is no
longer/was never necessary to avoid race conditions with collection.
Specifically:
  * We only want to avoid driving aggregation jobs if there is a
    _completed_ collect job covering the relevant batch unit. (If there
    is an in-progress collect job, we still want to drive aggregation
    jobs, since the collect job will be waiting for the aggregation jobs
    to complete.)
  * We only acquire aggregation jobs whose state is IN_PROGRESS
    [datastore.rs, L865].
  * The "acquire incomplete collect jobs" operation will only acquire
    collect jobs that don't have any IN_PROGRESS aggregation jobs
    [datastore.rs, L1381].

(N.B. we will probably want to change the collect acquire operation
eventually, since I suppose it races with the _creation_ of aggregation
jobs--it should ideally also check that there are no reports not yet
included in an aggregation job over the relevant time period. But this
is probably fine for now, since current VDAFs support incremental
aggregation.)

The removed TODO in collect_job_driver.rs is stale because the collect
job driver already respects maximum_retries_before_failure
[aggregate_share.rs, L273-282].

Closes #193.