### PR TITLE
Use workspace inheritance for common package values.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "build_script_utils"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "zstd",
 ]
@@ -1641,7 +1641,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration_tests"
-version = "0.1.11"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "backoff",
@@ -1674,7 +1674,7 @@ dependencies = [
 
 [[package]]
 name = "interop_binaries"
-version = "0.1.11"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "backoff",
@@ -1731,7 +1731,7 @@ checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "janus_client"
-version = "0.1.11"
+version = "0.2.0"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "janus_collector"
-version = "0.1.11"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1782,7 +1782,7 @@ dependencies = [
 
 [[package]]
 name = "janus_core"
-version = "0.1.11"
+version = "0.2.0"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -1816,7 +1816,7 @@ dependencies = [
 
 [[package]]
 name = "janus_messages"
-version = "0.1.12"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1835,7 +1835,7 @@ dependencies = [
 
 [[package]]
 name = "janus_server"
-version = "0.1.11"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,14 @@ members = [
 ]
 resolver = "2"
 
+[workspace.package]
+edition = "2021"
+homepage = "https://divviup.org"
+license = "MPL-2.0"
+repository = "https://github.com/divviup/janus"
+rust-version = "1.64.0"
+version = "0.2.0"
+
 [profile.dev]
 # Disabling debug info improves build speeds & reduces
 # build artifact sizes (which helps CI caching).

--- a/build_script_utils/Cargo.toml
+++ b/build_script_utils/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "build_script_utils"
-version = "0.1.0"
-edition = "2021"
-license = "MPL-2.0"
-rust-version = "1.63"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
 publish = false
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
 zstd = { version = "0.11" }

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "integration_tests"
-version = "0.1.11"
-edition = "2021"
-license = "MPL-2.0"
-rust-version = "1.63"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
 publish = false
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [features]
 daphne = [

--- a/interop_binaries/Cargo.toml
+++ b/interop_binaries/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "interop_binaries"
-version = "0.1.11"
-edition = "2021"
-license = "MPL-2.0"
-rust-version = "1.63"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
 publish = false
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [features]
 test-util = [

--- a/janus_client/Cargo.toml
+++ b/janus_client/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
 name = "janus_client"
-version = "0.1.11"
-edition = "2021"
 description = "Client for Janus, the server powering ISRG's Divvi Up."
 documentation = "https://docs.rs/janus_client"
-homepage = "https://divviup.org"
-license = "MPL-2.0"
-repository = "https://github.com/divviup/janus"
-rust-version = "1.63"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
 backoff = { version = "0.4.0", features = ["tokio"] }
 derivative = "2.2.0"
 http = "0.2.8"
 http-api-problem = "0.55.0"
-janus_core = { version = "0.1", path = "../janus_core" }
-janus_messages = { version = "0.1", path = "../janus_messages" }
+janus_core = { version = "0.2", path = "../janus_core" }
+janus_messages = { version = "0.2", path = "../janus_messages" }
 prio = { version = "0.10.0", features = ["multithreaded"] }
 rand = "0.8"
 reqwest = { version = "0.11.12", default-features = false, features = ["rustls-tls", "json"] }

--- a/janus_collector/Cargo.toml
+++ b/janus_collector/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "janus_collector"
-version = "0.1.11"
-edition = "2021"
 description = "Collector for Janus, the server powering ISRG's Divvi Up."
 documentation = "https://docs.rs/janus_collector"
-homepage = "https://divviup.org"
-license = "MPL-2.0"
-repository = "https://github.com/divviup/janus"
-rust-version = "1.63"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [features]
 test-util = []
@@ -16,8 +16,8 @@ test-util = []
 backoff = { version = "0.4.0", features = ["tokio"] }
 derivative = "2.2.0"
 http-api-problem = "0.55.0"
-janus_core = { version = "0.1", path = "../janus_core" }
-janus_messages = { version = "0.1", path = "../janus_messages" }
+janus_core = { version = "0.2", path = "../janus_core" }
+janus_messages = { version = "0.2", path = "../janus_messages" }
 prio = "0.10.0"
 reqwest = { version = "0.11.12", default-features = false, features = ["rustls-tls", "json"] }
 retry-after = "0.3.1"

--- a/janus_core/Cargo.toml
+++ b/janus_core/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "janus_core"
-version = "0.1.11"
-edition = "2021"
 description = "Core type definitions and utilities used in various components of Janus."
 documentation = "https://docs.rs/janus_core"
-homepage = "https://divviup.org"
-license = "MPL-2.0"
-repository = "https://github.com/divviup/janus"
-rust-version = "1.63"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [features]
 test-util = [
@@ -32,7 +32,7 @@ futures = "0.3.24"
 hex = "0.4"
 hpke-dispatch = "0.4.0"
 http-api-problem = "0.55.0"
-janus_messages = { version = "0.1", path = "../janus_messages" }
+janus_messages = { version = "0.2", path = "../janus_messages" }
 kube = { version = "0.65", optional = true, default-features = false, features = ["client", "rustls-tls"] }
 k8s-openapi = { version = "0.13.1", optional = true, features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
 prio = { version = "0.10.0", features = ["multithreaded"] }

--- a/janus_messages/Cargo.toml
+++ b/janus_messages/Cargo.toml
@@ -1,17 +1,16 @@
 [package]
 name = "janus_messages"
-version = "0.1.12"
-edition = "2021"
 description = "Distributed Aggregation Protocol message definitions used in Janus, the server powering ISRG's Divvi Up."
 documentation = "https://docs.rs/janus_messages"
-homepage = "https://divviup.org"
-license = "MPL-2.0"
-repository = "https://github.com/divviup/janus"
-rust-version = "1.63"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [features]
 dap-decode-bin = ["dep:structopt"]
-
 test-util = []
 
 [dependencies]

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "janus_server"
-version = "0.1.11"
-edition = "2021"
-license = "MPL-2.0"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
 publish = false
-rust-version = "1.63"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [features]
 default = ["kube-rustls"]


### PR DESCRIPTION
Specifically, specify the edition, homepage, license, repository, rust-version, and version package configuration values in the workspace's Cargo.toml, allowing these values to be easily configured for all packages in the workspace.

Also:
 * Bump MSRV to 1.64 -- required to use workspace inheritance.
 * Bump package version to 0.2.0 -- won't matter until we publish.
 * Add homepage/repository to a few packages that didn't have them.