### PR TITLE
Specify versions for dev dependencies, too.

### DIFF
--- a/janus_core/Cargo.toml
+++ b/janus_core/Cargo.toml
@@ -30,9 +30,9 @@ anyhow = "1"
 base64 = "0.13.0"
 bytes = { version = "1.2.1", optional = true }
 chrono = "0.4"
-hex = "0.4.3"
+hex = "0.4"
 hpke-dispatch = "0.3.0"
-kube = { version = "0.65.0", optional = true, default-features = false, features = ["client", "rustls-tls"] }
+kube = { version = "0.65", optional = true, default-features = false, features = ["client", "rustls-tls"] }
 k8s-openapi = { version = "0.13.1", optional = true, features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
 num_enum = "0.5.6"
 postgres-protocol = { version = "0.6.4", optional = true }
@@ -54,10 +54,10 @@ tracing-log = { version = "0.1.3", optional = true }
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt"], optional = true }
 
 [dev-dependencies]
-hex = { version = "*", features = ["serde"] }
+hex = { version = "0.4", features = ["serde"] }  # ensure this remains compatible with the non-dev dependency
 janus_core = { path = ".", features = ["test-util"] }
 # Enable `kube`'s `openssl-tls` feature (which takes precedence over the
 # `rustls-tls` feature when creating a default client) to work around rustls's
 # lack of support for connecting to servers by IP addresses, which affects many
 # Kubernetes clusters.
-kube = { version = "*", features = ["openssl-tls"] }
+kube = { version = "0.65", features = ["openssl-tls"] }  # ensure this remains compatible with the non-dev dependency

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -34,7 +34,7 @@ http = "0.2.8"
 hyper = "0.14.20"
 itertools = "0.10.3"
 janus_core = { path = "../janus_core", features = ["database"] }
-k8s-openapi = { version = "*", features = ["v1_20"] }
+k8s-openapi = { version = "0.13.1", features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
 kube = { version = "0.65.0", default-features = false, features = ["client"] }
 lazy_static = { version = "1", optional = true }
 num_enum = "0.5.6"
@@ -82,6 +82,6 @@ libc = "0.2.127"
 mockito = "0.31.0"
 serde_test = "1.0.143"
 tempfile = "3.3.0"
-tokio = { version = "*", features = ["test-util"] }
+tokio = { version = "1", features = ["test-util"] }  # ensure this remains compatible with the non-dev dependency
 trycmd = "0.13.5"
 wait-timeout = "0.2.0"


### PR DESCRIPTION
This is a guess; I get the same error as in
https://github.com/divviup/janus/pull/386, but the only remaining "*"
dependencies are dev-dependencies. Unhelpfully, `cargo publish
--dry-run` does not encounter this error.

IMO this is a wart in cargo/crates.io: "\*" dependencies aren't allowed
since it means "this will work with every version ever". But specifying
"\*" is the only way to say "I don't care, use whatever version is
already included due to other dependencies." There's apparently no way
to add a feature to an already-included dependency and also publish to
crates.io.