### PR TITLE
metrics: Use BoundCounter, initialize with zeros

### DIFF
--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -37,7 +37,7 @@ use janus_core::{
     time::Clock,
 };
 use opentelemetry::{
-    metrics::{Counter, Meter, Unit, ValueRecorder},
+    metrics::{BoundCounter, Meter, Unit, ValueRecorder},
     KeyValue,
 };
 use prio::{
@@ -202,6 +202,72 @@ impl From<datastore::Error> for Error {
     }
 }
 
+/// Bound counters to record each possible cause of failures when stepping a report's aggregation.
+#[derive(Debug)]
+pub(crate) struct AggregateStepFailureCounters {
+    missing_leader_input_share: BoundCounter<u64>,
+    missing_helper_input_share: BoundCounter<u64>,
+    prepare_init_failure: BoundCounter<u64>,
+    prepare_step_failure: BoundCounter<u64>,
+    prepare_message_failure: BoundCounter<u64>,
+    unknown_hpke_config_id: BoundCounter<u64>,
+    decrypt_failure: BoundCounter<u64>,
+    input_share_decode_failure: BoundCounter<u64>,
+    continue_mismatch: BoundCounter<u64>,
+    accumulate_failure: BoundCounter<u64>,
+    finish_mismatch: BoundCounter<u64>,
+    helper_step_failure: BoundCounter<u64>,
+}
+
+impl AggregateStepFailureCounters {
+    fn new(meter: &Meter) -> AggregateStepFailureCounters {
+        let counter = meter
+            .u64_counter("janus_step_failures")
+            .with_description(concat!(
+                "Failures while stepping aggregation jobs; these failures are ",
+                "related to individual client reports rather than entire aggregation jobs."
+            ))
+            .init();
+
+        static TYPE: &str = "type";
+        let counters = AggregateStepFailureCounters {
+            missing_leader_input_share: counter
+                .bind(&[KeyValue::new(TYPE, "missing_leader_input_share")]),
+            missing_helper_input_share: counter
+                .bind(&[KeyValue::new(TYPE, "missing_helper_input_share")]),
+            prepare_init_failure: counter.bind(&[KeyValue::new(TYPE, "prepare_init_failure")]),
+            prepare_step_failure: counter.bind(&[KeyValue::new(TYPE, "prepare_step_failure")]),
+            prepare_message_failure: counter
+                .bind(&[KeyValue::new(TYPE, "prepare_message_failure")]),
+            unknown_hpke_config_id: counter.bind(&[KeyValue::new(TYPE, "unknown_hpke_config_id")]),
+            decrypt_failure: counter.bind(&[KeyValue::new(TYPE, "decrypt_failure")]),
+            input_share_decode_failure: counter
+                .bind(&[KeyValue::new(TYPE, "input_share_decode_failure")]),
+            continue_mismatch: counter.bind(&[KeyValue::new(TYPE, "continue_mismatch")]),
+            accumulate_failure: counter.bind(&[KeyValue::new(TYPE, "accumulate_failure")]),
+            finish_mismatch: counter.bind(&[KeyValue::new(TYPE, "finish_mismatch")]),
+            helper_step_failure: counter.bind(&[KeyValue::new(TYPE, "helper_step_failure")]),
+        };
+
+        // Prime each counter with zeros so that Prometheus will see that as a baseline, and
+        // recognize increases upon the first counter increment.
+        counters.missing_leader_input_share.add(0);
+        counters.missing_helper_input_share.add(0);
+        counters.prepare_init_failure.add(0);
+        counters.prepare_step_failure.add(0);
+        counters.prepare_message_failure.add(0);
+        counters.unknown_hpke_config_id.add(0);
+        counters.decrypt_failure.add(0);
+        counters.input_share_decode_failure.add(0);
+        counters.continue_mismatch.add(0);
+        counters.accumulate_failure.add(0);
+        counters.finish_mismatch.add(0);
+        counters.helper_step_failure.add(0);
+
+        counters
+    }
+}
+
 /// Aggregator implements a PPM aggregator.
 pub struct Aggregator<C: Clock> {
     /// Datastore used for durable storage.
@@ -213,9 +279,10 @@ pub struct Aggregator<C: Clock> {
 
     // Metrics.
     /// Counter tracking the number of failed decryptions while handling the /upload endpoint.
-    upload_decrypt_failure_counter: Counter<u64>,
-    /// Counter tracking the number of failures to step client reports through the aggregation process.
-    aggregate_step_failure_counter: Counter<u64>,
+    upload_decrypt_failure_counter: BoundCounter<u64>,
+    /// Counters tracking the number of failures to step client reports through the aggregation
+    /// process.
+    aggregate_step_failure_counters: AggregateStepFailureCounters,
 }
 
 impl<C: Clock> Aggregator<C> {
@@ -223,21 +290,17 @@ impl<C: Clock> Aggregator<C> {
         let upload_decrypt_failure_counter = meter
             .u64_counter("janus_upload_decrypt_failures")
             .with_description("Number of decryption failures in the /upload endpoint.")
-            .init();
-        let aggregate_step_failure_counter = meter
-            .u64_counter("janus_step_failures")
-            .with_description(concat!(
-                "Failures while stepping aggregation jobs; these failures are ",
-                "related to individual client reports rather than entire aggregation jobs."
-            ))
-            .init();
+            .init()
+            .bind(&[]);
+        upload_decrypt_failure_counter.add(0);
+        let aggregate_step_failure_counters = AggregateStepFailureCounters::new(&meter);
 
         Self {
             datastore,
             clock,
             task_aggregators: Mutex::new(HashMap::new()),
             upload_decrypt_failure_counter,
-            aggregate_step_failure_counter,
+            aggregate_step_failure_counters,
         }
     }
 
@@ -295,7 +358,7 @@ impl<C: Clock> Aggregator<C> {
             return Err(Error::UnrecognizedTask(task_id));
         }
         Ok(task_aggregator
-            .handle_aggregate_init(&self.datastore, &self.aggregate_step_failure_counter, req)
+            .handle_aggregate_init(&self.datastore, &self.aggregate_step_failure_counters, req)
             .await?
             .get_encoded())
     }
@@ -327,11 +390,7 @@ impl<C: Clock> Aggregator<C> {
             return Err(Error::UnrecognizedTask(task_id));
         }
         Ok(task_aggregator
-            .handle_aggregate_continue(
-                &self.datastore,
-                self.aggregate_step_failure_counter.clone(),
-                req,
-            )
+            .handle_aggregate_continue(&self.datastore, &self.aggregate_step_failure_counters, req)
             .await?
             .get_encoded())
     }
