### PR TITLE
Return batch-collected & report-replayed from helper aggregation.

### DIFF
--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -2971,13 +2971,13 @@ mod tests {
 
         // report_share_3 has an unknown HPKE config ID.
         let nonce_3 = Nonce::generate(&clock);
-        let wrong_hpke_config = HpkeConfig::new(
-            HpkeConfigId::from(u8::from(hpke_key.0.id()) + 1),
-            hpke_key.0.kem_id(),
-            hpke_key.0.kdf_id(),
-            hpke_key.0.aead_id(),
-            hpke_key.0.public_key().clone(),
-        );
+        let wrong_hpke_config = loop {
+            let hpke_config = generate_hpke_config_and_private_key().0;
+            if task.hpke_keys.contains_key(&hpke_config.id()) {
+                continue;
+            }
+            break hpke_config;
+        };
         let report_share_3 = generate_helper_report_share::<Prio3Aes128Count>(
             task_id,
             nonce_3,


### PR DESCRIPTION
The `batch-collected` error is returned when aggregation is attempted
for a report that falls into a batch unit that has already been
collected. The `report-replayed` error occurs when aggregation is
attempted for a report that has already been aggregated.

Also, a few small finished-TODO & naming cleanups.

A few spec-related notes, I will drive the spec changes if these make
sense to reviewers:
  * The DAP specification language says to return `report-replayed` "if
    the report has already been aggregated." However, some VDAFs (e.g.
    poplar1) require aggregating the same report multiple times with
    varying aggregation parameters. I think the DAP specification should
    be updated to return `report-replayed` if the report has already
    been aggregated _with the same aggregation parameter_.
  * The DAP spec says that `report-dropped` may be returned under
    conditions prescribed in Section 4.4.6; however, the language of
    that section does not make it clear how this error code is distinct
    from `report-replayed`. I think the idea is that `report-dropped`
    would be returned if the aggregator has forgotten about reports in
    the appropriate batch window, but the spec language doesn't make
    this clear.