### PR TITLE
Optimize query in count_client_reports_for_interval()

### DIFF
--- a/aggregator/src/datastore.rs
+++ b/aggregator/src/datastore.rs
@@ -919,7 +919,8 @@ impl<C: Clock> Transaction<'_, C> {
             .prepare_cached(
                 "SELECT COUNT(1) AS count FROM client_reports
                 WHERE client_reports.task_id = (SELECT id FROM tasks WHERE task_id = $1)
-                AND client_reports.client_timestamp <@ $2::TSRANGE",
+                AND client_reports.client_timestamp >= lower($2::TSRANGE)
+                AND client_reports.client_timestamp < upper($2::TSRANGE)",
             )
             .await?;
         let row = self


### PR DESCRIPTION
This rewrites one query to use `>=` and `<` operators instead of `<@`, so that the query planner can better apply an index scan. (This relies on the fact that all our timestamp ranges are closed on the left and open on the right, which is enforced by our SQL conversion of the `Interval` type)

There are two other queries that use `<@` on `client_reports.client_timestamp`, which I'm leaving alone. In my testing, making the same change didn't seem to improve query plans, as the condition was applied as a join filter deep in a nested loop join. In both, the interval side of the containment operator came from another table. Moreover, these queries will need to be revisited in #269 and #519.

Here are the before-and-after query plans:

```
postgres=# EXPLAIN SELECT COUNT(1) AS count FROM client_reports WHERE client_reports.task_id = 0 AND client_reports.client_timestamp <@ '[2022-11-08 00:00:00, 2022-11-09 00:00:00)'::tsrange;
                                                       QUERY PLAN                                                        
-------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=4.30..4.31 rows=1 width=8)
   ->  Index Only Scan using client_reports_task_and_timestamp_index on client_reports  (cost=0.28..4.30 rows=1 width=0)
         Index Cond: (task_id = 0)
         Filter: (client_timestamp <@ '["2022-11-08 00:00:00","2022-11-09 00:00:00")'::tsrange)
```

```
postgres=# EXPLAIN SELECT COUNT(1) AS count FROM client_reports WHERE client_reports.task_id = 0 AND client_reports.client_timestamp >= lower('[2022-11-08 00:00:00, 2022-11-09 00:00:00)'::tsrange) AND client_reports.client_timestamp < upper('[2022-11-08 00:00:00, 2022-11-09 00:00:00)'::tsrange);
                                                                                          QUERY PLAN                                                                                          
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=4.31..4.32 rows=1 width=8)
   ->  Index Only Scan using client_reports_task_and_timestamp_index on client_reports  (cost=0.28..4.30 rows=1 width=0)
         Index Cond: ((task_id = 0) AND (client_timestamp >= '2022-11-08 00:00:00'::timestamp without time zone) AND (client_timestamp < '2022-11-09 00:00:00'::timestamp without time zone))
```

Closes #714.