### PR TITLE
Trim down overly verbose Debug output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1623,6 +1623,7 @@ name = "janus_client"
 version = "0.1.8"
 dependencies = [
  "assert_matches",
+ "derivative",
  "http",
  "janus_core",
  "mockito",

--- a/janus_client/Cargo.toml
+++ b/janus_client/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/divviup/janus"
 rust-version = "1.60"
 
 [dependencies]
+derivative = "2.2.0"
 http = "0.2.8"
 janus_core = { version = "0.1", path = "../janus_core" }
 prio = "0.8.2"

--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -207,7 +207,6 @@ impl From<datastore::Error> for Error {
 }
 
 /// Bound counters to record each possible cause of failures when stepping a report's aggregation.
-#[derive(Debug)]
 pub(crate) struct AggregateStepFailureCounters {
     missing_leader_input_share: BoundCounter<u64>,
     missing_helper_input_share: BoundCounter<u64>,

--- a/janus_server/src/aggregator/aggregate_share.rs
+++ b/janus_server/src/aggregator/aggregate_share.rs
@@ -12,6 +12,7 @@ use crate::{
     task::{Task, PRIO3_AES128_VERIFY_KEY_LENGTH},
     task::{VdafInstance, DAP_AUTH_HEADER},
 };
+use derivative::Derivative;
 use futures::{future::BoxFuture, try_join};
 use http::header::CONTENT_TYPE;
 #[cfg(test)]
@@ -29,13 +30,15 @@ use prio::{
         Aggregatable,
     },
 };
-use std::{fmt::Debug, sync::Arc};
+use std::sync::Arc;
 use tracing::{debug, error, warn};
 
 /// Drives a collect job.
-#[derive(Debug)]
+#[derive(Derivative)]
+#[derivative(Debug)]
 pub struct CollectJobDriver {
     http_client: reqwest::Client,
+    #[derivative(Debug = "ignore")]
     job_cancel_counter: BoundCounter<u64>,
 }
 

--- a/janus_server/src/aggregator/aggregation_job_creator.rs
+++ b/janus_server/src/aggregator/aggregation_job_creator.rs
@@ -177,7 +177,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
         }
     }
 
