### PR TITLE
janus_collector: Store problem details error info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1762,6 +1762,7 @@ dependencies = [
  "chrono",
  "clap 4.0.8",
  "derivative",
+ "http-api-problem",
  "janus_collector",
  "janus_core",
  "janus_messages",

--- a/janus_collector/Cargo.toml
+++ b/janus_collector/Cargo.toml
@@ -15,10 +15,11 @@ test-util = []
 [dependencies]
 backoff = { version = "0.4.0", features = ["tokio"] }
 derivative = "2.2.0"
+http-api-problem = "0.55.0"
 janus_core = { version = "0.1", path = "../janus_core" }
 janus_messages = { version = "0.1", path = "../janus_messages" }
 prio = "0.10.0"
-reqwest = { version = "0.11.12", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.11.12", default-features = false, features = ["rustls-tls", "json"] }
 retry-after = "0.3.1"
 thiserror = "1.0"
 tokio = { version = "1.21", features = ["full"] }


### PR DESCRIPTION
This adds parsing of problem details to `janus_collector`, similar to #608 and #613. This will be a breaking change for 0.2, as it changes a variant of a public enum.