### PR TITLE
Add support for fixed size tasks to interop binaries and integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1666,6 +1666,7 @@ name = "janus_integration_tests"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "backoff",
  "base64",
  "futures",
@@ -1684,6 +1685,7 @@ dependencies = [
  "prio",
  "rand",
  "reqwest",
+ "serde",
  "serde_json",
  "tempfile",
  "testcontainers",

--- a/aggregator/src/task.rs
+++ b/aggregator/src/task.rs
@@ -733,6 +733,14 @@ pub mod test_util {
             })
         }
 
+        /// Sets the task query type
+        pub fn with_query_type(self, query_type: QueryType) -> Self {
+            Self(Task {
+                query_type,
+                ..self.0
+            })
+        }
+
         /// Consumes this task builder & produces a [`Task`] with the given specifications.
         pub fn build(self) -> Task {
             self.0.validate().unwrap();

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -13,6 +13,7 @@ kube-openssl = ["kube/openssl-tls"]
 
 [dependencies]
 anyhow = "1"
+async-trait = "0.1"
 backoff = { version = "0.4", features = ["tokio"] }
 base64 = "0.13.1"
 futures = "0.3.25"
@@ -28,6 +29,7 @@ portpicker = "0.1"
 prio = { version = "0.10.0", features = ["multithreaded"] }
 rand = "0.8"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
+serde = "1.0.147"
 serde_json = "1.0.89"
 testcontainers = "0.14.0"
 tokio = { version = "1", features = ["full", "tracing"] }

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -1,8 +1,13 @@
 //! Functionality for tests interacting with Janus (<https://github.com/divviup/janus>).
 
+use crate::BatchDiscovery;
+use anyhow::{anyhow, Context};
+use async_trait::async_trait;
+use base64::URL_SAFE_NO_PAD;
 use janus_aggregator::{
     binary_utils::{database_pool, datastore},
     config::DbConfig,
+    datastore::Datastore,
     task::Task,
 };
 use janus_core::{
@@ -13,13 +18,17 @@ use janus_interop_binaries::{
     log_export_path, test_util::await_http_server, testcontainer::Aggregator,
     AggregatorAddTaskRequest,
 };
-use janus_messages::Role;
+use janus_messages::{BatchId, Role, TaskId};
 use k8s_openapi::api::core::v1::Secret;
 use portpicker::pick_unused_port;
+use prio::codec::{Decode, Encode};
+use serde::Deserialize;
+use serde_json::json;
 use std::{
     collections::HashMap,
     path::Path,
     process::{Command, Stdio},
+    sync::Arc,
     thread::panicking,
 };
 use testcontainers::{clients::Cli, Container, RunnableImage};
@@ -33,6 +42,7 @@ pub enum Janus<'a> {
     Container {
         role: Role,
         container: Container<'a, Aggregator>,
+        batch_discovery: Arc<dyn BatchDiscovery>,
     },
 
     /// Janus components are assumed to already be running in the Kubernetes cluster. Running tests
@@ -40,6 +50,7 @@ pub enum Janus<'a> {
     /// new tasks and reports into its datastore.
     KubernetesCluster {
         aggregator_port_forward: PortForward,
+        batch_discovery: Arc<dyn BatchDiscovery>,
     },
 }
 
@@ -80,21 +91,44 @@ impl<'a> Janus<'a> {
             resp.get("error")
         );
 
+        let fetch_batch_ids_url = Url::parse(&format!(
+            "http://127.0.0.1:{}/internal/test/fetch_batch_ids",
+            port
+        ))
+        .unwrap();
+        let batch_discovery = Arc::new(JanusContainerBatchFetch {
+            http_client,
+            fetch_batch_ids_url,
+        });
+
         Self::Container {
             role: *task.role(),
             container,
+            batch_discovery,
         }
     }
 
     /// Returns the port of the aggregator on the host.
     pub fn port(&self) -> u16 {
         match self {
-            Janus::Container { role: _, container } => {
+            Janus::Container { container, .. } => {
                 container.get_host_port_ipv4(Aggregator::INTERNAL_SERVING_PORT)
             }
             Janus::KubernetesCluster {
                 aggregator_port_forward,
+                ..
             } => aggregator_port_forward.local_port(),
+        }
+    }
+
+    pub fn batch_discovery(&self) -> Arc<dyn BatchDiscovery> {
+        match self {
+            Janus::KubernetesCluster {
+                batch_discovery, ..
+            }
+            | Janus::Container {
+                batch_discovery, ..
+            } => Arc::clone(batch_discovery),
         }
     }
 }
