### PR TITLE
Turn down log level in Rust CI test

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -42,7 +42,7 @@ jobs:
       run: cargo build --verbose
     - name: test
       env:
-        RUST_LOG: trace
+        RUST_LOG: info
       # set PATH to ensure we use go binaries installed above
       run: PATH=$(go env GOPATH)/bin:$PATH cargo test --verbose
     - name: document


### PR DESCRIPTION
Sets `RUST_LOG` to `info` instead of `trace` to reduce noise in test
output.

A number of dependabot PRs were failing, but then would succeed when re-run. GitHub seems to disappear the logs from failed tests so I have attached an archive of logs from one such failure. In any case, it's hard to read these logs because they're nearly 40,000 lines long, since `RUST_LOG` was set to `trace`.
[logs_875.zip](https://github.com/divviup/janus/files/9293522/logs_875.zip)
