### PR TITLE
Detect & skip build scripts for rust-analyzer.

### DIFF
--- a/integration_tests/build.rs
+++ b/integration_tests/build.rs
@@ -1,9 +1,19 @@
+use std::env;
+
 fn main() {
+    // Skip running this build script for rust-analyzer.
+    println!("cargo:rerun-if-env-changed=RUSTC_WRAPPER");
+    if let Ok(rustc_wrapper) = env::var("RUSTC_WRAPPER") {
+        if rustc_wrapper.ends_with("/rust-analyzer") {
+            return;
+        }
+    }
+
     #[cfg(feature = "daphne")]
     {
         use janus_build_script_utils::save_zstd_compressed_docker_image;
         use serde_json::json;
-        use std::{env, fs::File, process::Command};
+        use std::{fs::File, process::Command};
         use tempfile::tempdir;
 
         // This build script is self-contained, so we only need to rebuild if the build script

--- a/integration_tests/build.rs
+++ b/integration_tests/build.rs
@@ -5,6 +5,9 @@ fn main() {
     println!("cargo:rerun-if-env-changed=RUSTC_WRAPPER");
     if let Ok(rustc_wrapper) = env::var("RUSTC_WRAPPER") {
         if rustc_wrapper.ends_with("/rust-analyzer") {
+            // This appears to be a false positive due to the rest of the code not being compiled
+            // under default features.
+            #[allow(clippy::needless_return)]
             return;
         }
     }

--- a/interop_binaries/build.rs
+++ b/interop_binaries/build.rs
@@ -1,11 +1,21 @@
+use std::env;
+
 fn main() {
+    // Skip running this build script for rust-analyzer.
+    println!("cargo:rerun-if-env-changed=RUSTC_WRAPPER");
+    if let Ok(rustc_wrapper) = env::var("RUSTC_WRAPPER") {
+        if rustc_wrapper.ends_with("/rust-analyzer") {
+            return;
+        }
+    }
+
     // We only build the container image if the `testcontainer` feature is enabled, in order to
     // avoid infinite recursion in our build process (since building the container image builds this
-    // package, among other things.)
+    // crate, among other things.)
     #[cfg(feature = "testcontainer")]
     {
         use janus_build_script_utils::save_zstd_compressed_docker_image;
-        use std::{env, fs::File, process::Command};
+        use std::{fs::File, process::Command};
 
         println!("cargo:rerun-if-env-changed=JANUS_INTEROP_CONTAINER");
         let container_strategy = env::var("JANUS_INTEROP_CONTAINER")


### PR DESCRIPTION
rust-analyzer has a setting which disables build scripts. Unfortunately, at least on my machine, this setting is ineffectual and build scripts are run anyway. This implies the `cargo check` done by rust-analyzer was actually building Janus as part of the container-build process. If the container build failed, the entire build process would be aborted & VSCode would not show any error highlighting in some cases.

This new check is based on `RUSTC_WRAPPER`, which rust-analyzer sets by default to the full path of the rust-analyzer binary. rust-analyzer can be configured to not set this environment variable -- please don't do so. :-)

As a side-effect, I think this speeds up how quickly rust-analyzer will be able to check Janus. Incremental container builds are quick, but not instantaneous.