### PR TITLE
Clean up kube features, document crate features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1403,6 +1403,8 @@ dependencies = [
  "futures",
  "hex",
  "hpke-dispatch",
+ "janus_core",
+ "k8s-openapi",
  "kube",
  "num_enum",
  "postgres-protocol",

--- a/README.md
+++ b/README.md
@@ -23,6 +23,23 @@ Tests require that [`docker`](https://www.docker.com) & [`kind`](https://kind.si
 
 To run janus tests, execute `cargo test`.
 
+## Cargo features
+
+`janus_core` has the following features available.
+
+* `database`: Enables implementations of `postgres_types::ToSql` and `postgres_types::FromSql` on `janus_core::Interval`.
+* `test-util`: Enables miscellaneous test-only APIs. This should not be used outside of tests, and any such APIs do not carry any stability guarantees.
+
+`janus_server` has the following features available.
+
+* `jaeger`: Enables tracing support and a Jaeger exporter; [see below](#jaeger).
+* `kube-rustls`: Sets the `kube/rustls-tls` feature. This is enabled by default. Note that if both `kube/rustls-tls` and `kube/openssl-tls` are set, OpenSSL will take precedence.
+* `kube-openssl`: Sets the `kube/openssl-tls` feature. Note that if both `kube/rustls-tls` and `kube/openssl-tls` are set, OpenSSL will take precedence. Enable this feature if you need to communicate with a Kind cluster, i.e. `cargo run --bin janus_cli --features kube-openssl -- <SUBCOMMAND> ...`. (this works around an issue with rustls and IP addresses as names in certificates)
+* `otlp`: Enables OTLP exporter support for both metrics ([see below](#honeycomb-1)) and tracing ([see below](#honeycomb)).
+* `prometheus`: Enables metrics support and a Prometheus exporter; [see below](#prometheus).
+* `test-util`: Enables miscellaneous test-only APIs. This should not be used outside of tests, and any such APIs do not carry any stability guarantees.
+* `tokio-console`: Enables a tracing subscriber and server to support [`tokio-console`](https://github.com/tokio-rs/console). [See below](#monitoring-with-tokio-console) for additional instructions.
+
 ### inotify limits
 
 If you experience issues with tests using Kind on Linux, you may need to [adjust inotify sysctls](https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files). Both systemd and Kubernetes inside each Kind node make use of inotify. When combined with other services and desktop applications, they may exhaust per-user limits.

--- a/janus_core/Cargo.toml
+++ b/janus_core/Cargo.toml
@@ -15,6 +15,7 @@ test-util = [
     "dep:assert_matches",
     "dep:futures",
     "dep:kube",
+    "dep:k8s-openapi",
     "dep:serde_json",
     "dep:tempfile",
     "dep:tracing",
@@ -31,7 +32,8 @@ bytes = { version = "1.2.0", optional = true }
 chrono = "0.4"
 hex = "0.4.3"
 hpke-dispatch = "0.3.0"
-kube = { version = "0.65.0", optional = true }
+kube = { version = "0.65.0", optional = true, default-features = false, features = ["client", "rustls-tls"] }
+k8s-openapi = { version = "*", optional = true, features = ["v1_20"] }
 num_enum = "0.5.6"
 postgres-protocol = { version = "0.6.4", optional = true }
 postgres-types = { version = "0.2.3", optional = true }
@@ -50,3 +52,12 @@ tempfile = { version = "3", optional = true }
 tracing = { version = "0.1.35", optional = true }
 tracing-log = { version = "0.1.3", optional = true }
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt"], optional = true }
+
+[dev-dependencies]
+hex = { version = "*", features = ["serde"] }
+janus_core = { path = ".", features = ["test-util"] }
+# Enable `kube`'s `openssl-tls` feature (which takes precedence over the
+# `rustls-tls` feature when creating a default client) to work around rustls's
+# lack of support for IP addresses in certificates when connecting to a Kind
+# cluster.
+kube = { version = "*", features = ["openssl-tls"] }

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -72,7 +72,12 @@ warp = { version = "^0.3", features = ["tls"] }
 assert_matches = "1"
 hex = { version = "0.4.3", features = ["serde"] }
 hyper = "0.14.20"
-janus_server = { path = ".", default-features = false, features = ["kube-openssl", "test-util"] }
+# Enable `kube`'s `openssl-tls` feature (which takes precedence over the
+# `rustls-tls` feature when creating a default client) to work around rustls's
+# lack of support for IP addresses in certificates when connecting to a Kind
+# cluster. Enable the `test-util` feature for various utilities used in unit
+# tests.
+janus_server = { path = ".", features = ["kube-openssl", "test-util"] }
 libc = "0.2.126"
 mockito = "0.31.0"
 serde_test = "1.0.140"


### PR DESCRIPTION
This PR does the following:

- Clean up the `janus_server` self-dev-dependency as discussed in #327.
- Extends the `create_clusters()` test in `janus_core` to test connecting to the clusters.
- Fix up `janus_core` dev-dependencies, so that `cargo test -p janus_core` works. (previously, this relied on Cargo coalescing features set by `janus_server`'s dev-dependencies when running `cargo test`)
- Document all of our crates' features.
- Document the `cargo run --bin janus_cli --features kube-openssl` suggestion in the context of the features list.

With this, I think we can close #327.