### PR TITLE
Box large error variants

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -185,7 +185,7 @@ pub enum Error {
     /// HTTP server returned an error status code.
     #[error("HTTP response status {problem_details}")]
     Http {
-        problem_details: HttpApiProblem,
+        problem_details: Box<HttpApiProblem>,
         dap_problem_type: Option<DapProblemType>,
     },
     /// An error representing a generic internal aggregation error; intended for "impossible"
@@ -604,7 +604,6 @@ pub struct TaskAggregator {
 impl TaskAggregator {
     /// Create a new aggregator. `report_recipient` is used to decrypt reports received by this
     /// aggregator.
-    #[allow(clippy::result_large_err)]
     fn new(task: Task) -> Result<Self, Error> {
         let vdaf_ops = match task.vdaf() {
             VdafInstance::Prio3Aes128Count => {
@@ -2685,7 +2684,6 @@ where
 const CORS_PREFLIGHT_CACHE_AGE: u32 = 24 * 60 * 60;
 
 /// Constructs a Warp filter with endpoints common to all aggregators.
-#[allow(clippy::result_large_err)]
 pub fn aggregator_filter<C: Clock>(
     datastore: Arc<Datastore<C>>,
     clock: C,
@@ -2910,7 +2908,6 @@ pub fn aggregator_filter<C: Clock>(
 /// If the `SocketAddr`'s `port` is 0, an ephemeral port is used. Returns a
 /// `SocketAddr` representing the address and port the server are listening on
 /// and a future that can be `await`ed to begin serving requests.
-#[allow(clippy::result_large_err)]
 pub fn aggregator_server<C: Clock>(
     datastore: Arc<Datastore<C>>,
     clock: C,
@@ -2994,7 +2991,7 @@ async fn post_to_helper<T: Encode>(
             .as_ref()
             .and_then(|str| str.parse::<DapProblemType>().ok());
         return Err(Error::Http {
-            problem_details,
+            problem_details: Box::new(problem_details),
             dap_problem_type,
         });
     }

--- a/aggregator/src/aggregator/accumulator.rs
+++ b/aggregator/src/aggregator/accumulator.rs
@@ -131,7 +131,6 @@ impl<const L: usize, A: vdaf::Aggregator<L>> Accumulation<L, A>
 where
     for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
 {
-    #[allow(clippy::result_large_err)]
     fn update(&mut self, report_id: &ReportId, output_share: &A::OutputShare) -> Result<(), Error> {
         self.aggregate_share.accumulate(output_share)?;
         self.report_count += 1;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -33,7 +33,7 @@ pub enum Error {
     #[error("codec error: {0}")]
     Codec(#[from] prio::codec::CodecError),
     #[error("HTTP response status {0}")]
-    Http(HttpApiProblem),
+    Http(Box<HttpApiProblem>),
     #[error("URL parse: {0}")]
     Url(#[from] url::ParseError),
     #[error("VDAF error: {0}")]
@@ -102,7 +102,6 @@ impl ClientParameters {
 
     /// The URL relative to which the API endpoints for the aggregator may be
     /// found, if the role is an aggregator, or an error otherwise.
-    #[allow(clippy::result_large_err)]
     fn aggregator_endpoint(&self, role: &Role) -> Result<&Url, Error> {
         Ok(&self.aggregator_endpoints[role
             .index()
@@ -111,14 +110,12 @@ impl ClientParameters {
 
     /// URL from which the HPKE configuration for the server filling `role` may
     /// be fetched per draft-gpew-priv-ppm §4.3.1
-    #[allow(clippy::result_large_err)]
     fn hpke_config_endpoint(&self, role: &Role) -> Result<Url, Error> {
         Ok(self.aggregator_endpoint(role)?.join("hpke_config")?)
     }
 
     /// URL to which reports may be uploaded by clients per draft-gpew-priv-ppm
     /// §4.3.2
-    #[allow(clippy::result_large_err)]
     fn upload_endpoint(&self) -> Result<Url, Error> {
         Ok(self.aggregator_endpoint(&Role::Leader)?.join("upload")?)
     }
@@ -151,9 +148,9 @@ pub async fn aggregator_hpke_config(
     .or_else(|e| e)?;
     let status = hpke_config_response.status();
     if !status.is_success() {
-        return Err(Error::Http(
+        return Err(Error::Http(Box::new(
             response_to_problem_details(hpke_config_response).await,
-        ));
+        )));
     }
 
     Ok(HpkeConfig::decode(&mut Cursor::new(
@@ -162,7 +159,6 @@ pub async fn aggregator_hpke_config(
 }
 
 /// Construct a [`reqwest::Client`] suitable for use in a DAP [`Client`].
-#[allow(clippy::result_large_err)]
 pub fn default_http_client() -> Result<reqwest::Client, Error> {
     Ok(reqwest::Client::builder()
         .user_agent(CLIENT_USER_AGENT)
@@ -207,7 +203,6 @@ where
 
     /// Shard a measurement, encrypt its shares, and construct a [`janus_core::message::Report`]
     /// to be uploaded.
-    #[allow(clippy::result_large_err)]
     fn prepare_report(&self, measurement: &V::Measurement) -> Result<Report, Error> {
         let (public_share, input_shares) = self.vdaf_client.shard(measurement)?;
         assert_eq!(input_shares.len(), 2); // DAP only supports VDAFs using two aggregators.
@@ -275,9 +270,9 @@ where
         .or_else(|e| e)?;
         let status = upload_response.status();
         if !status.is_success() {
-            return Err(Error::Http(
+            return Err(Error::Http(Box::new(
                 response_to_problem_details(upload_response).await,
-            ));
+            )));
         }
 
         Ok(())


### PR DESCRIPTION
This wraps the contents of two kinds of error variants in boxes, to reduce stack memory usage and non-inlined `memcpy`s. Each `HttpApiProblem` is now boxed, and the contents of `janus_aggregator::aggregator::Error::BatchMismatch` are moved into a new struct and boxed. Thus, we no longer need to ignore `clippy::result_large_err`.

With these changes `janus_aggregator::aggregator::Error` is 72 bytes (down from 160), `janus_client::Error` is 32 bytes (down from from 160), and `janus_collector::Error` is 40 bytes.

Closes #713