@@ -570,7 +629,7 @@ impl TaskAggregator {
         &self,
         datastore: &Datastore<C>,
         clock: &C,
-        upload_decrypt_failure_counter: &Counter<u64>,
+        upload_decrypt_failure_counter: &BoundCounter<u64>,
         report: Report,
     ) -> Result<(), Error> {
         self.vdaf_ops
@@ -587,22 +646,22 @@ impl TaskAggregator {
     async fn handle_aggregate_init<C: Clock>(
         &self,
         datastore: &Datastore<C>,
-        aggregate_step_failure_counter: &Counter<u64>,
+        aggregate_step_failure_counters: &AggregateStepFailureCounters,
         req: AggregateInitializeReq,
     ) -> Result<AggregateInitializeResp, Error> {
         self.vdaf_ops
-            .handle_aggregate_init(datastore, aggregate_step_failure_counter, &self.task, req)
+            .handle_aggregate_init(datastore, aggregate_step_failure_counters, &self.task, req)
             .await
     }
 
     async fn handle_aggregate_continue<C: Clock>(
         &self,
         datastore: &Datastore<C>,
-        aggregate_step_failure_counter: Counter<u64>,
+        aggregate_step_failure_counters: &AggregateStepFailureCounters,
         req: AggregateContinueReq,
     ) -> Result<AggregateContinueResp, Error> {
         self.vdaf_ops
-            .handle_aggregate_continue(datastore, aggregate_step_failure_counter, &self.task, req)
+            .handle_aggregate_continue(datastore, aggregate_step_failure_counters, &self.task, req)
             .await
     }
 
@@ -669,7 +728,7 @@ impl VdafOps {
         &self,
         datastore: &Datastore<C>,
         clock: &C,
-        upload_decrypt_failure_counter: &Counter<u64>,
+        upload_decrypt_failure_counter: &BoundCounter<u64>,
         task: &Task,
         report: Report,
     ) -> Result<(), Error> {
@@ -727,7 +786,7 @@ impl VdafOps {
     async fn handle_aggregate_init<C: Clock>(
         &self,
         datastore: &Datastore<C>,
-        aggregate_step_failure_counter: &Counter<u64>,
+        aggregate_step_failure_counters: &AggregateStepFailureCounters,
         task: &Task,
         req: AggregateInitializeReq,
     ) -> Result<AggregateInitializeResp, Error> {
@@ -740,7 +799,7 @@ impl VdafOps {
                 >(
                     datastore,
                     vdaf,
-                    aggregate_step_failure_counter,
+                    aggregate_step_failure_counters,
                     task,
                     verify_key,
                     req,
@@ -755,7 +814,7 @@ impl VdafOps {
                 >(
                     datastore,
                     vdaf,
-                    aggregate_step_failure_counter,
+                    aggregate_step_failure_counters,
                     task,
                     verify_key,
                     req,
@@ -770,7 +829,7 @@ impl VdafOps {
                 >(
                     datastore,
                     vdaf,
-                    aggregate_step_failure_counter,
+                    aggregate_step_failure_counters,
                     task,
                     verify_key,
                     req,
@@ -784,7 +843,7 @@ impl VdafOps {
                 Self::handle_aggregate_init_generic::<VERIFY_KEY_LENGTH, dummy_vdaf::Vdaf, _>(
                     datastore,
                     vdaf,
-                    aggregate_step_failure_counter,
+                    aggregate_step_failure_counters,
                     task,
                     &[],
                     req,
@@ -797,7 +856,7 @@ impl VdafOps {
     async fn handle_aggregate_continue<C: Clock>(
         &self,
         datastore: &Datastore<C>,
-        aggregate_step_failure_counter: Counter<u64>,
+        aggregate_step_failure_counters: &AggregateStepFailureCounters,
         task: &Task,
         req: AggregateContinueReq,
     ) -> Result<AggregateContinueResp, Error> {
@@ -810,7 +869,7 @@ impl VdafOps {
                 >(
                     datastore,
                     Arc::clone(vdaf),
-                    aggregate_step_failure_counter,
+                    aggregate_step_failure_counters.prepare_step_failure.clone(),
                     task,
                     req,
                 )
@@ -824,7 +883,7 @@ impl VdafOps {
                 >(
                     datastore,
                     Arc::clone(vdaf),
-                    aggregate_step_failure_counter,
+                    aggregate_step_failure_counters.prepare_step_failure.clone(),
                     task,
                     req,
                 )
@@ -838,7 +897,7 @@ impl VdafOps {
                 >(
                     datastore,
                     Arc::clone(vdaf),
-                    aggregate_step_failure_counter,
+                    aggregate_step_failure_counters.prepare_step_failure.clone(),
                     task,
                     req,
                 )
@@ -851,7 +910,7 @@ impl VdafOps {
                 Self::handle_aggregate_continue_generic::<VERIFY_KEY_LENGTH, dummy_vdaf::Vdaf, _>(
                     datastore,
                     Arc::clone(vdaf),
-                    aggregate_step_failure_counter,
+                    aggregate_step_failure_counters.prepare_step_failure.clone(),
                     task,
                     req,
                 )
@@ -863,7 +922,7 @@ impl VdafOps {
     async fn handle_upload_generic<const L: usize, A: vdaf::Aggregator<L>, C: Clock>(
         datastore: &Datastore<C>,
         clock: &C,
-        upload_decrypt_failure_counter: &Counter<u64>,
+        upload_decrypt_failure_counter: &BoundCounter<u64>,
         task: &Task,
         report: Report,
     ) -> Result<(), Error>
@@ -909,7 +968,7 @@ impl VdafOps {
             &report.associated_data(),
         ) {
             warn!(report.task_id = ?report.task_id(), report.nonce = ?report.nonce(), ?err, "Report decryption failed");
-            upload_decrypt_failure_counter.add(1, &[]);
+            upload_decrypt_failure_counter.add(1);
             return Ok(());
         }
 
@@ -955,7 +1014,7 @@ impl VdafOps {
     async fn handle_aggregate_init_generic<const L: usize, A: vdaf::Aggregator<L>, C: Clock>(
         datastore: &Datastore<C>,
         vdaf: &A,
-        aggregate_step_failure_counter: &Counter<u64>,
+        aggregate_step_failure_counters: &AggregateStepFailureCounters,
         task: &Task,
         verify_key: &[u8; L],
         req: AggregateInitializeReq,
@@ -1007,8 +1066,9 @@ impl VdafOps {
                         config_id = ?report_share.encrypted_input_share.config_id(),
                         "Helper encrypted input share references unknown HPKE config ID"
                     );
-                    aggregate_step_failure_counter
-                        .add(1, &[KeyValue::new("type", "unknown_hpke_config_id")]);
+                    aggregate_step_failure_counters
+                        .unknown_hpke_config_id
+                        .add(1);
                     ReportShareError::HpkeUnknownConfigId
                 });
 
@@ -1028,8 +1088,7 @@ impl VdafOps {
                         %err,
                         "Couldn't decrypt helper's report share"
                     );
-                    aggregate_step_failure_counter
-                        .add(1, &[KeyValue::new("type", "decrypt_failure")]);
+                    aggregate_step_failure_counters.decrypt_failure.add(1);
                     ReportShareError::HpkeDecryptError
                 })
             });
@@ -1043,8 +1102,7 @@ impl VdafOps {
                 A::InputShare::get_decoded_with_param(&(vdaf, Role::Helper.index().unwrap()), &plaintext)
                     .map_err(|err| {
                         warn!(?task_id, nonce = %report_share.nonce, %err, "Couldn't decode helper's input share");
-                        aggregate_step_failure_counter
-                            .add(1, &[KeyValue::new("type", "input_share_decode_failure")]);
+                        aggregate_step_failure_counters.input_share_decode_failure.add(1);
                         ReportShareError::VdafPrepError
                     })
             });
@@ -1063,8 +1121,7 @@ impl VdafOps {
                     )
                     .map_err(|err| {
                         warn!(?task_id, nonce = %report_share.nonce, %err, "Couldn't prepare_init report share");
-                        aggregate_step_failure_counter
-                            .add(1, &[KeyValue::new("type", "prepare_init_failure")]);
+                        aggregate_step_failure_counters.prepare_init_failure.add(1);
                         ReportShareError::VdafPrepError
                     })
             });
@@ -1180,7 +1237,7 @@ impl VdafOps {
     async fn handle_aggregate_continue_generic<const L: usize, A: vdaf::Aggregator<L>, C: Clock>(
         datastore: &Datastore<C>,
         vdaf: Arc<A>,
-        aggregate_step_failure_counter: Counter<u64>,
+        prepare_step_failure_counter: BoundCounter<u64>,
         task: &Task,
         req: AggregateContinueReq,
     ) -> Result<AggregateContinueResp, Error>
@@ -1204,8 +1261,8 @@ impl VdafOps {
         // TODO(#224): don't do O(n) network round-trips (where n is the number of prepare steps)
         Ok(datastore
             .run_tx(|tx| {
-                let (vdaf, prep_steps, aggregate_step_failure_counter) =
-                    (Arc::clone(&vdaf), Arc::clone(&prep_steps), aggregate_step_failure_counter.clone());
+                let (vdaf, prep_steps,prepare_step_failure_counter) =
+                    (Arc::clone(&vdaf), Arc::clone(&prep_steps), prepare_step_failure_counter.clone());
 
                 Box::pin(async move {
                     // Read existing state.
@@ -1318,8 +1375,7 @@ impl VdafOps {
 
                             Err(err) => {
                                 warn!(?task_id, job_id = ?req.job_id, nonce = %prep_step.nonce, %err, "Prepare step failed");
-                                aggregate_step_failure_counter
-                                    .add(1, &[KeyValue::new("type", "prepare_step_failure")]);
+                                prepare_step_failure_counter.add(1);
                                 report_aggregation.state =
                                     ReportAggregationState::Failed(ReportShareError::VdafPrepError);
                                 response_prep_steps.push(PrepareStep {

--- a/janus_server/src/aggregator/aggregation_job_driver.rs
+++ b/janus_server/src/aggregator/aggregation_job_driver.rs
@@ -1,5 +1,5 @@
 use crate::{
-    aggregator::accumulator::Accumulator,
+    aggregator::{accumulator::Accumulator, AggregateStepFailureCounters},
     datastore::{
         self,
         models::{
@@ -25,10 +25,7 @@ use janus_core::{
     message::{Duration, Report, Role},
     time::Clock,
 };
-use opentelemetry::{
-    metrics::{Counter, Meter},
-    KeyValue,
-};
+use opentelemetry::metrics::{BoundCounter, Meter};
 use prio::{
     codec::{Decode, Encode, ParameterizedDecode},
     vdaf::{
@@ -46,27 +43,23 @@ use tracing::warn;
 #[derive(Debug)]
 pub struct AggregationJobDriver {
     http_client: reqwest::Client,
-    aggregate_step_failure_counter: Counter<u64>,
-    job_cancel_counter: Counter<u64>,
+    aggregate_step_failure_counters: AggregateStepFailureCounters,
+    job_cancel_counter: BoundCounter<u64>,
 }
 
 impl AggregationJobDriver {
     pub fn new(http_client: reqwest::Client, meter: &Meter) -> AggregationJobDriver {
-        let aggregate_step_failure_counter = meter
-            .u64_counter("janus_step_failures")
-            .with_description(concat!(
-                "Failures while stepping aggregation jobs; these failures are ",
-                "related to individual client reports rather than entire aggregation jobs."
-            ))
-            .init();
+        let aggregate_step_failure_counters = AggregateStepFailureCounters::new(meter);
         let job_cancel_counter = meter
             .u64_counter("janus_job_cancellations")
             .with_description("Count of cancelled jobs.")
-            .init();
+            .init()
+            .bind(&[]);
+        job_cancel_counter.add(0);
 
         AggregationJobDriver {
             http_client,
-            aggregate_step_failure_counter,
+            aggregate_step_failure_counters,
             job_cancel_counter,
         }
     }
@@ -283,8 +276,9 @@ impl AggregationJobDriver {
                 Some(leader_encrypted_input_share) => leader_encrypted_input_share,
                 None => {
                     warn!(report_nonce = %report_aggregation.nonce, "Client report missing leader encrypted input share");
-                    self.aggregate_step_failure_counter
-                        .add(1, &[KeyValue::new("type", "missing_leader_input_share")]);
+                    self.aggregate_step_failure_counters
+                        .missing_leader_input_share
+                        .add(1);
                     report_aggregation.state = ReportAggregationState::Invalid;
                     report_aggregations_to_write.push(report_aggregation);
                     continue;
@@ -298,8 +292,9 @@ impl AggregationJobDriver {
                 Some(helper_encrypted_input_share) => helper_encrypted_input_share,
                 None => {
                     warn!(report_nonce = %report_aggregation.nonce, "Client report missing helper encrypted input share");
-                    self.aggregate_step_failure_counter
-                        .add(1, &[KeyValue::new("type", "missing_client_input_share")]);
+                    self.aggregate_step_failure_counters
+                        .missing_helper_input_share
+                        .add(1);
                     report_aggregation.state = ReportAggregationState::Invalid;
                     report_aggregations_to_write.push(report_aggregation);
                     continue;
@@ -314,8 +309,9 @@ impl AggregationJobDriver {
                 Some((hpke_config, hpke_private_key)) => (hpke_config, hpke_private_key),
                 None => {
                     warn!(report_nonce = %report_aggregation.nonce, hpke_config_id = %leader_encrypted_input_share.config_id(), "Leader encrypted input share references unknown HPKE config ID");
-                    self.aggregate_step_failure_counter
-                        .add(1, &[KeyValue::new("type", "unknown_hpke_config_id")]);
+                    self.aggregate_step_failure_counters
+                        .unknown_hpke_config_id
+                        .add(1);
                     report_aggregation.state =
                         ReportAggregationState::Failed(ReportShareError::HpkeUnknownConfigId);
                     report_aggregations_to_write.push(report_aggregation);
@@ -336,8 +332,7 @@ impl AggregationJobDriver {
                 Ok(leader_input_share_bytes) => leader_input_share_bytes,
                 Err(err) => {
                     warn!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't decrypt leader's encrypted input share");
-                    self.aggregate_step_failure_counter
-                        .add(1, &[KeyValue::new("type", "decrypt_failure")]);
+                    self.aggregate_step_failure_counters.decrypt_failure.add(1);
                     report_aggregation.state =
                         ReportAggregationState::Failed(ReportShareError::HpkeDecryptError);
                     report_aggregations_to_write.push(report_aggregation);
@@ -352,8 +347,9 @@ impl AggregationJobDriver {
                 Err(err) => {
                     // TODO(https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/issues/255): is moving to Invalid on a decoding error appropriate?
                     warn!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't decode leader's input share");
-                    self.aggregate_step_failure_counter
-                        .add(1, &[KeyValue::new("type", "input_share_decode_failure")]);
+                    self.aggregate_step_failure_counters
+                        .input_share_decode_failure
+                        .add(1);
                     report_aggregation.state = ReportAggregationState::Invalid;
                     report_aggregations_to_write.push(report_aggregation);
                     continue;
@@ -371,8 +367,9 @@ impl AggregationJobDriver {
                 Ok(prep_state_and_share) => prep_state_and_share,
                 Err(err) => {
                     warn!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't initialize leader's preparation state");
-                    self.aggregate_step_failure_counter
-                        .add(1, &[KeyValue::new("type", "prepare_init_failure")]);
+                    self.aggregate_step_failure_counters
+                        .prepare_init_failure
+                        .add(1);
                     report_aggregation.state =
                         ReportAggregationState::Failed(ReportShareError::VdafPrepError);
                     report_aggregations_to_write.push(report_aggregation);
@@ -470,8 +467,9 @@ impl AggregationJobDriver {
                     Ok(leader_transition) => leader_transition,
                     Err(err) => {
                         warn!(report_nonce = %report_aggregation.nonce, ?err, "Prepare step failed");
-                        self.aggregate_step_failure_counter
-                            .add(1, &[KeyValue::new("type", "prepare_step_failure")]);
+                        self.aggregate_step_failure_counters
+                            .prepare_step_failure
+                            .add(1);
                         report_aggregation.state =
                             ReportAggregationState::Failed(ReportShareError::VdafPrepError);
                         report_aggregations_to_write.push(report_aggregation);
@@ -593,15 +591,17 @@ impl AggregationJobDriver {
                             }
                             Err(err) => {
                                 warn!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't compute prepare message");
-                                self.aggregate_step_failure_counter
-                                    .add(1, &[KeyValue::new("type", "prepare_message_failure")]);
+                                self.aggregate_step_failure_counters
+                                    .prepare_message_failure
+                                    .add(1);
                                 ReportAggregationState::Failed(ReportShareError::VdafPrepError)
                             }
                         }
                     } else {
                         warn!(report_nonce = %report_aggregation.nonce, leader_transition = ?leader_transition, "Helper continued but leader did not");
-                        self.aggregate_step_failure_counter
-                            .add(1, &[KeyValue::new("type", "continue_mismatch")]);
+                        self.aggregate_step_failure_counters
+                            .continue_mismatch
+                            .add(1);
                         report_aggregation.state = ReportAggregationState::Invalid;
                     }
                 }
@@ -617,16 +617,16 @@ impl AggregationJobDriver {
                             }
                             Err(err) => {
                                 warn!(report_nonce = %report_aggregation.nonce, ?err, "Could not update batch unit aggregation");
-                                self.aggregate_step_failure_counter
-                                    .add(1, &[KeyValue::new("type", "accumulate_failure")]);
+                                self.aggregate_step_failure_counters
+                                    .accumulate_failure
+                                    .add(1);
                                 report_aggregation.state =
                                     ReportAggregationState::Failed(ReportShareError::VdafPrepError);
                             }
                         }
                     } else {
                         warn!(report_nonce = %report_aggregation.nonce, leader_transition = ?leader_transition, "Helper finished but leader did not");
-                        self.aggregate_step_failure_counter
-                            .add(1, &[KeyValue::new("type", "finish_mismatch")]);
+                        self.aggregate_step_failure_counters.finish_mismatch.add(1);
                         report_aggregation.state = ReportAggregationState::Invalid;
                     }
                 }
@@ -635,8 +635,9 @@ impl AggregationJobDriver {
                     // If the helper failed, we move to FAILED immediately.
                     // TODO(#236): is it correct to just record the transition error that the helper reports?
                     warn!(report_nonce = %report_aggregation.nonce, helper_err = ?err, "Helper couldn't step report aggregation");
-                    self.aggregate_step_failure_counter
-                        .add(1, &[KeyValue::new("type", "helper_step_failure")]);
+                    self.aggregate_step_failure_counters
+                        .helper_step_failure
+                        .add(1);
                     report_aggregation.state = ReportAggregationState::Failed(err);
                 }
             }
@@ -799,7 +800,7 @@ impl AggregationJobDriver {
                     warn!(attempts = ?lease.lease_attempts(),
                         max_attempts = ?maximum_attempts_before_failure,
                         "Canceling job due to too many failed attempts");
-                    this.job_cancel_counter.add(1, &[]);
+                    this.job_cancel_counter.add(1);
                     return this.cancel_aggregation_job(datastore, lease).await;
                 }
 


### PR DESCRIPTION
This replaces uses of `Counter` with `BoundCounter`, with label values supplied up front, and adds a measurement of zero to each counter upon creation. Using `BoundCounter` is more performant, as it avoids lock contention and label lookups upon each measurement. Adding zero to each counter upon creation causes our scrape endpoint to include each series right away, rather than only including them after the first measurement. This means that PromQL functions `rate()`, `irate()`, and `increase()` won't miss the first counter increment after each process startup or restart.

No change is made to the histograms, because there's no analogous way to make a no-op measurement. The OpenTelemetry SDK's controller will only include a series in a metrics scrape when an update counter for that series has been modified, and the only way to increment that update counter is by recording a measurement.

This was inspired by divviup/prio-server#1897.