### PR TITLE
Fixed-size tasks: implement leader collection.

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1,15 +1,15 @@
 //! Common functionality for DAP aggregators.
 
 pub mod accumulator;
-pub mod aggregate_share;
 pub mod aggregation_job_creator;
 pub mod aggregation_job_driver;
+pub mod collect_job_driver;
 pub mod query_type;
 
 use crate::{
     aggregator::{
         accumulator::Accumulator,
-        aggregate_share::{compute_aggregate_share, validate_batch_query_count_for_collect},
+        collect_job_driver::{compute_aggregate_share, validate_batch_query_count_for_collect},
         query_type::CollectableQueryType,
     },
     datastore::{
@@ -1916,7 +1916,7 @@ impl VdafOps {
                     }
 
                     let collect_job_id = Uuid::new_v4();
-                    tx.put_collect_job(&CollectJob::new(
+                    tx.put_collect_job(&CollectJob::<L, TimeInterval, A>::new(
                         *req.task_id(),
                         collect_job_id,
                         *req.query().batch_interval(),
@@ -2002,7 +2002,7 @@ impl VdafOps {
             .run_tx(|tx| {
                 let collect_job_id = Arc::clone(&collect_job_id);
                 Box::pin(async move {
-                    tx.get_collect_job::<L, A>(&collect_job_id)
+                    tx.get_collect_job::<L, TimeInterval, A>(&collect_job_id)
                         .await?
                         .ok_or_else(|| {
                             datastore::Error::User(
@@ -2145,7 +2145,7 @@ impl VdafOps {
             .run_tx(move |tx| {
                 Box::pin(async move {
                     let collect_job = tx
-                        .get_collect_job::<L, A>(&collect_job_id)
+                        .get_collect_job::<L, TimeInterval, A>(&collect_job_id)
                         .await?
                         .ok_or_else(|| {
                             datastore::Error::User(
@@ -2154,7 +2154,7 @@ impl VdafOps {
                         })?;
 
                     if collect_job.state() != &CollectJobState::Deleted {
-                        tx.update_collect_job::<L, A>(
+                        tx.update_collect_job::<L, TimeInterval, A>(
                             &collect_job.with_state(CollectJobState::Deleted),
                         )
                         .await?;
@@ -2242,11 +2242,14 @@ impl VdafOps {
                 Box::pin(async move {
                     // Check if we have already serviced an aggregate share request with these
                     // parameters and serve the cached results if so.
+                    let aggregation_param = A::AggregationParam::get_decoded(
+                        aggregate_share_req.aggregation_parameter(),
+                    )?;
                     let aggregate_share_job = match tx
                         .get_aggregate_share_job(
                             aggregate_share_req.task_id(),
                             aggregate_share_req.batch_selector().batch_interval(),
-                            aggregate_share_req.aggregation_parameter(),
+                            &aggregation_param,
                         )
                         .await?
                     {
@@ -3824,12 +3827,16 @@ mod tests {
             .run_tx(|tx| {
                 let task = task.clone();
                 Box::pin(async move {
-                    tx.put_collect_job(&CollectJob::new(
+                    tx.put_collect_job(&CollectJob::<
+                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        TimeInterval,
+                        Prio3Aes128Count,
+                    >::new(
                         *task.id(),
                         Uuid::new_v4(),
                         batch_interval,
                         (),
-                        CollectJobState::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>::Start,
+                        CollectJobState::Start,
                     ))
                     .await
                 })
@@ -6696,7 +6703,7 @@ mod tests {
                     .unwrap();
 
                     let collect_job = tx
-                        .get_collect_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                        .get_collect_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>(
                             &collect_job_id,
                         )
                         .await
@@ -6708,7 +6715,7 @@ mod tests {
                             leader_aggregate_share,
                         });
 
-                    tx.update_collect_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                    tx.update_collect_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>(
                         &collect_job,
                     )
                     .await

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -1281,7 +1281,7 @@ mod tests {
                 let task = Arc::clone(&task);
                 Box::pin(async move {
                     // This will encompass the members of batch_2_reports.
-                    tx.put_collect_job::<0, dummy_vdaf::Vdaf>(&CollectJob::new(
+                    tx.put_collect_job::<0, TimeInterval, dummy_vdaf::Vdaf>(&CollectJob::new(
                         *task.id(),
                         Uuid::new_v4(),
                         Interval::new(report_time, *task.time_precision()).unwrap(),
@@ -1290,7 +1290,7 @@ mod tests {
                     ))
                     .await?;
                     // This will encompass the members of both batch_1_reports and batch_2_reports.
-                    tx.put_collect_job::<0, dummy_vdaf::Vdaf>(&CollectJob::new(
+                    tx.put_collect_job::<0, TimeInterval, dummy_vdaf::Vdaf>(&CollectJob::new(
                         *task.id(),
                         Uuid::new_v4(),
                         Interval::new(

--- a/aggregator/src/aggregator/collect_job_driver.rs
+++ b/aggregator/src/aggregator/collect_job_driver.rs
@@ -1,5 +1,6 @@
 //! Implements portions of collect sub-protocol for DAP leader and helper.
 
+use super::query_type::CollectableQueryType;
 use crate::{
     aggregator::{post_to_helper, Error},
     datastore::{
@@ -8,7 +9,7 @@ use crate::{
         models::{BatchAggregation, CollectJobState, Lease},
         Datastore, Transaction,
     },
-    task::{Task, PRIO3_AES128_VERIFY_KEY_LENGTH},
+    task::{self, Task, PRIO3_AES128_VERIFY_KEY_LENGTH},
 };
 use derivative::Derivative;
 use futures::future::BoxFuture;
@@ -16,7 +17,7 @@ use futures::future::BoxFuture;
 use janus_core::test_util::dummy_vdaf;
 use janus_core::{report_id::ReportIdChecksumExt, task::VdafInstance, time::Clock};
 use janus_messages::{
-    query_type::{QueryType, TimeInterval},
+    query_type::{FixedSize, QueryType, TimeInterval},
     AggregateShareReq, AggregateShareResp, BatchSelector, Duration, Interval, ReportIdChecksum,
     Role,
 };
@@ -38,73 +39,6 @@ use prio::{
 use std::sync::Arc;
 use tokio::try_join;
 use tracing::{debug, error, info, warn};
-
-use super::query_type::CollectableQueryType;
-
-/// Holds various metrics instruments for a collect job driver.
-#[derive(Clone)]
-struct CollectJobDriverMetrics {
-    jobs_finished_counter: Counter<u64>,
-    http_request_duration_histogram: Histogram<f64>,
-    jobs_abandoned_counter: Counter<u64>,
-    jobs_already_finished_counter: Counter<u64>,
-    deleted_jobs_encountered_counter: Counter<u64>,
-    unexpected_job_state_counter: Counter<u64>,
-}
-
-impl CollectJobDriverMetrics {
-    fn new(meter: &Meter) -> Self {
-        let jobs_finished_counter = meter
-            .u64_counter("janus_collect_jobs_finished")
-            .with_description("Count of finished collect jobs.")
-            .init();
-        jobs_finished_counter.add(&Context::current(), 0, &[]);
-
-        let http_request_duration_histogram = meter
-            .f64_histogram("janus_http_request_duration_seconds")
-            .with_description(
-                "The amount of time elapsed while making an HTTP request to a helper.",
-            )
-            .with_unit(Unit::new("seconds"))
-            .init();
-
-        let jobs_abandoned_counter = meter
-            .u64_counter("janus_collect_jobs_abandoned")
-            .with_description("Count of abandoned collect jobs.")
-            .init();
-        jobs_abandoned_counter.add(&Context::current(), 0, &[]);
-
-        let jobs_already_finished_counter = meter
-            .u64_counter("janus_collect_jobs_already_finished")
-            .with_description(
-                "Count of collect jobs for which a lease was acquired but were already finished.",
-            )
-            .init();
-        jobs_already_finished_counter.add(&Context::current(), 0, &[]);
-
-        let deleted_jobs_encountered_counter = meter
-            .u64_counter("janus_collect_deleted_jobs_encountered")
-            .with_description(
-                "Count of collect jobs that were run to completion but found to have been deleted.",
-            )
-            .init();
-        deleted_jobs_encountered_counter.add(&Context::current(), 0, &[]);
-
-        let unexpected_job_state_counter = meter
-            .u64_counter("janus_collect_unexpected_job_state")
-            .with_description("Count of collect jobs that were run to completion but found in an unexpected state.").init();
-        unexpected_job_state_counter.add(&Context::current(), 0, &[]);
-
-        Self {
-            jobs_finished_counter,
-            http_request_duration_histogram,
-            jobs_abandoned_counter,
-            jobs_already_finished_counter,
-            deleted_jobs_encountered_counter,
-            unexpected_job_state_counter,
-        }
-    }
-}
 
 /// Drives a collect job.
 #[derive(Derivative)]
@@ -141,33 +75,33 @@ impl CollectJobDriver {
         datastore: Arc<Datastore<C>>,
         lease: Arc<Lease<AcquiredCollectJob>>,
     ) -> Result<(), Error> {
-        match lease.leased().vdaf() {
-            VdafInstance::Prio3Aes128Count => {
-                self.step_collect_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, Prio3Aes128Count>(
+        match (lease.leased().query_type(), lease.leased().vdaf()) {
+            (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128Count) => {
+                self.step_collect_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, TimeInterval, Prio3Aes128Count>(
                     datastore,
                     lease
                 )
                 .await
             }
 
-            VdafInstance::Prio3Aes128CountVec { .. } => {
-                self.step_collect_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, Prio3Aes128CountVecMultithreaded>(
+            (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128CountVec { .. }) => {
+                self.step_collect_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, TimeInterval, Prio3Aes128CountVecMultithreaded>(
                     datastore,
                     lease
                 )
                 .await
             }
 
-            VdafInstance::Prio3Aes128Sum { .. } => {
-                self.step_collect_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, Prio3Aes128Sum>(
+            (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128Sum { .. }) => {
+                self.step_collect_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, TimeInterval, Prio3Aes128Sum>(
                     datastore,
                     lease
                 )
                 .await
             }
 
-            VdafInstance::Prio3Aes128Histogram { .. } => {
-                self.step_collect_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, Prio3Aes128Histogram>(
+            (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128Histogram { .. }) => {
+                self.step_collect_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, TimeInterval, Prio3Aes128Histogram>(
                     datastore,
                     lease,
                 )
@@ -175,20 +109,67 @@ impl CollectJobDriver {
             }
 
             #[cfg(feature = "test-util")]
-            VdafInstance::Fake => {
-                self.step_collect_job_generic::<0, C, dummy_vdaf::Vdaf>(
+            (task::QueryType::TimeInterval, VdafInstance::Fake) => {
+                self.step_collect_job_generic::<0, C, TimeInterval, dummy_vdaf::Vdaf>(
                     datastore,
                     lease,
                 )
                 .await
             }
 
+            (task::QueryType::FixedSize{..}, VdafInstance::Prio3Aes128Count) => {
+                self.step_collect_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, FixedSize, Prio3Aes128Count>(
+                    datastore,
+                    lease
+                )
+                .await
+            }
+
+            (task::QueryType::FixedSize{..}, VdafInstance::Prio3Aes128CountVec { .. }) => {
+                self.step_collect_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, FixedSize, Prio3Aes128CountVecMultithreaded>(
+                    datastore,
+                    lease
+                )
+                .await
+            }
+
+            (task::QueryType::FixedSize{..}, VdafInstance::Prio3Aes128Sum { .. }) => {
+                self.step_collect_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, FixedSize, Prio3Aes128Sum>(
+                    datastore,
+                    lease
+                )
+                .await
+            }
+
+            (task::QueryType::FixedSize{..}, VdafInstance::Prio3Aes128Histogram { .. }) => {
+                self.step_collect_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, FixedSize, Prio3Aes128Histogram>(
+                    datastore,
+                    lease,
+                )
+                .await
+            }
+
+            #[cfg(feature = "test-util")]
+            (task::QueryType::FixedSize{..}, VdafInstance::Fake) => {
+                self.step_collect_job_generic::<0, C, FixedSize, dummy_vdaf::Vdaf>(
+                    datastore,
+                    lease,
+                )
+                .await
+            }
+
+
             _ => panic!("VDAF {:?} is not yet supported", lease.leased().vdaf()),
         }
     }
 
     #[tracing::instrument(skip(self, datastore), err)]
-    async fn step_collect_job_generic<const L: usize, C: Clock, A: vdaf::Aggregator<L>>(
+    async fn step_collect_job_generic<
+        const L: usize,
+        C: Clock,
+        Q: CollectableQueryType,
+        A: vdaf::Aggregator<L>,
+    >(
         &self,
         datastore: Arc<Datastore<C>>,
         lease: Arc<Lease<AcquiredCollectJob>>,
@@ -219,7 +200,7 @@ impl CollectJobDriver {
                         })?;
 
                     let collect_job = tx
-                        .get_collect_job::<L, A>(lease.leased().collect_job_id())
+                        .get_collect_job::<L, Q, A>(lease.leased().collect_job_id())
                         .await?
                         .ok_or_else(|| {
                             datastore::Error::User(
@@ -228,14 +209,13 @@ impl CollectJobDriver {
                             )
                         })?;
 
-                    let batch_aggregations =
-                        TimeInterval::get_batch_aggregations_for_collect_identifier(
-                            tx,
-                            &task,
-                            collect_job.batch_interval(),
-                            collect_job.aggregation_parameter(),
-                        )
-                        .await?;
+                    let batch_aggregations = Q::get_batch_aggregations_for_collect_identifier(
+                        tx,
+                        &task,
+                        collect_job.batch_identifier(),
+                        collect_job.aggregation_parameter(),
+                    )
+                    .await?;
 
                     Ok((task, collect_job, batch_aggregations))
                 })
@@ -251,14 +231,14 @@ impl CollectJobDriver {
         }
 
         let (leader_aggregate_share, report_count, checksum) =
-            compute_aggregate_share::<L, TimeInterval, A>(&task, &batch_aggregations)
+            compute_aggregate_share::<L, Q, A>(&task, &batch_aggregations)
                 .await
                 .map_err(|e| datastore::Error::User(e.into()))?;
 
         // Send an aggregate share request to the helper.
-        let req = AggregateShareReq::new(
+        let req = AggregateShareReq::<Q>::new(
             *task.id(),
-            BatchSelector::new_time_interval(*collect_job.batch_interval()),
+            BatchSelector::new(collect_job.batch_identifier().clone()),
             collect_job.aggregation_parameter().get_encoded(),
             report_count,
             checksum,
@@ -293,7 +273,7 @@ impl CollectJobDriver {
 
                 Box::pin(async move {
                     let maybe_updated_collect_job = tx
-                        .get_collect_job::<L, A>(collect_job.collect_job_id())
+                        .get_collect_job::<L, Q, A>(collect_job.collect_job_id())
                         .await?
                         .ok_or_else(|| {
                             datastore::Error::User(
@@ -303,7 +283,7 @@ impl CollectJobDriver {
 
                     match maybe_updated_collect_job.state() {
                         CollectJobState::Start => {
-                            tx.update_collect_job::<L, A>(&collect_job).await?;
+                            tx.update_collect_job::<L, Q, A>(&collect_job).await?;
                             tx.release_collect_job(&lease).await?;
                             metrics.jobs_finished_counter.add(&Context::current(), 1, &[]);
                         }
@@ -345,33 +325,33 @@ impl CollectJobDriver {
         datastore: Arc<Datastore<C>>,
         lease: Lease<AcquiredCollectJob>,
     ) -> Result<(), Error> {
-        match lease.leased().vdaf() {
-            VdafInstance::Prio3Aes128Count => {
-                self.abandon_collect_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, Prio3Aes128Count>(
+        match (lease.leased().query_type(), lease.leased().vdaf()) {
+            (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128Count) => {
+                self.abandon_collect_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, TimeInterval, Prio3Aes128Count>(
                     datastore,
                     lease
                 )
                 .await
             }
 
-            VdafInstance::Prio3Aes128CountVec { .. } => {
-                self.abandon_collect_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, Prio3Aes128CountVecMultithreaded>(
+            (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128CountVec{..}) => {
+                self.abandon_collect_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, TimeInterval, Prio3Aes128CountVecMultithreaded>(
                     datastore,
                     lease
                 )
                 .await
             }
 
-            VdafInstance::Prio3Aes128Sum { .. } => {
-                self.abandon_collect_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, Prio3Aes128Sum>(
+            (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128Sum{..}) => {
+                self.abandon_collect_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, TimeInterval, Prio3Aes128Sum>(
                     datastore,
                     lease
                 )
                 .await
             }
 
-            VdafInstance::Prio3Aes128Histogram { .. } => {
-                self.abandon_collect_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, Prio3Aes128Histogram>(
+            (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128Histogram{..}) => {
+                self.abandon_collect_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, TimeInterval, Prio3Aes128Histogram>(
                     datastore,
                     lease,
                 )
@@ -379,26 +359,71 @@ impl CollectJobDriver {
             }
 
             #[cfg(feature = "test-util")]
-            VdafInstance::Fake => {
-                self.abandon_collect_job_generic::<0, C, dummy_vdaf::Vdaf>(
+            (task::QueryType::TimeInterval, VdafInstance::Fake) => {
+                self.abandon_collect_job_generic::<0, C, TimeInterval, dummy_vdaf::Vdaf>(
                     datastore,
                     lease,
                 )
                 .await
             }
 
+            (task::QueryType::FixedSize{..}, VdafInstance::Prio3Aes128Count) => {
+                self.abandon_collect_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, FixedSize, Prio3Aes128Count>(
+                    datastore,
+                    lease
+                )
+                .await
+            }
+
+            (task::QueryType::FixedSize{..}, VdafInstance::Prio3Aes128CountVec{..}) => {
+                self.abandon_collect_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, FixedSize, Prio3Aes128CountVecMultithreaded>(
+                    datastore,
+                    lease
+                )
+                .await
+            }
+
+            (task::QueryType::FixedSize{..}, VdafInstance::Prio3Aes128Sum{..}) => {
+                self.abandon_collect_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, FixedSize, Prio3Aes128Sum>(
+                    datastore,
+                    lease
+                )
+                .await
+            }
+
+            (task::QueryType::FixedSize{..}, VdafInstance::Prio3Aes128Histogram{..}) => {
+                self.abandon_collect_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, FixedSize, Prio3Aes128Histogram>(
+                    datastore,
+                    lease,
+                )
+                .await
+            }
+
+            #[cfg(feature = "test-util")]
+            (task::QueryType::FixedSize{..}, VdafInstance::Fake) => {
+                self.abandon_collect_job_generic::<0, C, FixedSize, dummy_vdaf::Vdaf>(
+                    datastore,
+                    lease,
+                )
+                .await
+            }
+
+
             _ => panic!("VDAF {:?} is not yet supported", lease.leased().vdaf()),
         }
     }
 
-    async fn abandon_collect_job_generic<const L: usize, C, A>(
+    async fn abandon_collect_job_generic<
+        const L: usize,
+        C: Clock,
+        Q: QueryType,
+        A: vdaf::Aggregator<L>,
+    >(
         &self,
         datastore: Arc<Datastore<C>>,
         lease: Lease<AcquiredCollectJob>,
     ) -> Result<(), Error>
     where
-        C: Clock,
-        A: vdaf::Aggregator<L> + 'static,
         A::AggregationParam: Send + Sync,
         A::AggregateShare: Send + Sync,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
@@ -410,7 +435,7 @@ impl CollectJobDriver {
                 let lease = Arc::clone(&lease);
                 Box::pin(async move {
                     let collect_job = tx
-                        .get_collect_job::<L, A>(lease.leased().collect_job_id())
+                        .get_collect_job::<L, Q, A>(lease.leased().collect_job_id())
                         .await?
                         .ok_or_else(|| {
                             datastore::Error::DbState(format!(
@@ -478,6 +503,71 @@ impl CollectJobDriver {
                 this.step_collect_job(datastore, Arc::new(collect_job_lease))
                     .await
             })
+        }
+    }
+}
+
+/// Holds various metrics instruments for a collect job driver.
+#[derive(Clone)]
+struct CollectJobDriverMetrics {
+    jobs_finished_counter: Counter<u64>,
+    http_request_duration_histogram: Histogram<f64>,
+    jobs_abandoned_counter: Counter<u64>,
+    jobs_already_finished_counter: Counter<u64>,
+    deleted_jobs_encountered_counter: Counter<u64>,
+    unexpected_job_state_counter: Counter<u64>,
+}
+
+impl CollectJobDriverMetrics {
+    fn new(meter: &Meter) -> Self {
+        let jobs_finished_counter = meter
+            .u64_counter("janus_collect_jobs_finished")
+            .with_description("Count of finished collect jobs.")
+            .init();
+        jobs_finished_counter.add(&Context::current(), 0, &[]);
+
+        let http_request_duration_histogram = meter
+            .f64_histogram("janus_http_request_duration_seconds")
+            .with_description(
+                "The amount of time elapsed while making an HTTP request to a helper.",
+            )
+            .with_unit(Unit::new("seconds"))
+            .init();
+
+        let jobs_abandoned_counter = meter
+            .u64_counter("janus_collect_jobs_abandoned")
+            .with_description("Count of abandoned collect jobs.")
+            .init();
+        jobs_abandoned_counter.add(&Context::current(), 0, &[]);
+
+        let jobs_already_finished_counter = meter
+            .u64_counter("janus_collect_jobs_already_finished")
+            .with_description(
+                "Count of collect jobs for which a lease was acquired but were already finished.",
+            )
+            .init();
+        jobs_already_finished_counter.add(&Context::current(), 0, &[]);
+
+        let deleted_jobs_encountered_counter = meter
+            .u64_counter("janus_collect_deleted_jobs_encountered")
+            .with_description(
+                "Count of collect jobs that were run to completion but found to have been deleted.",
+            )
+            .init();
+        deleted_jobs_encountered_counter.add(&Context::current(), 0, &[]);
+
+        let unexpected_job_state_counter = meter
+            .u64_counter("janus_collect_unexpected_job_state")
+            .with_description("Count of collect jobs that were run to completion but found in an unexpected state.").init();
+        unexpected_job_state_counter.add(&Context::current(), 0, &[]);
+
+        Self {
+            jobs_finished_counter,
+            http_request_duration_histogram,
+            jobs_abandoned_counter,
+            jobs_already_finished_counter,
+            deleted_jobs_encountered_counter,
+            unexpected_job_state_counter,
         }
     }
 }
@@ -628,7 +718,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::{
-        aggregator::{aggregate_share::CollectJobDriver, DapProblemType, Error},
+        aggregator::{collect_job_driver::CollectJobDriver, DapProblemType, Error},
         binary_utils::job_driver::JobDriver,
         datastore::{
             models::{
@@ -671,7 +761,7 @@ mod tests {
         acquire_lease: bool,
     ) -> (
         Option<Lease<AcquiredCollectJob>>,
-        CollectJob<0, dummy_vdaf::Vdaf>,
+        CollectJob<0, TimeInterval, dummy_vdaf::Vdaf>,
     ) {
         let time_precision = Duration::from_seconds(500);
         let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Leader)
@@ -685,7 +775,7 @@ mod tests {
         let batch_interval = Interval::new(clock.now(), Duration::from_seconds(2000)).unwrap();
         let aggregation_param = AggregationParam(0);
 
-        let collect_job = CollectJob::new(
+        let collect_job = CollectJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
             *task.id(),
             Uuid::new_v4(),
             batch_interval,
@@ -699,7 +789,7 @@ mod tests {
                 Box::pin(async move {
                     tx.put_task(&task).await?;
 
-                    tx.put_collect_job::<0, dummy_vdaf::Vdaf>(&collect_job)
+                    tx.put_collect_job::<0, TimeInterval, dummy_vdaf::Vdaf>(&collect_job)
                         .await?;
 
                     let aggregation_job_id = random();
@@ -827,12 +917,12 @@ mod tests {
                     tx.put_task(&task).await?;
 
                     let collect_job_id = Uuid::new_v4();
-                    tx.put_collect_job(&CollectJob::new(
+                    tx.put_collect_job(&CollectJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
                         *task.id(),
                         collect_job_id,
                         batch_interval,
                         aggregation_param,
-                        CollectJobState::<0, dummy_vdaf::Vdaf>::Start,
+                        CollectJobState::Start,
                     ))
                     .await?;
 
@@ -995,7 +1085,7 @@ mod tests {
         ds.run_tx(|tx| {
             Box::pin(async move {
                 let collect_job = tx
-                    .get_collect_job::<0, dummy_vdaf::Vdaf>(&collect_job_id)
+                    .get_collect_job::<0, TimeInterval, dummy_vdaf::Vdaf>(&collect_job_id)
                     .await
                     .unwrap()
                     .unwrap();
@@ -1040,7 +1130,7 @@ mod tests {
             let helper_aggregate_share = helper_response.encrypted_aggregate_share().clone();
             Box::pin(async move {
                 let collect_job = tx
-                    .get_collect_job::<0, dummy_vdaf::Vdaf>(&collect_job_id)
+                    .get_collect_job::<0, TimeInterval, dummy_vdaf::Vdaf>(&collect_job_id)
                     .await
                     .unwrap()
                     .unwrap();
@@ -1089,7 +1179,9 @@ mod tests {
                 let collect_job = collect_job.clone();
                 Box::pin(async move {
                     let abandoned_collect_job = tx
-                        .get_collect_job::<0, dummy_vdaf::Vdaf>(collect_job.collect_job_id())
+                        .get_collect_job::<0, TimeInterval, dummy_vdaf::Vdaf>(
+                            collect_job.collect_job_id(),
+                        )
                         .await?
                         .unwrap();
 
@@ -1179,8 +1271,10 @@ mod tests {
             .run_tx(|tx| {
                 let collect_job = collect_job.clone();
                 Box::pin(async move {
-                    tx.get_collect_job::<0, dummy_vdaf::Vdaf>(collect_job.collect_job_id())
-                        .await
+                    tx.get_collect_job::<0, TimeInterval, dummy_vdaf::Vdaf>(
+                        collect_job.collect_job_id(),
+                    )
+                    .await
                 })
             })
             .await
@@ -1208,7 +1302,7 @@ mod tests {
         ds.run_tx(|tx| {
             let collect_job = collect_job.clone();
             Box::pin(async move {
-                tx.update_collect_job::<0, dummy_vdaf::Vdaf>(&collect_job)
+                tx.update_collect_job::<0, TimeInterval, dummy_vdaf::Vdaf>(&collect_job)
                     .await
             })
         })
@@ -1247,7 +1341,9 @@ mod tests {
             let collect_job = collect_job.clone();
             Box::pin(async move {
                 let collect_job = tx
-                    .get_collect_job::<0, dummy_vdaf::Vdaf>(collect_job.collect_job_id())
+                    .get_collect_job::<0, TimeInterval, dummy_vdaf::Vdaf>(
+                        collect_job.collect_job_id(),
+                    )
                     .await
                     .unwrap()
                     .unwrap();

--- a/aggregator/src/aggregator/query_type.rs
+++ b/aggregator/src/aggregator/query_type.rs
@@ -62,6 +62,11 @@ pub trait CollectableQueryType: QueryType {
         collect_identifier: &Self::BatchIdentifier,
     ) -> Self::Iter;
 
+    /// Some query types (e.g. [`TimeInterval`]) can represent their batch identifiers as an
+    /// interval. This method extracts the interval from such identifiers, or returns `None` if the
+    /// query type does not represent batch identifiers as an interval.
+    fn to_batch_interval(collect_identifier: &Self::BatchIdentifier) -> Option<&Interval>;
+
     /// Retrieves batch aggregations corresponding to all batches identified by the given collect
     /// identifier.
     async fn get_batch_aggregations_for_collect_identifier<
@@ -104,6 +109,10 @@ impl CollectableQueryType for TimeInterval {
         batch_interval: &Self::BatchIdentifier,
     ) -> Self::Iter {
         TimeIntervalBatchIdentifierIter::new(task, batch_interval)
+    }
+
+    fn to_batch_interval(collect_identifier: &Self::BatchIdentifier) -> Option<&Interval> {
+        Some(collect_identifier)
     }
 }
 
@@ -170,5 +179,9 @@ impl CollectableQueryType for FixedSize {
         batch_id: &Self::BatchIdentifier,
     ) -> Self::Iter {
         iter::once(*batch_id)
+    }
+
+    fn to_batch_interval(_: &Self::BatchIdentifier) -> Option<&Interval> {
+        None
     }
 }

--- a/aggregator/src/bin/collect_job_driver.rs
+++ b/aggregator/src/bin/collect_job_driver.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use clap::Parser;
 use janus_aggregator::{
-    aggregator::aggregate_share::CollectJobDriver,
+    aggregator::collect_job_driver::CollectJobDriver,
     binary_utils::{
         janus_main, job_driver::JobDriver, setup_signal_handler, BinaryOptions, CommonBinaryOptions,
     },

--- a/aggregator/src/datastore.rs
+++ b/aggregator/src/datastore.rs
@@ -3259,7 +3259,7 @@ pub mod models {
             &self.collect_job_id
         }
 
-        /// Returns the query type associated with this acquired aggregation job.
+        /// Returns the query type associated with this acquired collect job.
         pub fn query_type(&self) -> &task::QueryType {
             &self.query_type
         }

--- a/aggregator/src/datastore.rs
+++ b/aggregator/src/datastore.rs
@@ -9,6 +9,7 @@ use self::models::{
 #[cfg(test)]
 use crate::aggregator::aggregation_job_creator::VdafHasAggregationParameter;
 use crate::{
+    aggregator::query_type::CollectableQueryType,
     messages::TimeExt,
     task::{self, Task},
     SecretBytes,
@@ -23,9 +24,9 @@ use janus_core::{
 #[cfg(test)]
 use janus_messages::Report;
 use janus_messages::{
-    query_type::QueryType, AggregationJobId, BatchId, Duration, Extension, HpkeCiphertext,
-    HpkeConfig, Interval, ReportId, ReportIdChecksum, ReportMetadata, ReportShare, Role, TaskId,
-    Time,
+    query_type::{QueryType, TimeInterval},
+    AggregationJobId, BatchId, Duration, Extension, HpkeCiphertext, HpkeConfig, Interval, ReportId,
+    ReportIdChecksum, ReportMetadata, ReportShare, Role, TaskId, Time,
 };
 use opentelemetry::{metrics::Counter, Context, KeyValue};
 use postgres_types::{Json, ToSql};
@@ -1649,10 +1650,10 @@ impl<C: Clock> Transaction<'_, C> {
 
     /// Returns the collect job for the provided UUID, or `None` if no such collect job exists.
     #[tracing::instrument(skip(self), err)]
-    pub async fn get_collect_job<const L: usize, A: vdaf::Aggregator<L>>(
+    pub async fn get_collect_job<const L: usize, Q: QueryType, A: vdaf::Aggregator<L>>(
         &self,
         collect_job_id: &Uuid,
-    ) -> Result<Option<CollectJob<L, A>>, Error>
+    ) -> Result<Option<CollectJob<L, Q, A>>, Error>
     where
         for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Debug,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
@@ -1662,7 +1663,7 @@ impl<C: Clock> Transaction<'_, C> {
             .prepare_cached(
                 "SELECT
                     tasks.task_id,
-                    collect_jobs.batch_interval,
+                    collect_jobs.batch_identifier,
                     collect_jobs.aggregation_param,
                     collect_jobs.state,
                     collect_jobs.report_count,
@@ -1720,12 +1721,13 @@ impl<C: Clock> Transaction<'_, C> {
         Ok(row.map(|row| row.get("collect_job_id")))
     }
 
-    /// Returns all collect jobs for the given task which include the given timestamp.
+    /// Returns all collect jobs for the given task which include the given timestamp. Applies only
+    /// to time-interval tasks.
     pub async fn get_collect_jobs_including_time<const L: usize, A: vdaf::Aggregator<L>>(
         &self,
         task_id: &TaskId,
         timestamp: &Time,
-    ) -> Result<Vec<CollectJob<L, A>>, Error>
+    ) -> Result<Vec<CollectJob<L, TimeInterval, A>>, Error>
     where
         for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Debug,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
@@ -1735,7 +1737,7 @@ impl<C: Clock> Transaction<'_, C> {
             .prepare_cached(
                 "SELECT
                     collect_jobs.collect_job_id,
-                    collect_jobs.batch_interval,
+                    collect_jobs.batch_identifier,
                     collect_jobs.aggregation_param,
                     collect_jobs.state,
                     collect_jobs.report_count,
@@ -1750,7 +1752,7 @@ impl<C: Clock> Transaction<'_, C> {
             .query(
                 &stmt,
                 &[
-                    /* task_id */ &task_id.as_ref(),
+                    /* task_id */ task_id.as_ref(),
                     /* timestamp */ &timestamp.as_naive_date_time(),
                 ],
             )
@@ -1764,15 +1766,15 @@ impl<C: Clock> Transaction<'_, C> {
     }
 
     /// Returns all collect jobs for the given task whose collect intervals intersect with the given
-    /// interval.
+    /// interval. Applies only to time-interval tasks.
     pub async fn get_collect_jobs_jobs_intersecting_interval<
         const L: usize,
         A: vdaf::Aggregator<L>,
     >(
         &self,
         task_id: &TaskId,
-        interval: &Interval,
-    ) -> Result<Vec<CollectJob<L, A>>, Error>
+        batch_interval: &Interval,
+    ) -> Result<Vec<CollectJob<L, TimeInterval, A>>, Error>
     where
         for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Debug,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
@@ -1782,7 +1784,7 @@ impl<C: Clock> Transaction<'_, C> {
             .prepare_cached(
                 "SELECT
                     collect_jobs.collect_job_id,
-                    collect_jobs.batch_interval,
+                    collect_jobs.batch_identifier,
                     collect_jobs.aggregation_param,
                     collect_jobs.state,
                     collect_jobs.report_count,
@@ -1797,8 +1799,8 @@ impl<C: Clock> Transaction<'_, C> {
             .query(
                 &stmt,
                 &[
-                    /* task_id */ &task_id.as_ref(),
-                    /* collect_jobs.batch_interval */ &SqlInterval::from(interval),
+                    /* task_id */ task_id.as_ref(),
+                    /* batch_interval */ &SqlInterval::from(batch_interval),
                 ],
             )
             .await?
@@ -1810,17 +1812,16 @@ impl<C: Clock> Transaction<'_, C> {
             .collect()
     }
 
-    fn collect_job_from_row<const L: usize, A: vdaf::Aggregator<L>>(
+    fn collect_job_from_row<const L: usize, Q: QueryType, A: vdaf::Aggregator<L>>(
         task_id: &TaskId,
         collect_job_id: &Uuid,
         row: &Row,
-    ) -> Result<CollectJob<L, A>, Error>
+    ) -> Result<CollectJob<L, Q, A>, Error>
     where
         for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Debug,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
-        let sql_interval: SqlInterval = row.try_get("batch_interval")?;
-        let batch_interval = sql_interval.as_interval();
+        let batch_identifier = Q::BatchIdentifier::get_decoded(row.get("batch_identifier"))?;
         let aggregation_param = A::AggregationParam::get_decoded(row.get("aggregation_param"))?;
         let state: CollectJobStateCode = row.get("state");
         let report_count: Option<i64> = row.get("report_count");
@@ -1873,7 +1874,7 @@ impl<C: Clock> Transaction<'_, C> {
         Ok(CollectJob::new(
             *task_id,
             *collect_job_id,
-            batch_interval,
+            batch_identifier,
             aggregation_param,
             state,
         ))
@@ -1881,30 +1882,38 @@ impl<C: Clock> Transaction<'_, C> {
 
     /// Stores a new collect job.
     #[tracing::instrument(skip(self), err)]
-    pub(crate) async fn put_collect_job<const L: usize, A>(
+    pub(crate) async fn put_collect_job<
+        const L: usize,
+        Q: CollectableQueryType,
+        A: vdaf::Aggregator<L>,
+    >(
         &self,
-        collect_job: &CollectJob<L, A>,
+        collect_job: &CollectJob<L, Q, A>,
     ) -> Result<(), Error>
     where
-        A: vdaf::Aggregator<L>,
         A::AggregationParam: Encode + std::fmt::Debug,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
+        let batch_interval =
+            Q::to_batch_interval(collect_job.batch_identifier()).map(SqlInterval::from);
+
         let stmt = self
             .tx
             .prepare_cached(
                 "INSERT INTO collect_jobs
-                    (collect_job_id, task_id, batch_interval, aggregation_param, state)
-                VALUES ($1, (SELECT id FROM tasks WHERE task_id = $2), $3, $4, $5)",
+                    (collect_job_id, task_id, batch_identifier, batch_interval, aggregation_param,
+                    state)
+                VALUES ($1, (SELECT id FROM tasks WHERE task_id = $2), $3, $4, $5, $6)",
             )
             .await?;
         self.tx
             .execute(
                 &stmt,
                 &[
-                    /* collect_job_id */ &collect_job.collect_job_id(),
-                    /* task_id */ &collect_job.task_id().as_ref(),
-                    /* batch_interval */ &SqlInterval::from(collect_job.batch_interval()),
+                    /* collect_job_id */ collect_job.collect_job_id(),
+                    /* task_id */ collect_job.task_id().as_ref(),
+                    /* batch_identifier */ &collect_job.batch_identifier().get_encoded(),
+                    /* batch_interval */ &batch_interval,
                     /* aggregation_param */
                     &collect_job.aggregation_parameter().get_encoded(),
                     /* state */ &collect_job.state().collect_job_state_code(),
@@ -1962,9 +1971,10 @@ WITH updated as (
         -- Honor maximum_acquire_count *after* winnowing down to runnable collect jobs
         LIMIT $3
     )
-    RETURNING tasks.task_id, tasks.vdaf, collect_jobs.collect_job_id, collect_jobs.id, collect_jobs.lease_token, collect_jobs.lease_attempts
+    RETURNING tasks.task_id, tasks.query_type, tasks.vdaf, collect_jobs.collect_job_id,
+              collect_jobs.id, collect_jobs.lease_token, collect_jobs.lease_attempts
 )
-SELECT task_id, vdaf, collect_job_id, lease_token, lease_attempts FROM updated
+SELECT task_id, query_type, vdaf, collect_job_id, lease_token, lease_attempts FROM updated
 -- TODO (#174): revisit collect job queueing behavior implied by this ORDER BY
 ORDER BY id DESC
 "#,
@@ -1984,6 +1994,7 @@ ORDER BY id DESC
             .map(|row| {
                 let task_id = TaskId::get_decoded(row.get("task_id"))?;
                 let collect_job_id = row.get("collect_job_id");
+                let query_type = row.try_get::<_, Json<task::QueryType>>("query_type")?.0;
                 let vdaf = row.try_get::<_, Json<VdafInstance>>("vdaf")?.0;
                 let lease_token_bytes: [u8; LeaseToken::LEN] = row
                     .get::<_, Vec<u8>>("lease_token")
@@ -1992,7 +2003,7 @@ ORDER BY id DESC
                 let lease_token = LeaseToken::from(lease_token_bytes);
                 let lease_attempts = row.get_bigint_and_convert("lease_attempts")?;
                 Ok(Lease::new(
-                    AcquiredCollectJob::new(task_id, collect_job_id, vdaf),
+                    AcquiredCollectJob::new(task_id, collect_job_id, query_type, vdaf),
                     lease_expiry_time,
                     lease_token,
                     lease_attempts,
@@ -2036,12 +2047,11 @@ ORDER BY id DESC
 
     /// Updates an existing collect job.
     #[tracing::instrument(skip(self), err)]
-    pub(crate) async fn update_collect_job<const L: usize, A>(
+    pub(crate) async fn update_collect_job<const L: usize, Q: QueryType, A: vdaf::Aggregator<L>>(
         &self,
-        collect_job: &CollectJob<L, A>,
+        collect_job: &CollectJob<L, Q, A>,
     ) -> Result<(), Error>
     where
-        A: vdaf::Aggregator<L>,
         for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Debug,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
@@ -2236,7 +2246,7 @@ ORDER BY id DESC
         &self,
         task_id: &TaskId,
         batch_interval: &Interval,
-        aggregation_parameter: &[u8],
+        aggregation_parameter: &A::AggregationParam,
     ) -> Result<Option<AggregateShareJob<L, A>>, Error>
     where
         for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Debug,
@@ -2259,17 +2269,15 @@ ORDER BY id DESC
                     /* task_id */ &task_id.as_ref(),
                     /* batch_interval */
                     &SqlInterval::from(batch_interval),
-                    /* aggregation_param */ &aggregation_parameter,
+                    /* aggregation_param */ &aggregation_parameter.get_encoded(),
                 ],
             )
             .await?
             .map(|row| {
-                let aggregation_parameter =
-                    A::AggregationParam::get_decoded(aggregation_parameter)?;
                 Self::aggregate_share_job_from_row(
                     task_id,
                     batch_interval,
-                    aggregation_parameter,
+                    aggregation_parameter.clone(),
                     &row,
                 )
             })
@@ -3221,15 +3229,22 @@ pub mod models {
     pub struct AcquiredCollectJob {
         task_id: TaskId,
         collect_job_id: Uuid,
+        query_type: task::QueryType,
         vdaf: VdafInstance,
     }
 
     impl AcquiredCollectJob {
         /// Creates a new [`AcquiredCollectJob`].
-        pub fn new(task_id: TaskId, collect_job_id: Uuid, vdaf: VdafInstance) -> Self {
+        pub fn new(
+            task_id: TaskId,
+            collect_job_id: Uuid,
+            query_type: task::QueryType,
+            vdaf: VdafInstance,
+        ) -> Self {
             Self {
                 task_id,
                 collect_job_id,
+                query_type,
                 vdaf,
             }
         }
@@ -3242,6 +3257,11 @@ pub mod models {
         /// Returns the collect job ID associated with this acquired collect job.
         pub fn collect_job_id(&self) -> &Uuid {
             &self.collect_job_id
+        }
+
+        /// Returns the query type associated with this acquired aggregation job.
+        pub fn query_type(&self) -> &task::QueryType {
+            &self.query_type
         }
 
         /// Returns the VDAF associated with this acquired collect job.
@@ -3630,7 +3650,7 @@ pub mod models {
     /// running collect jobs and store the results of completed ones.
     #[derive(Clone, Derivative)]
     #[derivative(Debug)]
-    pub struct CollectJob<const L: usize, A: vdaf::Aggregator<L>>
+    pub struct CollectJob<const L: usize, Q: QueryType, A: vdaf::Aggregator<L>>
     where
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
@@ -3639,7 +3659,7 @@ pub mod models {
         /// The unique identifier for the collect job.
         collect_job_id: Uuid,
         /// The batch interval covered by the collect job.
-        batch_interval: Interval,
+        batch_identifier: Q::BatchIdentifier,
         /// The VDAF aggregation parameter used to prepare and aggregate input shares.
         #[derivative(Debug = "ignore")]
         aggregation_parameter: A::AggregationParam,
@@ -3647,7 +3667,7 @@ pub mod models {
         state: CollectJobState<L, A>,
     }
 
-    impl<const L: usize, A: vdaf::Aggregator<L>> CollectJob<L, A>
+    impl<const L: usize, Q: QueryType, A: vdaf::Aggregator<L>> CollectJob<L, Q, A>
     where
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
@@ -3655,14 +3675,14 @@ pub mod models {
         pub fn new(
             task_id: TaskId,
             collect_job_id: Uuid,
-            batch_interval: Interval,
+            batch_identifier: Q::BatchIdentifier,
             aggregation_parameter: A::AggregationParam,
             state: CollectJobState<L, A>,
         ) -> Self {
             Self {
                 task_id,
                 collect_job_id,
-                batch_interval,
+                batch_identifier,
                 aggregation_parameter,
                 state,
             }
@@ -3678,9 +3698,13 @@ pub mod models {
             &self.collect_job_id
         }
 
-        /// Returns the batch interval associated with this collect job.
-        pub fn batch_interval(&self) -> &Interval {
-            &self.batch_interval
+        /// Gets the batch identifier associated with this collect job.
+        ///
+        /// This method would typically be used for code which is generic over the query type.
+        /// Query-type specific code will typically call one of [`Self::batch_interval`] or
+        /// [`Self::batch_id`].
+        pub fn batch_identifier(&self) -> &Q::BatchIdentifier {
+            &self.batch_identifier
         }
 
         /// Returns the aggregation parameter associated with this collect job.
@@ -3700,7 +3724,27 @@ pub mod models {
         }
     }
 
-    impl<const L: usize, A: vdaf::Aggregator<L>> PartialEq for CollectJob<L, A>
+    impl<const L: usize, A: vdaf::Aggregator<L>> CollectJob<L, TimeInterval, A>
+    where
+        for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
+    {
+        /// Gets the batch interval associated with this collect job.
+        pub fn batch_interval(&self) -> &Interval {
+            self.batch_identifier()
+        }
+    }
+
+    impl<const L: usize, A: vdaf::Aggregator<L>> CollectJob<L, FixedSize, A>
+    where
+        for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
+    {
+        /// Gets the batch ID associated with this collect job.
+        pub fn batch_id(&self) -> &BatchId {
+            self.batch_identifier()
+        }
+    }
+
+    impl<const L: usize, Q: QueryType, A: vdaf::Aggregator<L>> PartialEq for CollectJob<L, Q, A>
     where
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
         A::AggregationParam: PartialEq,
@@ -3709,13 +3753,13 @@ pub mod models {
         fn eq(&self, other: &Self) -> bool {
             self.task_id == other.task_id
                 && self.collect_job_id == other.collect_job_id
-                && self.batch_interval == other.batch_interval
+                && self.batch_identifier == other.batch_identifier
                 && self.aggregation_parameter == other.aggregation_parameter
                 && self.state == other.state
         }
     }
 
-    impl<const L: usize, A: vdaf::Aggregator<L>> Eq for CollectJob<L, A>
+    impl<const L: usize, Q: QueryType, A: vdaf::Aggregator<L>> Eq for CollectJob<L, Q, A>
     where
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
         A::AggregationParam: Eq,
@@ -4316,7 +4360,7 @@ mod tests {
         hpke::{self, associated_data_for_aggregate_share, HpkeApplicationInfo, Label},
         task::VdafInstance,
         test_util::{
-            dummy_vdaf::{self, AggregationParam},
+            dummy_vdaf::{self, AggregateShare, AggregationParam},
             install_test_trace_subscriber,
         },
         time::{Clock, MockClock, TimeExt as CoreTimeExt},
@@ -4328,12 +4372,11 @@ mod tests {
         Time,
     };
     use prio::{
-        codec::{Decode, Encode},
-        field::Field64,
+        codec::Decode,
         vdaf::{
             self,
             prio3::{Prio3, Prio3Aes128Count},
-            AggregateShare, PrepareTransition,
+            PrepareTransition,
         },
     };
     use rand::{distributions::Standard, random, thread_rng, Rng};
@@ -4774,7 +4817,7 @@ mod tests {
 
                 // There are no client reports submitted under this task, so we shouldn't see
                 // this aggregation parameter at all.
-                tx.put_collect_job(&CollectJob::new(
+                tx.put_collect_job(&CollectJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
                     *unrelated_task.id(),
                     Uuid::new_v4(),
                     Interval::new(
@@ -4813,7 +4856,7 @@ mod tests {
                 *aggregated_report.metadata().time(),
             );
             Box::pin(async move {
-                tx.put_collect_job(&CollectJob::new(
+                tx.put_collect_job(&CollectJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
                     *task.id(),
                     Uuid::new_v4(),
                     Interval::new(
@@ -4825,7 +4868,7 @@ mod tests {
                     CollectJobState::<0, dummy_vdaf::Vdaf>::Start,
                 ))
                 .await?;
-                tx.put_collect_job(&CollectJob::new(
+                tx.put_collect_job(&CollectJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
                     *task.id(),
                     Uuid::new_v4(),
                     Interval::new(
@@ -4839,7 +4882,7 @@ mod tests {
                 .await?;
                 // No reports fall in this interval, so we shouldn't see it's aggregation
                 // parameter at all.
-                tx.put_collect_job(&CollectJob::new(
+                tx.put_collect_job(&CollectJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
                     *task.id(),
                     Uuid::new_v4(),
                     Interval::new(
@@ -4924,7 +4967,7 @@ mod tests {
         ds.run_tx(|tx| {
             let task = task.clone();
             Box::pin(async move {
-                tx.put_collect_job(&CollectJob::new(
+                tx.put_collect_job(&CollectJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
                     *task.id(),
                     Uuid::new_v4(),
                     Interval::new(
@@ -4933,10 +4976,10 @@ mod tests {
                     )
                     .unwrap(),
                     dummy_vdaf::AggregationParam(0),
-                    CollectJobState::<0, dummy_vdaf::Vdaf>::Start,
+                    CollectJobState::Start,
                 ))
                 .await?;
-                tx.put_collect_job(&CollectJob::new(
+                tx.put_collect_job(&CollectJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
                     *task.id(),
                     Uuid::new_v4(),
                     Interval::new(
@@ -4945,7 +4988,7 @@ mod tests {
                     )
                     .unwrap(),
                     dummy_vdaf::AggregationParam(1),
-                    CollectJobState::<0, dummy_vdaf::Vdaf>::Start,
+                    CollectJobState::Start,
                 ))
                 .await?;
                 Ok(())
@@ -5976,12 +6019,8 @@ mod tests {
     async fn lookup_collect_job() {
         install_test_trace_subscriber();
 
-        let task = TaskBuilder::new(
-            QueryType::TimeInterval,
-            VdafInstance::Prio3Aes128Count,
-            Role::Leader,
-        )
-        .build();
+        let task =
+            TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Leader).build();
         let batch_interval = Interval::new(
             Time::from_seconds_since_epoch(100),
             Duration::from_seconds(100),
@@ -5993,6 +6032,7 @@ mod tests {
             Duration::from_seconds(10),
         )
         .unwrap();
+        let aggregation_param = AggregationParam(23);
 
         let (ds, _db_handle) = ephemeral_datastore(MockClock::default()).await;
 
@@ -6007,10 +6047,10 @@ mod tests {
             .run_tx(|tx| {
                 let task = task.clone();
                 Box::pin(async move {
-                    tx.get_collect_job_id::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                    tx.get_collect_job_id::<0, dummy_vdaf::Vdaf>(
                         task.id(),
                         &batch_interval,
-                        &(),
+                        &aggregation_param,
                     )
                     .await
                 })
@@ -6023,12 +6063,12 @@ mod tests {
             .run_tx(|tx| {
                 let task = task.clone();
                 Box::pin(async move {
-                    let collect_job = CollectJob::new(
+                    let collect_job = CollectJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
                         *task.id(),
                         Uuid::new_v4(),
                         batch_interval,
-                        (),
-                        CollectJobState::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>::Start,
+                        aggregation_param,
+                        CollectJobState::<0, dummy_vdaf::Vdaf>::Start,
                     );
                     tx.put_collect_job(&collect_job).await?;
                     Ok(*collect_job.collect_job_id())
@@ -6041,10 +6081,10 @@ mod tests {
             .run_tx(|tx| {
                 let task = task.clone();
                 Box::pin(async move {
-                    tx.get_collect_job_id::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                    tx.get_collect_job_id::<0, dummy_vdaf::Vdaf>(
                         task.id(),
                         &batch_interval,
-                        &(),
+                        &aggregation_param,
                     )
                     .await
                 })
@@ -6061,24 +6101,29 @@ mod tests {
             .run_tx(|tx| {
                 let task = task.clone();
                 Box::pin(async move {
-                    let collect_jobs_by_time = tx.get_collect_jobs_including_time::
-                        <PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(task.id(), &timestamp).await?;
-                    let collect_jobs_by_interval = tx.get_collect_jobs_jobs_intersecting_interval::
-                        <PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(task.id(), &interval).await?;
+                    let collect_jobs_by_time = tx
+                        .get_collect_jobs_including_time::<0, dummy_vdaf::Vdaf>(
+                            task.id(),
+                            &timestamp,
+                        )
+                        .await?;
+                    let collect_jobs_by_interval = tx
+                        .get_collect_jobs_jobs_intersecting_interval::<0, dummy_vdaf::Vdaf>(
+                            task.id(),
+                            &interval,
+                        )
+                        .await?;
                     Ok((collect_jobs_by_time, collect_jobs_by_interval))
                 })
             })
             .await
             .unwrap();
 
-        let want_collect_jobs = Vec::from([CollectJob::<
-            PRIO3_AES128_VERIFY_KEY_LENGTH,
-            Prio3Aes128Count,
-        >::new(
+        let want_collect_jobs = Vec::from([CollectJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
             *task.id(),
             collect_job_id,
             batch_interval,
-            (),
+            aggregation_param,
             CollectJobState::Start,
         )]);
 
@@ -6109,12 +6154,12 @@ mod tests {
                 let task = task.clone();
                 Box::pin(async move {
                     let collect_job_id = Uuid::new_v4();
-                    tx.put_collect_job(&CollectJob::new(
+                    tx.put_collect_job(&CollectJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
                         *task.id(),
                         collect_job_id,
                         different_batch_interval,
-                        (),
-                        CollectJobState::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>::Start,
+                        aggregation_param,
+                        CollectJobState::Start,
                     ))
                     .await?;
                     Ok(collect_job_id)
@@ -6146,10 +6191,18 @@ mod tests {
             .run_tx(|tx| {
                 let task = task.clone();
                 Box::pin(async move {
-                    let collect_jobs_by_time = tx.get_collect_jobs_including_time::
-                        <PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(task.id(), &timestamp).await?;
-                    let collect_jobs_by_interval = tx.get_collect_jobs_jobs_intersecting_interval::
-                        <PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(task.id(), &interval).await?;
+                    let collect_jobs_by_time = tx
+                        .get_collect_jobs_including_time::<0, dummy_vdaf::Vdaf>(
+                            task.id(),
+                            &timestamp,
+                        )
+                        .await?;
+                    let collect_jobs_by_interval = tx
+                        .get_collect_jobs_jobs_intersecting_interval::<0, dummy_vdaf::Vdaf>(
+                            task.id(),
+                            &interval,
+                        )
+                        .await?;
                     Ok((collect_jobs_by_time, collect_jobs_by_interval))
                 })
             })
@@ -6159,18 +6212,18 @@ mod tests {
         collect_jobs_by_interval.sort_by(|x, y| x.collect_job_id().cmp(y.collect_job_id()));
 
         let mut want_collect_jobs = Vec::from([
-            CollectJob::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>::new(
+            CollectJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
                 *task.id(),
                 collect_job_id,
                 batch_interval,
-                (),
+                aggregation_param,
                 CollectJobState::Start,
             ),
-            CollectJob::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>::new(
+            CollectJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
                 *task.id(),
                 different_collect_job_id,
                 different_batch_interval,
-                (),
+                aggregation_param,
                 CollectJobState::Start,
             ),
         ]);
@@ -6184,23 +6237,16 @@ mod tests {
     async fn get_collect_job_task_id() {
         install_test_trace_subscriber();
 
-        let first_task = TaskBuilder::new(
-            QueryType::TimeInterval,
-            VdafInstance::Prio3Aes128Count,
-            Role::Leader,
-        )
-        .build();
-        let second_task = TaskBuilder::new(
-            QueryType::TimeInterval,
-            VdafInstance::Prio3Aes128Count,
-            Role::Leader,
-        )
-        .build();
+        let first_task =
+            TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Leader).build();
+        let second_task =
+            TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Leader).build();
         let batch_interval = Interval::new(
             Time::from_seconds_since_epoch(100),
             Duration::from_seconds(100),
         )
         .unwrap();
+        let aggregation_param = AggregationParam(23);
 
         let (ds, _db_handle) = ephemeral_datastore(MockClock::default()).await;
 
@@ -6211,23 +6257,23 @@ mod tests {
                 tx.put_task(&second_task).await.unwrap();
 
                 let first_collect_job_id = Uuid::new_v4();
-                tx.put_collect_job(&CollectJob::new(
+                tx.put_collect_job(&CollectJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
                     *first_task.id(),
                     first_collect_job_id,
                     batch_interval,
-                    (),
-                    CollectJobState::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>::Start,
+                    aggregation_param,
+                    CollectJobState::Start,
                 ))
                 .await
                 .unwrap();
 
                 let second_collect_job_id = Uuid::new_v4();
-                tx.put_collect_job(&CollectJob::new(
+                tx.put_collect_job(&CollectJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
                     *second_task.id(),
                     second_collect_job_id,
                     batch_interval,
-                    (),
-                    CollectJobState::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>::Start,
+                    aggregation_param,
+                    CollectJobState::Start,
                 ))
                 .await
                 .unwrap();
@@ -6262,12 +6308,8 @@ mod tests {
     async fn get_collect_job() {
         install_test_trace_subscriber();
 
-        let task = TaskBuilder::new(
-            QueryType::TimeInterval,
-            VdafInstance::Prio3Aes128Count,
-            Role::Leader,
-        )
-        .build();
+        let task =
+            TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Leader).build();
         let first_batch_interval = Interval::new(
             Time::from_seconds_since_epoch(100),
             Duration::from_seconds(100),
@@ -6278,6 +6320,7 @@ mod tests {
             Duration::from_seconds(200),
         )
         .unwrap();
+        let aggregation_param = AggregationParam(13);
 
         let (ds, _db_handle) = ephemeral_datastore(MockClock::default()).await;
 
@@ -6286,26 +6329,26 @@ mod tests {
             Box::pin(async move {
                 tx.put_task(&task).await.unwrap();
 
-                let first_collect_job = CollectJob::new(
+                let first_collect_job = CollectJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
                     *task.id(),
                     Uuid::new_v4(),
                     first_batch_interval,
-                    (),
-                    CollectJobState::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>::Start,
+                    aggregation_param,
+                    CollectJobState::Start,
                 );
                 tx.put_collect_job(&first_collect_job).await.unwrap();
 
-                let second_collect_job = CollectJob::new(
+                let second_collect_job = CollectJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
                     *task.id(),
                     Uuid::new_v4(),
                     second_batch_interval,
-                    (),
-                    CollectJobState::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>::Start,
+                    aggregation_param,
+                    CollectJobState::Start,
                 );
                 tx.put_collect_job(&second_collect_job).await.unwrap();
 
                 let first_collect_job_again = tx
-                    .get_collect_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                    .get_collect_job::<0, TimeInterval, dummy_vdaf::Vdaf>(
                         first_collect_job.collect_job_id(),
                     )
                     .await
@@ -6314,15 +6357,13 @@ mod tests {
                 assert_eq!(first_collect_job, first_collect_job_again);
 
                 let second_collect_job_again = tx
-                    .get_collect_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                    .get_collect_job::<0, TimeInterval, dummy_vdaf::Vdaf>(
                         second_collect_job.collect_job_id(),
                     )
                     .await
                     .unwrap()
                     .unwrap();
                 assert_eq!(second_collect_job, second_collect_job_again);
-
-                let leader_aggregate_share = AggregateShare::from(Vec::from([Field64::from(1)]));
 
                 let encrypted_helper_aggregate_share = hpke::seal(
                     task.collector_hpke_config(),
@@ -6342,17 +6383,15 @@ mod tests {
                 let first_collect_job = first_collect_job.with_state(CollectJobState::Finished {
                     report_count: 12,
                     encrypted_helper_aggregate_share,
-                    leader_aggregate_share,
+                    leader_aggregate_share: AggregateShare(41),
                 });
 
-                tx.update_collect_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
-                    &first_collect_job,
-                )
-                .await
-                .unwrap();
+                tx.update_collect_job::<0, TimeInterval, dummy_vdaf::Vdaf>(&first_collect_job)
+                    .await
+                    .unwrap();
 
                 let updated_first_collect_job = tx
-                    .get_collect_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                    .get_collect_job::<0, TimeInterval, dummy_vdaf::Vdaf>(
                         first_collect_job.collect_job_id(),
                     )
                     .await
@@ -6374,12 +6413,8 @@ mod tests {
 
         let (ds, _db_handle) = ephemeral_datastore(MockClock::default()).await;
 
-        let task = TaskBuilder::new(
-            QueryType::TimeInterval,
-            VdafInstance::Prio3Aes128Count,
-            Role::Leader,
-        )
-        .build();
+        let task =
+            TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Leader).build();
         let abandoned_batch_interval = Interval::new(
             Time::from_seconds_since_epoch(100),
             Duration::from_seconds(100),
@@ -6396,26 +6431,27 @@ mod tests {
             Box::pin(async move {
                 tx.put_task(&task).await?;
 
-                let abandoned_collect_job = CollectJob::new(
+                let aggregation_param = AggregationParam(10);
+                let abandoned_collect_job = CollectJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
                     *task.id(),
                     Uuid::new_v4(),
                     abandoned_batch_interval,
-                    (),
-                    CollectJobState::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>::Start,
+                    aggregation_param,
+                    CollectJobState::Start,
                 );
                 tx.put_collect_job(&abandoned_collect_job).await?;
 
-                let deleted_collect_job = CollectJob::new(
+                let deleted_collect_job = CollectJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
                     *task.id(),
                     Uuid::new_v4(),
                     deleted_batch_interval,
-                    (),
-                    CollectJobState::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>::Start,
+                    aggregation_param,
+                    CollectJobState::Start,
                 );
                 tx.put_collect_job(&deleted_collect_job).await?;
 
                 let abandoned_collect_job_again = tx
-                    .get_collect_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                    .get_collect_job::<0, TimeInterval, dummy_vdaf::Vdaf>(
                         abandoned_collect_job.collect_job_id(),
                     )
                     .await?
@@ -6429,24 +6465,20 @@ mod tests {
                     abandoned_collect_job.with_state(CollectJobState::Abandoned);
                 let deleted_collect_job = deleted_collect_job.with_state(CollectJobState::Deleted);
 
-                tx.update_collect_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
-                    &abandoned_collect_job,
-                )
-                .await?;
-                tx.update_collect_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
-                    &deleted_collect_job,
-                )
-                .await?;
+                tx.update_collect_job::<0, TimeInterval, dummy_vdaf::Vdaf>(&abandoned_collect_job)
+                    .await?;
+                tx.update_collect_job::<0, TimeInterval, dummy_vdaf::Vdaf>(&deleted_collect_job)
+                    .await?;
 
                 let abandoned_collect_job_again = tx
-                    .get_collect_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                    .get_collect_job::<0, TimeInterval, dummy_vdaf::Vdaf>(
                         abandoned_collect_job.collect_job_id(),
                     )
                     .await?
                     .unwrap();
 
                 let deleted_collect_job_again = tx
-                    .get_collect_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                    .get_collect_job::<0, TimeInterval, dummy_vdaf::Vdaf>(
                         deleted_collect_job.collect_job_id(),
                     )
                     .await?
@@ -6461,11 +6493,9 @@ mod tests {
                     abandoned_collect_job.with_state(CollectJobState::Start);
 
                 // Verify: Update should fail
-                tx.update_collect_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
-                    &abandoned_collect_job,
-                )
-                .await
-                .unwrap_err();
+                tx.update_collect_job::<0, TimeInterval, dummy_vdaf::Vdaf>(&abandoned_collect_job)
+                    .await
+                    .unwrap_err();
                 Ok(())
             })
         })
@@ -6540,7 +6570,7 @@ mod tests {
                 }
 
                 for test_case in test_case.collect_job_test_cases.iter_mut() {
-                    let collect_job = CollectJob::<0, dummy_vdaf::Vdaf>::new(
+                    let collect_job = CollectJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
                         test_case.task_id,
                         Uuid::new_v4(),
                         test_case.batch_interval,
@@ -6554,7 +6584,7 @@ mod tests {
                                     Vec::new(),
                                     Vec::new(),
                                 ),
-                                leader_aggregate_share: dummy_vdaf::AggregateShare(0),
+                                leader_aggregate_share: AggregateShare(0),
                             },
                             CollectJobTestCaseState::Abandoned => CollectJobState::Abandoned,
                             CollectJobTestCaseState::Deleted => CollectJobState::Deleted,
@@ -6601,6 +6631,7 @@ mod tests {
                             AcquiredCollectJob::new(
                                 c.task_id,
                                 c.collect_job_id.unwrap(),
+                                task::QueryType::TimeInterval,
                                 VdafInstance::Fake,
                             ),
                             clock.now().add(&Duration::from_seconds(100)).unwrap(),
@@ -7132,6 +7163,7 @@ mod tests {
                             AcquiredCollectJob::new(
                                 c.task_id,
                                 c.collect_job_id.unwrap(),
+                                task::QueryType::TimeInterval,
                                 VdafInstance::Fake,
                             ),
                             clock.now().add(&Duration::from_seconds(100)).unwrap(),
@@ -7565,14 +7597,12 @@ mod tests {
 
         ds.run_tx(|tx| {
             Box::pin(async move {
-                let task = TaskBuilder::new(
-                    QueryType::TimeInterval,
-                    VdafInstance::Prio3Aes128Count,
-                    Role::Helper,
-                ).build();
+                let task =
+                    TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Helper)
+                        .build();
                 tx.put_task(&task).await?;
 
-                let aggregate_share = AggregateShare::from(Vec::from([Field64::from(17)]));
+                let aggregate_share = AggregateShare(42);
                 let batch_interval = Interval::new(
                     Time::from_seconds_since_epoch(100),
                     Duration::from_seconds(100),
@@ -7585,27 +7615,26 @@ mod tests {
                 .unwrap();
                 let report_count = 10;
                 let checksum = ReportIdChecksum::get_decoded(&[1; 32]).unwrap();
+                let aggregation_param = AggregationParam(11);
 
-                let aggregate_share_job = AggregateShareJob::new(
+                let aggregate_share_job = AggregateShareJob::<0, dummy_vdaf::Vdaf>::new(
                     *task.id(),
                     batch_interval,
-                    (),
+                    aggregation_param,
                     aggregate_share.clone(),
                     report_count,
                     checksum,
                 );
 
-                tx.put_aggregate_share_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
-                    &aggregate_share_job,
-                )
-                .await
-                .unwrap();
+                tx.put_aggregate_share_job::<0, dummy_vdaf::Vdaf>(&aggregate_share_job)
+                    .await
+                    .unwrap();
 
                 let aggregate_share_job_again = tx
-                    .get_aggregate_share_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                    .get_aggregate_share_job::<0, dummy_vdaf::Vdaf>(
                         task.id(),
                         &batch_interval,
-                        &().get_encoded(),
+                        &aggregation_param,
                     )
                     .await
                     .unwrap()
@@ -7614,10 +7643,10 @@ mod tests {
                 assert_eq!(aggregate_share_job, aggregate_share_job_again);
 
                 assert!(tx
-                    .get_aggregate_share_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                    .get_aggregate_share_job::<0, dummy_vdaf::Vdaf>(
                         task.id(),
                         &other_batch_interval,
-                        &().get_encoded(),
+                        &aggregation_param,
                     )
                     .await
                     .unwrap()
@@ -7625,17 +7654,24 @@ mod tests {
 
                 let want_aggregate_share_jobs = Vec::from([aggregate_share_job]);
 
-                let got_aggregate_share_jobs = tx.get_aggregate_share_jobs_including_time::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
-                    task.id(), &Time::from_seconds_since_epoch(150)).await?;
+                let got_aggregate_share_jobs = tx
+                    .get_aggregate_share_jobs_including_time::<0, dummy_vdaf::Vdaf>(
+                        task.id(),
+                        &Time::from_seconds_since_epoch(150),
+                    )
+                    .await?;
                 assert_eq!(got_aggregate_share_jobs, want_aggregate_share_jobs);
 
-                let got_aggregate_share_jobs = tx.get_aggregate_share_jobs_intersecting_interval::
-                    <PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                let got_aggregate_share_jobs = tx
+                    .get_aggregate_share_jobs_intersecting_interval::<0, dummy_vdaf::Vdaf>(
                         task.id(),
                         &Interval::new(
                             Time::from_seconds_since_epoch(145),
-                            Duration::from_seconds(10))
-                        .unwrap()).await?;
+                            Duration::from_seconds(10),
+                        )
+                        .unwrap(),
+                    )
+                    .await?;
                 assert_eq!(got_aggregate_share_jobs, want_aggregate_share_jobs);
 
                 Ok(())

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -170,7 +170,8 @@ CREATE TABLE collect_jobs(
     id                      BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,  -- artificial ID, internal-only
     collect_job_id          UUID NOT NULL,               -- UUID used by collector to refer to this job
     task_id                 BIGINT NOT NULL,             -- the task ID being collected
-    batch_interval          TSRANGE NOT NULL,            -- the batch interval, as a range of timestamps
+    batch_identifier        BYTEA NOT NULL,              -- encoded query-type-specific batch identifier (corresponds to identifier in BatchSelector)
+    batch_interval          TSRANGE,                     -- batch interval, as a TSRANGE, populated only for time-interval tasks. (will always match batch_identifier)
     aggregation_param       BYTEA NOT NULL,              -- the aggregation parameter (opaque VDAF message)
     state                   COLLECT_JOB_STATE NOT NULL,  -- the current state of this collect job
     report_count            BIGINT,                      -- the number of reports included in this collect job (only if in state FINISHED)
@@ -181,7 +182,7 @@ CREATE TABLE collect_jobs(
     lease_token             BYTEA,                                             -- a value identifying the current leaseholder; NULL implies no current lease
     lease_attempts          BIGINT NOT NULL DEFAULT 0,                         -- the number of lease acquiries since the last successful lease release
 
-    CONSTRAINT unique_collect_job_task_id_interval_aggregation_param UNIQUE(task_id, batch_interval, aggregation_param),
+    CONSTRAINT unique_collect_job_task_id_interval_aggregation_param UNIQUE(task_id, batch_identifier, aggregation_param),
     CONSTRAINT fk_task_id FOREIGN KEY(task_id) REFERENCES tasks(id)
 );
 -- TODO(#224): verify that this index is optimal for purposes of acquiring collect jobs.

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -1210,7 +1210,7 @@ pub mod query_type {
 
     /// QueryType represents a DAP query type. This is a task-level configuration setting which
     /// determines how individual client reports are grouped together into batches for collection.
-    pub trait QueryType: Clone + Debug + PartialEq + Eq + 'static {
+    pub trait QueryType: Clone + Debug + PartialEq + Eq + Send + Sync + 'static {
         /// The [`Code`] associated with this query type.
         const CODE: Code;
 


### PR DESCRIPTION
Effectively, this PR finishes out fixed-size support for the collect job driver.

Part of #468.