### PR TITLE
Zeroize-related upgrades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,23 +10,12 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aead"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
+checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
 dependencies = [
+ "crypto-common",
  "generic-array",
-]
-
-[[package]]
-name = "aes"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
-dependencies = [
- "cfg-if",
- "cipher 0.3.0",
- "cpufeatures",
- "opaque-debug",
 ]
 
 [[package]]
@@ -36,20 +25,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfe0133578c0986e1fe3dfcd4af1cc5b2dd6c3dbf534d69916ce16a2701d40ba"
 dependencies = [
  "cfg-if",
- "cipher 0.4.3",
+ "cipher",
  "cpufeatures",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.9.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
+checksum = "82e1366e0c69c9f927b1fa5ce2c7bf9eafc8f9268c0b9800729e8b267612447c"
 dependencies = [
  "aead",
- "aes 0.7.5",
- "cipher 0.3.0",
- "ctr 0.8.0",
+ "aes",
+ "cipher",
+ "ctr",
  "ghash",
  "subtle",
 ]
@@ -173,7 +162,7 @@ dependencies = [
  "http-body",
  "hyper",
  "itoa",
- "matchit 0.5.0",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -240,15 +229,6 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "block-buffer"
@@ -321,25 +301,24 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c80e5460aa66fe3b91d40bcbdab953a597b60053e34d684ac6903f863b680a6"
+checksum = "c7fc89c7c5b9e7a02dfe45cd2367bae382f9ed31c61ca8debe5f827c420a2f08"
 dependencies = [
  "cfg-if",
- "cipher 0.3.0",
+ "cipher",
  "cpufeatures",
- "zeroize",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18446b09be63d457bbec447509e85f662f32952b035ce892290396bc0b0cff5"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
  "chacha20",
- "cipher 0.3.0",
+ "cipher",
  "poly1305",
  "zeroize",
 ]
@@ -362,21 +341,13 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "cipher"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -389,26 +360,9 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim 0.8.0",
- "textwrap 0.11.0",
+ "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "clap"
-version = "3.2.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
-dependencies = [
- "atty",
- "bitflags",
- "clap_derive 3.2.18",
- "clap_lex 0.2.4",
- "indexmap",
- "once_cell",
- "strsim 0.10.0",
- "termcolor",
- "textwrap 0.15.1",
 ]
 
 [[package]]
@@ -419,24 +373,11 @@ checksum = "6bf8832993da70a4c6d13c581f4463c2bdda27b9bf1c5498dc4365543abe6d6f"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive 4.0.13",
- "clap_lex 0.3.0",
+ "clap_derive",
+ "clap_lex",
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
-dependencies = [
- "heck 0.4.0",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -454,15 +395,6 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
-
-[[package]]
-name = "clap_lex"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
@@ -476,7 +408,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "606383658416244b8dc4b36f864ec1f86cb922b95c41a908fd07aeb01cad06fa"
 dependencies = [
- "cipher 0.4.3",
+ "cipher",
  "dbl",
  "digest 0.10.3",
 ]
@@ -557,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
 
 [[package]]
 name = "content_inspector"
@@ -657,21 +589,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.11"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
-dependencies = [
- "generic-array",
- "rand_core 0.6.3",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array",
  "rand_core 0.6.3",
@@ -686,26 +606,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.3",
  "typenum",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
-dependencies = [
- "generic-array",
- "subtle",
-]
-
-[[package]]
-name = "ctr"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
-dependencies = [
- "cipher 0.3.0",
 ]
 
 [[package]]
@@ -714,44 +616,20 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d14f329cfbaf5d0e06b5e87fff7e265d2673c5ea7d2c27691a2c107db1442a0"
 dependencies = [
- "cipher 0.4.3",
+ "cipher",
 ]
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
+checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
  "rand_core 0.5.1",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "daphne"
-version = "0.1.2"
-source = "git+https://github.com/cloudflare/daphne?rev=80b53c4b0f2c93d5f9df66dfce237b20756c9147#80b53c4b0f2c93d5f9df66dfce237b20756c9147"
-dependencies = [
- "anyhow",
- "assert_matches",
- "async-trait",
- "base64",
- "clap 3.2.22",
- "getrandom",
- "hex",
- "hpke 0.8.0",
- "matchit 0.6.0",
- "prio 0.8.2",
- "rand",
- "reqwest",
- "ring",
- "serde",
- "serde_json",
- "thiserror",
- "url",
 ]
 
 [[package]]
@@ -847,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
 dependencies = [
  "const-oid",
 ]
@@ -880,7 +758,7 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
- "block-buffer 0.10.3",
+ "block-buffer",
  "crypto-common",
  "subtle",
 ]
@@ -920,31 +798,18 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.6"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
-dependencies = [
- "crypto-bigint 0.2.11",
- "ff 0.10.1",
- "generic-array",
- "group 0.10.0",
- "rand_core 0.6.3",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "elliptic-curve"
-version = "0.11.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b477563c2bfed38a3b7a60964c49e058b2510ad3f12ba3483fd8f62c2306d6"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
  "base16ct",
- "crypto-bigint 0.3.2",
+ "crypto-bigint",
  "der",
- "ff 0.11.1",
+ "digest 0.10.3",
+ "ff",
  "generic-array",
- "group 0.11.0",
+ "group",
+ "hkdf",
  "rand_core 0.6.3",
  "sec1",
  "subtle",
@@ -977,19 +842,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.10.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
-dependencies = [
- "rand_core 0.6.3",
- "subtle",
-]
-
-[[package]]
-name = "ff"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "131655483be284720a17d74ff97592b8e76576dc25563148601df2d7c9080924"
+checksum = "df689201f395c6b90dfe87127685f8dbfc083a5e779e613575d8bd7314300c3e"
 dependencies = [
  "rand_core 0.6.3",
  "subtle",
@@ -1160,7 +1015,6 @@ version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
- "serde",
  "typenum",
  "version_check",
 ]
@@ -1180,9 +1034,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
+checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
 dependencies = [
  "opaque-debug",
  "polyval",
@@ -1196,22 +1050,11 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "group"
-version = "0.10.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
- "ff 0.10.1",
- "rand_core 0.6.3",
- "subtle",
-]
-
-[[package]]
-name = "group"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
-dependencies = [
- "ff 0.11.1",
+ "ff",
  "rand_core 0.6.3",
  "subtle",
 ]
@@ -1323,31 +1166,11 @@ dependencies = [
 
 [[package]]
 name = "hkdf"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01706d578d5c281058480e673ae4086a9f4710d8df1ad80a5b03e39ece5f886b"
-dependencies = [
- "digest 0.9.0",
- "hmac 0.11.0",
-]
-
-[[package]]
-name = "hkdf"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
 dependencies = [
- "hmac 0.12.1",
-]
-
-[[package]]
-name = "hmac"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
+ "hmac",
 ]
 
 [[package]]
@@ -1361,32 +1184,9 @@ dependencies = [
 
 [[package]]
 name = "hpke"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "849e95e93b040915ae2ea8ae9cc0e73a0dc9804e557fa7959c1ba9dce20215a6"
-dependencies = [
- "aead",
- "aes-gcm",
- "byteorder",
- "chacha20poly1305",
- "digest 0.9.0",
- "generic-array",
- "hkdf 0.11.0",
- "p256 0.9.0",
- "paste",
- "rand_core 0.6.3",
- "serde",
- "sha2 0.9.9",
- "subtle",
- "x25519-dalek",
- "zeroize",
-]
-
-[[package]]
-name = "hpke"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7f2ce6f102e00eaddce2801e237a781b67aeaae8c5733ff95ac03e52f22abf"
+checksum = "cf39e5461bfdc6ad0fbc97067519fcaf96a7a2e67f24cc0eb8a1e7c0c45af792"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1394,11 +1194,11 @@ dependencies = [
  "chacha20poly1305",
  "digest 0.10.3",
  "generic-array",
- "hkdf 0.12.3",
- "hmac 0.12.1",
- "p256 0.10.1",
+ "hkdf",
+ "hmac",
+ "p256",
  "rand_core 0.6.3",
- "sha2 0.10.5",
+ "sha2",
  "subtle",
  "x25519-dalek",
  "zeroize",
@@ -1406,13 +1206,13 @@ dependencies = [
 
 [[package]]
 name = "hpke-dispatch"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e135e806c9be3774bd772620f9775fae064a167f2740072fba13a1934f2e09"
+checksum = "9a82ec7195b71c0efe97204a79ed67e5f6384525a5c165b5d54cb4a7546392c4"
 dependencies = [
  "cfg-if",
  "getrandom",
- "hpke 0.9.0",
+ "hpke",
  "num_enum",
  "rand",
  "wasm-bindgen",
@@ -1689,7 +1489,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "postgres-protocol",
  "postgres-types",
- "prio 0.10.0",
+ "prio",
  "prometheus",
  "rand",
  "reqwest",
@@ -1736,7 +1536,7 @@ dependencies = [
  "janus_core",
  "janus_messages",
  "mockito",
- "prio 0.10.0",
+ "prio",
  "rand",
  "reqwest",
  "thiserror",
@@ -1763,7 +1563,7 @@ dependencies = [
  "janus_core",
  "janus_messages",
  "mockito",
- "prio 0.10.0",
+ "prio",
  "rand",
  "reqwest",
  "retry-after",
@@ -1793,7 +1593,7 @@ dependencies = [
  "kube",
  "lazy_static",
  "mockito",
- "prio 0.10.0",
+ "prio",
  "rand",
  "reqwest",
  "ring",
@@ -1815,13 +1615,11 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "backoff",
- "daphne",
  "futures",
  "hex",
  "http",
  "itertools",
  "janus_aggregator",
- "janus_build_script_utils",
  "janus_client",
  "janus_collector",
  "janus_core",
@@ -1830,11 +1628,9 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "portpicker",
- "prio 0.10.0",
+ "prio",
  "rand",
  "reqwest",
- "serde",
- "serde_json",
  "tempfile",
  "testcontainers",
  "tokio",
@@ -1861,7 +1657,7 @@ dependencies = [
  "janus_messages",
  "lazy_static",
  "opentelemetry",
- "prio 0.10.0",
+ "prio",
  "rand",
  "regex",
  "reqwest",
@@ -1888,7 +1684,7 @@ dependencies = [
  "derivative",
  "hex",
  "num_enum",
- "prio 0.10.0",
+ "prio",
  "rand",
  "serde",
  "structopt",
@@ -2069,12 +1865,6 @@ name = "matchit"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
-
-[[package]]
-name = "matchit"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dfc802da7b1cf80aefffa0c7b2f77247c8b32206cc83c270b61264f5b360a80"
 
 [[package]]
 name = "md-5"
@@ -2495,21 +2285,11 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256"
-version = "0.9.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d053368e1bae4c8a672953397bd1bd7183dde1c72b0b7612a15719173148d186"
+checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
- "elliptic-curve 0.10.6",
-]
-
-[[package]]
-name = "p256"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19736d80675fbe9fe33426268150b951a3fb8f5cfca2a23a17c85ef3adb24e3b"
-dependencies = [
- "elliptic-curve 0.11.12",
- "sec1",
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -2534,12 +2314,6 @@ dependencies = [
  "smallvec",
  "windows-sys",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "pem"
@@ -2624,9 +2398,9 @@ checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "poly1305"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures",
  "opaque-debug",
@@ -2635,9 +2409,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
+checksum = "7ef234e08c11dfcb2e56f79fd70f6f2eb7f025c0ce2333e82f4f0518ecad30c6"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2675,11 +2449,11 @@ dependencies = [
  "byteorder",
  "bytes",
  "fallible-iterator",
- "hmac 0.12.1",
+ "hmac",
  "md-5",
  "memchr",
  "rand",
- "sha2 0.10.5",
+ "sha2",
  "stringprep",
 ]
 
@@ -2718,35 +2492,15 @@ dependencies = [
 
 [[package]]
 name = "prio"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f508d78fd36a95fbd2b18796d7332c603fb622fa0d0216e09f0836a388767e"
-dependencies = [
- "aes 0.8.1",
- "aes-gcm",
- "base64",
- "byteorder",
- "cipher 0.4.3",
- "cmac",
- "ctr 0.9.1",
- "getrandom",
- "ring",
- "serde",
- "static_assertions",
- "thiserror",
-]
-
-[[package]]
-name = "prio"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0453e1ec5f2f48af9a67aab1d812f9aec48619dda0d9a59e2f79ebd235448ec"
 dependencies = [
- "aes 0.8.1",
+ "aes",
  "base64",
  "byteorder",
  "cmac",
- "ctr 0.9.1",
+ "ctr",
  "fixed",
  "getrandom",
  "rayon",
@@ -3019,12 +2773,10 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -3034,7 +2786,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tower-service",
  "url",
@@ -3174,10 +2925,11 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
+ "base16ct",
  "der",
  "generic-array",
  "subtle",
@@ -3337,19 +3089,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.3",
-]
-
-[[package]]
-name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
 ]
 
 [[package]]
@@ -3597,12 +3336,12 @@ dependencies = [
  "bollard-stubs",
  "futures",
  "hex",
- "hmac 0.12.1",
+ "hmac",
  "log",
  "rand",
  "serde",
  "serde_json",
- "sha2 0.10.5",
+ "sha2",
 ]
 
 [[package]]
@@ -3613,12 +3352,6 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"
@@ -4193,11 +3926,11 @@ checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "universal-hash"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
+checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
 dependencies = [
- "generic-array",
+ "crypto-common",
  "subtle",
 ]
 
@@ -4529,12 +4262,12 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "1.2.0"
+version = "2.0.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2392b6b94a576b4e2bf3c5b2757d63f10ada8020a2e4d08ac849ebcf6ea8e077"
+checksum = "e5da623d8af10a62342bcbbb230e33e58a63255a58012f8653c578e54bab48df"
 dependencies = [
  "curve25519-dalek",
- "rand_core 0.5.1",
+ "rand_core 0.6.3",
  "zeroize",
 ]
 
@@ -4555,9 +4288,9 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zeroize"
-version = "1.3.0"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1724,9 +1724,9 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f8de9873b904e74b3533f77493731ee26742418077503683db44e1b3c54aa5c"
+checksum = "0489fc937cc7616a9abfa61bf39c250d7e32e1325ef028c8d9278dd24ea395b3"
 dependencies = [
  "base64",
  "bytes",
@@ -1741,9 +1741,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.65.0"
+version = "0.67.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ec231e9ec9e84789f9eb414d1ac40ce6c90d0517fb272a335b4233f2e272b1e"
+checksum = "067efafecb445fc68e1f3071880fcf3eb9ca09a16115432033a0f4c1e5ad60ef"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -1752,9 +1752,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.65.0"
+version = "0.67.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95dddb1fcced906d79cdae530ff39079c2d3772b2d623088fdbebe610bfa8217"
+checksum = "4ec03dc0f21b475b32fe7768e1c1448a490c0400309b4358a68bee804cdc0701"
 dependencies = [
  "base64",
  "bytes",
@@ -1777,6 +1777,7 @@ dependencies = [
  "pin-project",
  "rustls",
  "rustls-pemfile 0.2.1",
+ "secrecy",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -1791,9 +1792,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.65.0"
+version = "0.67.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c52b6ab05d160691083430f6f431707a4e05b64903f2ffa0095ee5efde759117"
+checksum = "3d82994f9c9b0e13367db9f9b98b30c798da531d4ea2c4c5bebc22e45ba8c67c"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -2933,6 +2934,16 @@ dependencies = [
  "der",
  "generic-array",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
  "zeroize",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tower",
- "tower-http 0.3.4",
+ "tower-http",
  "tower-layer",
  "tower-service",
 ]
@@ -1074,7 +1074,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.7.3",
+ "tokio-util",
  "tracing",
 ]
 
@@ -1353,19 +1353,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
 ]
 
 [[package]]
@@ -1724,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0489fc937cc7616a9abfa61bf39c250d7e32e1325ef028c8d9278dd24ea395b3"
+checksum = "d2ae2c04fcee6b01b04e3aadd56bb418932c8e0a9d8a93f48bc68c6bdcdb559d"
 dependencies = [
  "base64",
  "bytes",
@@ -1741,9 +1728,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.67.0"
+version = "0.73.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "067efafecb445fc68e1f3071880fcf3eb9ca09a16115432033a0f4c1e5ad60ef"
+checksum = "f68b954ea9ad888de953fb1488bd8f377c4c78d82d4642efa5925189210b50b7"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -1752,9 +1739,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.67.0"
+version = "0.73.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec03dc0f21b475b32fe7768e1c1448a490c0400309b4358a68bee804cdc0701"
+checksum = "9150dc7107d9acf4986088f284a0a6dddc5ae37ef1ffdf142f6811dc5998dd58"
 dependencies = [
  "base64",
  "bytes",
@@ -1768,7 +1755,6 @@ dependencies = [
  "hyper-openssl",
  "hyper-rustls",
  "hyper-timeout",
- "hyper-tls",
  "jsonpath_lib",
  "k8s-openapi",
  "kube-core",
@@ -1776,25 +1762,24 @@ dependencies = [
  "pem",
  "pin-project",
  "rustls",
- "rustls-pemfile 0.2.1",
+ "rustls-pemfile 1.0.1",
  "secrecy",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
  "thiserror",
  "tokio",
- "tokio-native-tls",
- "tokio-util 0.6.10",
+ "tokio-util",
  "tower",
- "tower-http 0.2.5",
+ "tower-http",
  "tracing",
 ]
 
 [[package]]
 name = "kube-core"
-version = "0.67.0"
+version = "0.73.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d82994f9c9b0e13367db9f9b98b30c798da531d4ea2c4c5bebc22e45ba8c67c"
+checksum = "bc8c429676abe6a73b374438d5ca02caaf9ae7a635441253c589b779fa5d0622"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -1974,24 +1959,6 @@ dependencies = [
  "safemem",
  "tempfile",
  "twoway",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -3484,16 +3451,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-openssl"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3526,7 +3483,7 @@ dependencies = [
  "postgres-types",
  "socket2",
  "tokio",
- "tokio-util 0.7.3",
+ "tokio-util",
 ]
 
 [[package]]
@@ -3561,20 +3518,6 @@ dependencies = [
  "log",
  "tokio",
  "tungstenite",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]
@@ -3638,7 +3581,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tokio-util 0.7.3",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -3674,27 +3617,7 @@ dependencies = [
  "rand",
  "slab",
  "tokio",
- "tokio-util 0.7.3",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aba3f3efabf7fb41fae8534fc20a817013dd1c12cb45441efb6c82e6556b4cd8"
-dependencies = [
- "base64",
- "bitflags",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-range-header",
- "pin-project-lite",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3706,6 +3629,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c530c8675c1dbf98facee631536fa116b5fb6382d7dd6dc1b118d970eafe3ba"
 dependencies = [
+ "base64",
  "bitflags",
  "bytes",
  "futures-core",
@@ -3717,6 +3641,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4065,7 +3990,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-stream",
  "tokio-tungstenite",
- "tokio-util 0.7.3",
+ "tokio-util",
  "tower-service",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1711,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ae2c04fcee6b01b04e3aadd56bb418932c8e0a9d8a93f48bc68c6bdcdb559d"
+checksum = "6d9455388f4977de4d0934efa9f7d36296295537d774574113a20f6082de03da"
 dependencies = [
  "base64",
  "bytes",
@@ -1728,9 +1728,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.73.1"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f68b954ea9ad888de953fb1488bd8f377c4c78d82d4642efa5925189210b50b7"
+checksum = "9bb19108692aeafebb108fd0a1c381c06ac4c03859652599420975165e939b8a"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -1739,9 +1739,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.73.1"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150dc7107d9acf4986088f284a0a6dddc5ae37ef1ffdf142f6811dc5998dd58"
+checksum = "97e1a80ecd1b1438a2fc004549e155d47250b9e01fbfcf4cfbe9c8b56a085593"
 dependencies = [
  "base64",
  "bytes",
@@ -1777,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.73.1"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8c429676abe6a73b374438d5ca02caaf9ae7a635441253c589b779fa5d0622"
+checksum = "f4d780f2bb048eeef64a4c6b2582d26a0fe19e30b4d3cc9e081616e1779c5d47"
 dependencies = [
  "chrono",
  "form_urlencoded",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ repository = "https://github.com/divviup/janus"
 rust-version = "1.64.0"
 version = "0.2.0"
 
+[workspace.dependencies]
+k8s-openapi = { version = "0.16.0", features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
+kube = { version = "0.75.0", default-features = false, features = ["client"] }
+
 [profile.dev]
 # Disabling debug info improves build speeds & reduces
 # build artifact sizes (which helps CI caching).

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -47,8 +47,8 @@ hyper = "0.14.20"
 itertools = "0.10.5"
 janus_core = { path = "../core" }
 janus_messages = { path = "../messages" }
-k8s-openapi = { version = "0.16.0", features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
-kube = { version = "0.75.0", default-features = false, features = ["client"] }
+k8s-openapi.workspace = true
+kube.workspace = true
 lazy_static = { version = "1", optional = true }
 opentelemetry = { version = "0.18", features = ["metrics", "rt-tokio"] }
 opentelemetry-jaeger = { version = "0.17", optional = true, features = ["rt-tokio"] }

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -47,8 +47,8 @@ hyper = "0.14.20"
 itertools = "0.10.5"
 janus_core = { path = "../core" }
 janus_messages = { path = "../messages" }
-k8s-openapi = { version = "0.15.0", features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
-kube = { version = "0.73.1", default-features = false, features = ["client"] }
+k8s-openapi = { version = "0.16.0", features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
+kube = { version = "0.75.0", default-features = false, features = ["client"] }
 lazy_static = { version = "1", optional = true }
 opentelemetry = { version = "0.18", features = ["metrics", "rt-tokio"] }
 opentelemetry-jaeger = { version = "0.17", optional = true, features = ["rt-tokio"] }

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -47,8 +47,8 @@ hyper = "0.14.20"
 itertools = "0.10.5"
 janus_core = { path = "../core" }
 janus_messages = { path = "../messages" }
-k8s-openapi = { version = "0.13.1", features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
-kube = { version = "0.65.0", default-features = false, features = ["client"] }
+k8s-openapi = { version = "0.14.0", features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
+kube = { version = "0.67.0", default-features = false, features = ["client"] }
 lazy_static = { version = "1", optional = true }
 opentelemetry = { version = "0.18", features = ["metrics", "rt-tokio"] }
 opentelemetry-jaeger = { version = "0.17", optional = true, features = ["rt-tokio"] }

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -47,8 +47,8 @@ hyper = "0.14.20"
 itertools = "0.10.5"
 janus_core = { path = "../core" }
 janus_messages = { path = "../messages" }
-k8s-openapi = { version = "0.14.0", features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
-kube = { version = "0.67.0", default-features = false, features = ["client"] }
+k8s-openapi = { version = "0.15.0", features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
+kube = { version = "0.73.1", default-features = false, features = ["client"] }
 lazy_static = { version = "1", optional = true }
 opentelemetry = { version = "0.18", features = ["metrics", "rt-tokio"] }
 opentelemetry-jaeger = { version = "0.17", optional = true, features = ["rt-tokio"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -30,7 +30,7 @@ chrono = "0.4"
 derivative = "2.2.0"
 futures = "0.3.24"
 hex = "0.4"
-hpke-dispatch = "0.4.0"
+hpke-dispatch = "0.5.0"
 http-api-problem = "0.55.0"
 janus_messages = { version = "0.2", path = "../messages" }
 kube = { version = "0.65", optional = true, default-features = false, features = ["client", "rustls-tls"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,8 +33,8 @@ hex = "0.4"
 hpke-dispatch = "0.5.0"
 http-api-problem = "0.55.0"
 janus_messages = { version = "0.2", path = "../messages" }
-kube = { version = "0.65", optional = true, default-features = false, features = ["client", "rustls-tls"] }
-k8s-openapi = { version = "0.13.1", optional = true, features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
+kube = { version = "0.67", optional = true, default-features = false, features = ["client", "rustls-tls"] }
+k8s-openapi = { version = "0.14.0", optional = true, features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
 prio = { version = "0.10.0", features = ["multithreaded"] }
 rand = "0.8"
 reqwest = { version = "0.11.12", default-features = false, features = ["rustls-tls", "json"] }
@@ -60,6 +60,6 @@ janus_core = { path = ".", features = ["test-util"] }
 # `rustls-tls` feature when creating a default client) to work around rustls's
 # lack of support for connecting to servers by IP addresses, which affects many
 # Kubernetes clusters.
-kube = { version = "0.65", features = ["openssl-tls"] }  # ensure this remains compatible with the non-dev dependency
+kube = { version = "0.67", features = ["openssl-tls"] }  # ensure this remains compatible with the non-dev dependency
 mockito = "0.31.0"
 url = "2.3.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,8 +33,8 @@ hex = "0.4"
 hpke-dispatch = "0.5.0"
 http-api-problem = "0.55.0"
 janus_messages = { version = "0.2", path = "../messages" }
-kube = { version = "0.73", optional = true, default-features = false, features = ["client", "rustls-tls"] }
-k8s-openapi = { version = "0.15.0", optional = true, features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
+kube = { version = "0.75", optional = true, default-features = false, features = ["client", "rustls-tls"] }
+k8s-openapi = { version = "0.16.0", optional = true, features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
 prio = { version = "0.10.0", features = ["multithreaded"] }
 rand = "0.8"
 reqwest = { version = "0.11.12", default-features = false, features = ["rustls-tls", "json"] }
@@ -60,6 +60,6 @@ janus_core = { path = ".", features = ["test-util"] }
 # `rustls-tls` feature when creating a default client) to work around rustls's
 # lack of support for connecting to servers by IP addresses, which affects many
 # Kubernetes clusters.
-kube = { version = "0.73", features = ["openssl-tls"] }  # ensure this remains compatible with the non-dev dependency
+kube = { version = "0.75", features = ["openssl-tls"] }  # ensure this remains compatible with the non-dev dependency
 mockito = "0.31.0"
 url = "2.3.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,8 +33,8 @@ hex = "0.4"
 hpke-dispatch = "0.5.0"
 http-api-problem = "0.55.0"
 janus_messages = { version = "0.2", path = "../messages" }
-kube = { version = "0.67", optional = true, default-features = false, features = ["client", "rustls-tls"] }
-k8s-openapi = { version = "0.14.0", optional = true, features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
+kube = { version = "0.73", optional = true, default-features = false, features = ["client", "rustls-tls"] }
+k8s-openapi = { version = "0.15.0", optional = true, features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
 prio = { version = "0.10.0", features = ["multithreaded"] }
 rand = "0.8"
 reqwest = { version = "0.11.12", default-features = false, features = ["rustls-tls", "json"] }
@@ -60,6 +60,6 @@ janus_core = { path = ".", features = ["test-util"] }
 # `rustls-tls` feature when creating a default client) to work around rustls's
 # lack of support for connecting to servers by IP addresses, which affects many
 # Kubernetes clusters.
-kube = { version = "0.67", features = ["openssl-tls"] }  # ensure this remains compatible with the non-dev dependency
+kube = { version = "0.73", features = ["openssl-tls"] }  # ensure this remains compatible with the non-dev dependency
 mockito = "0.31.0"
 url = "2.3.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,8 +33,8 @@ hex = "0.4"
 hpke-dispatch = "0.5.0"
 http-api-problem = "0.55.0"
 janus_messages = { version = "0.2", path = "../messages" }
-kube = { version = "0.75", optional = true, default-features = false, features = ["client", "rustls-tls"] }
-k8s-openapi = { version = "0.16.0", optional = true, features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
+kube = { workspace = true, optional = true, features = ["rustls-tls"] }
+k8s-openapi = { workspace = true, optional = true }
 prio = { version = "0.10.0", features = ["multithreaded"] }
 rand = "0.8"
 reqwest = { version = "0.11.12", default-features = false, features = ["rustls-tls", "json"] }
@@ -60,6 +60,6 @@ janus_core = { path = ".", features = ["test-util"] }
 # `rustls-tls` feature when creating a default client) to work around rustls's
 # lack of support for connecting to servers by IP addresses, which affects many
 # Kubernetes clusters.
-kube = { version = "0.75", features = ["openssl-tls"] }  # ensure this remains compatible with the non-dev dependency
+kube = { workspace = true, features = ["openssl-tls"] }
 mockito = "0.31.0"
 url = "2.3.1"

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -20,8 +20,8 @@ janus_aggregator = { path = "../aggregator", features = ["test-util"] }
 janus_core = { path = "../core", features = ["test-util"] }
 janus_interop_binaries = { path = "../interop_binaries", features = ["testcontainer"] }
 janus_messages = { path = "../messages" }
-k8s-openapi = { version = "0.15.0", features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
-kube = { version = "0.73.1", default-features = false, features = ["client"] }
+k8s-openapi = { version = "0.16.0", features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
+kube = { version = "0.75.0", default-features = false, features = ["client"] }
 portpicker = "0.1"
 rand = "0.8"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -20,8 +20,8 @@ janus_aggregator = { path = "../aggregator", features = ["test-util"] }
 janus_core = { path = "../core", features = ["test-util"] }
 janus_interop_binaries = { path = "../interop_binaries", features = ["testcontainer"] }
 janus_messages = { path = "../messages" }
-k8s-openapi = { version = "0.13.1", features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
-kube = { version = "0.65.0", default-features = false, features = ["client"] }
+k8s-openapi = { version = "0.14.0", features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
+kube = { version = "0.67.0", default-features = false, features = ["client"] }
 portpicker = "0.1"
 rand = "0.8"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -20,8 +20,8 @@ janus_aggregator = { path = "../aggregator", features = ["test-util"] }
 janus_core = { path = "../core", features = ["test-util"] }
 janus_interop_binaries = { path = "../interop_binaries", features = ["testcontainer"] }
 janus_messages = { path = "../messages" }
-k8s-openapi = { version = "0.16.0", features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
-kube = { version = "0.75.0", default-features = false, features = ["client"] }
+k8s-openapi.workspace = true
+kube.workspace = true
 portpicker = "0.1"
 rand = "0.8"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -9,20 +9,11 @@ rust-version.workspace = true
 version.workspace = true
 
 [features]
-daphne = [
-    "dep:janus_build_script_utils",
-    "dep:daphne",
-    "dep:serde",
-    "dep:serde_json",
-    "dep:tempfile",
-    "janus_interop_binaries/test-util",
-]
 kube-openssl = ["kube/openssl-tls"]
 
 [dependencies]
 anyhow = "1"
 backoff = { version = "0.4", features = ["tokio"] }
-daphne = { git = "https://github.com/cloudflare/daphne", rev = "80b53c4b0f2c93d5f9df66dfce237b20756c9147", optional = true }  # Match this to the version referenced in README.md.
 futures = "0.3.24"
 hex = "0.4"
 janus_aggregator = { path = "../aggregator", features = ["test-util"] }
@@ -34,8 +25,6 @@ kube = { version = "0.65.0", default-features = false, features = ["client"] }
 portpicker = "0.1"
 rand = "0.8"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
-serde = { version = "1", optional = true }
-serde_json = { version = "1", optional = true }
 testcontainers = "0.14.0"
 tokio = { version = "1", features = ["full", "tracing"] }
 tracing = "0.1.37"
@@ -48,8 +37,3 @@ janus_client = { path = "../client" }
 janus_collector = { path = "../collector", features = ["test-util"] }
 prio = { version = "0.10.0", features = ["multithreaded"] }
 tempfile = "3"
-
-[build-dependencies]
-janus_build_script_utils = { path = "../build_script_utils", optional = true }
-serde_json = { version = "1", optional = true }
-tempfile = { version = "3", optional = true }

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -20,8 +20,8 @@ janus_aggregator = { path = "../aggregator", features = ["test-util"] }
 janus_core = { path = "../core", features = ["test-util"] }
 janus_interop_binaries = { path = "../interop_binaries", features = ["testcontainer"] }
 janus_messages = { path = "../messages" }
-k8s-openapi = { version = "0.14.0", features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
-kube = { version = "0.67.0", default-features = false, features = ["client"] }
+k8s-openapi = { version = "0.15.0", features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
+kube = { version = "0.73.1", default-features = false, features = ["client"] }
 portpicker = "0.1"
 rand = "0.8"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -2,6 +2,9 @@
 
 ## Daphne
 
+Note: The Daphne integration test has been temporarily disabled to accommodate implementation of
+DAP-02 and upgrading [`hpke`](https://crates.io/crates/hpke) to version 0.10.0.
+
 The [Daphne](https://github.com/cloudflare/daphne) testing functionality is implemented by running a
 compiled version of Daphne inside a container. The test container is built by this package's build
 script based on the test Dockerfile in the Daphne repository; the test container is included in

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -2,8 +2,11 @@
 
 ## Daphne
 
-Note: The Daphne integration test has been temporarily disabled to accommodate implementation of
-DAP-02 and upgrading [`hpke`](https://crates.io/crates/hpke) to version 0.10.0.
+Note: The Daphne integration test has been temporarily disabled to accommodate
+implementation of DAP-02 (see
+[issue #493](https://github.com/divviup/janus/issues/493)), and the dependency on
+Daphne has been temporarily removed in order to break a dependency cycle and
+upgrade [`hpke`](https://crates.io/crates/hpke) to version 0.10.0.
 
 The [Daphne](https://github.com/cloudflare/daphne) testing functionality is implemented by running a
 compiled version of Daphne inside a container. The test container is built by this package's build


### PR DESCRIPTION
This implements the plan in #655, temporarily removing our Daphne dependency in order to upgrade `hpke-dispatch`, `hpke`, `kube`, and `k8s-openapi`. I removed the entire `daphne` Cargo feature from `integration_tests/Cargo.toml` so that our `--all-features` builds wouldn't break. Aside from the tests here, I also confirmed that the `janus_janus` integration test still passes when run in `JANUS_E2E` mode.

The `kube` upgrades included some interesting changes: many of its dependencies have been moved behind off-by-default features, so we may see a reduction in compile time. There is now native support for port forwarding, so we could possibly use that rather than shelling out to `kubectl`.