### PR TITLE
Late-breaking DAP-02 message changes.

### DIFF
--- a/interop_binaries/src/bin/janus_interop_client.rs
+++ b/interop_binaries/src/bin/janus_interop_client.rs
@@ -61,8 +61,8 @@ struct UploadRequest {
     helper: Url,
     vdaf: VdafObject,
     measurement: Measurement,
-    #[serde(default)]
-    nonce_time: Option<u64>,
+    #[serde(default, rename = "nonceTime")]
+    timestamp: Option<u64>,
     min_batch_duration: u64,
 }
 
@@ -109,9 +109,9 @@ where
     .await
     .context("failed to fetch helper's HPKE configuration")?;
 
-    match request.nonce_time {
-        Some(nonce_time) => {
-            let clock = MockClock::new(Time::from_seconds_since_epoch(nonce_time));
+    match request.timestamp {
+        Some(timestamp) => {
+            let clock = MockClock::new(Time::from_seconds_since_epoch(timestamp));
             let client = janus_client::Client::new(
                 client_parameters,
                 vdaf_client,

--- a/janus_client/src/lib.rs
+++ b/janus_client/src/lib.rs
@@ -59,7 +59,7 @@ pub struct ClientParameters {
     #[derivative(Debug(format_with = "fmt_vector_of_urls"))]
     aggregator_endpoints: Vec<Url>,
     /// The minimum batch duration of the task. This value is shared by all
-    /// parties in the protocol, and is used to compute report nonces.
+    /// parties in the protocol, and is used to compute report timestamps.
     min_batch_duration: Duration,
     /// Parameters to use when retrying HTTP requests.
     http_request_retry_parameters: ExponentialBackoff,
@@ -397,7 +397,7 @@ mod tests {
     }
 
     #[test]
-    fn report_nonce_time() {
+    fn report_timestamp() {
         install_test_trace_subscriber();
         let vdaf = Prio3::new_aes128_count(2).unwrap();
         let mut client = setup_client(vdaf);

--- a/janus_client/src/lib.rs
+++ b/janus_client/src/lib.rs
@@ -215,8 +215,8 @@ where
                 Error::InvalidParameter("couldn't round time down to min_batch_duration")
             })?;
         let report_metadata = ReportMetadata::new(
-            time,
             random(),
+            time,
             Vec::new(), // No extensions supported yet
         );
         let public_share = Vec::new(); // TODO(#473): fill out public_share once possible

--- a/janus_collector/src/lib.rs
+++ b/janus_collector/src/lib.rs
@@ -512,7 +512,7 @@ mod tests {
     use chrono::{TimeZone, Utc};
     use janus_core::{
         hpke::{test_util::generate_test_hpke_config_and_private_key, Label},
-        message::{Duration, HpkeCiphertext, Time},
+        message::{Duration, HpkeCiphertext, PartialBatchSelector, Time},
         retries::test_http_request_exponential_backoff,
         test_util::{install_test_trace_subscriber, run_vdaf, VdafTranscript},
     };
@@ -557,7 +557,8 @@ mod tests {
             parameters.task_id,
             &batch_interval,
         );
-        CollectResp::new_time_interval(
+        CollectResp::new(
+            PartialBatchSelector::new_time_interval(),
             1,
             vec![
                 hpke::seal(
@@ -890,7 +891,10 @@ mod tests {
                 CONTENT_TYPE.as_str(),
                 CollectResp::<TimeInterval>::MEDIA_TYPE,
             )
-            .with_body(CollectResp::new_time_interval(0, Vec::new()).get_encoded())
+            .with_body(
+                CollectResp::new(PartialBatchSelector::new_time_interval(), 0, Vec::new())
+                    .get_encoded(),
+            )
             .expect_at_least(1)
             .create();
 
@@ -906,7 +910,8 @@ mod tests {
                 CollectResp::<TimeInterval>::MEDIA_TYPE,
             )
             .with_body(
-                CollectResp::new_time_interval(
+                CollectResp::new(
+                    PartialBatchSelector::new_time_interval(),
                     1,
                     Vec::from([
                         HpkeCiphertext::new(*collector.parameters.hpke_config.id(), vec![], vec![]),
@@ -927,7 +932,8 @@ mod tests {
             collector.parameters.task_id,
             &batch_interval,
         );
-        let collect_resp = CollectResp::new_time_interval(
+        let collect_resp = CollectResp::new(
+            PartialBatchSelector::new_time_interval(),
             1,
             Vec::from([
                 hpke::seal(
@@ -961,7 +967,8 @@ mod tests {
 
         mock_collect_job_bad_shares.assert();
 
-        let collect_resp = CollectResp::new_time_interval(
+        let collect_resp = CollectResp::new(
+            PartialBatchSelector::new_time_interval(),
             1,
             Vec::from([
                 hpke::seal(

--- a/janus_core/src/hpke.rs
+++ b/janus_core/src/hpke.rs
@@ -84,8 +84,7 @@ impl Label {
 pub struct HpkeApplicationInfo(Vec<u8>);
 
 impl HpkeApplicationInfo {
-    /// Construct HPKE application info from the provided PPM task ID, label and
-    /// participant roles.
+    /// Construct HPKE application info from the provided label and participant roles.
     pub fn new(label: Label, sender_role: Role, recipient_role: Role) -> Self {
         Self(
             [
@@ -135,15 +134,15 @@ impl FromStr for HpkePrivateKey {
 /// Encrypt `plaintext` using the provided `recipient_config` and return the HPKE ciphertext. The
 /// provided `application_info` and `associated_data` are cryptographically bound to the ciphertext
 /// and are required to successfully decrypt it.
-// In PPM, an HPKE context can only be used once (we have no means of
-// ensuring that sender and recipient "increment" nonces in lockstep), so
-// this method creates a new HPKE context on each call.
 pub fn seal(
     recipient_config: &HpkeConfig,
     application_info: &HpkeApplicationInfo,
     plaintext: &[u8],
     associated_data: &[u8],
 ) -> Result<HpkeCiphertext, Error> {
+    // In DAP, an HPKE context can only be used once (we have no means of ensuring that sender and
+    // recipient "increment" nonces in lockstep), so this method creates a new HPKE context on each
+    // call.
     let output = hpke_dispatch::Config::try_from(recipient_config)?.base_mode_seal(
         recipient_config.public_key().as_ref(),
         &application_info.0,
@@ -440,7 +439,7 @@ mod tests {
 
             for encryption in test_vector.encryptions {
                 if encryption.nonce != test_vector.base_nonce {
-                    // PPM only performs single-shot encryption with each context, ignore any
+                    // DAP only performs single-shot encryption with each context, ignore any
                     // other encryptions in the test vectors.
                     continue;
                 }

--- a/janus_core/src/message.rs
+++ b/janus_core/src/message.rs
@@ -1028,29 +1028,29 @@ impl Decode for HpkeConfig {
 /// DAP protocol message representing client report metadata.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ReportMetadata {
-    time: Time,
     nonce: Nonce,
+    time: Time,
     extensions: Vec<Extension>,
 }
 
 impl ReportMetadata {
     /// Construct a report's metadata from its components.
-    pub fn new(time: Time, nonce: Nonce, extensions: Vec<Extension>) -> Self {
+    pub fn new(nonce: Nonce, time: Time, extensions: Vec<Extension>) -> Self {
         Self {
-            time,
             nonce,
+            time,
             extensions,
         }
-    }
-
-    /// Retrieve the client timestamp from this report metadata.
-    pub fn time(&self) -> &Time {
-        &self.time
     }
 
     /// Retrieve the nonce from this report metadata.
     pub fn nonce(&self) -> &Nonce {
         &self.nonce
+    }
+
+    /// Retrieve the client timestamp from this report metadata.
+    pub fn time(&self) -> &Time {
+        &self.time
     }
 
     /// Retrieve the extensions from this report metadata.
@@ -1061,21 +1061,21 @@ impl ReportMetadata {
 
 impl Encode for ReportMetadata {
     fn encode(&self, bytes: &mut Vec<u8>) {
-        self.time.encode(bytes);
         self.nonce.encode(bytes);
+        self.time.encode(bytes);
         encode_u16_items(bytes, &(), &self.extensions);
     }
 }
 
 impl Decode for ReportMetadata {
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
-        let time = Time::decode(bytes)?;
         let nonce = Nonce::decode(bytes)?;
+        let time = Time::decode(bytes)?;
         let extensions = decode_u16_items(&(), bytes)?;
 
         Ok(Self {
-            time,
             nonce,
+            time,
             extensions,
         })
     }
@@ -1165,7 +1165,7 @@ impl Report {
         use rand::random;
         Report::new(
             task_id,
-            ReportMetadata::new(when, random(), Vec::new()),
+            ReportMetadata::new(random(), when, Vec::new()),
             Vec::new(),
             Vec::new(),
         )
@@ -1864,14 +1864,13 @@ mod tests {
         roundtrip_encoding(&[
             (
                 ReportMetadata::new(
-                    Time::from_seconds_since_epoch(12345),
                     Nonce::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+                    Time::from_seconds_since_epoch(12345),
                     Vec::new(),
                 ),
                 concat!(
-                    // nonce
+                    "0102030405060708090A0B0C0D0E0F10", // nonce
                     "0000000000003039",                 // time
-                    "0102030405060708090a0b0c0d0e0f10", // nonce
                     concat!(
                         // extensions
                         "0000", // length
@@ -1880,13 +1879,13 @@ mod tests {
             ),
             (
                 ReportMetadata::new(
-                    Time::from_seconds_since_epoch(54321),
                     Nonce::from([16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]),
+                    Time::from_seconds_since_epoch(54321),
                     Vec::from([Extension::new(ExtensionType::Tbd, Vec::from("0123"))]),
                 ),
                 concat!(
+                    "100F0E0D0C0B0A090807060504030201", // nonce
                     "000000000000D431",                 // time
-                    "100f0e0d0c0b0a090807060504030201", // nonce
                     concat!(
                         // extensions
                         "0008", // length
@@ -1911,8 +1910,8 @@ mod tests {
                 Report::new(
                     TaskId::from([u8::MIN; TaskId::LEN]),
                     ReportMetadata::new(
-                        Time::from_seconds_since_epoch(12345),
                         Nonce::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+                        Time::from_seconds_since_epoch(12345),
                         Vec::new(),
                     ),
                     Vec::new(),
@@ -1922,8 +1921,8 @@ mod tests {
                     "0000000000000000000000000000000000000000000000000000000000000000", // task_id
                     concat!(
                         // metadata
+                        "0102030405060708090A0B0C0D0E0F10", // nonce
                         "0000000000003039",                 // time
-                        "0102030405060708090a0b0c0d0e0f10", // nonce
                         concat!(
                             // extensions
                             "0000", // length
@@ -1943,8 +1942,8 @@ mod tests {
                 Report::new(
                     TaskId::from([u8::MAX; TaskId::LEN]),
                     ReportMetadata::new(
-                        Time::from_seconds_since_epoch(54321),
                         Nonce::from([16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]),
+                        Time::from_seconds_since_epoch(54321),
                         Vec::from([Extension::new(ExtensionType::Tbd, Vec::from("0123"))]),
                     ),
                     Vec::from("3210"),
@@ -1965,8 +1964,8 @@ mod tests {
                     "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", // task_id
                     concat!(
                         // metadata
-                        "000000000000D431",                 // time
                         "100f0e0d0c0b0a090807060504030201", // nonce
+                        "000000000000D431",                 // time
                         concat!(
                             // extensions
                             "0008", // length

--- a/janus_core/src/message.rs
+++ b/janus_core/src/message.rs
@@ -1444,7 +1444,7 @@ pub mod query_type {
         type BatchIdentifier: Debug + Clone + PartialEq + Eq + Encode + Decode;
 
         /// The type of a batch identifier as it appears in a `PartialBatchSelector`. Will be either
-        /// either be the same type as `BatchIdentifier`, or `()`.
+        /// the same type as `BatchIdentifier`, or `()`.
         type PartialBatchIdentifier: Debug + Clone + PartialEq + Eq + Encode + Decode;
 
         /// Computes the `PartialBatchIdentifier` corresponding to the given
@@ -1981,7 +1981,7 @@ mod tests {
                     "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", // task_id
                     concat!(
                         // metadata
-                        "100f0e0d0c0b0a090807060504030201", // report_id
+                        "100F0E0D0C0B0A090807060504030201", // report_id
                         "000000000000D431",                 // time
                         concat!(
                             // extensions

--- a/janus_core/src/message.rs
+++ b/janus_core/src/message.rs
@@ -1486,7 +1486,7 @@ pub mod query_type {
 
     /// DAP protocol message representing the type of a query.
     #[derive(Copy, Clone, Debug, PartialEq, Eq, TryFromPrimitive, Serialize, Deserialize)]
-    #[repr(u16)]
+    #[repr(u8)]
     pub enum Code {
         Reserved = 0,
         TimeInterval = 1,
@@ -1510,13 +1510,13 @@ pub mod query_type {
 
     impl Encode for Code {
         fn encode(&self, bytes: &mut Vec<u8>) {
-            (*self as u16).encode(bytes);
+            (*self as u8).encode(bytes);
         }
     }
 
     impl Decode for Code {
         fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
-            let val = u16::decode(bytes)?;
+            let val = u8::decode(bytes)?;
             Self::try_from(val).map_err(|_| {
                 CodecError::Other(anyhow!("unexpected QueryType value {}", val).into())
             })
@@ -2049,7 +2049,7 @@ mod tests {
                     .unwrap(),
                 },
                 concat!(
-                    "0001", // query_type
+                    "01", // query_type
                     concat!(
                         // batch_interval
                         "000000000000D431", // start
@@ -2066,7 +2066,7 @@ mod tests {
                     .unwrap(),
                 },
                 concat!(
-                    "0001", // query_type
+                    "01", // query_type
                     concat!(
                         // batch_interval
                         "000000000000BF11", // start
@@ -2083,7 +2083,7 @@ mod tests {
                     batch_identifier: BatchId::from([10u8; 32]),
                 },
                 concat!(
-                    "0002",                                                             // query_type
+                    "02",                                                               // query_type
                     "0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A", // batch_id
                 ),
             ),
@@ -2092,7 +2092,7 @@ mod tests {
                     batch_identifier: BatchId::from([8u8; 32]),
                 },
                 concat!(
-                    "0002",                                                             // query_type
+                    "02",                                                               // query_type
                     "0808080808080808080808080808080808080808080808080808080808080808", // batch_id
                 ),
             ),
@@ -2119,7 +2119,7 @@ mod tests {
                     "0000000000000000000000000000000000000000000000000000000000000000", // task_id,
                     concat!(
                         // query
-                        "0001", // query_type
+                        "01", // query_type
                         concat!(
                             // batch_interval
                             "000000000000D431", // start
@@ -2149,7 +2149,7 @@ mod tests {
                     "0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D", // task_id
                     concat!(
                         // query
-                        "0001", // query_type
+                        "01", // query_type
                         concat!(
                             // batch_interval
                             "000000000000BF11", // start
@@ -2179,7 +2179,7 @@ mod tests {
                     "0000000000000000000000000000000000000000000000000000000000000000", // task_id,
                     concat!(
                         // query
-                        "0002", // query_type
+                        "02", // query_type
                         "0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A", // batch_id
                     ),
                     concat!(
@@ -2201,7 +2201,7 @@ mod tests {
                     "0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D0D", // task_id
                     concat!(
                         // query
-                        "0002", // query_type
+                        "02", // query_type
                         "0808080808080808080808080808080808080808080808080808080808080808", // batch_id
                     ),
                     concat!(
@@ -2220,7 +2220,7 @@ mod tests {
         roundtrip_encoding(&[(
             PartialBatchSelector::new_time_interval(),
             concat!(
-                "0001", // query_type
+                "01", // query_type
             ),
         )]);
 
@@ -2229,14 +2229,14 @@ mod tests {
             (
                 PartialBatchSelector::new_fixed_size(BatchId::from([3u8; 32])),
                 concat!(
-                    "0002",                                                             // query_type
+                    "02",                                                               // query_type
                     "0303030303030303030303030303030303030303030303030303030303030303", // batch_id
                 ),
             ),
             (
                 PartialBatchSelector::new_fixed_size(BatchId::from([4u8; 32])),
                 concat!(
-                    "0002",                                                             // query_type
+                    "02",                                                               // query_type
                     "0404040404040404040404040404040404040404040404040404040404040404", // batch_id
                 ),
             ),
@@ -2256,7 +2256,7 @@ mod tests {
                 concat!(
                     concat!(
                         // partial_batch_selector
-                        "0001", // query_type
+                        "01", // query_type
                     ),
                     "0000000000000000", // report_count
                     concat!(
@@ -2285,7 +2285,7 @@ mod tests {
                 concat!(
                     concat!(
                         // partial_batch_selector
-                        "0001", // query_type
+                        "01", // query_type
                     ),
                     "0000000000000017", // report_count
                     concat!(
@@ -2335,7 +2335,7 @@ mod tests {
                 concat!(
                     concat!(
                         // partial_batch_selector
-                        "0002", // query_type
+                        "02", // query_type
                         "0303030303030303030303030303030303030303030303030303030303030303", // batch_id
                     ),
                     "0000000000000000", // report_count
@@ -2367,7 +2367,7 @@ mod tests {
                 concat!(
                     concat!(
                         // partial_batch_selector
-                        "0002", // query_type
+                        "02", // query_type
                         "0404040404040404040404040404040404040404040404040404040404040404", // batch_id
                     ),
                     "0000000000000017", // report_count
@@ -2409,9 +2409,9 @@ mod tests {
     #[test]
     fn roundtrip_code() {
         roundtrip_encoding(&[
-            (query_type::Code::Reserved, "0000"),
-            (query_type::Code::TimeInterval, "0001"),
-            (query_type::Code::FixedSize, "0002"),
+            (query_type::Code::Reserved, "00"),
+            (query_type::Code::TimeInterval, "01"),
+            (query_type::Code::FixedSize, "02"),
         ])
     }
 }

--- a/janus_core/src/test_util/mod.rs
+++ b/janus_core/src/test_util/mod.rs
@@ -1,4 +1,4 @@
-use crate::message::Nonce;
+use crate::message::ReportId;
 use assert_matches::assert_matches;
 use prio::{
     codec::Encode,
@@ -37,7 +37,7 @@ pub fn run_vdaf<const L: usize, V: vdaf::Aggregator<L> + vdaf::Client>(
     vdaf: &V,
     verify_key: &[u8; L],
     aggregation_param: &V::AggregationParam,
-    nonce: &Nonce,
+    report_id: &ReportId,
     measurement: &V::Measurement,
 ) -> VdafTranscript<L, V>
 where
@@ -45,7 +45,7 @@ where
 {
     // Shard inputs into input shares, and initialize the initial PrepareTransitions.
     let input_shares = vdaf.shard(measurement).unwrap();
-    let encoded_nonce = nonce.get_encoded();
+    let encoded_report_id = report_id.get_encoded();
     let mut prep_trans: Vec<Vec<PrepareTransition<V, L>>> = input_shares
         .iter()
         .enumerate()
@@ -54,7 +54,7 @@ where
                 verify_key,
                 agg_id,
                 aggregation_param,
-                &encoded_nonce,
+                &encoded_report_id,
                 input_share,
             )?;
             Ok(vec![PrepareTransition::Continue(prep_state, prep_share)])

--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -35,7 +35,7 @@ use janus_core::{
     hpke::{self, associated_data_for_aggregate_share, HpkeApplicationInfo, Label},
     message::{
         query_type::TimeInterval, CollectReq, CollectResp, HpkeConfig, HpkeConfigId, Interval,
-        Report, ReportId, ReportIdChecksum, Role, TaskId, Time,
+        PartialBatchSelector, Report, ReportId, ReportIdChecksum, Role, TaskId, Time,
     },
     task::DAP_AUTH_HEADER,
     time::Clock,
@@ -1724,7 +1724,8 @@ impl VdafOps {
                     &associated_data,
                 )?;
 
-                Ok(Some(CollectResp::new_time_interval(
+                Ok(Some(CollectResp::new(
+                    PartialBatchSelector::new_time_interval(),
                     0, // TODO(#469): fill out report_count once possible
                     vec![
                         encrypted_leader_aggregate_share,
@@ -3093,8 +3094,13 @@ mod tests {
 
         datastore.put_task(&task).await.unwrap();
 
-        let request =
-            AggregateInitializeReq::new_time_interval(task_id, random(), Vec::new(), Vec::new());
+        let request = AggregateInitializeReq::new(
+            task_id,
+            random(),
+            Vec::new(),
+            PartialBatchSelector::new_time_interval(),
+            Vec::new(),
+        );
 
         let filter = aggregator_filter(Arc::new(datastore), clock).unwrap();
 
@@ -3172,8 +3178,13 @@ mod tests {
 
         datastore.put_task(&task).await.unwrap();
 
-        let request =
-            AggregateInitializeReq::new_time_interval(task_id, random(), Vec::new(), Vec::new());
+        let request = AggregateInitializeReq::new(
+            task_id,
+            random(),
+            Vec::new(),
+            PartialBatchSelector::new_time_interval(),
+            Vec::new(),
+        );
 
         let filter = aggregator_filter(Arc::new(datastore), clock).unwrap();
 
@@ -3429,10 +3440,11 @@ mod tests {
             .await
             .unwrap();
 
-        let request = AggregateInitializeReq::new_time_interval(
+        let request = AggregateInitializeReq::new(
             task_id,
             random(),
             Vec::new(),
+            PartialBatchSelector::new_time_interval(),
             Vec::from([
                 report_share_0.clone(),
                 report_share_1.clone(),
@@ -3557,10 +3569,11 @@ mod tests {
             &hpke_key.0,
             &(),
         );
-        let request = AggregateInitializeReq::new_time_interval(
+        let request = AggregateInitializeReq::new(
             task_id,
             random(),
             AggregationParam(0).get_encoded(),
+            PartialBatchSelector::new_time_interval(),
             Vec::from([report_share.clone()]),
         );
 
@@ -3631,10 +3644,11 @@ mod tests {
             &hpke_key.0,
             &(),
         );
-        let request = AggregateInitializeReq::new_time_interval(
+        let request = AggregateInitializeReq::new(
             task_id,
             random(),
             AggregationParam(0).get_encoded(),
+            PartialBatchSelector::new_time_interval(),
             Vec::from([report_share.clone()]),
         );
 
@@ -3705,10 +3719,11 @@ mod tests {
             ),
         );
 
-        let request = AggregateInitializeReq::new_time_interval(
+        let request = AggregateInitializeReq::new(
             task_id,
             random(),
             AggregationParam(0).get_encoded(),
+            PartialBatchSelector::new_time_interval(),
             Vec::from([report_share.clone(), report_share]),
         );
 

--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -2543,8 +2543,8 @@ mod tests {
 
         let hpke_key = current_hpke_key(&task.hpke_keys);
         let report_metadata = ReportMetadata::new(
-            clock.now().sub(task.tolerable_clock_skew).unwrap(),
             random(),
+            clock.now().sub(task.tolerable_clock_skew).unwrap(),
             vec![],
         );
         let public_share = Vec::new(); // TODO(#473): fill out public_share once possible
@@ -2709,8 +2709,8 @@ mod tests {
         let bad_report = Report::new(
             *report.task_id(),
             ReportMetadata::new(
-                bad_report_time,
                 *report.metadata().nonce(),
+                bad_report_time,
                 report.metadata().extensions().to_vec(),
             ),
             Vec::new(), // TODO(#473): fill out public_share once possible
@@ -2769,11 +2769,11 @@ mod tests {
                 Report::new(
                     *report.task_id(),
                     ReportMetadata::new(
+                        random(),
                         clock
                             .now()
                             .to_batch_unit_interval_start(task.min_batch_duration)
                             .unwrap(),
-                        random(),
                         Vec::new(),
                     ),
                     Vec::new(), // TODO(#473): fill out public_share once possible
@@ -2993,12 +2993,12 @@ mod tests {
             Report::new(
                 *report.task_id(),
                 ReportMetadata::new(
+                    *report.metadata().nonce(),
                     aggregator
                         .clock
                         .now()
                         .add(task.tolerable_clock_skew)
                         .unwrap(),
-                    *report.metadata().nonce(),
                     report.metadata().extensions().to_vec(),
                 ),
                 Vec::new(), // TODO(#473): fill out public_share once possible
@@ -3025,6 +3025,7 @@ mod tests {
             Report::new(
                 *report.task_id(),
                 ReportMetadata::new(
+                    *report.metadata().nonce(),
                     aggregator
                         .clock
                         .now()
@@ -3032,7 +3033,6 @@ mod tests {
                         .unwrap()
                         .add(Duration::from_seconds(1))
                         .unwrap(),
-                    *report.metadata().nonce(),
                     report.metadata().extensions().to_vec(),
                 ),
                 Vec::new(), // TODO(#473): fill out public_share once possible
@@ -3261,11 +3261,11 @@ mod tests {
 
         // report_share_0 is a "happy path" report.
         let report_metadata_0 = ReportMetadata::new(
+            random(),
             clock
                 .now()
                 .to_batch_unit_interval_start(task.min_batch_duration)
                 .unwrap(),
-            random(),
             Vec::new(),
         );
         let input_share = run_vdaf(
@@ -3286,11 +3286,11 @@ mod tests {
 
         // report_share_1 fails decryption.
         let report_metadata_1 = ReportMetadata::new(
+            random(),
             clock
                 .now()
                 .to_batch_unit_interval_start(task.min_batch_duration)
                 .unwrap(),
-            random(),
             Vec::new(),
         );
         let encrypted_input_share = report_share_0.encrypted_input_share();
@@ -3309,11 +3309,11 @@ mod tests {
 
         // report_share_2 fails decoding.
         let report_metadata_2 = ReportMetadata::new(
+            random(),
             clock
                 .now()
                 .to_batch_unit_interval_start(task.min_batch_duration)
                 .unwrap(),
-            random(),
             Vec::new(),
         );
         let public_share_2 = Vec::new(); // TODO(#473): fill out public_share once possible
@@ -3328,11 +3328,11 @@ mod tests {
 
         // report_share_3 has an unknown HPKE config ID.
         let report_metadata_3 = ReportMetadata::new(
+            random(),
             clock
                 .now()
                 .to_batch_unit_interval_start(task.min_batch_duration)
                 .unwrap(),
-            random(),
             Vec::new(),
         );
         let wrong_hpke_config = loop {
@@ -3351,11 +3351,11 @@ mod tests {
 
         // report_share_4 has already been aggregated.
         let report_metadata_4 = ReportMetadata::new(
+            random(),
             clock
                 .now()
                 .to_batch_unit_interval_start(task.min_batch_duration)
                 .unwrap(),
-            random(),
             Vec::new(),
         );
         let input_share = run_vdaf(
@@ -3379,11 +3379,11 @@ mod tests {
             task.min_batch_duration.as_seconds() / 2,
         ));
         let report_metadata_5 = ReportMetadata::new(
+            random(),
             past_clock
                 .now()
                 .to_batch_unit_interval_start(task.min_batch_duration)
                 .unwrap(),
-            random(),
             Vec::new(),
         );
         let input_share = run_vdaf(
@@ -3530,11 +3530,11 @@ mod tests {
         let report_share = generate_helper_report_share::<dummy_vdaf::Vdaf>(
             task_id,
             &ReportMetadata::new(
+                random(),
                 clock
                     .now()
                     .to_batch_unit_interval_start(task.min_batch_duration)
                     .unwrap(),
-                random(),
                 Vec::new(),
             ),
             &hpke_key.0,
@@ -3601,11 +3601,11 @@ mod tests {
         let report_share = generate_helper_report_share::<dummy_vdaf::Vdaf>(
             task_id,
             &ReportMetadata::new(
+                random(),
                 clock
                     .now()
                     .to_batch_unit_interval_start(task.min_batch_duration)
                     .unwrap(),
-                random(),
                 Vec::new(),
             ),
             &hpke_key.0,
@@ -3669,8 +3669,8 @@ mod tests {
 
         let report_share = ReportShare::new(
             ReportMetadata::new(
-                Time::from_seconds_since_epoch(54321),
                 Nonce::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+                Time::from_seconds_since_epoch(54321),
                 Vec::new(),
             ),
             Vec::new(), // TODO(#473): fill out public_share when possible
@@ -3749,11 +3749,11 @@ mod tests {
 
         // report_share_0 is a "happy path" report.
         let report_metadata_0 = ReportMetadata::new(
+            random(),
             clock
                 .now()
                 .to_batch_unit_interval_start(task.min_batch_duration)
                 .unwrap(),
-            random(),
             Vec::new(),
         );
         let transcript_0 = run_vdaf(
@@ -3783,11 +3783,11 @@ mod tests {
 
         // report_share_1 is omitted by the leader's request.
         let report_metadata_1 = ReportMetadata::new(
+            random(),
             clock
                 .now()
                 .to_batch_unit_interval_start(task.min_batch_duration)
                 .unwrap(),
-            random(),
             Vec::new(),
         );
         let transcript_1 = run_vdaf(
@@ -3810,11 +3810,11 @@ mod tests {
             task.min_batch_duration.as_seconds() / 2,
         ));
         let report_metadata_2 = ReportMetadata::new(
+            random(),
             past_clock
                 .now()
                 .to_batch_unit_interval_start(task.min_batch_duration)
                 .unwrap(),
-            random(),
             Vec::new(),
         );
         let transcript_2 = run_vdaf(
@@ -4072,11 +4072,11 @@ mod tests {
 
         // report_share_0 is a "happy path" report.
         let report_metadata_0 = ReportMetadata::new(
+            random(),
             first_batch_unit_interval_clock
                 .now()
                 .to_batch_unit_interval_start(task.min_batch_duration)
                 .unwrap(),
-            random(),
             Vec::new(),
         );
         let transcript_0 = run_vdaf(
@@ -4099,11 +4099,11 @@ mod tests {
         // report_share_1 is another "happy path" report to exercise in-memory accumulation of
         // output shares
         let report_metadata_1 = ReportMetadata::new(
+            random(),
             first_batch_unit_interval_clock
                 .now()
                 .to_batch_unit_interval_start(task.min_batch_duration)
                 .unwrap(),
-            random(),
             Vec::new(),
         );
         let transcript_1 = run_vdaf(
@@ -4125,11 +4125,11 @@ mod tests {
 
         // report share 2 aggregates successfully, but into a distinct batch unit aggregation.
         let report_metadata_2 = ReportMetadata::new(
+            random(),
             second_batch_unit_interval_clock
                 .now()
                 .to_batch_unit_interval_start(task.min_batch_duration)
                 .unwrap(),
-            random(),
             Vec::new(),
         );
         let transcript_2 = run_vdaf(
@@ -4332,11 +4332,11 @@ mod tests {
         // batch_unit_aggregations rows created earlier.
         // report_share_3 gets aggreated into the first batch unit interval.
         let report_metadata_3 = ReportMetadata::new(
+            random(),
             first_batch_unit_interval_clock
                 .now()
                 .to_batch_unit_interval_start(task.min_batch_duration)
                 .unwrap(),
-            random(),
             Vec::new(),
         );
         let transcript_3 = run_vdaf(
@@ -4358,11 +4358,11 @@ mod tests {
 
         // report_share_4 gets aggregated into the second batch unit interval
         let report_metadata_4 = ReportMetadata::new(
+            random(),
             second_batch_unit_interval_clock
                 .now()
                 .to_batch_unit_interval_start(task.min_batch_duration)
                 .unwrap(),
-            random(),
             Vec::new(),
         );
         let transcript_4 = run_vdaf(
@@ -4384,11 +4384,11 @@ mod tests {
 
         // report share 5 also gets aggregated into the second batch unit interval
         let report_metadata_5 = ReportMetadata::new(
+            random(),
             second_batch_unit_interval_clock
                 .now()
                 .to_batch_unit_interval_start(task.min_batch_duration)
                 .unwrap(),
-            random(),
             Vec::new(),
         );
         let transcript_5 = run_vdaf(
@@ -4601,8 +4601,8 @@ mod tests {
         let task_id = random();
         let aggregation_job_id = random();
         let report_metadata = ReportMetadata::new(
-            Time::from_seconds_since_epoch(54321),
             Nonce::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+            Time::from_seconds_since_epoch(54321),
             Vec::new(),
         );
         let task = Task::new_dummy(task_id, VdafInstance::Fake, Role::Helper);
@@ -4710,8 +4710,8 @@ mod tests {
         let task_id = random();
         let aggregation_job_id = random();
         let report_metadata = ReportMetadata::new(
-            Time::from_seconds_since_epoch(54321),
             Nonce::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+            Time::from_seconds_since_epoch(54321),
             vec![],
         );
         let task = Task::new_dummy(task_id, VdafInstance::FakeFailsPrepStep, Role::Helper);
@@ -4867,8 +4867,8 @@ mod tests {
         let task_id = random();
         let aggregation_job_id = random();
         let report_metadata = ReportMetadata::new(
-            Time::from_seconds_since_epoch(54321),
             Nonce::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+            Time::from_seconds_since_epoch(54321),
             vec![],
         );
         let task = Task::new_dummy(task_id, VdafInstance::Fake, Role::Helper);
@@ -4978,13 +4978,13 @@ mod tests {
         let task_id = random();
         let aggregation_job_id = random();
         let report_metadata_0 = ReportMetadata::new(
-            Time::from_seconds_since_epoch(54321),
             Nonce::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+            Time::from_seconds_since_epoch(54321),
             vec![],
         );
         let report_metadata_1 = ReportMetadata::new(
-            Time::from_seconds_since_epoch(54321),
             Nonce::from([16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]),
+            Time::from_seconds_since_epoch(54321),
             vec![],
         );
 
@@ -5132,8 +5132,8 @@ mod tests {
         let task_id = random();
         let aggregation_job_id = random();
         let report_metadata = ReportMetadata::new(
-            Time::from_seconds_since_epoch(54321),
             Nonce::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+            Time::from_seconds_since_epoch(54321),
             vec![],
         );
 

--- a/janus_server/src/aggregator/aggregate_share.rs
+++ b/janus_server/src/aggregator/aggregate_share.rs
@@ -522,11 +522,11 @@ mod tests {
                     .await?;
 
                     let report_metadata = ReportMetadata::new(
+                        random(),
                         clock
                             .now()
                             .to_batch_unit_interval_start(task.min_batch_duration)
                             .unwrap(),
-                        random(),
                         Vec::new(),
                     );
                     tx.put_client_report(&Report::new(
@@ -752,11 +752,11 @@ mod tests {
                     .await?;
 
                     let report_metadata = ReportMetadata::new(
+                        random(),
                         clock
                             .now()
                             .to_batch_unit_interval_start(task.min_batch_duration)
                             .unwrap(),
-                        random(),
                         Vec::new(),
                     );
                     tx.put_client_report(&Report::new(
@@ -908,11 +908,11 @@ mod tests {
                     // can be picked up and the anti-replay check has something to check.
                     for i in 0..10 {
                         let report_metadata = ReportMetadata::new(
+                            random(),
                             clock
                                 .now()
                                 .to_batch_unit_interval_start(task.min_batch_duration)
                                 .unwrap(),
-                            random(),
                             Vec::new(),
                         );
                         tx.put_client_report(&Report::new(

--- a/janus_server/src/aggregator/aggregate_share.rs
+++ b/janus_server/src/aggregator/aggregate_share.rs
@@ -17,7 +17,7 @@ use http::header::CONTENT_TYPE;
 #[cfg(test)]
 use janus_core::test_util::dummy_vdaf;
 use janus_core::{
-    message::{query_type::TimeInterval, Duration, Interval, NonceChecksum, Role},
+    message::{query_type::TimeInterval, Duration, Interval, ReportIdChecksum, Role},
     task::DAP_AUTH_HEADER,
     time::Clock,
 };
@@ -63,7 +63,7 @@ impl CollectJobDriver {
 
     /// Step the provided collect job, for which a lease should have been acquired (though this
     /// should be idempotent). If the collect job runs to completion, the leader share, helper
-    /// share, report count and report nonce checksum will be written to the `collect_jobs` table,
+    /// share, report count and report ID checksum will be written to the `collect_jobs` table,
     /// and a subsequent request to the collect job URI will yield the aggregate shares. The collect
     /// job's lease is released, though it won't matter since the job will no longer be eligible to
     /// be run.
@@ -317,7 +317,7 @@ impl CollectJobDriver {
 pub(crate) async fn compute_aggregate_share<const L: usize, A: vdaf::Aggregator<L>>(
     task: &Task,
     batch_unit_aggregations: &[BatchUnitAggregation<L, A>],
-) -> Result<(A::AggregateShare, u64, NonceChecksum), Error>
+) -> Result<(A::AggregateShare, u64, ReportIdChecksum), Error>
 where
     Vec<u8>: for<'a> From<&'a A::AggregateShare>,
     for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Display,
@@ -344,7 +344,7 @@ where
     // In either case, we go ahead and service the aggregate share request with whatever batch unit
     // aggregations are available now.
     let mut total_report_count = 0;
-    let mut total_checksum = NonceChecksum::default();
+    let mut total_checksum = ReportIdChecksum::default();
     let mut total_aggregate_share: Option<A::AggregateShare> = None;
 
     for batch_unit_aggregation in batch_unit_aggregations {
@@ -544,7 +544,7 @@ mod tests {
                         aggregation_job_id,
                         task_id,
                         time: *report_metadata.time(),
-                        nonce: *report_metadata.nonce(),
+                        report_id: *report_metadata.report_id(),
                         ord: 0,
                         state: ReportAggregationState::Finished(OutputShare()),
                     })
@@ -589,7 +589,7 @@ mod tests {
                     aggregation_param,
                     aggregate_share: AggregateShare(0),
                     report_count: 5,
-                    checksum: NonceChecksum::get_decoded(&[3; 32]).unwrap(),
+                    checksum: ReportIdChecksum::get_decoded(&[3; 32]).unwrap(),
                 })
                 .await?;
 
@@ -602,7 +602,7 @@ mod tests {
                     aggregation_param,
                     aggregate_share: AggregateShare(0),
                     report_count: 5,
-                    checksum: NonceChecksum::get_decoded(&[2; 32]).unwrap(),
+                    checksum: ReportIdChecksum::get_decoded(&[2; 32]).unwrap(),
                 })
                 .await?;
 
@@ -617,7 +617,7 @@ mod tests {
             BatchSelector::new_time_interval(batch_interval),
             aggregation_param.get_encoded(),
             10,
-            NonceChecksum::get_decoded(&[3 ^ 2; 32]).unwrap(),
+            ReportIdChecksum::get_decoded(&[3 ^ 2; 32]).unwrap(),
         );
 
         // Simulate helper failing to service the aggregate share request.
@@ -774,7 +774,7 @@ mod tests {
                         aggregation_job_id,
                         task_id,
                         time: *report_metadata.time(),
-                        nonce: *report_metadata.nonce(),
+                        report_id: *report_metadata.report_id(),
                         ord: 0,
                         state: ReportAggregationState::Finished(OutputShare()),
                     })
@@ -789,7 +789,7 @@ mod tests {
                         aggregation_param,
                         aggregate_share: AggregateShare(0),
                         report_count: 5,
-                        checksum: NonceChecksum::get_decoded(&[3; 32]).unwrap(),
+                        checksum: ReportIdChecksum::get_decoded(&[3; 32]).unwrap(),
                     })
                     .await?;
                     tx.put_batch_unit_aggregation(&BatchUnitAggregation::<
@@ -801,7 +801,7 @@ mod tests {
                         aggregation_param,
                         aggregate_share: AggregateShare(0),
                         report_count: 5,
-                        checksum: NonceChecksum::get_decoded(&[2; 32]).unwrap(),
+                        checksum: ReportIdChecksum::get_decoded(&[2; 32]).unwrap(),
                     })
                     .await?;
 
@@ -929,7 +929,7 @@ mod tests {
                             aggregation_job_id,
                             task_id,
                             time: *report_metadata.time(),
-                            nonce: *report_metadata.nonce(),
+                            report_id: *report_metadata.report_id(),
                             ord: i,
                             state: ReportAggregationState::Finished(OutputShare()),
                         })
@@ -945,7 +945,7 @@ mod tests {
                         aggregation_param,
                         aggregate_share: AggregateShare(0),
                         report_count: 10,
-                        checksum: NonceChecksum::get_decoded(&[0xff; 32]).unwrap(),
+                        checksum: ReportIdChecksum::get_decoded(&[0xff; 32]).unwrap(),
                     })
                     .await?;
 

--- a/janus_server/src/aggregator/aggregation_job_driver.rs
+++ b/janus_server/src/aggregator/aggregation_job_driver.rs
@@ -914,11 +914,11 @@ mod tests {
         ];
 
         let report_metadata = ReportMetadata::new(
+            random(),
             clock
                 .now()
                 .to_batch_unit_interval_start(task.min_batch_duration)
                 .unwrap(),
-            random(),
             Vec::new(),
         );
         let verify_key: VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH> =
@@ -1121,11 +1121,11 @@ mod tests {
         ];
 
         let report_metadata = ReportMetadata::new(
+            random(),
             clock
                 .now()
                 .to_batch_unit_interval_start(task.min_batch_duration)
                 .unwrap(),
-            random(),
             Vec::new(),
         );
         let verify_key: VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH> =
@@ -1322,11 +1322,11 @@ mod tests {
             Url::parse(&mockito::server_url()).unwrap(),
         ];
         let report_metadata = ReportMetadata::new(
+            random(),
             clock
                 .now()
                 .to_batch_unit_interval_start(task.min_batch_duration)
                 .unwrap(),
-            random(),
             Vec::new(),
         );
         let verify_key: VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH> =
@@ -1548,11 +1548,11 @@ mod tests {
             Url::parse(&mockito::server_url()).unwrap(),
         ];
         let report_metadata = ReportMetadata::new(
+            random(),
             clock
                 .now()
                 .to_batch_unit_interval_start(task.min_batch_duration)
                 .unwrap(),
-            random(),
             Vec::new(),
         );
         let verify_key: VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH> =
@@ -1733,11 +1733,11 @@ mod tests {
 
         let vdaf = Prio3::new_aes128_count(2).unwrap();
         let report_metadata = ReportMetadata::new(
+            random(),
             clock
                 .now()
                 .to_batch_unit_interval_start(task.min_batch_duration)
                 .unwrap(),
-            random(),
             Vec::new(),
         );
         let transcript = run_vdaf(

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -17,8 +17,8 @@ use futures::try_join;
 use janus_core::{
     hpke::HpkePrivateKey,
     message::{
-        query_type::TimeInterval, Duration, Extension, HpkeCiphertext, HpkeConfig, Interval, Nonce,
-        NonceChecksum, Report, ReportMetadata, Role, TaskId, Time,
+        query_type::TimeInterval, Duration, Extension, HpkeCiphertext, HpkeConfig, Interval,
+        Report, ReportId, ReportIdChecksum, ReportMetadata, Role, TaskId, Time,
     },
     task::AuthenticationToken,
     time::Clock,
@@ -39,7 +39,7 @@ use tokio_postgres::{error::SqlState, row::RowIndex, IsolationLevel, Row};
 use url::Url;
 use uuid::Uuid;
 
-// TODO(#533): update indices used by queries looking up reports by (task_id, nonce) to drop nonce_time
+// TODO(#533): update indices used by queries looking up reports by (task_id, report_id) to drop nonce_time
 // TODO(#196): retry network-related & other transient failures once we know what they look like
 
 /// Datastore represents a datastore for Janus, with support for transactional reads and writes.
@@ -718,7 +718,7 @@ impl<C: Clock> Transaction<'_, C> {
     pub async fn get_client_report(
         &self,
         task_id: TaskId,
-        nonce: Nonce,
+        report_id: ReportId,
     ) -> Result<Option<Report>, Error> {
         let stmt = self
             .tx
@@ -734,7 +734,7 @@ impl<C: Clock> Transaction<'_, C> {
                 &stmt,
                 &[
                     /* task_id */ &task_id.as_ref(),
-                    /* nonce_rand */ &nonce.as_ref(),
+                    /* nonce_rand */ &report_id.as_ref(),
                 ],
             )
             .await?
@@ -751,7 +751,7 @@ impl<C: Clock> Transaction<'_, C> {
 
                 Ok(Report::new(
                     task_id,
-                    ReportMetadata::new(nonce, time, extensions),
+                    ReportMetadata::new(report_id, time, extensions),
                     Vec::new(), // TODO(#473): fill out public_share once possible
                     input_shares,
                 ))
@@ -759,18 +759,18 @@ impl<C: Clock> Transaction<'_, C> {
             .transpose()
     }
 
-    /// `get_unaggregated_client_report_nonces_for_task` returns some nonces corresponding to
+    /// `get_unaggregated_client_report_ids_for_task` returns some report IDs corresponding to
     /// unaggregated client reports for the task identified by the given task ID.
     ///
     /// This should only be used with VDAFs that have an aggregation parameter of the unit type.
     /// It relies on this assumption to find relevant reports without consulting collect jobs. For
     /// VDAFs that do have a different aggregation parameter,
-    /// `get_unaggregated_client_report_nonces_by_collect_for_task` should be used instead.
+    /// `get_unaggregated_client_report_ids_by_collect_for_task` should be used instead.
     #[tracing::instrument(skip(self), err)]
-    pub async fn get_unaggregated_client_report_nonces_for_task(
+    pub async fn get_unaggregated_client_report_ids_for_task(
         &self,
         task_id: TaskId,
-    ) -> Result<Vec<(Time, Nonce)>, Error> {
+    ) -> Result<Vec<(Time, ReportId)>, Error> {
         // We choose to return the newest client reports first (LIFO). The goal is to maintain
         // throughput even if we begin to fall behind enough that reports are too old to be
         // aggregated.
@@ -795,33 +795,33 @@ impl<C: Clock> Transaction<'_, C> {
         rows.into_iter()
             .map(|row| {
                 let time = Time::from_naive_date_time(row.get("nonce_time"));
-                let nonce_bytes: [u8; Nonce::LEN] = row
+                let report_id_bytes: [u8; ReportId::LEN] = row
                     .get::<_, Vec<u8>>("nonce_rand")
                     .try_into()
                     .map_err(|err| {
                         Error::DbState(format!("couldn't convert nonce_rand value: {err:?}"))
                     })?;
-                let nonce = Nonce::from(nonce_bytes);
-                Ok((time, nonce))
+                let report_id = ReportId::from(report_id_bytes);
+                Ok((time, report_id))
             })
             .collect::<Result<Vec<_>, Error>>()
     }
 
-    /// `get_unaggregated_client_report_nonces_by_collect_for_task` returns pairs of nonces and
+    /// `get_unaggregated_client_report_ids_by_collect_for_task` returns pairs of report IDs and
     /// aggregation parameters, corresponding to client reports that have not yet been aggregated,
     /// or not aggregated with a certain aggregation parameter, and for which there are collect
     /// jobs, for a given task.
     ///
     /// This should only be used with VDAFs with a non-unit type aggregation parameter. If a VDAF
     /// has the unit type as its aggregation parameter, then
-    /// `get_unaggregated_client_report_nonces_for_task` should be used instead. In such cases, it
+    /// `get_unaggregated_client_report_ids_for_task` should be used instead. In such cases, it
     /// is not necessary to wait for a collect job to arrive before preparing reports.
     #[cfg(test)]
     #[tracing::instrument(skip(self), err)]
-    pub async fn get_unaggregated_client_report_nonces_by_collect_for_task<const L: usize, A>(
+    pub async fn get_unaggregated_client_report_ids_by_collect_for_task<const L: usize, A>(
         &self,
         task_id: TaskId,
-    ) -> Result<Vec<(Time, Nonce, A::AggregationParam)>, Error>
+    ) -> Result<Vec<(Time, ReportId, A::AggregationParam)>, Error>
     where
         A: vdaf::Aggregator<L> + VdafHasAggregationParameter,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
@@ -857,24 +857,24 @@ impl<C: Clock> Transaction<'_, C> {
         rows.into_iter()
             .map(|row| {
                 let time = Time::from_naive_date_time(row.get("nonce_time"));
-                let nonce_bytes: [u8; Nonce::LEN] = row
+                let report_id_bytes: [u8; ReportId::LEN] = row
                     .get::<_, Vec<u8>>("nonce_rand")
                     .try_into()
                     .map_err(|err| {
                         Error::DbState(format!("couldn't convert nonce_rand value: {0:?}", err))
                     })?;
-                let nonce = Nonce::from(nonce_bytes);
+                let report_id = ReportId::from(report_id_bytes);
                 let agg_param = A::AggregationParam::get_decoded(row.get("aggregation_param"))?;
-                Ok((time, nonce, agg_param))
+                Ok((time, report_id, agg_param))
             })
-            .collect::<Result<Vec<(Time, Nonce, A::AggregationParam)>, Error>>()
+            .collect::<Result<Vec<(Time, ReportId, A::AggregationParam)>, Error>>()
     }
 
     /// put_client_report stores a client report.
     #[tracing::instrument(skip(self), err)]
     pub async fn put_client_report(&self, report: &Report) -> Result<(), Error> {
         let time = report.metadata().time();
-        let nonce = report.metadata().nonce();
+        let report_id = report.metadata().report_id();
 
         let mut encoded_extensions = Vec::new();
         encode_u16_items(&mut encoded_extensions, &(), report.metadata().extensions());
@@ -896,7 +896,7 @@ impl<C: Clock> Transaction<'_, C> {
                 &[
                     /* task_id */ &&report.task_id().get_encoded(),
                     /* nonce_time */ &time.as_naive_date_time(),
-                    /* nonce_rand */ &nonce.as_ref(),
+                    /* nonce_rand */ &report_id.as_ref(),
                     /* extensions */ &encoded_extensions,
                     /* input_shares */ &encoded_input_shares,
                 ],
@@ -906,14 +906,14 @@ impl<C: Clock> Transaction<'_, C> {
     }
 
     /// check_report_share_exists checks if a report share has been recorded in the datastore, given
-    /// its associated task ID & nonce.
+    /// its associated task ID & report ID.
     ///
     /// This method is intended for use by aggregators acting in the helper role.
     #[tracing::instrument(skip(self), err)]
     pub async fn check_report_share_exists(
         &self,
         task_id: TaskId,
-        nonce: Nonce,
+        report_id: ReportId,
     ) -> Result<bool, Error> {
         let stmt = self
             .tx
@@ -929,7 +929,7 @@ impl<C: Clock> Transaction<'_, C> {
                 &stmt,
                 &[
                     /* task_id */ &task_id.as_ref(),
-                    /* nonce_rand */ &nonce.as_ref(),
+                    /* nonce_rand */ &report_id.as_ref(),
                 ],
             )
             .await
@@ -961,7 +961,7 @@ impl<C: Clock> Transaction<'_, C> {
                 &[
                     /* task_id */ &task_id.get_encoded(),
                     /* nonce_time */ &report_share.metadata().time().as_naive_date_time(),
-                    /* nonce_rand */ &report_share.metadata().nonce().as_ref(),
+                    /* nonce_rand */ &report_share.metadata().report_id().as_ref(),
                 ],
             )
             .await?;
@@ -1220,7 +1220,7 @@ impl<C: Clock> Transaction<'_, C> {
         role: Role,
         task_id: TaskId,
         aggregation_job_id: AggregationJobId,
-        nonce: Nonce,
+        report_id: ReportId,
     ) -> Result<Option<ReportAggregation<L, A>>, Error>
     where
         for<'a> A::PrepareState: ParameterizedDecode<(&'a A, usize)>,
@@ -1246,7 +1246,7 @@ impl<C: Clock> Transaction<'_, C> {
                 &[
                     /* aggregation_job_id */ &aggregation_job_id.as_ref(),
                     /* task_id */ &task_id.as_ref(),
-                    /* nonce_rand */ &nonce.as_ref(),
+                    /* nonce_rand */ &report_id.as_ref(),
                 ],
             )
             .await?
@@ -1328,7 +1328,7 @@ impl<C: Clock> Transaction<'_, C> {
                     /* aggregation_job_id */
                     &report_aggregation.aggregation_job_id.as_ref(),
                     /* task_id */ &report_aggregation.task_id.as_ref(),
-                    /* nonce_rand */ &report_aggregation.nonce.as_ref(),
+                    /* nonce_rand */ &report_aggregation.report_id.as_ref(),
                     /* ord */ &report_aggregation.ord,
                     /* state */ &report_aggregation.state.state_code(),
                     /* prep_state */ &encoded_state_values.prep_state,
@@ -1377,7 +1377,7 @@ impl<C: Clock> Transaction<'_, C> {
                         /* aggregation_job_id */
                         &report_aggregation.aggregation_job_id.as_ref(),
                         /* task_id */ &report_aggregation.task_id.as_ref(),
-                        /* nonce_rand */ &report_aggregation.nonce.as_ref(),
+                        /* nonce_rand */ &report_aggregation.report_id.as_ref(),
                     ],
                 )
                 .await?,
@@ -1685,7 +1685,7 @@ WITH updated as (
         -- Join on report aggregations with matching aggregation job ID
         INNER JOIN report_aggregations
             ON report_aggregations.aggregation_job_id = aggregation_jobs.id
-        -- Join on reports whose nonce falls within the collect job batch interval and which are
+        -- Join on reports whose ID falls within the collect job batch interval and which are
         -- included in an aggregation job
         INNER JOIN client_reports
             ON client_reports.id = report_aggregations.client_report_id
@@ -1983,7 +1983,7 @@ ORDER BY id DESC
                     Time::from_naive_date_time(row.get("unit_interval_start"));
                 let aggregate_share = row.get_bytea_and_convert("aggregate_share")?;
                 let report_count = row.get_bigint_and_convert("report_count")?;
-                let checksum = NonceChecksum::get_decoded(row.get("checksum"))?;
+                let checksum = ReportIdChecksum::get_decoded(row.get("checksum"))?;
 
                 Ok(BatchUnitAggregation {
                     task_id,
@@ -2148,7 +2148,7 @@ ORDER BY id DESC
     {
         let helper_aggregate_share = row.get_bytea_and_convert("helper_aggregate_share")?;
         let report_count = row.get_bigint_and_convert("report_count")?;
-        let checksum = NonceChecksum::get_decoded(row.get("checksum"))?;
+        let checksum = ReportIdChecksum::get_decoded(row.get("checksum"))?;
 
         Ok(AggregateShareJob {
             task_id,
@@ -2226,11 +2226,11 @@ where
     for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
 {
     let time = Time::from_naive_date_time(row.get("nonce_time"));
-    let nonce_bytes: [u8; Nonce::LEN] = row
+    let report_id_bytes: [u8; ReportId::LEN] = row
         .get::<_, Vec<u8>>("nonce_rand")
         .try_into()
         .map_err(|err| Error::DbState(format!("couldn't convert nonce_rand value: {err:?}")))?;
-    let nonce = Nonce::from(nonce_bytes);
+    let report_id = ReportId::from(report_id_bytes);
     let ord: i64 = row.get("ord");
     let state: ReportAggregationStateCode = row.get("state");
     let prep_state_bytes: Option<Vec<u8>> = row.get("prep_state");
@@ -2291,7 +2291,7 @@ where
         aggregation_job_id,
         task_id,
         time,
-        nonce,
+        report_id,
         ord,
         state: agg_state,
     })
@@ -2546,7 +2546,9 @@ pub mod models {
         task::{self, VdafInstance},
     };
     use derivative::Derivative;
-    use janus_core::message::{HpkeCiphertext, Interval, Nonce, NonceChecksum, Role, TaskId, Time};
+    use janus_core::message::{
+        HpkeCiphertext, Interval, ReportId, ReportIdChecksum, Role, TaskId, Time,
+    };
     use postgres_types::{FromSql, ToSql};
     use prio::{codec::Encode, vdaf};
     use uuid::Uuid;
@@ -2717,7 +2719,7 @@ pub mod models {
         pub aggregation_job_id: AggregationJobId,
         pub task_id: TaskId,
         pub time: Time,
-        pub nonce: Nonce,
+        pub report_id: ReportId,
         pub ord: i64,
         pub state: ReportAggregationState<L, A>,
     }
@@ -2733,7 +2735,7 @@ pub mod models {
             self.aggregation_job_id == other.aggregation_job_id
                 && self.task_id == other.task_id
                 && self.time == other.time
-                && self.nonce == other.nonce
+                && self.report_id == other.report_id
                 && self.ord == other.ord
                 && self.state == other.state
         }
@@ -2902,7 +2904,7 @@ pub mod models {
         pub(crate) report_count: u64,
         /// Checksum over the aggregated report shares, as described in §4.4.4.3.
         #[derivative(Debug = "ignore")]
-        pub(crate) checksum: NonceChecksum,
+        pub(crate) checksum: ReportIdChecksum,
     }
 
     impl<const L: usize, A: vdaf::Aggregator<L>> PartialEq for BatchUnitAggregation<L, A>
@@ -3055,7 +3057,7 @@ pub mod models {
         pub(crate) report_count: u64,
         /// Checksum over the aggregated report shares, as described in §4.4.4.3.
         #[derivative(Debug = "ignore")]
-        pub(crate) checksum: NonceChecksum,
+        pub(crate) checksum: ReportIdChecksum,
     }
 
     impl<const L: usize, A: vdaf::Aggregator<L>> PartialEq for AggregateShareJob<L, A>
@@ -3450,7 +3452,7 @@ mod tests {
         let report = Report::new(
             random(),
             ReportMetadata::new(
-                Nonce::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+                ReportId::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
                 Time::from_seconds_since_epoch(12345),
                 vec![
                     Extension::new(ExtensionType::Tbd, Vec::from("extension_data_0")),
@@ -3490,8 +3492,8 @@ mod tests {
         let retrieved_report = ds
             .run_tx(|tx| {
                 let task_id = *report.task_id();
-                let nonce = *report.metadata().nonce();
-                Box::pin(async move { tx.get_client_report(task_id, nonce).await })
+                let report_id = *report.metadata().report_id();
+                Box::pin(async move { tx.get_client_report(task_id, report_id).await })
             })
             .await
             .unwrap();
@@ -3509,7 +3511,7 @@ mod tests {
                 Box::pin(async move {
                     tx.get_client_report(
                         random(),
-                        Nonce::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+                        ReportId::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
                     )
                     .await
                 })
@@ -3521,7 +3523,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_unaggregated_client_report_nonces_for_task() {
+    async fn get_unaggregated_client_report_ids_for_task() {
         install_test_trace_subscriber();
         let (ds, _db_handle) = ephemeral_datastore(MockClock::default()).await;
 
@@ -3606,7 +3608,7 @@ mod tests {
                         aggregation_job_id,
                         task_id,
                         time: *aggregated_report.metadata().time(),
-                        nonce: *aggregated_report.metadata().nonce(),
+                        report_id: *aggregated_report.metadata().report_id(),
                         ord: 0,
                         state: ReportAggregationState::<
                             PRIO3_AES128_VERIFY_KEY_LENGTH,
@@ -3624,7 +3626,7 @@ mod tests {
         let got_reports = HashSet::from_iter(
             ds.run_tx(|tx| {
                 Box::pin(async move {
-                    tx.get_unaggregated_client_report_nonces_for_task(task_id)
+                    tx.get_unaggregated_client_report_ids_for_task(task_id)
                         .await
                 })
             })
@@ -3637,18 +3639,18 @@ mod tests {
             HashSet::from([
                 (
                     *first_unaggregated_report.metadata().time(),
-                    *first_unaggregated_report.metadata().nonce()
+                    *first_unaggregated_report.metadata().report_id()
                 ),
                 (
                     *second_unaggregated_report.metadata().time(),
-                    *second_unaggregated_report.metadata().nonce()
+                    *second_unaggregated_report.metadata().report_id()
                 ),
             ]),
         );
     }
 
     #[tokio::test]
-    async fn get_unaggregated_client_report_nonces_with_agg_param_for_task() {
+    async fn get_unaggregated_client_report_ids_with_agg_param_for_task() {
         install_test_trace_subscriber();
         let (ds, _db_handle) = ephemeral_datastore(MockClock::default()).await;
 
@@ -3733,7 +3735,7 @@ mod tests {
         let got_reports = ds
             .run_tx(|tx| {
                 Box::pin(async move {
-                    tx.get_unaggregated_client_report_nonces_by_collect_for_task::<VERIFY_KEY_LENGTH, dummy_vdaf::Vdaf>(task_id)
+                    tx.get_unaggregated_client_report_ids_by_collect_for_task::<VERIFY_KEY_LENGTH, dummy_vdaf::Vdaf>(task_id)
                         .await
                 })
             })
@@ -3744,7 +3746,7 @@ mod tests {
         // Add collect jobs, and mark one report as having already been aggregated once.
         ds.run_tx(|tx| {
             let aggregated_report_time = *aggregated_report.metadata().time();
-            let aggregated_report_nonce = *aggregated_report.metadata().nonce();
+            let aggregated_report_id = *aggregated_report.metadata().report_id();
             Box::pin(async move {
                 tx.put_collect_job(
                     task_id,
@@ -3792,7 +3794,7 @@ mod tests {
                         aggregation_job_id,
                         task_id,
                         time: aggregated_report_time,
-                        nonce: aggregated_report_nonce,
+                        report_id: aggregated_report_id,
                         ord: 0,
                         state: ReportAggregationState::Start,
                     },
@@ -3808,7 +3810,7 @@ mod tests {
         let mut got_reports = ds
             .run_tx(|tx| {
                 Box::pin(async move {
-                    tx.get_unaggregated_client_report_nonces_by_collect_for_task::<VERIFY_KEY_LENGTH, dummy_vdaf::Vdaf>(task_id)
+                    tx.get_unaggregated_client_report_ids_by_collect_for_task::<VERIFY_KEY_LENGTH, dummy_vdaf::Vdaf>(task_id)
                         .await
                 })
             })
@@ -3818,27 +3820,27 @@ mod tests {
         let mut expected_reports = Vec::from([
             (
                 *first_unaggregated_report.metadata().time(),
-                *first_unaggregated_report.metadata().nonce(),
+                *first_unaggregated_report.metadata().report_id(),
                 AggregationParam(0),
             ),
             (
                 *first_unaggregated_report.metadata().time(),
-                *first_unaggregated_report.metadata().nonce(),
+                *first_unaggregated_report.metadata().report_id(),
                 AggregationParam(1),
             ),
             (
                 *second_unaggregated_report.metadata().time(),
-                *second_unaggregated_report.metadata().nonce(),
+                *second_unaggregated_report.metadata().report_id(),
                 AggregationParam(0),
             ),
             (
                 *second_unaggregated_report.metadata().time(),
-                *second_unaggregated_report.metadata().nonce(),
+                *second_unaggregated_report.metadata().report_id(),
                 AggregationParam(1),
             ),
             (
                 *aggregated_report.metadata().time(),
-                *aggregated_report.metadata().nonce(),
+                *aggregated_report.metadata().report_id(),
                 AggregationParam(1),
             ),
         ]);
@@ -3880,7 +3882,7 @@ mod tests {
         let mut got_reports = ds
             .run_tx(|tx| {
                 Box::pin(async move {
-                    tx.get_unaggregated_client_report_nonces_by_collect_for_task::<VERIFY_KEY_LENGTH, dummy_vdaf::Vdaf>(task_id)
+                    tx.get_unaggregated_client_report_ids_by_collect_for_task::<VERIFY_KEY_LENGTH, dummy_vdaf::Vdaf>(task_id)
                         .await
                 })
             })
@@ -3898,7 +3900,7 @@ mod tests {
         let task_id = random();
         let report_share = ReportShare::new(
             ReportMetadata::new(
-                Nonce::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+                ReportId::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
                 Time::from_seconds_since_epoch(12345),
                 Vec::from([
                     Extension::new(ExtensionType::Tbd, Vec::from("extension_data_0")),
@@ -3924,7 +3926,7 @@ mod tests {
                     ))
                     .await?;
                     let report_share_exists = tx
-                        .check_report_share_exists(task_id, *report_share.metadata().nonce())
+                        .check_report_share_exists(task_id, *report_share.metadata().report_id())
                         .await?;
                     tx.put_report_share(task_id, &report_share).await?;
                     Ok(report_share_exists)
@@ -3938,10 +3940,10 @@ mod tests {
             .run_tx(|tx| {
                 let report_share_metadata = report_share.metadata().clone();
                 Box::pin(async move {
-                    let report_share_exists = tx.check_report_share_exists(task_id, *report_share_metadata.nonce()).await?;
+                    let report_share_exists = tx.check_report_share_exists(task_id, *report_share_metadata.report_id()).await?;
 
                     let time = report_share_metadata.time();
-                    let nonce = report_share_metadata.nonce();
+                    let report_id = report_share_metadata.report_id();
                     let row = tx
                         .tx
                         .query_one(
@@ -3950,7 +3952,7 @@ mod tests {
                             WHERE nonce_time = $1 AND nonce_rand = $2",
                             &[
                                 /* nonce_time */ &time.as_naive_date_time(),
-                                /* nonce_rand */ &nonce.as_ref()
+                                /* nonce_rand */ &report_id.as_ref()
                             ],
                         )
                         .await?;
@@ -4451,7 +4453,7 @@ mod tests {
             let task_id = random();
             let aggregation_job_id = random();
             let time = Time::from_seconds_since_epoch(12345);
-            let nonce = Nonce::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+            let report_id = ReportId::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
 
             let report_aggregation = ds
                 .run_tx(|tx| {
@@ -4476,7 +4478,7 @@ mod tests {
                         tx.put_report_share(
                             task_id,
                             &ReportShare::new(
-                                ReportMetadata::new(nonce, time, Vec::new()),
+                                ReportMetadata::new(report_id, time, Vec::new()),
                                 Vec::from("public_share"),
                                 HpkeCiphertext::new(
                                     HpkeConfigId::from(12),
@@ -4491,7 +4493,7 @@ mod tests {
                             aggregation_job_id,
                             task_id,
                             time,
-                            nonce,
+                            report_id,
                             ord: ord as i64,
                             state: state.clone(),
                         };
@@ -4511,7 +4513,7 @@ mod tests {
                             Role::Leader,
                             task_id,
                             aggregation_job_id,
-                            nonce,
+                            report_id,
                         )
                         .await
                     })
@@ -4538,7 +4540,7 @@ mod tests {
                             Role::Leader,
                             task_id,
                             aggregation_job_id,
-                            nonce,
+                            report_id,
                         )
                         .await
                     })
@@ -4566,7 +4568,7 @@ mod tests {
                         Role::Leader,
                         random(),
                         random(),
-                        Nonce::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+                        ReportId::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
                     )
                     .await
                 })
@@ -4583,7 +4585,7 @@ mod tests {
                             aggregation_job_id: random(),
                             task_id: random(),
                             time: Time::from_seconds_since_epoch(12345),
-                            nonce: Nonce::from([
+                            report_id: ReportId::from([
                                 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
                             ]),
                             ord: 0,
@@ -4649,11 +4651,11 @@ mod tests {
                         .enumerate()
                     {
                         let time = Time::from_seconds_since_epoch(12345);
-                        let nonce = Nonce::from((ord as u128).to_be_bytes());
+                        let report_id = ReportId::from((ord as u128).to_be_bytes());
                         tx.put_report_share(
                             task_id,
                             &ReportShare::new(
-                                ReportMetadata::new(nonce, time, Vec::new()),
+                                ReportMetadata::new(report_id, time, Vec::new()),
                                 Vec::from("public_share"),
                                 HpkeCiphertext::new(
                                     HpkeConfigId::from(12),
@@ -4668,7 +4670,7 @@ mod tests {
                             aggregation_job_id,
                             task_id,
                             time,
-                            nonce,
+                            report_id,
                             ord: ord as i64,
                             state: state.clone(),
                         };
@@ -5305,7 +5307,7 @@ mod tests {
             aggregation_job_id,
             task_id,
             time: *reports[0].metadata().time(),
-            nonce: *reports[0].metadata().nonce(),
+            report_id: *reports[0].metadata().report_id(),
             ord: 0,
             // Doesn't matter what state the report aggregation is in
             state: ReportAggregationState::Start,
@@ -5525,7 +5527,7 @@ mod tests {
             aggregation_job_id,
             task_id,
             time: *reports[0].metadata().time(),
-            nonce: *reports[0].metadata().nonce(),
+            report_id: *reports[0].metadata().report_id(),
             ord: 0,
             // Shouldn't matter what state the report aggregation is in
             state: ReportAggregationState::Start,
@@ -5583,7 +5585,7 @@ mod tests {
                 aggregation_job_id,
                 task_id,
                 time: *reports[0].metadata().time(),
-                nonce: *reports[0].metadata().nonce(),
+                report_id: *reports[0].metadata().report_id(),
                 ord: 0,
                 state: ReportAggregationState::Start,
             }]);
@@ -5651,7 +5653,7 @@ mod tests {
                 aggregation_job_id: aggregation_job_ids[0],
                 task_id,
                 time: *reports[0].metadata().time(),
-                nonce: *reports[0].metadata().nonce(),
+                report_id: *reports[0].metadata().report_id(),
                 ord: 0,
                 state: ReportAggregationState::Start,
             },
@@ -5659,7 +5661,7 @@ mod tests {
                 aggregation_job_id: aggregation_job_ids[1],
                 task_id,
                 time: *reports[1].metadata().time(),
-                nonce: *reports[1].metadata().nonce(),
+                report_id: *reports[1].metadata().report_id(),
                 ord: 0,
                 state: ReportAggregationState::Start,
             },
@@ -5724,7 +5726,7 @@ mod tests {
                 aggregation_job_id: aggregation_job_ids[0],
                 task_id,
                 time: *reports[0].metadata().time(),
-                nonce: *reports[0].metadata().nonce(),
+                report_id: *reports[0].metadata().report_id(),
                 ord: 0,
                 state: ReportAggregationState::Start,
             },
@@ -5732,7 +5734,7 @@ mod tests {
                 aggregation_job_id: aggregation_job_ids[1],
                 task_id,
                 time: *reports[0].metadata().time(),
-                nonce: *reports[0].metadata().nonce(),
+                report_id: *reports[0].metadata().report_id(),
                 ord: 0,
                 state: ReportAggregationState::Start,
             },
@@ -5870,7 +5872,7 @@ mod tests {
                         aggregation_param: aggregation_param.clone(),
                         aggregate_share: aggregate_share.clone(),
                         report_count: 0,
-                        checksum: NonceChecksum::default(),
+                        checksum: ReportIdChecksum::default(),
                     };
 
                 let second_batch_unit_aggregation =
@@ -5880,7 +5882,7 @@ mod tests {
                         aggregation_param: aggregation_param.clone(),
                         aggregate_share: aggregate_share.clone(),
                         report_count: 0,
-                        checksum: NonceChecksum::default(),
+                        checksum: ReportIdChecksum::default(),
                     };
 
                 let third_batch_unit_aggregation =
@@ -5890,7 +5892,7 @@ mod tests {
                         aggregation_param: aggregation_param.clone(),
                         aggregate_share: aggregate_share.clone(),
                         report_count: 0,
-                        checksum: NonceChecksum::default(),
+                        checksum: ReportIdChecksum::default(),
                     };
 
                 // Start of this aggregation's interval is before the interval queried below.
@@ -5900,7 +5902,7 @@ mod tests {
                     aggregation_param: aggregation_param.clone(),
                     aggregate_share: aggregate_share.clone(),
                     report_count: 0,
-                    checksum: NonceChecksum::default(),
+                    checksum: ReportIdChecksum::default(),
                 })
                 .await?;
 
@@ -5923,7 +5925,7 @@ mod tests {
                     ]),
                     aggregate_share: aggregate_share.clone(),
                     report_count: 0,
-                    checksum: NonceChecksum::default(),
+                    checksum: ReportIdChecksum::default(),
                 })
                 .await?;
 
@@ -5934,7 +5936,7 @@ mod tests {
                     aggregation_param: aggregation_param.clone(),
                     aggregate_share: aggregate_share.clone(),
                     report_count: 0,
-                    checksum: NonceChecksum::default(),
+                    checksum: ReportIdChecksum::default(),
                 })
                 .await?;
 
@@ -5945,7 +5947,7 @@ mod tests {
                     aggregation_param: aggregation_param.clone(),
                     aggregate_share: aggregate_share.clone(),
                     report_count: 0,
-                    checksum: NonceChecksum::default(),
+                    checksum: ReportIdChecksum::default(),
                 })
                 .await?;
 
@@ -5956,7 +5958,7 @@ mod tests {
                     aggregation_param: aggregation_param.clone(),
                     aggregate_share: aggregate_share.clone(),
                     report_count: 0,
-                    checksum: NonceChecksum::default(),
+                    checksum: ReportIdChecksum::default(),
                 })
                 .await?;
 
@@ -5994,7 +5996,7 @@ mod tests {
                     BatchUnitAggregation::<PRG_SEED_SIZE, ToyPoplar1> {
                         aggregate_share: AggregateShare::from(vec![Field64::from(25)]),
                         report_count: 1,
-                        checksum: NonceChecksum::get_decoded(&[1; 32]).unwrap(),
+                        checksum: ReportIdChecksum::get_decoded(&[1; 32]).unwrap(),
                         ..first_batch_unit_aggregation
                     };
 
@@ -6066,7 +6068,7 @@ mod tests {
                 )
                 .unwrap();
                 let report_count = 10;
-                let checksum = NonceChecksum::get_decoded(&[1; 32]).unwrap();
+                let checksum = ReportIdChecksum::get_decoded(&[1; 32]).unwrap();
 
                 let aggregate_share_job = AggregateShareJob {
                     task_id,

--- a/janus_server/src/datastore.rs
+++ b/janus_server/src/datastore.rs
@@ -751,7 +751,7 @@ impl<C: Clock> Transaction<'_, C> {
 
                 Ok(Report::new(
                     task_id,
-                    ReportMetadata::new(time, nonce, extensions),
+                    ReportMetadata::new(nonce, time, extensions),
                     Vec::new(), // TODO(#473): fill out public_share once possible
                     input_shares,
                 ))
@@ -3450,8 +3450,8 @@ mod tests {
         let report = Report::new(
             random(),
             ReportMetadata::new(
-                Time::from_seconds_since_epoch(12345),
                 Nonce::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+                Time::from_seconds_since_epoch(12345),
                 vec![
                     Extension::new(ExtensionType::Tbd, Vec::from("extension_data_0")),
                     Extension::new(ExtensionType::Tbd, Vec::from("extension_data_1")),
@@ -3534,25 +3534,25 @@ mod tests {
 
         let first_unaggregated_report = Report::new(
             task_id,
-            ReportMetadata::new(when, random(), Vec::new()),
+            ReportMetadata::new(random(), when, Vec::new()),
             Vec::new(), // TODO(#473): fill out public_share once possible
             Vec::new(),
         );
         let second_unaggregated_report = Report::new(
             task_id,
-            ReportMetadata::new(when, random(), Vec::new()),
+            ReportMetadata::new(random(), when, Vec::new()),
             Vec::new(), // TODO(#473): fill out public_share once possible
             Vec::new(),
         );
         let aggregated_report = Report::new(
             task_id,
-            ReportMetadata::new(when, random(), Vec::new()),
+            ReportMetadata::new(random(), when, Vec::new()),
             Vec::new(), // TODO(#473): fill out public_share once possible
             Vec::new(),
         );
         let unrelated_report = Report::new(
             unrelated_task_id,
-            ReportMetadata::new(when, random(), Vec::new()),
+            ReportMetadata::new(random(), when, Vec::new()),
             Vec::new(), // TODO(#473): fill out public_share once possible
             Vec::new(),
         );
@@ -3659,25 +3659,25 @@ mod tests {
 
         let first_unaggregated_report = Report::new(
             task_id,
-            ReportMetadata::new(Time::from_seconds_since_epoch(12345), random(), Vec::new()),
+            ReportMetadata::new(random(), Time::from_seconds_since_epoch(12345), Vec::new()),
             Vec::new(), // TODO(#473): fill out public_share once possible
             Vec::new(),
         );
         let second_unaggregated_report = Report::new(
             task_id,
-            ReportMetadata::new(Time::from_seconds_since_epoch(12346), random(), Vec::new()),
+            ReportMetadata::new(random(), Time::from_seconds_since_epoch(12346), Vec::new()),
             Vec::new(), // TODO(#473): fill out public_share once possible
             Vec::new(),
         );
         let aggregated_report = Report::new(
             task_id,
-            ReportMetadata::new(Time::from_seconds_since_epoch(12347), random(), Vec::new()),
+            ReportMetadata::new(random(), Time::from_seconds_since_epoch(12347), Vec::new()),
             Vec::new(), // TODO(#473): fill out public_share once possible
             Vec::new(),
         );
         let unrelated_report = Report::new(
             unrelated_task_id,
-            ReportMetadata::new(Time::from_seconds_since_epoch(12348), random(), Vec::new()),
+            ReportMetadata::new(random(), Time::from_seconds_since_epoch(12348), Vec::new()),
             Vec::new(), // TODO(#473): fill out public_share once possible
             Vec::new(),
         );
@@ -3898,8 +3898,8 @@ mod tests {
         let task_id = random();
         let report_share = ReportShare::new(
             ReportMetadata::new(
-                Time::from_seconds_since_epoch(12345),
                 Nonce::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+                Time::from_seconds_since_epoch(12345),
                 Vec::from([
                     Extension::new(ExtensionType::Tbd, Vec::from("extension_data_0")),
                     Extension::new(ExtensionType::Tbd, Vec::from("extension_data_1")),
@@ -4476,7 +4476,7 @@ mod tests {
                         tx.put_report_share(
                             task_id,
                             &ReportShare::new(
-                                ReportMetadata::new(time, nonce, Vec::new()),
+                                ReportMetadata::new(nonce, time, Vec::new()),
                                 Vec::from("public_share"),
                                 HpkeCiphertext::new(
                                     HpkeConfigId::from(12),
@@ -4653,7 +4653,7 @@ mod tests {
                         tx.put_report_share(
                             task_id,
                             &ReportShare::new(
-                                ReportMetadata::new(time, nonce, Vec::new()),
+                                ReportMetadata::new(nonce, time, Vec::new()),
                                 Vec::from("public_share"),
                                 HpkeCiphertext::new(
                                     HpkeConfigId::from(12),

--- a/janus_server/src/message.rs
+++ b/janus_server/src/message.rs
@@ -699,8 +699,8 @@ mod tests {
                     result: PrepareStepResult::Finished,
                 },
                 concat!(
-                    "100F0E0DC0B0A090807060504030201", // report_id
-                    "01",                              // prepare_step_result
+                    "100F0E0D0C0B0A090807060504030201", // report_id
+                    "01",                               // prepare_step_result
                 ),
             ),
             (

--- a/janus_server/src/message.rs
+++ b/janus_server/src/message.rs
@@ -798,7 +798,7 @@ mod tests {
                 ),
                 concat!(
                     // partial_batch_selector
-                    "0001", // query_type
+                    "01", // query_type
                 ),
                 concat!(
                     // report_shares
@@ -930,7 +930,7 @@ mod tests {
                 ),
                 concat!(
                     // partial_batch_selector
-                    "0002", // query_type
+                    "02", // query_type
                     "0202020202020202020202020202020202020202020202020202020202020202", // batch_id
                 ),
                 concat!(
@@ -1174,7 +1174,7 @@ mod tests {
                     .unwrap(),
                 },
                 concat!(
-                    "0001", // query_type
+                    "01", // query_type
                     concat!(
                         // batch_interval
                         "000000000000D431", // start
@@ -1191,7 +1191,7 @@ mod tests {
                     .unwrap(),
                 },
                 concat!(
-                    "0001", // query_type
+                    "01", // query_type
                     concat!(
                         // batch_interval
                         "000000000000C685", // start
@@ -1209,7 +1209,7 @@ mod tests {
                 },
                 concat!(
                     // batch_selector
-                    "0002", // query_type
+                    "02", // query_type
                     "0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C", // batch_id
                 ),
             ),
@@ -1218,7 +1218,7 @@ mod tests {
                     batch_identifier: BatchId::from([7u8; 32]),
                 },
                 concat!(
-                    "0002",                                                             // query_type
+                    "02",                                                               // query_type
                     "0707070707070707070707070707070707070707070707070707070707070707", // batch_id
                 ),
             ),
@@ -1247,7 +1247,7 @@ mod tests {
                     "0000000000000000000000000000000000000000000000000000000000000000", // task_id
                     concat!(
                         // batch_selector
-                        "0001", // query_type
+                        "01", // query_type
                         concat!(
                             // batch_interval
                             "000000000000D431", // start
@@ -1281,7 +1281,7 @@ mod tests {
                     "0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C", // task_id
                     concat!(
                         // batch_selector
-                        "0001", // query_type
+                        "01", // query_type
                         concat!(
                             // batch_interval
                             "000000000000C685", // start
@@ -1315,7 +1315,7 @@ mod tests {
                     "0000000000000000000000000000000000000000000000000000000000000000", // task_id
                     concat!(
                         // batch_selector
-                        "0002", // query_type
+                        "02", // query_type
                         "0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C", // batch_id
                     ),
                     concat!(
@@ -1341,7 +1341,7 @@ mod tests {
                     "0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C", // task_id
                     concat!(
                         // batch_selector
-                        "0002", // query_type
+                        "02", // query_type
                         "0707070707070707070707070707070707070707070707070707070707070707", // batch_id
                     ),
                     concat!(

--- a/janus_server/src/message.rs
+++ b/janus_server/src/message.rs
@@ -801,8 +801,8 @@ mod tests {
                 report_shares: vec![
                     ReportShare {
                         metadata: ReportMetadata::new(
-                            Time::from_seconds_since_epoch(54321),
                             Nonce::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+                            Time::from_seconds_since_epoch(54321),
                             vec![Extension::new(ExtensionType::Tbd, Vec::from("0123"))],
                         ),
                         public_share: Vec::new(),
@@ -814,8 +814,8 @@ mod tests {
                     },
                     ReportShare {
                         metadata: ReportMetadata::new(
-                            Time::from_seconds_since_epoch(73542),
                             Nonce::from([16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]),
+                            Time::from_seconds_since_epoch(73542),
                             vec![Extension::new(ExtensionType::Tbd, Vec::from("3210"))],
                         ),
                         public_share: Vec::from("0123"),
@@ -842,8 +842,8 @@ mod tests {
                     concat!(
                         concat!(
                             // metadata
+                            "0102030405060708090A0B0C0D0E0F10", // nonce
                             "000000000000D431",                 // time
-                            "0102030405060708090a0b0c0d0e0f10", // nonce
                             concat!(
                                 // extensions
                                 "0008", // length
@@ -880,8 +880,8 @@ mod tests {
                     concat!(
                         concat!(
                             // metadata
-                            "0000000000011F46",                 // time
                             "100F0E0D0C0B0A090807060504030201", // nonce
+                            "0000000000011F46",                 // time
                             concat!(
                                 // extensions
                                 "0008", // length
@@ -928,8 +928,8 @@ mod tests {
                 report_shares: vec![
                     ReportShare {
                         metadata: ReportMetadata::new(
-                            Time::from_seconds_since_epoch(54321),
                             Nonce::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+                            Time::from_seconds_since_epoch(54321),
                             vec![Extension::new(ExtensionType::Tbd, Vec::from("0123"))],
                         ),
                         public_share: Vec::new(),
@@ -941,8 +941,8 @@ mod tests {
                     },
                     ReportShare {
                         metadata: ReportMetadata::new(
-                            Time::from_seconds_since_epoch(73542),
                             Nonce::from([16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]),
+                            Time::from_seconds_since_epoch(73542),
                             vec![Extension::new(ExtensionType::Tbd, Vec::from("3210"))],
                         ),
                         public_share: Vec::from("0123"),
@@ -970,8 +970,8 @@ mod tests {
                     concat!(
                         concat!(
                             // metadata
+                            "0102030405060708090A0B0C0D0E0F10", // nonce
                             "000000000000D431",                 // time
-                            "0102030405060708090a0b0c0d0e0f10", // nonce
                             concat!(
                                 // extensions
                                 "0008", // length
@@ -1008,8 +1008,8 @@ mod tests {
                     concat!(
                         concat!(
                             // metadata
-                            "0000000000011F46",                 // time
                             "100F0E0D0C0B0A090807060504030201", // nonce
+                            "0000000000011F46",                 // time
                             concat!(
                                 // extensions
                                 "0008", // length


### PR DESCRIPTION
Changes include:
* Rename Nonce to ReportID.
* Reorder ReportMetadata fields so that ReportID is first.
* Introduce PartialBatchSelector, use it for AggregateInitializeReq & CollectResp.
* Reduce QueryType from 2 bytes to 1.

See individual commits for more detail.