### PR TITLE
CI buildtime improvements.

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -15,6 +15,8 @@ jobs:
       RUSTFLAGS: "-D warnings"
     steps:
     - uses: actions/checkout@v3
+    - name: Setup Go toolchain
+      uses: actions/setup-go@v3
     - name: Install Kind
       # We should always make sure that the `kind` CLI we install is from the
       # same release as the node image version used by
@@ -31,8 +33,7 @@ jobs:
     - name: Build
       run: cargo test --no-run --locked
     - name: Test
-      # set PATH to ensure we use go binaries installed above
-      run: PATH=$(go env GOPATH)/bin:$PATH cargo test
+      run: cargo test
   
   janus_lints:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -29,13 +29,15 @@ jobs:
         components: clippy, rustfmt
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
-    - name: lint
+    - name: Lint
       run: cargo fmt --message-format human -- --check
-    - name: clippy
+    - name: Clippy
+      env:
+        CARGO_TARGET_DIR: "/tmp/target"
       run: cargo clippy --workspace --all-targets
     - name: Document
       env:
-        CARGO_TARGET_DIR: "/tmp/rustdoc"
+        CARGO_TARGET_DIR: "/tmp/target"
         RUSTDOCFLAGS: "-D warnings"
       run: cargo doc
     - name: Build

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -14,21 +14,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: cache
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Install Kind
       # We should always make sure that the `kind` CLI we install is from the
       # same release as the node image version used by
       # `janus_core::test_util::kubernetes::EphemeralCluster`
       run: go install sigs.k8s.io/kind@v0.14.0
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        override: true
+        components: clippy, rustfmt
+    - name: Cache dependencies
+      uses: Swatinem/rust-cache@v2
     - name: lint
       run: cargo fmt --message-format human -- --check
     - name: clippy

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -36,16 +36,16 @@ jobs:
       run: cargo clippy --workspace --all-targets
     - name: check, all features
       run: cargo check --all-features
+    - name: Document
+      env:
+        CARGO_TARGET_DIR: "/tmp/rustdoc"
+        RUSTDOCFLAGS: "-D warnings"
+      run: cargo doc
     - name: Build
       run: cargo test --no-run --locked
     - name: Test
       # set PATH to ensure we use go binaries installed above
       run: PATH=$(go env GOPATH)/bin:$PATH cargo test
-    - name: document
-      env:
-        CARGO_TARGET_DIR: "target/doc-deny"
-        RUSTDOCFLAGS: "-Dwarnings"
-      run: cargo doc
 
   janus_server_docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -34,8 +34,6 @@ jobs:
       run: cargo fmt --message-format human -- --check
     - name: clippy
       run: cargo clippy --workspace --all-targets
-    - name: check, all features
-      run: cargo check --all-features
     - name: Document
       env:
         CARGO_TARGET_DIR: "/tmp/rustdoc"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -6,14 +6,13 @@ on:
   pull_request:
   workflow_dispatch:
 
-env:
-  CARGO_INCREMENTAL: 0
-  CARGO_TERM_COLOR: always
-  RUSTFLAGS: "-D warnings"
-
 jobs:
   janus_server_build:
     runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: 0
+      CARGO_TERM_COLOR: always
+      RUSTFLAGS: "-D warnings"
     steps:
     - uses: actions/checkout@v3
     - name: Install Kind

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -40,6 +40,7 @@ jobs:
     env:
       CARGO_INCREMENTAL: 0
       CARGO_TERM_COLOR: always
+      JANUS_INTEROP_CONTAINER: skip
       RUSTDOCFLAGS: "-D warnings"
       RUSTFLAGS: "-D warnings"
     steps:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Clippy
       run: cargo clippy --workspace --all-targets
     - name: Document
-      run: cargo doc -- -D warnings
+      run: cargo doc --workspace
 
   janus_docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 env:
+  CARGO_INCREMENTAL: 0
   CARGO_TERM_COLOR: always
 
 jobs:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  janus_server_build:
+  janus_build:
     runs-on: ubuntu-latest
     env:
       CARGO_INCREMENTAL: 0
@@ -26,27 +26,38 @@ jobs:
         toolchain: stable
         profile: minimal
         override: true
-        components: clippy, rustfmt
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
-    - name: Lint
-      run: cargo fmt --message-format human -- --check
-    - name: Clippy
-      env:
-        CARGO_TARGET_DIR: "/tmp/target"
-      run: cargo clippy --workspace --all-targets
-    - name: Document
-      env:
-        CARGO_TARGET_DIR: "/tmp/target"
-        RUSTDOCFLAGS: "-D warnings"
-      run: cargo doc
     - name: Build
       run: cargo test --no-run --locked
     - name: Test
       # set PATH to ensure we use go binaries installed above
       run: PATH=$(go env GOPATH)/bin:$PATH cargo test
