### PR TITLE
Increment versions to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,7 +1361,7 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "janus_client"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "assert_matches",
  "http",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "janus_core"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "janus_server"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/janus_client/Cargo.toml
+++ b/janus_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "janus_client"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Client for Janus, the server powering ISRG's Divvi Up."
 documentation = "https://docs.rs/janus_client"
@@ -11,7 +11,7 @@ rust-version = "1.60"
 
 [dependencies]
 http = "0.2.8"
-janus_core = { version = "0.1.2", path = "../janus_core" }
+janus_core = { version = "0.1.3", path = "../janus_core" }
 prio = "0.8.2"
 reqwest = { version = "0.11.4", default-features = false, features = ["rustls-tls"] }
 thiserror = "1.0"

--- a/janus_core/Cargo.toml
+++ b/janus_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "janus_core"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Core type definitions and utilities used in various components of Janus."
 documentation = "https://docs.rs/janus_core"

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "janus_server"
-version = "0.1.0"
+version = "0.1.3"
 edition = "2021"
 license = "MPL-2.0"
 publish = false

--- a/janus_server/tests/cmd/aggregation_job_creator.trycmd
+++ b/janus_server/tests/cmd/aggregation_job_creator.trycmd
@@ -1,6 +1,6 @@
 ```
 $ aggregation_job_creator --help
-janus-aggregation-job-creator 0.1.0
+janus-aggregation-job-creator [..]
 Janus aggregation job creator
 
 USAGE:

--- a/janus_server/tests/cmd/aggregation_job_driver.trycmd
+++ b/janus_server/tests/cmd/aggregation_job_driver.trycmd
@@ -1,6 +1,6 @@
 ```
 $ aggregation_job_driver --help
-janus-aggregation-job-driver 0.1.0
+janus-aggregation-job-driver [..]
 Janus aggregation job driver
 
 USAGE:

--- a/janus_server/tests/cmd/aggregator.trycmd
+++ b/janus_server/tests/cmd/aggregator.trycmd
@@ -1,6 +1,6 @@
 ```
 $ aggregator --help
-janus-aggregator 0.1.0
+janus-aggregator [..]
 PPM aggregator server
 
 USAGE:


### PR DESCRIPTION
In the interest of getting a new aggregator image out that includes the health check endpoints, I suggest we cut a release for version 0.1.3. I chose to increment the version of the `janus_server` crate as well, so that container tags and `--version` output match. I fixed up the CLI reference tests with wildcards as well.