### PR TITLE
Update tracing to 0.1.37.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3971,9 +3971,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "log",
@@ -3984,9 +3984,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3995,9 +3995,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -36,7 +36,7 @@ serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 testcontainers = "0.14.0"
 tokio = { version = "1", features = ["full", "tracing"] }
-tracing = "0.1.36"
+tracing = "0.1.37"
 url = { version = "2.3.1", features = ["serde"] }
 
 [dev-dependencies]

--- a/interop_binaries/Cargo.toml
+++ b/interop_binaries/Cargo.toml
@@ -43,7 +43,7 @@ serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.86"
 testcontainers = { version = "0.14", optional = true }
 tokio = { version = "1.21", features = ["full", "tracing"] }
-tracing = "0.1.36"
+tracing = "0.1.37"
 tracing-log = "0.1.3"
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt"] }
 url = { version = "2.3.1", features = ["serde"] }

--- a/janus_client/Cargo.toml
+++ b/janus_client/Cargo.toml
@@ -21,7 +21,7 @@ rand = "0.8"
 reqwest = { version = "0.11.12", default-features = false, features = ["rustls-tls", "json"] }
 thiserror = "1.0"
 tokio = { version = "1.21", features = ["full"] }
-tracing = "0.1.36"
+tracing = "0.1.37"
 url = "2.3.1"
 
 [dev-dependencies]

--- a/janus_collector/Cargo.toml
+++ b/janus_collector/Cargo.toml
@@ -22,7 +22,7 @@ reqwest = { version = "0.11.12", default-features = false, features = ["rustls-t
 retry-after = "0.3.1"
 thiserror = "1.0"
 tokio = { version = "1.21", features = ["full"] }
-tracing = "0.1.36"
+tracing = "0.1.37"
 url = "2.3.1"
 
 [dev-dependencies]

--- a/janus_core/Cargo.toml
+++ b/janus_core/Cargo.toml
@@ -41,7 +41,7 @@ ring = "0.16.20"
 serde = { version = "1.0.145", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1.21", features = ["macros", "net", "rt"] }
-tracing = "0.1.36"
+tracing = "0.1.37"
 
 # Dependencies required only if feature "test-util" is enabled
 assert_matches = { version = "1", optional = true }

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -70,7 +70,7 @@ thiserror = "1.0"
 tokio = { version = "1.21", features = ["full", "tracing"] }
 tokio-postgres = { version = "0.7.7", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1", "array-impls"] }
 tonic = { version = "0.8", optional = true, features = ["tls", "tls-webpki-roots"] }  # keep this version in sync with what opentelemetry-otlp uses
-tracing = "0.1.36"
+tracing = "0.1.37"
 tracing-log = "0.1.3"
 tracing-opentelemetry = { version = "0.18", optional = true }
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt", "json"] }

--- a/janus_server/src/aggregator/aggregation_job_creator.rs
+++ b/janus_server/src/aggregator/aggregation_job_creator.rs
@@ -14,17 +14,18 @@ use opentelemetry::{
     metrics::{Histogram, Unit},
     Context, KeyValue,
 };
-use prio::vdaf;
-use prio::vdaf::prio3::{Prio3Aes128Count, Prio3Aes128Histogram, Prio3Aes128Sum};
-use prio::{codec::Encode, vdaf::prio3::Prio3Aes128CountVecMultithreaded};
+use prio::{
+    codec::Encode,
+    vdaf::prio3::Prio3Aes128CountVecMultithreaded,
+    vdaf::{
+        self,
+        prio3::{Prio3Aes128Count, Prio3Aes128Histogram, Prio3Aes128Sum},
+    },
+};
 use rand::{random, thread_rng, Rng};
-use std::collections::HashMap;
-#[cfg(test)]
-use std::hash::Hash;
-use std::sync::Arc;
-use std::time::Duration;
-use tokio::select;
+use std::{collections::HashMap, convert::Infallible, sync::Arc, time::Duration};
 use tokio::{
+    select,
     sync::oneshot::{self, Receiver, Sender},
     time::{self, Instant, MissedTickBehavior},
 };
@@ -85,7 +86,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
     }
 
     #[tracing::instrument(skip(self))]
-    pub async fn run(self: Arc<Self>) -> ! {
+    pub async fn run(self: Arc<Self>) -> Infallible {
         // TODO(#224): add support for handling only a subset of tasks in a single job (i.e. sharding).
 
         // Create metric instruments.
@@ -361,7 +362,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
         A::PrepareState: Send + Sync + Encode,
         A::OutputShare: Send + Sync,
         for<'a> &'a A::OutputShare: Into<Vec<u8>>,
-        A::AggregationParam: Send + Sync + Eq + Hash,
+        A::AggregationParam: Send + Sync + Eq + std::hash::Hash,
     {
         let max_aggregation_job_size = self.max_aggregation_job_size;
 

--- a/janus_server/src/binary_utils/job_driver.rs
+++ b/janus_server/src/binary_utils/job_driver.rs
@@ -8,6 +8,7 @@ use opentelemetry::{
     Context, KeyValue,
 };
 use std::{
+    convert::Infallible,
     fmt::{Debug, Display},
     future::Future,
     sync::Arc,
@@ -92,7 +93,7 @@ where
 
     /// Run this job driver, periodically seeking incomplete jobs and stepping them.
     #[tracing::instrument(skip(self))]
-    pub async fn run(self: Arc<Self>) -> ! {
+    pub async fn run(self: Arc<Self>) -> Infallible {
         // Create metric recorders.
         let job_acquire_time_histogram = self
             .meter


### PR DESCRIPTION
I also had to fix a compile error due to use of the `!` type.
I replaced it with std::convert::Infallible. Per that type's
documentation[1], using `!` as a function's return type is permitted in
stable Rust, so this was technically a brekaing change in the tracing
crate.

[1] https://doc.rust-lang.org/stable/std/convert/enum.Infallible.html