### PR TITLE
Don't fail copy logs step if no logs are found

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -66,7 +66,8 @@ jobs:
       with:
         name: container-logs
         path: ${{ github.workspace }}/test-logs/
-        if-no-files-found: error
+        # Not all test failures yield log files
+        if-no-files-found: ignore
     # Force overall job to fail if tests fail
     - name: test status
       if: steps.test.outcome == 'failure'


### PR DESCRIPTION
As of recently, we scrape logs out of running Janus or Daphne containers on unit test failures. However, if the test that fails isn't one that spawns a container, then the "Upload container logs" step fails because there are no log files to copy out. This isn't critical, because the action was going to fail no matter what due to the test failure, but it does cause the failure to be attribute to the wrong thing.

Example failing test run:
https://github.com/divviup/janus/runs/8277844344?check_suite_focus=true