### PR TITLE
Bugfix: fixup conflicting-collect check for fixed-size tasks.

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1620,9 +1620,11 @@ impl VdafOps {
                                 task.id(),
                                 share_data.report_share.metadata().id()
                             ),
-                            tx.get_aggregate_share_jobs_including_time::<L, A>(
+                            Q::get_conflicting_aggregate_share_jobs::<L, C, A>(
+                                tx,
                                 task.id(),
-                                share_data.report_share.metadata().time()
+                                req.batch_selector().batch_identifier(),
+                                share_data.report_share.metadata()
                             ),
                         )?;
                         if report_share_exists {

--- a/aggregator/src/aggregator/query_type.rs
+++ b/aggregator/src/aggregator/query_type.rs
@@ -1,6 +1,10 @@
 use super::Error;
 use crate::{
-    datastore::{self, gather_errors, models::BatchAggregation, Transaction},
+    datastore::{
+        self, gather_errors,
+        models::{AggregateShareJob, BatchAggregation},
+        Transaction,
+    },
     messages::TimeExt as _,
     task::Task,
 };
@@ -9,11 +13,12 @@ use futures::future::join_all;
 use janus_core::time::{Clock, TimeExt as _};
 use janus_messages::{
     query_type::{FixedSize, QueryType, TimeInterval},
-    Duration, Interval, Role, Time,
+    Duration, Interval, ReportMetadata, Role, TaskId, Time,
 };
 use prio::vdaf;
 use std::iter;
 
+#[async_trait]
 pub trait AccumulableQueryType: QueryType {
     /// This method converts various values related to a client report into a batch identifier. The
     /// arguments are somewhat arbitrary in the sense they are what "works out" to allow the
@@ -23,8 +28,23 @@ pub trait AccumulableQueryType: QueryType {
         _: &Self::PartialBatchIdentifier,
         client_timestamp: &Time,
     ) -> Result<Self::BatchIdentifier, datastore::Error>;
+
+    async fn get_conflicting_aggregate_share_jobs<
+        const L: usize,
+        C: Clock,
+        A: vdaf::Aggregator<L>,
+    >(
+        tx: &Transaction<'_, C>,
+        task_id: &TaskId,
+        partial_batch_identifier: &Self::PartialBatchIdentifier,
+        report_metadata: &ReportMetadata,
+    ) -> Result<Vec<AggregateShareJob<L, Self, A>>, datastore::Error>
+    where
+        for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Debug,
+        for<'a> &'a A::AggregateShare: Into<Vec<u8>>;
 }
 
+#[async_trait]
 impl AccumulableQueryType for TimeInterval {
     fn to_batch_identifier(
         task: &Task,
@@ -37,8 +57,27 @@ impl AccumulableQueryType for TimeInterval {
         Interval::new(batch_interval_start, *task.time_precision())
             .map_err(|e| datastore::Error::User(e.into()))
     }
+
+    async fn get_conflicting_aggregate_share_jobs<
+        const L: usize,
+        C: Clock,
+        A: vdaf::Aggregator<L>,
+    >(
+        tx: &Transaction<'_, C>,
+        task_id: &TaskId,
+        _: &Self::PartialBatchIdentifier,
+        report_metadata: &ReportMetadata,
+    ) -> Result<Vec<AggregateShareJob<L, Self, A>>, datastore::Error>
+    where
+        for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Debug,
+        for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
+    {
+        tx.get_aggregate_share_jobs_including_time::<L, A>(task_id, report_metadata.time())
+            .await
+    }
 }
 
+#[async_trait]
 impl AccumulableQueryType for FixedSize {
     fn to_batch_identifier(
         _: &Task,
@@ -46,6 +85,24 @@ impl AccumulableQueryType for FixedSize {
         _: &Time,
     ) -> Result<Self::BatchIdentifier, datastore::Error> {
         Ok(*batch_id)
+    }
+
+    async fn get_conflicting_aggregate_share_jobs<
+        const L: usize,
+        C: Clock,
+        A: vdaf::Aggregator<L>,
+    >(
+        tx: &Transaction<'_, C>,
+        task_id: &TaskId,
+        batch_id: &Self::PartialBatchIdentifier,
+        _: &ReportMetadata,
+    ) -> Result<Vec<AggregateShareJob<L, Self, A>>, datastore::Error>
+    where
+        for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Debug,
+        for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
+    {
+        tx.get_aggregate_share_jobs_by_batch_identifier(task_id, batch_id)
+            .await
     }
 }
 
@@ -82,7 +139,7 @@ pub trait CollectableQueryType: QueryType {
     ) -> Result<(), datastore::Error>
     where
         for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Debug,
-        Vec<u8>: for<'a> From<&'a A::AggregateShare>;
+        for<'a> &'a A::AggregateShare: Into<Vec<u8>>;
 
     /// Returns the number of client reports included in the given collect identifier, whether they
     /// have been aggregated or not.
@@ -168,7 +225,7 @@ impl CollectableQueryType for TimeInterval {
     ) -> Result<(), datastore::Error>
     where
         for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Debug,
-        Vec<u8>: for<'a> From<&'a A::AggregateShare>,
+        for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
         // Check how many rows in the relevant table have an intersecting batch interval.
         // Each such row consumes one unit of query count.
@@ -305,7 +362,7 @@ impl CollectableQueryType for FixedSize {
     ) -> Result<(), datastore::Error>
     where
         for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Debug,
-        Vec<u8>: for<'a> From<&'a A::AggregateShare>,
+        for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
         let query_count = match task.role() {
             Role::Leader => tx


### PR DESCRIPTION
This was specified in terms of time-interval tasks only, and written such that no compilation error occurred; I missed updating it on my first pass.