### PR TITLE
Use max_batch_lifetime of 1 in Task::new_dummy()

### DIFF
--- a/janus_server/src/task.rs
+++ b/janus_server/src/task.rs
@@ -623,7 +623,7 @@ pub mod test_util {
                 vdaf,
                 role,
                 Vec::from([vdaf_verify_key]),
-                0,
+                1,
                 0,
                 Duration::from_hours(8).unwrap(),
                 Duration::from_minutes(10).unwrap(),


### PR DESCRIPTION
Currently, `Task::new_dummy()` sets max_batch_lifetime to 0. This is irrelevant to most tests, but it would prevent all collect requests from being handled if the task weren't modified first. This change sets max_batch_lifetime to 1 as a more typical default value.