### PR TITLE
Update tokio requirement to 1.21

### DIFF
--- a/interop_binaries/Cargo.toml
+++ b/interop_binaries/Cargo.toml
@@ -41,7 +41,7 @@ ring = "0.16.20"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.85"
 testcontainers = { version = "0.14", optional = true }
-tokio = { version = "^1.20", features = ["full", "tracing"] }
+tokio = { version = "^1.21", features = ["full", "tracing"] }
 tracing = "0.1.36"
 tracing-log = "0.1.3"
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt"] }

--- a/interop_binaries/Cargo.toml
+++ b/interop_binaries/Cargo.toml
@@ -41,12 +41,12 @@ ring = "0.16.20"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.85"
 testcontainers = { version = "0.14", optional = true }
-tokio = { version = "^1.21", features = ["full", "tracing"] }
+tokio = { version = "1.21", features = ["full", "tracing"] }
 tracing = "0.1.36"
 tracing-log = "0.1.3"
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt"] }
 url = { version = "2.2.2", features = ["serde"] }
-warp = "^0.3"
+warp = "0.3"
 zstd = { version = "0.11", optional = true }
 
 [dev-dependencies]

--- a/janus_client/Cargo.toml
+++ b/janus_client/Cargo.toml
@@ -17,7 +17,7 @@ janus_core = { version = "0.1", path = "../janus_core" }
 prio = "0.8.2"
 reqwest = { version = "0.11.4", default-features = false, features = ["rustls-tls"] }
 thiserror = "1.0"
-tokio = { version = "^1.20", features = ["full"] }
+tokio = { version = "^1.21", features = ["full"] }
 tracing = "0.1.36"
 url = "2.2.2"
 

--- a/janus_client/Cargo.toml
+++ b/janus_client/Cargo.toml
@@ -17,7 +17,7 @@ janus_core = { version = "0.1", path = "../janus_core" }
 prio = "0.8.2"
 reqwest = { version = "0.11.4", default-features = false, features = ["rustls-tls"] }
 thiserror = "1.0"
-tokio = { version = "^1.21", features = ["full"] }
+tokio = { version = "1.21", features = ["full"] }
 tracing = "0.1.36"
 url = "2.2.2"
 

--- a/janus_core/Cargo.toml
+++ b/janus_core/Cargo.toml
@@ -46,7 +46,7 @@ reqwest = { version = "0.11.4", default-features = false, features = ["rustls-tl
 ring = "0.16.20"
 serde = { version = "1.0.144", features = ["derive"] }
 thiserror = "1.0"
-tokio = { version = "^1.21", features = ["macros", "net", "rt"] }
+tokio = { version = "1.21", features = ["macros", "net", "rt"] }
 tracing = "0.1.36"
 
 # Dependencies required only if feature "test-util" is enabled

--- a/janus_core/Cargo.toml
+++ b/janus_core/Cargo.toml
@@ -46,7 +46,7 @@ reqwest = { version = "0.11.4", default-features = false, features = ["rustls-tl
 ring = "0.16.20"
 serde = { version = "1.0.144", features = ["derive"] }
 thiserror = "1.0"
-tokio = { version = "^1.20", features = ["macros", "net", "rt"] }
+tokio = { version = "^1.21", features = ["macros", "net", "rt"] }
 tracing = "0.1.36"
 
 # Dependencies required only if feature "test-util" is enabled

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -57,7 +57,7 @@ signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
 structopt = "0.3.26"
 testcontainers = { version = "0.14.0", optional = true }
 thiserror = "1.0"
-tokio = { version = "^1.21", features = ["full", "tracing"] }
+tokio = { version = "1.21", features = ["full", "tracing"] }
 tokio-postgres = { version = "0.7.7", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1", "array-impls"] }
 tonic = { version = "0.6.2", optional = true, features = ["tls", "tls-webpki-roots"] }  # keep this version in sync with what opentelemetry-otlp uses
 tracing = "0.1.36"
@@ -66,7 +66,7 @@ tracing-opentelemetry = { version = "0.17.4", optional = true }
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt", "json"] }
 url = { version = "2.2.2", features = ["serde"] }
 uuid = { version = "1.1.2", features = ["v4"] }
-warp = { version = "^0.3", features = ["tls"] }
+warp = { version = "0.3", features = ["tls"] }
 
 [dev-dependencies]
 assert_matches = "1"

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -57,7 +57,7 @@ signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
 structopt = "0.3.26"
 testcontainers = { version = "0.14.0", optional = true }
 thiserror = "1.0"
-tokio = { version = "^1.20", features = ["full", "tracing"] }
+tokio = { version = "^1.21", features = ["full", "tracing"] }
 tokio-postgres = { version = "0.7.7", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1", "array-impls"] }
 tonic = { version = "0.6.2", optional = true, features = ["tls", "tls-webpki-roots"] }  # keep this version in sync with what opentelemetry-otlp uses
 tracing = "0.1.36"


### PR DESCRIPTION
This updates our version requirement on Tokio to 1.21. Note that there is no change to Cargo.lock; our lock file's version of Tokio is already at 1.21.0 due to some other recent upgrades. Since we upgraded `console-subscriber`, this is the only possible version we can select now (as it requires `tokio = ^1.21`), and later changes that regenerated the lockfile with Cargo reified this.