### PR TITLE
Update Dockerfile.interop to use alpine 3.16.2

### DIFF
--- a/Dockerfile.interop
+++ b/Dockerfile.interop
@@ -19,7 +19,7 @@ COPY janus_messages /src/janus_messages
 COPY janus_server /src/janus_server
 RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,target=/src/target cargo build --profile $PROFILE -p interop_binaries --bin $BINARY && cp /src/target/$PROFILE/$BINARY /$BINARY
 
-FROM alpine:3.16.1
+FROM alpine:3.16.2
 ARG BINARY
 RUN mkdir /logs
 COPY --from=builder /src/db/schema.sql /db/schema.sql


### PR DESCRIPTION
Our tag for alpine is different in `Dockerfile` and `Dockerfile.interop`. This bumps the latter to bring it up to date.

I noticed Dependabot was failing while processing this dependency, so my hope is that this might get it working again.