### PR TITLE
Dockerfile: remove openssl-dev dependency.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM rust:1.62.1-alpine as builder
 ARG BINARY=aggregator
-# openssl-dev is required to compile Daphne, which uses OpenSSL for TLS.
-RUN apk add libc-dev openssl-dev
+RUN apk add libc-dev
 
 WORKDIR /src
 COPY Cargo.toml /src/Cargo.toml


### PR DESCRIPTION
This was added in the Daphne integration test PR, but in retrospect does
not appear to be required.