### PR TITLE
`janus_cli`: automatically discover datastore keys

### DIFF
--- a/janus_server/src/binary_utils.rs
+++ b/janus_server/src/binary_utils.rs
@@ -157,7 +157,7 @@ pub trait BinaryOptions: StructOpt + Debug {
 }
 
 #[cfg_attr(doc, doc = "Common options that are used by all Janus binaries.")]
-#[derive(StructOpt)]
+#[derive(Default, StructOpt)]
 pub struct CommonBinaryOptions {
     /// Path to configuration YAML.
     #[structopt(

--- a/janus_server/src/config.rs
+++ b/janus_server/src/config.rs
@@ -3,7 +3,10 @@
 use crate::{metrics::MetricsConfiguration, trace::TraceConfiguration};
 use derivative::Derivative;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::{fmt::Debug, net::SocketAddr};
+use std::{
+    fmt::Debug,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+};
 use url::Url;
 
 /// Configuration options common to all Janus binaries.
@@ -21,7 +24,12 @@ pub struct CommonConfig {
     pub metrics_config: MetricsConfiguration,
 
     /// Address to serve HTTP health check requests on.
+    #[serde(default = "default_health_check_listen_address")]
     pub health_check_listen_address: SocketAddr,
+}
+
+fn default_health_check_listen_address() -> SocketAddr {
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9001)
 }
 
 /// Trait describing configuration structures for various Janus binaries.

--- a/janus_server/src/config.rs
+++ b/janus_server/src/config.rs
@@ -10,6 +10,20 @@ use std::{
 use url::Url;
 
 /// Configuration options common to all Janus binaries.
+///
+/// # Examples
+///
+/// ```
+/// use janus_server::config::CommonConfig;
+///
+/// let yaml_config = r#"
+/// ---
+/// database:
+///   url: postgres://postgres:postgres@localhost:5432/postgres
+/// "#;
+///
+/// let _decoded: CommonConfig = serde_yaml::from_str(yaml_config).unwrap();
+/// ```
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CommonConfig {
     /// The database configuration.

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -337,7 +337,7 @@ impl<C: Clock> Transaction<'_, C> {
 
     /// Deletes a task from the datastore. Fails if there is any data related to the task, such as
     /// client reports, aggregations, etc.
-    #[tracing::instrument(skip(self), err)]
+    #[tracing::instrument(skip(self))]
     pub async fn delete_task(&self, task_id: TaskId) -> Result<(), Error> {
         let params: &[&(dyn ToSql + Sync)] = &[&task_id.as_bytes()];
 


### PR DESCRIPTION
In order to provision tasks, `janus_cli` needs the datastore key, used
encrypt some database rows. This key can be provided with
`--datastore-keys`, but since `janus_cli` has to talk to a Kubernetes
cluster anyway, it can also fetch the secret value from Kubernetes
secrets, which is fewer steps for an operator (no need to fetch the
secret before running `janus_cli`) and less risk of exposing the
datastore key to an operator workstation (or worse, an operator's
clipboard).