### PR TITLE
Serve health check requests on a separate port

### DIFF
--- a/janus_server/src/bin/aggregation_job_creator.rs
+++ b/janus_server/src/bin/aggregation_job_creator.rs
@@ -100,7 +100,7 @@ mod tests {
         },
         CommonConfig,
     };
-    use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+    use std::net::{Ipv4Addr, SocketAddr};
 
     #[test]
     fn roundtrip_config() {
@@ -109,10 +109,7 @@ mod tests {
                 database: generate_db_config(),
                 logging_config: generate_trace_config(),
                 metrics_config: generate_metrics_config(),
-                health_check_listen_address: SocketAddr::V4(SocketAddrV4::new(
-                    Ipv4Addr::LOCALHOST,
-                    8080,
-                )),
+                health_check_listen_address: SocketAddr::from((Ipv4Addr::UNSPECIFIED, 8080)),
             },
             tasks_update_frequency_secs: 3600,
             aggregation_job_creation_interval_secs: 60,

--- a/janus_server/src/bin/aggregation_job_creator.rs
+++ b/janus_server/src/bin/aggregation_job_creator.rs
@@ -100,6 +100,7 @@ mod tests {
         },
         CommonConfig,
     };
+    use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
     #[test]
     fn roundtrip_config() {
@@ -108,6 +109,10 @@ mod tests {
                 database: generate_db_config(),
                 logging_config: generate_trace_config(),
                 metrics_config: generate_metrics_config(),
+                health_check_listen_address: SocketAddr::V4(SocketAddrV4::new(
+                    Ipv4Addr::LOCALHOST,
+                    8080,
+                )),
             },
             tasks_update_frequency_secs: 3600,
             aggregation_job_creation_interval_secs: 60,

--- a/janus_server/src/bin/aggregation_job_driver.rs
+++ b/janus_server/src/bin/aggregation_job_driver.rs
@@ -125,7 +125,7 @@ mod tests {
         },
         CommonConfig, JobDriverConfig,
     };
