### PR TITLE
Backport end_to_end test improvements to 0.1

### DIFF
--- a/interop_binaries/src/bin/janus_interop_aggregator.rs
+++ b/interop_binaries/src/bin/janus_interop_aggregator.rs
@@ -243,7 +243,7 @@ async fn main() -> anyhow::Result<()> {
     let aggregation_job_creator = Arc::new(AggregationJobCreator::new(
         Datastore::new(pool, crypter, clock),
         clock,
-        StdDuration::from_secs(5),
+        StdDuration::from_secs(2),
         StdDuration::from_secs(1),
         1,
         100,
@@ -261,7 +261,7 @@ async fn main() -> anyhow::Result<()> {
         TokioRuntime,
         aggregation_job_driver_meter,
         Duration::from_seconds(1),
-        Duration::from_seconds(5),
+        Duration::from_seconds(2),
         10,
         Duration::from_seconds(1),
         aggregation_job_driver.make_incomplete_job_acquirer_callback(
@@ -283,7 +283,7 @@ async fn main() -> anyhow::Result<()> {
         TokioRuntime,
         collect_job_driver_meter,
         Duration::from_seconds(1),
-        Duration::from_seconds(5),
+        Duration::from_seconds(2),
         10,
         Duration::from_seconds(1),
         collect_job_driver.make_incomplete_job_acquirer_callback(


### PR DESCRIPTION
This backports #515 to the 0.1 branch. We should take this to fix the test flakiness.