### PR TITLE
Log errors using Debug rather than Display implementations.

### DIFF
--- a/janus_core/src/retries.rs
+++ b/janus_core/src/retries.rs
@@ -94,7 +94,7 @@ where
             }
             Err(error) => {
                 if error.is_timeout() || error.is_connect() {
-                    warn!(%error, "encountered retryable error");
+                    warn!(?error, "encountered retryable error");
                     return Err(backoff::Error::transient(Err(error)));
                 }
 
@@ -103,7 +103,7 @@ where
                     | std::io::ErrorKind::ConnectionReset
                     | std::io::ErrorKind::ConnectionAborted = io_error.kind()
                     {
-                        warn!(%error, "encountered retryable error");
+                        warn!(?error, "encountered retryable error");
                         return Err(backoff::Error::transient(Err(error)));
                     }
                 }

--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -1091,7 +1091,7 @@ impl VdafOps {
                 report.public_share(),
             ),
         ) {
-            info!(report.task_id = ?report.task_id(), report.metadata = ?report.metadata(), %error, "Report decryption failed");
+            info!(report.task_id = %report.task_id(), report.metadata = ?report.metadata(), ?error, "Report decryption failed");
             upload_decrypt_failure_counter.add(&Context::current(), 1, &[]);
             return Ok(());
         }
