### PR TITLE
Add a simple health check endpoint

### DIFF
--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -2132,7 +2132,7 @@ fn aggregator_filter<C: Clock>(
             CONTENT_TYPE.as_str(),
             AggregateShareReq::MEDIA_TYPE,
         ))
-        .and(with_cloned_value(aggregator))
+        .and(with_cloned_value(aggregator.clone()))
         .and(warp::body::bytes())
         .and(warp::header::optional::<String>(DAP_AUTH_HEADER))
         .then(
@@ -2149,8 +2149,26 @@ fn aggregator_filter<C: Clock>(
         aggregate_share_routing,
         aggregate_share_responding,
         warp::cors().build(),
-        response_time_recorder,
+        response_time_recorder.clone(),
         "aggregate_share",
+    );
+
+    let health_check_routing = warp::path("_health_check");
+    let health_check_responding = warp::get().and(with_cloned_value(aggregator)).then(
+        |aggregator: Arc<Aggregator<C>>| async move {
+            aggregator.datastore.check_connection_pool().await?;
+            http::Response::builder()
+                .status(StatusCode::OK)
+                .body(Vec::new())
+                .map_err(|err| Error::Internal(format!("couldn't produce response: {}", err)))
+        },
+    );
+    let health_check_endpoint = compose_common_wrappers(
+        health_check_routing,
+        health_check_responding,
+        warp::cors().build(),
+        response_time_recorder,
+        "health_check",
     );
 
     Ok(hpke_config_endpoint
@@ -2159,6 +2177,7 @@ fn aggregator_filter<C: Clock>(
         .or(collect_endpoint)
         .or(collect_jobs_endpoint)
         .or(aggregate_share_endpoint)
+        .or(health_check_endpoint)
         .boxed())
 }
 
@@ -2182,7 +2201,8 @@ mod tests {
     use crate::{
         datastore::{
             models::BatchUnitAggregation,
-            test_util::{ephemeral_datastore, DbHandle},
+            test_util::{ephemeral_datastore, generate_aead_key, DbHandle},
+            Crypter,
         },
         task::{
             test_util::{generate_aggregator_auth_token, new_dummy_task},
@@ -2190,6 +2210,7 @@ mod tests {
         },
     };
     use assert_matches::assert_matches;
+    use deadpool_postgres::{Manager, Pool};
     use http::Method;
     use hyper::body;
     use janus_core::{
@@ -2213,7 +2234,13 @@ mod tests {
     };
     use rand::{thread_rng, Rng};
     use serde_json::json;
-    use std::{collections::HashMap, io::Cursor};
+    use std::{
+        collections::HashMap,
+        io::Cursor,
+        net::{Ipv4Addr, SocketAddrV4},
+    };
+    use tokio::{io::AsyncWriteExt, net::TcpListener};
+    use tokio_postgres::{Config, NoTls};
     use uuid::Uuid;
     use warp::{cors::CorsForbidden, reply::Reply, Rejection};
 
@@ -5795,5 +5822,61 @@ mod tests {
             )
             .unwrap(),
         }
+    }
+
+    #[tokio::test]
+    async fn health_check() {
+        install_test_trace_subscriber();
+
+        let clock = MockClock::default();
+        let (datastore, _db_handle) = ephemeral_datastore(clock.clone()).await;
+
+        let good_filter = aggregator_filter(Arc::new(datastore), clock.clone()).unwrap();
+
+        let good_response = warp::test::request()
+            .method("GET")
+            .path("/_health_check")
+            .filter(&good_filter)
+            .await
+            .unwrap()
+            .into_response();
+        assert_eq!(good_response.status(), 200);
+
+        // Set up a server that immediately closes all connections, try to connect to it as the
+        // database server, and confirm that the health check endpoint returns an error.
+        let listener = TcpListener::bind(SocketAddr::V4(SocketAddrV4::new(
+            Ipv4Addr::new(127, 0, 0, 1),
+            0,
+        )))
+        .await
+        .unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let handle = tokio::spawn(async move {
+            loop {
+                let (mut tcp_stream, _) = listener.accept().await.unwrap();
+                tcp_stream.shutdown().await.unwrap();
+            }
+        });
+
+        let mut bad_db_config = Config::new();
+        // We know this address is unroutable, so creating a connection should fail.
+        bad_db_config.host(&format!("127.0.0.1:{}", port));
+        let bad_pool = Pool::builder(Manager::new(bad_db_config, NoTls))
+            .build()
+            .unwrap();
+        let crypter = Crypter::new(vec![generate_aead_key()]);
+        let bad_datastore = Datastore::new(bad_pool, crypter, clock.clone());
+        let bad_filter = aggregator_filter(Arc::new(bad_datastore), clock).unwrap();
+
+        let bad_response = warp::test::request()
+            .method("GET")
+            .path("/_health_check")
+            .filter(&bad_filter)
+            .await
+            .unwrap()
+            .into_response();
+        assert_eq!(bad_response.status(), 500);
+
+        handle.abort();
     }
 }

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -128,6 +128,15 @@ impl<C: Clock> Datastore<C> {
         tx.tx.commit().await?;
         Ok(rslt)
     }
+
+    /// Attempt to fetch a connection from the connection pool, to check if
+    /// the database is accessible. This will either create a new database
+    /// connection or recycle an existing one, and then return the connection
+    /// back to the pool.
+    pub async fn check_connection_pool(&self) -> Result<(), Error> {
+        let _client = self.pool.get().await?;
+        Ok(())
+    }
 }
 
 /// Transaction represents an ongoing datastore transaction.


### PR DESCRIPTION
This is a first effort towards #36, adding a health check endpoint that tests if our database connection pool is able to connect. We can use this in Kubernetes readiness checks and in GCP load balancer health checks for our Ingress.