### PR TITLE
Apply input validation in TaskBuilder::build()

### DIFF
--- a/integration_tests/tests/common/mod.rs
+++ b/integration_tests/tests/common/mod.rs
@@ -34,7 +34,10 @@ pub fn test_task_builders() -> (HpkePrivateKey, TaskBuilder, TaskBuilder) {
     ]))
     .with_min_batch_size(46)
     .with_collector_hpke_config(collector_hpke_config);
-    let helper_task = leader_task.clone().with_role(Role::Helper);
+    let helper_task = leader_task
+        .clone()
+        .with_role(Role::Helper)
+        .with_collector_auth_tokens(Vec::new());
 
     (collector_private_key, leader_task, helper_task)
 }

--- a/janus_server/src/task.rs
+++ b/janus_server/src/task.rs
@@ -820,9 +820,38 @@ pub mod test_util {
             })
         }
 
+        /// Sets the collector authentication tokens for the task.
+        pub fn with_collector_auth_tokens(
+            self,
+            collector_auth_tokens: Vec<AuthenticationToken>,
+        ) -> Self {
+            Self(Task {
+                collector_auth_tokens,
+                ..self.0
+            })
+        }
+
         /// Consumes this task builder & produces a [`Task`] with the given specifications.
         pub fn build(self) -> Task {
-            self.0
+            // Round-trip through Task::new() for its parameter validation.
+            Task::new(
+                self.0.task_id,
+                self.0.aggregator_endpoints,
+                self.0.query_type,
+                self.0.vdaf,
+                self.0.role,
+                self.0.vdaf_verify_keys,
+                self.0.max_batch_query_count,
+                self.0.task_expiration,
+                self.0.min_batch_size,
+                self.0.time_precision,
+                self.0.tolerable_clock_skew,
+                self.0.collector_hpke_config,
+                self.0.aggregator_auth_tokens,
+                self.0.collector_auth_tokens,
+                self.0.hpke_keys.into_iter().map(|(_, pair)| pair),
+            )
+            .unwrap()
         }
     }
 


### PR DESCRIPTION
Currently, `TaskBuilder` can violate some of `Task`'s invariants, because it modifies its fields directly, and bypasses `Task::new()`. This round-trips the task through the constructor when `build()` is called, so that we still get the same input validation. This will help keep tests closer in line with production operation.