+  
+  janus_lints:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: 0
+      CARGO_TERM_COLOR: always
+      RUSTDOCFLAGS: "-D warnings"
+      RUSTFLAGS: "-D warnings"
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        override: true
+        components: clippy, rustfmt
+    - name: Format
+      run: cargo fmt --message-format human -- --check
+    - name: Clippy
+      run: cargo clippy --workspace --all-targets
+    - name: Document
+      run: cargo doc -- -D warnings
 
-  janus_server_docker:
+  janus_docker:
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: 1

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -9,6 +9,7 @@ on:
 env:
   CARGO_INCREMENTAL: 0
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
 
 jobs:
   janus_server_build:
@@ -32,7 +33,7 @@ jobs:
     - name: lint
       run: cargo fmt --message-format human -- --check
     - name: clippy
-      run: cargo clippy --workspace --all-targets -- -D warnings
+      run: cargo clippy --workspace --all-targets
     - name: check, all features
       run: cargo check --all-features
     - name: Build

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -34,13 +34,11 @@ jobs:
       run: cargo clippy --workspace --all-targets -- -D warnings
     - name: check, all features
       run: cargo check --all-features
-    - name: build
-      run: cargo build --verbose
-    - name: test
-      env:
-        RUST_LOG: info
+    - name: Build
+      run: cargo test --no-run --locked
+    - name: Test
       # set PATH to ensure we use go binaries installed above
-      run: PATH=$(go env GOPATH)/bin:$PATH cargo test --verbose
+      run: PATH=$(go env GOPATH)/bin:$PATH cargo test
     - name: document
       env:
         CARGO_TARGET_DIR: "target/doc-deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,11 @@
 members = ["build_script_utils", "interop_binaries", "janus_core", "janus_client", "janus_server", "monolithic_integration_test"]
 resolver = "2"
 
+[profile.dev]
+# Disabling debug info improves build speeds & reduces
+# build artifact sizes (which helps CI caching).
+debug = 0
+
 [profile.small]
 # We define a profile intended to minimize the eventual binary size, while still allowing for
 # relatively fast compilation. It is intended for use in size-constrained testing scenarios, e.g.

