### PR TITLE
Upgrade to serde_yaml 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hdrhistogram"
@@ -1320,9 +1320,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1465,7 +1465,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_test",
- "serde_yaml",
+ "serde_yaml 0.9.4",
  "signal-hook",
  "signal-hook-tokio",
  "structopt",
@@ -1563,7 +1563,7 @@ dependencies = [
  "rustls-pemfile 0.2.1",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "thiserror",
  "tokio",
  "tokio-native-tls",
@@ -2869,6 +2869,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79b7c9017c64a49806c6e8df8ef99b92446d09c92457f85f91835b01a8064ae0"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3738,6 +3751,12 @@ dependencies = [
  "generic-array",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "931179334a56395bcf64ba5e0ff56781381c1a5832178280c7d7f91d1679aeb0"
 
 [[package]]
 name = "untrusted"

--- a/README.md
+++ b/README.md
@@ -83,8 +83,7 @@ For local testing, start Jaeger by running `docker run -d -p6831:6831/udp -p6832
 
 ```yaml
 logging_config:
-  open_telemetry_config:
-    jaeger:
+  open_telemetry_config: jaeger
 ```
 
 ### Honeycomb

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -51,7 +51,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["rustls-t
 ring = "0.16.20"
 serde = { version = "1.0.141", features = ["derive"] }
 serde_json = "1.0.82"
-serde_yaml = "0.8.26"
+serde_yaml = "0.9.4"
 signal-hook = "0.3.14"
 signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
 structopt = "0.3.26"

--- a/janus_server/src/bin/aggregator.rs
+++ b/janus_server/src/bin/aggregator.rs
@@ -225,8 +225,7 @@ mod tests {
         url: "postgres://postgres:postgres@localhost:5432/postgres"
         connection_pool_timeouts_secs: 60
     logging_config:
-        open_telemetry_config:
-            jaeger:
+        open_telemetry_config: jaeger
     "#
             )
             .unwrap()

--- a/janus_server/src/metrics.rs
+++ b/janus_server/src/metrics.rs
@@ -49,7 +49,7 @@ pub enum Error {
 #[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct MetricsConfiguration {
     /// Configuration for OpenTelemetry metrics, with a choice of exporters.
-    #[serde(default)]
+    #[serde(default, with = "serde_yaml::with::singleton_map")]
     pub exporter: Option<MetricsExporterConfiguration>,
 }
 

--- a/janus_server/src/trace.rs
+++ b/janus_server/src/trace.rs
@@ -57,7 +57,7 @@ pub struct TraceConfiguration {
     #[serde(default)]
     pub tokio_console_config: TokioConsoleConfiguration,
     /// Configuration for OpenTelemetry traces, with a choice of exporters.
-    #[serde(default)]
+    #[serde(default, with = "serde_yaml::with::singleton_map")]
     pub open_telemetry_config: Option<OpenTelemetryTraceConfiguration>,
 }
 


### PR DESCRIPTION
This upgrades `serde_yaml`, and uses the new `serde_yaml::with::singleton_map` module in our configuration structs to opt out of the new format for value-carrying enum variants. By default, `serde_yaml` 0.9 would use YAML tags (prefixed with a `!`) to delimit enum variants that hold one or many values. The new attributes both preserve our prior configuration file format (mostly) and work around a bug I encountered where I couldn't get serde to parse `!Tag`-ged enum variants nested anywhere inside a `#[serde(flattened)]` struct. I've got a reduced test case for that mostly ready, and I'll report it upstream separately. I did have to make one change to the Jaeger configuration file example, because the new code is stricter about unit variants, and only lets them be represented as strings, not singleton maps with an empty map value.

Note that this affects our YAML file format for task serialization as well. That code sends `Task` through `serde_yaml`, which contains a `VdafInstance` enum. We don't have any flattened structs in that case, and I'm inclined to leave that as-is. This will mean that `Prio3Aes128Sum` and `Prio3Aes128Histogram` get encoded using YAML tags instead.

This supersedes #350.