### PR TITLE
Fix unit tests in `collect` example binary

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -53,14 +53,14 @@ jobs:
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
     - name: Build
-      run: cargo test --no-run --locked
+      run: cargo test --no-run --locked --all-targets
     - name: Build minimal janus_messages
       run: cargo build --package janus_messages --no-default-features
     - name: Test
       id: test
       env:
         JANUS_E2E_LOGS_PATH: ${{ github.workspace }}/test-logs
-      run: cargo test
+      run: cargo test --all-targets
       # Continue on error so we can upload logs
       continue-on-error: true
     - name: Upload container logs

--- a/janus_collector/examples/collect.rs
+++ b/janus_collector/examples/collect.rs
@@ -383,6 +383,7 @@ mod tests {
     use assert_matches::assert_matches;
     use janus_core::hpke::test_util::generate_test_hpke_config_and_private_key;
     use prio::codec::Encode;
+    use rand::random;
 
     #[test]
     fn verify_app() {
@@ -395,7 +396,7 @@ mod tests {
         let encoded_hpke_config = base64::encode_config(hpke_config.get_encoded(), URL_SAFE_NO_PAD);
         let encoded_private_key = base64::encode_config(hpke_private_key.as_ref(), URL_SAFE_NO_PAD);
 
-        let task_id = TaskId::random();
+        let task_id: TaskId = random();
         let task_id_encoded = base64::encode_config(task_id.get_encoded(), URL_SAFE_NO_PAD);
 
         let leader = Url::parse("https://example.com/dap/").unwrap();
@@ -501,7 +502,7 @@ mod tests {
         let bad_options = Options::try_parse_from(bad_arguments).unwrap();
         assert_matches!(
             run(bad_options).await.unwrap_err(),
-            Error::Clap(err) => assert_eq!(err.kind, ErrorKind::ArgumentConflict)
+            Error::Clap(err) => assert_eq!(err.kind(), ErrorKind::ArgumentConflict)
         );
 
         let mut bad_arguments = base_arguments.clone();
@@ -509,7 +510,7 @@ mod tests {
         let bad_options = Options::try_parse_from(bad_arguments).unwrap();
         assert_matches!(
             run(bad_options).await.unwrap_err(),
-            Error::Clap(err) => assert_eq!(err.kind, ErrorKind::ArgumentConflict)
+            Error::Clap(err) => assert_eq!(err.kind(), ErrorKind::ArgumentConflict)
         );
 
         let mut bad_arguments = base_arguments.clone();
@@ -517,7 +518,7 @@ mod tests {
         let bad_options = Options::try_parse_from(bad_arguments).unwrap();
         assert_matches!(
             run(bad_options).await.unwrap_err(),
-            Error::Clap(err) => assert_eq!(err.kind, ErrorKind::ArgumentConflict)
+            Error::Clap(err) => assert_eq!(err.kind(), ErrorKind::ArgumentConflict)
         );
 
         let mut bad_arguments = base_arguments.clone();
@@ -525,7 +526,7 @@ mod tests {
         let bad_options = Options::try_parse_from(bad_arguments).unwrap();
         assert_matches!(
             run(bad_options).await.unwrap_err(),
-            Error::Clap(err) => assert_eq!(err.kind, ErrorKind::ArgumentConflict)
+            Error::Clap(err) => assert_eq!(err.kind(), ErrorKind::ArgumentConflict)
         );
 
         let mut bad_arguments = base_arguments.clone();
@@ -540,7 +541,7 @@ mod tests {
         let bad_options = Options::try_parse_from(bad_arguments).unwrap();
         assert_matches!(
             run(bad_options).await.unwrap_err(),
-            Error::Clap(err) => assert_eq!(err.kind, ErrorKind::ArgumentConflict)
+            Error::Clap(err) => assert_eq!(err.kind(), ErrorKind::ArgumentConflict)
         );
 
         let mut bad_arguments = base_arguments.clone();
@@ -548,7 +549,7 @@ mod tests {
         let bad_options = Options::try_parse_from(bad_arguments).unwrap();
         assert_matches!(
             run(bad_options).await.unwrap_err(),
-            Error::Clap(err) => assert_eq!(err.kind, ErrorKind::ArgumentConflict)
+            Error::Clap(err) => assert_eq!(err.kind(), ErrorKind::ArgumentConflict)
         );
 
         let mut good_arguments = base_arguments.clone();


### PR DESCRIPTION
This fixes the unit tests in the `collect` example binary, and adds `--all-targets` to the `cargo test` invocation in CI to keep an eye on it going forward.