### PR TITLE
Datastore: basic DAP-02 message updates.

### DIFF
--- a/janus_collector/src/lib.rs
+++ b/janus_collector/src/lib.rs
@@ -385,7 +385,7 @@ where
         }
 
         let associated_data = associated_data_for_aggregate_share::<TimeInterval>(
-            self.parameters.task_id,
+            &self.parameters.task_id,
             &job.batch_interval,
         );
         let aggregate_shares_bytes = collect_response
@@ -562,7 +562,7 @@ mod tests {
         for<'a> Vec<u8>: From<&'a V::AggregateShare>,
     {
         let associated_data = associated_data_for_aggregate_share::<TimeInterval>(
-            parameters.task_id,
+            &parameters.task_id,
             &batch_interval,
         );
         CollectResp::new(
@@ -937,7 +937,7 @@ mod tests {
         mock_collect_job_bad_ciphertext.assert();
 
         let associated_data = associated_data_for_aggregate_share::<TimeInterval>(
-            collector.parameters.task_id,
+            &collector.parameters.task_id,
             &batch_interval,
         );
         let collect_resp = CollectResp::new(

--- a/janus_core/src/hpke.rs
+++ b/janus_core/src/hpke.rs
@@ -50,7 +50,7 @@ pub fn associated_data_for_report_share(
 
 /// Construct the HPKE associated data for sealing or opening an aggregate share.
 pub fn associated_data_for_aggregate_share<Q: QueryType>(
-    task_id: TaskId,
+    task_id: &TaskId,
     batch_identifier: &Q::BatchIdentifier,
 ) -> Vec<u8> {
     let mut associated_data = Vec::new();

--- a/janus_core/src/report_id.rs
+++ b/janus_core/src/report_id.rs
@@ -8,37 +8,35 @@ pub trait ReportIdChecksumExt {
     /// Initialize a checksum from a single report ID.
     fn for_report_id(report_id: &ReportId) -> Self;
 
-    /// Compute the SHA256 hash of a report ID.
-    fn report_id_digest(report_id: &ReportId) -> [u8; SHA256_OUTPUT_LEN];
-
     /// Incorporate the provided report ID into this checksum.
-    fn update(&mut self, report_id: &ReportId);
+    fn updated_with(self, report_id: &ReportId) -> Self;
 
     /// Combine another checksum with this one.
-    fn combine(&mut self, other: &ReportIdChecksum);
+    fn combined_with(self, other: &Self) -> Self;
 }
 
 impl ReportIdChecksumExt for ReportIdChecksum {
     fn for_report_id(report_id: &ReportId) -> Self {
-        Self::from(Self::report_id_digest(report_id))
+        Self::from(report_id_digest(report_id))
     }
 
-    fn report_id_digest(report_id: &ReportId) -> [u8; SHA256_OUTPUT_LEN] {
-        digest(&SHA256, report_id.as_ref())
-            .as_ref()
-            .try_into()
-            // panic if somehow the digest ring computes isn't 32 bytes long.
-            .unwrap()
+    fn updated_with(self, report_id: &ReportId) -> Self {
+        self.combined_with(&Self::for_report_id(report_id))
     }
 
-    fn update(&mut self, report_id: &ReportId) {
-        self.combine(&Self::for_report_id(report_id))
-    }
-
-    fn combine(&mut self, other: &ReportIdChecksum) {
+    fn combined_with(mut self, other: &Self) -> Self {
         self.as_mut()
             .iter_mut()
             .zip(other.as_ref())
-            .for_each(|(x, y)| *x ^= y)
+            .for_each(|(x, y)| *x ^= y);
+        self
     }
+}
+
+fn report_id_digest(report_id: &ReportId) -> [u8; SHA256_OUTPUT_LEN] {
+    digest(&SHA256, report_id.as_ref())
+        .as_ref()
+        .try_into()
+        // panic if somehow the digest ring computes isn't 32 bytes long.
+        .unwrap()
 }

--- a/janus_messages/src/lib.rs
+++ b/janus_messages/src/lib.rs
@@ -277,10 +277,15 @@ impl Distribution<ReportId> for Standard {
 
 /// Checksum over DAP report IDs, defined in §4.4.4.3.
 #[derive(Copy, Clone, Debug, Default, Hash, PartialEq, Eq)]
-pub struct ReportIdChecksum([u8; 32]);
+pub struct ReportIdChecksum([u8; Self::LEN]);
 
-impl From<[u8; 32]> for ReportIdChecksum {
-    fn from(checksum: [u8; 32]) -> Self {
+impl ReportIdChecksum {
+    /// LEN is the length of a report ID checksum in bytes.
+    pub const LEN: usize = 32;
+}
+
+impl From<[u8; Self::LEN]> for ReportIdChecksum {
+    fn from(checksum: [u8; Self::LEN]) -> Self {
         Self(checksum)
     }
 }

--- a/janus_server/src/bin/janus_cli.rs
+++ b/janus_server/src/bin/janus_cli.rs
@@ -175,7 +175,7 @@ async fn provision_tasks<C: Clock>(datastore: &Datastore<C>, tasks_file: &Path) 
                 for task in tasks.iter() {
                     // We attempt to delete the task, but ignore "task not found" errors since
                     // the task not existing is an OK outcome too.
-                    match tx.delete_task(task.id).await {
+                    match tx.delete_task(&task.id).await {
                         Ok(_) | Err(datastore::Error::MutationTargetNotFound) => (),
                         err => err?,
                     }

--- a/janus_server/src/binary_utils/job_driver.rs
+++ b/janus_server/src/binary_utils/job_driver.rs
@@ -235,7 +235,7 @@ where
         new_delay
     }
 
-    fn effective_lease_duration(&self, lease_expiry: Time) -> time::Duration {
+    fn effective_lease_duration(&self, lease_expiry: &Time) -> time::Duration {
         // Lease expiries are expressed as Time values (i.e. an absolute timestamp). Tokio Instant
         // values, unfortunately, can't be created directly from a timestamp. All we can do is
         // create an Instant::now(), then add durations to it. This function computes how long
@@ -367,7 +367,7 @@ mod tests {
                         let leases = incomplete_jobs
                             .iter()
                             .map(|job| {
-                                Lease::new(
+                                Lease::new_dummy(
                                     (job.task_id, VdafInstance::Fake, job.job_id),
                                     job.lease_expiry,
                                 )

--- a/janus_server/src/messages.rs
+++ b/janus_server/src/messages.rs
@@ -54,19 +54,19 @@ pub trait TimeExt: Sized {
     fn as_naive_date_time(&self) -> NaiveDateTime;
 
     /// Convert a [`NaiveDateTime`] representing an instant in the UTC timezone into a [`Time`].
-    fn from_naive_date_time(time: NaiveDateTime) -> Self;
+    fn from_naive_date_time(time: &NaiveDateTime) -> Self;
 
     /// Add the provided duration to this time.
-    fn add(&self, duration: Duration) -> Result<Self, Error>;
+    fn add(&self, duration: &Duration) -> Result<Self, Error>;
 
     /// Subtract the provided duration from this time.
-    fn sub(&self, duration: Duration) -> Result<Self, Error>;
+    fn sub(&self, duration: &Duration) -> Result<Self, Error>;
 
     /// Get the difference between the provided `other` and `self`. `self` must be after `other`.
-    fn difference(&self, other: Self) -> Result<Duration, Error>;
+    fn difference(&self, other: &Self) -> Result<Duration, Error>;
 
     /// Returns true if this [`Time`] occurs after `time`.
-    fn is_after(&self, time: Time) -> bool;
+    fn is_after(&self, time: &Time) -> bool;
 }
 
 impl TimeExt for Time {
@@ -75,12 +75,12 @@ impl TimeExt for Time {
     }
 
     /// Convert a [`NaiveDateTime`] representing an instant in the UTC timezone into a [`Time`].
-    fn from_naive_date_time(time: NaiveDateTime) -> Self {
+    fn from_naive_date_time(time: &NaiveDateTime) -> Self {
         Self::from_seconds_since_epoch(time.timestamp() as u64)
     }
 
     /// Add the provided duration to this time.
-    fn add(&self, duration: Duration) -> Result<Self, Error> {
+    fn add(&self, duration: &Duration) -> Result<Self, Error> {
         self.as_seconds_since_epoch()
             .checked_add(duration.as_seconds())
             .map(Self::from_seconds_since_epoch)
@@ -88,7 +88,7 @@ impl TimeExt for Time {
     }
 
     /// Subtract the provided duration from this time.
-    fn sub(&self, duration: Duration) -> Result<Self, Error> {
+    fn sub(&self, duration: &Duration) -> Result<Self, Error> {
         self.as_seconds_since_epoch()
             .checked_sub(duration.as_seconds())
             .map(Self::from_seconds_since_epoch)
@@ -96,7 +96,7 @@ impl TimeExt for Time {
     }
 
     /// Get the difference between the provided `other` and `self`. `self` must be after `other`.
-    fn difference(&self, other: Self) -> Result<Duration, Error> {
+    fn difference(&self, other: &Self) -> Result<Duration, Error> {
         self.as_seconds_since_epoch()
             .checked_sub(other.as_seconds_since_epoch())
             .map(Duration::from_seconds)
@@ -104,7 +104,7 @@ impl TimeExt for Time {
     }
 
     /// Returns true if this [`Time`] occurs after `time`.
-    fn is_after(&self, time: Time) -> bool {
+    fn is_after(&self, time: &Time) -> bool {
         self.as_seconds_since_epoch() > time.as_seconds_since_epoch()
     }
 }
@@ -119,7 +119,7 @@ impl IntervalExt for Interval {
     /// Returns a [`Time`] representing the excluded end of this interval.
     fn end(&self) -> Time {
         // [`Self::new`] verified that this addition doesn't overflow.
-        self.start().add(*self.duration()).unwrap()
+        self.start().add(self.duration()).unwrap()
     }
 }
 


### PR DESCRIPTION
Note these updates are just for time-interval tasks; fixed-size task
updates will be made as part of implementing fixed-size tasks.

* Rename & reorder fields as needed (e.g. nonce -> report_id).
* Update transaction methods to follow code standards for receiving
  references.
* Update datastore models to follow code standards for cross-module
  structured data.
* Update visibility of methods used cross-module to be pub -- we don't
  publish janus_server, so I don't think we care much about visibility
  other than pub/private-to-module/private.
* Fix up DB indices to allow efficient lookup of reports without the
  client timestamp.

Closes #533.