### PR TITLE
datastore: use `SMALLINT` for aggregation error

### DIFF
--- a/aggregator/src/datastore.rs
+++ b/aggregator/src/datastore.rs
@@ -1380,7 +1380,7 @@ impl<C: Clock> Transaction<'_, C> {
         let prep_state_bytes: Option<Vec<u8>> = row.get("prep_state");
         let prep_msg_bytes: Option<Vec<u8>> = row.get("prep_msg");
         let out_share_bytes: Option<Vec<u8>> = row.get("out_share");
-        let error_code: Option<i64> = row.get("error_code");
+        let error_code: Option<i16> = row.get("error_code");
 
         let error_code = match error_code {
             Some(c) => {
@@ -3235,7 +3235,7 @@ pub mod models {
                     (None, None, Some(output_share.into()), None)
                 }
                 ReportAggregationState::Failed(report_share_err) => {
-                    (None, None, None, Some(*report_share_err as i64))
+                    (None, None, None, Some(*report_share_err as i16))
                 }
                 ReportAggregationState::Invalid => (None, None, None, None),
             };
@@ -3252,7 +3252,7 @@ pub mod models {
         pub(super) prep_state: Option<Vec<u8>>,
         pub(super) prep_msg: Option<Vec<u8>>,
         pub(super) output_share: Option<Vec<u8>>,
-        pub(super) report_share_err: Option<i64>,
+        pub(super) report_share_err: Option<i16>,
     }
 
     // The private ReportAggregationStateCode exists alongside the public ReportAggregationState

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -132,7 +132,7 @@ CREATE TABLE report_aggregations(
     prep_state          BYTEA,                              -- the current preparation state (opaque VDAF message, only if in state WAITING)
     prep_msg            BYTEA,                              -- the next preparation message to be sent to the helper (opaque VDAF message, only if in state WAITING if this aggregator is the leader)
     out_share           BYTEA,                              -- the output share (opaque VDAF message, only if in state FINISHED)
-    error_code          BIGINT,                             -- error code corresponding to a DAP ReportShareError value; null if in a state other than FAILED
+    error_code          SMALLINT,                           -- error code corresponding to a DAP ReportShareError value; null if in a state other than FAILED
 
     CONSTRAINT unique_ord UNIQUE(aggregation_job_id, ord),
     CONSTRAINT fk_aggregation_job_id FOREIGN KEY(aggregation_job_id) REFERENCES aggregation_jobs(id),


### PR DESCRIPTION
Changes the type of `report_aggregation.error_code` from `BIGINT` to `SMALLINT` to save space. I opted against a SQL enum because then we'd have to duplicate the error enum defined in Rust in SQL and we'd still have to check for invalid errors when reading from the datastore.

Resolves #22