### PR TITLE
New configuration option, extra response headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1764,6 +1764,7 @@ dependencies = [
  "chrono",
  "deadpool-postgres",
  "futures",
+ "http",
  "janus_client",
  "janus_core",
  "janus_server",

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It is currently in active development.
 
 ## Running janus\_server
 
-The aggregator server requires a connection to a PostgreSQL 14 database. Prepare the database by executing the script at `db/schema.sql`. Most server configuration is done via a YAML file, following the structure documented on `janus_server::config::AggregatorConfig`. Record the database's connection URL, the address the aggregator server should listen on for incoming HTTP requests, and other settings in a YAML file, and pass the file's path on the command line as follows. (The database password can be passed through the command line or an environment variable rather than including it in the connection URL, see `aggregator --help`.)
+The aggregator server requires a connection to a PostgreSQL 14 database. Prepare the database by executing the script at `db/schema.sql`. Most server configuration is done via a YAML file, following the structure documented on `aggregator::Config`. Record the database's connection URL, the address the aggregator server should listen on for incoming HTTP requests, and other settings in a YAML file, and pass the file's path on the command line as follows. (The database password can be passed through the command line or an environment variable rather than including it in the connection URL, see `aggregator --help`.)
 
 ```bash
 aggregator --config-file <config-file> --role <role>

--- a/monolithic_integration_test/Cargo.toml
+++ b/monolithic_integration_test/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 chrono = "0.4.19"
 deadpool-postgres = "0.10.1"
 futures = "0.3.21"
+http = "0.2.8"
 janus_core = { path = "../janus_core", features = ["test-util"] }
 janus_client = { path = "../janus_client" }
 janus_server = { path = "../janus_server", features = ["test-util"] }

--- a/monolithic_integration_test/tests/integration_test.rs
+++ b/monolithic_integration_test/tests/integration_test.rs
@@ -1,3 +1,4 @@
+use http::HeaderMap;
 use janus_client::{self, Client, ClientParameters};
 use janus_core::{
     hpke::{
@@ -192,6 +193,7 @@ impl TestCase {
             Arc::clone(&leader_datastore),
             RealClock::default(),
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0),
+            HeaderMap::new(),
             async move { leader_shutdown_receiver.await.unwrap() },
         )
         .unwrap();
@@ -203,6 +205,7 @@ impl TestCase {
             Arc::clone(&helper_datastore),
             RealClock::default(),
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0),
+            HeaderMap::new(),
             async move { helper_shutdown_receiver.await.unwrap() },
         )
         .unwrap();


### PR DESCRIPTION
This adds a new optional field to the configuration file, with extra response headers to be added to outgoing responses.

Note that, as this uses Warp filters, it will not add the headers to requests that are rejected by our filter stack. If we wanted to do so, we would have to write some boilerplate to turn the Warp filter into a `hyper::service::Service`, add a header-setting middleware to it, and then use Hyper's TCP server directly. I opted not to go this route until we have a need for headers on error responses. (for example, only eTLD+1s are eligible for automatic enrollment in HSTS preloading, so it's okay if Janus can't serve a preload enrollment header on 404 responses for `/`)