### PR TITLE
Clean up output of the collect CLI

### DIFF
--- a/janus_collector/examples/collect.rs
+++ b/janus_collector/examples/collect.rs
@@ -292,8 +292,9 @@ where
     V::AggregateResult: Debug,
 {
     let collector = Collector::new(parameters, vdaf, http_client);
-    let agg_result = collector.collect(interval, agg_param).await?;
-    println!("Aggregation result: {:?}", agg_result);
+    let collection = collector.collect(interval, agg_param).await?;
+    println!("Aggregation result: {:?}", collection.aggregate_result());
+    println!("Number of reports: {}", collection.report_count());
     Ok(())
 }
 


### PR DESCRIPTION
This outputs the aggregation result and number of reports on separate labeled lines, rather than using `<Collection<T> as Debug>`.