### PR TITLE
provide `GITHUB_TOKEN` to `setup-protoc` action

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -50,6 +50,8 @@ jobs:
         override: true
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
     - name: Build
@@ -97,6 +99,8 @@ jobs:
         components: clippy, rustfmt
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Format
       run: cargo fmt --message-format human -- --check
     - name: Clippy


### PR DESCRIPTION
We saw at least one build failure ([1]) in CI that is down to the `arduino/setup-protoc` action encountering a rate limit. According to the action's README ([2]), it uses GitHub API to query releases on some `protoc` related repository. We can avoid rate limits by authenticating, which we do by passing the action's `GITHUB_TOKEN` into the `setup-protoc` action.

[1]: https://github.com/divviup/janus/actions/runs/3316231068/jobs/5477782062
[2]: https://github.com/arduino/setup-protoc#usage