### PR TITLE
janus_cli: don't require --datastore_keys unless they are used.

### DIFF
--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -2164,7 +2164,7 @@ fn aggregator_filter<C: Clock>(
         health_check_live_routing,
         health_check_live_responding,
         warp::cors().build(),
-        response_time_recorder.clone(),
+        response_time_recorder,
         "health_check_live",
     );
 
@@ -2235,7 +2235,6 @@ mod tests {
         collections::HashMap,
         io::Cursor,
         net::{Ipv4Addr, SocketAddrV4},
-        time::Duration as StdDuration,
     };
     use tokio::{io::AsyncWriteExt, net::TcpListener};
     use tokio_postgres::{Config, NoTls};

--- a/janus_server/src/bin/aggregation_job_creator.rs
+++ b/janus_server/src/bin/aggregation_job_creator.rs
@@ -82,7 +82,11 @@ struct Config {
 }
 
 impl BinaryConfig for Config {
-    fn common_config(&mut self) -> &mut CommonConfig {
+    fn common_config(&self) -> &CommonConfig {
+        &self.common_config
+    }
+
+    fn common_config_mut(&mut self) -> &mut CommonConfig {
         &mut self.common_config
     }
 }

--- a/janus_server/src/bin/aggregation_job_driver.rs
+++ b/janus_server/src/bin/aggregation_job_driver.rs
@@ -107,7 +107,11 @@ struct Config {
 }
 
 impl BinaryConfig for Config {
-    fn common_config(&mut self) -> &mut CommonConfig {
+    fn common_config(&self) -> &CommonConfig {
+        &self.common_config
+    }
+
+    fn common_config_mut(&mut self) -> &mut CommonConfig {
         &mut self.common_config
     }
 }

--- a/janus_server/src/bin/aggregator.rs
+++ b/janus_server/src/bin/aggregator.rs
@@ -107,7 +107,11 @@ struct Config {
 }
 
 impl BinaryConfig for Config {
-    fn common_config(&mut self) -> &mut CommonConfig {
+    fn common_config(&self) -> &CommonConfig {
+        &self.common_config
+    }
+
+    fn common_config_mut(&mut self) -> &mut CommonConfig {
         &mut self.common_config
     }
 }

--- a/janus_server/src/bin/collect_job_driver.rs
+++ b/janus_server/src/bin/collect_job_driver.rs
@@ -107,7 +107,11 @@ struct Config {
 }
 
 impl BinaryConfig for Config {
-    fn common_config(&mut self) -> &mut CommonConfig {
+    fn common_config(&self) -> &CommonConfig {
+        &self.common_config
+    }
+
+    fn common_config_mut(&mut self) -> &mut CommonConfig {
         &mut self.common_config
     }
 }

--- a/janus_server/src/config.rs
+++ b/janus_server/src/config.rs
@@ -21,7 +21,10 @@ pub struct CommonConfig {
 /// Trait describing configuration structures for various Janus binaries.
 pub trait BinaryConfig: Debug + DeserializeOwned {
     /// Get common configuration.
-    fn common_config(&mut self) -> &mut CommonConfig;
+    fn common_config(&self) -> &CommonConfig;
+
+    /// Get mutable reference to common configuration.
+    fn common_config_mut(&mut self) -> &mut CommonConfig;
 }
 
 /// Configuration for a Janus server using a database.

--- a/janus_server/tests/cmd/aggregation_job_creator.trycmd
+++ b/janus_server/tests/cmd/aggregation_job_creator.trycmd
@@ -4,7 +4,7 @@ janus-aggregation-job-creator [..]
 Janus aggregation job creator
 
 USAGE:
-    aggregation_job_creator [OPTIONS] --config-file <config-file> --datastore-keys <datastore-keys>...
+    aggregation_job_creator [OPTIONS] --config-file <config-file>
 
 FLAGS:
     -h, --help       Prints help information

--- a/janus_server/tests/cmd/aggregation_job_driver.trycmd
+++ b/janus_server/tests/cmd/aggregation_job_driver.trycmd
@@ -4,7 +4,7 @@ janus-aggregation-job-driver [..]
 Janus aggregation job driver
 
 USAGE:
-    aggregation_job_driver [OPTIONS] --config-file <config-file> --datastore-keys <datastore-keys>...
+    aggregation_job_driver [OPTIONS] --config-file <config-file>
 
 FLAGS:
     -h, --help       Prints help information

--- a/janus_server/tests/cmd/aggregator.trycmd
+++ b/janus_server/tests/cmd/aggregator.trycmd
@@ -4,7 +4,7 @@ janus-aggregator [..]
 PPM aggregator server
 
 USAGE:
-    aggregator [OPTIONS] --config-file <config-file> --datastore-keys <datastore-keys>...
+    aggregator [OPTIONS] --config-file <config-file>
 
 FLAGS:
     -h, --help       Prints help information


### PR DESCRIPTION
Now, commands that don't use the database won't crash out if they aren't
given --datastore_keys. Note that we still require a config to be
specified, which must specify a DB connection string -- I think this is
OK since I suspect folks will create & leave around configs for the
environments they care about.

There are a few other bits in this commit: most notably, I drop the
startup probe endpoint, as now we do our connect-to-database check every
time we create a new pool -- since we create the pool before we start
serving, the aggregator will not appear live (i.e. will not respond
positively to /healthz) until we have confirmed that we have a DB
connection. (I think Tim noted this.) This lets me drop the connection
pool checking logic included in the datastore, since it now lives with
connection-pool-creation code only.

Closes #315.