### PR TITLE
Disable Daphne integration tests.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1567,7 +1567,6 @@ dependencies = [
  "futures",
  "hex",
  "http",
- "integration_tests",
  "interop_binaries",
  "itertools",
  "janus_client",

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -10,11 +10,9 @@ publish = false
 daphne = [
     "dep:build_script_utils",
     "dep:daphne",
-    "dep:hex",
-    "dep:rand",
     "dep:serde",
     "dep:serde_json",
-    "dep:tokio",
+    "dep:tempfile",
     "interop_binaries/test-util",
 ]
 kube-openssl = ["kube/openssl-tls"]
@@ -24,32 +22,30 @@ anyhow = "1"
 backoff = { version = "0.4", features = ["tokio"] }
 daphne = { git = "https://github.com/cloudflare/daphne", rev = "80b53c4b0f2c93d5f9df66dfce237b20756c9147", optional = true }  # Match this to the version referenced in README.md.
 futures = "0.3.24"
-hex = { version = "0.4", optional = true }
+hex = "0.4"
 interop_binaries = { path = "../interop_binaries", features = ["testcontainer"] }
 janus_core = { path = "../janus_core", features = ["test-util"] }
 janus_server = { path = "../janus_server", features = ["test-util"] }
 k8s-openapi = { version = "0.13.1", features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
 kube = { version = "0.65.0", default-features = false, features = ["client"] }
 portpicker = "0.1"
-rand = { version = "0.8", optional = true }
+rand = "0.8"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 testcontainers = "0.14.0"
-tokio = { version = "1", features = ["full", "tracing"], optional = true }
+tokio = { version = "1", features = ["full", "tracing"] }
 tracing = "0.1.36"
 url = { version = "2.2.2", features = ["serde"] }
 
 [dev-dependencies]
 http = "0.2"
-integration_tests = { path = ".", features = ["daphne"] }
 itertools = "0.10"
 janus_client = { path = "../janus_client" }
-janus_server = { path = "../janus_server", features = ["test-util"] }
 prio = { version = "0.8.2", features = ["multithreaded"] }
 tempfile = "3"
 
 [build-dependencies]
 build_script_utils = { path = "../build_script_utils", optional = true }
-serde_json = "1"
-tempfile = "3"
+serde_json = { version = "1", optional = true }
+tempfile = { version = "3", optional = true }

--- a/integration_tests/tests/daphne.rs
+++ b/integration_tests/tests/daphne.rs
@@ -1,3 +1,5 @@
+#![cfg(daphne)]
+
 use common::{
     create_test_tasks, run_test_capturing_logs, submit_measurements_and_verify_aggregate,
 };


### PR DESCRIPTION
These will be re-enabled once our DAP-02 implementation is complete.

Also clean up the integration_tests' Cargo.toml. Mark a few dependencies non-optional (previously they were gated on the daphne feature, but were actually required whether or not that feature was enabled), and mark a few others optional or remove them entirely.