### PR TITLE
Fix another "unknown HpkeConfigId" flaky test - 0.1 backport

### DIFF
--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -2609,13 +2609,17 @@ mod tests {
 
         // should reject a report using the wrong HPKE config for the leader, and reply with
         // the error type outdatedConfig.
+        let unused_hpke_config_id = (0..)
+            .map(HpkeConfigId::from)
+            .find(|id| !task.hpke_keys.contains_key(id))
+            .unwrap();
         let bad_report = Report::new(
             report.task_id(),
             report.nonce(),
             report.extensions().to_vec(),
             vec![
                 HpkeCiphertext::new(
-                    HpkeConfigId::from(101),
+                    unused_hpke_config_id,
                     report.encrypted_input_shares()[0]
                         .encapsulated_context()
                         .to_vec(),


### PR DESCRIPTION
This backports #644 onto release/0.1, fixing a flaky test that fails with probability 1/256.