### PR TITLE
Clean up dummy report generation

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -658,11 +658,10 @@ mod tests {
     use super::AggregationJobCreator;
     use crate::{
         datastore::{
-            models::{AggregationJob, CollectJob, CollectJobState},
+            models::{AggregationJob, CollectJob, CollectJobState, LeaderStoredReport},
             test_util::ephemeral_datastore,
             Transaction,
         },
-        messages::test_util::new_dummy_report,
         messages::TimeExt,
         task::{
             test_util::TaskBuilder, QueryType as TaskQueryType, PRIO3_AES128_VERIFY_KEY_LENGTH,
@@ -679,7 +678,7 @@ mod tests {
     };
     use janus_messages::{
         query_type::{FixedSize, QueryType, TimeInterval},
-        AggregationJobId, Interval, Report, ReportId, Role, TaskId, Time,
+        AggregationJobId, Interval, ReportId, Role, TaskId, Time,
     };
     use prio::{
         codec::ParameterizedDecode,
@@ -721,7 +720,7 @@ mod tests {
             Role::Leader,
         )
         .build();
-        let leader_report = new_dummy_report(*leader_task.id(), report_time);
+        let leader_report = LeaderStoredReport::new_dummy(leader_task.id(), report_time);
 
         let helper_task = TaskBuilder::new(
             TaskQueryType::TimeInterval,
@@ -729,7 +728,7 @@ mod tests {
             Role::Helper,
         )
         .build();
-        let helper_report = new_dummy_report(*helper_task.id(), report_time);
+        let helper_report = LeaderStoredReport::new_dummy(helper_task.id(), report_time);
 
         ds.run_tx(|tx| {
             let (leader_task, helper_task) = (leader_task.clone(), helper_task.clone());
@@ -738,8 +737,8 @@ mod tests {
                 tx.put_task(&leader_task).await?;
                 tx.put_task(&helper_task).await?;
 
-                tx.put_client_report_message(&leader_report).await?;
-                tx.put_client_report_message(&helper_report).await
+                tx.put_client_report(&leader_report).await?;
+                tx.put_client_report(&helper_report).await
             })
         })
         .await
@@ -832,8 +831,8 @@ mod tests {
         // In the current batch, create MIN_AGGREGATION_JOB_SIZE reports. We expect an aggregation
         // job to be created containing these reports.
         let report_time = clock.now();
-        let cur_batch_reports: Vec<Report> =
-            iter::repeat_with(|| new_dummy_report(*task.id(), report_time))
+        let cur_batch_reports: Vec<LeaderStoredReport<0, dummy_vdaf::Vdaf>> =
+            iter::repeat_with(|| LeaderStoredReport::new_dummy(task.id(), report_time))
                 .take(MIN_AGGREGATION_JOB_SIZE)
                 .collect();
 
@@ -841,16 +840,16 @@ mod tests {
         // the minimum aggregation job size applies only to the current batch window, we expect an
         // aggregation job to be created for these reports.
         let report_time = report_time.sub(task.time_precision()).unwrap();
-        let small_batch_reports: Vec<Report> =
-            iter::repeat_with(|| new_dummy_report(*task.id(), report_time))
+        let small_batch_reports: Vec<LeaderStoredReport<0, dummy_vdaf::Vdaf>> =
+            iter::repeat_with(|| LeaderStoredReport::new_dummy(task.id(), report_time))
                 .take(MIN_AGGREGATION_JOB_SIZE - 1)
                 .collect();
 
         // In a (separate) previous "big" batch, create more than MAX_AGGREGATION_JOB_SIZE reports.
         // We expect these reports will be split into more than one aggregation job.
         let report_time = report_time.sub(task.time_precision()).unwrap();
-        let big_batch_reports: Vec<Report> =
-            iter::repeat_with(|| new_dummy_report(*task.id(), report_time))
+        let big_batch_reports: Vec<LeaderStoredReport<0, dummy_vdaf::Vdaf>> =
+            iter::repeat_with(|| LeaderStoredReport::new_dummy(task.id(), report_time))
                 .take(MAX_AGGREGATION_JOB_SIZE + 1)
                 .collect();
 
@@ -875,7 +874,7 @@ mod tests {
                     .chain(&small_batch_reports)
                     .chain(&big_batch_reports)
                 {
-                    tx.put_client_report_message(report).await?;
+                    tx.put_client_report(report).await?;
                 }
                 Ok(())
             })
@@ -956,14 +955,14 @@ mod tests {
             )
             .build(),
         );
-        let first_report = new_dummy_report(*task.id(), clock.now());
-        let second_report = new_dummy_report(*task.id(), clock.now());
+        let first_report = LeaderStoredReport::new_dummy(task.id(), clock.now());
+        let second_report = LeaderStoredReport::new_dummy(task.id(), clock.now());
 
         ds.run_tx(|tx| {
             let (task, first_report) = (Arc::clone(&task), first_report.clone());
             Box::pin(async move {
                 tx.put_task(&task).await?;
-                tx.put_client_report_message(&first_report).await
+                tx.put_client_report(&first_report).await
             })
         })
         .await
@@ -1007,7 +1006,7 @@ mod tests {
             .datastore
             .run_tx(|tx| {
                 let second_report = second_report.clone();
-                Box::pin(async move { tx.put_client_report_message(&second_report).await })
+                Box::pin(async move { tx.put_client_report(&second_report).await })
             })
             .await
             .unwrap();
@@ -1091,9 +1090,10 @@ mod tests {
 
         // Create MIN_BATCH_SIZE + MAX_BATCH_SIZE reports. We expect aggregation jobs to be created
         // containing these reports.
-        let reports: Vec<Report> = iter::repeat_with(|| new_dummy_report(*task.id(), clock.now()))
-            .take(MIN_BATCH_SIZE + MAX_BATCH_SIZE)
-            .collect();
+        let reports: Vec<LeaderStoredReport<0, dummy_vdaf::Vdaf>> =
+            iter::repeat_with(|| LeaderStoredReport::new_dummy(task.id(), clock.now()))
+                .take(MIN_BATCH_SIZE + MAX_BATCH_SIZE)
+                .collect();
 
         let report_ids: HashSet<ReportId> = reports
             .iter()
@@ -1105,7 +1105,7 @@ mod tests {
             Box::pin(async move {
                 tx.put_task(&task).await?;
                 for report in &reports {
-                    tx.put_client_report_message(report).await?;
+                    tx.put_client_report(report).await?;
                 }
                 Ok(())
             })
@@ -1208,16 +1208,16 @@ mod tests {
         // aggregation job per overlapping collect job for these reports. (and there is one such
         // collect job)
         let report_time = clock.now().sub(task.time_precision()).unwrap();
-        let batch_1_reports: Vec<Report> =
-            iter::repeat_with(|| new_dummy_report(*task.id(), report_time))
+        let batch_1_reports: Vec<LeaderStoredReport<0, dummy_vdaf::Vdaf>> =
+            iter::repeat_with(|| LeaderStoredReport::new_dummy(task.id(), report_time))
                 .take(MAX_AGGREGATION_JOB_SIZE)
                 .collect();
 
         // Create more than MAX_AGGREGATION_JOB_SIZE reports in another batch. This should result in
         // two aggregation jobs per overlapping collect job. (and there are two such collect jobs)
         let report_time = report_time.sub(task.time_precision()).unwrap();
-        let batch_2_reports: Vec<Report> =
-            iter::repeat_with(|| new_dummy_report(*task.id(), report_time))
+        let batch_2_reports: Vec<LeaderStoredReport<0, dummy_vdaf::Vdaf>> =
+            iter::repeat_with(|| LeaderStoredReport::new_dummy(task.id(), report_time))
                 .take(MAX_AGGREGATION_JOB_SIZE + 1)
                 .collect();
 
@@ -1230,10 +1230,10 @@ mod tests {
             Box::pin(async move {
                 tx.put_task(&task).await?;
                 for report in batch_1_reports {
-                    tx.put_client_report_message(&report).await?;
+                    tx.put_client_report(&report).await?;
                 }
                 for report in batch_2_reports {
-                    tx.put_client_report_message(&report).await?;
+                    tx.put_client_report(&report).await?;
                 }
                 Ok(())
             })

--- a/aggregator/src/datastore.rs
+++ b/aggregator/src/datastore.rs
@@ -20,8 +20,6 @@ use janus_core::{
     task::{AuthenticationToken, VdafInstance},
     time::Clock,
 };
-#[cfg(test)]
-use janus_messages::Report;
 use janus_messages::{
     query_type::QueryType, AggregationJobId, BatchId, Duration, Extension, HpkeCiphertext,
     HpkeConfig, Interval, ReportId, ReportIdChecksum, ReportMetadata, ReportShare, Role, TaskId,
@@ -956,52 +954,21 @@ impl<C: Clock> Transaction<'_, C> {
         let encoded_public_share = report.public_share().get_encoded();
         let encoded_leader_share = report.leader_input_share().get_encoded();
         let encoded_helper_share = report.helper_encrypted_input_share().get_encoded();
-
-        self.put_client_report_raw(
-            report.task_id(),
-            report.metadata(),
-            &encoded_public_share,
-            &encoded_leader_share,
-            &encoded_helper_share,
-        )
-        .await
-    }
-
-    #[cfg(test)]
-    pub(crate) async fn put_client_report_message(&self, report: &Report) -> Result<(), Error> {
-        let leader_input_share =
-            report.encrypted_input_shares()[Role::Leader.index().unwrap()].get_encoded();
-        let helper_input_share =
-            report.encrypted_input_shares()[Role::Helper.index().unwrap()].get_encoded();
-
-        self.put_client_report_raw(
-            report.task_id(),
-            report.metadata(),
-            report.public_share(),
-            &leader_input_share,
-            &helper_input_share,
-        )
-        .await
-    }
-
-    /// `put_client_report_raw` stores reports with arbitrary byte vectors as their leader and
-    /// helper input shares. This is exposed to the crate for use in tests.
-    pub(crate) async fn put_client_report_raw(
-        &self,
-        task_id: &TaskId,
-        report_metadata: &ReportMetadata,
-        public_share: &[u8],
-        leader_input_share: &[u8],
-        helper_input_share: &[u8],
-    ) -> Result<(), Error> {
         let mut encoded_extensions = Vec::new();
-        encode_u16_items(&mut encoded_extensions, &(), report_metadata.extensions());
+        encode_u16_items(&mut encoded_extensions, &(), report.metadata().extensions());
 
         let stmt = self
             .tx
             .prepare_cached(
-                "INSERT INTO client_reports
-                (task_id, report_id, client_timestamp, extensions, public_share, leader_input_share, helper_encrypted_input_share)
+                "INSERT INTO client_reports (
+                    task_id,
+                    report_id,
+                    client_timestamp,
+                    extensions,
+                    public_share,
+                    leader_input_share,
+                    helper_encrypted_input_share
+                )
                 VALUES ((SELECT id FROM tasks WHERE task_id = $1), $2, $3, $4, $5, $6, $7)",
             )
             .await?;
@@ -1009,13 +976,13 @@ impl<C: Clock> Transaction<'_, C> {
             .execute(
                 &stmt,
                 &[
-                    /* task_id */ &task_id.get_encoded(),
-                    /* report_id */ &report_metadata.id().as_ref(),
-                    /* client_timestamp */ &report_metadata.time().as_naive_date_time(),
+                    /* task_id */ &report.task_id().get_encoded(),
+                    /* report_id */ &report.metadata().id().get_encoded(),
+                    /* client_timestamp */ &report.metadata().time().as_naive_date_time(),
                     /* extensions */ &encoded_extensions,
-                    /* public_share */ &public_share,
-                    /* leader_input_share */ &leader_input_share,
-                    /* helper_encrypted_input_share */ &helper_input_share,
+                    /* public_share */ &encoded_public_share,
+                    /* leader_input_share */ &encoded_leader_share,
+                    /* helper_encrypted_input_share */ &encoded_helper_share,
                 ],
             )
             .await?;
@@ -2915,6 +2882,26 @@ pub mod models {
     {
     }
 
+    #[cfg(test)]
+    impl LeaderStoredReport<0, janus_core::test_util::dummy_vdaf::Vdaf> {
+        pub(crate) fn new_dummy(task_id: &TaskId, when: Time) -> Self {
+            use janus_messages::HpkeConfigId;
+            use rand::random;
+
+            Self::new(
+                *task_id,
+                ReportMetadata::new(random(), when, Vec::new()),
+                (),
+                (),
+                HpkeCiphertext::new(
+                    HpkeConfigId::from(13),
+                    Vec::from("encapsulated_context_0"),
+                    Vec::from("payload_0"),
+                ),
+            )
+        }
+    }
+
     /// AggregatorRole corresponds to the `AGGREGATOR_ROLE` enum in the schema.
     #[derive(Clone, Debug, ToSql, FromSql)]
     #[postgres(name = "aggregator_role")]
@@ -4307,7 +4294,7 @@ mod tests {
             test_util::{ephemeral_datastore, generate_aead_key},
             Crypter, Error,
         },
-        messages::{test_util::new_dummy_report, DurationExt, TimeExt},
+        messages::{DurationExt, TimeExt},
         task::{self, test_util::TaskBuilder, QueryType, Task, PRIO3_AES128_VERIFY_KEY_LENGTH},
     };
     use assert_matches::assert_matches;
@@ -4324,9 +4311,8 @@ mod tests {
     };
     use janus_messages::{
         query_type::{FixedSize, TimeInterval},
-        Duration, Extension, ExtensionType, HpkeCiphertext, HpkeConfigId, Interval, Report,
-        ReportId, ReportIdChecksum, ReportMetadata, ReportShare, ReportShareError, Role, TaskId,
-        Time,
+        Duration, Extension, ExtensionType, HpkeCiphertext, HpkeConfigId, Interval, ReportId,
+        ReportIdChecksum, ReportMetadata, ReportShare, ReportShareError, Role, TaskId, Time,
     };
     use prio::{
         codec::{Decode, Encode},
@@ -4568,43 +4554,10 @@ mod tests {
         )
         .build();
 
-        let dummy_input_share_ciphertexts = vec![
-            HpkeCiphertext::new(
-                HpkeConfigId::from(13),
-                Vec::from("encapsulated_context_0"),
-                Vec::from("payload_0"),
-            ),
-            HpkeCiphertext::new(
-                HpkeConfigId::from(13),
-                Vec::from("encapsulated_context_1"),
-                Vec::from("payload_1"),
-            ),
-        ];
-
-        let first_unaggregated_report = Report::new(
-            *task.id(),
-            ReportMetadata::new(random(), when, Vec::new()),
-            Vec::new(),
-            dummy_input_share_ciphertexts.clone(),
-        );
-        let second_unaggregated_report = Report::new(
-            *task.id(),
-            ReportMetadata::new(random(), when, Vec::new()),
-            Vec::new(),
-            dummy_input_share_ciphertexts.clone(),
-        );
-        let aggregated_report = Report::new(
-            *task.id(),
-            ReportMetadata::new(random(), when, Vec::new()),
-            Vec::new(),
-            dummy_input_share_ciphertexts.clone(),
-        );
-        let unrelated_report = Report::new(
-            *unrelated_task.id(),
-            ReportMetadata::new(random(), when, Vec::new()),
-            Vec::new(),
-            dummy_input_share_ciphertexts,
-        );
+        let first_unaggregated_report = LeaderStoredReport::new_dummy(task.id(), when);
+        let second_unaggregated_report = LeaderStoredReport::new_dummy(task.id(), when);
+        let aggregated_report = LeaderStoredReport::new_dummy(task.id(), when);
+        let unrelated_report = LeaderStoredReport::new_dummy(unrelated_task.id(), when);
 
         // Set up state.
         ds.run_tx(|tx| {
@@ -4628,12 +4581,10 @@ mod tests {
                 tx.put_task(&task).await?;
                 tx.put_task(&unrelated_task).await?;
 
-                tx.put_client_report_message(&first_unaggregated_report)
-                    .await?;
-                tx.put_client_report_message(&second_unaggregated_report)
-                    .await?;
-                tx.put_client_report_message(&aggregated_report).await?;
-                tx.put_client_report_message(&unrelated_report).await?;
+                tx.put_client_report(&first_unaggregated_report).await?;
+                tx.put_client_report(&second_unaggregated_report).await?;
+                tx.put_client_report(&aggregated_report).await?;
+                tx.put_client_report(&unrelated_report).await?;
 
                 let aggregation_job_id = random();
                 tx.put_aggregation_job(&AggregationJob::<
@@ -4706,42 +4657,15 @@ mod tests {
         let unrelated_task =
             TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Leader).build();
 
-        let dummy_input_share_ciphertexts = vec![
-            HpkeCiphertext::new(
-                HpkeConfigId::from(13),
-                Vec::from("encapsulated_context_0"),
-                Vec::from("payload_0"),
-            ),
-            HpkeCiphertext::new(
-                HpkeConfigId::from(13),
-                Vec::from("encapsulated_context_1"),
-                Vec::from("payload_1"),
-            ),
-        ];
-
-        let first_unaggregated_report = Report::new(
-            *task.id(),
-            ReportMetadata::new(random(), Time::from_seconds_since_epoch(12345), Vec::new()),
-            Vec::new(),
-            dummy_input_share_ciphertexts.clone(),
-        );
-        let second_unaggregated_report = Report::new(
-            *task.id(),
-            ReportMetadata::new(random(), Time::from_seconds_since_epoch(12346), Vec::new()),
-            Vec::new(),
-            dummy_input_share_ciphertexts.clone(),
-        );
-        let aggregated_report = Report::new(
-            *task.id(),
-            ReportMetadata::new(random(), Time::from_seconds_since_epoch(12347), Vec::new()),
-            Vec::new(),
-            dummy_input_share_ciphertexts.clone(),
-        );
-        let unrelated_report = Report::new(
-            *unrelated_task.id(),
-            ReportMetadata::new(random(), Time::from_seconds_since_epoch(12348), Vec::new()),
-            Vec::new(),
-            dummy_input_share_ciphertexts,
+        let first_unaggregated_report =
+            LeaderStoredReport::new_dummy(task.id(), Time::from_seconds_since_epoch(12345));
+        let second_unaggregated_report =
+            LeaderStoredReport::new_dummy(task.id(), Time::from_seconds_since_epoch(12346));
+        let aggregated_report =
+            LeaderStoredReport::new_dummy(task.id(), Time::from_seconds_since_epoch(12347));
+        let unrelated_report = LeaderStoredReport::new_dummy(
+            unrelated_task.id(),
+            Time::from_seconds_since_epoch(12348),
         );
 
         // Set up state.
@@ -4766,12 +4690,10 @@ mod tests {
                 tx.put_task(&task).await?;
                 tx.put_task(&unrelated_task).await?;
 
-                tx.put_client_report_message(&first_unaggregated_report)
-                    .await?;
-                tx.put_client_report_message(&second_unaggregated_report)
-                    .await?;
-                tx.put_client_report_message(&aggregated_report).await?;
-                tx.put_client_report_message(&unrelated_report).await?;
+                tx.put_client_report(&first_unaggregated_report).await?;
+                tx.put_client_report(&second_unaggregated_report).await?;
+                tx.put_client_report(&aggregated_report).await?;
+                tx.put_client_report(&unrelated_report).await?;
 
                 // There are no client reports submitted under this task, so we shouldn't see
                 // this aggregation parameter at all.
@@ -4983,42 +4905,15 @@ mod tests {
         let no_reports_task =
             TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Leader).build();
 
-        let dummy_input_share_ciphertexts = vec![
-            HpkeCiphertext::new(
-                HpkeConfigId::from(13),
-                Vec::from("encapsulated_context_0"),
-                Vec::from("payload_0"),
-            ),
-            HpkeCiphertext::new(
-                HpkeConfigId::from(13),
-                Vec::from("encapsulated_context_1"),
-                Vec::from("payload_1"),
-            ),
-        ];
-
-        let first_report_in_interval = Report::new(
-            *task.id(),
-            ReportMetadata::new(random(), Time::from_seconds_since_epoch(12340), Vec::new()),
-            Vec::new(),
-            dummy_input_share_ciphertexts.clone(),
-        );
-        let second_report_in_interval = Report::new(
-            *task.id(),
-            ReportMetadata::new(random(), Time::from_seconds_since_epoch(12341), Vec::new()),
-            Vec::new(),
-            dummy_input_share_ciphertexts.clone(),
-        );
-        let report_outside_interval = Report::new(
-            *task.id(),
-            ReportMetadata::new(random(), Time::from_seconds_since_epoch(12350), Vec::new()),
-            Vec::new(),
-            dummy_input_share_ciphertexts.clone(),
-        );
-        let report_for_other_task = Report::new(
-            *unrelated_task.id(),
-            ReportMetadata::new(random(), Time::from_seconds_since_epoch(12341), Vec::new()),
-            Vec::new(),
-            dummy_input_share_ciphertexts,
+        let first_report_in_interval =
+            LeaderStoredReport::new_dummy(task.id(), Time::from_seconds_since_epoch(12340));
+        let second_report_in_interval =
+            LeaderStoredReport::new_dummy(task.id(), Time::from_seconds_since_epoch(12341));
+        let report_outside_interval =
+            LeaderStoredReport::new_dummy(task.id(), Time::from_seconds_since_epoch(12350));
+        let report_for_other_task = LeaderStoredReport::new_dummy(
+            unrelated_task.id(),
+            Time::from_seconds_since_epoch(12341),
         );
 
         // Set up state.
@@ -5046,13 +4941,10 @@ mod tests {
                 tx.put_task(&unrelated_task).await?;
                 tx.put_task(&no_reports_task).await?;
 
-                tx.put_client_report_message(&first_report_in_interval)
-                    .await?;
-                tx.put_client_report_message(&second_report_in_interval)
-                    .await?;
-                tx.put_client_report_message(&report_outside_interval)
-                    .await?;
-                tx.put_client_report_message(&report_for_other_task).await?;
+                tx.put_client_report(&first_report_in_interval).await?;
+                tx.put_client_report(&second_report_in_interval).await?;
+                tx.put_client_report(&report_outside_interval).await?;
+                tx.put_client_report(&report_for_other_task).await?;
 
                 Ok(())
             })
@@ -6495,7 +6387,7 @@ mod tests {
     #[derive(Clone)]
     struct CollectJobAcquireTestCase {
         task_ids: Vec<TaskId>,
-        reports: Vec<Report>,
+        reports: Vec<LeaderStoredReport<0, dummy_vdaf::Vdaf>>,
         aggregation_jobs: Vec<AggregationJob<0, TimeInterval, dummy_vdaf::Vdaf>>,
         report_aggregations: Vec<ReportAggregation<0, dummy_vdaf::Vdaf>>,
         collect_job_test_cases: Vec<CollectJobTestCase>,
@@ -6522,14 +6414,7 @@ mod tests {
                 }
 
                 for report in &test_case.reports {
-                    tx.put_client_report_raw(
-                        report.task_id(),
-                        report.metadata(),
-                        report.public_share(),
-                        &[],
-                        &[],
-                    )
-                    .await?;
+                    tx.put_client_report(report).await?;
                 }
 
                 for aggregation_job in &test_case.aggregation_jobs {
@@ -6626,7 +6511,10 @@ mod tests {
         let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
 
         let task_id = random();
-        let reports = Vec::from([new_dummy_report(task_id, Time::from_seconds_since_epoch(0))]);
+        let reports = Vec::from([LeaderStoredReport::new_dummy(
+            &task_id,
+            Time::from_seconds_since_epoch(0),
+        )]);
         let aggregation_job_id = random();
         let aggregation_jobs =
             Vec::from([AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
@@ -6792,7 +6680,10 @@ mod tests {
         let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
 
         let task_id = random();
-        let reports = Vec::from([new_dummy_report(task_id, Time::from_seconds_since_epoch(0))]);
+        let reports = Vec::from([LeaderStoredReport::new_dummy(
+            &task_id,
+            Time::from_seconds_since_epoch(0),
+        )]);
 
         let aggregation_jobs =
             Vec::from([AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
@@ -6837,8 +6728,8 @@ mod tests {
         let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
 
         let task_id = random();
-        let reports = Vec::from([new_dummy_report(
-            task_id,
+        let reports = Vec::from([LeaderStoredReport::new_dummy(
+            &task_id,
             // Report associated with the aggregation job is outside the collect job's batch
             // interval
             Time::from_seconds_since_epoch(200),
@@ -6894,7 +6785,10 @@ mod tests {
         let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
 
         let task_id = random();
-        let reports = Vec::from([new_dummy_report(task_id, Time::from_seconds_since_epoch(0))]);
+        let reports = Vec::from([LeaderStoredReport::new_dummy(
+            &task_id,
+            Time::from_seconds_since_epoch(0),
+        )]);
         let aggregation_job_id = random();
         let aggregation_jobs =
             Vec::from([AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
@@ -6949,8 +6843,8 @@ mod tests {
 
         let task_id = random();
         let reports = Vec::from([
-            new_dummy_report(task_id, Time::from_seconds_since_epoch(0)),
-            new_dummy_report(task_id, Time::from_seconds_since_epoch(50)),
+            LeaderStoredReport::new_dummy(&task_id, Time::from_seconds_since_epoch(0)),
+            LeaderStoredReport::new_dummy(&task_id, Time::from_seconds_since_epoch(50)),
         ]);
 
         let aggregation_job_ids: [_; 2] = random();
@@ -7024,7 +6918,10 @@ mod tests {
         let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
 
         let task_id = random();
-        let reports = Vec::from([new_dummy_report(task_id, Time::from_seconds_since_epoch(0))]);
+        let reports = Vec::from([LeaderStoredReport::new_dummy(
+            &task_id,
+            Time::from_seconds_since_epoch(0),
+        )]);
         let aggregation_job_ids: [_; 2] = random();
         let aggregation_jobs = Vec::from([
             AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
@@ -7157,7 +7054,10 @@ mod tests {
         let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
 
         let task_id = random();
-        let reports = Vec::from([new_dummy_report(task_id, Time::from_seconds_since_epoch(0))]);
+        let reports = Vec::from([LeaderStoredReport::new_dummy(
+            &task_id,
+            Time::from_seconds_since_epoch(0),
+        )]);
         let aggregation_job_ids: [_; 3] = random();
         let aggregation_jobs = Vec::from([
             AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
@@ -7762,27 +7662,21 @@ mod tests {
                         report_aggregation_1_2,
                         report_aggregation_1_3,
                     ] {
-                        tx.put_client_report_message(&Report::new(
+                        tx.put_client_report::<0, dummy_vdaf::Vdaf>(&LeaderStoredReport::new(
                             *report_aggregation.task_id(),
                             ReportMetadata::new(
                                 *report_aggregation.report_id(),
                                 *report_aggregation.time(),
                                 Vec::new(),
                             ),
-                            Vec::new(),
-                            // Dummy HpkeCiphertexts for the input shares
-                            vec![
-                                HpkeCiphertext::new(
-                                    HpkeConfigId::from(13),
-                                    Vec::from("encapsulated_context_0"),
-                                    Vec::from("payload_0"),
-                                ),
-                                HpkeCiphertext::new(
-                                    HpkeConfigId::from(13),
-                                    Vec::from("encapsulated_context_1"),
-                                    Vec::from("payload_1"),
-                                ),
-                            ],
+                            (), // Dummy public share
+                            (), // Dummy leader input share
+                            // Dummy helper encrypted input share
+                            HpkeCiphertext::new(
+                                HpkeConfigId::from(13),
+                                Vec::from("encapsulated_context_0"),
+                                Vec::from("payload_0"),
+                            ),
                         ))
                         .await?;
                         tx.put_report_aggregation(report_aggregation).await?;

--- a/aggregator/src/messages.rs
+++ b/aggregator/src/messages.rs
@@ -122,29 +122,3 @@ impl IntervalExt for Interval {
         self.start().add(self.duration()).unwrap()
     }
 }
-
-#[cfg(feature = "test-util")]
-pub mod test_util {
-    use janus_messages::{HpkeCiphertext, HpkeConfigId, Report, ReportMetadata, TaskId, Time};
-    use rand::random;
-
-    pub fn new_dummy_report(task_id: TaskId, when: Time) -> Report {
-        Report::new(
-            task_id,
-            ReportMetadata::new(random(), when, Vec::new()),
-            Vec::new(),
-            vec![
-                HpkeCiphertext::new(
-                    HpkeConfigId::from(13),
-                    Vec::from("encapsulated_context_0"),
-                    Vec::from("payload_0"),
-                ),
-                HpkeCiphertext::new(
-                    HpkeConfigId::from(13),
-                    Vec::from("encapsulated_context_1"),
-                    Vec::from("payload_1"),
-                ),
-            ],
-        )
-    }
-}


### PR DESCRIPTION
Replaces the test-util item that generated dummy
`janus_messages::Report`s with one that generates dummy `janus_aggregator::datastore::models::LeaderStoredReport`s, which is more useful for testing code past the HTTP message handling layer (`Report` is a wire message, not the internal representation of a report). This allows us to delete some redundant methods on `Datastore` for writing reports, because we now consistently are writing `LeaderStoredReport` values.