### PR TITLE
Build containers for janus_cli

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -66,7 +66,11 @@ jobs:
     - env:
         DOCKER_BUILDKIT: 1
       run: docker build --tag janus_collect_job_driver --build-arg BINARY=collect_job_driver .
+    - env:
+        DOCKER_BUILDKIT: 1
+      run: docker build --tag janus_cli --build-arg BINARY=janus_cli .
     - run: docker run --rm janus_server --help
     - run: docker run --rm janus_aggregation_job_creator --help
     - run: docker run --rm janus_aggregation_job_driver --help
     - run: docker run --rm janus_collect_job_driver --help
+    - run: docker run --rm janus_cli --help

--- a/.github/workflows/push-docker-images-release.yml
+++ b/.github/workflows/push-docker-images-release.yml
@@ -65,3 +65,10 @@ jobs:
           .
     - run: docker push us-west2-docker.pkg.dev/janus-artifacts/janus/janus_collect_job_driver:latest
     - run: docker push us-west2-docker.pkg.dev/janus-artifacts/janus/janus_collect_job_driver:${{ steps.get_version.outputs.VERSION }}
+    - run: |-
+        docker build --tag us-west2-docker.pkg.dev/janus-artifacts/janus/janus_cli:latest \
+          --tag us-west2-docker.pkg.dev/janus-artifacts/janus/janus_cli:${{ steps.get_version.outputs.VERSION }} \
+          --build-arg BINARY=janus_cli \
+          .
+    - run: docker push us-west2-docker.pkg.dev/janus-artifacts/janus/janus_cli:latest
+    - run: docker push us-west2-docker.pkg.dev/janus-artifacts/janus/janus_cli:${{ steps.get_version.outputs.VERSION }}


### PR DESCRIPTION
This tacks on janus_cli to the list of containers we build. We can make use of this in automated Kind-based integration tests, to set up a task definition, and generally we can run it in-cluster for other maintenance tasks.