### PR TITLE
Run container builds in parallel

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -50,6 +50,7 @@ jobs:
         CARGO_TARGET_DIR: "target/doc-deny"
         RUSTDOCFLAGS: "-Dwarnings"
       run: cargo doc
+
   janus_server_docker:
     runs-on: ubuntu-latest
     env:
@@ -67,6 +68,12 @@ jobs:
     - run: docker run --rm janus_collect_job_driver --help
     - run: docker run --rm janus_cli --help
 
+  janus_interop_docker:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
+    steps:
+    - uses: actions/checkout@v3
     - run: docker build --tag janus_interop_client --build-arg BINARY=janus_interop_client -f Dockerfile.interop .
     - run: docker build --tag janus_interop_aggregator -f Dockerfile.interop_aggregator .
     - run: docker build --tag janus_interop_collector --build-arg BINARY=janus_interop_collector -f Dockerfile.interop .


### PR DESCRIPTION
In a recent PR of mine, the `janus_server_docker` step in `ci-build.yml`
took nearly 45 minutes[1]. It takes 18 minutes to build the
`janus_server` container from `Dockerfile`, and then the builds for the
other Janus components are quite swift because the build cache gets
mounted in. But it doesn't appear to speed up the build of
`janus_interop_client`, which takes another 15-16 minutes.

In this commit, we break out the builds of the `janus_interop_client`,
`janus_interop_aggregator` and `janus_interop_collector` containers into
their own job, so that GitHub can run those in parallel with building
the other containers and with running `janus_server_build`.

[1]: https://github.com/divviup/janus/runs/7887936297?check_suite_focus=true