### PR TITLE
Rename metrics with common prefix

### DIFF
--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -221,11 +221,11 @@ pub struct Aggregator<C: Clock> {
 impl<C: Clock> Aggregator<C> {
     fn new(datastore: Arc<Datastore<C>>, clock: C, meter: Meter) -> Self {
         let upload_decrypt_failure_counter = meter
-            .u64_counter("upload_decrypt_failures")
+            .u64_counter("janus_upload_decrypt_failures")
             .with_description("Number of decryption failures in the /upload endpoint.")
             .init();
         let aggregate_step_failure_counter = meter
-            .u64_counter("step_failures")
+            .u64_counter("janus_step_failures")
             .with_description(concat!(
                 "Failures while stepping aggregation jobs; these failures are ",
                 "related to individual client reports rather than entire aggregation jobs."
@@ -2010,7 +2010,7 @@ fn aggregator_filter<C: Clock>(
 ) -> Result<BoxedFilter<(impl Reply,)>, Error> {
     let meter = opentelemetry::global::meter("janus_server");
     let response_time_recorder = meter
-        .f64_value_recorder("aggregator_response_time")
+        .f64_value_recorder("janus_aggregator_response_time")
         .with_description("Elapsed time handling incoming requests, by endpoint & status.")
         .with_unit(Unit::new("seconds"))
         .init();

--- a/janus_server/src/aggregator/aggregate_share.rs
+++ b/janus_server/src/aggregator/aggregate_share.rs
@@ -43,8 +43,8 @@ impl CollectJobDriver {
     /// Create a new [`CollectJobDriver`].
     pub fn new(http_client: reqwest::Client, meter: &Meter) -> Self {
         let job_cancel_counter = meter
-            .u64_counter("job_cancellations")
-            .with_description("Count of cancelled collect jobs")
+            .u64_counter("janus_job_cancellations")
+            .with_description("Count of cancelled jobs.")
             .init();
 
         Self {

--- a/janus_server/src/aggregator/aggregation_job_creator.rs
+++ b/janus_server/src/aggregator/aggregation_job_creator.rs
@@ -94,12 +94,12 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
         // Create metric recorders.
         let meter = opentelemetry::global::meter("aggregation_job_creator");
         let task_update_time_recorder = meter
-            .f64_value_recorder("task_update_time")
+            .f64_value_recorder("janus_task_update_time")
             .with_description("Time spent updating tasks.")
             .with_unit(Unit::new("seconds"))
             .init();
         let job_creation_time_recorder = meter
-            .f64_value_recorder("job_creation_time")
+            .f64_value_recorder("janus_job_creation_time")
             .with_description("Time spent creating aggregation jobs.")
             .with_unit(Unit::new("seconds"))
             .init();

--- a/janus_server/src/aggregator/aggregation_job_driver.rs
+++ b/janus_server/src/aggregator/aggregation_job_driver.rs
@@ -53,15 +53,15 @@ pub struct AggregationJobDriver {
 impl AggregationJobDriver {
     pub fn new(http_client: reqwest::Client, meter: &Meter) -> AggregationJobDriver {
         let aggregate_step_failure_counter = meter
-            .u64_counter("step_failures")
+            .u64_counter("janus_step_failures")
             .with_description(concat!(
                 "Failures while stepping aggregation jobs; these failures are ",
                 "related to individual client reports rather than entire aggregation jobs."
             ))
             .init();
         let job_cancel_counter = meter
-            .u64_counter("job_cancellations")
-            .with_description("Count of cancelled aggregation jobs")
+            .u64_counter("janus_job_cancellations")
+            .with_description("Count of cancelled jobs.")
             .init();
 
         AggregationJobDriver {

--- a/janus_server/src/binary_utils/job_driver.rs
+++ b/janus_server/src/binary_utils/job_driver.rs
@@ -95,13 +95,13 @@ where
         // Create metric recorders.
         let job_acquire_time_recorder = self
             .meter
-            .f64_value_recorder("job_acquire_time")
+            .f64_value_recorder("janus_job_acquire_time")
             .with_description("Time spent acquiring jobs.")
             .with_unit(Unit::new("seconds"))
             .init();
         let job_step_time_recorder = self
             .meter
-            .f64_value_recorder("job_step_time")
+            .f64_value_recorder("janus_job_step_time")
             .with_description("Time spent stepping jobs.")
             .with_unit(Unit::new("seconds"))
             .init();

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -54,7 +54,7 @@ impl<C: Clock> Datastore<C> {
     pub fn new(pool: deadpool_postgres::Pool, crypter: Crypter, clock: C) -> Datastore<C> {
         let meter = opentelemetry::global::meter("janus_server");
         let transaction_status_counter = meter
-            .u64_counter("aggregator_database_transactions_total")
+            .u64_counter("janus_database_transactions_total")
             .with_description("Count of database transactions run, with their status.")
             .init();
         Self {


### PR DESCRIPTION
This closes #342. All counter and histogram metrics are renamed to have a common `janus_` prefix.