### PR TITLE
Raise limit on open Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "main"
+    open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -24,6 +25,7 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "release/0.1"
+    open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
This raises the limit on open Dependabot PRs (for Cargo) from five to ten, per branch.