### PR TITLE
1.65 clippy fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 homepage = "https://divviup.org"
 license = "MPL-2.0"
 repository = "https://github.com/divviup/janus"
-rust-version = "1.64.0"
+rust-version = "1.65.0"
 version = "0.2.0"
 
 [workspace.dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.64.0-alpine as builder
+FROM rust:1.65.0-alpine as builder
 ARG BINARY=aggregator
 RUN apk add libc-dev protobuf-dev protoc
 WORKDIR /src

--- a/Dockerfile.interop
+++ b/Dockerfile.interop
@@ -1,7 +1,7 @@
 ARG BINARY
 ARG PROFILE=release
 
-FROM rust:1.64.0-alpine as builder
+FROM rust:1.65.0-alpine as builder
 ARG BINARY
 ARG PROFILE
 RUN apk add libc-dev protobuf-dev protoc

--- a/Dockerfile.interop_aggregator
+++ b/Dockerfile.interop_aggregator
@@ -1,6 +1,6 @@
 ARG PROFILE=release
 
-FROM rust:1.64.0-alpine as builder
+FROM rust:1.65.0-alpine as builder
 ARG PROFILE
 RUN apk add libc-dev protobuf-dev protoc
 WORKDIR /src

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -588,6 +588,7 @@ pub struct TaskAggregator {
 impl TaskAggregator {
     /// Create a new aggregator. `report_recipient` is used to decrypt reports received by this
     /// aggregator.
+    #[allow(clippy::result_large_err)]
     fn new(task: Task) -> Result<Self, Error> {
         let vdaf_ops = match task.vdaf() {
             VdafInstance::Prio3Aes128Count => {
@@ -2502,6 +2503,7 @@ where
 const CORS_PREFLIGHT_CACHE_AGE: u32 = 24 * 60 * 60;
 
 /// Constructs a Warp filter with endpoints common to all aggregators.
+#[allow(clippy::result_large_err)]
 pub fn aggregator_filter<C: Clock>(
     datastore: Arc<Datastore<C>>,
     clock: C,
@@ -2726,6 +2728,7 @@ pub fn aggregator_filter<C: Clock>(
 /// If the `SocketAddr`'s `port` is 0, an ephemeral port is used. Returns a
 /// `SocketAddr` representing the address and port the server are listening on
 /// and a future that can be `await`ed to begin serving requests.
+#[allow(clippy::result_large_err)]
 pub fn aggregator_server<C: Clock>(
     datastore: Arc<Datastore<C>>,
     clock: C,

--- a/aggregator/src/aggregator/accumulator.rs
+++ b/aggregator/src/aggregator/accumulator.rs
@@ -31,6 +31,7 @@ impl<const L: usize, A: vdaf::Aggregator<L>> Accumulation<L, A>
 where
     for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
 {
+    #[allow(clippy::result_large_err)]
     fn update(&mut self, output_share: &A::OutputShare, report_id: &ReportId) -> Result<(), Error> {
         self.aggregate_share.accumulate(output_share)?;
         self.report_count += 1;

--- a/aggregator/src/bin/janus_cli.rs
+++ b/aggregator/src/bin/janus_cli.rs
@@ -233,7 +233,7 @@ async fn create_datastore_key(
         .sample_iter(Standard)
         .take(AES_128_GCM.key_len())
         .collect();
-    let secret_content = base64::encode_config(&key_bytes, STANDARD_NO_PAD);
+    let secret_content = base64::encode_config(key_bytes, STANDARD_NO_PAD);
 
     // Write the secret.
     secrets_api

--- a/aggregator/src/task.rs
+++ b/aggregator/src/task.rs
@@ -547,7 +547,7 @@ impl From<(HpkeConfig, HpkePrivateKey)> for SerializedHpkeKeypair {
     fn from(keypair: (HpkeConfig, HpkePrivateKey)) -> Self {
         Self {
             config: keypair.0.into(),
-            private_key: base64::encode_config(&keypair.1, URL_SAFE_NO_PAD),
+            private_key: base64::encode_config(keypair.1, URL_SAFE_NO_PAD),
         }
     }
 }
@@ -753,7 +753,7 @@ pub mod test_util {
 
     pub fn generate_auth_token() -> AuthenticationToken {
         let buf: [u8; 16] = random();
-        base64::encode_config(&buf, base64::URL_SAFE_NO_PAD)
+        base64::encode_config(buf, base64::URL_SAFE_NO_PAD)
             .into_bytes()
             .into()
     }

--- a/aggregator/tests/graceful_shutdown.rs
+++ b/aggregator/tests/graceful_shutdown.rs
@@ -158,7 +158,7 @@ async fn graceful_shutdown(binary: &Path, mut config: Mapping) {
         .env("RUSTLOG", "trace")
         .env(
             "DATASTORE_KEYS",
-            base64::encode_config(&db_handle.datastore_key_bytes(), base64::STANDARD_NO_PAD),
+            base64::encode_config(db_handle.datastore_key_bytes(), base64::STANDARD_NO_PAD),
         )
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -102,6 +102,7 @@ impl ClientParameters {
 
     /// The URL relative to which the API endpoints for the aggregator may be
     /// found, if the role is an aggregator, or an error otherwise.
+    #[allow(clippy::result_large_err)]
     fn aggregator_endpoint(&self, role: &Role) -> Result<&Url, Error> {
         Ok(&self.aggregator_endpoints[role
             .index()
@@ -110,12 +111,14 @@ impl ClientParameters {
 
     /// URL from which the HPKE configuration for the server filling `role` may
     /// be fetched per draft-gpew-priv-ppm §4.3.1
+    #[allow(clippy::result_large_err)]
     fn hpke_config_endpoint(&self, role: &Role) -> Result<Url, Error> {
         Ok(self.aggregator_endpoint(role)?.join("hpke_config")?)
     }
 
     /// URL to which reports may be uploaded by clients per draft-gpew-priv-ppm
     /// §4.3.2
+    #[allow(clippy::result_large_err)]
     fn upload_endpoint(&self) -> Result<Url, Error> {
         Ok(self.aggregator_endpoint(&Role::Leader)?.join("upload")?)
     }
@@ -159,6 +162,7 @@ pub async fn aggregator_hpke_config(
 }
 
 /// Construct a [`reqwest::Client`] suitable for use in a DAP [`Client`].
+#[allow(clippy::result_large_err)]
 pub fn default_http_client() -> Result<reqwest::Client, Error> {
     Ok(reqwest::Client::builder()
         .user_agent(CLIENT_USER_AGENT)
@@ -203,6 +207,7 @@ where
 
     /// Shard a measurement, encrypt its shares, and construct a [`janus_core::message::Report`]
     /// to be uploaded.
+    #[allow(clippy::result_large_err)]
     fn prepare_report(&self, measurement: &V::Measurement) -> Result<Report, Error> {
         let (public_share, input_shares) = self.vdaf_client.shard(measurement)?;
         assert_eq!(input_shares.len(), 2); // DAP only supports VDAFs using two aggregators.

--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -160,8 +160,8 @@ async fn run(
     let collector_auth_token = base64::encode_config(rand::random::<[u8; 16]>(), URL_SAFE_NO_PAD);
     let verify_key = rand::random::<[u8; PRIO3_AES128_VERIFY_KEY_LENGTH]>();
 
-    let task_id_encoded = base64::encode_config(&task_id.get_encoded(), URL_SAFE_NO_PAD);
-    let verify_key_encoded = base64::encode_config(&verify_key, URL_SAFE_NO_PAD);
+    let task_id_encoded = base64::encode_config(task_id.get_encoded(), URL_SAFE_NO_PAD);
+    let verify_key_encoded = base64::encode_config(verify_key, URL_SAFE_NO_PAD);
 
     // Endpoints, from the POV of this test (i.e. the Docker host).
     let local_client_endpoint = Url::parse(&format!("http://127.0.0.1:{client_port}/")).unwrap();


### PR DESCRIPTION
This fixes some new Clippy warnings with the latest toolchain. As discussed, the `clippy::result_large_err` lints are ignored in each place they occur.