### PR TITLE
Round down timestamps in report nonces

### DIFF
--- a/janus_client/src/lib.rs
+++ b/janus_client/src/lib.rs
@@ -4,7 +4,7 @@ use http::{header::CONTENT_TYPE, StatusCode};
 use janus_core::{
     hpke::associated_data_for_report_share,
     hpke::{self, HpkeApplicationInfo, Label},
-    message::{HpkeCiphertext, HpkeConfig, Nonce, Report, Role, TaskId},
+    message::{Duration, HpkeCiphertext, HpkeConfig, Nonce, Report, Role, TaskId},
     time::Clock,
 };
 use prio::{
@@ -48,14 +48,22 @@ pub struct ClientParameters {
     /// URLs relative to which aggregator API endpoints are found. The first
     /// entry is the leader's.
     aggregator_endpoints: Vec<Url>,
+    /// The minimum batch duration of the task. This value is shared by all
+    /// parties in the protocol, and is used to compute report nonces.
+    min_batch_duration: Duration,
 }
 
 impl ClientParameters {
     /// Creates a new set of client task parameters.
-    pub fn new(task_id: TaskId, aggregator_endpoints: Vec<Url>) -> Self {
+    pub fn new(
+        task_id: TaskId,
+        aggregator_endpoints: Vec<Url>,
+        min_batch_duration: Duration,
+    ) -> Self {
         Self {
             task_id,
             aggregator_endpoints,
+            min_batch_duration,
         }
     }
 
@@ -148,16 +156,16 @@ where
         }
     }
 
-    /// Upload a [`janus_core::message::Report`] to the leader, per §4.3.2 of
-    /// draft-gpew-priv-ppm. The provided measurement is sharded into one input
-    /// share plus one proof share for each aggregator and then uploaded to the
-    /// leader.
-    #[tracing::instrument(skip(measurement), err)]
-    pub async fn upload(&self, measurement: &V::Measurement) -> Result<(), Error> {
+    /// Shard a measurement, encrypt its shares, and construct a [`janus_core::message::Report`]
+    /// to be uploaded.
+    fn prepare_report(&self, measurement: &V::Measurement) -> Result<Report, Error> {
         let input_shares = self.vdaf_client.shard(measurement)?;
         assert_eq!(input_shares.len(), 2); // PPM only supports VDAFs using two aggregators.
 
-        let nonce = Nonce::generate(&self.clock);
+        let nonce =
+            Nonce::generate(&self.clock, self.parameters.min_batch_duration).map_err(|_| {
+                Error::InvalidParameter("Error rounding time down to min_batch_duration")
+            })?;
         let extensions = vec![]; // No extensions supported yet
         let associated_data =
             associated_data_for_report_share(self.parameters.task_id, nonce, &extensions);
@@ -178,12 +186,21 @@ where
         })
         .collect::<Result<_, Error>>()?;
 
-        let report = Report::new(
+        Ok(Report::new(
             self.parameters.task_id,
             nonce,
             extensions,
             encrypted_input_shares,
-        );
+        ))
+    }
+
+    /// Upload a [`janus_core::message::Report`] to the leader, per §4.3.2 of
+    /// draft-gpew-priv-ppm. The provided measurement is sharded into one input
+    /// share plus one proof share for each aggregator and then uploaded to the
+    /// leader.
+    #[tracing::instrument(skip(measurement), err)]
+    pub async fn upload(&self, measurement: &V::Measurement) -> Result<(), Error> {
+        let report = self.prepare_report(measurement)?;
 
         let upload_response = self
             .http_client
@@ -206,7 +223,10 @@ where
 mod tests {
     use super::*;
     use assert_matches::assert_matches;
-    use janus_core::{hpke::test_util::generate_hpke_config_and_private_key, message::TaskId};
+    use janus_core::{
+        hpke::test_util::generate_hpke_config_and_private_key,
+        message::{TaskId, Time},
+    };
     use janus_test_util::{install_test_trace_subscriber, MockClock};
     use mockito::mock;
     use prio::vdaf::prio3::Prio3;
@@ -227,6 +247,7 @@ mod tests {
         let client_parameters = ClientParameters {
             task_id,
             aggregator_endpoints: vec![server_url.clone(), server_url],
+            min_batch_duration: Duration::from_seconds(1),
         };
 
         Client::new(
@@ -283,5 +304,49 @@ mod tests {
         );
 
         mocked_upload.assert();
+    }
+
+    #[tokio::test]
+    async fn upload_bad_min_batch_duration() {
+        install_test_trace_subscriber();
+
+        let client_parameters =
+            ClientParameters::new(TaskId::random(), vec![], Duration::from_seconds(0));
+        let client = Client::new(
+            client_parameters,
+            Prio3::new_aes128_count(2).unwrap(),
+            MockClock::default(),
+            &default_http_client().unwrap(),
+            generate_hpke_config_and_private_key().0,
+            generate_hpke_config_and_private_key().0,
+        );
+        let result = client.upload(&1).await;
+        assert_matches!(result, Err(Error::InvalidParameter(_)));
+    }
+
+    #[test]
+    fn report_nonce_time() {
+        install_test_trace_subscriber();
+        let vdaf = Prio3::new_aes128_count(2).unwrap();
+        let mut client = setup_client(vdaf);
+
+        client.parameters.min_batch_duration = Duration::from_seconds(100);
+        client.clock = MockClock::new(Time::from_seconds_since_epoch(101));
+        assert_eq!(
+            client.prepare_report(&1).unwrap().nonce().time(),
+            Time::from_seconds_since_epoch(100),
+        );
+
+        client.clock = MockClock::new(Time::from_seconds_since_epoch(5200));
+        assert_eq!(
+            client.prepare_report(&1).unwrap().nonce().time(),
+            Time::from_seconds_since_epoch(5200),
+        );
+
+        client.clock = MockClock::new(Time::from_seconds_since_epoch(9814));
+        assert_eq!(
+            client.prepare_report(&1).unwrap().nonce().time(),
+            Time::from_seconds_since_epoch(9800),
+        );
     }
 }

--- a/janus_core/src/message.rs
+++ b/janus_core/src/message.rs
@@ -372,12 +372,14 @@ impl Nonce {
         Nonce { time, rand }
     }
 
-    /// Generate a fresh nonce with the current time.
-    pub fn generate<C: Clock>(clock: &C) -> Nonce {
-        Nonce {
-            time: clock.now(),
+    /// Generate a fresh nonce based on the current time.
+    pub fn generate<C: Clock>(clock: &C, min_batch_duration: Duration) -> Result<Nonce, Error> {
+        Ok(Nonce {
+            time: clock
+                .now()
+                .to_batch_unit_interval_start(min_batch_duration)?,
             rand: rand::random(),
-        }
+        })
     }
 
     /// Get the time component of a nonce.

--- a/janus_core/src/message.rs
+++ b/janus_core/src/message.rs
@@ -363,12 +363,12 @@ pub struct Nonce {
     /// The time at which the report was generated.
     time: Time,
     /// A randomly generated value.
-    rand: [u8; 8],
+    rand: [u8; 16],
 }
 
 impl Nonce {
     /// Construct a nonce with the given time and random parts.
-    pub fn new(time: Time, rand: [u8; 8]) -> Nonce {
+    pub fn new(time: Time, rand: [u8; 16]) -> Nonce {
         Nonce { time, rand }
     }
 
@@ -388,7 +388,7 @@ impl Nonce {
     }
 
     /// Get the random component of a nonce.
-    pub fn rand(&self) -> [u8; 8] {
+    pub fn rand(&self) -> [u8; 16] {
         self.rand
     }
 }
@@ -409,7 +409,7 @@ impl Encode for Nonce {
 impl Decode for Nonce {
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
         let time = Time::decode(bytes)?;
-        let mut rand = [0; 8];
+        let mut rand = [0; 16];
         bytes.read_exact(&mut rand)?;
 
         Ok(Self { time, rand })
@@ -1134,21 +1134,21 @@ mod tests {
             (
                 Nonce::new(
                     Time::from_seconds_since_epoch(12345),
-                    [1, 2, 3, 4, 5, 6, 7, 8],
+                    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
                 ),
                 concat!(
-                    "0000000000003039", // time
-                    "0102030405060708", // rand
+                    "0000000000003039",                 // time
+                    "0102030405060708090a0b0c0d0e0f10", // rand
                 ),
             ),
             (
                 Nonce::new(
                     Time::from_seconds_since_epoch(54321),
-                    [8, 7, 6, 5, 4, 3, 2, 1],
+                    [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
                 ),
                 concat!(
-                    "000000000000D431", // time
-                    "0807060504030201", // rand
+                    "000000000000D431",                 // time
+                    "100f0e0d0c0b0a090807060504030201", // rand
                 ),
             ),
         ])
@@ -1365,7 +1365,7 @@ mod tests {
                     TaskId::new([u8::MIN; 32]),
                     Nonce::new(
                         Time::from_seconds_since_epoch(12345),
-                        [1, 2, 3, 4, 5, 6, 7, 8],
+                        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
                     ),
                     vec![],
                     vec![],
@@ -1374,8 +1374,8 @@ mod tests {
                     "0000000000000000000000000000000000000000000000000000000000000000", // task_id
                     concat!(
                         // nonce
-                        "0000000000003039", // time
-                        "0102030405060708", // rand
+                        "0000000000003039",                 // time
+                        "0102030405060708090a0b0c0d0e0f10", // rand
                     ),
                     concat!(
                         // extensions
@@ -1392,7 +1392,7 @@ mod tests {
                     TaskId::new([u8::MAX; 32]),
                     Nonce::new(
                         Time::from_seconds_since_epoch(54321),
-                        [8, 7, 6, 5, 4, 3, 2, 1],
+                        [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
                     ),
                     vec![Extension::new(ExtensionType::Tbd, Vec::from("0123"))],
                     vec![
@@ -1411,8 +1411,8 @@ mod tests {
                 concat!(
                     "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", // task_id
                     concat!(
-                        "000000000000D431", // time
-                        "0807060504030201", // rand
+                        "000000000000D431",                 // time
+                        "100f0e0d0c0b0a090807060504030201", // rand
                     ),
                     concat!(
                         // extensions

--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -3277,7 +3277,7 @@ mod tests {
         let report_share = ReportShare {
             nonce: Nonce::new(
                 Time::from_seconds_since_epoch(54321),
-                [1, 2, 3, 4, 5, 6, 7, 8],
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
             ),
             extensions: Vec::new(),
             encrypted_input_share: HpkeCiphertext::new(
@@ -4072,7 +4072,7 @@ mod tests {
         let aggregation_job_id = AggregationJobId::random();
         let nonce = Nonce::new(
             Time::from_seconds_since_epoch(54321),
-            [1, 2, 3, 4, 5, 6, 7, 8],
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
         );
         let task = new_dummy_task(task_id, VdafInstance::Fake, Role::Helper);
         let clock = MockClock::default();
@@ -4180,7 +4180,7 @@ mod tests {
         let aggregation_job_id = AggregationJobId::random();
         let nonce = Nonce::new(
             Time::from_seconds_since_epoch(54321),
-            [1, 2, 3, 4, 5, 6, 7, 8],
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
         );
         let task = new_dummy_task(task_id, VdafInstance::FakeFailsPrepStep, Role::Helper);
         let clock = MockClock::default();
@@ -4335,7 +4335,7 @@ mod tests {
         let aggregation_job_id = AggregationJobId::random();
         let nonce = Nonce::new(
             Time::from_seconds_since_epoch(54321),
-            [1, 2, 3, 4, 5, 6, 7, 8],
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
         );
         let task = new_dummy_task(task_id, VdafInstance::Fake, Role::Helper);
         let clock = MockClock::default();
@@ -4395,7 +4395,7 @@ mod tests {
             prepare_steps: vec![PrepareStep {
                 nonce: Nonce::new(
                     Time::from_seconds_since_epoch(54321),
-                    [8, 7, 6, 5, 4, 3, 2, 1], // not the same as above
+                    [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1], // not the same as above
                 ),
                 result: PrepareStepResult::Continued(Vec::new()),
             }],
@@ -4445,11 +4445,11 @@ mod tests {
         let aggregation_job_id = AggregationJobId::random();
         let nonce_0 = Nonce::new(
             Time::from_seconds_since_epoch(54321),
-            [1, 2, 3, 4, 5, 6, 7, 8],
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
         );
         let nonce_1 = Nonce::new(
             Time::from_seconds_since_epoch(54321),
-            [8, 7, 6, 5, 4, 3, 2, 1],
+            [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
         );
 
         let task = new_dummy_task(task_id, VdafInstance::Fake, Role::Helper);
@@ -4591,7 +4591,7 @@ mod tests {
         let aggregation_job_id = AggregationJobId::random();
         let nonce = Nonce::new(
             Time::from_seconds_since_epoch(54321),
-            [1, 2, 3, 4, 5, 6, 7, 8],
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
         );
 
         let task = new_dummy_task(task_id, VdafInstance::Fake, Role::Helper);
@@ -4652,7 +4652,7 @@ mod tests {
             prepare_steps: vec![PrepareStep {
                 nonce: Nonce::new(
                     Time::from_seconds_since_epoch(54321),
-                    [1, 2, 3, 4, 5, 6, 7, 8],
+                    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
                 ),
                 result: PrepareStepResult::Continued(Vec::new()),
             }],

--- a/janus_server/src/aggregator/aggregate_share.rs
+++ b/janus_server/src/aggregator/aggregate_share.rs
@@ -494,7 +494,7 @@ mod tests {
                     })
                     .await?;
 
-                    let nonce = Nonce::generate(&clock);
+                    let nonce = Nonce::generate(&clock, task.min_batch_duration).unwrap();
                     tx.put_client_report(&Report::new(task_id, nonce, Vec::new(), Vec::new()))
                         .await?;
 
@@ -694,7 +694,7 @@ mod tests {
                     })
                     .await?;
 
-                    let nonce = Nonce::generate(&clock);
+                    let nonce = Nonce::generate(&clock, task.min_batch_duration).unwrap();
                     tx.put_client_report(&Report::new(task_id, nonce, Vec::new(), Vec::new()))
                         .await?;
 
@@ -832,7 +832,7 @@ mod tests {
                     // We need to have some report aggregations present, so that our collect job
                     // can be picked up and the anti-replay check has something to check.
                     for i in 0..10 {
-                        let nonce = Nonce::generate(&clock);
+                        let nonce = Nonce::generate(&clock, task.min_batch_duration).unwrap();
                         tx.put_client_report(&Report::new(task_id, nonce, vec![], vec![]))
                             .await?;
                         tx.put_report_aggregation(&ReportAggregation::<

--- a/janus_server/src/aggregator/aggregation_job_driver.rs
+++ b/janus_server/src/aggregator/aggregation_job_driver.rs
@@ -834,7 +834,6 @@ mod tests {
         let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
         let ds = Arc::new(ds);
         let vdaf = Arc::new(Prio3::new_aes128_count(2).unwrap());
-        let nonce = Nonce::generate(&clock);
 
         let task_id = TaskId::random();
         let mut task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count.into(), Role::Leader);
@@ -842,6 +841,7 @@ mod tests {
             Url::parse("http://irrelevant").unwrap(), // leader URL doesn't matter
             Url::parse(&mockito::server_url()).unwrap(),
         ];
+        let nonce = Nonce::generate(&clock, task.min_batch_duration).unwrap();
         let verify_key = task
             .vdaf_verify_keys
             .get(0)
@@ -1028,7 +1028,6 @@ mod tests {
         let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
         let ds = Arc::new(ds);
         let vdaf = Arc::new(Prio3::new_aes128_count(2).unwrap());
-        let nonce = Nonce::generate(&clock);
 
         let task_id = TaskId::random();
         let mut task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count.into(), Role::Leader);
@@ -1036,6 +1035,7 @@ mod tests {
             Url::parse("http://irrelevant").unwrap(), // leader URL doesn't matter
             Url::parse(&mockito::server_url()).unwrap(),
         ];
+        let nonce = Nonce::generate(&clock, task.min_batch_duration).unwrap();
         let verify_key = task
             .vdaf_verify_keys
             .get(0)
@@ -1208,7 +1208,6 @@ mod tests {
         let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
         let ds = Arc::new(ds);
         let vdaf = Arc::new(Prio3::new_aes128_count(2).unwrap());
-        let nonce = Nonce::generate(&clock);
 
         let task_id = TaskId::random();
         let mut task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count.into(), Role::Leader);
@@ -1216,6 +1215,7 @@ mod tests {
             Url::parse("http://irrelevant").unwrap(), // leader URL doesn't matter
             Url::parse(&mockito::server_url()).unwrap(),
         ];
+        let nonce = Nonce::generate(&clock, task.min_batch_duration).unwrap();
         let verify_key = task
             .vdaf_verify_keys
             .get(0)
@@ -1416,7 +1416,6 @@ mod tests {
         let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
         let ds = Arc::new(ds);
         let vdaf = Arc::new(Prio3::new_aes128_count(2).unwrap());
-        let nonce = Nonce::generate(&clock);
 
         let task_id = TaskId::random();
         let mut task = new_dummy_task(task_id, VdafInstance::Prio3Aes128Count.into(), Role::Leader);
@@ -1424,6 +1423,7 @@ mod tests {
             Url::parse("http://irrelevant").unwrap(), // leader URL doesn't matter
             Url::parse(&mockito::server_url()).unwrap(),
         ];
+        let nonce = Nonce::generate(&clock, task.min_batch_duration).unwrap();
         let verify_key = task
             .vdaf_verify_keys
             .get(0)
@@ -1588,7 +1588,7 @@ mod tests {
         let (helper_hpke_config, _) = generate_hpke_config_and_private_key();
 
         let vdaf = Prio3::new_aes128_count(2).unwrap();
-        let nonce = Nonce::generate(&clock);
+        let nonce = Nonce::generate(&clock, task.min_batch_duration).unwrap();
         let transcript = run_vdaf(&vdaf, &verify_key, &(), nonce, &0);
         let report = generate_report(
             task_id,

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -2998,7 +2998,7 @@ mod tests {
             TaskId::random(),
             Nonce::new(
                 Time::from_seconds_since_epoch(12345),
-                [1, 2, 3, 4, 5, 6, 7, 8],
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
             ),
             vec![
                 Extension::new(ExtensionType::Tbd, Vec::from("extension_data_0")),
@@ -3057,7 +3057,7 @@ mod tests {
                         TaskId::random(),
                         Nonce::new(
                             Time::from_seconds_since_epoch(12345),
-                            [1, 2, 3, 4, 5, 6, 7, 8],
+                            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
                         ),
                     )
                     .await
@@ -3081,7 +3081,7 @@ mod tests {
             task_id,
             Nonce::new(
                 Time::from_seconds_since_epoch(12345),
-                [1, 2, 3, 4, 5, 6, 7, 8],
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
             ),
             vec![],
             vec![],
@@ -3090,7 +3090,7 @@ mod tests {
             task_id,
             Nonce::new(
                 Time::from_seconds_since_epoch(12346),
-                [1, 2, 3, 4, 5, 6, 7, 8],
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
             ),
             vec![],
             vec![],
@@ -3099,7 +3099,7 @@ mod tests {
             task_id,
             Nonce::new(
                 Time::from_seconds_since_epoch(12347),
-                [1, 2, 3, 4, 5, 6, 7, 8],
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
             ),
             vec![],
             vec![],
@@ -3108,7 +3108,7 @@ mod tests {
             unrelated_task_id,
             Nonce::new(
                 Time::from_seconds_since_epoch(12348),
-                [1, 2, 3, 4, 5, 6, 7, 8],
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
             ),
             vec![],
             vec![],
@@ -3212,7 +3212,7 @@ mod tests {
             task_id,
             Nonce::new(
                 Time::from_seconds_since_epoch(12345),
-                [1, 2, 3, 4, 5, 6, 7, 8],
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
             ),
             vec![],
             vec![],
@@ -3221,7 +3221,7 @@ mod tests {
             task_id,
             Nonce::new(
                 Time::from_seconds_since_epoch(12346),
-                [1, 2, 3, 4, 5, 6, 7, 8],
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
             ),
             vec![],
             vec![],
@@ -3230,7 +3230,7 @@ mod tests {
             task_id,
             Nonce::new(
                 Time::from_seconds_since_epoch(12347),
-                [1, 2, 3, 4, 5, 6, 7, 8],
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
             ),
             vec![],
             vec![],
@@ -3239,7 +3239,7 @@ mod tests {
             unrelated_task_id,
             Nonce::new(
                 Time::from_seconds_since_epoch(12348),
-                [1, 2, 3, 4, 5, 6, 7, 8],
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
             ),
             vec![],
             vec![],
@@ -3443,7 +3443,7 @@ mod tests {
         let report_share = ReportShare {
             nonce: Nonce::new(
                 Time::from_seconds_since_epoch(12345),
-                [1, 2, 3, 4, 5, 6, 7, 8],
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
             ),
             extensions: vec![
                 Extension::new(ExtensionType::Tbd, Vec::from("extension_data_0")),
@@ -3991,7 +3991,7 @@ mod tests {
             let aggregation_job_id = AggregationJobId::random();
             let nonce = Nonce::new(
                 Time::from_seconds_since_epoch(12345),
-                [1, 2, 3, 4, 5, 6, 7, 8],
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
             );
 
             let report_aggregation = ds
@@ -4108,7 +4108,7 @@ mod tests {
                         AggregationJobId::random(),
                         Nonce::new(
                             Time::from_seconds_since_epoch(12345),
-                            [1, 2, 3, 4, 5, 6, 7, 8],
+                            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
                         ),
                     )
                     .await
@@ -4127,7 +4127,7 @@ mod tests {
                             task_id: TaskId::random(),
                             nonce: Nonce::new(
                                 Time::from_seconds_since_epoch(12345),
-                                [1, 2, 3, 4, 5, 6, 7, 8],
+                                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
                             ),
                             ord: 0,
                             state: ReportAggregationState::Invalid,
@@ -4193,7 +4193,7 @@ mod tests {
                     {
                         let nonce = Nonce::new(
                             Time::from_seconds_since_epoch(12345),
-                            (ord as u64).to_be_bytes(),
+                            (ord as u128).to_be_bytes(),
                         );
                         tx.put_report_share(
                             task_id,

--- a/janus_server/src/message.rs
+++ b/janus_server/src/message.rs
@@ -498,15 +498,15 @@ mod tests {
                 PrepareStep {
                     nonce: Nonce::new(
                         Time::from_seconds_since_epoch(54372),
-                        [1, 2, 3, 4, 5, 6, 7, 8],
+                        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
                     ),
                     result: PrepareStepResult::Continued(Vec::from("012345")),
                 },
                 concat!(
                     concat!(
                         // nonce
-                        "000000000000D464", // time
-                        "0102030405060708", // rand
+                        "000000000000D464",                 // time
+                        "0102030405060708090a0b0c0d0e0f10", // rand
                     ),
                     "00", // prepare_step_result
                     concat!(
@@ -520,29 +520,29 @@ mod tests {
                 PrepareStep {
                     nonce: Nonce::new(
                         Time::from_seconds_since_epoch(12345),
-                        [8, 7, 6, 5, 4, 3, 2, 1],
+                        [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
                     ),
                     result: PrepareStepResult::Finished,
                 },
                 concat!(
                     concat!(
                         // nonce
-                        "0000000000003039", // time
-                        "0807060504030201", // rand
+                        "0000000000003039",                 // time
+                        "100f0e0d0c0b0a090807060504030201", // rand
                     ),
                     "01", // prepare_step_result
                 ),
             ),
             (
                 PrepareStep {
-                    nonce: Nonce::new(Time::from_seconds_since_epoch(345078), [255; 8]),
+                    nonce: Nonce::new(Time::from_seconds_since_epoch(345078), [255; 16]),
                     result: PrepareStepResult::Failed(ReportShareError::VdafPrepError),
                 },
                 concat!(
                     concat!(
                         // nonce
-                        "00000000000543F6", // time
-                        "FFFFFFFFFFFFFFFF", // rand
+                        "00000000000543F6",                 // time
+                        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", // rand
                     ),
                     "02", // prepare_step_result
                     "05", // report_share_error
@@ -595,7 +595,7 @@ mod tests {
                     ReportShare {
                         nonce: Nonce::new(
                             Time::from_seconds_since_epoch(54321),
-                            [1, 2, 3, 4, 5, 6, 7, 8],
+                            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
                         ),
                         extensions: vec![Extension::new(ExtensionType::Tbd, Vec::from("0123"))],
                         encrypted_input_share: HpkeCiphertext::new(
@@ -607,7 +607,7 @@ mod tests {
                     ReportShare {
                         nonce: Nonce::new(
                             Time::from_seconds_since_epoch(73542),
-                            [8, 7, 6, 5, 4, 3, 2, 1],
+                            [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
                         ),
                         extensions: vec![Extension::new(ExtensionType::Tbd, Vec::from("3210"))],
                         encrypted_input_share: HpkeCiphertext::new(
@@ -628,12 +628,12 @@ mod tests {
                 ),
                 concat!(
                     // report_shares
-                    "0052", // length
+                    "0062", // length
                     concat!(
                         concat!(
                             // nonce
-                            "000000000000D431", // time
-                            "0102030405060708", // rand
+                            "000000000000D431",                 // time
+                            "0102030405060708090a0b0c0d0e0f10", // rand
                         ),
                         concat!(
                             // extensions
@@ -665,8 +665,8 @@ mod tests {
                     concat!(
                         concat!(
                             // nonce
-                            "0000000000011F46", // time
-                            "0807060504030201", // rand
+                            "0000000000011F46",                 // time
+                            "100f0e0d0c0b0a090807060504030201", // rand
                         ),
                         concat!(
                             // extensions
@@ -717,14 +717,14 @@ mod tests {
                         PrepareStep {
                             nonce: Nonce::new(
                                 Time::from_seconds_since_epoch(54372),
-                                [1, 2, 3, 4, 5, 6, 7, 8],
+                                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
                             ),
                             result: PrepareStepResult::Continued(Vec::from("012345")),
                         },
                         PrepareStep {
                             nonce: Nonce::new(
                                 Time::from_seconds_since_epoch(12345),
-                                [8, 7, 6, 5, 4, 3, 2, 1],
+                                [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
                             ),
                             result: PrepareStepResult::Finished,
                         },
@@ -732,12 +732,12 @@ mod tests {
                 },
                 concat!(concat!(
                     //prepare_steps
-                    "002A", // length
+                    "003A", // length
                     concat!(
                         concat!(
                             // nonce
-                            "000000000000D464", // time
-                            "0102030405060708", // rand
+                            "000000000000D464",                 // time
+                            "0102030405060708090a0b0c0d0e0f10", // rand
                         ),
                         "00", // prepare_step_result
                         concat!(
@@ -749,8 +749,8 @@ mod tests {
                     concat!(
                         concat!(
                             // nonce
-                            "0000000000003039", // time
-                            "0807060504030201", // rand
+                            "0000000000003039",                 // time
+                            "100f0e0d0c0b0a090807060504030201", // rand
                         ),
                         "01", // prepare_step_result
                     ),
@@ -769,14 +769,14 @@ mod tests {
                     PrepareStep {
                         nonce: Nonce::new(
                             Time::from_seconds_since_epoch(54372),
-                            [1, 2, 3, 4, 5, 6, 7, 8],
+                            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
                         ),
                         result: PrepareStepResult::Continued(Vec::from("012345")),
                     },
                     PrepareStep {
                         nonce: Nonce::new(
                             Time::from_seconds_since_epoch(12345),
-                            [8, 7, 6, 5, 4, 3, 2, 1],
+                            [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
                         ),
                         result: PrepareStepResult::Finished,
                     },
@@ -787,12 +787,12 @@ mod tests {
                 "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", // job_id
                 concat!(
                     // prepare_steps
-                    "002A", // length
+                    "003A", // length
                     concat!(
                         concat!(
                             // nonce
-                            "000000000000D464", // time
-                            "0102030405060708", // rand
+                            "000000000000D464",                 // time
+                            "0102030405060708090a0b0c0d0e0f10", // rand
                         ),
                         "00", // prepare_step_result
                         concat!(
@@ -804,8 +804,8 @@ mod tests {
                     concat!(
                         concat!(
                             // nonce
-                            "0000000000003039", // time
-                            "0807060504030201", // rand
+                            "0000000000003039",                 // time
+                            "100f0e0d0c0b0a090807060504030201", // rand
                         ),
                         "01", // prepare_step_result
                     )
@@ -832,14 +832,14 @@ mod tests {
                         PrepareStep {
                             nonce: Nonce::new(
                                 Time::from_seconds_since_epoch(54372),
-                                [1, 2, 3, 4, 5, 6, 7, 8],
+                                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
                             ),
                             result: PrepareStepResult::Continued(Vec::from("012345")),
                         },
                         PrepareStep {
                             nonce: Nonce::new(
                                 Time::from_seconds_since_epoch(12345),
-                                [8, 7, 6, 5, 4, 3, 2, 1],
+                                [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
                             ),
                             result: PrepareStepResult::Finished,
                         },
@@ -847,12 +847,12 @@ mod tests {
                 },
                 concat!(concat!(
                     //prepare_steps
-                    "002A", // length
+                    "003A", // length
                     concat!(
                         concat!(
                             // nonce
-                            "000000000000D464", // time
-                            "0102030405060708", // rand
+                            "000000000000D464",                 // time
+                            "0102030405060708090a0b0c0d0e0f10", // rand
                         ),
                         "00", // prepare_step_result
                         concat!(
@@ -864,8 +864,8 @@ mod tests {
                     concat!(
                         concat!(
                             // nonce
-                            "0000000000003039", // time
-                            "0807060504030201", // rand
+                            "0000000000003039",                 // time
+                            "100f0e0d0c0b0a090807060504030201", // rand
                         ),
                         "01", // prepare_step_result
                     ),

--- a/monolithic_integration_test/tests/integration_test.rs
+++ b/monolithic_integration_test/tests/integration_test.rs
@@ -360,6 +360,7 @@ impl TestCase {
         let client_parameters = ClientParameters::new(
             task_id,
             vec![leader_endpoint.clone(), helper_endpoint.clone()],
+            leader_task.min_batch_duration,
         );
         let http_client = janus_client::default_http_client().unwrap();
         let leader_report_config = janus_client::aggregator_hpke_config(


### PR DESCRIPTION
This implements the change in ietf-wg-ppm/draft-ietf-ppm-dap#281, rounding down timestamps of reports to the next multiple of `min_batch_duration`.