### PR TITLE
Parse problem types in errors from the helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,6 +1401,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-api-problem"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a4ac53ed8a1a36055d74e9edd37f5ee313d2f250ceb4203f1af68d1d04c4111"
+dependencies = [
+ "http",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1801,6 +1812,7 @@ dependencies = [
  "futures",
  "hex",
  "http",
+ "http-api-problem",
  "hyper",
  "itertools",
  "janus_core",

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -40,6 +40,7 @@ deadpool-postgres = "0.10.1"
 derivative = "2.2.0"
 futures = "0.3.24"
 http = "0.2.8"
+http-api-problem = "0.55.0"
 hyper = "0.14.20"
 itertools = "0.10.5"
 janus_core = { path = "../janus_core" }

--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -66,6 +66,7 @@ use std::{
     future::Future,
     io::Cursor,
     net::SocketAddr,
+    str::FromStr,
     sync::Arc,
     time::Instant,
 };
@@ -176,8 +177,8 @@ pub enum Error {
     #[error("HTTP client error: {0}")]
     HttpClient(#[from] reqwest::Error),
     /// HTTP server returned an error status code.
-    #[error("HTTP response status {0}")]
-    Http(StatusCode),
+    #[error("HTTP response status {0} (problem type {1:?})")]
+    Http(StatusCode, Option<DapProblemType>),
     /// An error representing a generic internal aggregation error; intended for "impossible"
     /// conditions.
     #[error("internal aggregator error: {0}")]
@@ -212,7 +213,7 @@ impl Error {
             Error::Hpke(_) => "hpke",
             Error::TaskParameters(_) => "task_parameters",
             Error::HttpClient(_) => "http_client",
-            Error::Http(_) => "http",
+            Error::Http(_, _) => "http",
             Error::Internal(_) => "internal",
         }
     }
@@ -2083,7 +2084,8 @@ where
 }
 
 /// Representation of the different problem types defined in Table 1 in §3.2.
-enum DapProblemType {
+#[derive(Debug, PartialEq, Eq)]
+pub enum DapProblemType {
     UnrecognizedMessage,
     UnrecognizedTask,
     MissingTaskId,
@@ -2176,6 +2178,45 @@ impl DapProblemType {
             DapProblemType::BatchOverlap => {
                 "The queried batch overlaps with a previously queried batch."
             }
+        }
+    }
+}
+
+/// An error indicating a problem type URI was not recognized as a DAP problem type.
+#[derive(Debug)]
+pub struct DapProblemTypeParseError;
+
+impl FromStr for DapProblemType {
+    type Err = DapProblemTypeParseError;
+
+    fn from_str(value: &str) -> Result<DapProblemType, DapProblemTypeParseError> {
+        match value {
+            "urn:ietf:params:ppm:dap:error:unrecognizedMessage" => {
+                Ok(DapProblemType::UnrecognizedMessage)
+            }
+            "urn:ietf:params:ppm:dap:error:unrecognizedTask" => {
+                Ok(DapProblemType::UnrecognizedTask)
+            }
+            "urn:ietf:params:ppm:dap:error:missingTaskID" => Ok(DapProblemType::MissingTaskId),
+            "urn:ietf:params:ppm:dap:error:unrecognizedAggregationJob" => {
+                Ok(DapProblemType::UnrecognizedAggregationJob)
+            }
+            "urn:ietf:params:ppm:dap:error:outdatedConfig" => Ok(DapProblemType::OutdatedConfig),
+            "urn:ietf:params:ppm:dap:error:reportTooLate" => Ok(DapProblemType::ReportTooLate),
+            "urn:ietf:params:ppm:dap:error:reportTooEarly" => Ok(DapProblemType::ReportTooEarly),
+            "urn:ietf:params:ppm:dap:error:batchInvalid" => Ok(DapProblemType::BatchInvalid),
+            "urn:ietf:params:ppm:dap:error:invalidBatchSize" => {
+                Ok(DapProblemType::InvalidBatchSize)
+            }
+            "urn:ietf:params:ppm:dap:error:batchQueriedTooManyTimes" => {
+                Ok(DapProblemType::BatchQueriedTooManyTimes)
+            }
+            "urn:ietf:params:ppm:dap:error:batchMismatch" => Ok(DapProblemType::BatchMismatch),
+            "urn:ietf:params:ppm:dap:error:unauthorizedRequest" => {
+                Ok(DapProblemType::UnauthorizedRequest)
+            }
+            "urn:ietf:params:ppm:dap:error:batchOverlap" => Ok(DapProblemType::BatchOverlap),
+            _ => Err(DapProblemTypeParseError),
         }
     }
 }
@@ -2311,7 +2352,7 @@ where
                     Err(Error::Url(_)) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
                     Err(Error::Message(_)) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
                     Err(Error::HttpClient(_)) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
-                    Err(Error::Http(_)) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+                    Err(Error::Http(_, _)) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
                     Err(Error::TaskParameters(_)) => {
                         StatusCode::INTERNAL_SERVER_ERROR.into_response()
                     }
@@ -2665,7 +2706,6 @@ async fn post_to_helper<T: Encode>(
 
     let status = response.status();
     if !status.is_success() {
-        // TODO(#381): Attempt to decode a problem details response.
         http_request_duration_histogram.record(
             &Context::current(),
             start.elapsed().as_secs_f64(),
@@ -2675,7 +2715,15 @@ async fn post_to_helper<T: Encode>(
                 KeyValue::new("endpoint", endpoint),
             ],
         );
-        return Err(Error::Http(status));
+        if let Ok(json_body) = response.json::<serde_json::Value>().await {
+            let type_opt = json_body
+                .as_object()
+                .and_then(|object| object.get("type"))
+                .and_then(|value| value.as_str())
+                .and_then(|str| str.parse::<DapProblemType>().ok());
+            return Err(Error::Http(status, type_opt));
+        }
+        return Err(Error::Http(status, None));
     }
 
     match response.bytes().await {
@@ -2728,12 +2776,13 @@ mod tests {
         },
         report_id::ReportIdChecksumExt,
         test_util::{dummy_vdaf, install_test_trace_subscriber, run_vdaf},
-        time::{MockClock, TimeExt as CoreTimeExt},
+        time::{MockClock, RealClock, TimeExt as CoreTimeExt},
     };
     use janus_messages::{
         BatchSelector, Duration, HpkeCiphertext, HpkeConfig, Query, ReportId, ReportMetadata,
         TaskId, Time,
     };
+    use mockito::mock;
     use opentelemetry::global::meter;
     use prio::{
         codec::Decode,
@@ -7233,5 +7282,177 @@ mod tests {
             )
             .unwrap(),
         )
+    }
+
+    #[test]
+    fn dap_problem_type_round_trip() {
+        for problem_type in [
+            DapProblemType::UnrecognizedMessage,
+            DapProblemType::UnrecognizedTask,
+            DapProblemType::MissingTaskId,
+            DapProblemType::UnrecognizedAggregationJob,
+            DapProblemType::OutdatedConfig,
+            DapProblemType::ReportTooLate,
+            DapProblemType::ReportTooEarly,
+            DapProblemType::BatchInvalid,
+            DapProblemType::InvalidBatchSize,
+            DapProblemType::BatchQueriedTooManyTimes,
+            DapProblemType::BatchMismatch,
+            DapProblemType::UnauthorizedRequest,
+            DapProblemType::BatchOverlap,
+        ] {
+            let uri = problem_type.type_uri();
+            assert_eq!(uri.parse::<DapProblemType>().unwrap(), problem_type);
+        }
+        assert_matches!("".parse::<DapProblemType>(), Err(DapProblemTypeParseError));
+    }
+
+    #[tokio::test]
+    async fn problem_details_round_trip() {
+        let meter = opentelemetry::global::meter("");
+        let response_histogram = meter.f64_histogram("janus_aggregator_response_time").init();
+        let request_histogram = meter
+            .f64_histogram("janus_http_request_duration_seconds")
+            .init();
+        let server_url: Url = mockito::server_url().parse().unwrap();
+        let auth_token = AuthenticationToken::from("auth".as_bytes().to_vec());
+        let http_client = Client::new();
+
+        struct TestCase {
+            error_factory: Box<dyn Fn() -> Error + Send + Sync>,
+            expected_problem_type: Option<DapProblemType>,
+        }
+
+        impl TestCase {
+            fn new(
+                error_factory: Box<dyn Fn() -> Error + Send + Sync>,
+                expected_problem_type: Option<DapProblemType>,
+            ) -> TestCase {
+                TestCase {
+                    error_factory,
+                    expected_problem_type,
+                }
+            }
+        }
+
+        let test_cases = [
+            TestCase::new(Box::new(|| Error::InvalidConfiguration("test")), None),
+            TestCase::new(
+                Box::new(|| Error::ReportTooLate(random(), random(), RealClock::default().now())),
+                Some(DapProblemType::ReportTooLate),
+            ),
+            TestCase::new(
+                Box::new(|| Error::UnrecognizedMessage(Some(random()), "test")),
+                Some(DapProblemType::UnrecognizedMessage),
+            ),
+            TestCase::new(
+                Box::new(|| Error::UnrecognizedTask(random())),
+                Some(DapProblemType::UnrecognizedTask),
+            ),
+            TestCase::new(
+                Box::new(|| Error::MissingTaskId),
+                Some(DapProblemType::MissingTaskId),
+            ),
+            TestCase::new(
+                Box::new(|| Error::UnrecognizedAggregationJob(random(), random())),
+                Some(DapProblemType::UnrecognizedAggregationJob),
+            ),
+            TestCase::new(
+                Box::new(|| Error::OutdatedHpkeConfig(random(), HpkeConfigId::from(0))),
+                Some(DapProblemType::OutdatedConfig),
+            ),
+            TestCase::new(
+                Box::new(|| Error::ReportTooEarly(random(), random(), RealClock::default().now())),
+                Some(DapProblemType::ReportTooEarly),
+            ),
+            TestCase::new(
+                Box::new(|| Error::UnauthorizedRequest(random())),
+                Some(DapProblemType::UnauthorizedRequest),
+            ),
+            TestCase::new(
+                Box::new(|| Error::InvalidBatchSize(random(), 8)),
+                Some(DapProblemType::InvalidBatchSize),
+            ),
+            TestCase::new(
+                Box::new(|| {
+                    Error::BatchInvalid(
+                        random(),
+                        Interval::new(RealClock::default().now(), Duration::from_seconds(3600))
+                            .unwrap(),
+                    )
+                }),
+                Some(DapProblemType::BatchInvalid),
+            ),
+            TestCase::new(
+                Box::new(|| {
+                    Error::BatchOverlap(
+                        random(),
+                        Interval::new(RealClock::default().now(), Duration::from_seconds(3600))
+                            .unwrap(),
+                    )
+                }),
+                Some(DapProblemType::BatchOverlap),
+            ),
+            TestCase::new(
+                Box::new(|| Error::BatchMismatch {
+                    task_id: random(),
+                    own_checksum: ReportIdChecksum::from([0; 32]),
+                    own_report_count: 100,
+                    peer_checksum: ReportIdChecksum::from([1; 32]),
+                    peer_report_count: 99,
+                }),
+                Some(DapProblemType::BatchMismatch),
+            ),
+            TestCase::new(
+                Box::new(|| Error::BatchQueriedTooManyTimes(random(), 99)),
+                Some(DapProblemType::BatchQueriedTooManyTimes),
+            ),
+        ];
+
+        for TestCase {
+            error_factory,
+            expected_problem_type,
+        } in test_cases
+        {
+            // Run error_handler() on the given error, and capture its response.
+            let error_factory = Arc::new(error_factory);
+            let base_filter = warp::post().map({
+                let error_factory = Arc::clone(&error_factory);
+                move || -> Result<Response, Error> { Err(error_factory()) }
+            });
+            let wrapped_filter = base_filter.with(warp::wrap_fn(error_handler(
+                response_histogram.clone(),
+                "test",
+            )));
+            let response = warp::test::request()
+                .method("POST")
+                .reply(&wrapped_filter)
+                .await;
+
+            // Serve the response via mockito, and run it through post_to_helper's error handling.
+            let error_mock = mock("POST", "/")
+                .with_status(response.status().as_u16().into())
+                .with_body(response.body())
+                .create();
+            let actual_error = post_to_helper(
+                &http_client,
+                server_url.clone(),
+                "text/plain",
+                (),
+                &auth_token,
+                &request_histogram,
+            )
+            .await
+            .unwrap_err();
+            error_mock.assert();
+
+            // Confirm that post_to_helper() correctly parsed the error type from error_handler().
+            assert_matches!(
+                actual_error,
+                Error::Http(_, problem_type) => {
+                    assert_eq!(problem_type, expected_problem_type);
+                }
+            );
+        }
     }
 }

--- a/janus_server/src/aggregator/aggregate_share.rs
+++ b/janus_server/src/aggregator/aggregate_share.rs
@@ -628,6 +628,7 @@ where
 mod tests {
     use super::*;
     use crate::{
+        aggregator::DapProblemType,
         binary_utils::job_driver::JobDriver,
         datastore::{
             models::{
@@ -947,13 +948,20 @@ mod tests {
             )
             .match_body(leader_request.get_encoded())
             .with_status(500)
+            .with_body("{\"type\": \"urn:ietf:params:ppm:dap:error:batchQueriedTooManyTimes\"}")
             .create();
 
         let error = collect_job_driver
             .step_collect_job(ds.clone(), Arc::clone(&lease))
             .await
             .unwrap_err();
-        assert_matches!(error, Error::Http(StatusCode::INTERNAL_SERVER_ERROR));
+        assert_matches!(
+            error,
+            Error::Http(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Some(DapProblemType::BatchQueriedTooManyTimes),
+            )
+        );
 
         mocked_failed_aggregate_share.assert();
 

--- a/janus_server/src/aggregator/aggregate_share.rs
+++ b/janus_server/src/aggregator/aggregate_share.rs
@@ -957,10 +957,12 @@ mod tests {
             .unwrap_err();
         assert_matches!(
             error,
-            Error::Http(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Some(DapProblemType::BatchQueriedTooManyTimes),
-            )
+            Error::Http {
+                problem_details,
+                dap_problem_type: Some(DapProblemType::BatchQueriedTooManyTimes),
+            } => {
+                assert_eq!(problem_details.status.unwrap(), StatusCode::INTERNAL_SERVER_ERROR);
+            }
         );
 
         mocked_failed_aggregate_share.assert();

--- a/janus_server/src/aggregator/aggregation_job_driver.rs
+++ b/janus_server/src/aggregator/aggregation_job_driver.rs
@@ -1305,9 +1305,9 @@ mod tests {
             .unwrap_err();
         assert_matches!(
             error.downcast().unwrap(),
-            Error::Http(status_code, problem_type) => {
-                assert_eq!(status_code, StatusCode::INTERNAL_SERVER_ERROR);
-                assert_eq!(problem_type, Some(DapProblemType::UnauthorizedRequest));
+            Error::Http { problem_details, dap_problem_type } => {
+                assert_eq!(problem_details.status.unwrap(), StatusCode::INTERNAL_SERVER_ERROR);
+                assert_eq!(dap_problem_type, Some(DapProblemType::UnauthorizedRequest));
             }
         );
         aggregation_job_driver
@@ -1517,9 +1517,9 @@ mod tests {
             .unwrap_err();
         assert_matches!(
             error.downcast().unwrap(),
-            Error::Http(status_code, problem_type) => {
-                assert_eq!(status_code, StatusCode::INTERNAL_SERVER_ERROR);
-                assert_eq!(problem_type, Some(DapProblemType::UnrecognizedTask));
+            Error::Http { problem_details, dap_problem_type } => {
+                assert_eq!(problem_details.status.unwrap(), StatusCode::INTERNAL_SERVER_ERROR);
+                assert_eq!(dap_problem_type, Some(DapProblemType::UnrecognizedTask));
             }
         );
         aggregation_job_driver

--- a/janus_server/src/aggregator/aggregation_job_driver.rs
+++ b/janus_server/src/aggregator/aggregation_job_driver.rs
@@ -903,6 +903,7 @@ where
 mod tests {
     use super::AggregationJobDriver;
     use crate::{
+        aggregator::{DapProblemType, Error},
         binary_utils::job_driver::JobDriver,
         datastore::{
             models::{
@@ -914,7 +915,7 @@ mod tests {
         task::{Task, VerifyKey, PRIO3_AES128_VERIFY_KEY_LENGTH},
     };
     use assert_matches::assert_matches;
-    use http::header::CONTENT_TYPE;
+    use http::{header::CONTENT_TYPE, StatusCode};
     use janus_core::{
         hpke::{
             self, associated_data_for_report_share,
@@ -1275,7 +1276,10 @@ mod tests {
             *report.metadata().report_id(),
             PrepareStepResult::Continued(helper_vdaf_msg.get_encoded()),
         )]));
-        let mocked_aggregate_failure = mock("POST", "/aggregate").with_status(500).create();
+        let mocked_aggregate_failure = mock("POST", "/aggregate")
+            .with_status(500)
+            .with_body("{\"type\": \"urn:ietf:params:ppm:dap:error:unauthorizedRequest\"}")
+            .create();
         let mocked_aggregate_success = mock("POST", "/aggregate")
             .match_header(
                 "DAP-Auth-Token",
@@ -1299,7 +1303,13 @@ mod tests {
             .step_aggregation_job(ds.clone(), Arc::new(lease.clone()))
             .await
             .unwrap_err();
-        assert!(error.to_string().contains("500 Internal Server Error"));
+        assert_matches!(
+            error.downcast().unwrap(),
+            Error::Http(status_code, problem_type) => {
+                assert_eq!(status_code, StatusCode::INTERNAL_SERVER_ERROR);
+                assert_eq!(problem_type, Some(DapProblemType::UnauthorizedRequest));
+            }
+        );
         aggregation_job_driver
             .step_aggregation_job(ds.clone(), Arc::new(lease))
             .await
@@ -1481,7 +1491,10 @@ mod tests {
             *report.metadata().report_id(),
             PrepareStepResult::Finished,
         )]));
-        let mocked_aggregate_failure = mock("POST", "/aggregate").with_status(500).create();
+        let mocked_aggregate_failure = mock("POST", "/aggregate")
+            .with_status(500)
+            .with_body("{\"type\": \"urn:ietf:params:ppm:dap:error:unrecognizedTask\"}")
+            .create();
         let mocked_aggregate_success = mock("POST", "/aggregate")
             .match_header(
                 "DAP-Auth-Token",
@@ -1502,7 +1515,13 @@ mod tests {
             .step_aggregation_job(ds.clone(), Arc::new(lease.clone()))
             .await
             .unwrap_err();
-        assert!(error.to_string().contains("500 Internal Server Error"));
+        assert_matches!(
+            error.downcast().unwrap(),
+            Error::Http(status_code, problem_type) => {
+                assert_eq!(status_code, StatusCode::INTERNAL_SERVER_ERROR);
+                assert_eq!(problem_type, Some(DapProblemType::UnrecognizedTask));
+            }
+        );
         aggregation_job_driver
             .step_aggregation_job(ds.clone(), Arc::new(lease))
             .await


### PR DESCRIPTION
This parses the problem type out of error responses from the helper, where available. Closes #381.