### PR TITLE
Fix compilation with nightly compiler

### DIFF
--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -80,6 +80,20 @@ impl<'a> Janus<'a> {
         }
     }
 
+    /// Returns the port of the aggregator on the host.
+    pub fn port(&self) -> u16 {
+        match self {
+            Janus::Container { role: _, container } => {
+                container.get_host_port_ipv4(Aggregator::INTERNAL_SERVING_PORT)
+            }
+            Janus::KubernetesCluster {
+                aggregator_port_forward,
+            } => aggregator_port_forward.local_port(),
+        }
+    }
+}
+
+impl Janus<'static> {
     /// Set up a test case running in a Kubernetes cluster where Janus components and a datastore
     /// are assumed to already be deployed.
     pub async fn new_with_kubernetes_cluster<P>(
@@ -161,18 +175,6 @@ impl<'a> Janus<'a> {
 
         Self::KubernetesCluster {
             aggregator_port_forward,
-        }
-    }
-
-    /// Returns the port of the aggregator on the host.
-    pub fn port(&self) -> u16 {
-        match self {
-            Janus::Container { role: _, container } => {
-                container.get_host_port_ipv4(Aggregator::INTERNAL_SERVING_PORT)
-            }
-            Janus::KubernetesCluster {
-                aggregator_port_forward,
-            } => aggregator_port_forward.local_port(),
         }
     }
 }


### PR DESCRIPTION
This fixes compilation of Janus with a nightly compiler. (useful for things like `cargo-udeps`) I moved the constructor that produces `Janus<'static>` into its own impl block, so that `Self` will have the correct lifetime.

I minimized the issue to the following snippet: https://play.rust-lang.org/?version=nightly&mode=debug&edition=2021&gist=7e82812f25083e301c7964fd5ed08323. I can't tell if this is a true regression in rustc, or if this was on us for not lining up lifetimes correctly. At any rate, here's what `cargo-bisect-rustc` pointed to:

searched nightlies: from nightly-2022-08-01 to nightly-2022-09-13
regressed nightly: nightly-2022-08-05
searched commit range: https://github.com/rust-lang/rust/compare/1b57946a405d5b2a87e612335db033edb2c3427f...f6f9d5e73d5524b6281c10a5c89b7db35c330634
regressed commit: https://github.com/rust-lang/rust/commit/caee496150a551fe1b9f77b3a58f7e66d54bc824

<details>
<summary>bisected with <a href='https://github.com/rust-lang/cargo-bisect-rustc'>cargo-bisect-rustc</a> v0.6.4</summary>


Host triple: x86_64-unknown-linux-gnu
Reproduce with:
```bash
cargo bisect-rustc 
```
</details>
