### PR TITLE
Fixed-size tasks: implement aggregation job driver.

### DIFF
--- a/aggregator/src/task.rs
+++ b/aggregator/src/task.rs
@@ -31,7 +31,7 @@ pub enum Error {
 }
 
 /// Identifiers for query types used by a task, along with query-type specific configuration.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum QueryType {
     /// Time-interval: used to support a collection style based on fixed time intervals.
     TimeInterval,


### PR DESCRIPTION
This effectively implements the leader side of the aggregation process. The functional changes are quite small here: effectively, the only change over what was done as part of e.g. the message updates is to pass along the "partial batch identifer" (i.e. batch ID, for fixed-size tasks) in the aggregate initialization request.