### PR TITLE
Update uses of thread_rng() throughout codebase.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,38 @@ metrics_config:
 ```
 
 The command line flag `--otlp-metrics-metadata` or environment variable `OTLP_METRICS_METADATA` may alternately be used to supply gRPC metadata for the metrics exporter.
+
+## Code Style
+
+* Functions & methods should take the type of argument (reference, mutable reference, or value) that
+  they need. For example, a function that computes a predicate on its argument, or returns a
+  reference to some part of its argument, should take a reference. A function that mutates its
+  argument should take a mutable reference. A function that moves its argument into a
+  newly-constructed struct which will be returned should take its arguments by value.
+
+  * This should always be followed for non-`Copy` types to avoid expensive `clone()` calls. Even
+    when using `Copy` types, it is a best practice to follow this rule.
+  
+  * In particular, when writing a constructor, receive the fields by value. Do not take a reference
+    and then call `clone()` on it. Doing so may incur an extra `clone()` if the caller already has a
+    value in hand which they are OK handing off. (And if they have a reference, or a value that
+    they wish to keep ownership of, they can call `clone()` themselves.)
+
+* Structured data intended for "public" use (i.e. outside of the current module & its descendants)
+  should not include public fields & should instead provide getters which return references to the
+  internal data. This allows the structure to enforce invariants at time of construction, allows
+  the fields in the structure to be different from the public API, and permits the structures to be
+  refactored to a greater degree while requiring fewer updates to users of the structure.
+
+* Types should generally implement traits rather than custom methods, where it makes sense to do so.
+  This is because these traits will "fit in" better with libraries written to work with these
+  traits.
+
+  * For example, don't write an `as_bytes() -> &[u8]` method; instead, implement `AsRef<[u8]>`.
+    Don't write a `random()` or `generate()` method; instead, `impl Distribution<Type> on Standard`.
+    Consider implementing `From` rather than `new` if the type conceptually is the thing it is being
+    created from (for example, a newtype over an array of bytes might implement `From<Vec<u8>>`).
+
+* Follow documented best practices of the crates Janus depends on. For exmaple, the `rand` crate
+  suggests using `random()` to generate random data, falling back to `thread_rng()` to gain more
+  control as-needed.

--- a/interop_binaries/src/bin/janus_interop_aggregator.rs
+++ b/interop_binaries/src/bin/janus_interop_aggregator.rs
@@ -25,7 +25,7 @@ use janus_server::{
 };
 use opentelemetry::global::meter;
 use prio::codec::Decode;
-use rand::{thread_rng, Rng};
+use rand::random;
 use ring::aead::{LessSafeKey, UnboundKey, AES_128_GCM};
 use serde::Serialize;
 use std::{
@@ -209,10 +209,9 @@ async fn main() -> anyhow::Result<()> {
         .unwrap_or_else(|| "/".to_string());
 
     // Make an ephemeral datastore key.
-    let mut key_bytes = [0u8; 16];
-    thread_rng().fill(&mut key_bytes);
+    let key_bytes: [u8; 16] = random();
     let datastore_key = LessSafeKey::new(UnboundKey::new(&AES_128_GCM, &key_bytes).unwrap());
-    let crypter = Crypter::new(vec![datastore_key]);
+    let crypter = Crypter::new(Vec::from([datastore_key]));
 
     // Connect to database, apply schema, and set up datastore.
     let db_config = DbConfig {

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -5,7 +5,7 @@ use janus_core::{
 };
 use janus_server::task::{Task, VdafInstance};
 use prio::codec::Encode;
-use rand::{thread_rng, Rng};
+use rand::random;
 use serde::{de::Visitor, Deserialize, Serialize};
 use std::{collections::HashMap, fmt::Display, marker::PhantomData, str::FromStr};
 use tracing_log::LogTracer;
@@ -242,8 +242,7 @@ impl HpkeConfigRegistry {
 
     /// Choose a random [`HpkeConfigId`], and then get the keypair associated with that ID.
     pub fn get_random_keypair(&mut self) -> (HpkeConfig, HpkePrivateKey) {
-        let id = HpkeConfigId::from(thread_rng().gen::<u8>());
-        self.fetch_keypair(id)
+        self.fetch_keypair(random::<u8>().into())
     }
 }
 
@@ -251,7 +250,7 @@ impl HpkeConfigRegistry {
 pub mod test_util {
     use backoff::{future::retry, ExponentialBackoff};
     use futures::{Future, TryFutureExt};
-    use rand::{thread_rng, Rng};
+    use rand::random;
     use std::{fmt::Debug, time::Duration};
     use url::Url;
 
@@ -372,8 +371,6 @@ pub mod test_util {
     }
 
     pub fn generate_unique_name(prefix: &str) -> String {
-        let mut buf = [0; 4];
-        thread_rng().fill(&mut buf);
-        format!("{}_{}", prefix, hex::encode(buf))
+        format!("{}_{}", prefix, hex::encode(random::<[u8; 4]>()))
     }
 }

--- a/janus_collector/examples/collect.rs
+++ b/janus_collector/examples/collect.rs
@@ -78,13 +78,12 @@ impl TypedValueParser for TaskIdValueParser {
         value: &std::ffi::OsStr,
     ) -> Result<Self::Value, clap::Error> {
         let input = self.inner.parse_ref(cmd, arg, value)?;
-        let task_id_bytes: [u8; TaskId::ENCODED_LEN] =
-            base64::decode_config(input, URL_SAFE_NO_PAD)
-                .map_err(|err| clap::Error::raw(ErrorKind::ValueValidation, err))?
-                .try_into()
-                .map_err(|_| {
-                    clap::Error::raw(ErrorKind::ValueValidation, "task ID length incorrect")
-                })?;
+        let task_id_bytes: [u8; TaskId::LEN] = base64::decode_config(input, URL_SAFE_NO_PAD)
+            .map_err(|err| clap::Error::raw(ErrorKind::ValueValidation, err))?
+            .try_into()
+            .map_err(|_| {
+                clap::Error::raw(ErrorKind::ValueValidation, "task ID length incorrect")
+            })?;
         Ok(TaskId::from(task_id_bytes))
     }
 }

--- a/janus_collector/src/lib.rs
+++ b/janus_collector/src/lib.rs
@@ -521,7 +521,7 @@ mod tests {
         field::Field64,
         vdaf::{prio3::Prio3, AggregateShare},
     };
-    use rand::{random, thread_rng, Rng};
+    use rand::random;
 
     fn setup_collector<V: vdaf::Collector>(vdaf_collector: V) -> Collector<V>
     where
@@ -542,9 +542,7 @@ mod tests {
     }
 
     fn random_verify_key() -> [u8; 16] {
-        let mut verify_key = [0u8; 16];
-        thread_rng().fill(&mut verify_key[..]);
-        verify_key
+        random()
     }
 
     fn build_collect_response<const L: usize, V: vdaf::Aggregator<L>>(

--- a/janus_core/src/message.rs
+++ b/janus_core/src/message.rs
@@ -362,21 +362,21 @@ impl ToSql for Interval {
 
 /// DAP protocol message representing an ID uniquely identifying a batch, for fixed-size tasks.
 #[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct BatchId([u8; Self::ENCODED_LEN]);
+pub struct BatchId([u8; Self::LEN]);
 
 impl BatchId {
-    /// ENCODED_LEN is the length of a batch ID in bytes when encoded.
-    pub const ENCODED_LEN: usize = 32;
+    /// LEN is the length of a batch ID in bytes.
+    pub const LEN: usize = 32;
 }
 
-impl From<[u8; Self::ENCODED_LEN]> for BatchId {
-    fn from(batch_id: [u8; Self::ENCODED_LEN]) -> Self {
+impl From<[u8; Self::LEN]> for BatchId {
+    fn from(batch_id: [u8; Self::LEN]) -> Self {
         Self(batch_id)
     }
 }
 
-impl AsRef<[u8; Self::ENCODED_LEN]> for BatchId {
-    fn as_ref(&self) -> &[u8; Self::ENCODED_LEN] {
+impl AsRef<[u8; Self::LEN]> for BatchId {
+    fn as_ref(&self) -> &[u8; Self::LEN] {
         &self.0
     }
 }
@@ -409,7 +409,7 @@ impl Encode for BatchId {
 
 impl Decode for BatchId {
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
-        let mut batch_id = [0; Self::ENCODED_LEN];
+        let mut batch_id = [0; Self::LEN];
         bytes.read_exact(&mut batch_id)?;
         Ok(Self(batch_id))
     }
@@ -423,21 +423,21 @@ impl Distribution<BatchId> for Standard {
 
 /// DAP protocol message representing a nonce uniquely identifying a client report.
 #[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Nonce([u8; Self::ENCODED_LEN]);
+pub struct Nonce([u8; Self::LEN]);
 
 impl Nonce {
-    /// ENCODED_LEN is the length of a nonce in bytes when encoded.
-    pub const ENCODED_LEN: usize = 16;
+    /// LEN is the length of a nonce in bytes.
+    pub const LEN: usize = 16;
 }
 
-impl From<[u8; Self::ENCODED_LEN]> for Nonce {
-    fn from(nonce: [u8; Self::ENCODED_LEN]) -> Self {
+impl From<[u8; Self::LEN]> for Nonce {
+    fn from(nonce: [u8; Self::LEN]) -> Self {
         Self(nonce)
     }
 }
 
-impl AsRef<[u8; Self::ENCODED_LEN]> for Nonce {
-    fn as_ref(&self) -> &[u8; Self::ENCODED_LEN] {
+impl AsRef<[u8; Self::LEN]> for Nonce {
+    fn as_ref(&self) -> &[u8; Self::LEN] {
         &self.0
     }
 }
@@ -470,7 +470,7 @@ impl Encode for Nonce {
 
 impl Decode for Nonce {
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
-        let mut nonce = [0; Self::ENCODED_LEN];
+        let mut nonce = [0; Self::LEN];
         bytes.read_exact(&mut nonce)?;
         Ok(Self(nonce))
     }
@@ -645,11 +645,11 @@ impl From<HpkeConfigId> for u8 {
 
 /// DAP protocol message representing an identifier for a DAP task.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct TaskId([u8; Self::ENCODED_LEN]);
+pub struct TaskId([u8; Self::LEN]);
 
 impl TaskId {
-    /// ENCODED_LEN is the length of a task ID in bytes when encoded.
-    pub const ENCODED_LEN: usize = 32;
+    /// LEN is the length of a task ID in bytes.
+    pub const LEN: usize = 32;
 }
 
 impl Debug for TaskId {
@@ -680,20 +680,20 @@ impl Encode for TaskId {
 
 impl Decode for TaskId {
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
-        let mut decoded = [0u8; Self::ENCODED_LEN];
+        let mut decoded = [0u8; Self::LEN];
         bytes.read_exact(&mut decoded)?;
         Ok(Self(decoded))
     }
 }
 
-impl From<[u8; Self::ENCODED_LEN]> for TaskId {
-    fn from(task_id: [u8; TaskId::ENCODED_LEN]) -> Self {
+impl From<[u8; Self::LEN]> for TaskId {
+    fn from(task_id: [u8; TaskId::LEN]) -> Self {
         Self(task_id)
     }
 }
 
-impl AsRef<[u8; Self::ENCODED_LEN]> for TaskId {
-    fn as_ref(&self) -> &[u8; Self::ENCODED_LEN] {
+impl AsRef<[u8; Self::LEN]> for TaskId {
+    fn as_ref(&self) -> &[u8; Self::LEN] {
         &self.0
     }
 }
@@ -1625,7 +1625,7 @@ mod tests {
     fn roundtrip_batch_id() {
         roundtrip_encoding(&[
             (
-                BatchId::from([u8::MIN; BatchId::ENCODED_LEN]),
+                BatchId::from([u8::MIN; BatchId::LEN]),
                 "0000000000000000000000000000000000000000000000000000000000000000",
             ),
             (
@@ -1636,7 +1636,7 @@ mod tests {
                 "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F",
             ),
             (
-                BatchId::from([u8::MAX; TaskId::ENCODED_LEN]),
+                BatchId::from([u8::MAX; TaskId::LEN]),
                 "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
             ),
         ])
@@ -1679,7 +1679,7 @@ mod tests {
     fn roundtrip_task_id() {
         roundtrip_encoding(&[
             (
-                TaskId::from([u8::MIN; TaskId::ENCODED_LEN]),
+                TaskId::from([u8::MIN; TaskId::LEN]),
                 "0000000000000000000000000000000000000000000000000000000000000000",
             ),
             (
@@ -1690,7 +1690,7 @@ mod tests {
                 "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F",
             ),
             (
-                TaskId::from([u8::MAX; TaskId::ENCODED_LEN]),
+                TaskId::from([u8::MAX; TaskId::LEN]),
                 "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
             ),
         ])
@@ -1909,7 +1909,7 @@ mod tests {
         roundtrip_encoding(&[
             (
                 Report::new(
-                    TaskId::from([u8::MIN; TaskId::ENCODED_LEN]),
+                    TaskId::from([u8::MIN; TaskId::LEN]),
                     ReportMetadata::new(
                         Time::from_seconds_since_epoch(12345),
                         Nonce::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
@@ -1941,7 +1941,7 @@ mod tests {
             ),
             (
                 Report::new(
-                    TaskId::from([u8::MAX; TaskId::ENCODED_LEN]),
+                    TaskId::from([u8::MAX; TaskId::LEN]),
                     ReportMetadata::new(
                         Time::from_seconds_since_epoch(54321),
                         Nonce::from([16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]),

--- a/janus_core/src/test_util/kubernetes.rs
+++ b/janus_core/src/test_util/kubernetes.rs
@@ -1,7 +1,7 @@
 //! Testing framework for functionality that interacts with Kubernetes.
 
 use kube::config::{KubeConfigOptions, Kubeconfig};
-use rand::{thread_rng, Rng};
+use rand::random;
 use std::{
     io::{self, ErrorKind},
     path::{Path, PathBuf},
@@ -122,9 +122,7 @@ impl EphemeralCluster {
         let kubeconfig_path = NamedTempFile::new().unwrap().into_temp_path().to_path_buf();
 
         // Choose a cluster name.
-        let mut randomness = [0u8; 4];
-        thread_rng().fill(&mut randomness);
-        let kind_cluster_name = format!("janus-ephemeral-{}", hex::encode(&randomness));
+        let kind_cluster_name = format!("janus-ephemeral-{}", hex::encode(random::<[u8; 4]>()));
 
         // Use kind to start the cluster, with the node image from kind v0.14.0 for Kubernetes 1.22,
         // matching current regular GKE release channel. This image version should be bumped in

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -47,7 +47,7 @@ opentelemetry-semantic-conventions = { version = "0.9.0", optional = true }
 postgres-types = { version = "0.2.4", features = ["derive", "array-impls"] }
 prio = { version = "0.8.2", features = ["multithreaded"] }
 prometheus = { version = "0.13.2", optional = true }
-rand = "0.8"
+rand = { version = "0.8", features = ["min_const_gen"] }
 reqwest = { version = "0.11.11", default-features = false, features = ["rustls-tls", "json"] }
 ring = "0.16.20"
 serde = { version = "1.0.144", features = ["derive"] }

--- a/janus_server/src/bin/janus_cli.rs
+++ b/janus_server/src/bin/janus_cli.rs
@@ -21,7 +21,7 @@ use janus_server::{
 use k8s_openapi::api::core::v1::Secret;
 use kube::api::{ObjectMeta, PostParams};
 use prio::codec::Decode;
-use rand::{thread_rng, Rng};
+use rand::{distributions::Standard, thread_rng, Rng};
 use ring::aead::AES_128_GCM;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -269,8 +269,10 @@ async fn create_datastore_key(
 
     // Generate a random datastore key & encode it into unpadded base64 as will be expected by
     // consumers of the secret we are about to write.
-    let mut key_bytes = vec![0u8; AES_128_GCM.key_len()];
-    thread_rng().fill(&mut key_bytes[..]);
+    let key_bytes: Vec<_> = thread_rng()
+        .sample_iter(Standard)
+        .take(AES_128_GCM.key_len())
+        .collect();
     let secret_content = base64::encode_config(&key_bytes, STANDARD_NO_PAD);
 
     // Write the secret.

--- a/janus_server/src/message.rs
+++ b/janus_server/src/message.rs
@@ -196,15 +196,15 @@ impl Decode for ReportShareError {
 
 /// DAP protocol message representing an identifier for an aggregation job.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct AggregationJobId([u8; Self::ENCODED_LEN]);
+pub struct AggregationJobId([u8; Self::LEN]);
 
 impl AggregationJobId {
-    /// ENCODED_LEN is the length of an aggregation job ID in bytes when encoded.
-    const ENCODED_LEN: usize = 32;
+    /// LEN is the length of an aggregation job ID in bytes.
+    pub const LEN: usize = 32;
 }
 
-impl AsRef<[u8; Self::ENCODED_LEN]> for AggregationJobId {
-    fn as_ref(&self) -> &[u8; Self::ENCODED_LEN] {
+impl AsRef<[u8; Self::LEN]> for AggregationJobId {
+    fn as_ref(&self) -> &[u8; Self::LEN] {
         &self.0
     }
 }
@@ -237,7 +237,7 @@ impl Encode for AggregationJobId {
 
 impl Decode for AggregationJobId {
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
-        let mut decoded = [0u8; 32];
+        let mut decoded = [0u8; Self::LEN];
         bytes.read_exact(&mut decoded)?;
         Ok(Self(decoded))
     }

--- a/janus_server/src/task.rs
+++ b/janus_server/src/task.rs
@@ -420,7 +420,7 @@ impl<'de> Deserialize<'de> for Task {
         let serialized_task = SerializedTask::deserialize(deserializer)?;
 
         // task_id
-        let task_id_bytes: [u8; TaskId::ENCODED_LEN] =
+        let task_id_bytes: [u8; TaskId::LEN] =
             base64::decode_config(serialized_task.id, URL_SAFE_NO_PAD)
                 .map_err(D::Error::custom)?
                 .try_into()


### PR DESCRIPTION
Specifically, prefer random() for one-off values, and thread_rng().sample_iter() for repeated values. The former is (IMO) both simpler & clearer than what it replaces; the latter is a more opinionated change but avoids us needing to create a mutable variable initialized to some arbitrary value every time we want to create an array of random values.

Also, rename ENCODED_LEN -> LEN for all opaque types. I suppose the opaque types really are just an array of bytes, so it makes sense to talk about their "length".