### PR TITLE
Fixed-size tasks: implement helper aggregation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1446,6 +1446,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "async-trait",
  "atty",
  "backoff",
  "base64",

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -29,6 +29,7 @@ kube-rustls = ["kube/rustls-tls"]
 kube-openssl = ["kube/openssl-tls"]
 
 [dependencies]
+async-trait = "0.1"
 anyhow = "1"
 atty = "0.2"
 backoff = { version = "0.4.0", features = ["tokio"] }

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1,29 +1,29 @@
 //! Common functionality for DAP aggregators.
 
-mod accumulator;
+pub mod accumulator;
 pub mod aggregate_share;
 pub mod aggregation_job_creator;
 pub mod aggregation_job_driver;
+pub mod query_type;
 
 use crate::{
     aggregator::{
         accumulator::Accumulator,
         aggregate_share::{compute_aggregate_share, validate_batch_query_count_for_collect},
+        query_type::CollectableQueryType,
     },
     datastore::{
         self,
         models::{
-            AggregateShareJob, AggregationJob, AggregationJobState, BatchAggregation, CollectJob,
-            CollectJobState, ReportAggregation, ReportAggregationState,
+            AggregateShareJob, AggregationJob, AggregationJobState, CollectJob, CollectJobState,
+            ReportAggregation, ReportAggregationState,
         },
-        Datastore, Transaction,
+        Datastore,
     },
     messages::TimeExt,
     task::{self, Task, VerifyKey, PRIO3_AES128_VERIFY_KEY_LENGTH},
 };
-use async_trait::async_trait;
 use bytes::Bytes;
-use futures::future::try_join_all;
 use http::{
     header::{CACHE_CONTROL, CONTENT_TYPE, LOCATION},
     HeaderMap, StatusCode,
@@ -39,9 +39,9 @@ use janus_core::{
     time::Clock,
 };
 use janus_messages::{
-    query_type::{FixedSize, QueryType, TimeInterval},
+    query_type::{FixedSize, TimeInterval},
     AggregateContinueReq, AggregateContinueResp, AggregateInitializeReq, AggregateInitializeResp,
-    AggregateShareReq, AggregateShareResp, AggregationJobId, CollectReq, CollectResp, Duration,
+    AggregateShareReq, AggregateShareResp, AggregationJobId, CollectReq, CollectResp,
     HpkeCiphertext, HpkeConfig, HpkeConfigId, Interval, PartialBatchSelector, PrepareStep,
     PrepareStepResult, Report, ReportId, ReportIdChecksum, ReportShare, ReportShareError, Role,
     TaskId, Time,
@@ -90,7 +90,7 @@ use janus_core::test_util::dummy_vdaf;
 #[cfg(feature = "test-util")]
 use prio::vdaf::VdafError;
 
-use self::accumulator::AccumulableQueryType;
+use self::query_type::AccumulableQueryType;
 
 /// Errors returned by functions and methods in this module
 #[derive(Debug, thiserror::Error)]
@@ -2937,131 +2937,6 @@ async fn post_to_helper<T: Encode>(
             );
             Err(error.into())
         }
-    }
-}
-
-/// CollectableQueryType represents a query type that can be collected by Janus. This trait extends
-/// [`QueryType`] with functionality required for collection.
-#[async_trait]
-pub trait CollectableQueryType: QueryType {
-    type Iter: Iterator<Item = Self::BatchIdentifier> + Send + Sync;
-
-    /// Some query types (e.g. [`TimeInterval`]) can receive a batch identifier in collect requests
-    /// which refers to multiple batches. This method takes a batch identifier received in a collect
-    /// request and provides an iterator over the individual batches' identifiers.
-    fn batch_identifiers_for_collect_identifier(
-        _: &Task,
-        collect_identifier: &Self::BatchIdentifier,
-    ) -> Self::Iter;
-
-    /// Retrieves batch aggregations corresponding to all batches identified by the given collect
-    /// identifier.
-    async fn get_batch_aggregations_for_collect_identifier<
-        const L: usize,
-        A: vdaf::Aggregator<L>,
-        C: Clock,
-    >(
-        tx: &Transaction<C>,
-        task: &Task,
-        collect_identifier: &Self::BatchIdentifier,
-        aggregation_param: &A::AggregationParam,
-    ) -> Result<Vec<BatchAggregation<L, Self, A>>, datastore::Error>
-    where
-        A::AggregationParam: Send + Sync,
-        A::AggregateShare: Send + Sync,
-        for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
-        for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Debug,
-    {
-        let batch_aggregations = try_join_all(
-            Self::batch_identifiers_for_collect_identifier(task, collect_identifier).map(
-                |batch_identifier| {
-                    let (task_id, aggregation_param) = (*task.id(), aggregation_param.clone());
-                    async move {
-                        tx.get_batch_aggregation(&task_id, &batch_identifier, &aggregation_param)
-                            .await
-                    }
-                },
-            ),
-        )
-        .await?;
-        Ok(batch_aggregations.into_iter().flatten().collect::<Vec<_>>())
-    }
-}
-
-impl CollectableQueryType for TimeInterval {
-    type Iter = TimeIntervalBatchIdentifierIter;
-
-    fn batch_identifiers_for_collect_identifier(
-        task: &Task,
-        batch_interval: &Self::BatchIdentifier,
-    ) -> Self::Iter {
-        TimeIntervalBatchIdentifierIter::new(task, batch_interval)
-    }
-}
-
-// This type only exists because the CollectableQueryType trait requires specifying the type of the
-// iterator explicitly (i.e. it cannot be inferred or replaced with an `impl Trait` expression), and
-// the type of the iterator created via method chaining does not have a type which is expressible.
-pub struct TimeIntervalBatchIdentifierIter {
-    step: u64,
-
-    total_step_count: u64,
-    start: Time,
-    time_precision: Duration,
-}
-
-impl TimeIntervalBatchIdentifierIter {
-    fn new(task: &Task, batch_interval: &Interval) -> Self {
-        // Sanity check that the given interval is of an appropriate length. We use an assert as
-        // this is expected to be checked before this method is used.
-        assert_eq!(
-            batch_interval.duration().as_seconds() % task.time_precision().as_seconds(),
-            0
-        );
-        let total_step_count =
-            batch_interval.duration().as_seconds() / task.time_precision().as_seconds();
-
-        Self {
-            step: 0,
-            total_step_count,
-            start: *batch_interval.start(),
-            time_precision: *task.time_precision(),
-        }
-    }
-}
-
-impl Iterator for TimeIntervalBatchIdentifierIter {
-    type Item = Interval;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.step == self.total_step_count {
-            return None;
-        }
-        // Unwrap safety: errors can only occur if the times being unwrapped cannot be represented
-        // as a Time. The relevant times can always be represented since they are internal to the
-        // batch interval used to create the iterator.
-        let interval = Interval::new(
-            self.start
-                .add(&Duration::from_seconds(
-                    self.step * self.time_precision.as_seconds(),
-                ))
-                .unwrap(),
-            self.time_precision,
-        )
-        .unwrap();
-        self.step += 1;
-        Some(interval)
-    }
-}
-
-impl CollectableQueryType for FixedSize {
-    type Iter = std::option::IntoIter<Self::BatchIdentifier>;
-
-    fn batch_identifiers_for_collect_identifier(
-        _: &Task,
-        batch_id: &Self::BatchIdentifier,
-    ) -> Self::Iter {
-        Some(*batch_id).into_iter()
     }
 }
 

--- a/aggregator/src/aggregator/accumulator.rs
+++ b/aggregator/src/aggregator/accumulator.rs
@@ -2,18 +2,131 @@
 
 use super::Error;
 use crate::{
-    datastore::{self, models::BatchUnitAggregation, Transaction},
+    datastore::{self, models::BatchAggregation, Transaction},
     task::Task,
 };
 use derivative::Derivative;
+use futures::future::try_join_all;
 use janus_core::{
     report_id::ReportIdChecksumExt,
     time::{Clock, TimeExt},
 };
-use janus_messages::{Interval, ReportId, ReportIdChecksum, Time};
+use janus_messages::{
+    query_type::{FixedSize, QueryType, TimeInterval},
+    Interval, ReportId, ReportIdChecksum, Time,
+};
 use prio::vdaf::{self, Aggregatable};
 use std::{collections::HashMap, sync::Arc};
 use tracing::debug;
