### PR TITLE
Plumb `Prio3Aes128CountVec` VDAF throughout Janus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2542,6 +2542,7 @@ dependencies = [
  "cmac",
  "ctr 0.9.1",
  "getrandom",
+ "rayon",
  "ring",
  "serde",
  "static_assertions",

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -46,7 +46,7 @@ integration_tests = { path = ".", features = ["daphne"] }
 itertools = "0.10"
 janus_client = { path = "../janus_client" }
 janus_server = { path = "../janus_server", features = ["test-util"] }
-prio = "0.8.2"
+prio = { version = "0.8.2", features = ["multithreaded"] }
 tempfile = "3"
 
 [build-dependencies]

--- a/interop_binaries/Cargo.toml
+++ b/interop_binaries/Cargo.toml
@@ -33,7 +33,7 @@ janus_client = { path = "../janus_client" }
 janus_core = { path = "../janus_core" }
 janus_server = { path = "../janus_server" }
 opentelemetry = { version = "0.17", features = ["metrics"] }
-prio = "0.8.2"
+prio = { version = "0.8.2", features = ["multithreaded"] }
 rand = "0.8"
 regex = { version = "1", optional = true }
 reqwest = { version = "0.11.4", default-features = false, features = ["rustls-tls"] }

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -85,6 +85,7 @@ where
 #[serde(tag = "type")]
 pub enum VdafObject {
     Prio3Aes128Count,
+    Prio3Aes128CountVec { length: usize },
     Prio3Aes128Sum { bits: u32 },
     Prio3Aes128Histogram { buckets: Vec<NumberAsString<u64>> },
 }
@@ -94,6 +95,9 @@ impl From<VdafInstance> for VdafObject {
         match vdaf {
             VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128Count) => {
                 VdafObject::Prio3Aes128Count
+            }
+            VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128CountVec { length }) => {
+                VdafObject::Prio3Aes128CountVec { length }
             }
             VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128Sum { bits }) => {
                 VdafObject::Prio3Aes128Sum { bits }
@@ -113,6 +117,9 @@ impl From<VdafObject> for VdafInstance {
         match vdaf {
             VdafObject::Prio3Aes128Count => {
                 VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128Count)
+            }
+            VdafObject::Prio3Aes128CountVec { length } => {
+                VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128CountVec { length })
             }
             VdafObject::Prio3Aes128Sum { bits } => {
                 VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128Sum { bits })

--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -445,29 +445,29 @@ async fn e2e_prio3_count() {
     let result = run(
         json!({"type": "Prio3Aes128Count"}),
         &[
-            json!(0),
-            json!(1),
-            json!(1),
-            json!(0),
-            json!(1),
-            json!(0),
-            json!(1),
-            json!(0),
-            json!(1),
-            json!(1),
-            json!(0),
-            json!(1),
-            json!(0),
-            json!(1),
-            json!(0),
-            json!(0),
-            json!(0),
-            json!(0),
+            json!("0"),
+            json!("1"),
+            json!("1"),
+            json!("0"),
+            json!("1"),
+            json!("0"),
+            json!("1"),
+            json!("0"),
+            json!("1"),
+            json!("1"),
+            json!("0"),
+            json!("1"),
+            json!("0"),
+            json!("1"),
+            json!("0"),
+            json!("0"),
+            json!("0"),
+            json!("0"),
         ],
         b"",
     )
     .await;
-    assert_eq!(result, json!(8));
+    assert_eq!(result, json!("8"));
 }
 
 #[tokio::test]
@@ -511,5 +511,21 @@ async fn e2e_prio3_histogram() {
         b"",
     )
     .await;
-    assert_eq!(result, json!([0, 1, 1, 2, 1, 2, 2, 1]));
+    assert_eq!(result, json!(["0", "1", "1", "2", "1", "2", "2", "1"]));
+}
+
+#[tokio::test]
+async fn e2e_prio3_count_vec() {
+    let result = run(
+        json!({"type": "Prio3Aes128CountVec", "length": 4}),
+        &[
+            json!(["0", "0", "0", "1"]),
+            json!(["0", "0", "1", "0"]),
+            json!(["0", "1", "0", "0"]),
+            json!(["1", "0", "0", "0"]),
+        ],
+        b"",
+    )
+    .await;
+    assert_eq!(result, json!(["1", "1", "1", "1"]));
 }

