### PR TITLE
Interop test API: Use strings for VDAF parameters, 0.1 backport

### DIFF
--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -83,8 +83,8 @@ where
 #[serde(tag = "type")]
 pub enum VdafObject {
     Prio3Aes128Count,
-    Prio3Aes128CountVec { length: usize },
-    Prio3Aes128Sum { bits: u32 },
+    Prio3Aes128CountVec { length: NumberAsString<usize> },
+    Prio3Aes128Sum { bits: NumberAsString<u32> },
     Prio3Aes128Histogram { buckets: Vec<NumberAsString<u64>> },
 }
 
@@ -95,10 +95,14 @@ impl From<VdafInstance> for VdafObject {
                 VdafObject::Prio3Aes128Count
             }
             VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128CountVec { length }) => {
-                VdafObject::Prio3Aes128CountVec { length }
+                VdafObject::Prio3Aes128CountVec {
+                    length: NumberAsString(length),
+                }
             }
             VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128Sum { bits }) => {
-                VdafObject::Prio3Aes128Sum { bits }
+                VdafObject::Prio3Aes128Sum {
+                    bits: NumberAsString(bits),
+                }
             }
             VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128Histogram {
                 buckets,
@@ -117,10 +121,12 @@ impl From<VdafObject> for VdafInstance {
                 VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128Count)
             }
             VdafObject::Prio3Aes128CountVec { length } => {
-                VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128CountVec { length })
+                VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128CountVec {
+                    length: length.0,
+                })
             }
             VdafObject::Prio3Aes128Sum { bits } => {
-                VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128Sum { bits })
+                VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128Sum { bits: bits.0 })
             }
             VdafObject::Prio3Aes128Histogram { buckets } => {
                 VdafInstance::Real(janus_core::task::VdafInstance::Prio3Aes128Histogram {

--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -481,7 +481,7 @@ async fn e2e_prio3_count() {
 #[tokio::test]
 async fn e2e_prio3_sum() {
     let result = run(
-        json!({"type": "Prio3Aes128Sum", "bits": 64}),
+        json!({"type": "Prio3Aes128Sum", "bits": "64"}),
         &[
             json!("0"),
             json!("10"),
@@ -525,7 +525,7 @@ async fn e2e_prio3_histogram() {
 #[tokio::test]
 async fn e2e_prio3_count_vec() {
     let result = run(
-        json!({"type": "Prio3Aes128CountVec", "length": 4}),
+        json!({"type": "Prio3Aes128CountVec", "length": "4"}),
         &[
             json!(["0", "0", "0", "1"]),
             json!(["0", "0", "1", "0"]),


### PR DESCRIPTION
This backports #605 to the 0.1 branch. See divergentdave/draft-dcook-ppm-dap-interop-test-design#8. I'm backporting this to keep up with the interop test API draft, and to ease testing of DAP draft 01 implementations, before DAP draft 02 implementations are ready.