### PR TITLE
Support JANUS_E2E_LOGS_PATH in interop_binaries tests

### DIFF
--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -10,7 +10,8 @@ use janus_core::{
     time::RealClock,
 };
 use janus_interop_binaries::{
-    test_util::await_http_server, testcontainer::Aggregator, AggregatorAddTaskRequest,
+    log_export_path, test_util::await_http_server, testcontainer::Aggregator,
+    AggregatorAddTaskRequest,
 };
 use janus_messages::Role;
 use k8s_openapi::api::core::v1::Secret;
@@ -24,8 +25,6 @@ use std::{
 use testcontainers::{clients::Cli, Container, RunnableImage};
 use tracing::debug;
 use url::Url;
-
-use crate::log_export_path;
 
 /// Represents a running Janus test instance
 #[allow(clippy::large_enum_variant)]

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -1,23 +1,5 @@
 //! This crate contains functionality useful for Janus integration tests.
 
-use std::{
-    env::{self, VarError},
-    path::PathBuf,
-    str::FromStr,
-};
-
 #[cfg(feature = "daphne")]
 pub mod daphne;
 pub mod janus;
-
-/// log_export_path returns the path to export container logs to, or None if container logs are not
-/// configured to be exported.
-///
-/// The resulting value is based directly on the JANUS_E2E_LOGS_PATH environment variable.
-fn log_export_path() -> Option<PathBuf> {
-    match env::var("JANUS_E2E_LOGS_PATH") {
-        Ok(logs_path) => Some(PathBuf::from_str(&logs_path).unwrap()),
-        Err(VarError::NotPresent) => None,
-        Err(err) => panic!("Failed to parse JANUS_E2E_LOGS_PATH: {err}"),
-    }
-}

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -5,7 +5,14 @@ use janus_messages::{HpkeAeadId, HpkeConfig, HpkeConfigId, HpkeKdfId, HpkeKemId,
 use prio::codec::Encode;
 use rand::random;
 use serde::{de::Visitor, Deserialize, Serialize};
-use std::{collections::HashMap, fmt::Display, marker::PhantomData, str::FromStr};
+use std::{
+    collections::HashMap,
+    env::{self, VarError},
+    fmt::Display,
+    marker::PhantomData,
+    path::PathBuf,
+    str::FromStr,
+};
 use tracing_log::LogTracer;
 use tracing_subscriber::{prelude::*, EnvFilter, Registry};
 use url::Url;
@@ -251,6 +258,18 @@ impl HpkeConfigRegistry {
     /// Choose a random [`HpkeConfigId`], and then get the keypair associated with that ID.
     pub fn get_random_keypair(&mut self) -> (HpkeConfig, HpkePrivateKey) {
         self.fetch_keypair(random::<u8>().into())
+    }
+}
+
+/// log_export_path returns the path to export container logs to, or None if container logs are not
+/// configured to be exported.
+///
+/// The resulting value is based directly on the JANUS_E2E_LOGS_PATH environment variable.
+pub fn log_export_path() -> Option<PathBuf> {
+    match env::var("JANUS_E2E_LOGS_PATH") {
+        Ok(logs_path) => Some(PathBuf::from_str(&logs_path).unwrap()),
+        Err(VarError::NotPresent) => None,
+        Err(err) => panic!("Failed to parse JANUS_E2E_LOGS_PATH: {err}"),
     }
 }
 


### PR DESCRIPTION
This adds support for exporting container logs to the `janus_interop_binaries` tests as well.