### PR TITLE
Fix compilation with Rust 1.64 compiler (#504)

### DIFF
--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -80,6 +80,20 @@ impl<'a> Janus<'a> {
         }
     }
 
+    /// Returns the port of the aggregator on the host.
+    pub fn port(&self) -> u16 {
+        match self {
+            Janus::Container { role: _, container } => {
+                container.get_host_port_ipv4(Aggregator::INTERNAL_SERVING_PORT)
+            }
+            Janus::KubernetesCluster {
+                aggregator_port_forward,
+            } => aggregator_port_forward.local_port(),
+        }
+    }
+}
+
+impl Janus<'static> {
     /// Set up a test case running in a Kubernetes cluster where Janus components and a datastore
     /// are assumed to already be deployed.
     pub async fn new_with_kubernetes_cluster<P>(
@@ -161,18 +175,6 @@ impl<'a> Janus<'a> {
 
         Self::KubernetesCluster {
             aggregator_port_forward,
-        }
-    }
-
-    /// Returns the port of the aggregator on the host.
-    pub fn port(&self) -> u16 {
-        match self {
-            Janus::Container { role: _, container } => {
-                container.get_host_port_ipv4(Aggregator::INTERNAL_SERVING_PORT)
-            }
-            Janus::KubernetesCluster {
-                aggregator_port_forward,
-            } => aggregator_port_forward.local_port(),
         }
     }
 }


### PR DESCRIPTION
Backport of #504 to `release/0.1`, as the change we noticed in the nightly is now apparently also in Rust 1.64.