### PR TITLE
Update to alpine 3.16.2, backport for release/0.1

### DIFF
--- a/Dockerfile.interop
+++ b/Dockerfile.interop
@@ -19,7 +19,7 @@ COPY janus_messages /src/janus_messages
 COPY janus_server /src/janus_server
 RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,target=/src/target cargo build --profile $PROFILE -p interop_binaries --bin $BINARY && cp /src/target/$PROFILE/$BINARY /$BINARY
 
-FROM alpine:3.16.1
+FROM alpine:3.16.2
 ARG BINARY
 RUN mkdir /logs
 COPY --from=builder /src/db/schema.sql /db/schema.sql


### PR DESCRIPTION
This backports #556, bringing the alpine container versions of two Dockerfiles in sync. Dependabot cannot propose this upgrade due to an error, and making this same change on the main branch resolved that error.