### PR TITLE
Exclude ciphertexts and VDAF messages from logs

### DIFF
--- a/janus_core/src/message.rs
+++ b/janus_core/src/message.rs
@@ -3,6 +3,7 @@
 use crate::{hpke::associated_data_for_report_share, time::Clock};
 use anyhow::anyhow;
 use chrono::NaiveDateTime;
+use derivative::Derivative;
 use hpke_dispatch::{Aead, Kdf, Kem};
 use num_enum::TryFromPrimitive;
 #[cfg(feature = "database")]
@@ -766,13 +767,16 @@ impl Decode for ExtensionType {
 }
 
 /// PPM protocol message representing an HPKE ciphertext.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Derivative, Eq, PartialEq)]
+#[derivative(Debug)]
 pub struct HpkeCiphertext {
     /// An identifier of the HPKE configuration used to seal the message.
     config_id: HpkeConfigId,
     /// An encasulated HPKE context.
+    #[derivative(Debug = "ignore")]
     encapsulated_context: Vec<u8>,
     /// An HPKE ciphertext.
+    #[derivative(Debug = "ignore")]
     payload: Vec<u8>,
 }
 

--- a/janus_server/src/aggregator/accumulator.rs
+++ b/janus_server/src/aggregator/accumulator.rs
@@ -11,11 +11,13 @@ use prio::vdaf::{self, Aggregatable};
 use std::collections::HashMap;
 use tracing::debug;
 
-#[derive(Debug)]
+#[derive(Derivative)]
+#[derivative(Debug)]
 struct Accumulation<const L: usize, A: vdaf::Aggregator<L>>
 where
     for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
 {
+    #[derivative(Debug = "ignore")]
     aggregate_share: A::AggregateShare,
     report_count: u64,
     checksum: NonceChecksum,

--- a/janus_server/src/aggregator/aggregation_job_driver.rs
+++ b/janus_server/src/aggregator/aggregation_job_driver.rs
@@ -603,7 +603,7 @@ impl AggregationJobDriver {
                             }
                         }
                     } else {
-                        warn!(report_nonce = %report_aggregation.nonce, leader_transition = ?leader_transition, "Helper continued but leader did not");
+                        warn!(report_nonce = %report_aggregation.nonce, "Helper continued but leader did not");
                         self.aggregate_step_failure_counters
                             .continue_mismatch
                             .add(1);
@@ -630,7 +630,7 @@ impl AggregationJobDriver {
                             }
                         }
                     } else {
-                        warn!(report_nonce = %report_aggregation.nonce, leader_transition = ?leader_transition, "Helper finished but leader did not");
+                        warn!(report_nonce = %report_aggregation.nonce, "Helper finished but leader did not");
                         self.aggregate_step_failure_counters.finish_mismatch.add(1);
                         report_aggregation.state = ReportAggregationState::Invalid;
                     }

--- a/janus_server/src/message.rs
+++ b/janus_server/src/message.rs
@@ -77,9 +77,10 @@ impl Decode for PrepareStep {
 
 /// DAP protocol message representing result-type-specific data associated with a preparation step
 /// in a VDAF evaluation. Included in a PrepareStep message.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Derivative, PartialEq, Eq)]
+#[derivative(Debug)]
 pub enum PrepareStepResult {
-    Continued(Vec<u8>), // content is a serialized preparation message
+    Continued(#[derivative(Debug = "ignore")] Vec<u8>), // content is a serialized preparation message
     Finished,
     Failed(ReportShareError),
 }


### PR DESCRIPTION
This excludes logging the contents of HPKE ciphertexts and various VDAF messages. Each of these is not meaningful on its own, either due to encryption or secret sharing, and would not be worth the space they take up. Moreover, not logging report shares raises the difficulty of attacking multiple aggregators to compromise privacy, by keeping report shares out of the blast radius of logging systems.

This is part of #392.