### PR TITLE
Extend collect timeout in end_to_end test

### DIFF
--- a/interop_binaries/src/bin/janus_interop_aggregator.rs
+++ b/interop_binaries/src/bin/janus_interop_aggregator.rs
@@ -243,7 +243,7 @@ async fn main() -> anyhow::Result<()> {
     let aggregation_job_creator = Arc::new(AggregationJobCreator::new(
         Datastore::new(pool, crypter, clock),
         clock,
-        StdDuration::from_secs(5),
+        StdDuration::from_secs(2),
         StdDuration::from_secs(1),
         1,
         100,
@@ -261,7 +261,7 @@ async fn main() -> anyhow::Result<()> {
         TokioRuntime,
         aggregation_job_driver_meter,
         Duration::from_seconds(1),
-        Duration::from_seconds(5),
+        Duration::from_seconds(2),
         10,
         Duration::from_seconds(1),
         aggregation_job_driver.make_incomplete_job_acquirer_callback(
@@ -283,7 +283,7 @@ async fn main() -> anyhow::Result<()> {
         TokioRuntime,
         collect_job_driver_meter,
         Duration::from_seconds(1),
-        Duration::from_seconds(5),
+        Duration::from_seconds(2),
         10,
         Duration::from_seconds(1),
         collect_job_driver.make_incomplete_job_acquirer_callback(

--- a/janus_server/src/message.rs
+++ b/janus_server/src/message.rs
@@ -5,7 +5,7 @@ use base64::display::Base64Display;
 use derivative::Derivative;
 use janus_core::{
     hpke::{associated_data_for_aggregate_share, associated_data_for_report_share},
-    message::{HpkeCiphertext, Interval, Nonce, NonceChecksum, ReportMetadata, TaskId, Time},
+    message::{HpkeCiphertext, Interval, Nonce, NonceChecksum, ReportMetadata, TaskId},
 };
 use num_enum::TryFromPrimitive;
 use postgres_types::{FromSql, ToSql};
@@ -397,7 +397,7 @@ impl Decode for AggregateShareResp {
 #[cfg(feature = "test-util")]
 pub mod test_util {
     use super::*;
-    use janus_core::message::{Report, ReportMetadata};
+    use janus_core::message::{Report, ReportMetadata, Time};
 
     pub fn new_dummy_report(task_id: TaskId, when: Time) -> Report {
         Report::new(


### PR DESCRIPTION
This should fix some CI flakiness I've been seeing today. The end_to_end integration test was taking 12-14s on my machine, and the code gave it ~15s (plus request time) to complete, which is uncomfortably close. I have extended that limit to 60s flat, and rewritten the loop using the backoff crate, to be less boutique.

I think the recent rewrite of `janus_interop_collector` likely caused this, because it made `/internal/test/collect_poll` requests much faster, as they no longer make subsidiary requests, instead only checking sync primitives in memory. This effectively decreased the amount of time we allowed the test to run before timing out. Combined with the constrained resources of CI builders, this pushed it past the deadline too often.

I separately plan to tune the various timers in each interop test container, so that aggregations finish quicker. (I have anecdotally noticed many database transaction conflicts)

I also fixed a compiler warning that only appears when building janus_server without the test-util feature.