### PR TITLE
Fix build with "otlp" feature

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -56,6 +56,8 @@ jobs:
       run: cargo fmt --message-format human -- --check
     - name: Clippy
       run: cargo clippy --workspace --all-targets
+    - name: Clippy (all features)
+      run: cargo clippy --workspace --all-targets --all-features
     - name: Document
       run: cargo doc --workspace
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1742,7 +1742,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-postgres",
- "tonic 0.8.0",
+ "tonic 0.6.2",
  "tracing",
  "tracing-log",
  "tracing-opentelemetry",
@@ -2946,7 +2946,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.22.3",
  "winreg",
 ]
 
@@ -3825,6 +3825,7 @@ dependencies = [
  "prost 0.9.0",
  "prost-derive 0.9.0",
  "tokio",
+ "tokio-rustls 0.22.0",
  "tokio-stream",
  "tokio-util 0.6.9",
  "tower",
@@ -3832,6 +3833,7 @@ dependencies = [
  "tower-service",
  "tracing",
  "tracing-futures",
+ "webpki-roots 0.21.1",
 ]
 
 [[package]]
@@ -3856,9 +3858,7 @@ dependencies = [
  "pin-project",
  "prost 0.11.0",
  "prost-derive 0.11.0",
- "rustls-pemfile 1.0.0",
  "tokio",
- "tokio-rustls 0.23.3",
  "tokio-stream",
  "tokio-util 0.7.1",
  "tower",
@@ -3866,7 +3866,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "tracing-futures",
- "webpki-roots",
 ]
 
 [[package]]
@@ -4397,6 +4396,15 @@ checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+dependencies = [
+ "webpki 0.21.4",
 ]
 
 [[package]]

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -59,7 +59,7 @@ testcontainers = { version = "0.14.0", optional = true }
 thiserror = "1.0"
 tokio = { version = "^1.20", features = ["full", "tracing"] }
 tokio-postgres = { version = "0.7.7", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1", "array-impls"] }
-tonic = { version = "0.8.0", optional = true, features = ["tls", "tls-webpki-roots"] }
+tonic = { version = "0.6.2", optional = true, features = ["tls", "tls-webpki-roots"] }  # keep this version in sync with what opentelemetry-otlp uses
 tracing = "0.1.36"
 tracing-log = "0.1.3"
 tracing-opentelemetry = { version = "0.17.4", optional = true }

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -40,7 +40,7 @@ lazy_static = { version = "1", optional = true }
 num_enum = "0.5.6"
 opentelemetry = { version = "0.17.0", features = ["metrics", "rt-tokio"] }
 opentelemetry-jaeger = { version = "0.16.0", optional = true, features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.10.0", optional = true, features = ["metrics"] }
+opentelemetry-otlp = { version = "0.10.0", optional = true, features = ["metrics"] }  # ensure that the version of tonic below matches what this uses
 opentelemetry-prometheus = { version = "0.10.0", optional = true }
 opentelemetry-semantic-conventions = { version = "0.9.0", optional = true }
 postgres-types = { version = "0.2.4", features = ["derive", "array-impls"] }


### PR DESCRIPTION
A version bump last week broke builds with the "otlp" feature enabled. We construct some objects using the `tonic` crate, and pass them to `opentelemery-otlp`, which does not re-export any of the `tonic` types it expects. The difference in crate versions was causing errors due to mismatching types. This PR reverts that version bump, makes note of the constraint between the two packages, and adds an `--all-features` step to the CI to catch such issues in the future.