### PR TITLE
Fix new clippy lint

### DIFF
--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -5077,7 +5077,6 @@ mod tests {
         task.min_batch_duration = Duration::from_seconds(500);
         task.min_batch_size = 10;
         task.collector_hpke_config = collector_hpke_config.clone();
-        let aggregation_param = ();
 
         let clock = MockClock::default();
         let (datastore, _db_handle) = ephemeral_datastore(clock.clone()).await;
@@ -5147,7 +5146,7 @@ mod tests {
                     > {
                         task_id,
                         unit_interval_start: Time::from_seconds_since_epoch(500),
-                        aggregation_param,
+                        aggregation_param: (),
                         aggregate_share: AggregateShare::from(vec![Field64::from(64)]),
                         report_count: 5,
                         checksum: NonceChecksum::get_decoded(&[3; 32]).unwrap(),
@@ -5160,7 +5159,7 @@ mod tests {
                     > {
                         task_id,
                         unit_interval_start: Time::from_seconds_since_epoch(1500),
-                        aggregation_param,
+                        aggregation_param: (),
                         aggregate_share: AggregateShare::from(vec![Field64::from(128)]),
                         report_count: 5,
                         checksum: NonceChecksum::get_decoded(&[2; 32]).unwrap(),
@@ -5173,7 +5172,7 @@ mod tests {
                     > {
                         task_id,
                         unit_interval_start: Time::from_seconds_since_epoch(2000),
-                        aggregation_param,
+                        aggregation_param: (),
                         aggregate_share: AggregateShare::from(vec![Field64::from(256)]),
                         report_count: 5,
                         checksum: NonceChecksum::get_decoded(&[4; 32]).unwrap(),
@@ -5186,7 +5185,7 @@ mod tests {
                     > {
                         task_id,
                         unit_interval_start: Time::from_seconds_since_epoch(2500),
-                        aggregation_param,
+                        aggregation_param: (),
                         aggregate_share: AggregateShare::from(vec![Field64::from(512)]),
                         report_count: 5,
                         checksum: NonceChecksum::get_decoded(&[8; 32]).unwrap(),

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -4412,7 +4412,6 @@ mod tests {
             Duration::from_seconds(200),
         )
         .unwrap();
-        let agg_param = ();
 
         let (ds, _db_handle) = ephemeral_datastore(MockClock::default()).await;
 
@@ -4425,12 +4424,13 @@ mod tests {
                 );
                 tx.put_task(&task).await.unwrap();
 
+                let agg_param_encoded = ().get_encoded();
                 let first_collect_job_id = tx
-                    .put_collect_job(task_id, first_batch_interval, &agg_param.get_encoded())
+                    .put_collect_job(task_id, first_batch_interval, &agg_param_encoded)
                     .await
                     .unwrap();
                 let second_collect_job_id = tx
-                    .put_collect_job(task_id, second_batch_interval, &agg_param.get_encoded())
+                    .put_collect_job(task_id, second_batch_interval, &agg_param_encoded)
                     .await
                     .unwrap();
 


### PR DESCRIPTION
[`clippy::let_unit_value`](https://rust-lang.github.io/rust-clippy/master/index.html#let_unit_value) was recently upgraded from the "pedantic" category to "style", after some refinements. With a 1.62.0 Rust toolchain, we get two of these lints. This fixes them by shuffling `()` around.