### PR TITLE
Add features to monolithic_integration_test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1977,6 +1977,7 @@ dependencies = [
  "janus_core",
  "janus_server",
  "lazy_static",
+ "monolithic_integration_test",
  "nix",
  "opentelemetry",
  "portpicker",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM rust:1.62.1-alpine as builder
 ARG BINARY=aggregator
-# openssl-dev is required to compile Daphne, which uses OpenSSL for TLS.
-RUN apk add libc-dev openssl-dev
+RUN apk add libc-dev
 
 WORKDIR /src
 COPY Cargo.toml /src/Cargo.toml

--- a/janus_core/Cargo.toml
+++ b/janus_core/Cargo.toml
@@ -58,6 +58,6 @@ hex = { version = "*", features = ["serde"] }
 janus_core = { path = ".", features = ["test-util"] }
 # Enable `kube`'s `openssl-tls` feature (which takes precedence over the
 # `rustls-tls` feature when creating a default client) to work around rustls's
-# lack of support for IP addresses in certificates when connecting to most
+# lack of support for connecting to servers by IP addresses, which affects many
 # Kubernetes clusters.
 kube = { version = "*", features = ["openssl-tls"] }

--- a/janus_core/Cargo.toml
+++ b/janus_core/Cargo.toml
@@ -58,6 +58,6 @@ hex = { version = "*", features = ["serde"] }
 janus_core = { path = ".", features = ["test-util"] }
 # Enable `kube`'s `openssl-tls` feature (which takes precedence over the
 # `rustls-tls` feature when creating a default client) to work around rustls's
-# lack of support for IP addresses in certificates when connecting to a Kind
-# cluster.
+# lack of support for IP addresses in certificates when connecting to most
+# Kubernetes clusters.
 kube = { version = "*", features = ["openssl-tls"] }

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -74,7 +74,7 @@ hex = { version = "0.4.3", features = ["serde"] }
 hyper = "0.14.20"
 # Enable `kube`'s `openssl-tls` feature (which takes precedence over the
 # `rustls-tls` feature when creating a default client) to work around rustls's
-# lack of support for IP addresses in certificates when connecting to most
+# lack of support for connecting to servers by IP addresses, which affects many
 # Kubernetes clusters. Enable the `test-util` feature for various utilities
 # used in unit tests.
 janus_server = { path = ".", features = ["kube-openssl", "test-util"] }

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -74,9 +74,9 @@ hex = { version = "0.4.3", features = ["serde"] }
 hyper = "0.14.20"
 # Enable `kube`'s `openssl-tls` feature (which takes precedence over the
 # `rustls-tls` feature when creating a default client) to work around rustls's
-# lack of support for IP addresses in certificates when connecting to a Kind
-# cluster. Enable the `test-util` feature for various utilities used in unit
-# tests.
+# lack of support for IP addresses in certificates when connecting to most
+# Kubernetes clusters. Enable the `test-util` feature for various utilities
+# used in unit tests.
 janus_server = { path = ".", features = ["kube-openssl", "test-util"] }
 libc = "0.2.126"
 mockito = "0.31.0"

--- a/monolithic_integration_test/Cargo.toml
+++ b/monolithic_integration_test/Cargo.toml
@@ -7,11 +7,13 @@ rust-version = "1.60"
 publish = false
 
 [features]
-test-util = [
+daphne = [
     "dep:daphne",
     "dep:nix",
     "dep:subprocess",
     "dep:tempfile",
+]
+janus = [
     "janus_core/test-util",
     "janus_server/test-util"
 ]
@@ -42,7 +44,7 @@ chrono = "0.4.19"
 deadpool-postgres = "0.10.1"
 futures = "0.3.21"
 janus_client = { path = "../janus_client" }
-monolithic_integration_test = { path = ".", features = ["test-util"] }
+monolithic_integration_test = { path = ".", features = ["daphne", "janus"] }
 portpicker = "0.1"
 prio = "0.8.2"
 ring = "0.16.20"

--- a/monolithic_integration_test/Cargo.toml
+++ b/monolithic_integration_test/Cargo.toml
@@ -6,24 +6,34 @@ license = "MPL-2.0"
 rust-version = "1.60"
 publish = false
 
+[features]
+test-util = [
+    "dep:daphne",
+    "dep:nix",
+    "dep:subprocess",
+    "dep:tempfile",
+    "janus_core/test-util",
+    "janus_server/test-util"
+]
+
 [dependencies]
 backoff = "0.4"
-daphne = { git = "https://github.com/cloudflare/daphne", rev = "6301e712df216a0301c42cb3177110dd8217fa84" }
+daphne = { git = "https://github.com/cloudflare/daphne", rev = "6301e712df216a0301c42cb3177110dd8217fa84", optional = true }
 hex = "0.4"
 hpke-dispatch = "0.3"
 http = "0.2"
 itertools = "0.10"
-janus_core = { path = "../janus_core", features = ["test-util"] }
-janus_server = { path = "../janus_server", features = ["test-util"] }
+janus_core = { path = "../janus_core" }
+janus_server = { path = "../janus_server" }
 lazy_static = "1"
-nix = { version = "0.24", default-features = false, features = ["signal"] }
+nix = { version = "0.24", default-features = false, features = ["signal"], optional = true }
 opentelemetry = { version = "0.17", features = ["metrics", "rt-tokio"] }
 rand = "0.8"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
 serde = "1"
 serde_json = "1"
-subprocess = "0.2"
-tempfile = "3"
+subprocess = { version = "0.2", optional = true }
+tempfile = { version = "3", optional = true }
 tokio = { version = "1", features = ["full", "tracing"] }
 toml = "0.5"
 
@@ -32,6 +42,7 @@ chrono = "0.4.19"
 deadpool-postgres = "0.10.1"
 futures = "0.3.21"
 janus_client = { path = "../janus_client" }
+monolithic_integration_test = { path = ".", features = ["test-util"] }
 portpicker = "0.1"
 prio = "0.8.2"
 ring = "0.16.20"

--- a/monolithic_integration_test/src/lib.rs
+++ b/monolithic_integration_test/src/lib.rs
@@ -1,6 +1,6 @@
 //! This crate contains functionality useful for Janus integration tests.
 
-#[cfg(feature = "test-util")]
+#[cfg(feature = "daphne")]
 pub mod daphne;
-#[cfg(feature = "test-util")]
+#[cfg(feature = "janus")]
 pub mod janus;

--- a/monolithic_integration_test/src/lib.rs
+++ b/monolithic_integration_test/src/lib.rs
@@ -1,4 +1,6 @@
 //! This crate contains functionality useful for Janus integration tests.
 
+#[cfg(feature = "test-util")]
 pub mod daphne;
+#[cfg(feature = "test-util")]
 pub mod janus;


### PR DESCRIPTION
This moves most of monolithic_integration_test and its novel dependencies behind a new "test-util" feature flag, similar to the other
crates. With this, our release builds will no longer have the feature flags janus_core/test-util, janus_server/test-util, nor reqwest/default-tls set, due to crate feature flags being unified across the workspace. As a result, we can once again eliminate OpenSSL as a build-time dependency.

I also fixed a tangentially related inaccuracy in some comments that Tim pointed out.