### PR TITLE
Rename aggregation job field/column/methods to `partial_batch_identifier`

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1609,7 +1609,7 @@ impl VdafOps {
                             share_data.agg_state
                         {
                             accumulator.update(
-                                aggregation_job.batch_identifier(),
+                                aggregation_job.partial_batch_identifier(),
                                 share_data.report_share.metadata().id(),
                                 share_data.report_share.metadata().time(),
                                 output_share,
@@ -1760,7 +1760,12 @@ impl VdafOps {
 
                             Ok(PrepareTransition::Finish(output_share)) => {
                                 saw_finish = true;
-                                accumulator.update(aggregation_job.batch_identifier(), prep_step.report_id(), report_aggregation.time(), &output_share)?;
+                                accumulator.update(
+                                    aggregation_job.partial_batch_identifier(),
+                                    prep_step.report_id(),
+                                    report_aggregation.time(),
+                                    &output_share,
+                                )?;
                                 response_prep_steps.push(PrepareStep::new(
                                     *prep_step.report_id(),
                                     PrepareStepResult::Finished,

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -381,7 +381,7 @@ impl AggregationJobDriver {
             *task.id(),
             *aggregation_job.id(),
             aggregation_job.aggregation_parameter().get_encoded(),
-            PartialBatchSelector::new(aggregation_job.batch_identifier().clone()),
+            PartialBatchSelector::new(aggregation_job.partial_batch_identifier().clone()),
             report_shares,
         );
 
@@ -602,7 +602,7 @@ impl AggregationJobDriver {
                     // If the leader didn't finish too, we transition to INVALID.
                     if let PrepareTransition::Finish(out_share) = leader_transition {
                         match accumulator.update(
-                            aggregation_job.batch_identifier(),
+                            aggregation_job.partial_batch_identifier(),
                             report_aggregation.report_id(),
                             report_aggregation.time(),
                             out_share,

--- a/aggregator/src/datastore.rs
+++ b/aggregator/src/datastore.rs
@@ -1373,7 +1373,7 @@ impl<C: Clock> Transaction<'_, C> {
                     /* task_id */ &aggregation_job.task_id().as_ref(),
                     /* aggregation_job_id */ &aggregation_job.id().as_ref(),
                     /* partial_batch_identifier */
-                    &aggregation_job.batch_identifier().get_encoded(),
+                    &aggregation_job.partial_batch_identifier().get_encoded(),
                     /* aggregation_param */
                     &aggregation_job.aggregation_parameter().get_encoded(),
                     /* state */ &aggregation_job.state(),
@@ -1408,7 +1408,7 @@ impl<C: Clock> Transaction<'_, C> {
                     &stmt,
                     &[
                         /* partial_batch_identifier */
-                        &aggregation_job.batch_identifier().get_encoded(),
+                        &aggregation_job.partial_batch_identifier().get_encoded(),
                         /* aggregation_param */
                         &aggregation_job.aggregation_parameter().get_encoded(),
                         /* state */ &aggregation_job.state(),
@@ -3109,7 +3109,7 @@ pub mod models {
     {
         task_id: TaskId,
         aggregation_job_id: AggregationJobId,
-        batch_identifier: Q::PartialBatchIdentifier,
+        partial_batch_identifier: Q::PartialBatchIdentifier,
         #[derivative(Debug = "ignore")]
         aggregation_parameter: A::AggregationParam,
         state: AggregationJobState,
@@ -3123,14 +3123,14 @@ pub mod models {
         pub fn new(
             task_id: TaskId,
             aggregation_job_id: AggregationJobId,
-            batch_identifier: Q::PartialBatchIdentifier,
+            partial_batch_identifier: Q::PartialBatchIdentifier,
             aggregation_parameter: A::AggregationParam,
             state: AggregationJobState,
         ) -> Self {
             Self {
                 task_id,
                 aggregation_job_id,
-                batch_identifier,
+                partial_batch_identifier,
                 aggregation_parameter,
                 state,
             }
@@ -3150,8 +3150,8 @@ pub mod models {
         ///
         /// This method would typically be used for code which is generic over the query type.
         /// Query-type specific code will typically call [`Self::batch_id`].
-        pub fn batch_identifier(&self) -> &Q::PartialBatchIdentifier {
-            &self.batch_identifier
+        pub fn partial_batch_identifier(&self) -> &Q::PartialBatchIdentifier {
+            &self.partial_batch_identifier
         }
 
         /// Returns the aggregation parameter associated with this aggregation job.
@@ -3177,7 +3177,7 @@ pub mod models {
     {
         /// Gets the batch ID associated with this aggregation job.
         pub fn batch_id(&self) -> &BatchId {
-            self.batch_identifier()
+            self.partial_batch_identifier()
         }
     }
 
@@ -3189,7 +3189,7 @@ pub mod models {
         fn eq(&self, other: &Self) -> bool {
             self.task_id == other.task_id
                 && self.aggregation_job_id == other.aggregation_job_id
-                && self.batch_identifier == other.batch_identifier
+                && self.partial_batch_identifier == other.partial_batch_identifier
                 && self.aggregation_parameter == other.aggregation_parameter
                 && self.state == other.state
         }

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -95,22 +95,22 @@ CREATE TYPE AGGREGATION_JOB_STATE AS ENUM(
 
 -- An aggregation job, representing the aggregation of a number of client reports.
 CREATE TABLE aggregation_jobs(
-    id                 BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY, -- artificial ID, internal-only
-    task_id            BIGINT NOT NULL,                 -- ID of related task
-    aggregation_job_id BYTEA NOT NULL,                  -- 32-byte AggregationJobID as defined by the DAP specification
-    batch_identifier   BYTEA NOT NULL,                  -- encoded query-type-specific batch identifier (corresponds to identifier in PartialBatchSelector)
-    aggregation_param  BYTEA NOT NULL,                  -- encoded aggregation parameter (opaque VDAF message)
-    state              AGGREGATION_JOB_STATE NOT NULL,  -- current state of the aggregation job
+    id                       BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY, -- artificial ID, internal-only
+    task_id                  BIGINT NOT NULL,                 -- ID of related task
+    aggregation_job_id       BYTEA NOT NULL,                  -- 32-byte AggregationJobID as defined by the DAP specification
+    partial_batch_identifier BYTEA NOT NULL,                  -- encoded query-type-specific batch identifier (corresponds to identifier in PartialBatchSelector)
+    aggregation_param        BYTEA NOT NULL,                  -- encoded aggregation parameter (opaque VDAF message)
+    state                    AGGREGATION_JOB_STATE NOT NULL,  -- current state of the aggregation job
 
-    lease_expiry       TIMESTAMP NOT NULL DEFAULT TIMESTAMP '-infinity',  -- when lease on this aggregation job expires; -infinity implies no current lease
-    lease_token        BYTEA,                                             -- a value identifying the current leaseholder; NULL implies no current lease
-    lease_attempts     BIGINT NOT NULL DEFAULT 0,                         -- the number of lease acquiries since the last successful lease release
+    lease_expiry             TIMESTAMP NOT NULL DEFAULT TIMESTAMP '-infinity',  -- when lease on this aggregation job expires; -infinity implies no current lease
+    lease_token              BYTEA,                                             -- a value identifying the current leaseholder; NULL implies no current lease
+    lease_attempts           BIGINT NOT NULL DEFAULT 0,                         -- the number of lease acquiries since the last successful lease release
 
     CONSTRAINT unique_aggregation_job_id UNIQUE(aggregation_job_id),
     CONSTRAINT fk_task_id FOREIGN KEY(task_id) REFERENCES tasks(id)
 );
 CREATE INDEX aggregation_jobs_state_and_lease_expiry ON aggregation_jobs(state, lease_expiry) WHERE state = 'IN_PROGRESS';
-CREATE INDEX aggregation_jobs_task_and_batch_id ON aggregation_jobs(task_id, batch_identifier);
+CREATE INDEX aggregation_jobs_task_and_batch_id ON aggregation_jobs(task_id, partial_batch_identifier);
 
 -- Specifies the possible state of aggregating a single report.
 CREATE TYPE REPORT_AGGREGATION_STATE AS ENUM(


### PR DESCRIPTION
This renames "batch_identifier" to "partial_batch_identifier" in the context of aggregation jobs, both in the database and in Rust types. I think the increased clarity between batch identifiers and partial batch identifiers is beneficial, plus this refactor is the first thing I need to do to prototype tracking leader aggregation job batch identifiers, for #519.