### PR TITLE
Update problem types to match latest DAP spec.

### DIFF
--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -105,7 +105,6 @@ pub enum Error {
     #[error("outdated HPKE config: {0} {1:?}")]
     OutdatedHpkeConfig(HpkeConfigId, TaskId),
     /// A report was rejected becuase the timestamp is too far in the future, §4.3.4.
-    // TODO(#221): define an error type in §3.1 and clarify language on rejecting future reports
     #[error("report from the future: {0} {1:?}")]
     ReportFromTheFuture(Nonce, TaskId),
     /// Corresponds to `unauthorizedRequest`, §3.1

--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -1651,10 +1651,8 @@ fn error_handler<R: Reply>(
             Err(Error::OutdatedHpkeConfig(_, task_id)) => {
                 build_problem_details_response(DapProblemType::OutdatedConfig, Some(task_id))
             }
-            Err(Error::ReportFromTheFuture(_, _)) => {
-                // TODO(#221): build a problem details document once an error type is defined for
-                // reports with timestamps too far in the future.
-                StatusCode::BAD_REQUEST.into_response()
+            Err(Error::ReportFromTheFuture(_, task_id)) => {
+                build_problem_details_response(DapProblemType::ReportTooEarly, Some(task_id))
             }
             Err(Error::UnauthorizedRequest(task_id)) => {
                 build_problem_details_response(DapProblemType::UnauthorizedRequest, Some(task_id))


### PR DESCRIPTION
The previous implementation roughly matched DAP-00; the new
implementation matches the current editor's copy of DAP-01.

Part of #221. Closes #273.