### PR TITLE
Replace vec! with Vec::{from,new}.

### DIFF
--- a/janus_collector/examples/collect.rs
+++ b/janus_collector/examples/collect.rs
@@ -479,7 +479,7 @@ mod tests {
             ErrorKind::ValueValidation,
         );
 
-        let base_arguments = vec![
+        let base_arguments = Vec::from([
             "collect",
             "--task-id",
             &task_id_encoded,
@@ -495,7 +495,7 @@ mod tests {
             "1000000",
             "--batch-interval-duration",
             "1000",
-        ];
+        ]);
 
         let mut bad_arguments = base_arguments.clone();
         bad_arguments.extend(["--vdaf=count", "--buckets=1,2,3,4"]);

--- a/janus_core/src/test_util/dummy_vdaf.rs
+++ b/janus_core/src/test_util/dummy_vdaf.rs
@@ -137,7 +137,7 @@ impl vdaf::Client for Vdaf {
         &self,
         _: &Self::Measurement,
     ) -> Result<(Self::PublicShare, Vec<Self::InputShare>), VdafError> {
-        Ok(((), vec![(), ()]))
+        Ok(((), Vec::from([(), ()])))
     }
 }
 

--- a/janus_core/src/test_util/mod.rs
+++ b/janus_core/src/test_util/mod.rs
@@ -60,7 +60,9 @@ where
                 &public_share,
                 input_share,
             )?;
-            Ok(vec![PrepareTransition::Continue(prep_state, prep_share)])
+            Ok(Vec::from([PrepareTransition::Continue(
+                prep_state, prep_share,
+            )]))
         })
         .collect::<Result<Vec<Vec<PrepareTransition<V, L>>>, VdafError>>()
         .unwrap();

--- a/janus_messages/src/bin/dap_decode.rs
+++ b/janus_messages/src/bin/dap_decode.rs
@@ -30,7 +30,7 @@ fn decode_dap_message(message_file: &str, media_type: &str) -> Result<Box<dyn De
         Box::new(File::open(message_file)?) as Box<dyn Read>
     };
 
-    let mut message_buf = vec![];
+    let mut message_buf = Vec::new();
     reader.read_to_end(&mut message_buf)?;
 
     let mut binary_message = Cursor::new(message_buf.as_slice());

