### PR TITLE
Additional changes for draft-dcook-ppm-dap-interop-test-design-01

### DIFF
--- a/interop_binaries/src/bin/janus_interop_client.rs
+++ b/interop_binaries/src/bin/janus_interop_client.rs
@@ -4,13 +4,14 @@ use clap::{Arg, Command};
 use interop_binaries::{
     install_tracing_subscriber,
     status::{ERROR, SUCCESS},
-    VdafObject,
+    NumberAsString, VdafObject,
 };
 use janus_client::ClientParameters;
 use janus_core::{
     message::{Duration, Role, TaskId, Time},
     time::{MockClock, RealClock},
 };
+use janus_server::task::VdafInstance;
 use prio::{
     codec::Decode,
     vdaf::{prio3::Prio3, Vdaf},
@@ -21,13 +22,29 @@ use url::Url;
 use warp::{hyper::StatusCode, reply::Response, Filter, Reply};
 
 #[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum Measurement {
+    Number(u64),
+    NumberAsString64(NumberAsString<u64>),
+}
+
+impl Measurement {
+    fn as_u64(&self) -> u64 {
+        match self {
+            Measurement::Number(value) => *value,
+            Measurement::NumberAsString64(NumberAsString(value)) => *value,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct UploadRequest {
     task_id: String,
     leader: Url,
     helper: Url,
     vdaf: VdafObject,
-    measurement: u64,
+    measurement: Measurement,
     #[serde(default)]
     nonce_time: Option<u64>,
     min_batch_duration: u64,
@@ -113,23 +130,27 @@ async fn handle_upload(
     http_client: &reqwest::Client,
     request: UploadRequest,
 ) -> anyhow::Result<()> {
-    let measurement = request.measurement;
-    match request.vdaf {
-        VdafObject::Prio3Aes128Count {} => {
+    let measurement = request.measurement.as_u64();
+    let vdaf_instance = request.vdaf.clone().into();
+    match vdaf_instance {
+        VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128Count {}) => {
             let vdaf_client =
                 Prio3::new_aes128_count(2).context("failed to construct Prio3Aes128Count VDAF")?;
             handle_upload_generic(http_client, vdaf_client, request, measurement).await?;
         }
-        VdafObject::Prio3Aes128Sum { bits } => {
+        VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128Sum { bits }) => {
             let vdaf_client = Prio3::new_aes128_sum(2, bits)
                 .context("failed to construct Prio3Aes128Sum VDAF")?;
             handle_upload_generic(http_client, vdaf_client, request, measurement.into()).await?;
         }
-        VdafObject::Prio3Aes128Histogram { ref buckets } => {
+        VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128Histogram {
+            ref buckets,
+        }) => {
             let vdaf_client = Prio3::new_aes128_histogram(2, buckets)
                 .context("failed to construct Prio3Aes128Histogram VDAF")?;
             handle_upload_generic(http_client, vdaf_client, request, measurement.into()).await?;
         }
+        _ => panic!("Unsupported VDAF: {:?}", vdaf_instance),
     }
     Ok(())
 }

--- a/interop_binaries/src/bin/janus_interop_collector.rs
+++ b/interop_binaries/src/bin/janus_interop_collector.rs
@@ -4,7 +4,7 @@ use clap::{Arg, Command};
 use interop_binaries::{
     install_tracing_subscriber,
     status::{COMPLETE, ERROR, IN_PROGRESS, SUCCESS},
-    HpkeConfigRegistry, VdafObject,
+    HpkeConfigRegistry, NumberAsString, VdafObject,
 };
 use janus_core::{
     hpke::{self, associated_data_for_aggregate_share, HpkeApplicationInfo, HpkePrivateKey, Label},
@@ -12,7 +12,7 @@ use janus_core::{
 };
 use janus_server::{
     message::{CollectReq, CollectResp},
-    task::DAP_AUTH_HEADER,
+    task::{VdafInstance, DAP_AUTH_HEADER},
 };
 use prio::{
     codec::{Decode, Encode},
@@ -80,6 +80,7 @@ struct CollectPollRequest {
 #[serde(untagged)]
 enum AggregationResult {
     Number(u64),
+    NumberAsString128(NumberAsString<u128>),
     NumberArray(Vec<u64>),
 }
 
@@ -283,8 +284,9 @@ async fn handle_collect_poll(
     )
     .context("could not decrypt aggregate share from the helper")?;
 
-    match task_state.vdaf {
-        VdafObject::Prio3Aes128Count {} => {
+    let vdaf_instance = task_state.vdaf.clone().into();
+    match vdaf_instance {
+        VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128Count {}) => {
             let leader_aggregate_share =
                 AggregateShare::<Field64>::try_from(leader_aggregate_share_bytes.as_ref())
                     .context("could not decode leader's aggregate share")?;
@@ -300,7 +302,7 @@ async fn handle_collect_poll(
                 .context("could not unshard aggregate result")?;
             Ok(Some(AggregationResult::Number(aggregate_result)))
         }
-        VdafObject::Prio3Aes128Sum { bits } => {
+        VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128Sum { bits }) => {
             let leader_aggregate_share =
                 AggregateShare::<Field128>::try_from(leader_aggregate_share_bytes.as_ref())
                     .context("could not decode leader's aggregate share")?;
@@ -314,13 +316,13 @@ async fn handle_collect_poll(
             let aggregate_result = vdaf
                 .unshard(&(), [leader_aggregate_share, helper_aggregate_share])
                 .context("could not unshard aggregate result")?;
-            Ok(Some(AggregationResult::Number(
-                aggregate_result
-                    .try_into()
-                    .context("aggregate result was too large to represent natively in JSON")?,
-            )))
+            Ok(Some(AggregationResult::NumberAsString128(NumberAsString(
+                aggregate_result,
+            ))))
         }
-        VdafObject::Prio3Aes128Histogram { ref buckets } => {
+        VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128Histogram {
+            ref buckets,
+        }) => {
             let leader_aggregate_share =
                 AggregateShare::<Field128>::try_from(leader_aggregate_share_bytes.as_ref())
                     .context("could not decode leader's aggregate share")?;
@@ -346,6 +348,7 @@ async fn handle_collect_poll(
                 .collect::<Result<Vec<_>, _>>()?;
             Ok(Some(AggregationResult::NumberArray(converted)))
         }
+        _ => panic!("Unsupported VDAF: {:?}", vdaf_instance),
     }
 }
 

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -65,7 +65,7 @@ impl From<VdafObject> for VdafInstance {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct AddTaskRequest {
+pub struct AggregatorAddTaskRequest {
     pub task_id: String, // in unpadded base64url
     pub leader: Url,
     pub helper: Url,
@@ -88,7 +88,7 @@ pub struct AddTaskResponse {
     pub error: Option<String>,
 }
 
-impl From<Task> for AddTaskRequest {
+impl From<Task> for AggregatorAddTaskRequest {
     fn from(task: Task) -> Self {
         Self {
             task_id: base64::encode_config(task.id.as_bytes(), URL_SAFE_NO_PAD),

--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -471,35 +471,38 @@ async fn e2e_prio3_sum() {
     let result = run(
         json!({"type": "Prio3Aes128Sum", "bits": 64}),
         &[
-            json!(0),
-            json!(10),
-            json!(9),
-            json!(21),
-            json!(8),
-            json!(12),
-            json!(14),
+            json!("0"),
+            json!("10"),
+            json!("9"),
+            json!("21"),
+            json!("8"),
+            json!("12"),
+            json!("14"),
         ],
         b"",
     )
     .await;
-    assert_eq!(result, json!(74));
+    assert_eq!(result, json!("74"));
 }
 
 #[tokio::test]
 async fn e2e_prio3_histogram() {
     let result = run(
-        json!({"type": "Prio3Aes128Histogram", "buckets": [0, 1, 10, 100, 1_000, 10_000, 100_000]}),
+        json!({
+            "type": "Prio3Aes128Histogram",
+            "buckets": ["0", "1", "10", "100", "1000", "10000", "100000"],
+        }),
         &[
-            json!(1),
-            json!(4),
-            json!(16),
-            json!(64),
-            json!(256),
-            json!(1024),
-            json!(4096),
-            json!(16384),
-            json!(65536),
-            json!(262144),
+            json!("1"),
+            json!("4"),
+            json!("16"),
+            json!("64"),
+            json!("256"),
+            json!("1024"),
+            json!("4096"),
+            json!("16384"),
+            json!("65536"),
+            json!("262144"),
         ],
         b"",
     )

--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -1,7 +1,7 @@
 use base64::URL_SAFE_NO_PAD;
 use futures::future::join_all;
 use interop_binaries::{
-    test_util::{await_http_server, generate_network_name, generate_unique_name},
+    test_util::{await_ready_ok, generate_network_name, generate_unique_name},
     testcontainer::{Aggregator, Client, Collector},
 };
 use janus_core::{
@@ -65,7 +65,7 @@ async fn run(
     join_all(
         [client_port, leader_port, helper_port, collector_port]
             .into_iter()
-            .map(await_http_server),
+            .map(await_ready_ok),
     )
     .await;
 

--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -101,10 +101,11 @@ async fn run(
         .json(&json!({
             "taskId": task_id_encoded,
             "aggregatorId": 0,
-            "hostnameAndPort": format!("{}:{}", local_leader_endpoint.host_str().unwrap(), local_leader_endpoint.port().unwrap()),
+            "hostname": local_leader_endpoint.host_str().unwrap(),
         }))
         .send()
-        .await.unwrap();
+        .await
+        .unwrap();
     assert_eq!(leader_endpoint_response.status(), StatusCode::OK);
     assert_eq!(
         leader_endpoint_response
@@ -142,10 +143,11 @@ async fn run(
         .json(&json!({
             "taskId": task_id_encoded,
             "aggregatorId": 1,
-            "hostnameAndPort": format!("{}:{}", local_helper_endpoint.host_str().unwrap(), local_helper_endpoint.port().unwrap()),
+            "hostname": local_helper_endpoint.host_str().unwrap(),
         }))
         .send()
-        .await.unwrap();
+        .await
+        .unwrap();
     assert_eq!(helper_endpoint_response.status(), StatusCode::OK);
     assert_eq!(
         helper_endpoint_response

--- a/monolithic_integration_test/src/janus.rs
+++ b/monolithic_integration_test/src/janus.rs
@@ -1,6 +1,8 @@
 //! Functionality for tests interacting with Janus (<https://github.com/divviup/janus>).
 
-use interop_binaries::{test_util::await_http_server, testcontainer::Aggregator, AddTaskRequest};
+use interop_binaries::{
+    test_util::await_http_server, testcontainer::Aggregator, AggregatorAddTaskRequest,
+};
 use janus_core::{
     test_util::kubernetes::{Cluster, PortForward},
     time::RealClock,
@@ -58,7 +60,7 @@ impl<'a> Janus<'a> {
         let http_client = reqwest::Client::default();
         let resp = http_client
             .post(Url::parse(&format!("http://localhost:{}/internal/test/add_task", port)).unwrap())
-            .json(&AddTaskRequest::from(task.clone()))
+            .json(&AggregatorAddTaskRequest::from(task.clone()))
             .send()
             .await
             .unwrap();


### PR DESCRIPTION
This implements the last few changes that will go in draft-dcook-ppm-dap-interop-test-design-01, which I plan to publish soon.

- Add `/internal/test/ready` endpoints, and use them in the end-to-end test when waiting for containers to start.
- Represent some 64-bit or 128-bit numbers for various VDAFs as JSON strings.
- `/internal/test/endpoint_for_task` is no longer provided a port, and the semantics have changed. (this unblocks #446)

I also renamed `AddTaskRequest` at the crate level, to help disambiguate from the one in the collector endpoint binary.