### PR TITLE
Fix propagation of database-related errors

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -22,6 +22,7 @@ use crate::{
     },
     messages::TimeExt,
     task::{self, Task, VerifyKey, PRIO3_AES128_VERIFY_KEY_LENGTH},
+    try_join,
 };
 use bytes::Bytes;
 use http::{
@@ -74,7 +75,7 @@ use std::{
     sync::Arc,
     time::Instant,
 };
-use tokio::{sync::Mutex, try_join};
+use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
 use url::Url;
 use uuid::Uuid;

--- a/aggregator/src/aggregator/aggregate_share.rs
+++ b/aggregator/src/aggregator/aggregate_share.rs
@@ -9,6 +9,7 @@ use crate::{
         Datastore, Transaction,
     },
     task::{Task, PRIO3_AES128_VERIFY_KEY_LENGTH},
+    try_join,
 };
 use derivative::Derivative;
 use futures::future::BoxFuture;
@@ -36,7 +37,6 @@ use prio::{
     },
 };
 use std::sync::Arc;
-use tokio::try_join;
 use tracing::{debug, error, info, warn};
 
 use super::query_type::CollectableQueryType;

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -4,6 +4,7 @@ use crate::{
     },
     datastore::{self, gather_errors, models::OutstandingBatch, Datastore},
     task::{self, Task, PRIO3_AES128_VERIFY_KEY_LENGTH},
+    try_join,
 };
 use anyhow::Result;
 use futures::{future::join_all, FutureExt};
@@ -36,7 +37,6 @@ use tokio::{
     select,
     sync::oneshot::{self, Receiver, Sender},
     time::{self, Instant, MissedTickBehavior},
-    try_join,
 };
 use tracing::{debug, error, info};
 

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -9,6 +9,7 @@ use crate::{
         Datastore,
     },
     task::{self, Task, VerifyKey, PRIO3_AES128_VERIFY_KEY_LENGTH},
+    try_join,
 };
 use anyhow::{anyhow, Context as _, Result};
 use derivative::Derivative;
@@ -36,7 +37,6 @@ use prio::{
     },
 };
 use std::{fmt, sync::Arc};
-use tokio::try_join;
 use tracing::{info, warn};
 
 use super::query_type::AccumulableQueryType;

--- a/aggregator/src/aggregator/query_type.rs
+++ b/aggregator/src/aggregator/query_type.rs
@@ -1,10 +1,10 @@
 use crate::{
-    datastore::{self, models::BatchAggregation, Transaction},
+    datastore::{self, gather_errors, models::BatchAggregation, Transaction},
     messages::TimeExt as _,
     task::Task,
 };
 use async_trait::async_trait;
-use futures::future::try_join_all;
+use futures::future::join_all;
 use janus_core::time::{Clock, TimeExt as _};
 use janus_messages::{
     query_type::{FixedSize, QueryType, TimeInterval},
@@ -80,18 +80,24 @@ pub trait CollectableQueryType: QueryType {
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
         for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Debug,
     {
-        let batch_aggregations = try_join_all(
-            Self::batch_identifiers_for_collect_identifier(task, collect_identifier).map(
-                |batch_identifier| {
-                    let (task_id, aggregation_param) = (*task.id(), aggregation_param.clone());
-                    async move {
-                        tx.get_batch_aggregation(&task_id, &batch_identifier, &aggregation_param)
+        let batch_aggregations = gather_errors(
+            join_all(
+                Self::batch_identifiers_for_collect_identifier(task, collect_identifier).map(
+                    |batch_identifier| {
+                        let (task_id, aggregation_param) = (*task.id(), aggregation_param.clone());
+                        async move {
+                            tx.get_batch_aggregation(
+                                &task_id,
+                                &batch_identifier,
+                                &aggregation_param,
+                            )
                             .await
-                    }
-                },
-            ),
-        )
-        .await?;
+                        }
+                    },
+                ),
+            )
+            .await,
+        )?;
         Ok(batch_aggregations.into_iter().flatten().collect::<Vec<_>>())
     }
 }

--- a/aggregator/src/lib.rs
+++ b/aggregator/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod aggregator;
 pub mod binary_utils;
 pub mod config;
+#[macro_use]
 pub mod datastore;
 pub mod messages;
 pub mod metrics;


### PR DESCRIPTION
This fixes #730 by replacing uses of `futures::future::try_join_all()` and `tokio::try_join!()`. It introduces a free function `gather_errors()` that can be used with `futures::future::join_all()` and a new `try_join!()` macro that wraps `tokio::join!()`. Both of these new code patterns will wait for all futures to complete, and select one error to propagate after seeing all outputs. If any future returns a serialization failure error, that will be returned. If some of the futures return an error indicating the transaction is already in a failed state, those are given a lower priority, because any other error will be more useful for diagnostic purposes.

I tested an earlier version of this change (focused on the aggregation job driver's critical window after talking to the helper) and I was able to run the integration tests for hours in a loop without any failures, so this could fix our last flaky test for now.

I wasn't able to write a straightforward unit test for `datastore::Error::combine()` because `tokio-postgres` doesn't provide any way to synthetically construct its errors. It would be possible to add `#[cfg(test)]`-only variants to `datastore::Error`, check for those in the predicate functions as well, and write a unit test based on that, but I'm not sure if it would be worth the complication.

Please chime in if you have any suggestions for naming improvements or code ergonomics, this could perhaps benefit from some more iteration. I tried writing a replacement `try_join_all()` at first, but I wound up with weird "action at a distance" rustc errors, likely due to a known issue with HRTBs. The `try_join!` macro could perhaps be generalized with some declarative macro tricks like passing around a list of placeholder tokens during recursion, but I decided to go with explicitly writing out cases for two to five arguments just to get things working.