### PR TITLE
Add missing check to only dump logs on panic

### DIFF
--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -194,25 +194,26 @@ impl<'a> Drop for Janus<'a> {
         // gather up logfiles with `kind export logs`)
 
         if let Janus::Container { role, container } = self {
-            if panicking() {
-                if let Some(mut destination_path) = log_export_path() {
-                    destination_path.push(format!("{}-{}", role, container.id()));
-                    let docker_cp_status = Command::new("docker")
-                        .args([
-                            "cp",
-                            &format!("{}:logs/", container.id()),
-                            destination_path.as_os_str().to_str().unwrap(),
-                        ])
-                        .stdin(Stdio::null())
-                        .stdout(Stdio::null())
-                        .stderr(Stdio::null())
-                        .status()
-                        .expect("Failed to execute `docker cp`");
-                    assert!(
-                        docker_cp_status.success(),
-                        "`docker cp` failed with status {docker_cp_status:?}"
-                    );
-                }
+            if !panicking() {
+                return;
+            }
+            if let Some(mut destination_path) = log_export_path() {
+                destination_path.push(format!("{}-{}", role, container.id()));
+                let docker_cp_status = Command::new("docker")
+                    .args([
+                        "cp",
+                        &format!("{}:logs/", container.id()),
+                        destination_path.as_os_str().to_str().unwrap(),
+                    ])
+                    .stdin(Stdio::null())
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .status()
+                    .expect("Failed to execute `docker cp`");
+                assert!(
+                    docker_cp_status.success(),
+                    "`docker cp` failed with status {docker_cp_status:?}"
+                );
             }
         }
     }

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -22,6 +22,7 @@ use std::{
     path::PathBuf,
     process::Command,
     str::FromStr,
+    thread::panicking,
 };
 use testcontainers::{Container, Image};
 use tracing_log::LogTracer;
@@ -332,37 +333,39 @@ impl<'d, I: Image> ContainerLogsDropGuard<'d, I> {
 
 impl<'d, I: Image> Drop for ContainerLogsDropGuard<'d, I> {
     fn drop(&mut self) {
-        if let Some(base_dir) = log_export_path() {
-            create_dir_all(&base_dir).expect("could not create log output directory");
+        if panicking() {
+            if let Some(base_dir) = log_export_path() {
+                create_dir_all(&base_dir).expect("could not create log output directory");
 
-            let id = self.container.id();
+                let id = self.container.id();
 
-            let inspect_output = Command::new("docker")
-                .args(["container", "inspect", id])
-                .output()
-                .expect("running `docker container inspect` failed");
-            stderr().write_all(&inspect_output.stderr).unwrap();
-            assert!(inspect_output.status.success());
-            let inspect_array: Vec<ContainerInspectEntry> =
-                serde_json::from_slice(&inspect_output.stdout).unwrap();
-            let inspect_entry = inspect_array
-                .first()
-                .expect("`docker container inspect` returned no results");
-            let name = &inspect_entry.name[inspect_entry
-                .name
-                .find('/')
-                .map(|index| index + 1)
-                .unwrap_or_default()..];
+                let inspect_output = Command::new("docker")
+                    .args(["container", "inspect", id])
+                    .output()
+                    .expect("running `docker container inspect` failed");
+                stderr().write_all(&inspect_output.stderr).unwrap();
+                assert!(inspect_output.status.success());
+                let inspect_array: Vec<ContainerInspectEntry> =
+                    serde_json::from_slice(&inspect_output.stdout).unwrap();
+                let inspect_entry = inspect_array
+                    .first()
+                    .expect("`docker container inspect` returned no results");
+                let name = &inspect_entry.name[inspect_entry
+                    .name
+                    .find('/')
+                    .map(|index| index + 1)
+                    .unwrap_or_default()..];
 
-            let destination = base_dir.join(name);
+                let destination = base_dir.join(name);
 
-            let copy_status = Command::new("docker")
-                .arg("cp")
-                .arg(format!("{}:/logs", id))
-                .arg(destination)
-                .status()
-                .expect("running `docker cp` failed");
-            assert!(copy_status.success());
+                let copy_status = Command::new("docker")
+                    .arg("cp")
+                    .arg(format!("{}:/logs", id))
+                    .arg(destination)
+                    .status()
+                    .expect("running `docker cp` failed");
+                assert!(copy_status.success());
+            }
         }
     }
 }


### PR DESCRIPTION
This PR brings `ContainerLogsDropGuard` in line with the Janus and Daphne integration tests, by only exporting logs when the current thread is panicking. I missed this check when implementing this, so interop_binary tests and divviup-ts tests were writing extra logs out from passing tests if `JANUS_E2E_LOG_PATH` was set.