### PR TITLE
GHA: Replace ::set-output with file redirection - backport

### DIFF
--- a/.github/workflows/publish-sql-schema.yml
+++ b/.github/workflows/publish-sql-schema.yml
@@ -27,7 +27,7 @@ jobs:
         install_components: "alpha"
     - name: Get the version
       id: get_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      run: echo VERSION=${GITHUB_REF/refs\/tags\//} >> $GITHUB_OUTPUT
     - name: "Upload schema file(s)"
       run: gcloud alpha storage cp db/schema.sql gs://janus-artifacts-sql-schemas/${{ steps.get_version.outputs.VERSION }}/schema.sql
     - name: "Upload schema file(s) to latest"

--- a/.github/workflows/push-docker-images-release.yml
+++ b/.github/workflows/push-docker-images-release.yml
@@ -45,7 +45,7 @@ jobs:
         password: ${{ steps.gcp-auth-private.outputs.access_token }}
     - name: Get the version
       id: get_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      run: echo VERSION=${GITHUB_REF/refs\/tags\//} >> $GITHUB_OUTPUT
     - name: update-version
       run: sed -i "s/^version =.*/version = \"${{ steps.get_version.outputs.VERSION }}\"/" janus_server/Cargo.toml
     - run: |-


### PR DESCRIPTION
This backports #643 to the 0.1 branch, to fix some deprecation warnings.