-    use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+    use std::net::{Ipv4Addr, SocketAddr};
 
     #[test]
     fn roundtrip_config() {
@@ -134,10 +134,7 @@ mod tests {
                 database: generate_db_config(),
                 logging_config: generate_trace_config(),
                 metrics_config: generate_metrics_config(),
-                health_check_listen_address: SocketAddr::V4(SocketAddrV4::new(
-                    Ipv4Addr::LOCALHOST,
-                    8080,
-                )),
+                health_check_listen_address: SocketAddr::from((Ipv4Addr::UNSPECIFIED, 8080)),
             },
             job_driver_config: JobDriverConfig {
                 min_job_discovery_delay_secs: 10,

--- a/janus_server/src/bin/aggregation_job_driver.rs
+++ b/janus_server/src/bin/aggregation_job_driver.rs
@@ -125,6 +125,7 @@ mod tests {
         },
         CommonConfig, JobDriverConfig,
     };
+    use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
     #[test]
     fn roundtrip_config() {
@@ -133,6 +134,10 @@ mod tests {
                 database: generate_db_config(),
                 logging_config: generate_trace_config(),
                 metrics_config: generate_metrics_config(),
+                health_check_listen_address: SocketAddr::V4(SocketAddrV4::new(
+                    Ipv4Addr::LOCALHOST,
+                    8080,
+                )),
             },
             job_driver_config: JobDriverConfig {
                 min_job_discovery_delay_secs: 10,

--- a/janus_server/src/bin/aggregator.rs
+++ b/janus_server/src/bin/aggregator.rs
@@ -166,21 +166,18 @@ mod tests {
     };
     use std::{
         collections::HashMap,
-        net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4},
+        net::{IpAddr, Ipv4Addr, SocketAddr},
     };
 
     #[test]
     fn roundtrip_config() {
         roundtrip_encoding(Config {
-            listen_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 8080),
+            listen_address: SocketAddr::from((Ipv4Addr::UNSPECIFIED, 8080)),
             common_config: CommonConfig {
                 database: generate_db_config(),
                 logging_config: generate_trace_config(),
                 metrics_config: generate_metrics_config(),
-                health_check_listen_address: SocketAddr::V4(SocketAddrV4::new(
-                    Ipv4Addr::LOCALHOST,
-                    8080,
-                )),
+                health_check_listen_address: SocketAddr::from((Ipv4Addr::UNSPECIFIED, 8080)),
             },
             response_headers: vec![HeaderEntry {
                 name: "name".to_owned(),

--- a/janus_server/src/bin/aggregator.rs
+++ b/janus_server/src/bin/aggregator.rs
@@ -166,7 +166,7 @@ mod tests {
     };
     use std::{
         collections::HashMap,
-        net::{IpAddr, Ipv4Addr, SocketAddr},
+        net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4},
     };
 
     #[test]
@@ -177,6 +177,10 @@ mod tests {
                 database: generate_db_config(),
                 logging_config: generate_trace_config(),
                 metrics_config: generate_metrics_config(),
+                health_check_listen_address: SocketAddr::V4(SocketAddrV4::new(
+                    Ipv4Addr::LOCALHOST,
+                    8080,
+                )),
             },
             response_headers: vec![HeaderEntry {
                 name: "name".to_owned(),
@@ -192,6 +196,7 @@ mod tests {
             serde_yaml::from_str::<Config>(
                 r#"---
     listen_address: "0.0.0.0:8080"
+    health_check_listen_address: "0.0.0.0:8080"
     database:
         url: "postgres://postgres:postgres@localhost:5432/postgres"
         connection_pool_timeouts_secs: 60
@@ -218,6 +223,7 @@ mod tests {
             serde_yaml::from_str::<Config>(
                 r#"---
     listen_address: "0.0.0.0:8080"
+    health_check_listen_address: "0.0.0.0:8080"
     database:
         url: "postgres://postgres:postgres@localhost:5432/postgres"
         connection_pool_timeouts_secs: 60
@@ -237,6 +243,7 @@ mod tests {
             serde_yaml::from_str::<Config>(
                 r#"---
     listen_address: "0.0.0.0:8080"
+    health_check_listen_address: "0.0.0.0:8080"
     database:
         url: "postgres://postgres:postgres@localhost:5432/postgres"
         connection_pool_timeouts_secs: 60
@@ -267,6 +274,7 @@ mod tests {
             serde_yaml::from_str::<Config>(
                 r#"---
     listen_address: "0.0.0.0:8080"
+    health_check_listen_address: "0.0.0.0:8080"
     database:
         url: "postgres://postgres:postgres@localhost:5432/postgres"
         connection_pool_timeouts_secs: 60
@@ -291,6 +299,7 @@ mod tests {
             serde_yaml::from_str::<Config>(
                 r#"---
     listen_address: "0.0.0.0:8080"
+    health_check_listen_address: "0.0.0.0:8080"
     database:
         url: "postgres://postgres:postgres@localhost:5432/postgres"
         connection_pool_timeouts_secs: 60

--- a/janus_server/src/bin/collect_job_driver.rs
+++ b/janus_server/src/bin/collect_job_driver.rs
@@ -125,7 +125,7 @@ mod tests {
         },
         CommonConfig, JobDriverConfig,
     };
-    use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+    use std::net::{Ipv4Addr, SocketAddr};
 
     #[test]
     fn roundtrip_config() {
@@ -134,10 +134,7 @@ mod tests {
                 database: generate_db_config(),
                 logging_config: generate_trace_config(),
                 metrics_config: generate_metrics_config(),
-                health_check_listen_address: SocketAddr::V4(SocketAddrV4::new(
-                    Ipv4Addr::LOCALHOST,
-                    8080,
-                )),
+                health_check_listen_address: SocketAddr::from((Ipv4Addr::UNSPECIFIED, 8080)),
             },
             job_driver_config: JobDriverConfig {
                 min_job_discovery_delay_secs: 10,

--- a/janus_server/src/bin/collect_job_driver.rs
+++ b/janus_server/src/bin/collect_job_driver.rs
@@ -125,6 +125,7 @@ mod tests {
         },
         CommonConfig, JobDriverConfig,
     };
+    use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
     #[test]
     fn roundtrip_config() {
@@ -133,6 +134,10 @@ mod tests {
                 database: generate_db_config(),
                 logging_config: generate_trace_config(),
                 metrics_config: generate_metrics_config(),
+                health_check_listen_address: SocketAddr::V4(SocketAddrV4::new(
+                    Ipv4Addr::LOCALHOST,
+                    8080,
+                )),
             },
             job_driver_config: JobDriverConfig {
                 min_job_discovery_delay_secs: 10,

--- a/janus_server/src/bin/janus_cli.rs
+++ b/janus_server/src/bin/janus_cli.rs
@@ -249,7 +249,7 @@ mod tests {
     use std::{
         collections::HashMap,
         io::Write,
-        net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+        net::{Ipv4Addr, SocketAddr},
     };
     use tempfile::NamedTempFile;
 
@@ -340,10 +340,7 @@ mod tests {
                 database: generate_db_config(),
                 logging_config: generate_trace_config(),
                 metrics_config: generate_metrics_config(),
-                health_check_listen_address: SocketAddr::V4(SocketAddrV4::new(
-                    Ipv4Addr::LOCALHOST,
-                    8080,
-                )),
+                health_check_listen_address: SocketAddr::from((Ipv4Addr::UNSPECIFIED, 8080)),
             },
         })
     }

--- a/janus_server/src/bin/janus_cli.rs
+++ b/janus_server/src/bin/janus_cli.rs
@@ -246,7 +246,11 @@ mod tests {
     };
     use k8s_openapi::api::core::v1::Secret;
     use ring::aead::{UnboundKey, AES_128_GCM};
-    use std::{collections::HashMap, io::Write};
+    use std::{
+        collections::HashMap,
+        io::Write,
+        net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    };
     use tempfile::NamedTempFile;
 
     #[tokio::test]
@@ -336,6 +340,10 @@ mod tests {
                 database: generate_db_config(),
                 logging_config: generate_trace_config(),
                 metrics_config: generate_metrics_config(),
+                health_check_listen_address: SocketAddr::V4(SocketAddrV4::new(
+                    Ipv4Addr::LOCALHOST,
+                    8080,
+                )),
             },
         })
     }

--- a/janus_server/src/config.rs
+++ b/janus_server/src/config.rs
@@ -159,7 +159,7 @@ mod tests {
         },
         CommonConfig, DbConfig, JobDriverConfig,
     };
-    use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+    use std::net::{Ipv4Addr, SocketAddr};
 
     #[test]
     fn roundtrip_db_config() {
@@ -180,10 +180,7 @@ mod tests {
             database: generate_db_config(),
             logging_config: generate_trace_config(),
             metrics_config: generate_metrics_config(),
-            health_check_listen_address: SocketAddr::V4(SocketAddrV4::new(
-                Ipv4Addr::LOCALHOST,
-                8080,
-            )),
+            health_check_listen_address: SocketAddr::from((Ipv4Addr::UNSPECIFIED, 8080)),
         })
     }
 

--- a/janus_server/src/config.rs
+++ b/janus_server/src/config.rs
@@ -2,7 +2,7 @@
 
 use crate::{metrics::MetricsConfiguration, trace::TraceConfiguration};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::fmt::Debug;
+use std::{fmt::Debug, net::SocketAddr};
 use url::Url;
 
 /// Configuration options common to all Janus binaries.
@@ -10,12 +10,17 @@ use url::Url;
 pub struct CommonConfig {
     /// The database configuration.
     pub database: DbConfig,
+
     /// Logging configuration.
     #[serde(default)]
     pub logging_config: TraceConfiguration,
+
     /// Application-level metrics configuration
     #[serde(default)]
     pub metrics_config: MetricsConfiguration,
+
+    /// Address to serve HTTP health check requests on.
+    pub health_check_listen_address: SocketAddr,
 }
 
 /// Trait describing configuration structures for various Janus binaries.
@@ -154,6 +159,7 @@ mod tests {
         },
         CommonConfig, DbConfig, JobDriverConfig,
     };
+    use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
     #[test]
     fn roundtrip_db_config() {
@@ -174,6 +180,10 @@ mod tests {
             database: generate_db_config(),
             logging_config: generate_trace_config(),
             metrics_config: generate_metrics_config(),
+            health_check_listen_address: SocketAddr::V4(SocketAddrV4::new(
+                Ipv4Addr::LOCALHOST,
+                8080,
+            )),
         })
     }
 

--- a/janus_server/tests/server_shutdown.rs
+++ b/janus_server/tests/server_shutdown.rs
@@ -16,7 +16,7 @@ use janus_server::{
 use reqwest::{Client, Url};
 use std::{
     io::{Read, Write},
-    net::{Ipv4Addr, SocketAddr, SocketAddrV4, TcpListener, TcpStream},
+    net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream},
     process::{Command, Stdio},
 };
 use wait_timeout::ChildExt;
@@ -25,7 +25,7 @@ use wait_timeout::ChildExt;
 /// number, and closing the listening socket. This may still fail due to race
 /// conditions if another program grabs the same port number.
 fn select_open_port() -> Result<u16, std::io::Error> {
-    let listener = TcpListener::bind(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)))?;
+    let listener = TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))?;
     let address = listener.local_addr()?;
     drop(listener);
     Ok(address.port())
@@ -56,11 +56,9 @@ async fn server_shutdown() {
     let (datastore, db_handle) = ephemeral_datastore(RealClock::default()).await;
 
     let aggregator_port = select_open_port().unwrap();
-    let aggregator_listen_address =
-        SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, aggregator_port));
+    let aggregator_listen_address = SocketAddr::from((Ipv4Addr::LOCALHOST, aggregator_port));
     let health_check_port = select_open_port().unwrap();
-    let health_check_listen_address =
-        SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, health_check_port));
+    let health_check_listen_address = SocketAddr::from((Ipv4Addr::LOCALHOST, health_check_port));
     assert_ne!(aggregator_port, health_check_port);
 
     let config = format!(
@@ -123,12 +121,10 @@ async fn server_shutdown() {
     });
 
     // Try to connect to the HTTP servers in a loop, until they are ready.
-    let aggregator_listen_address =
-        SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, aggregator_port));
+    let aggregator_listen_address = SocketAddr::from((Ipv4Addr::LOCALHOST, aggregator_port));
     wait_for_server(aggregator_listen_address)
         .expect("could not connect to aggregator server after starting it");
-    let health_check_listen_address =
-        SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, health_check_port));
+    let health_check_listen_address = SocketAddr::from((Ipv4Addr::LOCALHOST, health_check_port));
     wait_for_server(health_check_listen_address)
         .expect("could not connect to health check server after starting it");
 


### PR DESCRIPTION
This moves the `/healthz` endpoint to a separate HTTP server, on its own port, and adds health checks to the three remaining server components. This change adds a new required parameter to the configuration files. Part of #36.