--- a/janus_client/Cargo.toml
+++ b/janus_client/Cargo.toml
@@ -14,7 +14,7 @@ backoff = { version = "0.4.0", features = ["tokio"] }
 derivative = "2.2.0"
 http = "0.2.8"
 janus_core = { version = "0.1", path = "../janus_core" }
-prio = "0.8.2"
+prio = { version = "0.8.2", features = ["multithreaded"] }
 reqwest = { version = "0.11.4", default-features = false, features = ["rustls-tls"] }
 thiserror = "1.0"
 tokio = { version = "^1.20", features = ["full"] }

--- a/janus_core/Cargo.toml
+++ b/janus_core/Cargo.toml
@@ -40,7 +40,7 @@ k8s-openapi = { version = "0.13.1", optional = true, features = ["v1_20"] }  # k
 num_enum = "0.5.6"
 postgres-protocol = { version = "0.6.4", optional = true }
 postgres-types = { version = "0.2.4", optional = true }
-prio = "0.8.2"
+prio = { version = "0.8.2", features = ["multithreaded"] }
 rand = "0.8"
 reqwest = { version = "0.11.4", default-features = false, features = ["rustls-tls"] }
 ring = "0.16.20"

--- a/janus_core/src/retries.rs
+++ b/janus_core/src/retries.rs
@@ -209,7 +209,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn http_retry_server_error_eventuall1y_succeeds() {
+    async fn http_retry_server_error_eventually_succeeds() {
         install_test_trace_subscriber();
 
         let mock_500 = mock("GET", "/")

--- a/janus_core/src/task.rs
+++ b/janus_core/src/task.rs
@@ -6,6 +6,8 @@
 pub enum VdafInstance {
     /// A `prio3` counter using the AES 128 pseudorandom generator.
     Prio3Aes128Count,
+    /// A vector of `prio3` counters using the AES 128 pseudorandom generator.
+    Prio3Aes128CountVec { length: usize },
     /// A `prio3` sum using the AES 128 pseudorandom generator.
     Prio3Aes128Sum { bits: u32 },
     /// A `prio3` histogram using the AES 128 pseudorandom generator.

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -44,7 +44,7 @@ opentelemetry-otlp = { version = "0.10.0", optional = true, features = ["metrics
 opentelemetry-prometheus = { version = "0.10.0", optional = true }
 opentelemetry-semantic-conventions = { version = "0.9.0", optional = true }
 postgres-types = { version = "0.2.4", features = ["derive", "array-impls"] }
-prio = "0.8.2"
+prio = { version = "0.8.2", features = ["multithreaded"] }
 prometheus = { version = "0.13.1", optional = true }
 rand = "0.8"
 reqwest = { version = "0.11.11", default-features = false, features = ["rustls-tls", "json"] }

--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -44,7 +44,10 @@ use prio::{
     codec::{Decode, Encode, ParameterizedDecode},
     vdaf::{
         self,
-        prio3::{Prio3, Prio3Aes128Count, Prio3Aes128Histogram, Prio3Aes128Sum},
+        prio3::{
+            Prio3, Prio3Aes128Count, Prio3Aes128CountVecMultithreaded, Prio3Aes128Histogram,
+            Prio3Aes128Sum,
+        },
         PrepareTransition,
     },
 };
@@ -550,6 +553,12 @@ impl TaskAggregator {
                 VdafOps::Prio3Aes128Count(Arc::new(vdaf), verify_key)
             }
 
+            VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128CountVec { length }) => {
+                let vdaf = Prio3::new_aes128_count_vec_multithreaded(2, *length)?;
+                let verify_key = task.primary_vdaf_verify_key()?;
+                VdafOps::Prio3Aes128CountVec(Arc::new(vdaf), verify_key)
+            }
+
             VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128Sum { bits }) => {
                 let vdaf = Prio3::new_aes128_sum(2, *bits)?;
                 let verify_key = task.primary_vdaf_verify_key()?;
@@ -702,6 +711,10 @@ enum VdafOps {
         Arc<Prio3Aes128Count>,
         VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH>,
     ),
+    Prio3Aes128CountVec(
+        Arc<Prio3Aes128CountVecMultithreaded>,
+        VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH>,
+    ),
     Prio3Aes128Sum(
         Arc<Prio3Aes128Sum>,
         VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH>,
@@ -727,6 +740,20 @@ impl VdafOps {
         match self {
             VdafOps::Prio3Aes128Count(_, _) => {
                 Self::handle_upload_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count, _>(
+                    datastore,
+                    clock,
+                    upload_decrypt_failure_counter,
+                    task,
+                    report,
+                )
+                .await
+            }
+            VdafOps::Prio3Aes128CountVec(_, _) => {
+                Self::handle_upload_generic::<
+                    PRIO3_AES128_VERIFY_KEY_LENGTH,
+                    Prio3Aes128CountVecMultithreaded,
+                    _,
+                >(
                     datastore,
                     clock,
                     upload_decrypt_failure_counter,
@@ -798,6 +825,21 @@ impl VdafOps {
                 )
                 .await
             }
+            VdafOps::Prio3Aes128CountVec(vdaf, verify_key) => {
+                Self::handle_aggregate_init_generic::<
+                    PRIO3_AES128_VERIFY_KEY_LENGTH,
+                    Prio3Aes128CountVecMultithreaded,
+                    _,
+                >(
+                    datastore,
+                    vdaf,
+                    aggregate_step_failure_counters,
+                    task,
+                    verify_key,
+                    req,
+                )
+                .await
+            }
             VdafOps::Prio3Aes128Sum(vdaf, verify_key) => {
                 Self::handle_aggregate_init_generic::<
                     PRIO3_AES128_VERIFY_KEY_LENGTH,
@@ -857,6 +899,20 @@ impl VdafOps {
                 Self::handle_aggregate_continue_generic::<
                     PRIO3_AES128_VERIFY_KEY_LENGTH,
                     Prio3Aes128Count,
+                    _,
+                >(
+                    datastore,
+                    Arc::clone(vdaf),
+                    aggregate_step_failure_counters.prepare_step_failure.clone(),
+                    task,
+                    req,
+                )
+                .await
+            }
+            VdafOps::Prio3Aes128CountVec(vdaf, _) => {
+                Self::handle_aggregate_continue_generic::<
+                    PRIO3_AES128_VERIFY_KEY_LENGTH,
+                    Prio3Aes128CountVecMultithreaded,
                     _,
                 >(
                     datastore,
@@ -1429,6 +1485,14 @@ impl VdafOps {
                 )
                 .await
             }
+            VdafOps::Prio3Aes128CountVec(_, _) => {
+                Self::handle_collect_generic::<
+                    PRIO3_AES128_VERIFY_KEY_LENGTH,
+                    Prio3Aes128CountVecMultithreaded,
+                    _,
+                >(datastore, task, collect_req)
+                .await
+            }
             VdafOps::Prio3Aes128Sum(_, _) => {
                 Self::handle_collect_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Sum, _>(
                     datastore,
@@ -1511,6 +1575,14 @@ impl VdafOps {
                 Self::handle_collect_job_generic::<
                     PRIO3_AES128_VERIFY_KEY_LENGTH,
                     Prio3Aes128Count,
+                    _,
+                >(datastore, task, collect_job_id)
+                .await
+            }
+            VdafOps::Prio3Aes128CountVec(_, _) => {
+                Self::handle_collect_job_generic::<
+                    PRIO3_AES128_VERIFY_KEY_LENGTH,
+                    Prio3Aes128CountVecMultithreaded,
                     _,
                 >(datastore, task, collect_job_id)
                 .await
@@ -1637,6 +1709,14 @@ impl VdafOps {
                 Self::handle_aggregate_share_generic::<
                     PRIO3_AES128_VERIFY_KEY_LENGTH,
                     Prio3Aes128Count,
+                    _,
+                >(datastore, task, aggregate_share_req)
+                .await
+            }
+            VdafOps::Prio3Aes128CountVec(_, _) => {
+                Self::handle_aggregate_share_generic::<
+                    PRIO3_AES128_VERIFY_KEY_LENGTH,
+                    Prio3Aes128CountVecMultithreaded,
                     _,
                 >(datastore, task, aggregate_share_req)
                 .await

--- a/janus_server/src/aggregator/aggregate_share.rs
+++ b/janus_server/src/aggregator/aggregate_share.rs
@@ -26,7 +26,10 @@ use prio::{
     codec::{Decode, Encode},
     vdaf::{
         self,
-        prio3::{Prio3Aes128Count, Prio3Aes128Histogram, Prio3Aes128Sum},
+        prio3::{
+            Prio3Aes128Count, Prio3Aes128CountVecMultithreaded, Prio3Aes128Histogram,
+            Prio3Aes128Sum,
+        },
         Aggregatable,
     },
 };
@@ -78,6 +81,14 @@ impl CollectJobDriver {
         match lease.leased().vdaf {
             VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128Count) => {
                 self.step_collect_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, Prio3Aes128Count>(
+                    datastore,
+                    lease
+                )
+                .await
+            }
+
+            VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128CountVec { .. }) => {
+                self.step_collect_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, Prio3Aes128CountVecMultithreaded>(
                     datastore,
                     lease
                 )

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -3338,6 +3338,16 @@ mod tests {
             ),
             (
                 TaskId::random(),
+                janus_core::task::VdafInstance::Prio3Aes128CountVec { length: 8 },
+                Role::Leader,
+            ),
+            (
+                TaskId::random(),
+                janus_core::task::VdafInstance::Prio3Aes128CountVec { length: 64 },
+                Role::Helper,
+            ),
+            (
+                TaskId::random(),
                 janus_core::task::VdafInstance::Prio3Aes128Sum { bits: 64 },
                 Role::Helper,
             ),

--- a/janus_server/src/task.rs
+++ b/janus_server/src/task.rs
@@ -68,6 +68,9 @@ impl Serialize for VdafInstance {
             VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128Count) => {
                 VdafSerialization::Prio3Aes128Count
             }
+            VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128CountVec { length }) => {
+                VdafSerialization::Prio3Aes128CountVec { length: *length }
+            }
             VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128Sum { bits }) => {
                 VdafSerialization::Prio3Aes128Sum { bits: *bits }
             }
@@ -100,6 +103,9 @@ impl<'de> Deserialize<'de> for VdafInstance {
             VdafSerialization::Prio3Aes128Count => Ok(VdafInstance::Real(
                 janus_core::task::VdafInstance::Prio3Aes128Count,
             )),
+            VdafSerialization::Prio3Aes128CountVec { length } => Ok(VdafInstance::Real(
+                janus_core::task::VdafInstance::Prio3Aes128CountVec { length },
+            )),
             VdafSerialization::Prio3Aes128Sum { bits } => Ok(VdafInstance::Real(
                 janus_core::task::VdafInstance::Prio3Aes128Sum { bits },
             )),
@@ -127,6 +133,8 @@ impl<'de> Deserialize<'de> for VdafInstance {
 enum VdafSerialization {
     /// A `prio3` counter using the AES 128 pseudorandom generator.
     Prio3Aes128Count,
+    /// A vector of `prio3` counters using the AES 128 pseudorandom generator.
+    Prio3Aes128CountVec { length: usize },
     /// A `prio3` sum using the AES 128 pseudorandom generator.
     Prio3Aes128Sum { bits: u32 },
     /// A `prio3` histogram using the AES 128 pseudorandom generator.
@@ -769,6 +777,19 @@ mod tests {
                 name: "Vdaf",
                 variant: "Prio3Aes128Count",
             }],
+        );
+        assert_tokens(
+            &VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128CountVec { length: 8 }),
+            &[
+                Token::StructVariant {
+                    name: "Vdaf",
+                    variant: "Prio3Aes128CountVec",
+                    len: 1,
+                },
+                Token::Str("length"),
+                Token::U64(8),
+                Token::StructVariantEnd,
+            ],
         );
         assert_tokens(
             &VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128Sum { bits: 64 }),


### PR DESCRIPTION
Adds support to Janus for an extra VDAF. Also plumbs it into the interop
test API, which required allowing the representation of vectors of
numbers to a `Measurement`, and unconditionally representing numbers as
strings to avoid JSON number precision problems. A change to
draft-dcook-ppm-dap-interop-test-design will follow to update the
language describing how to encode measurements and aggregate results.

Resolves #478