### PR TITLE
Bump Rust crates to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,7 +1276,7 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "janus_client"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "assert_matches",
  "http",
@@ -1295,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "janus_core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/janus_client/Cargo.toml
+++ b/janus_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "janus_client"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Client for Janus, the server powering ISRG's Divvi Up."
 documentation = "https://docs.rs/janus_client"
@@ -11,7 +11,7 @@ rust-version = "1.58"
 
 [dependencies]
 http = "0.2.8"
-janus_core = { version = "0.1.1", path = "../janus_core" }
+janus_core = { version = "0.1.2", path = "../janus_core" }
 prio = "0.8.0"
 reqwest = { version = "0.11.4", default-features = false, features = ["rustls-tls"] }
 thiserror = "1.0"

--- a/janus_core/Cargo.toml
+++ b/janus_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "janus_core"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Core type definitions and utilities used in various components of Janus."
 documentation = "https://docs.rs/janus_core"


### PR DESCRIPTION
Bump the `janus_core` and `janus_client` crate versions to 0.1.2 so that
we can cut a `janus` release and exercise the artifact publishing
workflows e2e.

Part of #222