### PR TITLE
Store leader input shares unencrypted

### DIFF
--- a/aggregator/src/aggregator/aggregate_share.rs
+++ b/aggregator/src/aggregator/aggregate_share.rs
@@ -722,11 +722,22 @@ mod tests {
                             .unwrap(),
                         Vec::new(),
                     );
-                    tx.put_client_report(&Report::new(
+                    tx.put_client_report_message(&Report::new(
                         *task.id(),
                         report_metadata.clone(),
                         Vec::new(),
-                        Vec::new(),
+                        vec![
+                            HpkeCiphertext::new(
+                                HpkeConfigId::from(13),
+                                Vec::from("encapsulated_context_0"),
+                                Vec::from("payload_0"),
+                            ),
+                            HpkeCiphertext::new(
+                                HpkeConfigId::from(13),
+                                Vec::from("encapsulated_context_1"),
+                                Vec::from("payload_1"),
+                            ),
+                        ],
                     ))
                     .await?;
 
@@ -845,11 +856,22 @@ mod tests {
                             .unwrap(),
                         Vec::new(),
                     );
-                    tx.put_client_report(&Report::new(
+                    tx.put_client_report_message(&Report::new(
                         *task.id(),
                         report_metadata.clone(),
                         Vec::new(),
-                        Vec::new(),
+                        vec![
+                            HpkeCiphertext::new(
+                                HpkeConfigId::from(13),
+                                Vec::from("encapsulated_context_0"),
+                                Vec::from("payload_0"),
+                            ),
+                            HpkeCiphertext::new(
+                                HpkeConfigId::from(13),
+                                Vec::from("encapsulated_context_1"),
+                                Vec::from("payload_1"),
+                            ),
+                        ],
                     ))
                     .await?;
 

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -738,8 +738,8 @@ mod tests {
                 tx.put_task(&leader_task).await?;
                 tx.put_task(&helper_task).await?;
 
-                tx.put_client_report(&leader_report).await?;
-                tx.put_client_report(&helper_report).await
+                tx.put_client_report_message(&leader_report).await?;
+                tx.put_client_report_message(&helper_report).await
             })
         })
         .await
@@ -875,7 +875,7 @@ mod tests {
                     .chain(&small_batch_reports)
                     .chain(&big_batch_reports)
                 {
-                    tx.put_client_report(report).await?;
+                    tx.put_client_report_message(report).await?;
                 }
                 Ok(())
             })
@@ -963,7 +963,7 @@ mod tests {
             let (task, first_report) = (Arc::clone(&task), first_report.clone());
             Box::pin(async move {
                 tx.put_task(&task).await?;
-                tx.put_client_report(&first_report).await
+                tx.put_client_report_message(&first_report).await
             })
         })
         .await
@@ -1007,7 +1007,7 @@ mod tests {
             .datastore
             .run_tx(|tx| {
                 let second_report = second_report.clone();
-                Box::pin(async move { tx.put_client_report(&second_report).await })
+                Box::pin(async move { tx.put_client_report_message(&second_report).await })
             })
             .await
             .unwrap();
@@ -1105,7 +1105,7 @@ mod tests {
             Box::pin(async move {
                 tx.put_task(&task).await?;
                 for report in &reports {
-                    tx.put_client_report(report).await?;
+                    tx.put_client_report_message(report).await?;
                 }
                 Ok(())
             })
@@ -1230,10 +1230,10 @@ mod tests {
             Box::pin(async move {
                 tx.put_task(&task).await?;
                 for report in batch_1_reports {
-                    tx.put_client_report(&report).await?;
+                    tx.put_client_report_message(&report).await?;
                 }
                 for report in batch_2_reports {
-                    tx.put_client_report(&report).await?;
+                    tx.put_client_report_message(&report).await?;
                 }
                 Ok(())
             })

--- a/aggregator/src/messages.rs
+++ b/aggregator/src/messages.rs
@@ -125,7 +125,7 @@ impl IntervalExt for Interval {
 
 #[cfg(feature = "test-util")]
 pub mod test_util {
-    use janus_messages::{Report, ReportMetadata, TaskId, Time};
+    use janus_messages::{HpkeCiphertext, HpkeConfigId, Report, ReportMetadata, TaskId, Time};
     use rand::random;
 
     pub fn new_dummy_report(task_id: TaskId, when: Time) -> Report {
@@ -133,7 +133,18 @@ pub mod test_util {
             task_id,
             ReportMetadata::new(random(), when, Vec::new()),
             Vec::new(),
-            Vec::new(),
+            vec![
+                HpkeCiphertext::new(
+                    HpkeConfigId::from(13),
+                    Vec::from("encapsulated_context_0"),
+                    Vec::from("payload_0"),
+                ),
+                HpkeCiphertext::new(
+                    HpkeConfigId::from(13),
+                    Vec::from("encapsulated_context_1"),
+                    Vec::from("payload_1"),
+                ),
+            ],
         )
     }
 }

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -72,13 +72,14 @@ CREATE TABLE task_vdaf_verify_keys(
 
 -- Individual reports received from clients.
 CREATE TABLE client_reports(
-    id                BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY, -- artificial ID, internal-only
-    task_id           BIGINT NOT NULL,     -- task ID the report is associated with
-    report_id         BYTEA NOT NULL,      -- 16-byte ReportID as defined by the DAP specification
-    client_timestamp  TIMESTAMP NOT NULL,  -- report timestamp, from client
-    extensions        BYTEA,               -- encoded sequence of Extension messages (populated for leader only)
-    public_share      BYTEA,               -- encoded public share (opaque VDAF message, populated for leader only)
-    input_shares      BYTEA,               -- encoded sequence of HpkeCiphertext messages (populated for leader only)
+    id                              BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY, -- artificial ID, internal-only
+    task_id                         BIGINT NOT NULL,     -- task ID the report is associated with
+    report_id                       BYTEA NOT NULL,      -- 16-byte ReportID as defined by the DAP specification
+    client_timestamp                TIMESTAMP NOT NULL,  -- report timestamp, from client
+    extensions                      BYTEA,               -- encoded sequence of Extension messages (populated for leader only)
+    public_share                    BYTEA,               -- encoded public share (opaque VDAF message, populated for leader only)
+    leader_input_share              BYTEA,               -- encoded, decrypted leader input share (populated for leader only)
+    helper_encrypted_input_share    BYTEA,               -- encdoed HpkeCiphertext message containing the helper's input share (populated for leader only)
 
     CONSTRAINT unique_task_id_and_report_id UNIQUE(task_id, report_id),
     CONSTRAINT fk_task_id FOREIGN KEY(task_id) REFERENCES tasks(id)


### PR DESCRIPTION
When handling uploads, the leader now decrypts and decodes its input share and the public share before recording them in the datastore. This allows us to discard immediately reports that can never be aggregated and simplifies the implementation of the aggregation job creator, since it can now fetch well-formed values from the datastore.

See #442 for rationale.

Resolves #442