--- a/interop_binaries/build.rs
+++ b/interop_binaries/build.rs
@@ -7,59 +7,87 @@ fn main() {
         use build_script_utils::save_zstd_compressed_docker_image;
         use std::{env, fs::File, process::Command};
 
-        println!("cargo:rerun-if-changed=../Dockerfile.interop_aggregator");
+        println!("cargo:rerun-if-env-changed=JANUS_INTEROP_CONTAINER");
+        let container_strategy = env::var("JANUS_INTEROP_CONTAINER")
+            .ok()
+            .unwrap_or_else(|| "build".to_string());
 
-        // These directives should match the dependencies copied into Dockerfile.interop_aggregator.
-        println!("cargo:rerun-if-changed=../Cargo.lock");
-        println!("cargo:rerun-if-changed=../Cargo.toml");
-        println!("cargo:rerun-if-changed=../db/schema.sql");
-        println!("cargo:rerun-if-changed=../interop_binaries");
-        println!("cargo:rerun-if-changed=../janus_core");
-        println!("cargo:rerun-if-changed=../janus_client");
-        println!("cargo:rerun-if-changed=../janus_server");
-        println!("cargo:rerun-if-changed=../monolithic_integration_test");
+        match container_strategy.as_str() {
+            "build" => {
+                // The "build" strategy causes us to build a container image based on the current
+                // repository, and embed it in the test library.
+                println!("cargo:rerun-if-changed=../Dockerfile.interop_aggregator");
 
-        // Build & save off a container image for the interop_aggregator.
-        // Note: `docker build` has an `--output` flag which writes the output to somewhere, which
-        // may be a tarfile. But `docker build --output` only exports the image filesystem, and not
-        // any other image metadata (such as exposed ports, the entrypoint, etc), so we can't easily
-        // use it.
-        let build_output = Command::new("docker")
-            .args([
-                "build",
-                "--file=Dockerfile.interop_aggregator",
-                "--build-arg",
-                "PROFILE=small",
-                "--quiet",
-                ".",
-            ])
-            .current_dir("..")
-            .env("DOCKER_BUILDKIT", "1")
-            .output()
-            .expect("Failed to execute `docker build` for interop aggregator");
-        assert!(
-            build_output.status.success(),
-            "Docker build of interop aggregator failed:\n{}",
-            String::from_utf8_lossy(&build_output.stderr)
-        );
-        let image_id = String::from_utf8(build_output.stdout).unwrap();
-        let image_id = image_id.trim();
+                // These directives should match the dependencies copied into Dockerfile.interop_aggregator.
+                println!("cargo:rerun-if-changed=../Cargo.lock");
+                println!("cargo:rerun-if-changed=../Cargo.toml");
+                println!("cargo:rerun-if-changed=../db/schema.sql");
+                println!("cargo:rerun-if-changed=../interop_binaries");
+                println!("cargo:rerun-if-changed=../janus_core");
+                println!("cargo:rerun-if-changed=../janus_client");
+                println!("cargo:rerun-if-changed=../janus_server");
+                println!("cargo:rerun-if-changed=../monolithic_integration_test");
 
-        let image_file = File::create(format!(
-            "{}/interop_aggregator.tar.zst",
-            env::var("OUT_DIR").unwrap()
-        ))
-        .expect("Couldn't create interop aggregator image file");
-        save_zstd_compressed_docker_image(image_id, &image_file);
-        image_file
-            .sync_all()
-            .expect("Couldn't write compressed image file");
-        drop(image_file);
+                // Build & save off a container image for the interop_aggregator.
+                // Note: `docker build` has an `--output` flag which writes the output to somewhere, which
+                // may be a tarfile. But `docker build --output` only exports the image filesystem, and not
+                // any other image metadata (such as exposed ports, the entrypoint, etc), so we can't easily
+                // use it.
+                let build_output = Command::new("docker")
+                    .args([
+                        "build",
+                        "--file=Dockerfile.interop_aggregator",
+                        "--build-arg",
+                        "PROFILE=small",
+                        "--quiet",
+                        ".",
+                    ])
+                    .current_dir("..")
+                    .env("DOCKER_BUILDKIT", "1")
+                    .output()
+                    .expect("Failed to execute `docker build` for interop aggregator");
+                assert!(
+                    build_output.status.success(),
+                    "Docker build of interop aggregator failed:\n{}",
+                    String::from_utf8_lossy(&build_output.stderr)
+                );
+                let image_id = String::from_utf8(build_output.stdout).unwrap();
+                let image_id = image_id.trim();
 
-        // Make a best-effort attempt to clean up after ourselves.
-        Command::new("docker")
-            .args(["rmi", image_id])
-            .status()
-            .expect("Failed to execute `docker rmi` for interop aggregator");
+                let image_file = File::create(format!(
+                    "{}/interop_aggregator.tar.zst",
+                    env::var("OUT_DIR").unwrap()
+                ))
+                .expect("Couldn't create interop aggregator image file");
+                save_zstd_compressed_docker_image(image_id, &image_file);
+                image_file
+                    .sync_all()
+                    .expect("Couldn't write compressed image file");
+                drop(image_file);
+
+                // Make a best-effort attempt to clean up after ourselves.
+                Command::new("docker")
+                    .args(["rmi", image_id])
+                    .status()
+                    .expect("Failed to execute `docker rmi` for interop aggregator");
+            }
+
+            "skip" => {
+                // The "skip" strategy causes us to skip building a container at all. Tests
+                // depending on having the image available will fail.
+
+                // We create an empty file since it's necessary for compilation to succeed; the
+                // consumer (testcontainer.rs) will panic if someone attempts to instantiate a Janus
+                // instance in this case.
+                let image_file = File::create(format!(
+                    "{}/interop_aggregator.tar.zst",
+                    env::var("OUT_DIR").unwrap()
+                ))
+                .expect("Couldn't create interop aggregator image file");
+                image_file.sync_all().expect("Couldn't write interop aggregator image file");
+            }
+
+            _ => panic!("Unexpected JANUS_INTEROP_CONTAINER value {container_strategy:?} (valid values are \"build\" & \"skip\")")
+        }
     }
 }

--- a/interop_binaries/src/testcontainer.rs
+++ b/interop_binaries/src/testcontainer.rs
@@ -17,6 +17,9 @@ impl Default for Aggregator {
     fn default() -> Self {
         // One-time initialization step: load compiled image into docker, recording its image tag,
         // so that we can launch it later.
+        if INTEROP_AGGREGATOR_IMAGE_BYTES.is_empty() {
+            panic!("Cannot create interop aggregator image. (Likley compiled with JANUS_INTEROP_CONTAINER=skip.)");
+        }
         let mut image_hash = INTEROP_AGGREGATOR_IMAGE_HASH.lock().unwrap();
         if image_hash.is_none() {
             *image_hash = Some(load_zstd_compressed_docker_image(


### PR DESCRIPTION
* Split the main build steps from the lint-like steps to ensure the cache does not include the lint-like steps' outputs.
* Use a more precise caching strategy.
* Disable incremental compilation.
* Disable debuginfo.
* Allow `cargo clippy` to skip building the interop test container.

Before these changes, a CI run I kicked off this morning took 45 minutes: https://github.com/divviup/janus/actions/runs/2891132620
With these changes, CI runs are more like 21 minutes: https://github.com/divviup/janus/actions/runs/2892438113
... or 30 minutes on a cache miss: https://github.com/divviup/janus/actions/runs/2892294130

Most of the strategies in this PR were taken from [Fast Rust Builds](https://matklad.github.io/2021/09/04/fast-rust-builds.html).