### PR TITLE
Increment versions to 0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1620,7 +1620,7 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "janus_client"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "assert_matches",
  "http",
@@ -1638,7 +1638,7 @@ dependencies = [
 
 [[package]]
 name = "janus_core"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "janus_server"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/janus_client/Cargo.toml
+++ b/janus_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "janus_client"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 description = "Client for Janus, the server powering ISRG's Divvi Up."
 documentation = "https://docs.rs/janus_client"

--- a/janus_core/Cargo.toml
+++ b/janus_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "janus_core"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 description = "Core type definitions and utilities used in various components of Janus."
 documentation = "https://docs.rs/janus_core"

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "janus_server"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 license = "MPL-2.0"
 publish = false


### PR DESCRIPTION
This will allow us to deploy a version of Janus that enforces that no collector auth token is provided to helpers.