### PR TITLE
Add integration tests with divviup-ts

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -5,6 +5,11 @@ on:
     branches: [ main, release/** ]
   pull_request:
   workflow_dispatch:
+    inputs:
+      divviup_ts_interop_container:
+        description: divviup-ts container image tag for use in integration tests
+        required: false
+        type: string
 
 jobs:
   janus_build:
@@ -16,9 +21,13 @@ jobs:
       CARGO_INCREMENTAL: 0
       CARGO_TERM_COLOR: always
       DAPHNE_INTEROP_CONTAINER: prebuilt=${{ secrets.DAPHNE_PREBUILT_IMAGE_NAME_AND_TAG }}
-      DIVVIUP_TS_INTEROP_CONTAINER: ${{ secrets.DIVVIUP_TS_INTEROP_IMAGE_NAME_AND_TAG }}
       RUSTFLAGS: "-D warnings"
     steps:
+    - name: Set default input values
+      id: default-input-values
+      run: |
+        DIVVIUP_TS_INTEROP_CONTAINER= ${{ inputs.divviup_ts_interop_container }}
+        echo "divviup_ts_interop_container=${DIVVIUP_TS_INTEROP_CONTAINER:-us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-ts/divviup_ts_interop_client:dap-draft-02@sha256:dc4c111adce5719fef9d231f79aecb842c3f626d51363b04355e987d6a40aadc}" >> $GITHUB_OUTPUT
     - uses: actions/checkout@v3
     # See https://github.com/google-github-actions/auth#authenticating-to-container-registry-and-artifact-registry
     - id: "gcp-auth"
@@ -59,6 +68,7 @@ jobs:
       id: test
       env:
         JANUS_E2E_LOGS_PATH: ${{ github.workspace }}/test-logs
+        DIVVIUP_TS_INTEROP_CONTAINER: ${{ steps.default-input-values.outputs.divviup_ts_interop_container }}
       run: cargo test --all-targets
       # Continue on error so we can upload logs
       continue-on-error: true

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -16,6 +16,7 @@ jobs:
       CARGO_INCREMENTAL: 0
       CARGO_TERM_COLOR: always
       DAPHNE_INTEROP_CONTAINER: prebuilt=${{ secrets.DAPHNE_PREBUILT_IMAGE_NAME_AND_TAG }}
+      DIVVIUP_TS_INTEROP_CONTAINER: ${{ secrets.DIVVIUP_TS_INTEROP_IMAGE_NAME_AND_TAG }}
       RUSTFLAGS: "-D warnings"
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -10,7 +10,6 @@ on:
         description: divviup-ts container image tag for use in integration tests
         required: false
         type: string
-        default: us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-ts/divviup_ts_interop_client:dap-draft-02@sha256:dc4c111adce5719fef9d231f79aecb842c3f626d51363b04355e987d6a40aadc
 
 jobs:
   janus_build:
@@ -24,8 +23,11 @@ jobs:
       DAPHNE_INTEROP_CONTAINER: prebuilt=${{ secrets.DAPHNE_PREBUILT_IMAGE_NAME_AND_TAG }}
       RUSTFLAGS: "-D warnings"
     steps:
-    - name: Echo input value
-      run: echo ${{ inputs.divviup_ts_interop_container }}
+    - name: Set default input values
+      id: default-input-values
+      run: |
+        DIVVIUP_TS_INTEROP_CONTAINER= ${{ inputs.divviup_ts_interop_container }}
+        echo "divviup_ts_interop_container=${DIVVIUP_TS_INTEROP_CONTAINER:-us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-ts/divviup_ts_interop_client:dap-draft-02@sha256:dc4c111adce5719fef9d231f79aecb842c3f626d51363b04355e987d6a40aadc}" >> $GITHUB_OUTPUT
     - uses: actions/checkout@v3
     # See https://github.com/google-github-actions/auth#authenticating-to-container-registry-and-artifact-registry
     - id: "gcp-auth"
@@ -66,7 +68,7 @@ jobs:
       id: test
       env:
         JANUS_E2E_LOGS_PATH: ${{ github.workspace }}/test-logs
-        DIVVIUP_TS_INTEROP_CONTAINER: ${{ inputs.divviup_ts_interop_container }}
+        DIVVIUP_TS_INTEROP_CONTAINER: ${{ steps.default-input-values.outputs.divviup_ts_interop_container }}
       run: cargo test --all-targets
       # Continue on error so we can upload logs
       continue-on-error: true

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -10,6 +10,7 @@ on:
         description: divviup-ts container image tag for use in integration tests
         required: false
         type: string
+        default: us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-ts/divviup_ts_interop_client:dap-draft-02@sha256:dc4c111adce5719fef9d231f79aecb842c3f626d51363b04355e987d6a40aadc
 
 jobs:
   janus_build:
@@ -23,11 +24,8 @@ jobs:
       DAPHNE_INTEROP_CONTAINER: prebuilt=${{ secrets.DAPHNE_PREBUILT_IMAGE_NAME_AND_TAG }}
       RUSTFLAGS: "-D warnings"
     steps:
-    - name: Set default input values
-      id: default-input-values
-      run: |
-        DIVVIUP_TS_INTEROP_CONTAINER= ${{ inputs.divviup_ts_interop_container }}
-        echo "divviup_ts_interop_container=${DIVVIUP_TS_INTEROP_CONTAINER:-us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-ts/divviup_ts_interop_client:dap-draft-02@sha256:dc4c111adce5719fef9d231f79aecb842c3f626d51363b04355e987d6a40aadc}" >> $GITHUB_OUTPUT
+    - name: Echo input value
+      run: echo ${{ inputs.divviup_ts_interop_container }}
     - uses: actions/checkout@v3
     # See https://github.com/google-github-actions/auth#authenticating-to-container-registry-and-artifact-registry
     - id: "gcp-auth"
@@ -68,7 +66,7 @@ jobs:
       id: test
       env:
         JANUS_E2E_LOGS_PATH: ${{ github.workspace }}/test-logs
-        DIVVIUP_TS_INTEROP_CONTAINER: ${{ steps.default-input-values.outputs.divviup_ts_interop_container }}
+        DIVVIUP_TS_INTEROP_CONTAINER: ${{ inputs.divviup_ts_interop_container }}
       run: cargo test --all-targets
       # Continue on error so we can upload logs
       continue-on-error: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1602,6 +1602,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "backoff",
+ "base64",
  "futures",
  "hex",
  "http",
@@ -1618,6 +1619,7 @@ dependencies = [
  "prio",
  "rand",
  "reqwest",
+ "serde_json",
  "tempfile",
  "testcontainers",
  "tokio",

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -14,17 +14,21 @@ kube-openssl = ["kube/openssl-tls"]
 [dependencies]
 anyhow = "1"
 backoff = { version = "0.4", features = ["tokio"] }
+base64 = "0.13.1"
 futures = "0.3.25"
 hex = "0.4"
 janus_aggregator = { path = "../aggregator", features = ["test-util"] }
+janus_client = { path = "../client" }
 janus_core = { path = "../core", features = ["test-util"] }
 janus_interop_binaries = { path = "../interop_binaries", features = ["testcontainer"] }
 janus_messages = { path = "../messages" }
 k8s-openapi.workspace = true
 kube.workspace = true
 portpicker = "0.1"
+prio = { version = "0.10.0", features = ["multithreaded"] }
 rand = "0.8"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
+serde_json = "1.0.87"
 testcontainers = "0.14.0"
 tokio = { version = "1", features = ["full", "tracing"] }
 tracing = "0.1.37"
@@ -33,7 +37,5 @@ url = { version = "2.3.1", features = ["serde"] }
 [dev-dependencies]
 http = "0.2"
 itertools = "0.10"
-janus_client = { path = "../client" }
 janus_collector = { path = "../collector", features = ["test-util"] }
-prio = { version = "0.10.0", features = ["multithreaded"] }
 tempfile = "3"

--- a/integration_tests/src/client.rs
+++ b/integration_tests/src/client.rs
@@ -114,7 +114,7 @@ impl InteropClient {
         } else {
             InteropClient {
                 name: "us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-ts/divviup_ts_interop_client".to_string(),
-                tag: "dap-draft-02".to_string(),
+                tag: "dap-draft-02@sha256:dc4c111adce5719fef9d231f79aecb842c3f626d51363b04355e987d6a40aadc".to_string(),
             }
         }
     }

--- a/integration_tests/src/client.rs
+++ b/integration_tests/src/client.rs
@@ -1,0 +1,309 @@
+use anyhow::anyhow;
+use base64::URL_SAFE_NO_PAD;
+use janus_aggregator::task::Task;
+use janus_client::{aggregator_hpke_config, default_http_client, Client, ClientParameters};
+use janus_core::{task::VdafInstance, time::RealClock};
+use janus_interop_binaries::ContainerLogsDropGuard;
+use janus_messages::{Duration, Role, TaskId};
+use prio::{
+    codec::Encode,
+    vdaf::{
+        self,
+        prio3::{Prio3Aes128Count, Prio3Aes128CountVec, Prio3Aes128Histogram, Prio3Aes128Sum},
+    },
+};
+use rand::random;
+use serde_json::{json, Value};
+use std::env;
+use testcontainers::{clients::Cli, core::WaitFor, Image, RunnableImage};
+use url::Url;
+
+/// Extension trait to encode measurements for VDAFs as JSON objects, according to
+/// draft-dcook-ppm-dap-interop-test-design-02.
+pub trait InteropClientEncoding: vdaf::Client
+where
+    for<'a> Vec<u8>: From<&'a Self::AggregateShare>,
+{
+    fn json_encode_measurement(&self, measurement: &Self::Measurement) -> Value;
+}
+
+impl InteropClientEncoding for Prio3Aes128Count {
+    fn json_encode_measurement(&self, measurement: &Self::Measurement) -> Value {
+        Value::String(format!("{measurement}"))
+    }
+}
+
+impl InteropClientEncoding for Prio3Aes128Sum {
+    fn json_encode_measurement(&self, measurement: &Self::Measurement) -> Value {
+        Value::String(format!("{measurement}"))
+    }
+}
+
+impl InteropClientEncoding for Prio3Aes128Histogram {
+    fn json_encode_measurement(&self, measurement: &Self::Measurement) -> Value {
+        Value::String(format!("{measurement}"))
+    }
+}
+
+impl InteropClientEncoding for Prio3Aes128CountVec {
+    fn json_encode_measurement(&self, measurement: &Self::Measurement) -> Value {
+        Value::Array(
+            measurement
+                .iter()
+                .map(|value| Value::String(format!("{value}")))
+                .collect(),
+        )
+    }
+}
+
+fn json_encode_vdaf(vdaf: &VdafInstance) -> Value {
+    match vdaf {
+        VdafInstance::Prio3Aes128Count => json!({
+            "type": "Prio3Aes128Count"
+        }),
+        VdafInstance::Prio3Aes128CountVec { length } => json!({
+            "type": "Prio3Aes128CountVec",
+            "length": format!("{length}"),
+        }),
+        VdafInstance::Prio3Aes128Sum { bits } => json!({
+            "type": "Prio3Aes128Sum",
+            "bits": format!("{bits}"),
+        }),
+        VdafInstance::Prio3Aes128Histogram { buckets } => {
+            let buckets = Value::Array(
+                buckets
+                    .iter()
+                    .map(|value| Value::String(format!("{value}")))
+                    .collect(),
+            );
+            json!({
+                "type": "Prio3Aes128Histogram",
+                "buckets": buckets,
+            })
+        }
+        _ => panic!("VDAF {:?} is not yet supported", vdaf),
+    }
+}
+
+/// This represents a container image that implements the client role of
+/// draft-dcook-ppm-dap-interop-test-design-02, for use with [`testcontainers`].
+#[derive(Clone)]
+pub struct InteropClient {
+    name: String,
+    tag: String,
+}
+
+impl InteropClient {
+    /// By default, this creates an object referencing the latest divviup-ts interoperation test
+    /// container image (for the correct DAP version). If the environment variable
+    /// `DIVVIUP_TS_INTEROP_CONTAINER is set to a name and tag, then that image will be used
+    /// instead.
+    pub fn divviup_ts() -> InteropClient {
+        if let Ok(value) = env::var("DIVVIUP_TS_INTEROP_CONTAINER") {
+            if let Some((name, tag)) = value.rsplit_once(':') {
+                InteropClient {
+                    name: name.to_string(),
+                    tag: tag.to_string(),
+                }
+            } else {
+                InteropClient {
+                    name: value.to_string(),
+                    tag: "latest".to_string(),
+                }
+            }
+        } else {
+            InteropClient {
+                name: "us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-ts/divviup_ts_interop_client".to_string(),
+                tag: "dap-draft-02".to_string(),
+            }
+        }
+    }
+}
+
+impl Image for InteropClient {
+    type Args = ();
+
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn tag(&self) -> String {
+        self.tag.clone()
+    }
+
+    fn ready_conditions(&self) -> Vec<testcontainers::core::WaitFor> {
+        Vec::from([WaitFor::Healthcheck])
+    }
+}
+
+/// This selects which DAP client implementation will be used in an integration test.
+pub enum ClientBackend<'a> {
+    /// Uploads reports using `janus-client` as a library.
+    InProcess,
+    /// Uploads reports by starting a containerized client implementation, and sending it requests
+    /// using draft-dcook-ppm-dap-interop-test-design-02.
+    Container {
+        container_client: &'a Cli,
+        container_image: InteropClient,
+        network: &'a str,
+    },
+}
+
+impl<'a> ClientBackend<'a> {
+    pub async fn build<V>(
+        &self,
+        task: &Task,
+        aggregator_endpoints: Vec<Url>,
+        vdaf: V,
+    ) -> anyhow::Result<ClientImplementation<'a, V>>
+    where
+        V: vdaf::Client + InteropClientEncoding,
+        for<'b> Vec<u8>: From<&'b V::AggregateShare>,
+    {
+        match self {
+            ClientBackend::InProcess => {
+                ClientImplementation::new_in_process(task, aggregator_endpoints, vdaf)
+                    .await
+                    .map_err(Into::into)
+            }
+            ClientBackend::Container {
+                container_client,
+                container_image,
+                network,
+            } => Ok(ClientImplementation::new_container(
+                container_client,
+                container_image.clone(),
+                network,
+                task,
+                vdaf,
+            )),
+        }
+    }
+}
+
+pub struct ContainerClientImplementation<'d, V>
+where
+    V: vdaf::Client,
+    for<'a> Vec<u8>: From<&'a V::AggregateShare>,
+{
+    _container: ContainerLogsDropGuard<'d, InteropClient>,
+    leader: Url,
+    helper: Url,
+    task_id: TaskId,
+    time_precision: Duration,
+    vdaf: V,
+    vdaf_instance: VdafInstance,
+    host_port: u16,
+    http_client: reqwest::Client,
+}
+
+/// A DAP client implementation, specialized to work with a particular VDAF. See also
+/// [`ClientBackend`].
+pub enum ClientImplementation<'d, V>
+where
+    V: vdaf::Client,
+    for<'a> Vec<u8>: From<&'a V::AggregateShare>,
+{
+    InProcess { client: Client<V, RealClock> },
+    Container(Box<ContainerClientImplementation<'d, V>>),
+}
+
+impl<'d, V> ClientImplementation<'d, V>
+where
+    V: vdaf::Client + InteropClientEncoding,
+    for<'a> Vec<u8>: From<&'a V::AggregateShare>,
+{
+    pub async fn new_in_process(
+        task: &Task,
+        aggregator_endpoints: Vec<Url>,
+        vdaf: V,
+    ) -> Result<ClientImplementation<'static, V>, janus_client::Error> {
+        let client_parameters =
+            ClientParameters::new(*task.id(), aggregator_endpoints, *task.time_precision());
+        let http_client = default_http_client()?;
+        let leader_config =
+            aggregator_hpke_config(&client_parameters, &Role::Leader, task.id(), &http_client)
+                .await?;
+        let helper_config =
+            aggregator_hpke_config(&client_parameters, &Role::Helper, task.id(), &http_client)
+                .await?;
+        let client = Client::new(
+            client_parameters,
+            vdaf,
+            RealClock::default(),
+            &http_client,
+            leader_config,
+            helper_config,
+        );
+        Ok(ClientImplementation::InProcess { client })
+    }
+
+    pub fn new_container(
+        container_client: &'d Cli,
+        container_image: InteropClient,
+        network: &str,
+        task: &Task,
+        vdaf: V,
+    ) -> Self {
+        let random_part = hex::encode(random::<[u8; 4]>());
+        let client_container_name = format!("client-{random_part}");
+        let container = container_client.run(
+            RunnableImage::from(container_image)
+                .with_network(network)
+                .with_container_name(client_container_name),
+        );
+        let container = ContainerLogsDropGuard::new(container);
+        let host_port = container.get_host_port_ipv4(8080);
+        let http_client = reqwest::Client::new();
+        ClientImplementation::Container(Box::new(ContainerClientImplementation {
+            _container: container,
+            leader: task.aggregator_endpoints()[Role::Leader.index().unwrap()].clone(),
+            helper: task.aggregator_endpoints()[Role::Helper.index().unwrap()].clone(),
+            task_id: *task.id(),
+            time_precision: *task.time_precision(),
+            vdaf,
+            vdaf_instance: task.vdaf().clone(),
+            host_port,
+            http_client,
+        }))
+    }
+
+    pub async fn upload(&self, measurement: &V::Measurement) -> anyhow::Result<()> {
+        match self {
+            ClientImplementation::InProcess { client } => {
+                client.upload(measurement).await.map_err(Into::into)
+            }
+            ClientImplementation::Container(inner) => {
+                let task_id_encoded =
+                    base64::encode_config(&inner.task_id.get_encoded(), URL_SAFE_NO_PAD);
+                let upload_response = inner
+                    .http_client
+                    .post(format!(
+                        "http://127.0.0.1:{}/internal/test/upload",
+                        inner.host_port
+                    ))
+                    .json(&json!({
+                        "task_id": task_id_encoded,
+                        "leader": inner.leader,
+                        "helper": inner.helper,
+                        "vdaf": json_encode_vdaf(&inner.vdaf_instance),
+                        "measurement": inner.vdaf.json_encode_measurement(measurement),
+                        "time_precision": inner.time_precision.as_seconds(),
+                    }))
+                    .send()
+                    .await?
+                    .error_for_status()?
+                    .json::<Value>()
+                    .await?;
+                match upload_response.get("status") {
+                    Some(status) if status == "success" => Ok(()),
+                    Some(status) => Err(anyhow!(
+                        "upload request got {status} status, error is {:?}",
+                        upload_response.get("error")
+                    )),
+                    None => Err(anyhow!("upload response is missing \"status\"")),
+                }
+            }
+        }
+    }
+}

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -1,5 +1,6 @@
 //! This crate contains functionality useful for Janus integration tests.
 
+pub mod client;
 #[cfg(feature = "daphne")]
 pub mod daphne;
 pub mod janus;

--- a/integration_tests/tests/divviup_ts.rs
+++ b/integration_tests/tests/divviup_ts.rs
@@ -1,0 +1,70 @@
+//! These tests check interoperation between the divviup-ts client and Janus aggregators.
+
+use janus_core::{
+    task::VdafInstance,
+    test_util::{install_test_trace_subscriber, testcontainers::container_client},
+};
+use janus_integration_tests::{
+    client::{ClientBackend, InteropClient},
+    janus::Janus,
+};
+use janus_interop_binaries::test_util::generate_network_name;
+use testcontainers::clients::Cli;
+
+mod common;
+
+use common::{submit_measurements_and_verify_aggregate, test_task_builders};
+
+async fn run_divviup_ts_integration_test(container_client: &Cli, vdaf: VdafInstance) {
+    let (collector_private_key, leader_task, helper_task) = test_task_builders(vdaf);
+    let leader_task = leader_task.build();
+    let network = generate_network_name();
+    let leader = Janus::new_in_container(container_client, &network, &leader_task).await;
+    let helper = Janus::new_in_container(container_client, &network, &helper_task.build()).await;
+
+    let client_backend = ClientBackend::Container {
+        container_client,
+        container_image: InteropClient::divviup_ts(),
+        network: &network,
+    };
+    submit_measurements_and_verify_aggregate(
+        (leader.port(), helper.port()),
+        &leader_task,
+        &collector_private_key,
+        &client_backend,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn janus_divviup_ts_count() {
+    install_test_trace_subscriber();
+
+    run_divviup_ts_integration_test(&container_client(), VdafInstance::Prio3Aes128Count).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn janus_divviup_ts_sum() {
+    install_test_trace_subscriber();
+
+    run_divviup_ts_integration_test(
+        &container_client(),
+        VdafInstance::Prio3Aes128Sum { bits: 8 },
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn janus_divviup_ts_histogram() {
+    install_test_trace_subscriber();
+
+    run_divviup_ts_integration_test(
+        &container_client(),
+        VdafInstance::Prio3Aes128Histogram {
+            buckets: Vec::from([1, 10, 100, 1000]),
+        },
+    )
+    .await;
+}
+
+// TODO(https://github.com/divviup/divviup-ts/issues/100): Test CountVec once it is implemented.

--- a/integration_tests/tests/janus.rs
+++ b/integration_tests/tests/janus.rs
@@ -5,7 +5,7 @@ use janus_core::{
     task::VdafInstance,
     test_util::{install_test_trace_subscriber, testcontainers::container_client},
 };
-use janus_integration_tests::janus::Janus;
+use janus_integration_tests::{client::ClientBackend, janus::Janus};
 use janus_interop_binaries::test_util::generate_network_name;
 use std::env::{self, VarError};
 use testcontainers::clients::Cli;
@@ -151,6 +151,7 @@ async fn janus_janus_count() {
         (janus_pair.leader.port(), janus_pair.helper.port()),
         &janus_pair.leader_task,
         &janus_pair.collector_private_key,
+        &ClientBackend::InProcess,
     )
     .await;
 }
@@ -170,6 +171,7 @@ async fn janus_janus_sum_16() {
         (janus_pair.leader.port(), janus_pair.helper.port()),
         &janus_pair.leader_task,
         &janus_pair.collector_private_key,
+        &ClientBackend::InProcess,
     )
     .await;
 }
@@ -194,6 +196,7 @@ async fn janus_janus_histogram_4_buckets() {
         (janus_pair.leader.port(), janus_pair.helper.port()),
         &janus_pair.leader_task,
         &janus_pair.collector_private_key,
+        &ClientBackend::InProcess,
     )
     .await;
 }
@@ -216,6 +219,7 @@ async fn janus_janus_count_vec_15() {
         (janus_pair.leader.port(), janus_pair.helper.port()),
         &janus_pair.leader_task,
         &janus_pair.collector_private_key,
+        &ClientBackend::InProcess,
     )
     .await;
 }

--- a/interop_binaries/Cargo.toml
+++ b/interop_binaries/Cargo.toml
@@ -18,7 +18,6 @@ test-util = [
 ]
 testcontainer = [
     "dep:janus_build_script_utils",
-    "dep:testcontainers",
     "test-util",
 ]
 
@@ -43,7 +42,7 @@ reqwest = { version = "0.11.12", default-features = false, features = ["rustls-t
 ring = "0.16.20"
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.87"
-testcontainers = { version = "0.14", optional = true }
+testcontainers = { version = "0.14" }
 tokio = { version = "1.21", features = ["full", "tracing"] }
 tracing = "0.1.37"
 tracing-log = "0.1.3"
@@ -53,10 +52,9 @@ warp = "0.3"
 zstd = { version = "0.11", optional = true }
 
 [dev-dependencies]
-janus_interop_binaries = { path = ".", features = ["testcontainer"] }
+janus_interop_binaries = { path = ".", features = ["testcontainer", "test-util"] }
 janus_core = { path = "../core", features = ["test-util"] }
 reqwest = { version = "0.11.12", default-features = false, features = ["json"] }
-testcontainers = "0.14.0"
 
 [build-dependencies]
 janus_build_script_utils = { path = "../build_script_utils", optional = true }


### PR DESCRIPTION
This refactors some components of the integration tests and adds new integration tests with divviup-ts, running it inside a Docker container managed by `testcontainers`.