+
+/// Accumulates output shares in memory and eventually flushes accumulations to a datastore. Janus'
+/// leader aligns aggregate jobs with batch intervals, but this is not generally required for DAP
+/// implementations, so we accumulate output shares into a HashMap mapping the Time at which the
+/// batch interval begins to the accumulated aggregate share, report count and checksum.
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub struct Accumulator<const L: usize, Q: AccumulableQueryType, A: vdaf::Aggregator<L>>
+where
+    for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
+{
+    task: Arc<Task>,
+    #[derivative(Debug = "ignore")]
+    aggregation_param: A::AggregationParam,
+    accumulations: HashMap<Q::BatchIdentifier, Accumulation<L, A>>,
+}
+
+impl<'t, const L: usize, Q: AccumulableQueryType, A: vdaf::Aggregator<L>> Accumulator<L, Q, A>
+where
+    for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
+    for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Debug,
+{
+    /// Create a new accumulator
+    pub fn new(task: Arc<Task>, aggregation_param: A::AggregationParam) -> Self {
+        Self {
+            task,
+            aggregation_param,
+            accumulations: HashMap::new(),
+        }
+    }
+
+    /// Update the in-memory accumulators with the provided output share and report timestamp.
+    pub fn update(
+        &mut self,
+        partial_batch_identifier: &Q::PartialBatchIdentifier,
+        report_id: &ReportId,
+        client_timestamp: &Time,
+        output_share: &A::OutputShare,
+    ) -> Result<(), datastore::Error> {
+        let batch_identifier =
+            Q::to_batch_identifier(&self.task, partial_batch_identifier, client_timestamp)?;
+        // This slightly-awkward usage of `rslt` is due to the Entry API not having a fallible
+        // interface -- we need some way to smuggle an error out of `and_modify`.
+        let mut rslt = Ok(());
+        self.accumulations
+            .entry(batch_identifier)
+            .and_modify(|acc| {
+                rslt = acc
+                    .update(report_id, output_share)
+                    .map_err(|err| datastore::Error::User(err.into()))
+            })
+            .or_insert_with(|| Accumulation {
+                aggregate_share: A::AggregateShare::from(output_share.clone()),
+                report_count: 1,
+                checksum: ReportIdChecksum::for_report_id(report_id),
+            });
+        rslt
+    }
+
+    /// Write the accumulated aggregate shares, report counts and checksums to the datastore. If a
+    /// batch aggregation already exists for some accumulator, it is updated. If no batch
+    /// aggregation exists, one is created and initialized with the accumulated values.
+    #[tracing::instrument(skip(self, tx), err)]
+    pub async fn flush_to_datastore<C: Clock>(
+        &self,
+        tx: &Transaction<'_, C>,
+    ) -> Result<(), datastore::Error> {
+        try_join_all(self.accumulations.iter().map(
+            |(batch_identifier, accumulation)| async move {
+                let batch_aggregation = tx
+                    .get_batch_aggregation::<L, Q, A>(
+                        self.task.id(),
+                        batch_identifier,
+                        &self.aggregation_param,
+                    )
+                    .await?;
+                match batch_aggregation {
+                    Some(batch_aggregation) => {
+                        debug!(
+                            ?batch_identifier,
+                            "Accumulating into existing batch aggregation",
+                        );
+                        tx.update_batch_aggregation(&batch_aggregation.merged_with(
+                            &accumulation.aggregate_share,
+                            accumulation.report_count,
+                            &accumulation.checksum,
+                        )?)
+                        .await?;
+                    }
+                    None => {
+                        debug!(?batch_identifier, "Inserting new batch aggregation");
+                        tx.put_batch_aggregation(&BatchAggregation::<L, Q, A>::new(
+                            *self.task.id(),
+                            batch_identifier.clone(),
+                            self.aggregation_param.clone(),
+                            accumulation.aggregate_share.clone(),
+                            accumulation.report_count,
+                            accumulation.checksum,
+                        ))
+                        .await?;
+                    }
+                }
+                Ok::<(), datastore::Error>(())
+            },
+        ))
+        .await?;
+        Ok(())
+    }
+}
 
 #[derive(Derivative)]
 #[derivative(Debug)]
