### PR TITLE
Upgrade to prio 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "az"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
+
+[[package]]
 name = "backoff"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,6 +292,12 @@ name = "bumpalo"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+
+[[package]]
+name = "bytemuck"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da"
 
 [[package]]
 name = "byteorder"
@@ -614,6 +626,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,7 +720,7 @@ dependencies = [
  "hex",
  "hpke 0.8.0",
  "matchit 0.6.0",
- "prio",
+ "prio 0.8.2",
  "rand",
  "reqwest",
  "ring",
@@ -966,6 +984,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixed"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0371cd413fb63f8ec1b9eb4dff47fa2c88b21abc681771234c84808b9920991"
+dependencies = [
+ "az",
+ "bytemuck",
+ "half",
+ "typenum",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1180,6 +1210,15 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.3",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad6a9459c9c30b177b925162351f97e7d967c7ea8bab3b8352805327daf45554"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -1582,7 +1621,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "portpicker",
- "prio",
+ "prio 0.10.0",
  "rand",
  "reqwest",
  "serde",
@@ -1613,7 +1652,7 @@ dependencies = [
  "janus_server",
  "lazy_static",
  "opentelemetry",
- "prio",
+ "prio 0.10.0",
  "rand",
  "regex",
  "reqwest",
@@ -1662,7 +1701,7 @@ dependencies = [
  "janus_core",
  "janus_messages",
  "mockito",
- "prio",
+ "prio 0.10.0",
  "rand",
  "reqwest",
  "thiserror",
@@ -1687,7 +1726,7 @@ dependencies = [
  "janus_core",
  "janus_messages",
  "mockito",
- "prio",
+ "prio 0.10.0",
  "rand",
  "reqwest",
  "retry-after",
@@ -1716,7 +1755,7 @@ dependencies = [
  "kube",
  "lazy_static",
  "mockito",
- "prio",
+ "prio 0.10.0",
  "rand",
  "reqwest",
  "ring",
@@ -1742,7 +1781,7 @@ dependencies = [
  "derivative",
  "hex",
  "num_enum",
- "prio",
+ "prio 0.10.0",
  "rand",
  "serde",
  "structopt",
@@ -1786,7 +1825,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "postgres-protocol",
  "postgres-types",
- "prio",
+ "prio 0.10.0",
  "prometheus",
  "rand",
  "reqwest",
@@ -2643,8 +2682,26 @@ dependencies = [
  "cmac",
  "ctr 0.9.1",
  "getrandom",
- "rayon",
  "ring",
+ "serde",
+ "static_assertions",
+ "thiserror",
+]
+
+[[package]]
+name = "prio"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0453e1ec5f2f48af9a67aab1d812f9aec48619dda0d9a59e2f79ebd235448ec"
+dependencies = [
+ "aes 0.8.1",
+ "base64",
+ "byteorder",
+ "cmac",
+ "ctr 0.9.1",
+ "fixed",
+ "getrandom",
+ "rayon",
  "serde",
  "static_assertions",
  "thiserror",

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -76,6 +76,7 @@ CREATE TABLE client_reports(
     nonce_time    TIMESTAMP NOT NULL,  -- timestamp from nonce
     nonce_rand    BYTEA NOT NULL,      -- random value from nonce
     extensions    BYTEA,               -- encoded sequence of Extension messages (populated for leader only)
+    public_share  BYTEA,               -- encoded public share (opaque VDAF message, populated for leader only)
     input_shares  BYTEA,               -- encoded sequence of HpkeCiphertext messages (populated for leader only)
 
     CONSTRAINT unique_task_id_and_nonce UNIQUE(task_id, nonce_time, nonce_rand),

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -44,7 +44,7 @@ http = "0.2"
 itertools = "0.10"
 janus_client = { path = "../janus_client" }
 janus_collector = { path = "../janus_collector", features = ["test-util"] }
-prio = { version = "0.8.2", features = ["multithreaded"] }
+prio = { version = "0.10.0", features = ["multithreaded"] }
 tempfile = "3"
 
 [build-dependencies]

--- a/interop_binaries/Cargo.toml
+++ b/interop_binaries/Cargo.toml
@@ -34,7 +34,7 @@ janus_core = { path = "../janus_core" }
 janus_messages = { path = "../janus_messages" }
 janus_server = { path = "../janus_server" }
 opentelemetry = { version = "0.18", features = ["metrics"] }
-prio = { version = "0.8.2", features = ["multithreaded"] }
+prio = { version = "0.10.0", features = ["multithreaded"] }
 rand = "0.8"
 regex = { version = "1", optional = true }
 reqwest = { version = "0.11.4", default-features = false, features = ["rustls-tls"] }

--- a/janus_client/Cargo.toml
+++ b/janus_client/Cargo.toml
@@ -15,7 +15,7 @@ derivative = "2.2.0"
 http = "0.2.8"
 janus_core = { version = "0.1", path = "../janus_core" }
 janus_messages = { version = "0.1", path = "../janus_messages" }
-prio = { version = "0.8.2", features = ["multithreaded"] }
+prio = { version = "0.10.0", features = ["multithreaded"] }
 rand = "0.8"
 reqwest = { version = "0.11.4", default-features = false, features = ["rustls-tls"] }
 thiserror = "1.0"

--- a/janus_client/src/lib.rs
+++ b/janus_client/src/lib.rs
@@ -204,7 +204,7 @@ where
     /// Shard a measurement, encrypt its shares, and construct a [`janus_core::message::Report`]
     /// to be uploaded.
     fn prepare_report(&self, measurement: &V::Measurement) -> Result<Report, Error> {
-        let input_shares = self.vdaf_client.shard(measurement)?;
+        let (public_share, input_shares) = self.vdaf_client.shard(measurement)?;
         assert_eq!(input_shares.len(), 2); // DAP only supports VDAFs using two aggregators.
 
         let time = self
@@ -219,7 +219,7 @@ where
             time,
             Vec::new(), // No extensions supported yet
         );
-        let public_share = Vec::new(); // TODO(#473): fill out public_share once possible
+        let public_share = public_share.get_encoded();
         let associated_data = associated_data_for_report_share(
             self.parameters.task_id,
             &report_metadata,

--- a/janus_collector/Cargo.toml
+++ b/janus_collector/Cargo.toml
@@ -17,7 +17,7 @@ backoff = { version = "0.4.0", features = ["tokio"] }
 derivative = "2.2.0"
 janus_core = { version = "0.1", path = "../janus_core" }
 janus_messages = { version = "0.1", path = "../janus_messages" }
-prio = "0.8.2"
+prio = "0.10.0"
 reqwest = { version = "0.11.4", default-features = false, features = ["rustls-tls"] }
 retry-after = "0.3.1"
 thiserror = "1.0"

--- a/janus_core/Cargo.toml
+++ b/janus_core/Cargo.toml
@@ -34,7 +34,7 @@ hpke-dispatch = "0.3.0"
 janus_messages = { version = "0.1", path = "../janus_messages" }
 kube = { version = "0.65", optional = true, default-features = false, features = ["client", "rustls-tls"] }
 k8s-openapi = { version = "0.13.1", optional = true, features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
-prio = { version = "0.8.2", features = ["multithreaded"] }
+prio = { version = "0.10.0", features = ["multithreaded"] }
 rand = "0.8"
 reqwest = { version = "0.11.4", default-features = false, features = ["rustls-tls"] }
 ring = "0.16.20"

--- a/janus_core/src/task.rs
+++ b/janus_core/src/task.rs
@@ -5,9 +5,9 @@ use ring::constant_time;
 pub const DAP_AUTH_HEADER: &str = "DAP-Auth-Token";
 
 /// Identifiers for supported VDAFs, corresponding to definitions in
-/// [draft-irtf-cfrg-vdaf-00][1] and implementations in [`prio::vdaf::prio3`].
+/// [draft-irtf-cfrg-vdaf-03][1] and implementations in [`prio::vdaf::prio3`].
 ///
-/// [1]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/00/
+/// [1]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/03/
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum VdafInstance {
     /// A `prio3` counter using the AES 128 pseudorandom generator.

--- a/janus_core/src/test_util/dummy_vdaf.rs
+++ b/janus_core/src/test_util/dummy_vdaf.rs
@@ -71,9 +71,12 @@ impl Default for Vdaf {
 }
 
 impl vdaf::Vdaf for Vdaf {
+    const ID: u32 = 0xFFFF0000;
+
     type Measurement = ();
     type AggregateResult = ();
     type AggregationParam = AggregationParam;
+    type PublicShare = ();
     type InputShare = ();
     type OutputShare = OutputShare;
     type AggregateShare = AggregateShare;
@@ -94,6 +97,7 @@ impl vdaf::Aggregator<0> for Vdaf {
         _: usize,
         aggregation_param: &Self::AggregationParam,
         _: &[u8],
+        _: &Self::PublicShare,
         _: &Self::InputShare,
     ) -> Result<(Self::PrepareState, Self::PrepareShare), VdafError> {
         (self.prep_init_fn)(aggregation_param)?;
@@ -129,8 +133,11 @@ impl vdaf::Aggregator<0> for Vdaf {
 }
 
 impl vdaf::Client for Vdaf {
-    fn shard(&self, _: &Self::Measurement) -> Result<Vec<Self::InputShare>, VdafError> {
-        Ok(vec![(), ()])
+    fn shard(
+        &self,
+        _: &Self::Measurement,
+    ) -> Result<(Self::PublicShare, Vec<Self::InputShare>), VdafError> {
+        Ok(((), vec![(), ()]))
     }
 }
 

--- a/janus_messages/Cargo.toml
+++ b/janus_messages/Cargo.toml
@@ -20,7 +20,7 @@ base64 = "0.13.0"
 derivative = "2.2.0"
 hex = "0.4"
 num_enum = "0.5.6"
-prio = { version = "0.8.2", default-features = false } # important: do not enable prio/crypto-dependencies by default!
+prio = { version = "0.10.0", default-features = false } # important: do not enable prio/crypto-dependencies by default!
 rand = "0.8"
 serde = { version = "1.0.145", features = ["derive"] }
 structopt = { version = "0.3.26", optional = true }

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -54,7 +54,7 @@ opentelemetry-prometheus = { version = "0.11", optional = true }
 opentelemetry-semantic-conventions = { version = "0.10", optional = true }
 postgres-protocol = "0.6.4"
 postgres-types = { version = "0.2.4", features = ["derive", "array-impls"] }
-prio = { version = "0.8.2", features = ["multithreaded"] }
+prio = { version = "0.10.0", features = ["multithreaded"] }
 prometheus = { version = "0.13.2", optional = true }
 rand = { version = "0.8", features = ["min_const_gen"] }
 reqwest = { version = "0.11.11", default-features = false, features = ["rustls-tls", "json"] }

--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -1180,7 +1180,7 @@ impl VdafOps {
             });
 
             let public_share = A::PublicShare::get_decoded_with_param(&vdaf, report_share.public_share()).map_err(|error|{
-                info!(?task_id, metadata = ?report_share.metadata(), %error, "Couldnt' decode public share");
+                info!(?task_id, metadata = ?report_share.metadata(), %error, "Couldn't decode public share");
                 aggregate_step_failure_counter.add(&Context::current(), 1, &[KeyValue::new("type", "public_share_decode_failure")]);
                 ReportShareError::VdafPrepError
             });

--- a/janus_server/src/aggregator/aggregate_share.rs
+++ b/janus_server/src/aggregator/aggregate_share.rs
@@ -536,7 +536,7 @@ mod tests {
                     tx.put_client_report(&Report::new(
                         task_id,
                         report_metadata.clone(),
-                        Vec::new(), // TODO(#473): fill out public_share once possible
+                        Vec::new(),
                         Vec::new(),
                     ))
                     .await?;
@@ -766,7 +766,7 @@ mod tests {
                     tx.put_client_report(&Report::new(
                         task_id,
                         report_metadata.clone(),
-                        Vec::new(), // TODO(#473): fill out public_share once possible
+                        Vec::new(),
                         Vec::new(),
                     ))
                     .await?;
@@ -922,7 +922,7 @@ mod tests {
                         tx.put_client_report(&Report::new(
                             task_id,
                             report_metadata.clone(),
-                            Vec::new(), // TODO(#473): fill out public_share once possible
+                            Vec::new(),
                             Vec::new(),
                         ))
                         .await?;

--- a/janus_server/src/task.rs
+++ b/janus_server/src/task.rs
@@ -31,10 +31,10 @@ pub enum Error {
 }
 
 /// Identifiers for VDAFs supported by this aggregator, corresponding to
-/// definitions in [draft-irtf-cfrg-vdaf-00][1] and implementations in
+/// definitions in [draft-irtf-cfrg-vdaf-03][1] and implementations in
 /// [`prio::vdaf::prio3`].
 ///
-/// [1]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/00/
+/// [1]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/03/
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum VdafInstance {
     Real(janus_core::task::VdafInstance),


### PR DESCRIPTION
This updates libprio to 0.10, which entails a breaking upgrade to VDAF draft 03, introduction of the public share, a database schema change to store that public share, and passing the report count to unshard. This touches a number of tests as well. As this is more invasive than the average Dependabot update, I'd like review on this.

This supersedes #553 and closes #473.