### PR TITLE
Switch to dtolnay/rust-toolchain action

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -43,11 +43,9 @@ jobs:
       # `janus_core::test_util::kubernetes::EphemeralCluster`
       run: go install sigs.k8s.io/kind@v0.14.0
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@v1
       with:
         toolchain: stable
-        profile: minimal
-        override: true
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
       with:
@@ -91,11 +89,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@v1
       with:
         toolchain: stable
-        profile: minimal
-        override: true
         components: clippy, rustfmt
     - name: Install Protoc
       uses: arduino/setup-protoc@v1

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -43,9 +43,7 @@ jobs:
       # `janus_core::test_util::kubernetes::EphemeralCluster`
       run: go install sigs.k8s.io/kind@v0.14.0
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@v1
-      with:
-        toolchain: stable
+      uses: dtolnay/rust-toolchain@stable
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
       with:
@@ -89,9 +87,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
         components: clippy, rustfmt
     - name: Install Protoc
       uses: arduino/setup-protoc@v1


### PR DESCRIPTION
This replaces our use of actions-rs/toolchain (which is unmaintained) with dtolnay/rust-toolchain. There's no support for setting a rustup override, but that should be okay, as the action will install a new default toolchain, and we don't have any `rust-toolchain` files that would supersede that. The profile is not configurable, but that's fine, since the action hardcodes --profile=minimal.