@@ -32,128 +145,45 @@ where
     for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
 {
     #[allow(clippy::result_large_err)]
-    fn update(&mut self, output_share: &A::OutputShare, report_id: &ReportId) -> Result<(), Error> {
+    fn update(&mut self, report_id: &ReportId, output_share: &A::OutputShare) -> Result<(), Error> {
         self.aggregate_share.accumulate(output_share)?;
         self.report_count += 1;
         self.checksum = self.checksum.updated_with(report_id);
-
         Ok(())
     }
 }
 
-/// Accumulates output shares in memory and eventually flushes accumulations to a datastore. Janus'
-/// leader aligns aggregate jobs with batch unit intervals, but this is not generally required for
-/// DAP implementations, so we accumulate output shares into a HashMap mapping the Time at which the
-/// batch unit interval begins to the accumulated aggregate share, report count and checksum.
-#[derive(Derivative)]
-#[derivative(Debug)]
-pub(super) struct Accumulator<const L: usize, A: vdaf::Aggregator<L>>
-where
-    for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
-{
-    task: Arc<Task>,
-    #[derivative(Debug = "ignore")]
-    aggregation_param: A::AggregationParam,
-    accumulations: HashMap<Time, Accumulation<L, A>>,
+pub trait AccumulableQueryType: QueryType {
+    /// This method converts various values related to a client report into a batch identifier. The
+    /// arguments are somewhat arbitrary in the sense they are what "works out" to allow the
+    /// necessary functionality to be implemented for all query types.
+    fn to_batch_identifier(
+        _: &Task,
+        _: &Self::PartialBatchIdentifier,
+        client_timestamp: &Time,
+    ) -> Result<Self::BatchIdentifier, datastore::Error>;
 }
 
-impl<'t, const L: usize, A: vdaf::Aggregator<L>> Accumulator<L, A>
-where
-    for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
-    for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Display,
-{
-    /// Create a new accumulator
-    pub(super) fn new(task: Arc<Task>, aggregation_param: A::AggregationParam) -> Self {
-        Self {
-            task,
-            aggregation_param,
-            accumulations: HashMap::new(),
-        }
-    }
-
-    /// Update the in-memory accumulators with the provided output share and report timestamp.
-    pub(super) fn update(
-        &mut self,
-        output_share: &A::OutputShare,
-        report_time: &Time,
-        report_id: &ReportId,
-    ) -> Result<(), datastore::Error> {
-        let key = report_time
-            .to_batch_unit_interval_start(self.task.time_precision())
+impl AccumulableQueryType for TimeInterval {
+    fn to_batch_identifier(
+        task: &Task,
+        _: &Self::PartialBatchIdentifier,
+        client_timestamp: &Time,
+    ) -> Result<Self::BatchIdentifier, datastore::Error> {
+        let batch_interval_start = client_timestamp
+            .to_batch_interval_start(task.time_precision())
             .map_err(|e| datastore::Error::User(e.into()))?;
-        if let Some(accumulation) = self.accumulations.get_mut(&key) {
-            accumulation
-                .update(output_share, report_id)
-                .map_err(|e| datastore::Error::User(e.into()))?;
-        } else {
-            self.accumulations.insert(
-                key,
-                Accumulation {
-                    aggregate_share: A::AggregateShare::from(output_share.clone()),
-                    report_count: 1,
-                    checksum: ReportIdChecksum::for_report_id(report_id),
-                },
-            );
-        }
-
-        Ok(())
+        Interval::new(batch_interval_start, *task.time_precision())
+            .map_err(|e| datastore::Error::User(e.into()))
     }
+}
 
-    /// Write the accumulated aggregate shares, report counts and checksums to the datastore. If a
-    /// batch unit aggregation already exists for some accumulator, it is updated. If no batch unit
-    /// aggregation exists, one is created and initialized with the accumulated values.
-    #[tracing::instrument(skip(self, tx), err)]
-    pub(super) async fn flush_to_datastore<C: Clock>(
-        &self,
-        tx: &Transaction<'_, C>,
-    ) -> Result<(), datastore::Error> {
-        for (unit_interval_start, accumulation) in &self.accumulations {
-            let unit_interval = Interval::new(*unit_interval_start, *self.task.time_precision())?;
-
-            let batch_unit_aggregations = tx
-                .get_batch_unit_aggregations_for_task_in_interval::<L, A>(
-                    self.task.id(),
-                    &unit_interval,
-                    &self.aggregation_param,
-                )
-                .await?;
-
-            if batch_unit_aggregations.len() > 1 {
-                return Err(datastore::Error::DbState(format!(
-                    "found {} batch unit aggregation rows for task {}, interval {unit_interval}",
-                    batch_unit_aggregations.len(),
-                    self.task.id(),
-                )));
-            }
-
-            if let Some(batch_unit_aggregation) = batch_unit_aggregations.into_iter().next() {
-                debug!(
-                    unit_interval_start = %unit_interval.start(),
-                    "accumulating into existing batch_unit_aggregation_row",
-                );
-                tx.update_batch_unit_aggregation(&batch_unit_aggregation.merged_with(
-                    &accumulation.aggregate_share,
-                    accumulation.report_count,
-                    &accumulation.checksum,
-                )?)
-                .await?;
-            } else {
-                debug!(
-                    unit_interval_start = %unit_interval.start(),
-                    "inserting new batch_unit_aggregation row",
-                );
-                tx.put_batch_unit_aggregation(&BatchUnitAggregation::<L, A>::new(
-                    *self.task.id(),
-                    *unit_interval.start(),
-                    self.aggregation_param.clone(),
-                    accumulation.aggregate_share.clone(),
-                    accumulation.report_count,
-                    accumulation.checksum,
-                ))
-                .await?;
-            }
-        }
-
-        Ok(())
+impl AccumulableQueryType for FixedSize {
+    fn to_batch_identifier(
+        _: &Task,
+        batch_id: &Self::PartialBatchIdentifier,
+        _: &Time,
+    ) -> Result<Self::BatchIdentifier, datastore::Error> {
+        Ok(*batch_id)
     }
 }

--- a/aggregator/src/aggregator/aggregate_share.rs
+++ b/aggregator/src/aggregator/aggregate_share.rs
@@ -5,7 +5,7 @@ use crate::{
     datastore::{
         self,
         models::AcquiredCollectJob,
-        models::{BatchUnitAggregation, CollectJobState, Lease},
+        models::{BatchAggregation, CollectJobState, Lease},
         Datastore, Transaction,
     },
     task::{Task, PRIO3_AES128_VERIFY_KEY_LENGTH},
@@ -16,8 +16,9 @@ use futures::future::BoxFuture;
 use janus_core::test_util::dummy_vdaf;
 use janus_core::{report_id::ReportIdChecksumExt, task::VdafInstance, time::Clock};
 use janus_messages::{
-    query_type::TimeInterval, AggregateShareReq, AggregateShareResp, BatchSelector, Duration,
-    Interval, ReportIdChecksum, Role,
+    query_type::{QueryType, TimeInterval},
+    AggregateShareReq, AggregateShareResp, BatchSelector, Duration, Interval, ReportIdChecksum,
+    Role,
 };
 use opentelemetry::{
     metrics::{Counter, Histogram, Meter, Unit},
@@ -38,8 +39,7 @@ use std::sync::Arc;
 use tokio::try_join;
 use tracing::{debug, error, info, warn};
 
-#[cfg(feature = "test-util")]
-const DUMMY_VERIFY_KEY_LENGTH: usize = dummy_vdaf::Vdaf::VERIFY_KEY_LENGTH;
+use super::CollectableQueryType;
 
 /// Holds various metrics instruments for a collect job driver.
 #[derive(Clone)]
@@ -176,7 +176,7 @@ impl CollectJobDriver {
 
             #[cfg(feature = "test-util")]
             VdafInstance::Fake => {
-                self.step_collect_job_generic::<DUMMY_VERIFY_KEY_LENGTH, C, dummy_vdaf::Vdaf>(
+                self.step_collect_job_generic::<0, C, dummy_vdaf::Vdaf>(
                     datastore,
                     lease,
                 )
@@ -198,12 +198,12 @@ impl CollectJobDriver {
         A::AggregationParam: Send + Sync,
         A::AggregateShare: 'static + Send + Sync,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
-        for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Display,
+        for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Debug,
         Vec<u8>: for<'a> From<&'a A::AggregateShare>,
         A::OutputShare: PartialEq + Eq + Send + Sync + for<'a> TryFrom<&'a [u8]>,
         for<'a> &'a A::OutputShare: Into<Vec<u8>>,
     {
-        let (task, collect_job, batch_unit_aggregations) = datastore
+        let (task, collect_job, batch_aggregations) = datastore
             .run_tx(|tx| {
                 let lease = Arc::clone(&lease);
                 Box::pin(async move {
@@ -228,15 +228,16 @@ impl CollectJobDriver {
                             )
                         })?;
 
-                    let batch_unit_aggregations = tx
-                        .get_batch_unit_aggregations_for_task_in_interval::<L, A>(
-                            task.id(),
+                    let batch_aggregations =
+                        TimeInterval::get_batch_aggregations_for_collect_identifier(
+                            tx,
+                            &task,
                             collect_job.batch_interval(),
                             collect_job.aggregation_parameter(),
                         )
                         .await?;
 
-                    Ok((task, collect_job, batch_unit_aggregations))
+                    Ok((task, collect_job, batch_aggregations))
                 })
             })
             .await?;
@@ -250,7 +251,7 @@ impl CollectJobDriver {
         }
 
         let (leader_aggregate_share, report_count, checksum) =
-            compute_aggregate_share::<L, A>(&task, &batch_unit_aggregations)
+            compute_aggregate_share::<L, TimeInterval, A>(&task, &batch_aggregations)
                 .await
                 .map_err(|e| datastore::Error::User(e.into()))?;
 
@@ -379,7 +380,7 @@ impl CollectJobDriver {
 
             #[cfg(feature = "test-util")]
             VdafInstance::Fake => {
-                self.abandon_collect_job_generic::<DUMMY_VERIFY_KEY_LENGTH, C, dummy_vdaf::Vdaf>(
+                self.abandon_collect_job_generic::<0, C, dummy_vdaf::Vdaf>(
                     datastore,
                     lease,
                 )
@@ -401,7 +402,7 @@ impl CollectJobDriver {
         A::AggregationParam: Send + Sync,
         A::AggregateShare: Send + Sync,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
-        for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Display,
+        for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Debug,
     {
         let lease = Arc::new(lease);
         datastore
@@ -481,23 +482,23 @@ impl CollectJobDriver {
     }
 }
 
-/// Computes the aggregate share over the provided batch unit aggregations.
-/// The assumption is that all aggregation jobs contributing to those batch unit aggregations have
+/// Computes the aggregate share over the provided batch aggregations.
+/// The assumption is that all aggregation jobs contributing to those batch aggregations have
 /// been driven to completion, and that the query count requirements have been validated for the
-/// included batch units.
+/// included batches.
 #[tracing::instrument(err)]
-pub(crate) async fn compute_aggregate_share<const L: usize, A: vdaf::Aggregator<L>>(
+pub(crate) async fn compute_aggregate_share<const L: usize, Q: QueryType, A: vdaf::Aggregator<L>>(
     task: &Task,
-    batch_unit_aggregations: &[BatchUnitAggregation<L, A>],
+    batch_aggregations: &[BatchAggregation<L, Q, A>],
 ) -> Result<(A::AggregateShare, u64, ReportIdChecksum), Error>
 where
     Vec<u8>: for<'a> From<&'a A::AggregateShare>,
-    for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Display,
+    for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Debug,
 {
     // At the moment we construct an aggregate share (either handling AggregateShareReq in the
     // helper or driving a collect job in the leader), there could be some incomplete aggregation
-    // jobs whose results not been accumulated into the batch unit aggregations we just queried from
-    // the datastore, meaning we will aggregate over an incomplete view of data, which:
+    // jobs whose results not been accumulated into the batch aggregations we just queried from the
+    // datastore, meaning we will aggregate over an incomplete view of data, which:
     //
     //  * reduces fidelity of the resulting aggregates,
     //  * could cause us to fail to meet the minimum batch size for the task,
@@ -513,28 +514,28 @@ where
     // On the leader side, we know/assume that we would not be stepping a collect job unless we had
     // verified that the constituent aggregation jobs were finished.
     //
-    // In either case, we go ahead and service the aggregate share request with whatever batch unit
+    // In either case, we go ahead and service the aggregate share request with whatever batch
     // aggregations are available now.
     let mut total_report_count = 0;
     let mut total_checksum = ReportIdChecksum::default();
     let mut total_aggregate_share: Option<A::AggregateShare> = None;
 
-    for batch_unit_aggregation in batch_unit_aggregations {
+    for batch_aggregation in batch_aggregations {
         // XOR this batch interval's checksum into the overall checksum
         // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-02.html#section-4.5.2
-        total_checksum = total_checksum.combined_with(batch_unit_aggregation.checksum());
+        total_checksum = total_checksum.combined_with(batch_aggregation.checksum());
 
         // Sum all the report counts
         // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-02.html#section-4.5.2
-        total_report_count += batch_unit_aggregation.report_count();
+        total_report_count += batch_aggregation.report_count();
 
         match &mut total_aggregate_share {
-            Some(share) => share.merge(batch_unit_aggregation.aggregate_share())?,
-            None => total_aggregate_share = Some(batch_unit_aggregation.aggregate_share().clone()),
+            Some(share) => share.merge(batch_aggregation.aggregate_share())?,
+            None => total_aggregate_share = Some(batch_aggregation.aggregate_share().clone()),
         }
     }
 
-    // Only happens if there were no batch unit aggregations, which would get caught by the
+    // Only happens if there were no batch aggregations, which would get caught by the
     // min_batch_size check below, but we have to unwrap the option.
     let total_aggregate_share = total_aggregate_share
         .ok_or_else(|| Error::InvalidBatchSize(*task.id(), total_report_count))?;
@@ -563,7 +564,7 @@ pub(crate) async fn validate_batch_query_count_for_collect<
     collect_interval: Interval,
 ) -> Result<(), datastore::Error>
 where
-    for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Display,
+    for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Debug,
     for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
 {
     // Check how many rows in the relevant table have an intersecting batch interval.
@@ -631,7 +632,7 @@ mod tests {
         binary_utils::job_driver::JobDriver,
         datastore::{
             models::{
-                AcquiredCollectJob, AggregationJob, AggregationJobState, BatchUnitAggregation,
+                AcquiredCollectJob, AggregationJob, AggregationJobState, BatchAggregation,
                 CollectJob, CollectJobState, Lease, ReportAggregation, ReportAggregationState,
             },
             test_util::ephemeral_datastore,
@@ -664,22 +665,21 @@ mod tests {
     use url::Url;
     use uuid::Uuid;
 
-    use super::DUMMY_VERIFY_KEY_LENGTH;
-
     async fn setup_collect_job_test_case(
         clock: MockClock,
         datastore: Arc<Datastore<MockClock>>,
         acquire_lease: bool,
     ) -> (
         Option<Lease<AcquiredCollectJob>>,
-        CollectJob<DUMMY_VERIFY_KEY_LENGTH, dummy_vdaf::Vdaf>,
+        CollectJob<0, dummy_vdaf::Vdaf>,
     ) {
+        let time_precision = Duration::from_seconds(500);
         let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Leader)
             .with_aggregator_endpoints(Vec::from([
                 Url::parse("http://irrelevant").unwrap(), // leader URL doesn't matter
                 Url::parse(&mockito::server_url()).unwrap(),
             ]))
-            .with_time_precision(Duration::from_seconds(500))
+            .with_time_precision(time_precision)
             .with_min_batch_size(10)
             .build();
         let batch_interval = Interval::new(clock.now(), Duration::from_seconds(2000)).unwrap();
@@ -699,28 +699,26 @@ mod tests {
                 Box::pin(async move {
                     tx.put_task(&task).await?;
 
-                    tx.put_collect_job::<DUMMY_VERIFY_KEY_LENGTH, dummy_vdaf::Vdaf>(&collect_job)
+                    tx.put_collect_job::<0, dummy_vdaf::Vdaf>(&collect_job)
                         .await?;
 
                     let aggregation_job_id = random();
-                    tx.put_aggregation_job(&AggregationJob::<
-                        DUMMY_VERIFY_KEY_LENGTH,
-                        TimeInterval,
-                        dummy_vdaf::Vdaf,
-                    >::new(
-                        *task.id(),
-                        aggregation_job_id,
-                        (),
-                        aggregation_param,
-                        AggregationJobState::Finished,
-                    ))
+                    tx.put_aggregation_job(
+                        &AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
+                            *task.id(),
+                            aggregation_job_id,
+                            (),
+                            aggregation_param,
+                            AggregationJobState::Finished,
+                        ),
+                    )
                     .await?;
 
                     let report_metadata = ReportMetadata::new(
                         random(),
                         clock
                             .now()
-                            .to_batch_unit_interval_start(task.time_precision())
+                            .to_batch_interval_start(task.time_precision())
                             .unwrap(),
                         Vec::new(),
                     );
@@ -732,10 +730,7 @@ mod tests {
                     ))
                     .await?;
 
-                    tx.put_report_aggregation(&ReportAggregation::<
-                        DUMMY_VERIFY_KEY_LENGTH,
-                        dummy_vdaf::Vdaf,
-                    >::new(
+                    tx.put_report_aggregation(&ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
                         *task.id(),
                         aggregation_job_id,
                         *report_metadata.id(),
@@ -745,29 +740,31 @@ mod tests {
                     ))
                     .await?;
 
-                    tx.put_batch_unit_aggregation(&BatchUnitAggregation::<
-                        DUMMY_VERIFY_KEY_LENGTH,
-                        dummy_vdaf::Vdaf,
-                    >::new(
-                        *task.id(),
-                        clock.now(),
-                        aggregation_param,
-                        AggregateShare(0),
-                        5,
-                        ReportIdChecksum::get_decoded(&[3; 32]).unwrap(),
-                    ))
+                    tx.put_batch_aggregation(
+                        &BatchAggregation::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
+                            *task.id(),
+                            Interval::new(clock.now(), time_precision).unwrap(),
+                            aggregation_param,
+                            AggregateShare(0),
+                            5,
+                            ReportIdChecksum::get_decoded(&[3; 32]).unwrap(),
+                        ),
+                    )
                     .await?;
-                    tx.put_batch_unit_aggregation(&BatchUnitAggregation::<
-                        DUMMY_VERIFY_KEY_LENGTH,
-                        dummy_vdaf::Vdaf,
-                    >::new(
-                        *task.id(),
-                        clock.now().add(&Duration::from_seconds(1000)).unwrap(),
-                        aggregation_param,
-                        AggregateShare(0),
-                        5,
-                        ReportIdChecksum::get_decoded(&[2; 32]).unwrap(),
-                    ))
+                    tx.put_batch_aggregation(
+                        &BatchAggregation::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
+                            *task.id(),
+                            Interval::new(
+                                clock.now().add(&Duration::from_seconds(1000)).unwrap(),
+                                time_precision,
+                            )
+                            .unwrap(),
+                            aggregation_param,
+                            AggregateShare(0),
+                            5,
+                            ReportIdChecksum::get_decoded(&[2; 32]).unwrap(),
+                        ),
+                    )
                     .await?;
 
                     if acquire_lease {
@@ -799,12 +796,13 @@ mod tests {
         let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
         let ds = Arc::new(ds);
 
+        let time_precision = Duration::from_seconds(500);
         let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Leader)
             .with_aggregator_endpoints(Vec::from([
                 Url::parse("http://irrelevant").unwrap(), // leader URL doesn't matter
                 Url::parse(&mockito::server_url()).unwrap(),
             ]))
-            .with_time_precision(Duration::from_seconds(500))
+            .with_time_precision(time_precision)
             .with_min_batch_size(10)
             .build();
         let agg_auth_token = task.primary_aggregator_auth_token();
@@ -823,29 +821,27 @@ mod tests {
                         collect_job_id,
                         batch_interval,
                         aggregation_param,
-                        CollectJobState::<DUMMY_VERIFY_KEY_LENGTH, dummy_vdaf::Vdaf>::Start,
+                        CollectJobState::<0, dummy_vdaf::Vdaf>::Start,
                     ))
                     .await?;
 
                     let aggregation_job_id = random();
-                    tx.put_aggregation_job(&AggregationJob::<
-                        DUMMY_VERIFY_KEY_LENGTH,
-                        TimeInterval,
-                        dummy_vdaf::Vdaf,
-                    >::new(
-                        *task.id(),
-                        aggregation_job_id,
-                        (),
-                        aggregation_param,
-                        AggregationJobState::Finished,
-                    ))
+                    tx.put_aggregation_job(
+                        &AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
+                            *task.id(),
+                            aggregation_job_id,
+                            (),
+                            aggregation_param,
+                            AggregationJobState::Finished,
+                        ),
+                    )
                     .await?;
 
                     let report_metadata = ReportMetadata::new(
                         random(),
                         clock
                             .now()
-                            .to_batch_unit_interval_start(task.time_precision())
+                            .to_batch_interval_start(task.time_precision())
                             .unwrap(),
                         Vec::new(),
                     );
@@ -857,10 +853,7 @@ mod tests {
                     ))
                     .await?;
 
-                    tx.put_report_aggregation(&ReportAggregation::<
-                        DUMMY_VERIFY_KEY_LENGTH,
-                        dummy_vdaf::Vdaf,
-                    >::new(
+                    tx.put_report_aggregation(&ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
                         *task.id(),
                         aggregation_job_id,
                         *report_metadata.id(),
@@ -889,7 +882,7 @@ mod tests {
             &meter("collect_job_driver"),
         );
 
-        // No batch unit aggregations inserted yet
+        // No batch aggregations inserted yet.
         let error = collect_job_driver
             .step_collect_job(ds.clone(), Arc::clone(&lease))
             .await
@@ -898,34 +891,36 @@ mod tests {
             assert_eq!(task.id(), &error_task_id)
         });
 
-        // Put some batch unit aggregations in the DB
+        // Put some batch aggregations in the DB.
         ds.run_tx(|tx| {
             let (clock, task) = (clock.clone(), task.clone());
             Box::pin(async move {
-                tx.put_batch_unit_aggregation(&BatchUnitAggregation::<
-                    DUMMY_VERIFY_KEY_LENGTH,
-                    dummy_vdaf::Vdaf,
-                >::new(
-                    *task.id(),
-                    clock.now(),
-                    aggregation_param,
-                    AggregateShare(0),
-                    5,
-                    ReportIdChecksum::get_decoded(&[3; 32]).unwrap(),
-                ))
+                tx.put_batch_aggregation(
+                    &BatchAggregation::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
+                        *task.id(),
+                        Interval::new(clock.now(), time_precision).unwrap(),
+                        aggregation_param,
+                        AggregateShare(0),
+                        5,
+                        ReportIdChecksum::get_decoded(&[3; 32]).unwrap(),
+                    ),
+                )
                 .await?;
 
-                tx.put_batch_unit_aggregation(&BatchUnitAggregation::<
-                    DUMMY_VERIFY_KEY_LENGTH,
-                    dummy_vdaf::Vdaf,
-                >::new(
-                    *task.id(),
-                    clock.now().add(&Duration::from_seconds(1000)).unwrap(),
-                    aggregation_param,
-                    AggregateShare(0),
-                    5,
-                    ReportIdChecksum::get_decoded(&[2; 32]).unwrap(),
-                ))
+                tx.put_batch_aggregation(
+                    &BatchAggregation::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
+                        *task.id(),
+                        Interval::new(
+                            clock.now().add(&Duration::from_seconds(1000)).unwrap(),
+                            time_precision,
+                        )
+                        .unwrap(),
+                        aggregation_param,
+                        AggregateShare(0),
+                        5,
+                        ReportIdChecksum::get_decoded(&[2; 32]).unwrap(),
+                    ),
+                )
                 .await?;
 
                 Ok(())
@@ -978,7 +973,7 @@ mod tests {
         ds.run_tx(|tx| {
             Box::pin(async move {
                 let collect_job = tx
-                    .get_collect_job::<DUMMY_VERIFY_KEY_LENGTH, dummy_vdaf::Vdaf>(&collect_job_id)
+                    .get_collect_job::<0, dummy_vdaf::Vdaf>(&collect_job_id)
                     .await
                     .unwrap()
                     .unwrap();
@@ -1023,7 +1018,7 @@ mod tests {
             let helper_aggregate_share = helper_response.encrypted_aggregate_share().clone();
             Box::pin(async move {
                 let collect_job = tx
-                    .get_collect_job::<DUMMY_VERIFY_KEY_LENGTH, dummy_vdaf::Vdaf>(&collect_job_id)
+                    .get_collect_job::<0, dummy_vdaf::Vdaf>(&collect_job_id)
                     .await
                     .unwrap()
                     .unwrap();
@@ -1072,9 +1067,7 @@ mod tests {
                 let collect_job = collect_job.clone();
                 Box::pin(async move {
                     let abandoned_collect_job = tx
-                        .get_collect_job::<DUMMY_VERIFY_KEY_LENGTH, dummy_vdaf::Vdaf>(
-                            collect_job.collect_job_id(),
-                        )
+                        .get_collect_job::<0, dummy_vdaf::Vdaf>(collect_job.collect_job_id())
                         .await?
                         .unwrap();
 
@@ -1164,10 +1157,8 @@ mod tests {
             .run_tx(|tx| {
                 let collect_job = collect_job.clone();
                 Box::pin(async move {
-                    tx.get_collect_job::<DUMMY_VERIFY_KEY_LENGTH, dummy_vdaf::Vdaf>(
-                        collect_job.collect_job_id(),
-                    )
-                    .await
+                    tx.get_collect_job::<0, dummy_vdaf::Vdaf>(collect_job.collect_job_id())
+                        .await
                 })
             })
             .await
@@ -1195,7 +1186,7 @@ mod tests {
         ds.run_tx(|tx| {
             let collect_job = collect_job.clone();
             Box::pin(async move {
-                tx.update_collect_job::<DUMMY_VERIFY_KEY_LENGTH, dummy_vdaf::Vdaf>(&collect_job)
+                tx.update_collect_job::<0, dummy_vdaf::Vdaf>(&collect_job)
                     .await
             })
         })
@@ -1234,9 +1225,7 @@ mod tests {
             let collect_job = collect_job.clone();
             Box::pin(async move {
                 let collect_job = tx
-                    .get_collect_job::<DUMMY_VERIFY_KEY_LENGTH, dummy_vdaf::Vdaf>(
-                        collect_job.collect_job_id(),
-                    )
+                    .get_collect_job::<0, dummy_vdaf::Vdaf>(collect_job.collect_job_id())
                     .await
                     .unwrap()
                     .unwrap();

--- a/aggregator/src/aggregator/aggregate_share.rs
+++ b/aggregator/src/aggregator/aggregate_share.rs
@@ -39,7 +39,7 @@ use std::sync::Arc;
 use tokio::try_join;
 use tracing::{debug, error, info, warn};
 
-use super::CollectableQueryType;
+use super::query_type::CollectableQueryType;
 
 /// Holds various metrics instruments for a collect job driver.
 #[derive(Clone)]

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -43,7 +43,7 @@ use std::{fmt, sync::Arc};
 use tokio::try_join;
 use tracing::{info, warn};
 
-use super::accumulator::AccumulableQueryType;
+use super::query_type::AccumulableQueryType;
 
 #[derive(Derivative)]
 #[derivative(Debug)]

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -43,6 +43,8 @@ use std::{fmt, sync::Arc};
 use tokio::try_join;
 use tracing::{info, warn};
 
+use super::accumulator::AccumulableQueryType;
+
 #[derive(Derivative)]
 #[derivative(Debug)]
 pub struct AggregationJobDriver {
@@ -146,7 +148,7 @@ impl AggregationJobDriver {
     async fn step_aggregation_job_generic<
         const L: usize,
         C: Clock,
-        Q: QueryType,
+        Q: AccumulableQueryType,
         A: vdaf::Aggregator<L>,
     >(
         &self,
@@ -159,7 +161,7 @@ impl AggregationJobDriver {
         A::AggregationParam: Send + Sync,
         A::AggregateShare: Send + Sync,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
-        for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: fmt::Display,
+        for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: fmt::Debug,
         A::OutputShare: PartialEq + Eq + Send + Sync + for<'a> TryFrom<&'a [u8]>,
         for<'a> &'a A::OutputShare: Into<Vec<u8>>,
         for<'a> A::PrepareState:
@@ -285,7 +287,7 @@ impl AggregationJobDriver {
     async fn step_aggregation_job_aggregate_init<
         const L: usize,
         C: Clock,
-        Q: QueryType,
+        Q: AccumulableQueryType,
         A: vdaf::Aggregator<L>,
     >(
         &self,
@@ -303,7 +305,7 @@ impl AggregationJobDriver {
         A::AggregationParam: Send + Sync,
         A::AggregateShare: Send + Sync,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
-        for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: fmt::Display,
+        for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: fmt::Debug,
         A::OutputShare: PartialEq + Eq + Send + Sync,
         for<'a> &'a A::OutputShare: Into<Vec<u8>>,
         A::PrepareState: PartialEq + Eq + Send + Sync + Encode,
@@ -531,7 +533,7 @@ impl AggregationJobDriver {
     async fn step_aggregation_job_aggregate_continue<
         const L: usize,
         C: Clock,
-        Q: QueryType,
+        Q: AccumulableQueryType,
         A: vdaf::Aggregator<L>,
     >(
         &self,
@@ -547,7 +549,7 @@ impl AggregationJobDriver {
         A::AggregationParam: Send + Sync,
         A::AggregateShare: Send + Sync,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
-        for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: fmt::Display,
+        for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: fmt::Debug,
         A::OutputShare: Send + Sync,
         for<'a> &'a A::OutputShare: Into<Vec<u8>>,
         A::PrepareState: Send + Sync + Encode,
@@ -629,7 +631,7 @@ impl AggregationJobDriver {
     async fn process_response_from_helper<
         const L: usize,
         C: Clock,
-        Q: QueryType,
+        Q: AccumulableQueryType,
         A: vdaf::Aggregator<L>,
     >(
         &self,
@@ -647,7 +649,7 @@ impl AggregationJobDriver {
         A::AggregationParam: Send + Sync,
         A::AggregateShare: Send + Sync,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
-        for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: fmt::Display,
+        for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: fmt::Debug,
         A::OutputShare: Send + Sync,
         for<'a> &'a A::OutputShare: Into<Vec<u8>>,
         A::PrepareMessage: Send + Sync,
@@ -659,7 +661,7 @@ impl AggregationJobDriver {
                 "missing, duplicate, out-of-order, or unexpected prepare steps in response"
             ));
         }
-        let mut accumulator = Accumulator::<L, A>::new(
+        let mut accumulator = Accumulator::<L, Q, A>::new(
             Arc::clone(&task),
             aggregation_job.aggregation_parameter().clone(),
         );
@@ -721,13 +723,14 @@ impl AggregationJobDriver {
                     // If the leader didn't finish too, we transition to INVALID.
                     if let PrepareTransition::Finish(out_share) = leader_transition {
                         match accumulator.update(
-                            out_share,
-                            report_aggregation.time(),
+                            aggregation_job.batch_identifier(),
                             report_aggregation.report_id(),
+                            report_aggregation.time(),
+                            out_share,
                         ) {
                             Ok(_) => ReportAggregationState::Finished(out_share.clone()),
                             Err(error) => {
-                                warn!(report_id = %report_aggregation.report_id(), ?error, "Could not update batch unit aggregation");
+                                warn!(report_id = %report_aggregation.report_id(), ?error, "Could not update batch aggregation");
                                 self.aggregate_step_failure_counter.add(
                                     &Context::current(),
                                     1,
@@ -794,13 +797,13 @@ impl AggregationJobDriver {
                             .iter()
                             .map(|aggregation_job| tx.update_aggregation_job(aggregation_job)),
                     );
-                    let batch_unit_aggregations_future = accumulator.flush_to_datastore(tx);
+                    let batch_aggregations_future = accumulator.flush_to_datastore(tx);
 
                     try_join!(
                         tx.release_aggregation_job(&lease),
                         report_aggregations_future,
                         aggregation_job_future,
-                        batch_unit_aggregations_future,
+                        batch_aggregations_future,
                     )?;
                     Ok(())
                 })
@@ -976,11 +979,11 @@ where
 mod tests {
     use super::AggregationJobDriver;
     use crate::{
-        aggregator::{DapProblemType, Error},
+        aggregator::{CollectableQueryType, DapProblemType, Error},
         binary_utils::job_driver::JobDriver,
         datastore::{
             models::{
-                AggregationJob, AggregationJobState, BatchUnitAggregation, ReportAggregation,
+                AggregationJob, AggregationJobState, BatchAggregation, ReportAggregation,
                 ReportAggregationState,
             },
             test_util::ephemeral_datastore,
@@ -1049,7 +1052,7 @@ mod tests {
             random(),
             clock
                 .now()
-                .to_batch_unit_interval_start(task.time_precision())
+                .to_batch_interval_start(task.time_precision())
                 .unwrap(),
             Vec::new(),
         );
@@ -1263,7 +1266,7 @@ mod tests {
             random(),
             clock
                 .now()
-                .to_batch_unit_interval_start(task.time_precision())
+                .to_batch_interval_start(task.time_precision())
                 .unwrap(),
             Vec::new(),
         );
@@ -1481,7 +1484,7 @@ mod tests {
             random(),
             clock
                 .now()
-                .to_batch_unit_interval_start(task.time_precision())
+                .to_batch_interval_start(task.time_precision())
                 .unwrap(),
             Vec::new(),
         );
@@ -1700,7 +1703,7 @@ mod tests {
             random(),
             clock
                 .now()
-                .to_batch_unit_interval_start(task.time_precision())
+                .to_batch_interval_start(task.time_precision())
                 .unwrap(),
             Vec::new(),
         );
@@ -1864,21 +1867,22 @@ mod tests {
         let batch_interval_start = report
             .metadata()
             .time()
-            .to_batch_unit_interval_start(task.time_precision())
+            .to_batch_interval_start(task.time_precision())
             .unwrap();
-        let want_batch_unit_aggregations = Vec::from([BatchUnitAggregation::<
+        let want_batch_aggregations = Vec::from([BatchAggregation::<
             PRIO3_AES128_VERIFY_KEY_LENGTH,
+            TimeInterval,
             Prio3Aes128Count,
         >::new(
             *task.id(),
-            batch_interval_start,
+            Interval::new(batch_interval_start, *task.time_precision()).unwrap(),
             (),
             leader_aggregate_share,
             1,
             ReportIdChecksum::for_report_id(report.metadata().id()),
         )]);
 
-        let (got_aggregation_job, got_report_aggregation, got_batch_unit_aggregations) = ds
+        let (got_aggregation_job, got_report_aggregation, got_batch_aggregations) = ds
             .run_tx(|tx| {
                 let (vdaf, task, report_metadata) = (Arc::clone(&vdaf), task.clone(), report.metadata().clone());
                 Box::pin(async move {
@@ -1899,16 +1903,15 @@ mod tests {
                         )
                         .await?
                         .unwrap();
-                    let batch_unit_aggregations = tx
-                        .get_batch_unit_aggregations_for_task_in_interval::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
-                            task.id(),
-                            &Interval::new(
-                                report_metadata.time().to_batch_unit_interval_start(task.time_precision()).unwrap(),
-                                *task.time_precision()).unwrap(),
-                            &())
-                        .await
-                        .unwrap();
-                    Ok((aggregation_job, report_aggregation, batch_unit_aggregations))
+                    let batch_aggregations = TimeInterval::get_batch_aggregations_for_collect_identifier::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count, _>(
+                        tx,
+                        &task,
+                        &Interval::new(
+                            report_metadata.time().to_batch_interval_start(task.time_precision()).unwrap(),
+                            *task.time_precision()).unwrap(),
+                        &(),
+                    ).await.unwrap();
+                    Ok((aggregation_job, report_aggregation, batch_aggregations))
                 })
             })
             .await
@@ -1916,7 +1919,7 @@ mod tests {
 
         assert_eq!(want_aggregation_job, got_aggregation_job);
         assert_eq!(want_report_aggregation, got_report_aggregation);
-        assert_eq!(want_batch_unit_aggregations, got_batch_unit_aggregations);
+        assert_eq!(want_batch_aggregations, got_batch_aggregations);
     }
 
     #[tokio::test]
@@ -1943,7 +1946,7 @@ mod tests {
             random(),
             clock
                 .now()
-                .to_batch_unit_interval_start(task.time_precision())
+                .to_batch_interval_start(task.time_precision())
                 .unwrap(),
             Vec::new(),
         );
@@ -2105,24 +2108,20 @@ mod tests {
                 0,
                 ReportAggregationState::Finished(leader_output_share),
             );
-        let batch_interval_start = report
-            .metadata()
-            .time()
-            .to_batch_unit_interval_start(task.time_precision())
-            .unwrap();
-        let want_batch_unit_aggregations = Vec::from([BatchUnitAggregation::<
+        let want_batch_aggregations = Vec::from([BatchAggregation::<
             PRIO3_AES128_VERIFY_KEY_LENGTH,
+            FixedSize,
             Prio3Aes128Count,
         >::new(
             *task.id(),
-            batch_interval_start,
+            batch_id,
             (),
             leader_aggregate_share,
             1,
             ReportIdChecksum::for_report_id(report.metadata().id()),
         )]);
 
-        let (got_aggregation_job, got_report_aggregation, got_batch_unit_aggregations) = ds
+        let (got_aggregation_job, got_report_aggregation, got_batch_aggregations) = ds
             .run_tx(|tx| {
                 let (vdaf, task, report_metadata) = (Arc::clone(&vdaf), task.clone(), report.metadata().clone());
                 Box::pin(async move {
@@ -2143,16 +2142,13 @@ mod tests {
                         )
                         .await?
                         .unwrap();
-                    let batch_unit_aggregations = tx
-                        .get_batch_unit_aggregations_for_task_in_interval::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
-                            task.id(),
-                            &Interval::new(
-                                report_metadata.time().to_batch_unit_interval_start(task.time_precision()).unwrap(),
-                                *task.time_precision()).unwrap(),
-                            &())
-                        .await
-                        .unwrap();
-                    Ok((aggregation_job, report_aggregation, batch_unit_aggregations))
+                    let batch_aggregations = FixedSize::get_batch_aggregations_for_collect_identifier::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count, _>(
+                        tx,
+                        &task,
+                        &batch_id,
+                        &(),
+                    ).await?;
+                    Ok((aggregation_job, report_aggregation, batch_aggregations))
                 })
             })
             .await
@@ -2160,7 +2156,7 @@ mod tests {
 
         assert_eq!(want_aggregation_job, got_aggregation_job);
         assert_eq!(want_report_aggregation, got_report_aggregation);
-        assert_eq!(want_batch_unit_aggregations, got_batch_unit_aggregations);
+        assert_eq!(want_batch_aggregations, got_batch_aggregations);
     }
 
     #[tokio::test]
@@ -2186,7 +2182,7 @@ mod tests {
             random(),
             clock
                 .now()
-                .to_batch_unit_interval_start(task.time_precision())
+                .to_batch_interval_start(task.time_precision())
                 .unwrap(),
             Vec::new(),
         );
@@ -2374,7 +2370,7 @@ mod tests {
             random(),
             clock
                 .now()
-                .to_batch_unit_interval_start(task.time_precision())
+                .to_batch_interval_start(task.time_precision())
                 .unwrap(),
             Vec::new(),
         );

--- a/aggregator/src/aggregator/query_type.rs
+++ b/aggregator/src/aggregator/query_type.rs
@@ -11,6 +11,7 @@ use janus_messages::{
     Duration, Interval, Time,
 };
 use prio::vdaf;
+use std::iter;
 
 pub trait AccumulableQueryType: QueryType {
     /// This method converts various values related to a client report into a batch identifier. The
@@ -162,12 +163,12 @@ impl Iterator for TimeIntervalBatchIdentifierIter {
 }
 
 impl CollectableQueryType for FixedSize {
-    type Iter = std::option::IntoIter<Self::BatchIdentifier>;
+    type Iter = iter::Once<Self::BatchIdentifier>;
 
     fn batch_identifiers_for_collect_identifier(
         _: &Task,
         batch_id: &Self::BatchIdentifier,
     ) -> Self::Iter {
-        Some(*batch_id).into_iter()
+        iter::once(*batch_id)
     }
 }

--- a/aggregator/src/aggregator/query_type.rs
+++ b/aggregator/src/aggregator/query_type.rs
@@ -1,0 +1,173 @@
+use crate::{
+    datastore::{self, models::BatchAggregation, Transaction},
+    messages::TimeExt as _,
+    task::Task,
+};
+use async_trait::async_trait;
+use futures::future::try_join_all;
+use janus_core::time::{Clock, TimeExt as _};
+use janus_messages::{
+    query_type::{FixedSize, QueryType, TimeInterval},
+    Duration, Interval, Time,
+};
+use prio::vdaf;
+
+pub trait AccumulableQueryType: QueryType {
+    /// This method converts various values related to a client report into a batch identifier. The
+    /// arguments are somewhat arbitrary in the sense they are what "works out" to allow the
+    /// necessary functionality to be implemented for all query types.
+    fn to_batch_identifier(
+        _: &Task,
+        _: &Self::PartialBatchIdentifier,
+        client_timestamp: &Time,
+    ) -> Result<Self::BatchIdentifier, datastore::Error>;
+}
+
+impl AccumulableQueryType for TimeInterval {
+    fn to_batch_identifier(
+        task: &Task,
+        _: &Self::PartialBatchIdentifier,
+        client_timestamp: &Time,
+    ) -> Result<Self::BatchIdentifier, datastore::Error> {
+        let batch_interval_start = client_timestamp
+            .to_batch_interval_start(task.time_precision())
+            .map_err(|e| datastore::Error::User(e.into()))?;
+        Interval::new(batch_interval_start, *task.time_precision())
+            .map_err(|e| datastore::Error::User(e.into()))
+    }
+}
+
+impl AccumulableQueryType for FixedSize {
+    fn to_batch_identifier(
+        _: &Task,
+        batch_id: &Self::PartialBatchIdentifier,
+        _: &Time,
+    ) -> Result<Self::BatchIdentifier, datastore::Error> {
+        Ok(*batch_id)
+    }
+}
+
+/// CollectableQueryType represents a query type that can be collected by Janus. This trait extends
+/// [`QueryType`] with functionality required for collection.
+#[async_trait]
+pub trait CollectableQueryType: QueryType {
+    type Iter: Iterator<Item = Self::BatchIdentifier> + Send + Sync;
+
+    /// Some query types (e.g. [`TimeInterval`]) can receive a batch identifier in collect requests
+    /// which refers to multiple batches. This method takes a batch identifier received in a collect
+    /// request and provides an iterator over the individual batches' identifiers.
+    fn batch_identifiers_for_collect_identifier(
+        _: &Task,
+        collect_identifier: &Self::BatchIdentifier,
+    ) -> Self::Iter;
+
+    /// Retrieves batch aggregations corresponding to all batches identified by the given collect
+    /// identifier.
+    async fn get_batch_aggregations_for_collect_identifier<
+        const L: usize,
+        A: vdaf::Aggregator<L>,
+        C: Clock,
+    >(
+        tx: &Transaction<C>,
+        task: &Task,
+        collect_identifier: &Self::BatchIdentifier,
+        aggregation_param: &A::AggregationParam,
+    ) -> Result<Vec<BatchAggregation<L, Self, A>>, datastore::Error>
+    where
+        A::AggregationParam: Send + Sync,
+        A::AggregateShare: Send + Sync,
+        for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
+        for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Debug,
+    {
+        let batch_aggregations = try_join_all(
+            Self::batch_identifiers_for_collect_identifier(task, collect_identifier).map(
+                |batch_identifier| {
+                    let (task_id, aggregation_param) = (*task.id(), aggregation_param.clone());
+                    async move {
+                        tx.get_batch_aggregation(&task_id, &batch_identifier, &aggregation_param)
+                            .await
+                    }
+                },
+            ),
+        )
+        .await?;
+        Ok(batch_aggregations.into_iter().flatten().collect::<Vec<_>>())
+    }
+}
+
+impl CollectableQueryType for TimeInterval {
+    type Iter = TimeIntervalBatchIdentifierIter;
+
+    fn batch_identifiers_for_collect_identifier(
+        task: &Task,
+        batch_interval: &Self::BatchIdentifier,
+    ) -> Self::Iter {
+        TimeIntervalBatchIdentifierIter::new(task, batch_interval)
+    }
+}
+
+// This type only exists because the CollectableQueryType trait requires specifying the type of the
+// iterator explicitly (i.e. it cannot be inferred or replaced with an `impl Trait` expression), and
+// the type of the iterator created via method chaining does not have a type which is expressible.
+pub struct TimeIntervalBatchIdentifierIter {
+    step: u64,
+
+    total_step_count: u64,
+    start: Time,
+    time_precision: Duration,
+}
+
+impl TimeIntervalBatchIdentifierIter {
+    fn new(task: &Task, batch_interval: &Interval) -> Self {
+        // Sanity check that the given interval is of an appropriate length. We use an assert as
+        // this is expected to be checked before this method is used.
+        assert_eq!(
+            batch_interval.duration().as_seconds() % task.time_precision().as_seconds(),
+            0
+        );
+        let total_step_count =
+            batch_interval.duration().as_seconds() / task.time_precision().as_seconds();
+
+        Self {
+            step: 0,
+            total_step_count,
+            start: *batch_interval.start(),
+            time_precision: *task.time_precision(),
+        }
+    }
+}
+
+impl Iterator for TimeIntervalBatchIdentifierIter {
+    type Item = Interval;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.step == self.total_step_count {
+            return None;
+        }
+        // Unwrap safety: errors can only occur if the times being unwrapped cannot be represented
+        // as a Time. The relevant times can always be represented since they are internal to the
+        // batch interval used to create the iterator.
+        let interval = Interval::new(
+            self.start
+                .add(&Duration::from_seconds(
+                    self.step * self.time_precision.as_seconds(),
+                ))
+                .unwrap(),
+            self.time_precision,
+        )
+        .unwrap();
+        self.step += 1;
+        Some(interval)
+    }
+}
+
+impl CollectableQueryType for FixedSize {
+    type Iter = std::option::IntoIter<Self::BatchIdentifier>;
+
+    fn batch_identifiers_for_collect_identifier(
+        _: &Task,
+        batch_id: &Self::BatchIdentifier,
+    ) -> Self::Iter {
+        Some(*batch_id).into_iter()
+    }
+}

--- a/aggregator/src/bin/aggregation_job_creator.rs
+++ b/aggregator/src/bin/aggregation_job_creator.rs
@@ -83,8 +83,8 @@ struct Config {
     /// How frequently we attempt to create new aggregation jobs for each task, in seconds.
     aggregation_job_creation_interval_secs: u64,
     /// The minimum number of client reports to include in an aggregation job. Applies to the
-    /// "current" batch unit only; historical batch units will create aggregation jobs of any size,
-    /// on the theory that almost all reports will have be received for these batch units already.
+    /// "current" batch only; historical batches will create aggregation jobs of any size, on the
+    /// theory that almost all reports will have be received for these batches already.
     min_aggregation_job_size: usize,
     /// The maximum number of client reports to include in an aggregation job.
     max_aggregation_job_size: usize,

--- a/aggregator/src/datastore.rs
+++ b/aggregator/src/datastore.rs
@@ -3324,7 +3324,7 @@ pub mod models {
 
     /// BatchAggregation corresponds to a row in the `batch_aggregations` table and represents the
     /// possibly-ongoing aggregation of the set of input shares that fall within the batch
-    /// identifier by `batch_identifier`. This is the finest-grained possible aggregate share we can
+    /// identified by `batch_identifier`. This is the finest-grained possible aggregate share we can
     /// emit for this task. The aggregate share constructed to service a collect or aggregate share
     /// request consists of one or more `BatchAggregation`s merged together.
     #[derive(Clone, Derivative)]
@@ -4143,7 +4143,7 @@ pub mod test_util {
 #[cfg(test)]
 mod tests {
     use crate::{
-        aggregator::CollectableQueryType,
+        aggregator::query_type::CollectableQueryType,
         datastore::{
             models::{
                 AcquiredAggregationJob, AggregateShareJob, AggregationJob, AggregationJobState,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -215,7 +215,7 @@ where
         let time = self
             .clock
             .now()
-            .to_batch_unit_interval_start(&self.parameters.time_precision)
+            .to_batch_interval_start(&self.parameters.time_precision)
             .map_err(|_| Error::InvalidParameter("couldn't round time down to time_precision"))?;
         let report_metadata = ReportMetadata::new(
             random(),

--- a/core/src/time.rs
+++ b/core/src/time.rs
@@ -79,16 +79,16 @@ impl Default for MockClock {
 
 /// Extension methods on [`Time`].
 pub trait TimeExt: Sized {
-    /// Compute the start of the batch interval containing this Time, given the batch unit duration.
-    fn to_batch_unit_interval_start(
+    /// Compute the start of the batch interval containing this Time, given the task time precision.
+    fn to_batch_interval_start(
         &self,
         time_precision: &Duration,
     ) -> Result<Self, janus_messages::Error>;
 }
 
 impl TimeExt for Time {
-    /// Compute the start of the batch interval containing this Time, given the batch unit duration.
-    fn to_batch_unit_interval_start(
+    /// Compute the start of the batch interval containing this Time, given the task time precision.
+    fn to_batch_interval_start(
         &self,
         time_precision: &Duration,
     ) -> Result<Self, janus_messages::Error> {

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -141,18 +141,18 @@ CREATE TABLE report_aggregations(
 CREATE INDEX report_aggregations_aggregation_job_id_index ON report_aggregations(aggregation_job_id);
 CREATE INDEX report_aggregations_client_report_id_index ON report_aggregations(client_report_id);
 
--- Information on aggregation for a single batch unit. This information may be incremental if the
--- VDAF supports incremental aggregation.
-CREATE TABLE batch_unit_aggregations(
+-- Information on aggregation for a single batch. This information may be incremental if the VDAF
+-- supports incremental aggregation.
+CREATE TABLE batch_aggregations(
     id                    BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,  -- artificial ID, internal-only
     task_id               BIGINT NOT NULL,     -- the task ID
-    unit_interval_start   TIMESTAMP NOT NULL,  -- the start of the batch unit
+    batch_identifier      BYTEA NOT NULL,      -- encoded query-type-specific batch identifier (corresponds to identifier in BatchSelector)
     aggregation_param     BYTEA NOT NULL,      -- the aggregation parameter (opaque VDAF message)
     aggregate_share       BYTEA NOT NULL,      -- the (possibly-incremental) aggregate share
     report_count          BIGINT NOT NULL,     -- the (possibly-incremental) client report count
     checksum              BYTEA NOT NULL,      -- the (possibly-incremental) checksum
 
-    CONSTRAINT unique_task_id_interval_aggregation_param UNIQUE(task_id, unit_interval_start, aggregation_param),
+    CONSTRAINT unique_task_id_interval_aggregation_param UNIQUE(task_id, batch_identifier, aggregation_param),
     CONSTRAINT fk_task_id FOREIGN KEY(task_id) REFERENCES tasks(id)
 );
 

--- a/integration_tests/tests/common/mod.rs
+++ b/integration_tests/tests/common/mod.rs
@@ -76,7 +76,7 @@ pub async fn submit_measurements_and_verify_aggregate_generic<V>(
     // Send a collect request.
     let batch_interval = Interval::new(
         before_timestamp
-            .to_batch_unit_interval_start(leader_task.time_precision())
+            .to_batch_interval_start(leader_task.time_precision())
             .unwrap(),
         // Use two time precisions as the interval duration in order to avoid a race condition if
         // this test happens to run very close to the end of a batch window.

--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -92,7 +92,7 @@ async fn run(
     let collector_auth_token = base64::encode_config(rand::random::<[u8; 16]>(), URL_SAFE_NO_PAD);
     let verify_key = rand::random::<[u8; PRIO3_AES128_VERIFY_KEY_LENGTH]>();
 
-    let task_id_encoded = base64::encode_config(task_id.get_encoded(), URL_SAFE_NO_PAD);
+    let task_id_encoded = base64::encode_config(&task_id.get_encoded(), URL_SAFE_NO_PAD);
     let verify_key_encoded = base64::encode_config(verify_key, URL_SAFE_NO_PAD);
 
     // Endpoints, from the POV of this test (i.e. the Docker host).
@@ -333,7 +333,7 @@ async fn run(
     // determine what batch time to start the aggregation at.
     let start_timestamp = RealClock::default().now();
     let batch_interval_start = start_timestamp
-        .to_batch_unit_interval_start(&Duration::from_seconds(TIME_PRECISION))
+        .to_batch_interval_start(&Duration::from_seconds(TIME_PRECISION))
         .unwrap()
         .as_seconds_since_epoch();
     // Span the aggregation over two time precisions, just in case our measurements spilled over a

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -1206,7 +1206,7 @@ pub mod query_type {
     use num_enum::TryFromPrimitive;
     use prio::codec::{CodecError, Decode, Encode};
     use serde::{Deserialize, Serialize};
-    use std::{fmt::Debug, io::Cursor};
+    use std::{fmt::Debug, hash::Hash, io::Cursor};
 
     /// QueryType represents a DAP query type. This is a task-level configuration setting which
     /// determines how individual client reports are grouped together into batches for collection.
@@ -1215,17 +1215,25 @@ pub mod query_type {
         const CODE: Code;
 
         /// The type of a batch identifier.
-        type BatchIdentifier: Debug + Clone + PartialEq + Eq + Encode + Decode + Send + Sync;
+        type BatchIdentifier: Debug + Clone + Hash + PartialEq + Eq + Encode + Decode + Send + Sync;
 
         /// The type of a batch identifier as it appears in a `PartialBatchSelector`. Will be either
         /// the same type as `BatchIdentifier`, or `()`.
-        type PartialBatchIdentifier: Debug + Clone + PartialEq + Eq + Encode + Decode + Send + Sync;
+        type PartialBatchIdentifier: Debug
+            + Clone
+            + Hash
+            + PartialEq
+            + Eq
+            + Encode
+            + Decode
+            + Send
+            + Sync;
 
         /// Computes the `PartialBatchIdentifier` corresponding to the given
         /// `BatchIdentifier`.
         fn partial_batch_identifier(
-            batch_identifier: Self::BatchIdentifier,
-        ) -> Self::PartialBatchIdentifier;
+            batch_identifier: &Self::BatchIdentifier,
+        ) -> &Self::PartialBatchIdentifier;
     }
 
     /// Represents a `time-interval` DAP query type.
@@ -1238,7 +1246,9 @@ pub mod query_type {
         type BatchIdentifier = Interval;
         type PartialBatchIdentifier = ();
 
-        fn partial_batch_identifier(_: Self::BatchIdentifier) -> Self::PartialBatchIdentifier {}
+        fn partial_batch_identifier(_: &Self::BatchIdentifier) -> &Self::PartialBatchIdentifier {
+            &()
+        }
     }
 
     /// Represents a `fixed-size` DAP query type.
@@ -1252,8 +1262,8 @@ pub mod query_type {
         type PartialBatchIdentifier = BatchId;
 
         fn partial_batch_identifier(
-            batch_identifier: Self::BatchIdentifier,
-        ) -> Self::PartialBatchIdentifier {
+            batch_identifier: &Self::BatchIdentifier,
+        ) -> &Self::PartialBatchIdentifier {
             batch_identifier
         }
     }


### PR DESCRIPTION
I made some opinionated choices about how to deal with the fact that a time-interval collect request may span multiple batches (née batch units). Instead of making a single request, I now do a (pipelined) set of requests for all of the individual batch units. We load multiple values using pipelined requests for single values elsewhere; we can fix this up easily enough later, if we want to, by doing a lexicographic search over the batch_identifiers.

Part of #468.