@@ -169,11 +203,13 @@ impl Janus<'static> {
         // depends on this task being defined will likely time out or otherwise fail.
         // This should become more robust in the future when we implement dynamic task provisioning
         // (#44).
-        datastore(pool, RealClock::default(), &[datastore_key])
-            .unwrap()
-            .put_task(task)
-            .await
-            .unwrap();
+        let datastore = datastore(pool, RealClock::default(), &[datastore_key]).unwrap();
+        datastore.put_task(task).await.unwrap();
+
+        let batch_discovery = Arc::new(JanusClusterBatchFetch {
+            datastore,
+            _datastore_port_forward,
+        });
 
         let aggregator_port_forward = cluster
             .forward_port(namespace, "aggregator", pick_unused_port().unwrap(), 80)
@@ -181,6 +217,7 @@ impl Janus<'static> {
 
         Self::KubernetesCluster {
             aggregator_port_forward,
+            batch_discovery,
         }
     }
 }
@@ -193,7 +230,10 @@ impl<'a> Drop for Janus<'a> {
         // (log export is a no-op for non-containers: when running tests against a cluster, we
         // gather up logfiles with `kind export logs`)
 
-        if let Janus::Container { role, container } = self {
+        if let Janus::Container {
+            role, container, ..
+        } = self
+        {
             if !panicking() {
                 return;
             }
@@ -216,5 +256,81 @@ impl<'a> Drop for Janus<'a> {
                 );
             }
         }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct InteropFetchBatchIdsResponse {
+    status: String,
+    error: Option<String>,
+    batch_ids: Option<Vec<String>>,
+}
+
+struct JanusContainerBatchFetch {
+    http_client: reqwest::Client,
+    fetch_batch_ids_url: Url,
+}
+
+#[async_trait]
+impl BatchDiscovery for JanusContainerBatchFetch {
+    async fn get_batch_ids(&self, task_id: &TaskId) -> anyhow::Result<Vec<BatchId>> {
+        let task_id_encoded = base64::encode_config(&task_id.get_encoded(), URL_SAFE_NO_PAD);
+        let response = self
+            .http_client
+            .post(self.fetch_batch_ids_url.clone())
+            .json(&json!({
+                "task_id": task_id_encoded,
+            }))
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<InteropFetchBatchIdsResponse>()
+            .await?;
+        if &response.status != "success" {
+            if let Some(error) = &response.error {
+                return Err(anyhow!(
+                    "Error from /internal/test/fetch_batch_ids: {error}"
+                ));
+            } else {
+                return Err(anyhow!("Error from /internal/test/fetch_batch_ids"));
+            }
+        }
+        if let Some(batch_ids) = &response.batch_ids {
+            batch_ids
+                .iter()
+                .map(|text| {
+                    let bytes = base64::decode_config(text, URL_SAFE_NO_PAD)
+                        .context("Invalid base64url content in fetch_batch_ids repsonse")?;
+                    BatchId::get_decoded(&bytes)
+                        .context("Incorrect batch ID length in fetch_batch_ids response")
+                })
+                .collect::<Result<Vec<BatchId>, _>>()
+                .map_err(Into::into)
+        } else {
+            Err(anyhow!("Response is missing \"batch_ids\" attribute"))
+        }
+    }
+}
+
+struct JanusClusterBatchFetch {
+    datastore: Datastore<RealClock>,
+    _datastore_port_forward: PortForward,
+}
+
+#[async_trait]
+impl BatchDiscovery for JanusClusterBatchFetch {
+    async fn get_batch_ids(&self, task_id: &TaskId) -> anyhow::Result<Vec<BatchId>> {
+        let outstanding_batches = self
+            .datastore
+            .run_tx(|tx| {
+                let task_id = *task_id;
+                Box::pin(async move { tx.get_outstanding_batches_for_task(&task_id).await })
+            })
+            .await?;
+        let batch_ids = outstanding_batches
+            .into_iter()
+            .map(|outstanding_batch| *outstanding_batch.id())
+            .collect();
+        Ok(batch_ids)
     }
 }

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -1,6 +1,16 @@
 //! This crate contains functionality useful for Janus integration tests.
 
+use janus_messages::{BatchId, TaskId};
+
 pub mod client;
 #[cfg(feature = "daphne")]
 pub mod daphne;
 pub mod janus;
+
+/// Provides access to find which batch identifiers have been assigned in a fixed-size task.
+///
+/// Note that this will be made obsolete by "current_batch" requests in DAP-03.
+#[async_trait::async_trait]
+pub trait BatchDiscovery {
+    async fn get_batch_ids(&self, task_id: &TaskId) -> anyhow::Result<Vec<BatchId>>;
+}

--- a/integration_tests/tests/divviup_ts.rs
+++ b/integration_tests/tests/divviup_ts.rs
@@ -16,7 +16,8 @@ mod common;
 use common::{submit_measurements_and_verify_aggregate, test_task_builders};
 
 async fn run_divviup_ts_integration_test(container_client: &Cli, vdaf: VdafInstance) {
-    let (collector_private_key, leader_task, helper_task) = test_task_builders(vdaf);
+    let (collector_private_key, leader_task, helper_task) =
+        test_task_builders(vdaf, janus_aggregator::task::QueryType::TimeInterval);
     let leader_task = leader_task.build();
     let network = generate_network_name();
     let leader = Janus::new_in_container(container_client, &network, &leader_task).await;
@@ -32,6 +33,7 @@ async fn run_divviup_ts_integration_test(container_client: &Cli, vdaf: VdafInsta
         &leader_task,
         &collector_private_key,
         &client_backend,
+        leader.batch_discovery(),
     )
     .await;
 }

--- a/integration_tests/tests/janus.rs
+++ b/integration_tests/tests/janus.rs
@@ -1,5 +1,5 @@
 use common::{submit_measurements_and_verify_aggregate, test_task_builders};
-use janus_aggregator::task::Task;
+use janus_aggregator::task::{QueryType, Task};
 use janus_core::{
     hpke::HpkePrivateKey,
     task::VdafInstance,
@@ -48,8 +48,13 @@ impl<'a> JanusPair<'a> {
     ///    permissions to view secrets and forward ports to services.
     ///  - `JANUS_E2E_LEADER_NAMESPACE`: The Kubernetes namespace where the DAP leader is deployed.
     ///  - `JANUS_E2E_HELPER_NAMESPACE`: The Kubernetes namespace where the DAP helper is deployed.
-    pub async fn new(container_client: &'a Cli, vdaf: VdafInstance) -> JanusPair<'a> {
-        let (collector_private_key, leader_task, helper_task) = test_task_builders(vdaf);
+    pub async fn new(
+        container_client: &'a Cli,
+        vdaf: VdafInstance,
+        query_type: QueryType,
+    ) -> JanusPair<'a> {
+        let (collector_private_key, leader_task, helper_task) =
+            test_task_builders(vdaf, query_type);
 
         // The environment variables should either all be present, or all be absent
         let (leader_task, leader, helper) = match (
@@ -144,7 +149,12 @@ async fn janus_janus_count() {
 
     // Start servers.
     let container_client = container_client();
-    let janus_pair = JanusPair::new(&container_client, VdafInstance::Prio3Aes128Count).await;
+    let janus_pair = JanusPair::new(
+        &container_client,
+        VdafInstance::Prio3Aes128Count,
+        QueryType::TimeInterval,
+    )
+    .await;
 
     // Run the behavioral test.
     submit_measurements_and_verify_aggregate(
@@ -152,6 +162,7 @@ async fn janus_janus_count() {
         &janus_pair.leader_task,
         &janus_pair.collector_private_key,
         &ClientBackend::InProcess,
+        janus_pair.leader.batch_discovery(),
     )
     .await;
 }
@@ -163,8 +174,12 @@ async fn janus_janus_sum_16() {
 
     // Start servers.
     let container_client = container_client();
-    let janus_pair =
-        JanusPair::new(&container_client, VdafInstance::Prio3Aes128Sum { bits: 16 }).await;
+    let janus_pair = JanusPair::new(
+        &container_client,
+        VdafInstance::Prio3Aes128Sum { bits: 16 },
+        QueryType::TimeInterval,
+    )
+    .await;
 
     // Run the behavioral test.
     submit_measurements_and_verify_aggregate(
@@ -172,6 +187,7 @@ async fn janus_janus_sum_16() {
         &janus_pair.leader_task,
         &janus_pair.collector_private_key,
         &ClientBackend::InProcess,
+        janus_pair.leader.batch_discovery(),
     )
     .await;
 }
@@ -188,6 +204,7 @@ async fn janus_janus_histogram_4_buckets() {
     let janus_pair = JanusPair::new(
         &container_client,
         VdafInstance::Prio3Aes128Histogram { buckets },
+        QueryType::TimeInterval,
     )
     .await;
 
@@ -197,6 +214,7 @@ async fn janus_janus_histogram_4_buckets() {
         &janus_pair.leader_task,
         &janus_pair.collector_private_key,
         &ClientBackend::InProcess,
+        janus_pair.leader.batch_discovery(),
     )
     .await;
 }
@@ -211,6 +229,7 @@ async fn janus_janus_count_vec_15() {
     let janus_pair = JanusPair::new(
         &container_client,
         VdafInstance::Prio3Aes128CountVec { length: 15 },
+        QueryType::TimeInterval,
     )
     .await;
 
@@ -220,6 +239,32 @@ async fn janus_janus_count_vec_15() {
         &janus_pair.leader_task,
         &janus_pair.collector_private_key,
         &ClientBackend::InProcess,
+        janus_pair.leader.batch_discovery(),
+    )
+    .await;
+}
+
+/// This test exercises the fixed-size query type with Janus as both the leader and the helper.
+#[tokio::test(flavor = "multi_thread")]
+async fn janus_janus_fixed_size() {
+    install_test_trace_subscriber();
+
+    // Start servers.
+    let container_client = container_client();
+    let janus_pair = JanusPair::new(
+        &container_client,
+        VdafInstance::Prio3Aes128Count,
+        QueryType::FixedSize { max_batch_size: 50 },
+    )
+    .await;
+
+    // Run the behavioral test.
+    submit_measurements_and_verify_aggregate(
+        (janus_pair.leader.port(), janus_pair.helper.port()),
+        &janus_pair.leader_task,
+        &janus_pair.collector_private_key,
+        &ClientBackend::InProcess,
+        janus_pair.leader.batch_discovery(),
     )
     .await;
 }

--- a/interop_binaries/src/bin/janus_interop_aggregator.rs
+++ b/interop_binaries/src/bin/janus_interop_aggregator.rs
@@ -17,7 +17,11 @@ use janus_interop_binaries::{
 use janus_messages::{BatchId, Duration, HpkeConfig, TaskId, Time};
 use prio::codec::Decode;
 use serde::{Deserialize, Serialize};
-use std::{net::SocketAddr, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    net::SocketAddr,
+    sync::Arc,
+};
 use tokio::sync::Mutex;
 use warp::{hyper::StatusCode, reply::Response, Filter, Reply};
 
@@ -39,6 +43,32 @@ struct FetchBatchIdsResponse {
     error: Option<String>,
     #[serde(default)]
     batch_ids: Option<Vec<String>>,
+}
+
+/// This data structure records batch IDs as they are observed. Batch IDs are stored here to adapt
+/// between the semantics of the `outstanding_batches` table, which only stores batches before they
+/// are collected for the first time, and the `/internal/test/fetch_batch_ids` API, which returns
+/// all batches for a task.
+struct BatchIdStorage {
+    map: HashMap<TaskId, HashSet<BatchId>>,
+}
+
+impl BatchIdStorage {
+    fn new() -> BatchIdStorage {
+        BatchIdStorage {
+            map: HashMap::new(),
+        }
+    }
+
+    fn update(
+        &mut self,
+        task_id: TaskId,
+        batch_ids: impl Iterator<Item = BatchId>,
+    ) -> &HashSet<BatchId> {
+        let hash_set = self.map.entry(task_id).or_default();
+        hash_set.extend(batch_ids);
+        hash_set
+    }
 }
 
 async fn handle_add_task(
@@ -124,14 +154,30 @@ async fn handle_add_task(
 }
 
 async fn handle_fetch_batch_ids(
-    _datastore: &Datastore<RealClock>,
+    datastore: &Datastore<RealClock>,
+    batch_id_storage: &Mutex<BatchIdStorage>,
     request: FetchBatchIdsRequest,
 ) -> anyhow::Result<Vec<BatchId>> {
     let task_id_bytes = base64::decode_config(request.task_id, URL_SAFE_NO_PAD)
         .context("invalid base64url content in \"task_id\"")?;
-    let _task_id = TaskId::get_decoded(&task_id_bytes).context("invalid length of TaskId")?;
+    let task_id = TaskId::get_decoded(&task_id_bytes).context("invalid length of TaskId")?;
 
-    Err(anyhow::anyhow!("fixed size queries are not yet supported"))
+    let outstanding_batches = datastore
+        .run_tx(move |tx| {
+            Box::pin(async move { tx.get_outstanding_batches_for_task(&task_id).await })
+        })
+        .await
+        .context("error fetching batches from database")?;
+    let new_batch_ids = outstanding_batches
+        .into_iter()
+        .map(|outstanding_batch| *outstanding_batch.id());
+    let mut guard = batch_id_storage.lock().await;
+    let batch_ids = guard
+        .update(task_id, new_batch_ids)
+        .iter()
+        .copied()
+        .collect::<Vec<_>>();
+    Ok(batch_ids)
 }
 
 fn make_filter(
@@ -139,6 +185,7 @@ fn make_filter(
     dap_serving_prefix: String,
 ) -> anyhow::Result<impl Filter<Extract = (Response,)> + Clone> {
     let keyring = Arc::new(Mutex::new(HpkeConfigRegistry::new()));
+    let batch_id_storage = Arc::new(Mutex::new(BatchIdStorage::new()));
     let dap_filter = aggregator_filter(Arc::clone(&datastore), RealClock::default())?;
 
     // Respect dap_serving_prefix.
@@ -187,26 +234,28 @@ fn make_filter(
     let fetch_batch_ids_filter = warp::path!("fetch_batch_ids").and(warp::body::json()).then(
         move |request: FetchBatchIdsRequest| {
             let datastore = Arc::clone(&datastore);
+            let batch_id_storage = Arc::clone(&batch_id_storage);
             async move {
-                let response = match handle_fetch_batch_ids(&datastore, request).await {
-                    Ok(batch_ids) => FetchBatchIdsResponse {
-                        status: SUCCESS,
-                        error: None,
-                        batch_ids: Some(
-                            batch_ids
-                                .into_iter()
-                                .map(|batch_id| {
-                                    base64::encode_config(batch_id.as_ref(), URL_SAFE_NO_PAD)
-                                })
-                                .collect(),
-                        ),
-                    },
-                    Err(e) => FetchBatchIdsResponse {
-                        status: ERROR,
-                        error: Some(format!("{:?}", e)),
-                        batch_ids: None,
-                    },
-                };
+                let response =
+                    match handle_fetch_batch_ids(&datastore, &batch_id_storage, request).await {
+                        Ok(batch_ids) => FetchBatchIdsResponse {
+                            status: SUCCESS,
+                            error: None,
+                            batch_ids: Some(
+                                batch_ids
+                                    .into_iter()
+                                    .map(|batch_id| {
+                                        base64::encode_config(batch_id.as_ref(), URL_SAFE_NO_PAD)
+                                    })
+                                    .collect(),
+                            ),
+                        },
+                        Err(e) => FetchBatchIdsResponse {
+                            status: ERROR,
+                            error: Some(format!("{:?}", e)),
+                            batch_ids: None,
+                        },
+                    };
                 warp::reply::with_status(warp::reply::json(&response), StatusCode::OK)
                     .into_response()
             }


### PR DESCRIPTION
This adds a more-complete integration test for fixed size tasks. I had to solve the batch ID discovery problem ~3 times, so there is some near-repetition between different settings. We'll be able to rip this out once we move on to DAP-03, thanks to the `current_batch` query sub-type. I successfully tested this against a hacked-up collect job driver. I did notice one test flake, possibly related to #763, which I'll investigate further.