### PR TITLE
Unify problem details handling, log parse errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1791,6 +1791,7 @@ dependencies = [
  "futures",
  "hex",
  "hpke-dispatch",
+ "http-api-problem",
  "janus_core",
  "janus_messages",
  "k8s-openapi",

--- a/janus_core/Cargo.toml
+++ b/janus_core/Cargo.toml
@@ -31,12 +31,13 @@ derivative = "2.2.0"
 futures = "0.3.24"
 hex = "0.4"
 hpke-dispatch = "0.4.0"
+http-api-problem = "0.55.0"
 janus_messages = { version = "0.1", path = "../janus_messages" }
 kube = { version = "0.65", optional = true, default-features = false, features = ["client", "rustls-tls"] }
 k8s-openapi = { version = "0.13.1", optional = true, features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
 prio = { version = "0.10.0", features = ["multithreaded"] }
 rand = "0.8"
-reqwest = { version = "0.11.12", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.11.12", default-features = false, features = ["rustls-tls", "json"] }
 ring = "0.16.20"
 serde = { version = "1.0.145", features = ["derive"] }
 thiserror = "1.0"

--- a/janus_core/src/http.rs
+++ b/janus_core/src/http.rs
@@ -4,7 +4,7 @@ use tracing::warn;
 
 /// Turn a [`reqwest::Response`] into a [`HttpApiProblem`]. If applicable, a JSON problem details
 /// document is parsed from the request's body, otherwise it is solely constructed from the
-/// response's status code.
+/// response's status code. (see [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807.html))
 pub async fn response_to_problem_details(response: Response) -> HttpApiProblem {
     let status = response.status();
     if let Some(content_type) = response.headers().get(CONTENT_TYPE) {

--- a/janus_core/src/http.rs
+++ b/janus_core/src/http.rs
@@ -1,0 +1,22 @@
+use http_api_problem::{HttpApiProblem, PROBLEM_JSON_MEDIA_TYPE};
+use reqwest::{header::CONTENT_TYPE, Response};
+use tracing::warn;
+
+/// Turn a [`reqwest::Response`] into a [`HttpApiProblem`]. If applicable, a JSON problem details
+/// document is parsed from the request's body, otherwise it is solely constructed from the
+/// response's status code.
+pub async fn response_to_problem_details(response: Response) -> HttpApiProblem {
+    let status = response.status();
+    if let Some(content_type) = response.headers().get(CONTENT_TYPE) {
+        if content_type == PROBLEM_JSON_MEDIA_TYPE {
+            match response.json::<HttpApiProblem>().await {
+                Ok(mut problem) => {
+                    problem.status = Some(status);
+                    return problem;
+                }
+                Err(error) => warn!(%error, "Failed to parse problem details"),
+            }
+        }
+    }
+    HttpApiProblem::new(status)
+}

--- a/janus_core/src/lib.rs
+++ b/janus_core/src/lib.rs
@@ -2,6 +2,7 @@ use std::future::Future;
 use tokio::task::JoinHandle;
 
 pub mod hpke;
+pub mod http;
 pub mod report_id;
 pub mod retries;
 pub mod task;

--- a/janus_server/src/aggregator/aggregate_share.rs
+++ b/janus_server/src/aggregator/aggregate_share.rs
@@ -951,6 +951,7 @@ mod tests {
             )
             .match_body(leader_request.get_encoded())
             .with_status(500)
+            .with_header("Content-Type", "application/problem+json")
             .with_body("{\"type\": \"urn:ietf:params:ppm:dap:error:batchQueriedTooManyTimes\"}")
             .create();
 

--- a/janus_server/src/aggregator/aggregation_job_driver.rs
+++ b/janus_server/src/aggregator/aggregation_job_driver.rs
@@ -1281,6 +1281,7 @@ mod tests {
         )]));
         let mocked_aggregate_failure = mock("POST", "/aggregate")
             .with_status(500)
+            .with_header("Content-Type", "application/problem+json")
             .with_body("{\"type\": \"urn:ietf:params:ppm:dap:error:unauthorizedRequest\"}")
             .create();
         let mocked_aggregate_success = mock("POST", "/aggregate")
@@ -1499,6 +1500,7 @@ mod tests {
         )]));
         let mocked_aggregate_failure = mock("POST", "/aggregate")
             .with_status(500)
+            .with_header("Content-Type", "application/problem+json")
             .with_body("{\"type\": \"urn:ietf:params:ppm:dap:error:unrecognizedTask\"}")
             .create();
         let mocked_aggregate_success = mock("POST", "/aggregate")


### PR DESCRIPTION
This is a follow-up to #614, applying the same error logging in the aggregator and client. The relevant helper method is moved from `janus_collector` to `janus_core`.