### PR TITLE
Task: require/allow collector_auth_token iff we are in Leader role.

### DIFF
--- a/monolithic_integration_test/src/daphne.rs
+++ b/monolithic_integration_test/src/daphne.rs
@@ -106,9 +106,13 @@ impl Daphne {
         let aggregator_bearer_token_list = json!({
             hex::encode(task.id.as_bytes()): String::from_utf8(task.primary_aggregator_auth_token().as_bytes().to_vec()).unwrap()
         }).to_string();
-        let collector_bearer_token_list = json!({
-            hex::encode(task.id.as_bytes()): String::from_utf8(task.primary_collector_auth_token().as_bytes().to_vec()).unwrap()
-        }).to_string();
+        let collector_bearer_token_list = if task.role == Role::Leader {
+            json!({
+                hex::encode(task.id.as_bytes()): String::from_utf8(task.primary_collector_auth_token().as_bytes().to_vec()).unwrap()
+            }).to_string()
+        } else {
+            String::new()
+        };
 
         // Write wrangler.toml.
         let wrangler_content = toml::to_string(&WranglerConfig {

--- a/monolithic_integration_test/tests/common/mod.rs
+++ b/monolithic_integration_test/tests/common/mod.rs
@@ -56,7 +56,6 @@ pub fn create_test_tasks(
     thread_rng().fill(&mut vdaf_verify_key[..]);
     let vdaf_verify_keys = Vec::from([vdaf_verify_key.to_vec()]);
     let aggregator_auth_tokens = Vec::from([generate_auth_token()]);
-    let collector_auth_tokens = Vec::from([generate_auth_token()]);
 
     // Create tasks & return.
     let leader_task = Task::new(
@@ -71,7 +70,7 @@ pub fn create_test_tasks(
         Duration::from_minutes(10).unwrap(),
         collector_hpke_config.clone(),
         aggregator_auth_tokens.clone(),
-        collector_auth_tokens.clone(),
+        Vec::from([generate_auth_token()]),
         Vec::from([generate_hpke_config_and_private_key()]),
     )
     .unwrap();
@@ -87,7 +86,7 @@ pub fn create_test_tasks(
         Duration::from_minutes(10).unwrap(),
         collector_hpke_config.clone(),
         aggregator_auth_tokens,
-        collector_auth_tokens,
+        Vec::new(),
         Vec::from([generate_hpke_config_and_private_key()]),
     )
     .unwrap();


### PR DESCRIPTION
This matches how things will be configured: helpers don't have knowledge
of the leader-collector auth token.

Also, update aggregator endpoint checks to return a 404 if the endpoint
doesn't apply to the task role BEFORE checking auth. I think this makes
more sense since I suppose the desired semantics are "the resource does
not exist if the task is for the wrong role" and it doesn't make sense
to authenticate against a task that doesn't exist.

Closes #370.