### PR TITLE
Change logging format for interop test containers

### DIFF
--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -201,6 +201,7 @@ pub fn install_tracing_subscriber() -> anyhow::Result<()> {
         .with_target(true)
         .with_file(true)
         .with_line_number(true)
+        .with_ansi(false)
         .pretty();
     let subscriber = Registry::default().with(stdout_filter.and_then(layer));
     tracing::subscriber::set_global_default(subscriber)?;


### PR DESCRIPTION
This turns off ANSI terminal escape codes in interop_binaries, to keep them out of log files in the test containers. This is related to #476.

<details><summary>Sample output</summary>

```
$ docker exec dap-leader cat /logs/aggregator_stdout.log
  2022-09-16T17:41:55.129309Z  INFO janus_server::binary_utils::job_driver: Acquiring jobs, max_acquire_count: 10
    at janus_server/src/binary_utils/job_driver.rs:134 on ThreadId(5)
    in janus_server::binary_utils::job_driver::run

  2022-09-16T17:41:55.129312Z  INFO janus_server::binary_utils::job_driver: Acquiring jobs, max_acquire_count: 10
    at janus_server/src/binary_utils/job_driver.rs:134 on ThreadId(8)
    in janus_server::binary_utils::job_driver::run

  2022-09-16T17:41:55.129325Z  INFO janus_server::aggregator::aggregation_job_creator: Updating tasks
    at janus_server/src/aggregator/aggregation_job_creator.rs:119 on ThreadId(7)
    in janus_server::aggregator::aggregation_job_creator::run

  2022-09-16T17:41:56.135091Z  INFO janus_server::binary_utils::job_driver: Acquiring jobs, max_acquire_count: 10
    at janus_server/src/binary_utils/job_driver.rs:134 on ThreadId(7)
    in janus_server::binary_utils::job_driver::run

  2022-09-16T17:41:56.168942Z  INFO janus_server::binary_utils::job_driver: Acquiring jobs, max_acquire_count: 10
    at janus_server/src/binary_utils/job_driver.rs:134 on ThreadId(7)
    in janus_server::binary_utils::job_driver::run

...

  2022-09-16T17:44:30.129588Z  INFO janus_server::aggregator::aggregation_job_creator: Updating tasks
    at janus_server/src/aggregator/aggregation_job_creator.rs:119 on ThreadId(8)
    in janus_server::aggregator::aggregation_job_creator::run

  2022-09-16T17:44:30.130305Z  INFO janus_server::aggregator::aggregation_job_creator: Starting job creation worker, task_id: TaskId(ShHIzJSPJ0IaFLQUk9CeE2MIaQHAXlrT73f5b1iO4SY)
    at janus_server/src/aggregator/aggregation_job_creator.rs:160 on ThreadId(8)
    in janus_server::aggregator::aggregation_job_creator::run

  2022-09-16T17:44:30.131462Z  INFO janus_server::aggregator::aggregation_job_creator: Creating aggregation jobs for task, task_id: TaskId(ShHIzJSPJ0IaFLQUk9CeE2MIaQHAXlrT73f5b1iO4SY)
    at janus_server/src/aggregator/aggregation_job_creator.rs:198 on ThreadId(8)
    in janus_server::aggregator::aggregation_job_creator::run_for_task with task: Task { id: TaskId(ShHIzJSPJ0IaFLQUk9CeE2MIaQHAXlrT73f5b1iO4SY), aggregator_endpoints: ["http://dap-leader:8080/", "http://dap-helper:8080/"], vdaf: Real(Prio3Aes128Count), role: Leader, max_batch_lifetime: 1, min_batch_size: 1, min_batch_duration: Duration(3600), tolerable_clock_skew: Duration(1), collector_hpke_config: HpkeConfig { id: HpkeConfigId(56), kem_id: X25519HkdfSha256, kdf_id: HkdfSha256, aead_id: Aes128Gcm, public_key: 10b14824f52c7e0f6402b044d2e0a493c382405ba4cdf02633166bdc4d8a470f }, hpke_keys: {HpkeConfigId(44): (HpkeConfig { id: HpkeConfigId(44), kem_id: X25519HkdfSha256, kdf_id: HkdfSha256, aead_id: Aes128Gcm, public_key: 3fedbc5c729f373e9d8f9ce29f779b58ffe18cb052f8a77ddcf1cb2bc24ab33d }, HpkePrivateKey)} }

  2022-09-16T17:44:30.249098Z  INFO warp::filters::trace: processing request
    at /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/warp-0.3.2/src/filters/trace.rs:297 on ThreadId(8)

  2022-09-16T17:44:30.249741Z  INFO warp::filters::trace: finished processing with success, status: 202
    at /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/warp-0.3.2/src/filters/trace.rs:243 on ThreadId(8)

  2022-09-16T17:44:30.904847Z  INFO warp::filters::trace: processing request
    at /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/warp-0.3.2/src/filters/trace.rs:297 on ThreadId(8)

  2022-09-16T17:44:30.905764Z  INFO warp::filters::trace: finished processing with success, status: 202
    at /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/warp-0.3.2/src/filters/trace.rs:243 on ThreadId(8)

  2022-09-16T17:44:31.131986Z  INFO janus_server::aggregator::aggregation_job_creator: Creating aggregation jobs for task, task_id: TaskId(ShHIzJSPJ0IaFLQUk9CeE2MIaQHAXlrT73f5b1iO4SY)
    at janus_server/src/aggregator/aggregation_job_creator.rs:198 on ThreadId(8)
    in janus_server::aggregator::aggregation_job_creator::run_for_task with task: Task { id: TaskId(ShHIzJSPJ0IaFLQUk9CeE2MIaQHAXlrT73f5b1iO4SY), aggregator_endpoints: ["http://dap-leader:8080/", "http://dap-helper:8080/"], vdaf: Real(Prio3Aes128Count), role: Leader, max_batch_lifetime: 1, min_batch_size: 1, min_batch_duration: Duration(3600), tolerable_clock_skew: Duration(1), collector_hpke_config: HpkeConfig { id: HpkeConfigId(56), kem_id: X25519HkdfSha256, kdf_id: HkdfSha256, aead_id: Aes128Gcm, public_key: 10b14824f52c7e0f6402b044d2e0a493c382405ba4cdf02633166bdc4d8a470f }, hpke_keys: {HpkeConfigId(44): (HpkeConfig { id: HpkeConfigId(44), kem_id: X25519HkdfSha256, kdf_id: HkdfSha256, aead_id: Aes128Gcm, public_key: 3fedbc5c729f373e9d8f9ce29f779b58ffe18cb052f8a77ddcf1cb2bc24ab33d }, HpkePrivateKey)} }

  2022-09-16T17:44:31.790851Z  INFO warp::filters::trace: processing request
    at /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/warp-0.3.2/src/filters/trace.rs:297 on ThreadId(8)

  2022-09-16T17:44:31.791480Z  INFO warp::filters::trace: finished processing with success, status: 202
    at /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/warp-0.3.2/src/filters/trace.rs:243 on ThreadId(8)

  2022-09-16T17:44:32.131970Z  INFO janus_server::aggregator::aggregation_job_creator: Creating aggregation jobs for task, task_id: TaskId(ShHIzJSPJ0IaFLQUk9CeE2MIaQHAXlrT73f5b1iO4SY)
    at janus_server/src/aggregator/aggregation_job_creator.rs:198 on ThreadId(8)
    in janus_server::aggregator::aggregation_job_creator::run_for_task with task: Task { id: TaskId(ShHIzJSPJ0IaFLQUk9CeE2MIaQHAXlrT73f5b1iO4SY), aggregator_endpoints: ["http://dap-leader:8080/", "http://dap-helper:8080/"], vdaf: Real(Prio3Aes128Count), role: Leader, max_batch_lifetime: 1, min_batch_size: 1, min_batch_duration: Duration(3600), tolerable_clock_skew: Duration(1), collector_hpke_config: HpkeConfig { id: HpkeConfigId(56), kem_id: X25519HkdfSha256, kdf_id: HkdfSha256, aead_id: Aes128Gcm, public_key: 10b14824f52c7e0f6402b044d2e0a493c382405ba4cdf02633166bdc4d8a470f }, hpke_keys: {HpkeConfigId(44): (HpkeConfig { id: HpkeConfigId(44), kem_id: X25519HkdfSha256, kdf_id: HkdfSha256, aead_id: Aes128Gcm, public_key: 3fedbc5c729f373e9d8f9ce29f779b58ffe18cb052f8a77ddcf1cb2bc24ab33d }, HpkePrivateKey)} }

  2022-09-16T17:44:32.186931Z  INFO janus_server::binary_utils::job_driver: Acquiring jobs, max_acquire_count: 10
    at janus_server/src/binary_utils/job_driver.rs:134 on ThreadId(8)
    in janus_server::binary_utils::job_driver::run

  2022-09-16T17:44:32.196234Z  INFO janus_server::binary_utils::job_driver: Acquired jobs, acquired_job_count: 1
    at janus_server/src/binary_utils/job_driver.rs:167 on ThreadId(8)
    in janus_server::binary_utils::job_driver::run

  2022-09-16T17:44:32.196263Z  INFO janus_server::binary_utils::job_driver: Stepping job, lease_expiry: Time(1663350282)
    at janus_server/src/binary_utils/job_driver.rs:189 on ThreadId(8)
    in janus_server::binary_utils::job_driver::Job stepper with acquired_job: AcquiredAggregationJob { vdaf: Real(Prio3Aes128Count), task_id: TaskId(ShHIzJSPJ0IaFLQUk9CeE2MIaQHAXlrT73f5b1iO4SY), aggregation_job_id: AggregationJobId(XCtWtfRL_Y_4l2gAUxoBJnTx7JG7dP2JIf6f1dVXZv4) }
    in janus_server::binary_utils::job_driver::run
```

</details>