### PR TITLE
Migrate from `structopt` to `clap::Parser`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,21 +380,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim 0.8.0",
- "textwrap 0.11.0",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
 version = "3.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
@@ -405,9 +390,9 @@ dependencies = [
  "clap_lex",
  "indexmap",
  "once_cell",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
- "textwrap 0.15.0",
+ "textwrap",
 ]
 
 [[package]]
@@ -695,7 +680,7 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "base64",
- "clap 3.2.20",
+ "clap",
  "getrandom",
  "hex",
  "hpke 0.8.0",
@@ -730,7 +715,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn",
 ]
 
@@ -1596,7 +1581,7 @@ dependencies = [
  "backoff",
  "base64",
  "build_script_utils",
- "clap 3.2.20",
+ "clap",
  "futures",
  "hex",
  "interop_binaries",
@@ -1712,6 +1697,7 @@ dependencies = [
  "base64",
  "bytes",
  "chrono",
+ "clap",
  "console-subscriber",
  "deadpool",
  "deadpool-postgres",
@@ -1746,7 +1732,6 @@ dependencies = [
  "serde_yaml 0.9.11",
  "signal-hook",
  "signal-hook-tokio",
- "structopt",
  "tempfile",
  "testcontainers",
  "thiserror",
@@ -3337,39 +3322,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "subtle"
@@ -3444,15 +3399,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.5",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -4063,12 +4009,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4135,12 +4075,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -23,6 +23,7 @@ backoff = { version = "0.4.0", features = ["tokio"] }
 base64 = "0.13.0"
 bytes = "1.2.1"
 chrono = "0.4"
+clap = { version = "3.2.20", features = ["derive", "env"] }
 console-subscriber = { version = "0.1.8", optional = true }
 deadpool = { version = "0.9.5", features = ["rt_tokio_1"] }
 deadpool-postgres = "0.10.1"
@@ -54,7 +55,6 @@ serde_json = "1.0.85"
 serde_yaml = "0.9.11"
 signal-hook = "0.3.14"
 signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
-structopt = "0.3.26"
 testcontainers = { version = "0.14.0", optional = true }
 thiserror = "1.0"
 tokio = { version = "1.21", features = ["full", "tracing"] }

--- a/janus_server/src/bin/aggregation_job_creator.rs
+++ b/janus_server/src/bin/aggregation_job_creator.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use clap::Parser;
 use janus_core::time::RealClock;
 use janus_server::aggregator::aggregation_job_creator::AggregationJobCreator;
 use janus_server::binary_utils::{
@@ -8,7 +9,6 @@ use janus_server::config::{BinaryConfig, CommonConfig};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::Duration;
-use structopt::StructOpt;
 use tokio::select;
 
 #[tokio::main]
@@ -36,15 +36,15 @@ async fn main() -> anyhow::Result<()> {
     .await
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(
+#[derive(Debug, Parser)]
+#[clap(
     name = "janus-aggregation-job-creator",
     about = "Janus aggregation job creator",
     rename_all = "kebab-case",
     version = env!("CARGO_PKG_VERSION"),
 )]
 struct Options {
-    #[structopt(flatten)]
+    #[clap(flatten)]
     common: CommonBinaryOptions,
 }
 
@@ -102,7 +102,8 @@ impl BinaryConfig for Config {
 
 #[cfg(test)]
 mod tests {
-    use super::Config;
+    use super::{Config, Options};
+    use clap::IntoApp;
     use janus_server::config::{
         test_util::{
             generate_db_config, generate_metrics_config, generate_trace_config, roundtrip_encoding,
@@ -110,6 +111,11 @@ mod tests {
         CommonConfig,
     };
     use std::net::{Ipv4Addr, SocketAddr};
+
+    #[test]
+    fn verify_app() {
+        Options::into_app().debug_assert()
+    }
 
     #[test]
     fn roundtrip_config() {

--- a/janus_server/src/bin/aggregation_job_driver.rs
+++ b/janus_server/src/bin/aggregation_job_driver.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use clap::Parser;
 use janus_core::{message::Duration, time::RealClock, TokioRuntime};
 use janus_server::{
     aggregator::aggregation_job_driver::AggregationJobDriver,
@@ -9,7 +10,6 @@ use janus_server::{
 };
 use serde::{Deserialize, Serialize};
 use std::{fmt::Debug, sync::Arc};
-use structopt::StructOpt;
 use tokio::select;
 
 #[tokio::main]
@@ -66,15 +66,15 @@ async fn main() -> anyhow::Result<()> {
     .await
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(
+#[derive(Debug, Parser)]
+#[clap(
     name = "janus-aggregation-job-driver",
     about = "Janus aggregation job driver",
     rename_all = "kebab-case",
     version = env!("CARGO_PKG_VERSION"),
 )]
 struct Options {
-    #[structopt(flatten)]
+    #[clap(flatten)]
     common: CommonBinaryOptions,
 }
 
@@ -125,7 +125,8 @@ impl BinaryConfig for Config {
 
 #[cfg(test)]
 mod tests {
-    use super::Config;
+    use super::{Config, Options};
+    use clap::IntoApp;
     use janus_server::config::{
         test_util::{
             generate_db_config, generate_metrics_config, generate_trace_config, roundtrip_encoding,
@@ -133,6 +134,11 @@ mod tests {
         CommonConfig, JobDriverConfig,
     };
     use std::net::{Ipv4Addr, SocketAddr};
+
+    #[test]
+    fn verify_app() {
+        Options::into_app().debug_assert()
+    }
 
     #[test]
     fn roundtrip_config() {

--- a/janus_server/src/bin/aggregator.rs
+++ b/janus_server/src/bin/aggregator.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use clap::Parser;
 use http::HeaderMap;
 use janus_core::time::RealClock;
 use janus_server::{
@@ -8,7 +9,6 @@ use janus_server::{
 };
 use serde::{Deserialize, Serialize};
 use std::{iter::Iterator, net::SocketAddr, sync::Arc};
-use structopt::StructOpt;
 use tracing::info;
 
 #[tokio::main]
@@ -35,15 +35,15 @@ async fn main() -> Result<()> {
     .await
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(
+#[derive(Debug, Parser)]
+#[clap(
     name = "janus-aggregator",
     about = "PPM aggregator server",
     rename_all = "kebab-case",
     version = env!("CARGO_PKG_VERSION"),
 )]
 struct Options {
-    #[structopt(flatten)]
+    #[clap(flatten)]
     common: CommonBinaryOptions,
 }
 
@@ -120,7 +120,8 @@ impl BinaryConfig for Config {
 
 #[cfg(test)]
 mod tests {
-    use super::{Config, HeaderEntry};
+    use super::{Config, HeaderEntry, Options};
+    use clap::IntoApp;
     use janus_server::{
         config::{
             test_util::{
@@ -138,6 +139,11 @@ mod tests {
         collections::HashMap,
         net::{IpAddr, Ipv4Addr, SocketAddr},
     };
+
+    #[test]
+    fn verify_app() {
+        Options::into_app().debug_assert()
+    }
 
     #[test]
     fn roundtrip_config() {

--- a/janus_server/src/bin/collect_job_driver.rs
+++ b/janus_server/src/bin/collect_job_driver.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use clap::Parser;
 use janus_core::{message::Duration, time::RealClock, TokioRuntime};
 use janus_server::{
     aggregator::aggregate_share::CollectJobDriver,
@@ -9,7 +10,6 @@ use janus_server::{
 };
 use serde::{Deserialize, Serialize};
 use std::{fmt::Debug, sync::Arc};
-use structopt::StructOpt;
 use tokio::select;
 
 #[tokio::main]
@@ -66,15 +66,15 @@ async fn main() -> anyhow::Result<()> {
     .await
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(
+#[derive(Debug, Parser)]
+#[clap(
     name = "janus-collect-job-driver",
     about = "Janus collect job driver",
     rename_all = "kebab-case",
     version = env!("CARGO_PKG_VERSION"),
 )]
 struct Options {
-    #[structopt(flatten)]
+    #[clap(flatten)]
     common: CommonBinaryOptions,
 }
 
@@ -125,7 +125,8 @@ impl BinaryConfig for Config {
 
 #[cfg(test)]
 mod tests {
-    use super::Config;
+    use super::{Config, Options};
+    use clap::IntoApp;
     use janus_server::config::{
         test_util::{
             generate_db_config, generate_metrics_config, generate_trace_config, roundtrip_encoding,
@@ -133,6 +134,11 @@ mod tests {
         CommonConfig, JobDriverConfig,
     };
     use std::net::{Ipv4Addr, SocketAddr};
+
+    #[test]
+    fn verify_app() {
+        Options::into_app().debug_assert()
+    }
 
     #[test]
     fn roundtrip_config() {

--- a/janus_server/src/bin/janus_cli.rs
+++ b/janus_server/src/bin/janus_cli.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Context, Result};
 use base64::STANDARD_NO_PAD;
+use clap::Parser;
 use deadpool_postgres::Pool;
 use janus_core::{
     message::{HpkeConfig, Report},
@@ -31,7 +32,6 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
-use structopt::StructOpt;
 use tokio::fs;
 use tracing::{debug, info};
 
@@ -47,20 +47,20 @@ async fn main() -> Result<()> {
     options.cmd.execute().await
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 enum Command {
     /// Write the Janus database schema to the database.
     WriteSchema {
-        #[structopt(flatten)]
+        #[clap(flatten)]
         common_options: CommonBinaryOptions,
     },
 
     /// Write a set of tasks identified in a file to the datastore.
     ProvisionTasks {
-        #[structopt(flatten)]
+        #[clap(flatten)]
         common_options: CommonBinaryOptions,
 
-        #[structopt(flatten)]
+        #[clap(flatten)]
         kubernetes_secret_options: KubernetesSecretOptions,
 
         /// A YAML file containing a list of tasks to be written. Existing tasks (matching by task
@@ -70,10 +70,10 @@ enum Command {
 
     /// Create a datastore key and write it to a Kubernetes secret.
     CreateDatastoreKey {
-        #[structopt(flatten)]
+        #[clap(flatten)]
         common_options: CommonBinaryOptions,
 
-        #[structopt(flatten)]
+        #[clap(flatten)]
         kubernetes_secret_options: KubernetesSecretOptions,
     },
 
@@ -83,7 +83,7 @@ enum Command {
         message_file: String,
 
         /// Media type of the message to decode.
-        #[structopt(long, short = "t", required = true, possible_values(&[
+        #[clap(long, short = 't', required = true, possible_values(&[
             "hpke-config",
             "report",
             "aggregate-initialize-req",
@@ -338,10 +338,10 @@ fn decode_dap_message(message_file: &str, media_type: &str) -> Result<Box<dyn De
     Ok(decoded)
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct KubernetesSecretOptions {
     /// The Kubernetes namespace where secrets are stored.
-    #[structopt(
+    #[clap(
         long,
         env = "SECRETS_K8S_NAMESPACE",
         takes_value = true,
@@ -351,7 +351,7 @@ struct KubernetesSecretOptions {
     secrets_k8s_namespace: Option<String>,
 
     /// Kubernetes secret containing the datastore key(s).
-    #[structopt(
+    #[clap(
         long,
         env = "DATASTORE_KEYS_SECRET_NAME",
         takes_value = true,
@@ -360,7 +360,7 @@ struct KubernetesSecretOptions {
     datastore_keys_secret_name: String,
 
     /// Key into data of datastore key Kubernetes secret
-    #[structopt(
+    #[clap(
         long,
         env = "DATASTORE_KEYS_SECRET_KEY",
         takes_value = true,
@@ -398,15 +398,15 @@ impl KubernetesSecretOptions {
     }
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(
+#[derive(Debug, Parser)]
+#[clap(
     name = "janus_cli",
     about = "Janus CLI tool",
     rename_all = "kebab-case",
     version = env!("CARGO_PKG_VERSION"),
 )]
 struct Options {
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     cmd: Command,
 }
 
@@ -428,8 +428,9 @@ impl BinaryConfig for Config {
 
 #[cfg(test)]
 mod tests {
-    use super::{fetch_datastore_keys, Config, KubernetesSecretOptions};
+    use super::{fetch_datastore_keys, Config, KubernetesSecretOptions, Options};
     use base64::STANDARD_NO_PAD;
+    use clap::IntoApp;
     use janus_core::{
         message::{Role, TaskId},
         task::VdafInstance,
@@ -452,6 +453,11 @@ mod tests {
         net::{Ipv4Addr, SocketAddr},
     };
     use tempfile::NamedTempFile;
+
+    #[test]
+    fn verify_app() {
+        Options::into_app().debug_assert()
+    }
 
     #[tokio::test]
     async fn options_datastore_keys() {

--- a/janus_server/tests/cmd/aggregation_job_creator.trycmd
+++ b/janus_server/tests/cmd/aggregation_job_creator.trycmd
@@ -4,23 +4,30 @@ janus-aggregation-job-creator [..]
 Janus aggregation job creator
 
 USAGE:
-    aggregation_job_creator [OPTIONS] --config-file <config-file>
-
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    aggregation_job_creator [OPTIONS] --config-file <CONFIG_FILE>
 
 OPTIONS:
-        --config-file <config-file>                path to configuration file [env: CONFIG_FILE=]
-        --database-password <database-password>    PostgreSQL password [env: PGPASSWORD=]
-        --datastore-keys <datastore-keys>...
-            datastore encryption keys, encoded in base64 then comma-separated [env: DATASTORE_KEYS=]
+        --config-file <CONFIG_FILE>
+            path to configuration file [env: CONFIG_FILE=]
 
-        --otlp-metrics-metadata <KEY=value>...
-            additional OTLP/gRPC metadata key/value pairs for the metrics exporter [env: OTLP_METRICS_METADATA=]
+        --database-password <DATABASE_PASSWORD>
+            PostgreSQL password [env: PGPASSWORD]
 
-        --otlp-tracing-metadata <KEY=value>...
-            additional OTLP/gRPC metadata key/value pairs for the tracing exporter [env: OTLP_TRACING_METADATA=]
+        --datastore-keys <DATASTORE_KEYS>
+            datastore encryption keys, encoded in base64 then comma-separated [env: DATASTORE_KEYS]
 
+    -h, --help
+            Print help information
+
+        --otlp-metrics-metadata <KEY=value>
+            additional OTLP/gRPC metadata key/value pairs for the metrics exporter [env:
+            OTLP_METRICS_METADATA=]
+
+        --otlp-tracing-metadata <KEY=value>
+            additional OTLP/gRPC metadata key/value pairs for the tracing exporter [env:
+            OTLP_TRACING_METADATA=]
+
+    -V, --version
+            Print version information
 
 ```

--- a/janus_server/tests/cmd/aggregation_job_driver.trycmd
+++ b/janus_server/tests/cmd/aggregation_job_driver.trycmd
@@ -4,23 +4,30 @@ janus-aggregation-job-driver [..]
 Janus aggregation job driver
 
 USAGE:
-    aggregation_job_driver [OPTIONS] --config-file <config-file>
-
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    aggregation_job_driver [OPTIONS] --config-file <CONFIG_FILE>
 
 OPTIONS:
-        --config-file <config-file>                path to configuration file [env: CONFIG_FILE=]
-        --database-password <database-password>    PostgreSQL password [env: PGPASSWORD=]
-        --datastore-keys <datastore-keys>...
-            datastore encryption keys, encoded in base64 then comma-separated [env: DATASTORE_KEYS=]
+        --config-file <CONFIG_FILE>
+            path to configuration file [env: CONFIG_FILE=]
 
-        --otlp-metrics-metadata <KEY=value>...
-            additional OTLP/gRPC metadata key/value pairs for the metrics exporter [env: OTLP_METRICS_METADATA=]
+        --database-password <DATABASE_PASSWORD>
+            PostgreSQL password [env: PGPASSWORD]
 
-        --otlp-tracing-metadata <KEY=value>...
-            additional OTLP/gRPC metadata key/value pairs for the tracing exporter [env: OTLP_TRACING_METADATA=]
+        --datastore-keys <DATASTORE_KEYS>
+            datastore encryption keys, encoded in base64 then comma-separated [env: DATASTORE_KEYS]
 
+    -h, --help
+            Print help information
+
+        --otlp-metrics-metadata <KEY=value>
+            additional OTLP/gRPC metadata key/value pairs for the metrics exporter [env:
+            OTLP_METRICS_METADATA=]
+
+        --otlp-tracing-metadata <KEY=value>
+            additional OTLP/gRPC metadata key/value pairs for the tracing exporter [env:
+            OTLP_TRACING_METADATA=]
+
+    -V, --version
+            Print version information
 
 ```

--- a/janus_server/tests/cmd/aggregator.trycmd
+++ b/janus_server/tests/cmd/aggregator.trycmd
@@ -4,23 +4,30 @@ janus-aggregator [..]
 PPM aggregator server
 
 USAGE:
-    aggregator [OPTIONS] --config-file <config-file>
-
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    aggregator [OPTIONS] --config-file <CONFIG_FILE>
 
 OPTIONS:
-        --config-file <config-file>                path to configuration file [env: CONFIG_FILE=]
-        --database-password <database-password>    PostgreSQL password [env: PGPASSWORD=]
-        --datastore-keys <datastore-keys>...
-            datastore encryption keys, encoded in base64 then comma-separated [env: DATASTORE_KEYS=]
+        --config-file <CONFIG_FILE>
+            path to configuration file [env: CONFIG_FILE=]
 
-        --otlp-metrics-metadata <KEY=value>...
-            additional OTLP/gRPC metadata key/value pairs for the metrics exporter [env: OTLP_METRICS_METADATA=]
+        --database-password <DATABASE_PASSWORD>
+            PostgreSQL password [env: PGPASSWORD]
 
-        --otlp-tracing-metadata <KEY=value>...
-            additional OTLP/gRPC metadata key/value pairs for the tracing exporter [env: OTLP_TRACING_METADATA=]
+        --datastore-keys <DATASTORE_KEYS>
+            datastore encryption keys, encoded in base64 then comma-separated [env: DATASTORE_KEYS]
 
+    -h, --help
+            Print help information
+
+        --otlp-metrics-metadata <KEY=value>
+            additional OTLP/gRPC metadata key/value pairs for the metrics exporter [env:
+            OTLP_METRICS_METADATA=]
+
+        --otlp-tracing-metadata <KEY=value>
+            additional OTLP/gRPC metadata key/value pairs for the tracing exporter [env:
+            OTLP_TRACING_METADATA=]
+
+    -V, --version
+            Print version information
 
 ```


### PR DESCRIPTION
`structopt` has been migrated into `clap`, so we now use `clap::Parser`, which is virtually a drop-in replacement for `structopt::Structopt`, using the instructions in `clap`'s handy migration guide[1]. The name `Structopt` is still exported from `clap`, but it's easy enough to adopt `clap::Parser` instead. There's no changes except some minor diff in the help output of binaries. We also add simple tests based on `clap::App::debug_assert` as suggested in the migration guide.

[1]: https://github.com/clap-rs/clap/blob/v3-master/CHANGELOG.md?plain=1#L584

Resolves #177