-    #[tracing::instrument(skip(self, job_creation_time_recorder))]
+    #[tracing::instrument(skip(self, shutdown, job_creation_time_recorder))]
     async fn run_for_task(
         &self,
         mut shutdown: Receiver<()>,

--- a/janus_server/src/aggregator/aggregation_job_creator.rs
+++ b/janus_server/src/aggregator/aggregation_job_creator.rs
@@ -177,7 +177,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
         }
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self, job_creation_time_recorder))]
     async fn run_for_task(
         &self,
         mut shutdown: Receiver<()>,

--- a/janus_server/src/aggregator/aggregation_job_driver.rs
+++ b/janus_server/src/aggregator/aggregation_job_driver.rs
@@ -15,6 +15,7 @@ use crate::{
     task::{Task, VdafInstance, DAP_AUTH_HEADER, PRIO3_AES128_VERIFY_KEY_LENGTH},
 };
 use anyhow::{anyhow, Context, Result};
+use derivative::Derivative;
 use futures::{
     future::{try_join_all, BoxFuture, FutureExt},
     try_join,
@@ -34,16 +35,16 @@ use prio::{
         PrepareTransition,
     },
 };
-use std::{
-    fmt::{self, Debug},
-    sync::Arc,
-};
+use std::{fmt, sync::Arc};
 use tracing::warn;
 
-#[derive(Debug)]
+#[derive(Derivative)]
+#[derivative(Debug)]
 pub struct AggregationJobDriver {
     http_client: reqwest::Client,
+    #[derivative(Debug = "ignore")]
     aggregate_step_failure_counters: AggregateStepFailureCounters,
+    #[derivative(Debug = "ignore")]
     job_cancel_counter: BoundCounter<u64>,
 }
 

--- a/janus_server/src/config.rs
+++ b/janus_server/src/config.rs
@@ -1,6 +1,7 @@
 //! Configuration for various Janus binaries.
 
 use crate::{metrics::MetricsConfiguration, trace::TraceConfiguration};
+use derivative::Derivative;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{fmt::Debug, net::SocketAddr};
 use url::Url;
@@ -33,9 +34,11 @@ pub trait BinaryConfig: Debug + DeserializeOwned {
 }
 
 /// Configuration for a Janus server using a database.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Derivative, PartialEq, Eq, Serialize, Deserialize)]
+#[derivative(Debug)]
 pub struct DbConfig {
     /// URL at which to connect to the database.
+    #[derivative(Debug(format_with = "std::fmt::Display::fmt"))]
     pub url: Url,
     /// Timeout in seconds to apply when creating, waiting for, or recycling
     /// connection pool objects. This value will be used to construct a

--- a/janus_server/src/task.rs
+++ b/janus_server/src/task.rs
@@ -11,7 +11,10 @@ use janus_core::{
 };
 use ring::constant_time;
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    fmt::{self, Formatter},
+};
 use url::Url;
 
 /// HTTP header where auth tokens are provided in inter-aggregator messages.
@@ -175,6 +178,7 @@ pub struct Task {
     pub id: TaskId,
     /// URLs relative to which aggregator API endpoints are found. The first
     /// entry is the leader's.
+    #[derivative(Debug(format_with = "fmt_vector_of_urls"))]
     pub aggregator_endpoints: Vec<Url>,
     /// The VDAF this task executes.
     pub vdaf: VdafInstance,
@@ -321,6 +325,14 @@ impl Task {
             .rev()
             .any(|t| t == auth_token)
     }
+}
+
+fn fmt_vector_of_urls(urls: &Vec<Url>, f: &mut Formatter<'_>) -> fmt::Result {
+    let mut list = f.debug_list();
+    for url in urls {
+        list.entry(&format!("{}", url));
+    }
+    list.finish()
 }
 
 /// SerializedTask is an intermediate representation for tasks being serialized via the Serialize &


### PR DESCRIPTION
This makes the following changes to slim down Debug output:

- Skip logging OpenTelemetry SDK instruments. These are always going to be the same, and they are only included in structs or function arguments for performance.
- Skip logging a Tokio channel receiver in one location.
- Modify Debug implementations to print out `Url` objects with their Display formatting, for conciseness.

Examples of "before" output:

```
"job_creation_time_recorder":"ValueRecorder(SyncInstrument { instrument: SyncInstrument { instrument: Instrument { descriptor: Descriptor { name: \"janus_job_creation_time\", instrument_kind: ValueRecorder, number_kind: F64, config: InstrumentConfig { description: Some(\"Time spent creating aggregation jobs.\"), unit: Some(Unit(\"seconds\")), instrumentation_library: InstrumentationLibrary { name: \"aggregation_job_creator\", version: None } }, attribute_hash: 3686441284350234660 }, meter: \"Accumulator\" } }, _marker: PhantomData })"

"shutdown":"Receiver { inner: Some(Inner { state: State { is_complete: false, is_closed: false, is_rx_task_set: false, is_tx_task_set: false } }) }"

aggregator_endpoints: [Url { scheme: \"http\", cannot_be_a_base: false, username: \"\", password: None, host: Some(Domain(\"localhost\")), port: Some(22718), path: \"/\", query: None, fragment: None }, Url { scheme: \"http\", cannot_be_a_base: false, username: \"\", password: None, host: Some(Domain(\"aggregator.kind-ci-pollux.svc.cluster.local\")), port: None, path: \"/\", query: None, fragment: None }]
```

New URL output:

```
aggregator_endpoints: ["http://leader_endpoint/", "http://helper_endpoint/"]
```

This is part of #392.