### PR TITLE
Histogram metric for outgoing HTTP requests

### DIFF
--- a/janus_server/src/binary_utils/job_driver.rs
+++ b/janus_server/src/binary_utils/job_driver.rs
@@ -182,7 +182,7 @@ where
                     // Unwrap safety: we have seen that at least `leases.len()` permits are
                     // available, and this task is the only task that acquires permits.
                     let span = info_span!("Job stepper", acquired_job = ?lease.leased());
-                    let (this, permit, job_step_time_recorder) = (
+                    let (this, permit, job_step_time_histogram) = (
                         Arc::clone(&self),
                         Arc::clone(&sem).try_acquire_owned().unwrap(),
                         job_step_time_histogram.clone(),
@@ -207,7 +207,7 @@ where
                                 status = "error"
                             }
                         }
-                        job_step_time_recorder.record(
+                        job_step_time_histogram.record(
                             &Context::current(),
                             start.elapsed().as_secs_f64(),
                             &[KeyValue::new("status", status)],


### PR DESCRIPTION
This adds a new histogram metric for the time spent making outgoing HTTP requests, which will be output by the two job driver components. I moved common request-related logic into a new helper function, and then added metrics handling there. Labels are included for "success" or "error" status, the endpoint ("aggregate" or "aggregate_share"), and the domain.

This resolves #535.

Sample output:
```
# HELP janus_http_request_duration_seconds The amount of time elapsed while making an HTTP request to a helper.
# TYPE janus_http_request_duration_seconds histogram
janus_http_request_duration_seconds_bucket{domain="aggregator.kind-ci-castor.svc.cluster.local",endpoint="aggregate",service_name="unknown_service",status="error",le="0.005"} 327
janus_http_request_duration_seconds_bucket{domain="aggregator.kind-ci-castor.svc.cluster.local",endpoint="aggregate",service_name="unknown_service",status="error",le="0.01"} 327
janus_http_request_duration_seconds_bucket{domain="aggregator.kind-ci-castor.svc.cluster.local",endpoint="aggregate",service_name="unknown_service",status="error",le="0.025"} 327
janus_http_request_duration_seconds_bucket{domain="aggregator.kind-ci-castor.svc.cluster.local",endpoint="aggregate",service_name="unknown_service",status="error",le="0.05"} 327
janus_http_request_duration_seconds_bucket{domain="aggregator.kind-ci-castor.svc.cluster.local",endpoint="aggregate",service_name="unknown_service",status="error",le="0.1"} 327
janus_http_request_duration_seconds_bucket{domain="aggregator.kind-ci-castor.svc.cluster.local",endpoint="aggregate",service_name="unknown_service",status="error",le="0.25"} 327
janus_http_request_duration_seconds_bucket{domain="aggregator.kind-ci-castor.svc.cluster.local",endpoint="aggregate",service_name="unknown_service",status="error",le="0.5"} 327
janus_http_request_duration_seconds_bucket{domain="aggregator.kind-ci-castor.svc.cluster.local",endpoint="aggregate",service_name="unknown_service",status="error",le="1"} 327
janus_http_request_duration_seconds_bucket{domain="aggregator.kind-ci-castor.svc.cluster.local",endpoint="aggregate",service_name="unknown_service",status="error",le="2.5"} 327
janus_http_request_duration_seconds_bucket{domain="aggregator.kind-ci-castor.svc.cluster.local",endpoint="aggregate",service_name="unknown_service",status="error",le="5"} 327
janus_http_request_duration_seconds_bucket{domain="aggregator.kind-ci-castor.svc.cluster.local",endpoint="aggregate",service_name="unknown_service",status="error",le="10"} 327
janus_http_request_duration_seconds_bucket{domain="aggregator.kind-ci-castor.svc.cluster.local",endpoint="aggregate",service_name="unknown_service",status="error",le="+Inf"} 327
janus_http_request_duration_seconds_sum{domain="aggregator.kind-ci-castor.svc.cluster.local",endpoint="aggregate",service_name="unknown_service",status="error"} 0.14154237800000002
janus_http_request_duration_seconds_count{domain="aggregator.kind-ci-castor.svc.cluster.local",endpoint="aggregate",service_name="unknown_service",status="error"} 327
```