### PR TITLE
Add metrics to job drivers & for partial failures in HTTP handlers.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1560,6 +1560,7 @@ dependencies = [
  "janus_core",
  "janus_server",
  "lazy_static",
+ "opentelemetry",
  "prio",
  "rand",
  "reqwest",

--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -1140,7 +1140,8 @@ impl VdafOps {
         // TODO(#224): don't do O(n) network round-trips (where n is the number of prepare steps)
         Ok(datastore
             .run_tx(|tx| {
-                let (vdaf, prep_steps, aggregate_step_failure_counter) = (Arc::clone(&vdaf), Arc::clone(&prep_steps), Arc::clone(&aggregate_step_failure_counter)); // XXX: wrap
+                let (vdaf, prep_steps, aggregate_step_failure_counter) =
+                    (Arc::clone(&vdaf), Arc::clone(&prep_steps), Arc::clone(&aggregate_step_failure_counter));
 
                 Box::pin(async move {
                     // Read existing state.

--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -37,7 +37,7 @@ use janus_core::{
     time::Clock,
 };
 use opentelemetry::{
-    metrics::{Counter, Unit, ValueRecorder},
+    metrics::{Counter, Meter, Unit, ValueRecorder},
     KeyValue,
 };
 use prio::{
@@ -87,28 +87,28 @@ pub enum Error {
     #[error("invalid message: {0}")]
     Message(#[from] janus_core::message::Error),
     /// Corresponds to `reportTooLate`, §3.1
-    #[error("stale report: {0} {1:?}")]
+    #[error("task {1:?}: stale report: {0}")]
     ReportTooLate(Nonce, TaskId),
     /// Corresponds to `reportTooEarly`, §3.1. A report was rejected becuase the timestamp is too far in the future, §4.3.4.
-    #[error("report from the future: {0} {1:?}")]
+    #[error("task {1:?}: report from the future: {0}")]
     ReportTooEarly(Nonce, TaskId),
     /// Corresponds to `unrecognizedMessage`, §3.1
-    #[error("unrecognized message: {0} {1:?}")]
+    #[error("task {1:?}: unrecognized message: {0}")]
     UnrecognizedMessage(&'static str, Option<TaskId>),
     /// Corresponds to `unrecognizedTask`, §3.1
-    #[error("unrecognized task: {0:?}")]
+    #[error("task {0:?}: unrecognized task")]
     UnrecognizedTask(TaskId),
     /// An attempt was made to act on an unknown aggregation job.
-    #[error("unrecognized aggregation job: {0:?}")]
+    #[error("task {1:?}: unrecognized aggregation job: {0:?}")]
     UnrecognizedAggregationJob(AggregationJobId, TaskId),
     /// An attempt was made to act on an unknown collect job.
     #[error("unrecognized collect job: {0}")]
     UnrecognizedCollectJob(Uuid),
     /// Corresponds to `outdatedHpkeConfig`, §3.1
-    #[error("outdated HPKE config: {0} {1:?}")]
+    #[error("task {1:?}: outdated HPKE config: {0}")]
     OutdatedHpkeConfig(HpkeConfigId, TaskId),
     /// Corresponds to `unauthorizedRequest`, §3.1
-    #[error("unauthorized request: {0:?}")]
+    #[error("task {0:?}: unauthorized request")]
     UnauthorizedRequest(TaskId),
     /// An error from the datastore.
     #[error("datastore error: {0}")]
@@ -117,10 +117,10 @@ pub enum Error {
     #[error("VDAF error: {0}")]
     Vdaf(#[from] vdaf::VdafError),
     /// A collect or aggregate share request was rejected because the interval is valid, per §4.6
-    #[error("invalid batch interval: {0} {1:?}")]
+    #[error("task {1:?}: invalid batch interval: {0}")]
     BatchInvalid(Interval, TaskId),
     /// There are not enough reports in the batch interval to meet the task's minimum batch size.
-    #[error("insufficient number of reports ({0}) for task {1:?}")]
+    #[error("task {1:?}: insufficient number of reports ({0})")]
     InsufficientBatchSize(u64, TaskId),
     #[error("URL parse error: {0}")]
     Url(#[from] url::ParseError),
@@ -138,7 +138,7 @@ peer checksum: {peer_checksum:?} peer report count: {peer_report_count}"
         peer_report_count: u64,
     },
     /// Too many queries against a single batch.
-    #[error("maxiumum batch lifetime for task {0:?} exceeded")]
+    #[error("task {0:?}: maxiumum batch lifetime exceeded")]
     BatchLifetimeExceeded(TaskId),
     /// HPKE failure.
     #[error("HPKE error: {0}")]
@@ -179,14 +179,36 @@ pub struct Aggregator<C: Clock> {
     clock: C,
     /// Cache of task aggregators.
     task_aggregators: Mutex<HashMap<TaskId, Arc<TaskAggregator>>>,
+
+    // Metrics.
+    /// Counter tracking the number of failed decryptions while handling the /upload endpoint.
+    upload_decrypt_failure_counter: Counter<u64>,
+    /// Counter tracking the number of failures to step client reports through the aggregation process.
+    aggregate_step_failure_counter: Arc<Counter<u64>>,
 }
 
 impl<C: Clock> Aggregator<C> {
-    fn new(datastore: Arc<Datastore<C>>, clock: C) -> Self {
+    fn new(datastore: Arc<Datastore<C>>, clock: C, meter: Meter) -> Self {
+        let upload_decrypt_failure_counter = meter
+            .u64_counter("upload_decrypt_failures")
+            .with_description("Number of decryption failures in the /upload endpoint.")
+            .init();
+        let aggregate_step_failure_counter = Arc::new(
+            meter
+                .u64_counter("step_failures")
+                .with_description(concat!(
+                    "Failures while stepping aggregation jobs; these failures are ",
+                    "related to individual client reports rather than entire aggregation jobs."
+                ))
+                .init(),
+        );
+
         Self {
             datastore,
             clock,
             task_aggregators: Mutex::new(HashMap::new()),
+            upload_decrypt_failure_counter,
+            aggregate_step_failure_counter,
         }
     }
 
@@ -208,7 +230,12 @@ impl<C: Clock> Aggregator<C> {
             return Err(Error::UnrecognizedTask(report.task_id()));
         }
         task_aggregator
-            .handle_upload(&self.datastore, &self.clock, report)
+            .handle_upload(
+                &self.datastore,
+                &self.clock,
+                &self.upload_decrypt_failure_counter,
+                report,
+            )
             .await
     }
 
@@ -239,7 +266,7 @@ impl<C: Clock> Aggregator<C> {
             return Err(Error::UnrecognizedTask(task_id));
         }
         Ok(task_aggregator
-            .handle_aggregate_init(&self.datastore, req)
+            .handle_aggregate_init(&self.datastore, &self.aggregate_step_failure_counter, req)
             .await?
             .get_encoded())
     }
@@ -271,7 +298,11 @@ impl<C: Clock> Aggregator<C> {
             return Err(Error::UnrecognizedTask(task_id));
         }
         Ok(task_aggregator
-            .handle_aggregate_continue(&self.datastore, req)
+            .handle_aggregate_continue(
+                &self.datastore,
+                Arc::clone(&self.aggregate_step_failure_counter),
+                req,
+            )
             .await?
             .get_encoded())
     }
@@ -404,7 +435,7 @@ impl TaskAggregator {
                     .clone()
                     .try_into()
                     .map_err(|_| Error::TaskParameters(task::Error::AggregatorAuthKeySize))?;
-                VdafOps::Prio3Aes128Count(vdaf, verify_key)
+                VdafOps::Prio3Aes128Count(Arc::new(vdaf), verify_key)
             }
 
             VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128Sum { bits }) => {
@@ -413,7 +444,7 @@ impl TaskAggregator {
                     .clone()
                     .try_into()
                     .map_err(|_| Error::TaskParameters(task::Error::AggregatorAuthKeySize))?;
-                VdafOps::Prio3Aes128Sum(vdaf, verify_key)
+                VdafOps::Prio3Aes128Sum(Arc::new(vdaf), verify_key)
             }
 
             VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128Histogram {
@@ -424,31 +455,31 @@ impl TaskAggregator {
                     .clone()
                     .try_into()
                     .map_err(|_| Error::TaskParameters(task::Error::AggregatorAuthKeySize))?;
-                VdafOps::Prio3Aes128Histogram(vdaf, verify_key)
+                VdafOps::Prio3Aes128Histogram(Arc::new(vdaf), verify_key)
             }
 
             #[cfg(test)]
-            VdafInstance::Fake => VdafOps::Fake(dummy_vdaf::Vdaf::new()),
+            VdafInstance::Fake => VdafOps::Fake(Arc::new(dummy_vdaf::Vdaf::new())),
 
             #[cfg(test)]
-            VdafInstance::FakeFailsPrepInit => VdafOps::Fake(
+            VdafInstance::FakeFailsPrepInit => VdafOps::Fake(Arc::new(
                 dummy_vdaf::Vdaf::new().with_prep_init_fn(|_| -> Result<(), VdafError> {
                     Err(VdafError::Uncategorized(
                         "FakeFailsPrepInit failed at prep_init".to_string(),
                     ))
                 }),
-            ),
+            )),
 
             #[cfg(test)]
             VdafInstance::FakeFailsPrepStep => {
                 const VERIFY_KEY_LENGTH: usize = dummy_vdaf::Vdaf::VERIFY_KEY_LENGTH;
-                VdafOps::Fake(dummy_vdaf::Vdaf::new().with_prep_step_fn(
+                VdafOps::Fake(Arc::new(dummy_vdaf::Vdaf::new().with_prep_step_fn(
                     || -> Result<PrepareTransition<dummy_vdaf::Vdaf, VERIFY_KEY_LENGTH>, VdafError> {
                         Err(VdafError::Uncategorized(
                             "FakeFailsPrepStep failed at prep_step".to_string(),
                         ))
                     },
-                ))
+                )))
             }
 
             _ => panic!("VDAF {:?} is not yet supported", task.vdaf),
@@ -475,30 +506,39 @@ impl TaskAggregator {
         &self,
         datastore: &Datastore<C>,
         clock: &C,
+        upload_decrypt_failure_counter: &Counter<u64>,
         report: Report,
     ) -> Result<(), Error> {
         self.vdaf_ops
-            .handle_upload(datastore, clock, &self.task, report)
+            .handle_upload(
+                datastore,
+                clock,
+                upload_decrypt_failure_counter,
+                &self.task,
+                report,
+            )
             .await
     }
 
     async fn handle_aggregate_init<C: Clock>(
         &self,
         datastore: &Datastore<C>,
+        aggregate_step_failure_counter: &Counter<u64>,
         req: AggregateInitializeReq,
     ) -> Result<AggregateInitializeResp, Error> {
         self.vdaf_ops
-            .handle_aggregate_init(datastore, &self.task, req)
+            .handle_aggregate_init(datastore, aggregate_step_failure_counter, &self.task, req)
             .await
     }
 
     async fn handle_aggregate_continue<C: Clock>(
         &self,
         datastore: &Datastore<C>,
+        aggregate_step_failure_counter: Arc<Counter<u64>>,
         req: AggregateContinueReq,
     ) -> Result<AggregateContinueResp, Error> {
         self.vdaf_ops
-            .handle_aggregate_continue(datastore, &self.task, req)
+            .handle_aggregate_continue(datastore, aggregate_step_failure_counter, &self.task, req)
             .await
     }
 
@@ -549,12 +589,15 @@ impl TaskAggregator {
 #[allow(clippy::enum_variant_names)]
 enum VdafOps {
     // For the Prio3 VdafOps, the second parameter is the verify_key.
-    Prio3Aes128Count(Prio3Aes128Count, [u8; PRIO3_AES128_VERIFY_KEY_LENGTH]),
-    Prio3Aes128Sum(Prio3Aes128Sum, [u8; PRIO3_AES128_VERIFY_KEY_LENGTH]),
-    Prio3Aes128Histogram(Prio3Aes128Histogram, [u8; PRIO3_AES128_VERIFY_KEY_LENGTH]),
+    Prio3Aes128Count(Arc<Prio3Aes128Count>, [u8; PRIO3_AES128_VERIFY_KEY_LENGTH]),
+    Prio3Aes128Sum(Arc<Prio3Aes128Sum>, [u8; PRIO3_AES128_VERIFY_KEY_LENGTH]),
+    Prio3Aes128Histogram(
+        Arc<Prio3Aes128Histogram>,
+        [u8; PRIO3_AES128_VERIFY_KEY_LENGTH],
+    ),
 
     #[cfg(test)]
-    Fake(dummy_vdaf::Vdaf),
+    Fake(Arc<dummy_vdaf::Vdaf>),
 }
 
 impl VdafOps {
@@ -562,19 +605,28 @@ impl VdafOps {
         &self,
         datastore: &Datastore<C>,
         clock: &C,
+        upload_decrypt_failure_counter: &Counter<u64>,
         task: &Task,
         report: Report,
     ) -> Result<(), Error> {
         match self {
             VdafOps::Prio3Aes128Count(_, _) => {
                 Self::handle_upload_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count, _>(
-                    datastore, clock, task, report,
+                    datastore,
+                    clock,
+                    upload_decrypt_failure_counter,
+                    task,
+                    report,
                 )
                 .await
             }
             VdafOps::Prio3Aes128Sum(_, _) => {
                 Self::handle_upload_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Sum, _>(
-                    datastore, clock, task, report,
+                    datastore,
+                    clock,
+                    upload_decrypt_failure_counter,
+                    task,
+                    report,
                 )
                 .await
             }
@@ -582,14 +634,24 @@ impl VdafOps {
                 PRIO3_AES128_VERIFY_KEY_LENGTH,
                 Prio3Aes128Histogram,
                 _,
-            >(datastore, clock, task, report)
+            >(
+                datastore,
+                clock,
+                upload_decrypt_failure_counter,
+                task,
+                report,
+            )
             .await,
 
             #[cfg(test)]
             VdafOps::Fake(_) => {
                 const VERIFY_KEY_LENGTH: usize = dummy_vdaf::Vdaf::VERIFY_KEY_LENGTH;
                 Self::handle_upload_generic::<VERIFY_KEY_LENGTH, dummy_vdaf::Vdaf, _>(
-                    datastore, clock, task, report,
+                    datastore,
+                    clock,
+                    upload_decrypt_failure_counter,
+                    task,
+                    report,
                 )
                 .await
             }
@@ -601,6 +663,7 @@ impl VdafOps {
     async fn handle_aggregate_init<C: Clock>(
         &self,
         datastore: &Datastore<C>,
+        aggregate_step_failure_counter: &Counter<u64>,
         task: &Task,
         req: AggregateInitializeReq,
     ) -> Result<AggregateInitializeResp, Error> {
@@ -610,7 +673,14 @@ impl VdafOps {
                     PRIO3_AES128_VERIFY_KEY_LENGTH,
                     Prio3Aes128Count,
                     _,
-                >(datastore, vdaf, task, verify_key, req)
+                >(
+                    datastore,
+                    vdaf,
+                    aggregate_step_failure_counter,
+                    task,
+                    verify_key,
+                    req,
+                )
                 .await
             }
             VdafOps::Prio3Aes128Sum(vdaf, verify_key) => {
@@ -618,7 +688,14 @@ impl VdafOps {
                     PRIO3_AES128_VERIFY_KEY_LENGTH,
                     Prio3Aes128Sum,
                     _,
-                >(datastore, vdaf, task, verify_key, req)
+                >(
+                    datastore,
+                    vdaf,
+                    aggregate_step_failure_counter,
+                    task,
+                    verify_key,
+                    req,
+                )
                 .await
             }
             VdafOps::Prio3Aes128Histogram(vdaf, verify_key) => {
@@ -626,7 +703,14 @@ impl VdafOps {
                     PRIO3_AES128_VERIFY_KEY_LENGTH,
                     Prio3Aes128Histogram,
                     _,
-                >(datastore, vdaf, task, verify_key, req)
+                >(
+                    datastore,
+                    vdaf,
+                    aggregate_step_failure_counter,
+                    task,
+                    verify_key,
+                    req,
+                )
                 .await
             }
 
@@ -636,6 +720,7 @@ impl VdafOps {
                 Self::handle_aggregate_init_generic::<VERIFY_KEY_LENGTH, dummy_vdaf::Vdaf, _>(
                     datastore,
                     vdaf,
+                    aggregate_step_failure_counter,
                     task,
                     &[],
                     req,
@@ -648,6 +733,7 @@ impl VdafOps {
     async fn handle_aggregate_continue<C: Clock>(
         &self,
         datastore: &Datastore<C>,
+        aggregate_step_failure_counter: Arc<Counter<u64>>,
         task: &Task,
         req: AggregateContinueReq,
     ) -> Result<AggregateContinueResp, Error> {
@@ -657,7 +743,13 @@ impl VdafOps {
                     PRIO3_AES128_VERIFY_KEY_LENGTH,
                     Prio3Aes128Count,
                     _,
-                >(datastore, vdaf, task, req)
+                >(
+                    datastore,
+                    Arc::clone(vdaf),
+                    aggregate_step_failure_counter,
+                    task,
+                    req,
+                )
                 .await
             }
             VdafOps::Prio3Aes128Sum(vdaf, _) => {
@@ -665,7 +757,13 @@ impl VdafOps {
                     PRIO3_AES128_VERIFY_KEY_LENGTH,
                     Prio3Aes128Sum,
                     _,
-                >(datastore, vdaf, task, req)
+                >(
+                    datastore,
+                    Arc::clone(vdaf),
+                    aggregate_step_failure_counter,
+                    task,
+                    req,
+                )
                 .await
             }
             VdafOps::Prio3Aes128Histogram(vdaf, _) => {
@@ -673,7 +771,13 @@ impl VdafOps {
                     PRIO3_AES128_VERIFY_KEY_LENGTH,
                     Prio3Aes128Histogram,
                     _,
-                >(datastore, vdaf, task, req)
+                >(
+                    datastore,
+                    Arc::clone(vdaf),
+                    aggregate_step_failure_counter,
+                    task,
+                    req,
+                )
                 .await
             }
 
@@ -681,7 +785,11 @@ impl VdafOps {
             VdafOps::Fake(vdaf) => {
                 const VERIFY_KEY_LENGTH: usize = dummy_vdaf::Vdaf::VERIFY_KEY_LENGTH;
                 Self::handle_aggregate_continue_generic::<VERIFY_KEY_LENGTH, dummy_vdaf::Vdaf, _>(
-                    datastore, vdaf, task, req,
+                    datastore,
+                    Arc::clone(vdaf),
+                    aggregate_step_failure_counter,
+                    task,
+                    req,
                 )
                 .await
             }
@@ -691,6 +799,7 @@ impl VdafOps {
     async fn handle_upload_generic<const L: usize, A: vdaf::Aggregator<L>, C: Clock>(
         datastore: &Datastore<C>,
         clock: &C,
+        upload_decrypt_failure_counter: &Counter<u64>,
         task: &Task,
         report: Report,
     ) -> Result<(), Error>
@@ -702,10 +811,6 @@ impl VdafOps {
     {
         // §4.2.2 The leader's report is the first one
         if report.encrypted_input_shares().len() != 2 {
-            warn!(
-                share_count = report.encrypted_input_shares().len(),
-                "Unexpected number of encrypted shares in report"
-            );
             return Err(Error::UnrecognizedMessage(
                 "unexpected number of encrypted shares in report",
                 Some(report.task_id()),
@@ -718,10 +823,6 @@ impl VdafOps {
             .hpke_keys
             .get(&leader_report.config_id())
             .ok_or_else(|| {
-                warn!(
-                    config_id = ?leader_report.config_id(),
-                    "Unknown HPKE config ID"
-                );
                 Error::OutdatedHpkeConfig(leader_report.config_id(), report.task_id())
             })?;
 
@@ -729,7 +830,6 @@ impl VdafOps {
 
         // §4.2.4: reject reports from too far in the future
         if report.nonce().time().is_after(report_deadline) {
-            warn!(report.task_id = ?report.task_id(), report.nonce = ?report.nonce(), "Report timestamp exceeds tolerable clock skew");
             return Err(Error::ReportTooEarly(report.nonce(), report.task_id()));
         }
 
@@ -744,42 +844,45 @@ impl VdafOps {
             leader_report,
             &report.associated_data(),
         ) {
-            warn!(report.task_id = ?report.task_id(), report.nonce = ?report.nonce(), ?err, "Report decryption failed");
+            error!(report.task_id = ?report.task_id(), report.nonce = ?report.nonce(), ?err, "Report decryption failed");
+            upload_decrypt_failure_counter.add(1, &[]);
             return Ok(());
         }
 
         datastore
-                    .run_tx(|tx| {
-                        let report = report.clone();
-                        Box::pin(async move {
-                            let (existing_client_report, conflicting_collect_jobs) = try_join!(
-                                tx.get_client_report(report.task_id(), report.nonce()),
-                                tx.find_collect_jobs_including_time::<L, A>(report.task_id(), report.nonce().time()),
-                            )?;
+            .run_tx(|tx| {
+                let report = report.clone();
+                Box::pin(async move {
+                    let (existing_client_report, conflicting_collect_jobs) = try_join!(
+                        tx.get_client_report(report.task_id(), report.nonce()),
+                        tx.find_collect_jobs_including_time::<L, A>(
+                            report.task_id(),
+                            report.nonce().time()
+                        ),
+                    )?;
 
-                            // §4.2.2 and 4.3.2.2: reject reports whose nonce has been seen before.
-                            if existing_client_report.is_some() {
-                                warn!(report.task_id = ?report.task_id(), report.nonce = ?report.nonce(), "Report replayed");
-                                // TODO(#34): change this error type.
-                                return Err(datastore::Error::User(
-                                    Error::ReportTooLate(report.nonce(), report.task_id()).into(),
-                                ));
-                            }
+                    // §4.2.2 and 4.3.2.2: reject reports whose nonce has been seen before.
+                    if existing_client_report.is_some() {
+                        // TODO(#34): change this error type.
+                        return Err(datastore::Error::User(
+                            Error::ReportTooLate(report.nonce(), report.task_id()).into(),
+                        ));
+                    }
 
-                            // §4.3.2: reject reports whose timestamps fall into a batch interval
-                            // that has already been collected.
-                            if !conflicting_collect_jobs.is_empty() {
-                                return Err(datastore::Error::User(
-                                    Error::ReportTooLate(report.nonce(), report.task_id()).into(),
-                                ));
-                            }
+                    // §4.3.2: reject reports whose timestamps fall into a batch interval
+                    // that has already been collected.
+                    if !conflicting_collect_jobs.is_empty() {
+                        return Err(datastore::Error::User(
+                            Error::ReportTooLate(report.nonce(), report.task_id()).into(),
+                        ));
+                    }
 
-                            // Store the report.
-                            tx.put_client_report(&report).await?;
-                            Ok(())
-                        })
-                    })
-                    .await?;
+                    // Store the report.
+                    tx.put_client_report(&report).await?;
+                    Ok(())
+                })
+            })
+            .await?;
         Ok(())
     }
 
@@ -788,6 +891,7 @@ impl VdafOps {
     async fn handle_aggregate_init_generic<const L: usize, A: vdaf::Aggregator<L>, C: Clock>(
         datastore: &Datastore<C>,
         vdaf: &A,
+        aggregate_step_failure_counter: &Counter<u64>,
         task: &Task,
         verify_key: &[u8; L],
         req: AggregateInitializeReq,
@@ -835,10 +939,12 @@ impl VdafOps {
                 .hpke_keys
                 .get(&report_share.encrypted_input_share.config_id())
                 .ok_or_else(|| {
-                    warn!(
+                    error!(
                         config_id = ?report_share.encrypted_input_share.config_id(),
-                        "Unknown HPKE config ID"
+                        "Helper encrypted input share references unknown HPKE config ID"
                     );
+                    aggregate_step_failure_counter
+                        .add(1, &[KeyValue::new("type", "unknown_hpke_config_id")]);
                     ReportShareError::HpkeUnknownConfigId
                 });
 
@@ -852,12 +958,14 @@ impl VdafOps {
                     &report_share.associated_data(task_id),
                 )
                 .map_err(|err| {
-                    warn!(
+                    error!(
                         ?task_id,
                         nonce = %report_share.nonce,
                         %err,
-                        "Couldn't decrypt report share"
+                        "Couldn't decrypt helper's report share"
                     );
+                    aggregate_step_failure_counter
+                        .add(1, &[KeyValue::new("type", "decrypt_failure")]);
                     ReportShareError::HpkeDecryptError
                 })
             });
@@ -870,7 +978,9 @@ impl VdafOps {
             let input_share = plaintext.and_then(|plaintext| {
                 A::InputShare::get_decoded_with_param(&(vdaf, Role::Helper.index().unwrap()), &plaintext)
                     .map_err(|err| {
-                        warn!(?task_id, nonce = %report_share.nonce, %err, "Couldn't decode input share from report share");
+                        error!(?task_id, nonce = %report_share.nonce, %err, "Couldn't decode helper's input share");
+                        aggregate_step_failure_counter
+                            .add(1, &[KeyValue::new("type", "input_share_decode_failure")]);
                         ReportShareError::VdafPrepError
                     })
             });
@@ -888,7 +998,9 @@ impl VdafOps {
                         &input_share,
                     )
                     .map_err(|err| {
-                        warn!(?task_id, nonce = %report_share.nonce, %err, "Couldn't prepare_init report share");
+                        error!(?task_id, nonce = %report_share.nonce, %err, "Couldn't prepare_init report share");
+                        aggregate_step_failure_counter
+                            .add(1, &[KeyValue::new("type", "prepare_init_failure")]);
                         ReportShareError::VdafPrepError
                     })
             });
@@ -1003,7 +1115,8 @@ impl VdafOps {
 
     async fn handle_aggregate_continue_generic<const L: usize, A: vdaf::Aggregator<L>, C: Clock>(
         datastore: &Datastore<C>,
-        vdaf: &A,
+        vdaf: Arc<A>,
+        aggregate_step_failure_counter: Arc<Counter<u64>>,
         task: &Task,
         req: AggregateContinueReq,
     ) -> Result<AggregateContinueResp, Error>
@@ -1021,15 +1134,13 @@ impl VdafOps {
     {
         let task_id = task.id;
         let min_batch_duration = task.min_batch_duration;
-        let vdaf = Arc::new(vdaf.clone());
         let prep_steps = Arc::new(req.prepare_steps);
 
         // TODO(#224): don't hold DB transaction open while computing VDAF updates?
         // TODO(#224): don't do O(n) network round-trips (where n is the number of prepare steps)
         Ok(datastore
             .run_tx(|tx| {
-                let vdaf = Arc::clone(&vdaf);
-                let prep_steps = Arc::clone(&prep_steps);
+                let (vdaf, prep_steps, aggregate_step_failure_counter) = (Arc::clone(&vdaf), Arc::clone(&prep_steps), Arc::clone(&aggregate_step_failure_counter)); // XXX: wrap
 
                 Box::pin(async move {
                     // Read existing state.
@@ -1055,7 +1166,6 @@ impl VdafOps {
                         // and extract the stored preparation step.
                         let mut report_aggregation = loop {
                             let mut report_agg = report_aggregations.next().ok_or_else(|| {
-                                warn!(?task_id, job_id = ?req.job_id, nonce = %prep_step.nonce, "Leader sent unexpected, duplicate, or out-of-order prepare steps");
                                 datastore::Error::User(Error::UnrecognizedMessage(
                                     "leader sent unexpected, duplicate, or out-of-order prepare steps",
                                     Some(task_id),
@@ -1091,7 +1201,6 @@ impl VdafOps {
                             match report_aggregation.state {
                                 ReportAggregationState::Waiting(prep_state, _) => prep_state,
                                 _ => {
-                                    warn!(?task_id, job_id = ?req.job_id, nonce = %prep_step.nonce, "Leader sent prepare step for non-WAITING report aggregation");
                                     return Err(datastore::Error::User(
                                         Error::UnrecognizedMessage(
                                             "leader sent prepare step for non-WAITING report aggregation",
@@ -1110,7 +1219,6 @@ impl VdafOps {
                                 )?
                             }
                             _ => {
-                                warn!(?task_id, job_id = ?req.job_id, nonce = %prep_step.nonce, "Leader sent non-Continued prepare step");
                                 return Err(datastore::Error::User(
                                     Error::UnrecognizedMessage(
                                         "leader sent non-Continued prepare step",
@@ -1144,7 +1252,9 @@ impl VdafOps {
                             }
 
                             Err(err) => {
-                                warn!(?task_id, job_id = ?req.job_id, nonce = %prep_step.nonce, %err, "Prepare step failed");
+                                error!(?task_id, job_id = ?req.job_id, nonce = %prep_step.nonce, %err, "Prepare step failed");
+                                aggregate_step_failure_counter
+                                    .add(1, &[KeyValue::new("type", "prepare_step_failure")]);
                                 report_aggregation.state =
                                     ReportAggregationState::Failed(ReportShareError::VdafPrepError);
                                 response_prep_steps.push(PrepareStep {
@@ -1710,8 +1820,8 @@ fn error_handler<R: Reply>(
     ]);
 
     move |result| {
-        if let Err(error) = &result {
-            error!(%error);
+        if let Err(err) = &result {
+            error!(%err, endpoint = name, "Error handling aggregator endpoint");
             bound_counter_error.add(1);
         } else {
             bound_counter_success.add(1);
@@ -1858,8 +1968,6 @@ fn aggregator_filter<C: Clock>(
     datastore: Arc<Datastore<C>>,
     clock: C,
 ) -> Result<BoxedFilter<(impl Reply,)>, Error> {
-    let aggregator = Arc::new(Aggregator::new(datastore, clock));
-
     let meter = opentelemetry::global::meter("janus_server");
     let response_counter = meter
         .u64_counter("aggregator_response")
@@ -1870,6 +1978,8 @@ fn aggregator_filter<C: Clock>(
         .with_description("Elapsed time handling incoming requests.")
         .with_unit(Unit::new("seconds"))
         .init();
+
+    let aggregator = Arc::new(Aggregator::new(datastore, clock, meter));
 
     let hpke_config_routing = warp::path("hpke_config");
     let hpke_config_responding = warp::get()
@@ -2094,6 +2204,7 @@ mod tests {
         test_util::{dummy_vdaf, install_test_trace_subscriber, run_vdaf},
         time::test_util::MockClock,
     };
+    use opentelemetry::global::meter;
     use prio::{
         codec::Decode,
         field::Field64,
@@ -2532,7 +2643,7 @@ mod tests {
         let datastore = Arc::new(datastore);
         let report = setup_report(&task, &datastore, &clock).await;
 
-        let aggregator = Aggregator::new(datastore.clone(), clock);
+        let aggregator = Aggregator::new(datastore.clone(), clock, meter("janus_server"));
 
         (aggregator, task, report, datastore, db_handle)
     }

--- a/janus_server/src/aggregator/aggregate_share.rs
+++ b/janus_server/src/aggregator/aggregate_share.rs
@@ -42,7 +42,7 @@ impl CollectJobDriver {
     pub fn new(http_client: reqwest::Client, meter: &Meter) -> Self {
         let job_cancel_counter = meter
             .u64_counter("job_cancellations")
-            .with_description("Count of cancelled aggregation jobs")
+            .with_description("Count of cancelled collect jobs")
             .init();
 
         Self {

--- a/janus_server/src/aggregator/aggregate_share.rs
+++ b/janus_server/src/aggregator/aggregate_share.rs
@@ -18,6 +18,7 @@ use janus_core::{
     message::{Duration, Interval, NonceChecksum, Role},
     time::Clock,
 };
+use opentelemetry::metrics::{Counter, Meter};
 use prio::{
     codec::{Decode, Encode},
     vdaf::{
@@ -33,12 +34,21 @@ use tracing::{debug, error, warn};
 #[derive(Debug)]
 pub struct CollectJobDriver {
     http_client: reqwest::Client,
+    job_cancel_counter: Counter<u64>,
 }
 
 impl CollectJobDriver {
     /// Create a new [`CollectJobDriver`].
-    pub fn new(http_client: reqwest::Client) -> Self {
-        Self { http_client }
+    pub fn new(http_client: reqwest::Client, meter: &Meter) -> Self {
+        let job_cancel_counter = meter
+            .u64_counter("job_cancellations")
+            .with_description("Count of cancelled aggregation jobs")
+            .init();
+
+        Self {
+            http_client,
+            job_cancel_counter,
+        }
     }
 
     /// Step the provided collect job, for which a lease should have been acquired (though this
@@ -235,11 +245,10 @@ impl CollectJobDriver {
     /// Produce a closure for use as a `[JobDriver::JobAcquirer`].
     pub fn make_incomplete_job_acquirer_callback<C: Clock>(
         &self,
-        datastore: &Arc<Datastore<C>>,
+        datastore: Arc<Datastore<C>>,
         lease_duration: Duration,
     ) -> impl Fn(usize) -> BoxFuture<'static, Result<Vec<Lease<AcquiredCollectJob>>, datastore::Error>>
     {
-        let datastore = Arc::clone(datastore);
         move |maximum_acquire_count| {
             let datastore = Arc::clone(&datastore);
             Box::pin(async move {
@@ -260,15 +269,12 @@ impl CollectJobDriver {
 
     /// Produce a closure for use as a `[JobDriver::JobStepper]`.
     pub fn make_job_stepper_callback<C: Clock>(
-        self: &Arc<Self>,
-        datastore: &Arc<Datastore<C>>,
+        self: Arc<Self>,
+        datastore: Arc<Datastore<C>>,
         maximum_attempts_before_failure: usize,
     ) -> impl Fn(Lease<AcquiredCollectJob>) -> BoxFuture<'static, Result<(), super::Error>> {
-        let datastore = Arc::clone(datastore);
-        let driver = Arc::clone(self);
         move |collect_job_lease: Lease<AcquiredCollectJob>| {
-            let datastore = Arc::clone(&datastore);
-            let driver = Arc::clone(&driver);
+            let (this, datastore) = (Arc::clone(&self), Arc::clone(&datastore));
             Box::pin(async move {
                 if collect_job_lease.lease_attempts() > maximum_attempts_before_failure {
                     warn!(
@@ -276,12 +282,11 @@ impl CollectJobDriver {
                         max_attempts = ?maximum_attempts_before_failure,
                         "Canceling job due to too many failed attempts"
                     );
-                    return driver
-                        .cancel_collect_job(datastore, collect_job_lease)
-                        .await;
+                    this.job_cancel_counter.add(1, &[]);
+                    return this.cancel_collect_job(datastore, collect_job_lease).await;
                 }
 
-                driver.step_collect_job(datastore, collect_job_lease).await
+                this.step_collect_job(datastore, collect_job_lease).await
             })
         }
     }
@@ -520,9 +525,10 @@ mod tests {
             .await
             .unwrap();
 
-        let collect_job_driver = CollectJobDriver {
-            http_client: reqwest::Client::builder().build().unwrap(),
-        };
+        let collect_job_driver = CollectJobDriver::new(
+            reqwest::Client::builder().build().unwrap(),
+            &meter("collect_job_driver"),
+        );
 
         // No batch unit aggregations inserted yet
         let error = collect_job_driver
@@ -745,9 +751,10 @@ mod tests {
             .await
             .unwrap();
 
-        let collect_job_driver = CollectJobDriver {
-            http_client: reqwest::Client::builder().build().unwrap(),
-        };
+        let collect_job_driver = CollectJobDriver::new(
+            reqwest::Client::builder().build().unwrap(),
+            &meter("collect_job_driver"),
+        );
 
         // Run: cancel the collect job.
         collect_job_driver
@@ -869,18 +876,21 @@ mod tests {
             .unwrap();
 
         // Set up the collect job driver
-        let collect_job_driver = Arc::new(CollectJobDriver::new(reqwest::Client::new()));
+        let meter = meter("collect_job_driver");
+        let collect_job_driver = Arc::new(CollectJobDriver::new(reqwest::Client::new(), &meter));
         let job_driver = Arc::new(JobDriver::new(
             clock.clone(),
             runtime_manager.with_label("stepper"),
-            meter("collect_job_driver"),
+            meter,
             Duration::from_seconds(1),
             Duration::from_seconds(1),
             10,
             Duration::from_seconds(60),
-            collect_job_driver
-                .make_incomplete_job_acquirer_callback(&ds, Duration::from_seconds(600)),
-            collect_job_driver.make_job_stepper_callback(&ds, 3),
+            collect_job_driver.make_incomplete_job_acquirer_callback(
+                Arc::clone(&ds),
+                Duration::from_seconds(600),
+            ),
+            collect_job_driver.make_job_stepper_callback(Arc::clone(&ds), 3),
         ));
 
         // Set up three error responses from our mock helper. These will cause errors in the

--- a/janus_server/src/aggregator/aggregate_share.rs
+++ b/janus_server/src/aggregator/aggregate_share.rs
@@ -447,6 +447,7 @@ mod tests {
         Runtime,
     };
     use mockito::mock;
+    use opentelemetry::global::meter;
     use std::str;
     use url::Url;
 
@@ -872,6 +873,7 @@ mod tests {
         let job_driver = Arc::new(JobDriver::new(
             clock.clone(),
             runtime_manager.with_label("stepper"),
+            meter("collect_job_driver"),
             Duration::from_seconds(1),
             Duration::from_seconds(1),
             10,

--- a/janus_server/src/aggregator/aggregation_job_driver.rs
+++ b/janus_server/src/aggregator/aggregation_job_driver.rs
@@ -46,21 +46,28 @@ use tracing::{error, warn};
 #[derive(Debug)]
 pub struct AggregationJobDriver {
     http_client: reqwest::Client,
-    step_failures_counter: Counter<u64>,
+    aggregate_step_failure_counter: Counter<u64>,
+    job_cancel_counter: Counter<u64>,
 }
 
 impl AggregationJobDriver {
     pub fn new(http_client: reqwest::Client, meter: &Meter) -> AggregationJobDriver {
-        let step_failures_counter = meter
+        let aggregate_step_failure_counter = meter
             .u64_counter("step_failures")
             .with_description(concat!(
                 "Failures while stepping aggregation jobs; these failures are ",
                 "related to individual client reports rather than entire aggregation jobs."
             ))
             .init();
+        let job_cancel_counter = meter
+            .u64_counter("job_cancellations")
+            .with_description("Count of cancelled aggregation jobs")
+            .init();
+
         AggregationJobDriver {
             http_client,
-            step_failures_counter,
+            aggregate_step_failure_counter,
+            job_cancel_counter,
         }
     }
 
@@ -276,7 +283,7 @@ impl AggregationJobDriver {
                 Some(leader_encrypted_input_share) => leader_encrypted_input_share,
                 None => {
                     error!(report_nonce = %report_aggregation.nonce, "Client report missing leader encrypted input share");
-                    self.step_failures_counter
+                    self.aggregate_step_failure_counter
                         .add(1, &[KeyValue::new("type", "missing_leader_input_share")]);
                     report_aggregation.state = ReportAggregationState::Invalid;
                     report_aggregations_to_write.push(report_aggregation);
@@ -291,7 +298,7 @@ impl AggregationJobDriver {
                 Some(helper_encrypted_input_share) => helper_encrypted_input_share,
                 None => {
                     error!(report_nonce = %report_aggregation.nonce, "Client report missing helper encrypted input share");
-                    self.step_failures_counter
+                    self.aggregate_step_failure_counter
                         .add(1, &[KeyValue::new("type", "missing_client_input_share")]);
                     report_aggregation.state = ReportAggregationState::Invalid;
                     report_aggregations_to_write.push(report_aggregation);
@@ -307,7 +314,7 @@ impl AggregationJobDriver {
                 Some((hpke_config, hpke_private_key)) => (hpke_config, hpke_private_key),
                 None => {
                     error!(report_nonce = %report_aggregation.nonce, hpke_config_id = %leader_encrypted_input_share.config_id(), "Leader encrypted input share references unknown HPKE config ID");
-                    self.step_failures_counter
+                    self.aggregate_step_failure_counter
                         .add(1, &[KeyValue::new("type", "unknown_hpke_config_id")]);
                     report_aggregation.state =
                         ReportAggregationState::Failed(ReportShareError::HpkeUnknownConfigId);
@@ -329,7 +336,7 @@ impl AggregationJobDriver {
                 Ok(leader_input_share_bytes) => leader_input_share_bytes,
                 Err(err) => {
                     error!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't decrypt leader's encrypted input share");
-                    self.step_failures_counter
+                    self.aggregate_step_failure_counter
                         .add(1, &[KeyValue::new("type", "decrypt_failure")]);
                     report_aggregation.state =
                         ReportAggregationState::Failed(ReportShareError::HpkeDecryptError);
@@ -345,7 +352,7 @@ impl AggregationJobDriver {
                 Err(err) => {
                     // TODO(https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/issues/255): is moving to Invalid on a decoding error appropriate?
                     error!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't decode leader's input share");
-                    self.step_failures_counter
+                    self.aggregate_step_failure_counter
                         .add(1, &[KeyValue::new("type", "input_share_decode_failure")]);
                     report_aggregation.state = ReportAggregationState::Invalid;
                     report_aggregations_to_write.push(report_aggregation);
@@ -364,7 +371,7 @@ impl AggregationJobDriver {
                 Ok(prep_state_and_share) => prep_state_and_share,
                 Err(err) => {
                     error!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't initialize leader's preparation state");
-                    self.step_failures_counter
+                    self.aggregate_step_failure_counter
                         .add(1, &[KeyValue::new("type", "prepare_init_failure")]);
                     report_aggregation.state =
                         ReportAggregationState::Failed(ReportShareError::VdafPrepError);
@@ -462,8 +469,8 @@ impl AggregationJobDriver {
                 {
                     Ok(leader_transition) => leader_transition,
                     Err(err) => {
-                        error!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't step report aggregation");
-                        self.step_failures_counter
+                        error!(report_nonce = %report_aggregation.nonce, ?err, "Prepare step failed");
+                        self.aggregate_step_failure_counter
                             .add(1, &[KeyValue::new("type", "prepare_step_failure")]);
                         report_aggregation.state =
                             ReportAggregationState::Failed(ReportShareError::VdafPrepError);
@@ -586,14 +593,14 @@ impl AggregationJobDriver {
                             }
                             Err(err) => {
                                 error!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't compute prepare message");
-                                self.step_failures_counter
+                                self.aggregate_step_failure_counter
                                     .add(1, &[KeyValue::new("type", "prepare_message_failure")]);
                                 ReportAggregationState::Failed(ReportShareError::VdafPrepError)
                             }
                         }
                     } else {
                         error!(report_nonce = %report_aggregation.nonce, leader_transition = ?leader_transition, "Helper continued but leader did not");
-                        self.step_failures_counter
+                        self.aggregate_step_failure_counter
                             .add(1, &[KeyValue::new("type", "continue_mismatch")]);
                         report_aggregation.state = ReportAggregationState::Invalid;
                     }
@@ -610,7 +617,7 @@ impl AggregationJobDriver {
                             }
                             Err(err) => {
                                 error!(report_nonce = %report_aggregation.nonce, ?err, "Could not update batch unit aggregation");
-                                self.step_failures_counter
+                                self.aggregate_step_failure_counter
                                     .add(1, &[KeyValue::new("type", "accumulate_failure")]);
                                 report_aggregation.state =
                                     ReportAggregationState::Failed(ReportShareError::VdafPrepError);
@@ -618,7 +625,7 @@ impl AggregationJobDriver {
                         }
                     } else {
                         error!(report_nonce = %report_aggregation.nonce, leader_transition = ?leader_transition, "Helper finished but leader did not");
-                        self.step_failures_counter
+                        self.aggregate_step_failure_counter
                             .add(1, &[KeyValue::new("type", "finish_mismatch")]);
                         report_aggregation.state = ReportAggregationState::Invalid;
                     }
@@ -628,7 +635,7 @@ impl AggregationJobDriver {
                     // If the helper failed, we move to FAILED immediately.
                     // TODO(#236): is it correct to just record the transition error that the helper reports?
                     error!(report_nonce = %report_aggregation.nonce, helper_err = ?err, "Helper couldn't step report aggregation");
-                    self.step_failures_counter
+                    self.aggregate_step_failure_counter
                         .add(1, &[KeyValue::new("type", "helper_step_failure")]);
                     report_aggregation.state = ReportAggregationState::Failed(err);
                 }
@@ -756,11 +763,10 @@ impl AggregationJobDriver {
     /// Produce a closure for use as a `[JobDriver::JobAcquirer]`.
     pub fn make_incomplete_job_acquirer_callback<C: Clock>(
         &self,
-        datastore: &Arc<Datastore<C>>,
+        datastore: Arc<Datastore<C>>,
         lease_duration: Duration,
     ) -> impl Fn(usize) -> BoxFuture<'static, Result<Vec<Lease<AcquiredAggregationJob>>, datastore::Error>>
     {
-        let datastore = Arc::clone(datastore);
         move |max_acquire_count: usize| {
             let datastore = Arc::clone(&datastore);
             Box::pin(async move {
@@ -781,25 +787,23 @@ impl AggregationJobDriver {
 
     /// Produce a closure for use as a `[JobDriver::JobStepper]`.
     pub fn make_job_stepper_callback<C: Clock>(
-        self: &Arc<Self>,
-        datastore: &Arc<Datastore<C>>,
+        self: Arc<Self>,
+        datastore: Arc<Datastore<C>>,
         maximum_attempts_before_failure: usize,
     ) -> impl Fn(Lease<AcquiredAggregationJob>) -> BoxFuture<'static, Result<(), anyhow::Error>>
     {
-        let datastore = Arc::clone(datastore);
-        let driver = Arc::clone(self);
         move |lease| {
-            let datastore = Arc::clone(&datastore);
-            let driver = Arc::clone(&driver);
+            let (this, datastore) = (Arc::clone(&self), Arc::clone(&datastore));
             Box::pin(async move {
                 if lease.lease_attempts() > maximum_attempts_before_failure {
                     warn!(attempts = ?lease.lease_attempts(),
                         max_attempts = ?maximum_attempts_before_failure,
                         "Canceling job due to too many failed attempts");
-                    return driver.cancel_aggregation_job(datastore, lease).await;
+                    this.job_cancel_counter.add(1, &[]);
+                    return this.cancel_aggregation_job(datastore, lease).await;
                 }
 
-                driver.step_aggregation_job(datastore, lease).await
+                this.step_aggregation_job(datastore, lease).await
             })
         }
     }
@@ -978,10 +982,8 @@ mod tests {
             })
             .collect();
         let meter = meter("aggregation_job_driver");
-        let aggregation_job_driver = Arc::new(AggregationJobDriver {
-            http_client: reqwest::Client::new(),
-            step_failures_counter: meter.u64_counter("step_failures").init(),
-        });
+        let aggregation_job_driver =
+            Arc::new(AggregationJobDriver::new(reqwest::Client::new(), &meter));
 
         // Run. Let the aggregation job driver step aggregation jobs, then kill it.
         let aggregation_job_driver = Arc::new(JobDriver::new(
@@ -992,9 +994,11 @@ mod tests {
             Duration::from_seconds(1),
             10,
             Duration::from_seconds(60),
-            aggregation_job_driver
-                .make_incomplete_job_acquirer_callback(&ds, Duration::from_seconds(600)),
-            aggregation_job_driver.make_job_stepper_callback(&ds, 5),
+            aggregation_job_driver.make_incomplete_job_acquirer_callback(
+                Arc::clone(&ds),
+                Duration::from_seconds(600),
+            ),
+            aggregation_job_driver.make_job_stepper_callback(Arc::clone(&ds), 5),
         ));
 
         let task_handle = runtime_manager.with_label("driver").spawn({
@@ -1691,9 +1695,11 @@ mod tests {
             Duration::from_seconds(1),
             10,
             Duration::from_seconds(60),
-            aggregation_job_driver
-                .make_incomplete_job_acquirer_callback(&ds, Duration::from_seconds(600)),
-            aggregation_job_driver.make_job_stepper_callback(&ds, 3),
+            aggregation_job_driver.make_incomplete_job_acquirer_callback(
+                Arc::clone(&ds),
+                Duration::from_seconds(600),
+            ),
+            aggregation_job_driver.make_job_stepper_callback(Arc::clone(&ds), 3),
         ));
 
         // Set up three error responses from our mock helper. These will cause errors in the

--- a/janus_server/src/aggregator/aggregation_job_driver.rs
+++ b/janus_server/src/aggregator/aggregation_job_driver.rs
@@ -25,6 +25,10 @@ use janus_core::{
     message::{Duration, Report, Role},
     time::Clock,
 };
+use opentelemetry::{
+    metrics::{Counter, Meter},
+    KeyValue,
+};
 use prio::{
     codec::{Decode, Encode, ParameterizedDecode},
     vdaf::{
@@ -42,11 +46,22 @@ use tracing::{error, warn};
 #[derive(Debug)]
 pub struct AggregationJobDriver {
     http_client: reqwest::Client,
+    step_failures_counter: Counter<u64>,
 }
 
 impl AggregationJobDriver {
-    pub fn new(http_client: reqwest::Client) -> AggregationJobDriver {
-        AggregationJobDriver { http_client }
+    pub fn new(http_client: reqwest::Client, meter: &Meter) -> AggregationJobDriver {
+        let step_failures_counter = meter
+            .u64_counter("step_failures")
+            .with_description(concat!(
+                "Failures while stepping aggregation jobs; these failures are ",
+                "related to individual client reports rather than entire aggregation jobs."
+            ))
+            .init();
+        AggregationJobDriver {
+            http_client,
+            step_failures_counter,
+        }
     }
 
     async fn step_aggregation_job<C: Clock>(
@@ -261,6 +276,8 @@ impl AggregationJobDriver {
                 Some(leader_encrypted_input_share) => leader_encrypted_input_share,
                 None => {
                     error!(report_nonce = %report_aggregation.nonce, "Client report missing leader encrypted input share");
+                    self.step_failures_counter
+                        .add(1, &[KeyValue::new("type", "missing_leader_input_share")]);
                     report_aggregation.state = ReportAggregationState::Invalid;
                     report_aggregations_to_write.push(report_aggregation);
                     continue;
@@ -274,6 +291,8 @@ impl AggregationJobDriver {
                 Some(helper_encrypted_input_share) => helper_encrypted_input_share,
                 None => {
                     error!(report_nonce = %report_aggregation.nonce, "Client report missing helper encrypted input share");
+                    self.step_failures_counter
+                        .add(1, &[KeyValue::new("type", "missing_client_input_share")]);
                     report_aggregation.state = ReportAggregationState::Invalid;
                     report_aggregations_to_write.push(report_aggregation);
                     continue;
@@ -288,6 +307,8 @@ impl AggregationJobDriver {
                 Some((hpke_config, hpke_private_key)) => (hpke_config, hpke_private_key),
                 None => {
                     error!(report_nonce = %report_aggregation.nonce, hpke_config_id = %leader_encrypted_input_share.config_id(), "Leader encrypted input share references unknown HPKE config ID");
+                    self.step_failures_counter
+                        .add(1, &[KeyValue::new("type", "unknown_hpke_config_id")]);
                     report_aggregation.state =
                         ReportAggregationState::Failed(ReportShareError::HpkeUnknownConfigId);
                     report_aggregations_to_write.push(report_aggregation);
@@ -308,6 +329,8 @@ impl AggregationJobDriver {
                 Ok(leader_input_share_bytes) => leader_input_share_bytes,
                 Err(err) => {
                     error!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't decrypt leader's encrypted input share");
+                    self.step_failures_counter
+                        .add(1, &[KeyValue::new("type", "decrypt_failure")]);
                     report_aggregation.state =
                         ReportAggregationState::Failed(ReportShareError::HpkeDecryptError);
                     report_aggregations_to_write.push(report_aggregation);
@@ -322,6 +345,8 @@ impl AggregationJobDriver {
                 Err(err) => {
                     // TODO(https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/issues/255): is moving to Invalid on a decoding error appropriate?
                     error!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't decode leader's input share");
+                    self.step_failures_counter
+                        .add(1, &[KeyValue::new("type", "input_share_decode_failure")]);
                     report_aggregation.state = ReportAggregationState::Invalid;
                     report_aggregations_to_write.push(report_aggregation);
                     continue;
@@ -339,6 +364,8 @@ impl AggregationJobDriver {
                 Ok(prep_state_and_share) => prep_state_and_share,
                 Err(err) => {
                     error!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't initialize leader's preparation state");
+                    self.step_failures_counter
+                        .add(1, &[KeyValue::new("type", "prepare_init_failure")]);
                     report_aggregation.state =
                         ReportAggregationState::Failed(ReportShareError::VdafPrepError);
                     report_aggregations_to_write.push(report_aggregation);
@@ -436,6 +463,8 @@ impl AggregationJobDriver {
                     Ok(leader_transition) => leader_transition,
                     Err(err) => {
                         error!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't step report aggregation");
+                        self.step_failures_counter
+                            .add(1, &[KeyValue::new("type", "prepare_step_failure")]);
                         report_aggregation.state =
                             ReportAggregationState::Failed(ReportShareError::VdafPrepError);
                         report_aggregations_to_write.push(report_aggregation);
@@ -557,11 +586,15 @@ impl AggregationJobDriver {
                             }
                             Err(err) => {
                                 error!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't compute prepare message");
+                                self.step_failures_counter
+                                    .add(1, &[KeyValue::new("type", "prepare_message_failure")]);
                                 ReportAggregationState::Failed(ReportShareError::VdafPrepError)
                             }
                         }
                     } else {
                         error!(report_nonce = %report_aggregation.nonce, leader_transition = ?leader_transition, "Helper continued but leader did not");
+                        self.step_failures_counter
+                            .add(1, &[KeyValue::new("type", "continue_mismatch")]);
                         report_aggregation.state = ReportAggregationState::Invalid;
                     }
                 }
@@ -577,12 +610,16 @@ impl AggregationJobDriver {
                             }
                             Err(err) => {
                                 error!(report_nonce = %report_aggregation.nonce, ?err, "Could not update batch unit aggregation");
+                                self.step_failures_counter
+                                    .add(1, &[KeyValue::new("type", "accumulate_failure")]);
                                 report_aggregation.state =
                                     ReportAggregationState::Failed(ReportShareError::VdafPrepError);
                             }
                         }
                     } else {
                         error!(report_nonce = %report_aggregation.nonce, leader_transition = ?leader_transition, "Helper finished but leader did not");
+                        self.step_failures_counter
+                            .add(1, &[KeyValue::new("type", "finish_mismatch")]);
                         report_aggregation.state = ReportAggregationState::Invalid;
                     }
                 }
@@ -591,6 +628,8 @@ impl AggregationJobDriver {
                     // If the helper failed, we move to FAILED immediately.
                     // TODO(#236): is it correct to just record the transition error that the helper reports?
                     error!(report_nonce = %report_aggregation.nonce, helper_err = ?err, "Helper couldn't step report aggregation");
+                    self.step_failures_counter
+                        .add(1, &[KeyValue::new("type", "helper_step_failure")]);
                     report_aggregation.state = ReportAggregationState::Failed(err);
                 }
             }
@@ -808,6 +847,7 @@ mod tests {
         Runtime,
     };
     use mockito::mock;
+    use opentelemetry::global::meter;
     use prio::{
         codec::Encode,
         vdaf::{
@@ -937,14 +977,17 @@ mod tests {
                     .create()
             })
             .collect();
+        let meter = meter("aggregation_job_driver");
         let aggregation_job_driver = Arc::new(AggregationJobDriver {
             http_client: reqwest::Client::new(),
+            step_failures_counter: meter.u64_counter("step_failures").init(),
         });
 
         // Run. Let the aggregation job driver step aggregation jobs, then kill it.
         let aggregation_job_driver = Arc::new(JobDriver::new(
             clock,
             runtime_manager.with_label("stepper"),
+            meter,
             Duration::from_seconds(1),
             Duration::from_seconds(1),
             10,
@@ -1136,9 +1179,9 @@ mod tests {
             .create();
 
         // Run: create an aggregation job driver & step the aggregation we've created.
-        let aggregation_job_driver = AggregationJobDriver {
-            http_client: reqwest::Client::builder().build().unwrap(),
-        };
+        let meter = meter("aggregation_job_driver");
+        let aggregation_job_driver =
+            AggregationJobDriver::new(reqwest::Client::builder().build().unwrap(), &meter);
         aggregation_job_driver
             .step_aggregation_job(ds.clone(), lease)
             .await
@@ -1321,9 +1364,9 @@ mod tests {
             .create();
 
         // Run: create an aggregation job driver & step the aggregation we've created.
-        let aggregation_job_driver = AggregationJobDriver {
-            http_client: reqwest::Client::builder().build().unwrap(),
-        };
+        let meter = meter("aggregation_job_driver");
+        let aggregation_job_driver =
+            AggregationJobDriver::new(reqwest::Client::builder().build().unwrap(), &meter);
         aggregation_job_driver
             .step_aggregation_job(ds.clone(), lease)
             .await
@@ -1484,9 +1527,9 @@ mod tests {
         assert_eq!(lease.leased().aggregation_job_id, aggregation_job_id);
 
         // Run: create an aggregation job driver & cancel the aggregation job.
-        let aggregation_job_driver = AggregationJobDriver {
-            http_client: reqwest::Client::builder().build().unwrap(),
-        };
+        let meter = meter("aggregation_job_driver");
+        let aggregation_job_driver =
+            AggregationJobDriver::new(reqwest::Client::builder().build().unwrap(), &meter);
         aggregation_job_driver
             .cancel_aggregation_job(Arc::clone(&ds), lease)
             .await
@@ -1637,10 +1680,13 @@ mod tests {
         .unwrap();
 
         // Set up the aggregation job driver.
-        let aggregation_job_driver = Arc::new(AggregationJobDriver::new(reqwest::Client::new()));
+        let meter = meter("aggregation_job_driver");
+        let aggregation_job_driver =
+            Arc::new(AggregationJobDriver::new(reqwest::Client::new(), &meter));
         let job_driver = Arc::new(JobDriver::new(
             clock.clone(),
             runtime_manager.with_label("stepper"),
+            meter,
             Duration::from_seconds(1),
             Duration::from_seconds(1),
             10,

--- a/janus_server/src/bin/aggregation_job_driver.rs
+++ b/janus_server/src/bin/aggregation_job_driver.rs
@@ -45,9 +45,9 @@ async fn main() -> anyhow::Result<()> {
                     .worker_lease_clock_skew_allowance_secs,
             ),
             aggregation_job_driver
-                .make_incomplete_job_acquirer_callback(&datastore, lease_duration),
+                .make_incomplete_job_acquirer_callback(Arc::clone(&datastore), lease_duration),
             aggregation_job_driver.make_job_stepper_callback(
-                &datastore,
+                Arc::clone(&datastore),
                 ctx.config.job_driver_config.maximum_attempts_before_failure,
             ),
         ))

--- a/janus_server/src/bin/aggregator.rs
+++ b/janus_server/src/bin/aggregator.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
             shutdown_signal,
         )
         .context("failed to create aggregator server")?;
-        info!(?bound_address, "running aggregator");
+        info!(?bound_address, "Running aggregator");
 
         server.await;
         Ok(())

--- a/janus_server/src/bin/collect_job_driver.rs
+++ b/janus_server/src/bin/collect_job_driver.rs
@@ -19,6 +19,7 @@ async fn main() -> anyhow::Result<()> {
     );
 
     janus_main::<Options, _, Config, _, _>(RealClock::default(), |ctx| async move {
+        let meter = opentelemetry::global::meter("collect_job_driver");
         let datastore = Arc::new(ctx.datastore);
         let collect_job_driver = Arc::new(CollectJobDriver::new(
             reqwest::Client::builder()
@@ -33,6 +34,7 @@ async fn main() -> anyhow::Result<()> {
         Arc::new(JobDriver::new(
             ctx.clock,
             TokioRuntime,
+            meter,
             Duration::from_seconds(ctx.config.job_driver_config.min_job_discovery_delay_secs),
             Duration::from_seconds(ctx.config.job_driver_config.max_job_discovery_delay_secs),
             ctx.config.job_driver_config.max_concurrent_job_workers,

--- a/janus_server/src/bin/collect_job_driver.rs
+++ b/janus_server/src/bin/collect_job_driver.rs
@@ -26,6 +26,7 @@ async fn main() -> anyhow::Result<()> {
                 .user_agent(CLIENT_USER_AGENT)
                 .build()
                 .context("couldn't create HTTP client")?,
+            &meter,
         ));
         let lease_duration =
             Duration::from_seconds(ctx.config.job_driver_config.worker_lease_duration_secs);
@@ -43,9 +44,10 @@ async fn main() -> anyhow::Result<()> {
                     .job_driver_config
                     .worker_lease_clock_skew_allowance_secs,
             ),
-            collect_job_driver.make_incomplete_job_acquirer_callback(&datastore, lease_duration),
+            collect_job_driver
+                .make_incomplete_job_acquirer_callback(Arc::clone(&datastore), lease_duration),
             collect_job_driver.make_job_stepper_callback(
-                &datastore,
+                Arc::clone(&datastore),
                 ctx.config.job_driver_config.maximum_attempts_before_failure,
             ),
         ))

--- a/monolithic_integration_test/Cargo.toml
+++ b/monolithic_integration_test/Cargo.toml
@@ -14,6 +14,7 @@ janus_core = { path = "../janus_core", features = ["test-util"] }
 janus_client = { path = "../janus_client" }
 janus_server = { path = "../janus_server", features = ["test-util"] }
 lazy_static = "1"
+opentelemetry = { version = "0.17.0", features = ["metrics", "rt-tokio"] }
 prio = "0.8.0"
 rand = "0.8"
 reqwest = { version = "0.11.11", default-features = false, features = ["rustls-tls"] }


### PR DESCRIPTION
Also, clean up some double-logging in the aggregator HTTP handlers, and tweak some log lines & error messages.

Closes #290.