### PR TITLE
Introduce `CollectJobState::Deleted`

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -156,7 +156,8 @@ CREATE TABLE batch_unit_aggregations(
 CREATE TYPE COLLECT_JOB_STATE AS ENUM(
     'START',     -- the aggregator is waiting to run this collect job
     'FINISHED',  -- this collect job has run successfully and is ready for collection
-    'ABANDONED'  -- this collect job has been abandoned & will never be run again
+    'ABANDONED', -- this collect job has been abandoned & will never be run again
+    'DELETED'    -- this collect job has been deleted
 );
 
 -- The leader's view of collect requests from the Collector.

--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -13,7 +13,7 @@ use crate::{
     datastore::{
         self,
         models::{
-            AggregateShareJob, AggregationJob, AggregationJobState, CollectJobState,
+            AggregateShareJob, AggregationJob, AggregationJobState, CollectJob, CollectJobState,
             ReportAggregation, ReportAggregationState,
         },
         Datastore,
@@ -1576,11 +1576,14 @@ impl VdafOps {
                 let task = task.clone();
                 let req = req.clone();
                 Box::pin(async move {
+                    let aggregation_param =
+                        A::AggregationParam::get_decoded(req.aggregation_parameter())?;
+
                     if let Some(collect_job_id) = tx
-                        .get_collect_job_id(
+                        .get_collect_job_id::<L, A>(
                             task.id,
                             *req.query().batch_interval(),
-                            req.aggregation_parameter(),
+                            &aggregation_param,
                         )
                         .await?
                     {
@@ -1595,12 +1598,13 @@ impl VdafOps {
                         *req.query().batch_interval(),
                     )
                     .await?;
-                    tx.put_collect_job(
-                        *req.task_id(),
-                        *req.query().batch_interval(),
-                        req.aggregation_parameter(),
-                    )
-                    .await
+
+                    let collect_job =
+                        CollectJob::new(task.id, *req.query().batch_interval(), aggregation_param);
+
+                    tx.put_collect_job::<L, A>(&collect_job).await?;
+
+                    Ok(collect_job.id)
                 })
             })
             .await?)
@@ -1738,6 +1742,11 @@ impl VdafOps {
                     "Attempting to collect abandoned collect job"
                 );
                 Ok(None)
+            }
+
+            CollectJobState::Deleted => {
+                // TODO(#344): return appropriate status to caller here
+                todo!()
             }
         }
     }
@@ -3155,7 +3164,12 @@ mod tests {
         .unwrap();
         datastore
             .run_tx(|tx| {
-                Box::pin(async move { tx.put_collect_job(task_id, batch_interval, &[]).await })
+                Box::pin(async move {
+                    tx.put_collect_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                        &CollectJob::new(task_id, batch_interval, ()),
+                    )
+                    .await
+                })
             })
             .await
             .unwrap();
@@ -5821,10 +5835,20 @@ mod tests {
                     )
                     .unwrap();
 
+                    let mut collect_job = tx
+                        .get_collect_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                            collect_job_id,
+                        )
+                        .await
+                        .unwrap()
+                        .unwrap();
+                    collect_job.state = CollectJobState::Finished {
+                        encrypted_helper_aggregate_share,
+                        leader_aggregate_share,
+                    };
+
                     tx.update_collect_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
-                        collect_job_id,
-                        &leader_aggregate_share,
-                        &encrypted_helper_aggregate_share,
+                        &collect_job,
                     )
                     .await
                     .unwrap();

--- a/janus_server/src/aggregator/aggregation_job_creator.rs
+++ b/janus_server/src/aggregator/aggregation_job_creator.rs
@@ -452,7 +452,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
 mod tests {
     use super::AggregationJobCreator;
     use crate::{
-        datastore::{test_util::ephemeral_datastore, Transaction},
+        datastore::{models::CollectJob, test_util::ephemeral_datastore, Transaction},
         messages::test_util::new_dummy_report,
         messages::TimeExt,
         task::{Task, PRIO3_AES128_VERIFY_KEY_LENGTH},
@@ -910,14 +910,14 @@ mod tests {
             .run_tx(|tx| {
                 Box::pin(async move {
                     // This will encompass the members of batch_2_reports.
-                    tx.put_collect_job(
+                    tx.put_collect_job::<VERIFY_KEY_LENGTH, dummy_vdaf::Vdaf>(&CollectJob::new(
                         task_id,
                         Interval::new(report_time, task.min_batch_duration).unwrap(),
-                        &[7],
-                    )
+                        AggregationParam(7),
+                    ))
                     .await?;
                     // This will encompass the members of both batch_1_reports and batch_2_reports.
-                    tx.put_collect_job(
+                    tx.put_collect_job::<VERIFY_KEY_LENGTH, dummy_vdaf::Vdaf>(&CollectJob::new(
                         task_id,
                         Interval::new(
                             report_time,
@@ -926,8 +926,8 @@ mod tests {
                             ),
                         )
                         .unwrap(),
-                        &[11],
-                    )
+                        AggregationParam(11),
+                    ))
                     .await?;
                     Ok(())
                 })


### PR DESCRIPTION
For https://github.com/divviup/janus/issues/344, we introduce a "Deleted" state for a collect job. We have to distinguish from the "Abandoned" state so that we can eventually return the right HTTP status if a collector polls the collect job URI.

This commit defines the new state in the SQL schema and adds support for entering it using `Datastore::update_collect_job`. Along the way, we resolve https://github.com/divviup/janus/issues/242: `put_collect_job` and `update_collect_job` now take
`&CollectJob` as an argument instead of just the field values to set.

Part of https://github.com/divviup/janus/issues/344
Resolves https://github.com/divviup/janus/issues/242