### PR TITLE
Pin Kind node image used in EphemeralCluster

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -24,6 +24,11 @@ jobs:
           ~/.cargo/git/db/
           target/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Install latest version of Kind
+      # We should always make sure that the `kind` CLI we install is from the
+      # same release as the node image version used by
+      # `janus_core::test_util::kubernetes::EphemeralCluster`
+      run: go install sigs.k8s.io/kind@v0.14.0
     - name: lint
       run: cargo fmt --message-format human -- --check
     - name: clippy
@@ -35,7 +40,8 @@ jobs:
     - name: test
       env:
         RUST_LOG: trace
-      run: cargo test --verbose
+      # set PATH to ensure we use go binaries installed above
+      run: PATH=$(go env GOPATH)/bin:$PATH cargo test --verbose
     - name: document
       env:
         CARGO_TARGET_DIR: "target/doc-deny"

--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ aggregator --config-file <config-file> --role <role>
 
 ## Running tests
 
-Tests require that [docker](https://www.docker.com) & [kind](https://kind.sigs.k8s.io) be installed
-on the machine running the tests and in the `PATH` of the test-runner's environment. The docker
-daemon must be running.
+Tests require that [`docker`](https://www.docker.com) & [`kind`](https://kind.sigs.k8s.io) be installed on the machine running the tests and in the `PATH` of the test-runner's environment. The `docker` daemon must be running. CI tests currently use [`kind` 0.14.0](https://github.com/kubernetes-sigs/kind/releases/tag/v0.14.0) and the corresponding [Kubernetes 1.22 node image](kindest/node:v1.22.9@sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105) and using the same versions for local development is recommended.
 
 To run janus tests, execute `cargo test`.
 

--- a/janus_core/src/test_util/kubernetes.rs
+++ b/janus_core/src/test_util/kubernetes.rs
@@ -23,7 +23,11 @@ impl EphemeralCluster {
         thread_rng().fill(&mut randomness);
         let cluster_name = format!("janus-ephemeral-{}", hex::encode(&randomness));
 
-        // Use kind to start the cluster.
+        // Use kind to start the cluster, with the node image from kind v0.14.0 for Kubernetes 1.22,
+        // matching current regular GKE release channel. This image version should be bumped in
+        // lockstep with the version of kind installed by the ci-build workflow.
+        // https://github.com/kubernetes-sigs/kind/releases/tag/v0.14.0
+        // https://cloud.google.com/kubernetes-engine/docs/release-notes#regular-channel
         assert!(Command::new("kind")
             .args([
                 "create",
@@ -32,6 +36,8 @@ impl EphemeralCluster {
                 &kubeconfig_path.to_string_lossy(),
                 "--name",
                 &cluster_name,
+                "--image",
+                "kindest/node:v1.22.9@sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105",
             ])
             .stdin(Stdio::null())
             .stdout(Stdio::null())


### PR DESCRIPTION
By default, `kind` would install a node image for Kubernetes 1.24, which
is a couple minor versions past what we deploy to cloud environments and
which runs afoul of some Terraform bugs[1]. Pin the Kind node image we
use to a Kubernetes 1.22 image, to match the Kind we use in other CI
contexts.

[1]: https://github.com/hashicorp/terraform-provider-kubernetes/issues/1724