### PR TITLE
janus_core: specify version of k8s-openapi.

### DIFF
--- a/janus_core/Cargo.toml
+++ b/janus_core/Cargo.toml
@@ -33,7 +33,7 @@ chrono = "0.4"
 hex = "0.4.3"
 hpke-dispatch = "0.3.0"
 kube = { version = "0.65.0", optional = true, default-features = false, features = ["client", "rustls-tls"] }
-k8s-openapi = { version = "*", optional = true, features = ["v1_20"] }
+k8s-openapi = { version = "0.13.1", optional = true, features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
 num_enum = "0.5.6"
 postgres-protocol = { version = "0.6.4", optional = true }
 postgres-types = { version = "0.2.3", optional = true }


### PR DESCRIPTION
We don't actually use this dependency (directly) anywhere. It's pulled
in via `kube`; we only specify it so that we can specify the `v1_20`
feature. We previously specified a wildcard version since we just want
to match what `kube` pulls in. Unfortunately, crates.io disallows the
use of wildcard versions, which blocks us publishing 0.1.5 to crates.io:

```
error: failed to publish to registry at https://crates.io

Caused by:
  the remote server responded with an error: wildcard (`*`) dependency constraints are not allowed on crates.io. See https://doc.rust-lang.org/cargo/faq.html#can-libraries-use--as-a-version-for-their-dependencies for more information
```

Now, we just specify what is getting pulled in anyway. The downside is
that we'll need to do manual work to keep these in sync if `kube` ever
changes its effectively-major version.