### PR TITLE
Add integration test with fixed-size task

### DIFF
--- a/aggregator/src/task.rs
+++ b/aggregator/src/task.rs
@@ -733,6 +733,14 @@ pub mod test_util {
             })
         }
 
+        /// Sets the task query type
+        pub fn with_query_type(self, query_type: QueryType) -> Self {
+            Self(Task {
+                query_type,
+                ..self.0
+            })
+        }
+
         /// Consumes this task builder & produces a [`Task`] with the given specifications.
         pub fn build(self) -> Task {
             self.0.validate().unwrap();

--- a/integration_tests/tests/common/mod.rs
+++ b/integration_tests/tests/common/mod.rs
@@ -17,7 +17,10 @@ use std::iter;
 use tokio::time;
 
 // Returns (collector_private_key, leader_task, helper_task).
-pub fn test_task_builders(vdaf: VdafInstance) -> (HpkePrivateKey, TaskBuilder, TaskBuilder) {
+pub fn test_task_builders(
+    vdaf: VdafInstance,
+    query_type: QueryType,
+) -> (HpkePrivateKey, TaskBuilder, TaskBuilder) {
     let endpoint_random_value = hex::encode(random::<[u8; 4]>());
     let (collector_hpke_config, collector_private_key) =
         generate_test_hpke_config_and_private_key();
@@ -26,6 +29,7 @@ pub fn test_task_builders(vdaf: VdafInstance) -> (HpkePrivateKey, TaskBuilder, T
             Url::parse(&format!("http://leader-{endpoint_random_value}:8080/")).unwrap(),
             Url::parse(&format!("http://helper-{endpoint_random_value}:8080/")).unwrap(),
         ]))
+        .with_query_type(query_type)
         .with_min_batch_size(46)
         .with_collector_hpke_config(collector_hpke_config);
     let helper_task = leader_task

--- a/integration_tests/tests/divviup_ts.rs
+++ b/integration_tests/tests/divviup_ts.rs
@@ -16,7 +16,8 @@ mod common;
 use common::{submit_measurements_and_verify_aggregate, test_task_builders};
 
 async fn run_divviup_ts_integration_test(container_client: &Cli, vdaf: VdafInstance) {
-    let (collector_private_key, leader_task, helper_task) = test_task_builders(vdaf);
+    let (collector_private_key, leader_task, helper_task) =
+        test_task_builders(vdaf, janus_aggregator::task::QueryType::TimeInterval);
     let leader_task = leader_task.build();
     let network = generate_network_name();
     let leader = Janus::new_in_container(container_client, &network, &leader_task).await;


### PR DESCRIPTION
This adds an end-to-end integration test with a fixed size task.

I ran this, saved the logs, and I identified the following errors contributing to its failure, indicating some serialization/deserialization type confusion.

```json
Helper:
{"timestamp":"2022-11-15T16:24:32.428508Z",
"level":"ERROR",
"fields":{
"error":"decoding error: 32 bytes left in buffer after decoding value"},
"target":"janus_aggregator::datastore",
"filename":"aggregator/src/datastore.rs",
"line_number":1134,
"spans":[
{"name":"run_tx_once"},
{"aggregation_job_id":"AggregationJobId(u_ormoXfonsTVpsS5-7kMYZX5MgF6Wc_b8PebRXf2Q4)",
"task_id":"TaskId(aTv1dGy-mw0Ek0hTZOX-6_ivvYrzYU7aRXB2za5KQrM)",
"name":"get_aggregation_job"}]
,"threadId":"ThreadId(4)"}

Leader, collect job driver:
{"timestamp":"2022-11-15T16:25:06.892988Z",
"level":"ERROR",
"fields":{
"error":"decoding error: I/O error"},
"target":"janus_aggregator::datastore",
"filename":"aggregator/src/datastore.rs",
"line_number":1696,
"spans":[
{"name":"run"},
{"acquired_job":"AcquiredCollectJob { task_id: TaskId(aTv1dGy-mw0Ek0hTZOX-6_ivvYrzYU7aRXB2za5KQrM), collect_job_id: 4c19f4af-6df6-4b6a-bec8-a4af35fc55b3, query_type: FixedSize { max_batch_size: 50 }, vdaf: Prio3Aes128Count }",
"name":"Job stepper"},
{"lease":"Lease { leased: AcquiredCollectJob { task_id: TaskId(aTv1dGy-mw0Ek0hTZOX-6_ivvYrzYU7aRXB2za5KQrM), collect_job_id: 4c19f4af-6df6-4b6a-bec8-a4af35fc55b3, query_type: FixedSize { max_batch_size: 50 }, vdaf: Prio3Aes128Count }, lease_expiry_time: Time(1668529516), lease_token: LeaseToken(6Wv_iCRDzPtEEQKOgx91ag), lease_attempts: 1 }",
"name":"step_collect_job_generic"},
{"name":"run_tx_once"},
{"collect_job_id":"4c19f4af-6df6-4b6a-bec8-a4af35fc55b3",
"name":"get_collect_job"}],
"threadId":"ThreadId(7)"}
```