--- a/janus_messages/src/lib.rs
+++ b/janus_messages/src/lib.rs
@@ -2665,7 +2665,7 @@ mod tests {
                 CollectResp {
                     partial_batch_selector: PartialBatchSelector::new_time_interval(),
                     report_count: 23,
-                    encrypted_aggregate_shares: vec![
+                    encrypted_aggregate_shares: Vec::from([
                         HpkeCiphertext::new(
                             HpkeConfigId::from(10),
                             Vec::from("0123"),
@@ -2676,7 +2676,7 @@ mod tests {
                             Vec::from("01234"),
                             Vec::from("567"),
                         ),
-                    ],
+                    ]),
                 },
                 concat!(
                     concat!(
@@ -2747,7 +2747,7 @@ mod tests {
                         [4u8; 32],
                     )),
                     report_count: 23,
-                    encrypted_aggregate_shares: vec![
+                    encrypted_aggregate_shares: Vec::from([
                         HpkeCiphertext::new(
                             HpkeConfigId::from(10),
                             Vec::from("0123"),
@@ -2758,7 +2758,7 @@ mod tests {
                             Vec::from("01234"),
                             Vec::from("567"),
                         ),
-                    ],
+                    ]),
                 },
                 concat!(
                     concat!(
@@ -2899,12 +2899,12 @@ mod tests {
                 job_id: AggregationJobId([u8::MIN; 32]),
                 aggregation_parameter: Vec::from("012345"),
                 partial_batch_selector: PartialBatchSelector::new_time_interval(),
-                report_shares: vec![
+                report_shares: Vec::from([
                     ReportShare {
                         metadata: ReportMetadata::new(
                             ReportId::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
                             Time::from_seconds_since_epoch(54321),
-                            vec![Extension::new(ExtensionType::Tbd, Vec::from("0123"))],
+                            Vec::from([Extension::new(ExtensionType::Tbd, Vec::from("0123"))]),
                         ),
                         public_share: Vec::new(),
                         encrypted_input_share: HpkeCiphertext::new(
@@ -2917,7 +2917,7 @@ mod tests {
                         metadata: ReportMetadata::new(
                             ReportId::from([16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]),
                             Time::from_seconds_since_epoch(73542),
-                            vec![Extension::new(ExtensionType::Tbd, Vec::from("3210"))],
+                            Vec::from([Extension::new(ExtensionType::Tbd, Vec::from("3210"))]),
                         ),
                         public_share: Vec::from("0123"),
                         encrypted_input_share: HpkeCiphertext::new(
@@ -2926,7 +2926,7 @@ mod tests {
                             Vec::from("abfd"),
                         ),
                     },
-                ],
+                ]),
             },
             concat!(
                 "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", // task_id
@@ -3031,12 +3031,12 @@ mod tests {
                 partial_batch_selector: PartialBatchSelector::new_fixed_size(BatchId::from(
                     [2u8; 32],
                 )),
-                report_shares: vec![
+                report_shares: Vec::from([
                     ReportShare {
                         metadata: ReportMetadata::new(
                             ReportId::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
                             Time::from_seconds_since_epoch(54321),
-                            vec![Extension::new(ExtensionType::Tbd, Vec::from("0123"))],
+                            Vec::from([Extension::new(ExtensionType::Tbd, Vec::from("0123"))]),
                         ),
                         public_share: Vec::new(),
                         encrypted_input_share: HpkeCiphertext::new(
@@ -3049,7 +3049,7 @@ mod tests {
                         metadata: ReportMetadata::new(
                             ReportId::from([16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]),
                             Time::from_seconds_since_epoch(73542),
-                            vec![Extension::new(ExtensionType::Tbd, Vec::from("3210"))],
+                            Vec::from([Extension::new(ExtensionType::Tbd, Vec::from("3210"))]),
                         ),
                         public_share: Vec::from("0123"),
                         encrypted_input_share: HpkeCiphertext::new(
@@ -3058,7 +3058,7 @@ mod tests {
                             Vec::from("abfd"),
                         ),
                     },
-                ],
+                ]),
             },
             concat!(
                 "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", // task_id
@@ -3162,7 +3162,7 @@ mod tests {
         roundtrip_encoding(&[
             (
                 AggregateInitializeResp {
-                    prepare_steps: vec![],
+                    prepare_steps: Vec::new(),
                 },
                 concat!(concat!(
                     // prepare_steps
@@ -3171,7 +3171,7 @@ mod tests {
             ),
             (
                 AggregateInitializeResp {
-                    prepare_steps: vec![
+                    prepare_steps: Vec::from([
                         PrepareStep {
                             report_id: ReportId::from([
                                 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
@@ -3184,7 +3184,7 @@ mod tests {
                             ]),
                             result: PrepareStepResult::Finished,
                         },
-                    ],
+                    ]),
                 },
                 concat!(concat!(
                     // prepare_steps
@@ -3213,7 +3213,7 @@ mod tests {
             AggregateContinueReq {
                 task_id: TaskId::from([u8::MIN; 32]),
                 job_id: AggregationJobId([u8::MAX; 32]),
-                prepare_steps: vec![
+                prepare_steps: Vec::from([
                     PrepareStep {
                         report_id: ReportId::from([
                             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
@@ -3226,7 +3226,7 @@ mod tests {
                         ]),
                         result: PrepareStepResult::Finished,
                     },
-                ],
+                ]),
             },
             concat!(
                 "0000000000000000000000000000000000000000000000000000000000000000", // task_id
@@ -3257,7 +3257,7 @@ mod tests {
         roundtrip_encoding(&[
             (
                 AggregateContinueResp {
-                    prepare_steps: vec![],
+                    prepare_steps: Vec::new(),
                 },
                 concat!(concat!(
                     // prepare_steps
@@ -3266,7 +3266,7 @@ mod tests {
             ),
             (
                 AggregateContinueResp {
-                    prepare_steps: vec![
+                    prepare_steps: Vec::from([
                         PrepareStep {
                             report_id: ReportId::from([
                                 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
@@ -3279,7 +3279,7 @@ mod tests {
                             ]),
                             result: PrepareStepResult::Finished,
                         },
-                    ],
+                    ]),
                 },
                 concat!(concat!(
                     // prepare_steps

--- a/janus_server/src/bin/aggregator.rs
+++ b/janus_server/src/bin/aggregator.rs
@@ -155,10 +155,10 @@ mod tests {
                 metrics_config: generate_metrics_config(),
                 health_check_listen_address: SocketAddr::from((Ipv4Addr::UNSPECIFIED, 8080)),
             },
-            response_headers: vec![HeaderEntry {
+            response_headers: Vec::from([HeaderEntry {
                 name: "name".to_owned(),
                 value: "value".to_owned(),
-            }],
+            }]),
         })
     }
 

--- a/janus_server/src/binary_utils/job_driver.rs
+++ b/janus_server/src/binary_utils/job_driver.rs
@@ -301,12 +301,12 @@ mod tests {
 
         let test_state = Arc::new(Mutex::new(TestState {
             job_acquire_counter: 0,
-            stepped_jobs: vec![],
+            stepped_jobs: Vec::new(),
         }));
         // View of incomplete jobs acquired from datastore fed to job finder closure
-        let incomplete_jobs = Arc::new(vec![
+        let incomplete_jobs = Arc::new(Vec::from([
             // First job finder call: acquire some jobs.
-            vec![
+            Vec::from([
                 IncompleteJob {
                     task_id: random(),
                     job_id: random(),
@@ -317,13 +317,13 @@ mod tests {
                     job_id: random(),
                     lease_expiry: Time::from_seconds_since_epoch(200),
                 },
-            ],
+            ]),
             // Second job finder call will be immediately after the first: no more jobs
             // available yet. Should cause a minimum delay before job finder runs again.
-            vec![],
+            Vec::new(),
             // Third job finder call: return some new jobs to simulate lease being released and
             // re-acquired (it doesn't matter if the task and job IDs change).
-            vec![
+            Vec::from([
                 IncompleteJob {
                     task_id: random(),
                     job_id: random(),
@@ -334,8 +334,8 @@ mod tests {
                     job_id: random(),
                     lease_expiry: Time::from_seconds_since_epoch(400),
                 },
-            ],
-        ]);
+            ]),
+        ]));
 
         // Run. Let the aggregation job driver step aggregation jobs, then kill it.
         let job_driver = Arc::new(JobDriver::new(
@@ -420,7 +420,7 @@ mod tests {
         assert!(final_test_state.job_acquire_counter >= 3);
         assert_eq!(
             final_test_state.stepped_jobs,
-            vec![
+            Vec::from([
                 // First acquirer run should have caused INCOMPLETE_JOBS[0] to be stepped.
                 SteppedJob {
                     observed_jobs_acquire_counter: 1,
@@ -444,7 +444,7 @@ mod tests {
                     task_id: incomplete_jobs[2][1].task_id,
                     job_id: incomplete_jobs[2][1].job_id,
                 },
-            ]
+            ])
         );
     }
 }

--- a/janus_server/src/trace.rs
+++ b/janus_server/src/trace.rs
@@ -188,19 +188,18 @@ pub fn install_trace_subscriber(config: &TraceConfiguration) -> Result<(), Error
             map.insert(MetadataKey::from_str(key)?, MetadataValue::try_from(value)?);
         }
 
-        let tracer =
-            opentelemetry_otlp::new_pipeline()
-                .tracing()
-                .with_exporter(
-                    opentelemetry_otlp::new_exporter()
-                        .tonic()
-                        .with_endpoint(otlp_config.endpoint.clone())
-                        .with_metadata(map),
-                )
-                .with_trace_config(trace::config().with_resource(Resource::new(vec![
-                    KeyValue::new(SERVICE_NAME, "janus_server"),
-                ])))
-                .install_batch(opentelemetry::runtime::Tokio)?;
+        let tracer = opentelemetry_otlp::new_pipeline()
+            .tracing()
+            .with_exporter(
+                opentelemetry_otlp::new_exporter()
+                    .tonic()
+                    .with_endpoint(otlp_config.endpoint.clone())
+                    .with_metadata(map),
+            )
+            .with_trace_config(trace::config().with_resource(Resource::new(Vec::from([
+                KeyValue::new(SERVICE_NAME, "janus_server"),
+            ]))))
+            .install_batch(opentelemetry::runtime::Tokio)?;
 
         // Filter out some spans from h2, internal to the OTLP exporter (via tonic). These spans
         // would otherwise drown out root spans from the application.


### PR DESCRIPTION
Opinionated change: since Rust 1.44 [1], it has been possible to use Vec::from to write vector literals. On the idea that a method call is a simpler tool than a macro, prefer a method call. (Vec::new is also used, if the vector being created is empty.)

[1] https://github.com/rust-lang/rust/pull/68692/