### PR TITLE
Skip "span" attribute in JSON logging output

### DIFF
--- a/janus_server/src/trace.rs
+++ b/janus_server/src/trace.rs
@@ -119,7 +119,13 @@ pub fn install_trace_subscriber(config: &TraceConfiguration) -> Result<(), Error
 
     let mut layers = Vec::new();
     match (output_json, config.use_test_writer) {
-        (true, false) => layers.push(base_layer().json().with_filter(stdout_filter).boxed()),
+        (true, false) => layers.push(
+            base_layer()
+                .json()
+                .with_current_span(false)
+                .with_filter(stdout_filter)
+                .boxed(),
+        ),
         (false, false) => layers.push(base_layer().pretty().with_filter(stdout_filter).boxed()),
         (_, true) => layers.push(
             base_layer()


### PR DESCRIPTION
By default, the JSON tracing subscriber emits both the current span's fields, in an object under the "span" key, and all fields of all spans, under the "spans" key. This disables the former to reduce duplication.