### PR TITLE
Fix typo in GitHub secret name

### DIFF
--- a/.github/workflows/publish-sql-schema.yml
+++ b/.github/workflows/publish-sql-schema.yml
@@ -17,7 +17,7 @@ jobs:
       name: "Authenticate to GCP"
       uses: "google-github-actions/auth@v0"
       with:
-        workload_identity_provider: ${{ secrets.GCP_ARTIFACT_PUBISHER_WORKLOAD_IDENTITY_PROVIDER }}
+        workload_identity_provider: ${{ secrets.GCP_ARTIFACT_PUBLISHER_WORKLOAD_IDENTITY_PROVIDER }}
         service_account: ${{ secrets.GCP_ARTIFACT_PUBLISHER_DEPLOY_SERVICE_ACCOUNT }}
     - name: "Set up Google Cloud SDK"
       uses: "google-github-actions/setup-gcloud@v0"

--- a/.github/workflows/push-docker-images-release.yml
+++ b/.github/workflows/push-docker-images-release.yml
@@ -22,7 +22,7 @@ jobs:
       name: "Authenticate to GCP (private repositories)"
       uses: "google-github-actions/auth@v0"
       with:
-        workload_identity_provider: ${{ secrets.GCP_ARTIFACT_PUBISHER_WORKLOAD_IDENTITY_PROVIDER }}
+        workload_identity_provider: ${{ secrets.GCP_ARTIFACT_PUBLISHER_WORKLOAD_IDENTITY_PROVIDER }}
         service_account: ${{ secrets.GCP_ARTIFACT_PUBLISHER_DEPLOY_SERVICE_ACCOUNT }}
         token_format: "access_token"
         access_token_lifetime: "3600s"
@@ -32,7 +32,7 @@ jobs:
       name: "Authenticate to GCP (public repositories)"
       uses: "google-github-actions/auth@v0"
       with:
-        workload_identity_provider: ${{ secrets.GCP_PUBLIC_ARTIFACT_PUBISHER_WORKLOAD_IDENTITY_PROVIDER }}
+        workload_identity_provider: ${{ secrets.GCP_PUBLIC_ARTIFACT_PUBLISHER_WORKLOAD_IDENTITY_PROVIDER }}
         service_account: ${{ secrets.GCP_PUBLIC_ARTIFACT_PUBLISHER_DEPLOY_SERVICE_ACCOUNT }}
         token_format: "access_token"
         access_token_lifetime: "3600s"

--- a/.github/workflows/push-docker-images-release.yml
+++ b/.github/workflows/push-docker-images-release.yml
@@ -27,7 +27,6 @@ jobs:
         token_format: "access_token"
         access_token_lifetime: "3600s"
         access_token_scopes: "https://www.googleapis.com/auth/cloud-platform"
-        export_environment_variables: true
     - id: "gcp-auth-public"
       name: "Authenticate to GCP (public repositories)"
       uses: "google-github-actions/auth@v0"
@@ -37,7 +36,6 @@ jobs:
         token_format: "access_token"
         access_token_lifetime: "3600s"
         access_token_scopes: "https://www.googleapis.com/auth/cloud-platform"
-        export_environment_variables: true
     - uses: "docker/login-action@v2"
       with:
         registry: "us-west2-docker.pkg.dev"


### PR DESCRIPTION
This fixes some typos in secret names used by actions. Here, I change two secret names (one for the public repository and one for the private repository) to use the corrected spelling. (I've already created a new secret for this, plus an additional misspelled secret, and I plan to keep all four around until I'm done testing the 0.1.20 release runs)

I also rolled in a fix for a GitHub Actions warning, along the lines of https://github.com/divviup/divviup-ts/pull/135.