### PR TITLE
Change field name for errors, use Display to format them

### DIFF
--- a/janus_core/src/retries.rs
+++ b/janus_core/src/retries.rs
@@ -94,7 +94,7 @@ where
             }
             Err(error) => {
                 if error.is_timeout() || error.is_connect() {
-                    warn!(?error, "encountered retryable error");
+                    warn!(%error, "encountered retryable error");
                     return Err(backoff::Error::transient(Err(error)));
                 }
 
@@ -103,7 +103,7 @@ where
                     | std::io::ErrorKind::ConnectionReset
                     | std::io::ErrorKind::ConnectionAborted = io_error.kind()
                     {
-                        warn!(?error, "encountered retryable error");
+                        warn!(%error, "encountered retryable error");
                         return Err(backoff::Error::transient(Err(error)));
                     }
                 }

--- a/janus_server/src/aggregator/aggregation_job_creator.rs
+++ b/janus_server/src/aggregator/aggregation_job_creator.rs
@@ -131,8 +131,8 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                     })
                     .collect::<HashMap<_, _>>(),
 
-                Err(err) => {
-                    error!(?err, "Couldn't update tasks");
+                Err(error) => {
+                    error!(%error, "Couldn't update tasks");
                     task_update_time_recorder.record(
                         start.elapsed().as_secs_f64(),
                         &[KeyValue::new("status", "error")],
@@ -197,8 +197,8 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                 _ = aggregation_job_creation_ticker.tick() => {
                     info!(task_id = ?task.id, "Creating aggregation jobs for task");
                     let (start, mut status) = (Instant::now(), "success");
-                    if let Err(err) = self.create_aggregation_jobs_for_task(&task).await {
-                        error!(task_id = ?task.id, ?err, "Couldn't create aggregation jobs for task");
+                    if let Err(error) = self.create_aggregation_jobs_for_task(&task).await {
+                        error!(task_id = ?task.id, %error, "Couldn't create aggregation jobs for task");
                         status = "error";
                     }
                     job_creation_time_recorder.record(start.elapsed().as_secs_f64(), &[KeyValue::new("status", status)]);

--- a/janus_server/src/aggregator/aggregation_job_driver.rs
+++ b/janus_server/src/aggregator/aggregation_job_driver.rs
@@ -333,8 +333,8 @@ impl AggregationJobDriver {
                 &associated_data,
             ) {
                 Ok(leader_input_share_bytes) => leader_input_share_bytes,
-                Err(err) => {
-                    info!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't decrypt leader's encrypted input share");
+                Err(error) => {
+                    info!(report_nonce = %report_aggregation.nonce, %error, "Couldn't decrypt leader's encrypted input share");
                     self.aggregate_step_failure_counters.decrypt_failure.add(1);
                     report_aggregation.state =
                         ReportAggregationState::Failed(ReportShareError::HpkeDecryptError);
@@ -347,9 +347,9 @@ impl AggregationJobDriver {
                 &leader_input_share_bytes,
             ) {
                 Ok(leader_input_share) => leader_input_share,
-                Err(err) => {
+                Err(error) => {
                     // TODO(https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/issues/255): is moving to Invalid on a decoding error appropriate?
-                    info!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't decode leader's input share");
+                    info!(report_nonce = %report_aggregation.nonce, %error, "Couldn't decode leader's input share");
                     self.aggregate_step_failure_counters
                         .input_share_decode_failure
                         .add(1);
@@ -368,8 +368,8 @@ impl AggregationJobDriver {
                 &leader_input_share,
             ) {
                 Ok(prep_state_and_share) => prep_state_and_share,
-                Err(err) => {
-                    info!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't initialize leader's preparation state");
+                Err(error) => {
+                    info!(report_nonce = %report_aggregation.nonce, %error, "Couldn't initialize leader's preparation state");
                     self.aggregate_step_failure_counters
                         .prepare_init_failure
                         .add(1);
@@ -472,8 +472,8 @@ impl AggregationJobDriver {
                     .prepare_step(prep_state.clone(), prep_msg.clone())
                 {
                     Ok(leader_transition) => leader_transition,
-                    Err(err) => {
-                        info!(report_nonce = %report_aggregation.nonce, ?err, "Prepare step failed");
+                    Err(error) => {
+                        info!(report_nonce = %report_aggregation.nonce, %error, "Prepare step failed");
                         self.aggregate_step_failure_counters
                             .prepare_step_failure
                             .add(1);
@@ -601,8 +601,8 @@ impl AggregationJobDriver {
                             Ok(prep_msg) => {
                                 ReportAggregationState::Waiting(leader_prep_state, Some(prep_msg))
                             }
-                            Err(err) => {
-                                info!(report_nonce = %report_aggregation.nonce, ?err, "Couldn't compute prepare message");
+                            Err(error) => {
+                                info!(report_nonce = %report_aggregation.nonce, %error, "Couldn't compute prepare message");
                                 self.aggregate_step_failure_counters
                                     .prepare_message_failure
                                     .add(1);
@@ -631,8 +631,8 @@ impl AggregationJobDriver {
                                 report_aggregation.state =
                                     ReportAggregationState::Finished(out_share)
                             }
-                            Err(err) => {
-                                warn!(report_nonce = %report_aggregation.nonce, ?err, "Could not update batch unit aggregation");
+                            Err(error) => {
+                                warn!(report_nonce = %report_aggregation.nonce, %error, "Could not update batch unit aggregation");
                                 self.aggregate_step_failure_counters
                                     .accumulate_failure
                                     .add(1);
@@ -650,7 +650,7 @@ impl AggregationJobDriver {
                 PrepareStepResult::Failed(err) => {
                     // If the helper failed, we move to FAILED immediately.
                     // TODO(#236): is it correct to just record the transition error that the helper reports?
-                    info!(report_nonce = %report_aggregation.nonce, helper_err = ?err, "Helper couldn't step report aggregation");
+                    info!(report_nonce = %report_aggregation.nonce, helper_error = ?err, "Helper couldn't step report aggregation");
                     self.aggregate_step_failure_counters
                         .helper_step_failure
                         .add(1);

--- a/janus_server/src/binary_utils.rs
+++ b/janus_server/src/binary_utils.rs
@@ -108,7 +108,7 @@ pub async fn database_pool(db_config: &DbConfig, db_password: Option<&str>) -> R
         || async {
             pool.get().await.map_err(|error| match error {
                 PoolError::Timeout(TimeoutType::Create) | PoolError::Backend(_) => {
-                    tracing::debug!(?error, "transient error connecting to database");
+                    tracing::debug!(%error, "transient error connecting to database");
                     backoff::Error::transient(error)
                 }
                 _ => backoff::Error::permanent(error),

--- a/janus_server/src/metrics.rs
+++ b/janus_server/src/metrics.rs
@@ -143,8 +143,8 @@ pub fn install_metrics_exporter(
                             // `header()` call, and its arguments are always valid.
                             .unwrap()
                             .into_response(),
-                        Err(err) => {
-                            tracing::error!(%err, "Failed to encode Prometheus metrics");
+                        Err(error) => {
+                            tracing::error!(%error, "Failed to encode Prometheus metrics");
                             StatusCode::INTERNAL_SERVER_ERROR.into_response()
                         }
                     }


### PR DESCRIPTION
tracing::instrument [uses the field name "error" when emitting an event upon returning an error](https://docs.rs/tracing-attributes/latest/src/tracing_attributes/expand.rs.html#207). We should use the same field name in our events for consistency. Additionally, errors are now formatted with Display rather than Debug where possible, again for consistency.