@@ -1194,7 +1194,7 @@ impl VdafOps {
                 .get(report_share.encrypted_input_share().config_id())
                 .ok_or_else(|| {
                     info!(
-                        config_id = ?report_share.encrypted_input_share().config_id(),
+                        config_id = %report_share.encrypted_input_share().config_id(),
                         "Helper encrypted input share references unknown HPKE config ID"
                     );
                     aggregate_step_failure_counter.add(
@@ -1222,7 +1222,7 @@ impl VdafOps {
                     info!(
                         task_id = %task.id(),
                         metadata = ?report_share.metadata(),
-                        %error,
+                        ?error,
                         "Couldn't decrypt helper's report share"
                     );
                     aggregate_step_failure_counter.add(
@@ -1242,14 +1242,14 @@ impl VdafOps {
             let input_share = plaintext.and_then(|plaintext| {
                 A::InputShare::get_decoded_with_param(&(vdaf, Role::Helper.index().unwrap()), &plaintext)
                     .map_err(|error| {
-                        info!(task_id = %task.id(), metadata = ?report_share.metadata(), %error, "Couldn't decode helper's input share");
+                        info!(task_id = %task.id(), metadata = ?report_share.metadata(), ?error, "Couldn't decode helper's input share");
                         aggregate_step_failure_counter.add(&Context::current(), 1, &[KeyValue::new("type", "input_share_decode_failure")]);
                         ReportShareError::VdafPrepError
                     })
             });
 
             let public_share = A::PublicShare::get_decoded_with_param(&vdaf, report_share.public_share()).map_err(|error|{
-                info!(task_id = %task.id(), metadata = ?report_share.metadata(), %error, "Couldn't decode public share");
+                info!(task_id = %task.id(), metadata = ?report_share.metadata(), ?error, "Couldn't decode public share");
                 aggregate_step_failure_counter.add(&Context::current(), 1, &[KeyValue::new("type", "public_share_decode_failure")]);
                 ReportShareError::VdafPrepError
             });
@@ -1270,7 +1270,7 @@ impl VdafOps {
                         &input_share,
                     )
                     .map_err(|error| {
-                        info!(task_id = %task.id(), report_id = %report_share.metadata().id(), %error, "Couldn't prepare_init report share");
+                        info!(task_id = %task.id(), report_id = %report_share.metadata().id(), ?error, "Couldn't prepare_init report share");
                         aggregate_step_failure_counter.add(&Context::current(), 1, &[KeyValue::new("type", "prepare_init_failure")]);
                         ReportShareError::VdafPrepError
                     })
@@ -1525,7 +1525,7 @@ impl VdafOps {
                             }
 
                             Err(error) => {
-                                info!(task_id = %task.id(), job_id = %req.job_id(), report_id = %prep_step.report_id(), %error, "Prepare step failed");
+                                info!(task_id = %task.id(), job_id = %req.job_id(), report_id = %prep_step.report_id(), ?error, "Prepare step failed");
                                 aggregate_step_failure_counter.add(&Context::current(), 1, &[KeyValue::new("type", "prepare_step_failure")]);
                                 response_prep_steps.push(PrepareStep::new(
                                     *prep_step.report_id(),
@@ -2284,7 +2284,7 @@ where
             .and(filter)
             .map(move |start: Instant, result: Result<T, Error>| {
                 let error_code = if let Err(error) = &result {
-                    warn!(%error, endpoint = name, "Error handling endpoint");
+                    warn!(?error, endpoint = name, "Error handling endpoint");
                     error.error_code()
                 } else {
                     ""

--- a/janus_server/src/aggregator/accumulator.rs
+++ b/janus_server/src/aggregator/accumulator.rs
@@ -127,7 +127,7 @@ where
 
             if let Some(batch_unit_aggregation) = batch_unit_aggregations.into_iter().next() {
                 debug!(
-                    unit_interval_start = ?unit_interval.start(),
+                    unit_interval_start = %unit_interval.start(),
                     "accumulating into existing batch_unit_aggregation_row",
                 );
                 tx.update_batch_unit_aggregation(&batch_unit_aggregation.merged_with(
@@ -138,7 +138,7 @@ where
                 .await?;
             } else {
                 debug!(
-                    unit_interval_start = ?unit_interval.start(),
+                    unit_interval_start = %unit_interval.start(),
                     "inserting new batch_unit_aggregation row",
                 );
                 tx.put_batch_unit_aggregation(&BatchUnitAggregation::<L, A>::new(

--- a/janus_server/src/aggregator/aggregate_share.rs
+++ b/janus_server/src/aggregator/aggregate_share.rs
@@ -312,8 +312,8 @@ impl CollectJobDriver {
                             // appropriate status can be returned from polling the collect job URI and GC
                             // can run (#313).
                             info!(
-                                "collect job {} was deleted while lease was held. Discarding aggregate results.",
-                                collect_job.collect_job_id(),
+                                collect_job_id = %collect_job.collect_job_id(),
+                                "collect job was deleted while lease was held. Discarding aggregate results.",
                             );
                             metrics.deleted_jobs_encountered_counter.add(&Context::current(), 1, &[]);
                         }
@@ -463,8 +463,8 @@ impl CollectJobDriver {
             Box::pin(async move {
                 if collect_job_lease.lease_attempts() > maximum_attempts_before_failure {
                     warn!(
-                        attempts = ?collect_job_lease.lease_attempts(),
-                        max_attempts = ?maximum_attempts_before_failure,
+                        attempts = %collect_job_lease.lease_attempts(),
+                        max_attempts = %maximum_attempts_before_failure,
                         "Abandoning job due to too many failed attempts"
                     );
                     this.metrics
@@ -605,7 +605,7 @@ where
     let max_batch_query_count: usize = task.max_batch_query_count().try_into()?;
     if intersecting_intervals.len() == max_batch_query_count {
         debug!(
-            task_id = %task.id(), ?collect_interval,
+            task_id = %task.id(), %collect_interval,
             "Refusing aggregate share request because query count has been consumed"
         );
         return Err(datastore::Error::User(
@@ -614,7 +614,7 @@ where
     }
     if intersecting_intervals.len() > max_batch_query_count {
         error!(
-            task_id = %task.id(), ?collect_interval,
+            task_id = %task.id(), %collect_interval,
             "query count has been consumed more times than task allows"
         );
 

--- a/janus_server/src/aggregator/aggregation_job_creator.rs
+++ b/janus_server/src/aggregator/aggregation_job_creator.rs
@@ -129,7 +129,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                     .collect::<HashMap<_, _>>(),
 
                 Err(error) => {
-                    error!(%error, "Couldn't update tasks");
+                    error!(?error, "Couldn't update tasks");
                     task_update_time_histogram.record(
                         &Context::current(),
                         start.elapsed().as_secs_f64(),
@@ -146,7 +146,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                 }
                 // We don't need to send on the channel: dropping the sender is enough to cause the
                 // receiver future to resolve with a RecvError, which will trigger shutdown.
-                info!(?task_id, "Stopping job creation worker");
+                info!(%task_id, "Stopping job creation worker");
                 false
             });
 
@@ -301,7 +301,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                             debug!(
                                 task_id = %task.id(),
                                 %aggregation_job_id,
-                                report_count = agg_job_reports.len(),
+                                report_count = %agg_job_reports.len(),
                                 "Creating aggregation job"
                             );
                             agg_jobs.push(AggregationJob::<L, A>::new(
@@ -398,7 +398,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                             debug!(
                                 task_id = %task.id(),
                                 %aggregation_job_id,
-                                report_count = agg_job_reports.len(),
+                                report_count = %agg_job_reports.len(),
                                 "Creating aggregation job"
                             );
                             agg_jobs.push(AggregationJob::<L, A>::new(

--- a/janus_server/src/aggregator/aggregation_job_driver.rs
+++ b/janus_server/src/aggregator/aggregation_job_driver.rs
@@ -370,7 +370,7 @@ impl AggregationJobDriver {
             ) {
                 Ok(leader_input_share_bytes) => leader_input_share_bytes,
                 Err(error) => {
-                    info!(report_id = %report_aggregation.report_id(), %error, "Couldn't decrypt leader's encrypted input share");
+                    info!(report_id = %report_aggregation.report_id(), ?error, "Couldn't decrypt leader's encrypted input share");
                     self.aggregate_step_failure_counter.add(
                         &Context::current(),
                         1,
@@ -389,7 +389,7 @@ impl AggregationJobDriver {
                 Ok(leader_input_share) => leader_input_share,
                 Err(error) => {
                     // TODO(https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/issues/255): is moving to Invalid on a decoding error appropriate?
-                    info!(report_id = %report_aggregation.report_id(), %error, "Couldn't decode leader's input share");
+                    info!(report_id = %report_aggregation.report_id(), ?error, "Couldn't decode leader's input share");
                     self.aggregate_step_failure_counter.add(
                         &Context::current(),
                         1,
@@ -407,7 +407,7 @@ impl AggregationJobDriver {
             ) {
                 Ok(public_share) => public_share,
                 Err(error) => {
-                    info!(report_id = %report_aggregation.report_id(), %error, "Couldn't decode public share");
+                    info!(report_id = %report_aggregation.report_id(), ?error, "Couldn't decode public share");
                     self.aggregate_step_failure_counter.add(
                         &Context::current(),
                         1,
@@ -430,7 +430,7 @@ impl AggregationJobDriver {
             ) {
                 Ok(prep_state_and_share) => prep_state_and_share,
                 Err(error) => {
-                    info!(report_id = %report_aggregation.report_id(), %error, "Couldn't initialize leader's preparation state");
+                    info!(report_id = %report_aggregation.report_id(), ?error, "Couldn't initialize leader's preparation state");
                     self.aggregate_step_failure_counter.add(
                         &Context::current(),
                         1,
@@ -532,7 +532,7 @@ impl AggregationJobDriver {
                 {
                     Ok(leader_transition) => leader_transition,
                     Err(error) => {
-                        info!(report_id = %report_aggregation.report_id(), %error, "Prepare step failed");
+                        info!(report_id = %report_aggregation.report_id(), ?error, "Prepare step failed");
                         self.aggregate_step_failure_counter.add(
                             &Context::current(),
                             1,
@@ -651,7 +651,7 @@ impl AggregationJobDriver {
                                 ReportAggregationState::Waiting(leader_prep_state, Some(prep_msg))
                             }
                             Err(error) => {
-                                info!(report_id = %report_aggregation.report_id(), %error, "Couldn't compute prepare message");
+                                info!(report_id = %report_aggregation.report_id(), ?error, "Couldn't compute prepare message");
                                 self.aggregate_step_failure_counter.add(
                                     &Context::current(),
                                     1,
@@ -682,7 +682,7 @@ impl AggregationJobDriver {
                         ) {
                             Ok(_) => ReportAggregationState::Finished(out_share.clone()),
                             Err(error) => {
-                                warn!(report_id = %report_aggregation.report_id(), %error, "Could not update batch unit aggregation");
+                                warn!(report_id = %report_aggregation.report_id(), ?error, "Could not update batch unit aggregation");
                                 self.aggregate_step_failure_counter.add(
                                     &Context::current(),
                                     1,
@@ -874,9 +874,11 @@ impl AggregationJobDriver {
             let (this, datastore) = (Arc::clone(&self), Arc::clone(&datastore));
             Box::pin(async move {
                 if lease.lease_attempts() > maximum_attempts_before_failure {
-                    warn!(attempts = ?lease.lease_attempts(),
-                        max_attempts = ?maximum_attempts_before_failure,
-                        "Canceling job due to too many failed attempts");
+                    warn!(
+                        attempts = %lease.lease_attempts(),
+                        max_attempts = %maximum_attempts_before_failure,
+                        "Canceling job due to too many failed attempts"
+                    );
                     this.job_cancel_counter.add(&Context::current(), 1, &[]);
                     return this.cancel_aggregation_job(datastore, lease).await;
                 }

--- a/janus_server/src/bin/janus_cli.rs
+++ b/janus_server/src/bin/janus_cli.rs
@@ -168,7 +168,7 @@ async fn provision_tasks<C: Clock>(datastore: &Datastore<C>, tasks_file: &Path) 
 
     // Write all tasks requested.
     let tasks = Arc::new(tasks);
-    info!(task_count = tasks.len(), "Writing tasks");
+    info!(task_count = %tasks.len(), "Writing tasks");
     datastore
         .run_tx(|tx| {
             let tasks = Arc::clone(&tasks);

--- a/janus_server/src/binary_utils.rs
+++ b/janus_server/src/binary_utils.rs
@@ -28,7 +28,7 @@ use std::{
     time::Duration,
 };
 use tokio_postgres::NoTls;
-use tracing::info;
+use tracing::{debug, info};
 use warp::Filter;
 
 /// Reads, parses, and returns the config referenced by the given options, or None if no config file
@@ -108,7 +108,7 @@ pub async fn database_pool(db_config: &DbConfig, db_password: Option<&str>) -> R
         || async {
             pool.get().await.map_err(|error| match error {
                 PoolError::Timeout(TimeoutType::Create) | PoolError::Backend(_) => {
-                    tracing::debug!(%error, "transient error connecting to database");
+                    debug!(?error, "transient error connecting to database");
                     backoff::Error::transient(error)
                 }
                 _ => backoff::Error::permanent(error),

--- a/janus_server/src/metrics.rs
+++ b/janus_server/src/metrics.rs
@@ -163,7 +163,7 @@ pub fn install_metrics_exporter(
                             .unwrap()
                             .into_response(),
                         Err(error) => {
-                            tracing::error!(%error, "Failed to encode Prometheus metrics");
+                            tracing::error!(?error, "Failed to encode Prometheus metrics");
                             StatusCode::INTERNAL_SERVER_ERROR.into_response()
                         }
                     }

--- a/janus_server/tests/graceful_shutdown.rs
+++ b/janus_server/tests/graceful_shutdown.rs
@@ -222,7 +222,7 @@ async fn graceful_shutdown(binary: &Path, mut config: Mapping) {
     } else {
         binary_io_tasks.await;
         let elapsed = end - start;
-        info!(?elapsed, binary_name, "Graceful shutdown test succeeded");
+        info!(?elapsed, %binary_name, "Graceful shutdown test succeeded");
     }
 }
 


### PR DESCRIPTION
This is necessary because anyhow error types do not render their internally-wrapped "source" errors with their Display implementations, only their Debug implementations.

While I'm examining all the log lines, also fixup a few things to use Display as needed -- this is most important for ID types, which would previously be logged as e.g. `task_id = TaskId(abcde)` instead of just `task_id = abcde`. The additional type information is not helpful to humans & stutters with the field name.

Closes #609.