### PR TITLE
DAP-02: populate CollectResp::report_count.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1714,6 +1714,7 @@ dependencies = [
  "chrono",
  "clap 3.2.22",
  "derivative",
+ "janus_collector",
  "janus_core",
  "janus_messages",
  "mockito",

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -168,6 +168,7 @@ CREATE TABLE collect_jobs(
     batch_interval          TSRANGE NOT NULL,            -- the batch interval, as a range of timestamps
     aggregation_param       BYTEA NOT NULL,              -- the aggregation parameter (opaque VDAF message)
     state                   COLLECT_JOB_STATE NOT NULL,  -- the current state of this collect job
+    report_count            BIGINT,                      -- the number of reports included in this collect job (only if in state FINISHED)
     helper_aggregate_share  BYTEA,                       -- the helper's encrypted aggregate share (HpkeCiphertext, only if in state FINISHED)
     leader_aggregate_share  BYTEA,                       -- the leader's unencrypted aggregate share (opaque VDAF message, only if in state FINISHED)
 

--- a/integration_tests/tests/common/mod.rs
+++ b/integration_tests/tests/common/mod.rs
@@ -2,7 +2,7 @@ use backoff::ExponentialBackoffBuilder;
 use itertools::Itertools;
 use janus_client::{Client, ClientParameters};
 use janus_collector::{
-    test_util::collect_with_rewritten_url, CollectionResult, Collector, CollectorParameters,
+    test_util::collect_with_rewritten_url, Collection, Collector, CollectorParameters,
 };
 use janus_core::{
     hpke::{test_util::generate_test_hpke_config_and_private_key, HpkePrivateKey},
@@ -179,14 +179,14 @@ pub async fn submit_measurements_and_verify_aggregate(
         vdaf,
         janus_collector::default_http_client().unwrap(),
     );
-    let collect_result =
+    let collection =
         collect_with_rewritten_url(&collector, batch_interval, &(), "127.0.0.1", leader_port)
             .await
             .unwrap();
 
     // Verify that we got the correct result.
     assert_eq!(
-        collect_result,
-        CollectionResult::new(total_measurements as u64, num_nonzero_measurements as u64)
+        collection,
+        Collection::new(total_measurements as u64, num_nonzero_measurements as u64)
     );
 }

--- a/interop_binaries/src/bin/janus_interop_collector.rs
+++ b/interop_binaries/src/bin/janus_interop_collector.rs
@@ -82,6 +82,7 @@ enum AggregationResult {
 }
 
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct CollectPollResponse {
     status: &'static str,
     #[serde(default)]

--- a/janus_collector/Cargo.toml
+++ b/janus_collector/Cargo.toml
@@ -31,6 +31,7 @@ assert_matches = "1"
 base64 = "0.13.0"
 chrono = "0.4"
 clap = { version = "3.2.22", features = ["derive", "env"] }
+janus_collector = { path = ".", features = ["test-util"] }
 janus_core = { path = "../janus_core", features = ["test-util"] }
 mockito = "0.31.0"
 rand = "0.8"

--- a/janus_collector/src/lib.rs
+++ b/janus_collector/src/lib.rs
@@ -240,7 +240,7 @@ impl<P> CollectJob<P> {
 /// or indicate that the collection is still being processed.
 enum PollResult<T> {
     /// The collection result from a completed collect request.
-    CollectionResult(#[derivative(Debug = "ignore")] CollectionResult<T>),
+    CollectionResult(#[derivative(Debug = "ignore")] Collection<T>),
     /// The collect request is not yet ready. If present, the [`RetryAfter`] object is the time at
     /// which the leader recommends retrying the request.
     NextAttempt(Option<RetryAfter>),
@@ -248,12 +248,12 @@ enum PollResult<T> {
 
 /// The result of a collection operation.
 #[derive(Debug)]
-pub struct CollectionResult<T> {
+pub struct Collection<T> {
     report_count: u64,
     aggregate_result: T,
 }
 
-impl<T> CollectionResult<T> {
+impl<T> Collection<T> {
     /// Retrieves the number of client reports included in this collection.
     pub fn report_count(&self) -> u64 {
         self.report_count
@@ -266,8 +266,8 @@ impl<T> CollectionResult<T> {
 }
 
 #[cfg(feature = "test-util")]
-impl<T> CollectionResult<T> {
-    /// Creates a new [`CollectionResult`].
+impl<T> Collection<T> {
+    /// Creates a new [`Collection`].
     pub fn new(report_count: u64, aggregate_result: T) -> Self {
         Self {
             report_count,
@@ -276,13 +276,13 @@ impl<T> CollectionResult<T> {
     }
 }
 
-impl<T: PartialEq> PartialEq for CollectionResult<T> {
+impl<T: PartialEq> PartialEq for Collection<T> {
     fn eq(&self, other: &Self) -> bool {
         self.report_count == other.report_count && self.aggregate_result == other.aggregate_result
     }
 }
 
-impl<T: Eq> Eq for CollectionResult<T> {}
+impl<T: Eq> Eq for Collection<T> {}
 
 /// A DAP collector.
 #[derive(Debug)]
@@ -455,7 +455,7 @@ where
             report_count,
         )?;
 
-        Ok(PollResult::CollectionResult(CollectionResult {
+        Ok(PollResult::CollectionResult(Collection {
             report_count: collect_response.report_count(),
             aggregate_result,
         }))
@@ -466,7 +466,7 @@ where
     async fn poll_until_complete(
         &self,
         job: &CollectJob<V::AggregationParam>,
-    ) -> Result<CollectionResult<V::AggregateResult>, Error> {
+    ) -> Result<Collection<V::AggregateResult>, Error> {
         let mut backoff = self.parameters.collect_poll_wait_parameters.clone();
         backoff.reset();
         let deadline = backoff
@@ -521,7 +521,7 @@ where
         &self,
         batch_interval: Interval,
         aggregation_parameter: &V::AggregationParam,
-    ) -> Result<CollectionResult<V::AggregateResult>, Error> {
+    ) -> Result<Collection<V::AggregateResult>, Error> {
         let job = self
             .start_collection(batch_interval, aggregation_parameter)
             .await?;
@@ -531,7 +531,7 @@ where
 
 #[cfg(feature = "test-util")]
 pub mod test_util {
-    use crate::{CollectionResult, Collector, Error};
+    use crate::{Collection, Collector, Error};
     use janus_messages::Interval;
     use prio::vdaf;
 
@@ -541,7 +541,7 @@ pub mod test_util {
         aggregation_parameter: &V::AggregationParam,
         host: &str,
         port: u16,
-    ) -> Result<CollectionResult<V::AggregateResult>, Error>
+    ) -> Result<Collection<V::AggregateResult>, Error>
     where
         for<'a> Vec<u8>: From<&'a <V as vdaf::Vdaf>::AggregateShare>,
     {
@@ -720,8 +720,8 @@ mod tests {
         let poll_result = collector.poll_once(&job).await.unwrap();
         assert_matches!(poll_result, PollResult::NextAttempt(None));
 
-        let collect_result = collector.poll_until_complete(&job).await.unwrap();
-        assert_eq!(collect_result, CollectionResult::new(1, 1));
+        let collection = collector.poll_until_complete(&job).await.unwrap();
+        assert_eq!(collection, Collection::new(1, 1));
 
         mocked_collect_start_error.assert();
         mocked_collect_start_success.assert();
@@ -773,8 +773,8 @@ mod tests {
         assert_eq!(job.collect_job_url.as_str(), collect_job_url);
         assert_eq!(job.batch_interval, batch_interval);
 
-        let collect_result = collector.poll_until_complete(&job).await.unwrap();
-        assert_eq!(collect_result, CollectionResult::new(1, 144));
+        let collection = collector.poll_until_complete(&job).await.unwrap();
+        assert_eq!(collection, Collection::new(1, 144));
 
         mocked_collect_start_success.assert();
         mocked_collect_complete.assert();
@@ -823,11 +823,8 @@ mod tests {
         assert_eq!(job.collect_job_url.as_str(), collect_job_url);
         assert_eq!(job.batch_interval, batch_interval);
 
-        let collect_result = collector.poll_until_complete(&job).await.unwrap();
-        assert_eq!(
-            collect_result,
-            CollectionResult::new(1, Vec::from([0, 0, 0, 1, 0]))
-        );
+        let collection = collector.poll_until_complete(&job).await.unwrap();
+        assert_eq!(collection, Collection::new(1, Vec::from([0, 0, 0, 1, 0])));
 
         mocked_collect_start_success.assert();
         mocked_collect_complete.assert();

--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -1754,6 +1754,7 @@ impl VdafOps {
             }
 
             CollectJobState::Finished {
+                report_count,
                 encrypted_helper_aggregate_share,
                 leader_aggregate_share,
             } => {
@@ -1785,7 +1786,7 @@ impl VdafOps {
 
                 Ok(Some(CollectResp::new(
                     PartialBatchSelector::new_time_interval(),
-                    0, // TODO(#469): fill out report_count once possible
+                    *report_count,
                     vec![
                         encrypted_leader_aggregate_share,
                         encrypted_helper_aggregate_share.clone(),
@@ -6153,6 +6154,7 @@ mod tests {
                         .unwrap()
                         .unwrap()
                         .with_state(CollectJobState::Finished {
+                            report_count: 12,
                             encrypted_helper_aggregate_share,
                             leader_aggregate_share,
                         });

--- a/janus_server/src/aggregator/aggregate_share.rs
+++ b/janus_server/src/aggregator/aggregate_share.rs
@@ -34,7 +34,7 @@ use prio::{
         Aggregatable,
     },
 };
-use std::{borrow::Borrow, sync::Arc};
+use std::sync::Arc;
 use tracing::{debug, error, info, warn};
 
 #[cfg(test)]
@@ -276,6 +276,7 @@ impl CollectJobDriver {
         // job URI can serve it up.
         let collect_job = Arc::new(
             collect_job.with_state(CollectJobState::Finished {
+                report_count,
                 encrypted_helper_aggregate_share: AggregateShareResp::get_decoded(&resp_bytes)?
                     .encrypted_aggregate_share()
                     .clone(),
@@ -299,7 +300,7 @@ impl CollectJobDriver {
 
                     match maybe_updated_collect_job.state() {
                         CollectJobState::Start => {
-                            tx.update_collect_job::<L, A>(collect_job.borrow()).await?;
+                            tx.update_collect_job::<L, A>(&collect_job).await?;
                             tx.release_collect_job(&lease).await?;
                             metrics.jobs_finished_counter.add(&Context::current(), 1, &[]);
                         }


### PR DESCRIPTION
I also update the interop collector to return the report count; technically this could have been in another PR, but I need this functionality to augment the integration tests to check that the correct number of reports are returned. (This should be specified; I'm going to do so in a followup PR.)

Closes #469.