### PR TITLE
Set timeouts in deadpool_postgres

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom",
+ "instant",
+ "pin-project-lite",
+ "rand",
+ "tokio",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,10 +1427,12 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "atty",
+ "backoff",
  "base64",
  "bytes",
  "chrono",
  "console-subscriber",
+ "deadpool",
  "deadpool-postgres",
  "derivative",
  "futures",

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -19,10 +19,12 @@ kube-openssl = ["kube/openssl-tls"]
 [dependencies]
 anyhow = "1"
 atty = "0.2"
+backoff = { version = "0.4.0", features = ["tokio"] }
 base64 = "0.13.0"
 bytes = "1.1.0"
 chrono = "0.4"
 console-subscriber = { version = "0.1.6", optional = true }
+deadpool = { version = "0.9.5", features = ["rt_tokio_1"] }
 deadpool-postgres = "0.10.1"
 derivative = "2.2.0"
 futures = "0.3.21"

--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -2256,6 +2256,7 @@ mod tests {
         collections::HashMap,
         io::Cursor,
         net::{Ipv4Addr, SocketAddrV4},
+        time::Duration as StdDuration,
     };
     use tokio::{io::AsyncWriteExt, net::TcpListener};
     use tokio_postgres::{Config, NoTls};
@@ -5892,7 +5893,8 @@ mod tests {
             .build()
             .unwrap();
         let crypter = Crypter::new(vec![generate_aead_key()]);
-        let bad_datastore = Datastore::new(bad_pool, crypter, clock.clone());
+        let bad_datastore =
+            Datastore::new(bad_pool, StdDuration::from_secs(1), crypter, clock.clone());
         let bad_filter = aggregator_filter(Arc::new(bad_datastore), clock).unwrap();
 
         let bad_response = warp::test::request()

--- a/janus_server/src/bin/aggregator.rs
+++ b/janus_server/src/bin/aggregator.rs
@@ -154,6 +154,7 @@ mod tests {
     listen_address: "0.0.0.0:8080"
     database:
         url: "postgres://postgres:postgres@localhost:5432/postgres"
+        connection_pool_timeouts_secs: 60
     logging_config:
         tokio_console_config:
             enabled: true
@@ -179,6 +180,7 @@ mod tests {
     listen_address: "0.0.0.0:8080"
     database:
         url: "postgres://postgres:postgres@localhost:5432/postgres"
+        connection_pool_timeouts_secs: 60
     logging_config:
         open_telemetry_config:
             jaeger:
@@ -197,6 +199,7 @@ mod tests {
     listen_address: "0.0.0.0:8080"
     database:
         url: "postgres://postgres:postgres@localhost:5432/postgres"
+        connection_pool_timeouts_secs: 60
     logging_config:
         open_telemetry_config:
             otlp:
@@ -226,6 +229,7 @@ mod tests {
     listen_address: "0.0.0.0:8080"
     database:
         url: "postgres://postgres:postgres@localhost:5432/postgres"
+        connection_pool_timeouts_secs: 60
     metrics_config:
         exporter:
             prometheus:
@@ -249,6 +253,7 @@ mod tests {
     listen_address: "0.0.0.0:8080"
     database:
         url: "postgres://postgres:postgres@localhost:5432/postgres"
+        connection_pool_timeouts_secs: 60
     metrics_config:
         exporter:
             otlp:

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -12,6 +12,9 @@ use crate::{
     task::{self, AggregatorAuthenticationToken, Task, VdafInstance},
 };
 use anyhow::anyhow;
+use backoff::{future::retry, ExponentialBackoff};
+use deadpool::managed::TimeoutType;
+use deadpool_postgres::PoolError;
 use futures::try_join;
 use janus_core::{
     hpke::HpkePrivateKey,
@@ -31,7 +34,7 @@ use rand::{thread_rng, Rng};
 use ring::aead::{self, LessSafeKey, AES_128_GCM};
 use std::{
     collections::HashMap, convert::TryFrom, fmt::Display, future::Future, io::Cursor, mem::size_of,
-    pin::Pin,
+    pin::Pin, time::Duration as StdDuration,
 };
 use tokio_postgres::{error::SqlState, row::RowIndex, IsolationLevel, Row};
 use url::Url;
@@ -43,6 +46,7 @@ use uuid::Uuid;
 /// In practice, Datastore instances are currently backed by a PostgreSQL database.
 pub struct Datastore<C: Clock> {
     pool: deadpool_postgres::Pool,
+    connection_pool_timeout: StdDuration,
     crypter: Crypter,
     clock: C,
     transaction_status_counter: Counter<u64>,
@@ -51,7 +55,12 @@ pub struct Datastore<C: Clock> {
 impl<C: Clock> Datastore<C> {
     /// new creates a new Datastore using the given Client for backing storage. It is assumed that
     /// the Client is connected to a database with a compatible version of the Janus database schema.
-    pub fn new(pool: deadpool_postgres::Pool, crypter: Crypter, clock: C) -> Datastore<C> {
+    pub fn new(
+        pool: deadpool_postgres::Pool,
+        connection_pool_timeout: StdDuration,
+        crypter: Crypter,
+        clock: C,
+    ) -> Datastore<C> {
         let meter = opentelemetry::global::meter("janus_server");
         let transaction_status_counter = meter
             .u64_counter("aggregator_database_transactions_total")
@@ -59,6 +68,7 @@ impl<C: Clock> Datastore<C> {
             .init();
         Self {
             pool,
+            connection_pool_timeout,
             crypter,
             clock,
             transaction_status_counter,
@@ -134,7 +144,28 @@ impl<C: Clock> Datastore<C> {
     /// connection or recycle an existing one, and then return the connection
     /// back to the pool.
     pub async fn check_connection_pool(&self) -> Result<(), Error> {
-        let _client = self.pool.get().await?;
+        let backoff = ExponentialBackoff {
+            initial_interval: StdDuration::from_secs(1),
+            max_interval: StdDuration::from_secs(30),
+            multiplier: 2.0,
+            max_elapsed_time: Some(self.connection_pool_timeout),
+            ..Default::default()
+        };
+
+        // Retrying if we encounter timeouts when creating a connection or connection refused errors
+        // (which occur if the Cloud SQL Proxy hasn't started yet and manifest as
+        // `PoolError::Backend`)
+        let _client = retry(backoff, || async {
+            self.pool.get().await.map_err(|error| match error {
+                PoolError::Timeout(TimeoutType::Create) | PoolError::Backend(_) => {
+                    tracing::info!(?error, "transient error connecting to database");
+                    backoff::Error::transient(error)
+                }
+                _ => backoff::Error::permanent(error),
+            })
+        })
+        .await?;
+
         Ok(())
     }
 }
@@ -2976,6 +3007,7 @@ pub mod test_util {
         env::{self, VarError},
         process::Command,
         str::FromStr,
+        time::Duration,
     };
     use testcontainers::{images::postgres::Postgres, Container, RunnableImage};
     use tokio_postgres::{Config, NoTls};
@@ -3006,7 +3038,7 @@ pub mod test_util {
                 LessSafeKey::new(UnboundKey::new(&AES_128_GCM, &self.datastore_key_bytes).unwrap());
             let crypter = Crypter::new(vec![datastore_key]);
 
-            Datastore::new(self.pool(), crypter, clock)
+            Datastore::new(self.pool(), Duration::from_secs(10), crypter, clock)
         }
 
         /// Retrieve a Postgres connection pool attached to the ephemeral database.

--- a/janus_server/tests/server_shutdown.rs
+++ b/janus_server/tests/server_shutdown.rs
@@ -63,6 +63,7 @@ async fn server_shutdown() {
     listen_address: "{}"
     database:
         url: "{}"
+        connection_pool_timeouts_secs: 60
     "#,
         listen_address,
         db_handle.connection_string()


### PR DESCRIPTION
When deployed to GCP, Janus connects to its Postgres database through
the `cloud-sql-proxy`, which is deployed as a sidecar container to Janus
itself. Kubernetes provides no guarantees about the order in which it
will start the containers in a pod, which means that it's possible for
Janus components to attempt to connect to the proxy before it has
started and established a connection to the real database, which will
fail with "connection refused". This is a problem for the
`aggregation_job_creator`: it is configured to query the database once
an hour for defined tasks, so if it fails to do so at startup, it won't
retry for an hour. Other Janus components either query the DB in
response to API traffic or poll the database more often.

With this change, we now wait up to 60 seconds while trying to connect
to the database, which should help `aggregation_job_creator` get started
more reliably.