### PR TITLE
Use info! instead of warn! for bad client reports

### DIFF
--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -67,7 +67,7 @@ use std::{
     time::Instant,
 };
 use tokio::sync::Mutex;
-use tracing::{debug, error, warn};
+use tracing::{debug, error, info, warn};
 use url::Url;
 use uuid::Uuid;
 use warp::{
@@ -1022,7 +1022,7 @@ impl VdafOps {
             leader_report,
             &report.associated_data(),
         ) {
-            warn!(report.task_id = ?report.task_id(), report.metadata = ?report.metadata(), ?err, "Report decryption failed");
+            info!(report.task_id = ?report.task_id(), report.metadata = ?report.metadata(), ?err, "Report decryption failed");
             upload_decrypt_failure_counter.add(1);
             return Ok(());
         }
@@ -1119,7 +1119,7 @@ impl VdafOps {
                 .hpke_keys
                 .get(&report_share.encrypted_input_share.config_id())
                 .ok_or_else(|| {
-                    warn!(
+                    info!(
                         config_id = ?report_share.encrypted_input_share.config_id(),
                         "Helper encrypted input share references unknown HPKE config ID"
                     );
@@ -1139,7 +1139,7 @@ impl VdafOps {
                     &report_share.associated_data(task_id),
                 )
                 .map_err(|err| {
-                    warn!(
+                    info!(
                         ?task_id,
                         metadata = %report_share.metadata,
                         %err,
@@ -1158,7 +1158,7 @@ impl VdafOps {
             let input_share = plaintext.and_then(|plaintext| {
                 A::InputShare::get_decoded_with_param(&(vdaf, Role::Helper.index().unwrap()), &plaintext)
                     .map_err(|err| {
-                        warn!(?task_id, metadata = %report_share.metadata, %err, "Couldn't decode helper's input share");
+                        info!(?task_id, metadata = %report_share.metadata, %err, "Couldn't decode helper's input share");
                         aggregate_step_failure_counters.input_share_decode_failure.add(1);
                         ReportShareError::VdafPrepError
                     })
@@ -1177,7 +1177,7 @@ impl VdafOps {
                         &input_share,
                     )
                     .map_err(|err| {
-                        warn!(?task_id, nonce = %report_share.metadata.nonce(), %err, "Couldn't prepare_init report share");
+                        info!(?task_id, nonce = %report_share.metadata.nonce(), %err, "Couldn't prepare_init report share");
                         aggregate_step_failure_counters.prepare_init_failure.add(1);
                         ReportShareError::VdafPrepError
                     })
@@ -1439,7 +1439,7 @@ impl VdafOps {
                             }
 
                             Err(err) => {
-                                warn!(?task_id, job_id = ?req.job_id, nonce = %prep_step.nonce, %err, "Prepare step failed");
+                                info!(?task_id, job_id = ?req.job_id, nonce = %prep_step.nonce, %err, "Prepare step failed");
                                 prepare_step_failure_counter.add(1);
                                 report_aggregation.state =
                                     ReportAggregationState::Failed(ReportShareError::VdafPrepError);

--- a/janus_server/src/aggregator/aggregation_job_driver.rs
+++ b/janus_server/src/aggregator/aggregation_job_driver.rs
@@ -40,7 +40,7 @@ use prio::{
     },
 };
 use std::{fmt, sync::Arc};
-use tracing::warn;
+use tracing::{info, warn};
 
 #[derive(Derivative)]
 #[derivative(Debug)]
@@ -279,7 +279,7 @@ impl AggregationJobDriver {
             {
                 Some(leader_encrypted_input_share) => leader_encrypted_input_share,
                 None => {
-                    warn!(report_nonce = %report_aggregation.nonce, "Client report missing leader encrypted input share");
+                    info!(report_nonce = %report_aggregation.nonce, "Client report missing leader encrypted input share");
                     self.aggregate_step_failure_counters
                         .missing_leader_input_share
                         .add(1);
@@ -295,7 +295,7 @@ impl AggregationJobDriver {
             {
                 Some(helper_encrypted_input_share) => helper_encrypted_input_share,
                 None => {
-                    warn!(report_nonce = %report_aggregation.nonce, "Client report missing helper encrypted input share");
+                    info!(report_nonce = %report_aggregation.nonce, "Client report missing helper encrypted input share");
                     self.aggregate_step_failure_counters
                         .missing_helper_input_share
                         .add(1);
@@ -312,7 +312,7 @@ impl AggregationJobDriver {
             {
                 Some((hpke_config, hpke_private_key)) => (hpke_config, hpke_private_key),
                 None => {
-                    warn!(report_nonce = %report_aggregation.nonce, hpke_config_id = %leader_encrypted_input_share.config_id(), "Leader encrypted input share references unknown HPKE config ID");
+                    info!(report_nonce = %report_aggregation.nonce, hpke_config_id = %leader_encrypted_input_share.config_id(), "Leader encrypted input share references unknown HPKE config ID");
                     self.aggregate_step_failure_counters
                         .unknown_hpke_config_id
                         .add(1);
@@ -334,7 +334,7 @@ impl AggregationJobDriver {
             ) {
                 Ok(leader_input_share_bytes) => leader_input_share_bytes,
                 Err(err) => {
-                    warn!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't decrypt leader's encrypted input share");
+                    info!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't decrypt leader's encrypted input share");
                     self.aggregate_step_failure_counters.decrypt_failure.add(1);
                     report_aggregation.state =
                         ReportAggregationState::Failed(ReportShareError::HpkeDecryptError);
@@ -349,7 +349,7 @@ impl AggregationJobDriver {
                 Ok(leader_input_share) => leader_input_share,
                 Err(err) => {
                     // TODO(https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/issues/255): is moving to Invalid on a decoding error appropriate?
-                    warn!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't decode leader's input share");
+                    info!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't decode leader's input share");
                     self.aggregate_step_failure_counters
                         .input_share_decode_failure
                         .add(1);
@@ -369,7 +369,7 @@ impl AggregationJobDriver {
             ) {
                 Ok(prep_state_and_share) => prep_state_and_share,
                 Err(err) => {
-                    warn!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't initialize leader's preparation state");
+                    info!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't initialize leader's preparation state");
                     self.aggregate_step_failure_counters
                         .prepare_init_failure
                         .add(1);
@@ -473,7 +473,7 @@ impl AggregationJobDriver {
                 {
                     Ok(leader_transition) => leader_transition,
                     Err(err) => {
-                        warn!(report_nonce = %report_aggregation.nonce, ?err, "Prepare step failed");
+                        info!(report_nonce = %report_aggregation.nonce, ?err, "Prepare step failed");
                         self.aggregate_step_failure_counters
                             .prepare_step_failure
                             .add(1);
@@ -602,7 +602,7 @@ impl AggregationJobDriver {
                                 ReportAggregationState::Waiting(leader_prep_state, Some(prep_msg))
                             }
                             Err(err) => {
-                                warn!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't compute prepare message");
+                                info!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't compute prepare message");
                                 self.aggregate_step_failure_counters
                                     .prepare_message_failure
                                     .add(1);
@@ -650,7 +650,7 @@ impl AggregationJobDriver {
                 PrepareStepResult::Failed(err) => {
                     // If the helper failed, we move to FAILED immediately.
                     // TODO(#236): is it correct to just record the transition error that the helper reports?
-                    warn!(report_nonce = %report_aggregation.nonce, helper_err = ?err, "Helper couldn't step report aggregation");
+                    info!(report_nonce = %report_aggregation.nonce, helper_err = ?err, "Helper couldn't step report aggregation");
                     self.aggregate_step_failure_counters
                         .helper_step_failure
                         .add(1);


### PR DESCRIPTION
This reduces the severity of several tracing events from `Warn` to `Info` in places where the event is triggered by a misbehaving client. The following cases are covered:

- Wrong number of report shares
- The HPKE configuration ID in a report share ciphertext is not recognized
- Report share cannot be decrypted
- Input share cannot be decoded
- VDAF preparation fails (prep_init, prep_next, or prep_shares_to_prep)

This closes #384.