### PR TITLE
1.65 clippy fixes, for release/0.1

### DIFF
--- a/integration_tests/src/daphne.rs
+++ b/integration_tests/src/daphne.rs
@@ -193,11 +193,11 @@ impl<'a> Daphne<'a> {
                 "DAP_HPKE_RECEIVER_CONFIG_LIST".to_string(),
                 dap_hpke_receiver_config_list,
             ),
-            ("DAP_BUCKET_KEY".to_string(), hex::encode(&dap_bucket_key)),
+            ("DAP_BUCKET_KEY".to_string(), hex::encode(dap_bucket_key)),
             ("DAP_BUCKET_COUNT".to_string(), "2".to_string()),
             (
                 "DAP_COLLECT_ID_KEY".to_string(),
-                hex::encode(&dap_collect_id_key),
+                hex::encode(dap_collect_id_key),
             ),
             ("DAP_TASK_LIST".to_string(), dap_task_list),
             (

--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -78,8 +78,8 @@ async fn run(
     let collector_auth_token = base64::encode_config(rand::random::<[u8; 16]>(), URL_SAFE_NO_PAD);
     let verify_key = rand::random::<[u8; PRIO3_AES128_VERIFY_KEY_LENGTH]>();
 
-    let task_id_encoded = base64::encode_config(&task_id.get_encoded(), URL_SAFE_NO_PAD);
-    let verify_key_encoded = base64::encode_config(&verify_key, URL_SAFE_NO_PAD);
+    let task_id_encoded = base64::encode_config(task_id.get_encoded(), URL_SAFE_NO_PAD);
+    let verify_key_encoded = base64::encode_config(verify_key, URL_SAFE_NO_PAD);
 
     // Endpoints, from the POV of this test (i.e. the Docker host).
     let local_client_endpoint = Url::parse(&format!("http://127.0.0.1:{client_port}/")).unwrap();

--- a/janus_core/src/test_util/kubernetes.rs
+++ b/janus_core/src/test_util/kubernetes.rs
@@ -124,7 +124,7 @@ impl EphemeralCluster {
         // Choose a cluster name.
         let mut randomness = [0u8; 4];
         thread_rng().fill(&mut randomness);
-        let kind_cluster_name = format!("janus-ephemeral-{}", hex::encode(&randomness));
+        let kind_cluster_name = format!("janus-ephemeral-{}", hex::encode(randomness));
 
         // Use kind to start the cluster, with the node image from kind v0.14.0 for Kubernetes 1.22,
         // matching current regular GKE release channel. This image version should be bumped in

--- a/janus_server/src/bin/janus_cli.rs
+++ b/janus_server/src/bin/janus_cli.rs
@@ -231,7 +231,7 @@ async fn create_datastore_key(
     // consumers of the secret we are about to write.
     let mut key_bytes = vec![0u8; AES_128_GCM.key_len()];
     thread_rng().fill(&mut key_bytes[..]);
-    let secret_content = base64::encode_config(&key_bytes, STANDARD_NO_PAD);
+    let secret_content = base64::encode_config(key_bytes, STANDARD_NO_PAD);
 
     // Write the secret.
     secrets_api

--- a/janus_server/src/task.rs
+++ b/janus_server/src/task.rs
@@ -542,7 +542,7 @@ impl From<(HpkeConfig, HpkePrivateKey)> for SerializedHpkeKeypair {
     fn from(keypair: (HpkeConfig, HpkePrivateKey)) -> Self {
         Self {
             config: keypair.0.into(),
-            private_key: base64::encode_config(&keypair.1, URL_SAFE_NO_PAD),
+            private_key: base64::encode_config(keypair.1, URL_SAFE_NO_PAD),
         }
     }
 }
@@ -641,7 +641,7 @@ pub mod test_util {
     pub fn generate_auth_token() -> AuthenticationToken {
         let mut buf = [0; 16];
         thread_rng().fill(&mut buf);
-        base64::encode_config(&buf, base64::URL_SAFE_NO_PAD)
+        base64::encode_config(buf, base64::URL_SAFE_NO_PAD)
             .into_bytes()
             .into()
     }

--- a/janus_server/tests/graceful_shutdown.rs
+++ b/janus_server/tests/graceful_shutdown.rs
@@ -151,7 +151,7 @@ async fn graceful_shutdown(binary: &Path, mut config: Mapping) {
         .env("RUSTLOG", "trace")
         .env(
             "DATASTORE_KEYS",
-            base64::encode_config(&db_handle.datastore_key_bytes(), base64::STANDARD_NO_PAD),
+            base64::encode_config(db_handle.datastore_key_bytes(), base64::STANDARD_NO_PAD),
         )
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())


### PR DESCRIPTION
This fixes new Clippy warnings with the latest toolchain. All the changes are removals of unnecessary `&` on function or method arguments that take an `AsRef` parameter.