### PR TITLE
Improve collector error handling

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -40,12 +40,13 @@ use janus_core::{
     time::Clock,
 };
 use janus_messages::{
+    problem_type::DapProblemType,
     query_type::{FixedSize, QueryType, TimeInterval},
     AggregateContinueReq, AggregateContinueResp, AggregateInitializeReq, AggregateInitializeResp,
     AggregateShareReq, AggregateShareResp, AggregationJobId, CollectReq, CollectResp,
-    DapProblemType, HpkeCiphertext, HpkeConfig, HpkeConfigId, Interval, PartialBatchSelector,
-    PrepareStep, PrepareStepResult, Report, ReportId, ReportIdChecksum, ReportShare,
-    ReportShareError, Role, TaskId, Time,
+    HpkeCiphertext, HpkeConfig, HpkeConfigId, Interval, PartialBatchSelector, PrepareStep,
+    PrepareStepResult, Report, ReportId, ReportIdChecksum, ReportShare, ReportShareError, Role,
+    TaskId, Time,
 };
 use opentelemetry::{
     metrics::{Counter, Histogram, Meter, Unit},
@@ -3281,12 +3282,13 @@ mod tests {
         time::{Clock, MockClock, RealClock, TimeExt as _},
     };
     use janus_messages::{
-        query_type::TimeInterval, AggregateContinueReq, AggregateContinueResp,
-        AggregateInitializeReq, AggregateInitializeResp, AggregateShareReq, AggregateShareResp,
-        BatchSelector, CollectReq, CollectResp, DapProblemType, DapProblemTypeParseError, Duration,
-        HpkeCiphertext, HpkeConfig, HpkeConfigId, Interval, PartialBatchSelector, PrepareStep,
-        PrepareStepResult, Query, Report, ReportId, ReportIdChecksum, ReportMetadata, ReportShare,
-        ReportShareError, Role, TaskId, Time,
+        problem_type::{DapProblemType, DapProblemTypeParseError},
+        query_type::TimeInterval,
+        AggregateContinueReq, AggregateContinueResp, AggregateInitializeReq,
+        AggregateInitializeResp, AggregateShareReq, AggregateShareResp, BatchSelector, CollectReq,
+        CollectResp, Duration, HpkeCiphertext, HpkeConfig, HpkeConfigId, Interval,
+        PartialBatchSelector, PrepareStep, PrepareStepResult, Query, Report, ReportId,
+        ReportIdChecksum, ReportMetadata, ReportShare, ReportShareError, Role, TaskId, Time,
     };
     use mockito::mock;
     use opentelemetry::global::meter;

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -63,7 +63,7 @@ use janus_core::{
 };
 use janus_messages::{
     query_type::{QueryType, TimeInterval},
-    CollectReq, CollectResp, HpkeConfig, Query, Role, TaskId,
+    CollectReq, CollectResp, DapProblemType, HpkeConfig, Query, Role, TaskId,
 };
 use prio::{
     codec::{Decode, Encode},
@@ -71,7 +71,7 @@ use prio::{
 };
 use reqwest::{
     header::{HeaderValue, ToStrError, CONTENT_TYPE, LOCATION, RETRY_AFTER},
-    StatusCode,
+    Response, StatusCode,
 };
 use retry_after::FromHeaderValueError;
 use retry_after::RetryAfter;
@@ -87,8 +87,11 @@ use url::Url;
 pub enum Error {
     #[error("HTTP client error: {0}")]
     HttpClient(#[from] reqwest::Error),
-    #[error("HTTP response status {0}")]
-    Http(Box<HttpApiProblem>),
+    #[error("HTTP response status {problem_details}")]
+    Http {
+        problem_details: Box<HttpApiProblem>,
+        dap_problem_type: Option<DapProblemType>,
+    },
     #[error("URL parse: {0}")]
     Url(#[from] url::ParseError),
     #[error("missing Location header in See Other response")]
@@ -113,6 +116,22 @@ pub enum Error {
     CollectPollTimeout,
     #[error("report count was too large")]
     ReportCountOverflow,
+}
+
+impl Error {
+    /// Construct an error from an HTTP response's status and problem details document, if present
+    /// in the body.
+    async fn from_http_response(response: Response) -> Error {
+        let problem_details = response_to_problem_details(response).await;
+        let dap_problem_type = problem_details
+            .type_url
+            .as_ref()
+            .and_then(|str| str.parse::<DapProblemType>().ok());
+        Error::Http {
+            problem_details: Box::new(problem_details),
+            dap_problem_type,
+        }
+    }
 }
 
 static COLLECTOR_USER_AGENT: &str = concat!(
@@ -355,19 +374,17 @@ where
                 if status == StatusCode::SEE_OTHER {
                     response
                 } else if status.is_client_error() || status.is_server_error() {
-                    return Err(Error::Http(Box::new(
-                        response_to_problem_details(response).await,
-                    )));
+                    return Err(Error::from_http_response(response).await);
                 } else {
-                    return Err(Error::Http(Box::new(HttpApiProblem::new(status))));
+                    // Incorrect success/redirect status code:
+                    return Err(Error::Http {
+                        problem_details: Box::new(HttpApiProblem::new(status)),
+                        dap_problem_type: None,
+                    });
                 }
             }
             // Retryable error status code, but ran out of retries:
-            Err(Ok(response)) => {
-                return Err(Error::Http(Box::new(
-                    response_to_problem_details(response).await,
-                )))
-            }
+            Err(Ok(response)) => return Err(Error::from_http_response(response).await),
             // Lower level errors, either unretryable or ran out of retries:
             Err(Err(error)) => return Err(Error::HttpClient(error)),
         };
@@ -422,19 +439,18 @@ where
                         return Ok(PollResult::NextAttempt(retry_after_opt));
                     }
                     _ if status.is_client_error() || status.is_server_error() => {
-                        return Err(Error::Http(Box::new(
-                            response_to_problem_details(response).await,
-                        )));
+                        return Err(Error::from_http_response(response).await);
                     }
-                    _ => return Err(Error::Http(Box::new(HttpApiProblem::new(status)))),
+                    _ => {
+                        return Err(Error::Http {
+                            problem_details: Box::new(HttpApiProblem::new(status)),
+                            dap_problem_type: None,
+                        })
+                    }
                 }
             }
             // Retryable error status code, but ran out of retries:
-            Err(Ok(response)) => {
-                return Err(Error::Http(Box::new(
-                    response_to_problem_details(response).await,
-                )))
-            }
+            Err(Ok(response)) => return Err(Error::from_http_response(response).await),
             // Lower level errors, either unretryable or ran out of retries:
             Err(Err(error)) => return Err(Error::HttpClient(error)),
         };
@@ -603,8 +619,8 @@ mod tests {
     };
     use janus_messages::{
         query_type::{FixedSize, TimeInterval},
-        BatchId, CollectReq, CollectResp, Duration, HpkeCiphertext, Interval, PartialBatchSelector,
-        Query, Role, Time,
+        BatchId, CollectReq, CollectResp, DapProblemType, Duration, HpkeCiphertext, Interval,
+        PartialBatchSelector, Query, Role, Time,
     };
     use mockito::mock;
     use prio::{
@@ -990,8 +1006,9 @@ mod tests {
             .start_collection(Query::new_time_interval(batch_interval), &())
             .await
             .unwrap_err();
-        assert_matches!(error, Error::Http(problem) => {
-            assert_eq!(problem.status.unwrap(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_matches!(error, Error::Http { problem_details, dap_problem_type } => {
+            assert_eq!(problem_details.status.unwrap(), StatusCode::INTERNAL_SERVER_ERROR);
+            assert_eq!(dap_problem_type, None);
         });
 
         mock_server_error.assert();
@@ -1011,9 +1028,10 @@ mod tests {
             .start_collection(Query::new_time_interval(batch_interval), &())
             .await
             .unwrap_err();
-        assert_matches!(error, Error::Http(problem) => {
-            assert_eq!(problem.status.unwrap(), StatusCode::INTERNAL_SERVER_ERROR);
-            assert_eq!(problem.type_url.unwrap(), "http://example.com/test_server_error");
+        assert_matches!(error, Error::Http { problem_details, dap_problem_type } => {
+            assert_eq!(problem_details.status.unwrap(), StatusCode::INTERNAL_SERVER_ERROR);
+            assert_eq!(problem_details.type_url.unwrap(), "http://example.com/test_server_error");
+            assert_eq!(dap_problem_type, None);
         });
 
         mock_server_error_details.assert();
@@ -1055,10 +1073,11 @@ mod tests {
             .start_collection(Query::new_time_interval(batch_interval), &())
             .await
             .unwrap_err();
-        assert_matches!(error, Error::Http(problem) => {
-            assert_eq!(problem.status.unwrap(), StatusCode::BAD_REQUEST);
-            assert_eq!(problem.type_url.unwrap(), "urn:ietf:params:ppm:dap:error:unrecognizedMessage");
-            assert_eq!(problem.detail.unwrap(), "The message type for a response was incorrect or the payload was malformed.");
+        assert_matches!(error, Error::Http { problem_details, dap_problem_type } => {
+            assert_eq!(problem_details.status.unwrap(), StatusCode::BAD_REQUEST);
+            assert_eq!(problem_details.type_url.unwrap(), "urn:ietf:params:ppm:dap:error:unrecognizedMessage");
+            assert_eq!(problem_details.detail.unwrap(), "The message type for a response was incorrect or the payload was malformed.");
+            assert_eq!(dap_problem_type, Some(DapProblemType::UnrecognizedMessage));
         });
 
         mock_bad_request.assert();
@@ -1096,8 +1115,9 @@ mod tests {
             .await
             .unwrap();
         let error = collector.poll_once(&job).await.unwrap_err();
-        assert_matches!(error, Error::Http(problem) => {
-            assert_eq!(problem.status.unwrap(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_matches!(error, Error::Http { problem_details, dap_problem_type } => {
+            assert_eq!(problem_details.status.unwrap(), StatusCode::INTERNAL_SERVER_ERROR);
+            assert_eq!(dap_problem_type, None);
         });
 
         mock_collect_start.assert();
@@ -1111,9 +1131,10 @@ mod tests {
             .create();
 
         let error = collector.poll_once(&job).await.unwrap_err();
-        assert_matches!(error, Error::Http(problem) => {
-            assert_eq!(problem.status.unwrap(), StatusCode::INTERNAL_SERVER_ERROR);
-            assert_eq!(problem.type_url.unwrap(), "http://example.com/test_server_error");
+        assert_matches!(error, Error::Http { problem_details, dap_problem_type } => {
+            assert_eq!(problem_details.status.unwrap(), StatusCode::INTERNAL_SERVER_ERROR);
+            assert_eq!(problem_details.type_url.unwrap(), "http://example.com/test_server_error");
+            assert_eq!(dap_problem_type, None);
         });
 
         mock_collect_job_server_error_details.assert();
@@ -1129,10 +1150,11 @@ mod tests {
             .create();
 
         let error = collector.poll_once(&job).await.unwrap_err();
-        assert_matches!(error, Error::Http(problem) => {
-            assert_eq!(problem.status.unwrap(), StatusCode::BAD_REQUEST);
-            assert_eq!(problem.type_url.unwrap(), "urn:ietf:params:ppm:dap:error:unrecognizedMessage");
-            assert_eq!(problem.detail.unwrap(), "The message type for a response was incorrect or the payload was malformed.");
+        assert_matches!(error, Error::Http { problem_details, dap_problem_type } => {
+            assert_eq!(problem_details.status.unwrap(), StatusCode::BAD_REQUEST);
+            assert_eq!(problem_details.type_url.unwrap(), "urn:ietf:params:ppm:dap:error:unrecognizedMessage");
+            assert_eq!(problem_details.detail.unwrap(), "The message type for a response was incorrect or the payload was malformed.");
+            assert_eq!(dap_problem_type, Some(DapProblemType::UnrecognizedMessage));
         });
 
         mock_collect_job_bad_request.assert();
@@ -1301,8 +1323,9 @@ mod tests {
             .expect_at_least(3)
             .create();
         let error = collector.poll_until_complete(&job).await.unwrap_err();
-        assert_matches!(error, Error::Http(problem) => {
-            assert_eq!(problem.status.unwrap(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_matches!(error, Error::Http { problem_details, dap_problem_type } => {
+            assert_eq!(problem_details.status.unwrap(), StatusCode::INTERNAL_SERVER_ERROR);
+            assert_eq!(dap_problem_type, None);
         });
         mock_collect_job_always_fail.assert();
     }

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -62,8 +62,9 @@ use janus_core::{
     task::{url_ensure_trailing_slash, AuthenticationToken, DAP_AUTH_HEADER},
 };
 use janus_messages::{
+    problem_type::DapProblemType,
     query_type::{QueryType, TimeInterval},
-    CollectReq, CollectResp, DapProblemType, HpkeConfig, Query, Role, TaskId,
+    CollectReq, CollectResp, HpkeConfig, Query, Role, TaskId,
 };
 use prio::{
     codec::{Decode, Encode},
@@ -618,9 +619,10 @@ mod tests {
         test_util::{install_test_trace_subscriber, run_vdaf, VdafTranscript},
     };
     use janus_messages::{
+        problem_type::DapProblemType,
         query_type::{FixedSize, TimeInterval},
-        BatchId, CollectReq, CollectResp, DapProblemType, Duration, HpkeCiphertext, Interval,
-        PartialBatchSelector, Query, Role, Time,
+        BatchId, CollectReq, CollectResp, Duration, HpkeCiphertext, Interval, PartialBatchSelector,
+        Query, Role, Time,
     };
     use mockito::mock;
     use prio::{

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -1961,6 +1961,133 @@ impl Decode for AggregateShareResp {
     }
 }
 
+/// Representation of the different problem types defined in Table 1 in §3.2.
+#[derive(Debug, PartialEq, Eq)]
+pub enum DapProblemType {
+    UnrecognizedMessage,
+    UnrecognizedTask,
+    MissingTaskId,
+    UnrecognizedAggregationJob,
+    OutdatedConfig,
+    ReportTooLate,
+    ReportTooEarly,
+    BatchInvalid,
+    InvalidBatchSize,
+    BatchQueriedTooManyTimes,
+    BatchMismatch,
+    UnauthorizedRequest,
+    BatchOverlap,
+}
+
+impl DapProblemType {
+    /// Returns the problem type URI for a particular kind of error.
+    pub fn type_uri(&self) -> &'static str {
+        match self {
+            DapProblemType::UnrecognizedMessage => {
+                "urn:ietf:params:ppm:dap:error:unrecognizedMessage"
+            }
+            DapProblemType::UnrecognizedTask => "urn:ietf:params:ppm:dap:error:unrecognizedTask",
+            DapProblemType::MissingTaskId => "urn:ietf:params:ppm:dap:error:missingTaskID",
+            DapProblemType::UnrecognizedAggregationJob => {
+                "urn:ietf:params:ppm:dap:error:unrecognizedAggregationJob"
+            }
+            DapProblemType::OutdatedConfig => "urn:ietf:params:ppm:dap:error:outdatedConfig",
+            DapProblemType::ReportTooLate => "urn:ietf:params:ppm:dap:error:reportTooLate",
+            DapProblemType::ReportTooEarly => "urn:ietf:params:ppm:dap:error:reportTooEarly",
+            DapProblemType::BatchInvalid => "urn:ietf:params:ppm:dap:error:batchInvalid",
+            DapProblemType::InvalidBatchSize => "urn:ietf:params:ppm:dap:error:invalidBatchSize",
+            DapProblemType::BatchQueriedTooManyTimes => {
+                "urn:ietf:params:ppm:dap:error:batchQueriedTooManyTimes"
+            }
+            DapProblemType::BatchMismatch => "urn:ietf:params:ppm:dap:error:batchMismatch",
+            DapProblemType::UnauthorizedRequest => {
+                "urn:ietf:params:ppm:dap:error:unauthorizedRequest"
+            }
+            DapProblemType::BatchOverlap => "urn:ietf:params:ppm:dap:error:batchOverlap",
+        }
+    }
+
+    /// Returns a human-readable summary of a problem type.
+    pub fn description(&self) -> &'static str {
+        match self {
+            DapProblemType::UnrecognizedMessage => {
+                "The message type for a response was incorrect or the payload was malformed."
+            }
+            DapProblemType::UnrecognizedTask => {
+                "An endpoint received a message with an unknown task ID."
+            }
+            DapProblemType::MissingTaskId => {
+                "HPKE configuration was requested without specifying a task ID."
+            }
+            DapProblemType::UnrecognizedAggregationJob => {
+                "An endpoint received a message with an unknown aggregation job ID."
+            }
+            DapProblemType::OutdatedConfig => {
+                "The message was generated using an outdated configuration."
+            }
+            DapProblemType::ReportTooLate => {
+                "Report could not be processed because it arrived too late."
+            }
+            DapProblemType::ReportTooEarly => {
+                "Report could not be processed because it arrived too early."
+            }
+            DapProblemType::BatchInvalid => "The batch implied by the query is invalid.",
+            DapProblemType::InvalidBatchSize => {
+                "The number of reports included in the batch is invalid."
+            }
+            DapProblemType::BatchQueriedTooManyTimes => {
+                "The batch described by the query has been queried too many times."
+            }
+            DapProblemType::BatchMismatch => {
+                "Leader and helper disagree on reports aggregated in a batch."
+            }
+            DapProblemType::UnauthorizedRequest => "The request's authorization is not valid.",
+            DapProblemType::BatchOverlap => {
+                "The queried batch overlaps with a previously queried batch."
+            }
+        }
+    }
+}
+
+/// An error indicating a problem type URI was not recognized as a DAP problem type.
+#[derive(Debug)]
+pub struct DapProblemTypeParseError;
+
+impl FromStr for DapProblemType {
+    type Err = DapProblemTypeParseError;
+
+    fn from_str(value: &str) -> Result<DapProblemType, DapProblemTypeParseError> {
+        match value {
+            "urn:ietf:params:ppm:dap:error:unrecognizedMessage" => {
+                Ok(DapProblemType::UnrecognizedMessage)
+            }
+            "urn:ietf:params:ppm:dap:error:unrecognizedTask" => {
+                Ok(DapProblemType::UnrecognizedTask)
+            }
+            "urn:ietf:params:ppm:dap:error:missingTaskID" => Ok(DapProblemType::MissingTaskId),
+            "urn:ietf:params:ppm:dap:error:unrecognizedAggregationJob" => {
+                Ok(DapProblemType::UnrecognizedAggregationJob)
+            }
+            "urn:ietf:params:ppm:dap:error:outdatedConfig" => Ok(DapProblemType::OutdatedConfig),
+            "urn:ietf:params:ppm:dap:error:reportTooLate" => Ok(DapProblemType::ReportTooLate),
+            "urn:ietf:params:ppm:dap:error:reportTooEarly" => Ok(DapProblemType::ReportTooEarly),
+            "urn:ietf:params:ppm:dap:error:batchInvalid" => Ok(DapProblemType::BatchInvalid),
+            "urn:ietf:params:ppm:dap:error:invalidBatchSize" => {
+                Ok(DapProblemType::InvalidBatchSize)
+            }
+            "urn:ietf:params:ppm:dap:error:batchQueriedTooManyTimes" => {
+                Ok(DapProblemType::BatchQueriedTooManyTimes)
+            }
+            "urn:ietf:params:ppm:dap:error:batchMismatch" => Ok(DapProblemType::BatchMismatch),
+            "urn:ietf:params:ppm:dap:error:unauthorizedRequest" => {
+                Ok(DapProblemType::UnauthorizedRequest)
+            }
+            "urn:ietf:params:ppm:dap:error:batchOverlap" => Ok(DapProblemType::BatchOverlap),
+            _ => Err(DapProblemTypeParseError),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -20,6 +20,8 @@ use std::{
     str::FromStr,
 };
 
+pub mod problem_type;
+
 /// Errors returned by functions and methods in this module
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -1958,133 +1960,6 @@ impl Decode for AggregateShareResp {
         Ok(Self {
             encrypted_aggregate_share,
         })
-    }
-}
-
-/// Representation of the different problem types defined in Table 1 in §3.2.
-#[derive(Debug, PartialEq, Eq)]
-pub enum DapProblemType {
-    UnrecognizedMessage,
-    UnrecognizedTask,
-    MissingTaskId,
-    UnrecognizedAggregationJob,
-    OutdatedConfig,
-    ReportTooLate,
-    ReportTooEarly,
-    BatchInvalid,
-    InvalidBatchSize,
-    BatchQueriedTooManyTimes,
-    BatchMismatch,
-    UnauthorizedRequest,
-    BatchOverlap,
-}
-
-impl DapProblemType {
-    /// Returns the problem type URI for a particular kind of error.
-    pub fn type_uri(&self) -> &'static str {
-        match self {
-            DapProblemType::UnrecognizedMessage => {
-                "urn:ietf:params:ppm:dap:error:unrecognizedMessage"
-            }
-            DapProblemType::UnrecognizedTask => "urn:ietf:params:ppm:dap:error:unrecognizedTask",
-            DapProblemType::MissingTaskId => "urn:ietf:params:ppm:dap:error:missingTaskID",
-            DapProblemType::UnrecognizedAggregationJob => {
-                "urn:ietf:params:ppm:dap:error:unrecognizedAggregationJob"
-            }
-            DapProblemType::OutdatedConfig => "urn:ietf:params:ppm:dap:error:outdatedConfig",
-            DapProblemType::ReportTooLate => "urn:ietf:params:ppm:dap:error:reportTooLate",
-            DapProblemType::ReportTooEarly => "urn:ietf:params:ppm:dap:error:reportTooEarly",
-            DapProblemType::BatchInvalid => "urn:ietf:params:ppm:dap:error:batchInvalid",
-            DapProblemType::InvalidBatchSize => "urn:ietf:params:ppm:dap:error:invalidBatchSize",
-            DapProblemType::BatchQueriedTooManyTimes => {
-                "urn:ietf:params:ppm:dap:error:batchQueriedTooManyTimes"
-            }
-            DapProblemType::BatchMismatch => "urn:ietf:params:ppm:dap:error:batchMismatch",
-            DapProblemType::UnauthorizedRequest => {
-                "urn:ietf:params:ppm:dap:error:unauthorizedRequest"
-            }
-            DapProblemType::BatchOverlap => "urn:ietf:params:ppm:dap:error:batchOverlap",
-        }
-    }
-
-    /// Returns a human-readable summary of a problem type.
-    pub fn description(&self) -> &'static str {
-        match self {
-            DapProblemType::UnrecognizedMessage => {
-                "The message type for a response was incorrect or the payload was malformed."
-            }
-            DapProblemType::UnrecognizedTask => {
-                "An endpoint received a message with an unknown task ID."
-            }
-            DapProblemType::MissingTaskId => {
-                "HPKE configuration was requested without specifying a task ID."
-            }
-            DapProblemType::UnrecognizedAggregationJob => {
-                "An endpoint received a message with an unknown aggregation job ID."
-            }
-            DapProblemType::OutdatedConfig => {
-                "The message was generated using an outdated configuration."
-            }
-            DapProblemType::ReportTooLate => {
-                "Report could not be processed because it arrived too late."
-            }
-            DapProblemType::ReportTooEarly => {
-                "Report could not be processed because it arrived too early."
-            }
-            DapProblemType::BatchInvalid => "The batch implied by the query is invalid.",
-            DapProblemType::InvalidBatchSize => {
-                "The number of reports included in the batch is invalid."
-            }
-            DapProblemType::BatchQueriedTooManyTimes => {
-                "The batch described by the query has been queried too many times."
-            }
-            DapProblemType::BatchMismatch => {
-                "Leader and helper disagree on reports aggregated in a batch."
-            }
-            DapProblemType::UnauthorizedRequest => "The request's authorization is not valid.",
-            DapProblemType::BatchOverlap => {
-                "The queried batch overlaps with a previously queried batch."
-            }
-        }
-    }
-}
-
-/// An error indicating a problem type URI was not recognized as a DAP problem type.
-#[derive(Debug)]
-pub struct DapProblemTypeParseError;
-
-impl FromStr for DapProblemType {
-    type Err = DapProblemTypeParseError;
-
-    fn from_str(value: &str) -> Result<DapProblemType, DapProblemTypeParseError> {
-        match value {
-            "urn:ietf:params:ppm:dap:error:unrecognizedMessage" => {
-                Ok(DapProblemType::UnrecognizedMessage)
-            }
-            "urn:ietf:params:ppm:dap:error:unrecognizedTask" => {
-                Ok(DapProblemType::UnrecognizedTask)
-            }
-            "urn:ietf:params:ppm:dap:error:missingTaskID" => Ok(DapProblemType::MissingTaskId),
-            "urn:ietf:params:ppm:dap:error:unrecognizedAggregationJob" => {
-                Ok(DapProblemType::UnrecognizedAggregationJob)
-            }
-            "urn:ietf:params:ppm:dap:error:outdatedConfig" => Ok(DapProblemType::OutdatedConfig),
-            "urn:ietf:params:ppm:dap:error:reportTooLate" => Ok(DapProblemType::ReportTooLate),
-            "urn:ietf:params:ppm:dap:error:reportTooEarly" => Ok(DapProblemType::ReportTooEarly),
-            "urn:ietf:params:ppm:dap:error:batchInvalid" => Ok(DapProblemType::BatchInvalid),
-            "urn:ietf:params:ppm:dap:error:invalidBatchSize" => {
-                Ok(DapProblemType::InvalidBatchSize)
-            }
-            "urn:ietf:params:ppm:dap:error:batchQueriedTooManyTimes" => {
-                Ok(DapProblemType::BatchQueriedTooManyTimes)
-            }
-            "urn:ietf:params:ppm:dap:error:batchMismatch" => Ok(DapProblemType::BatchMismatch),
-            "urn:ietf:params:ppm:dap:error:unauthorizedRequest" => {
-                Ok(DapProblemType::UnauthorizedRequest)
-            }
-            "urn:ietf:params:ppm:dap:error:batchOverlap" => Ok(DapProblemType::BatchOverlap),
-            _ => Err(DapProblemTypeParseError),
-        }
     }
 }
 

--- a/messages/src/problem_type.rs
+++ b/messages/src/problem_type.rs
@@ -1,0 +1,128 @@
+use std::str::FromStr;
+
+/// Representation of the different problem types defined in Table 1 in §3.2.
+#[derive(Debug, PartialEq, Eq)]
+pub enum DapProblemType {
+    UnrecognizedMessage,
+    UnrecognizedTask,
+    MissingTaskId,
+    UnrecognizedAggregationJob,
+    OutdatedConfig,
+    ReportTooLate,
+    ReportTooEarly,
+    BatchInvalid,
+    InvalidBatchSize,
+    BatchQueriedTooManyTimes,
+    BatchMismatch,
+    UnauthorizedRequest,
+    BatchOverlap,
+}
+
+impl DapProblemType {
+    /// Returns the problem type URI for a particular kind of error.
+    pub fn type_uri(&self) -> &'static str {
+        match self {
+            DapProblemType::UnrecognizedMessage => {
+                "urn:ietf:params:ppm:dap:error:unrecognizedMessage"
+            }
+            DapProblemType::UnrecognizedTask => "urn:ietf:params:ppm:dap:error:unrecognizedTask",
+            DapProblemType::MissingTaskId => "urn:ietf:params:ppm:dap:error:missingTaskID",
+            DapProblemType::UnrecognizedAggregationJob => {
+                "urn:ietf:params:ppm:dap:error:unrecognizedAggregationJob"
+            }
+            DapProblemType::OutdatedConfig => "urn:ietf:params:ppm:dap:error:outdatedConfig",
+            DapProblemType::ReportTooLate => "urn:ietf:params:ppm:dap:error:reportTooLate",
+            DapProblemType::ReportTooEarly => "urn:ietf:params:ppm:dap:error:reportTooEarly",
+            DapProblemType::BatchInvalid => "urn:ietf:params:ppm:dap:error:batchInvalid",
+            DapProblemType::InvalidBatchSize => "urn:ietf:params:ppm:dap:error:invalidBatchSize",
+            DapProblemType::BatchQueriedTooManyTimes => {
+                "urn:ietf:params:ppm:dap:error:batchQueriedTooManyTimes"
+            }
+            DapProblemType::BatchMismatch => "urn:ietf:params:ppm:dap:error:batchMismatch",
+            DapProblemType::UnauthorizedRequest => {
+                "urn:ietf:params:ppm:dap:error:unauthorizedRequest"
+            }
+            DapProblemType::BatchOverlap => "urn:ietf:params:ppm:dap:error:batchOverlap",
+        }
+    }
+
+    /// Returns a human-readable summary of a problem type.
+    pub fn description(&self) -> &'static str {
+        match self {
+            DapProblemType::UnrecognizedMessage => {
+                "The message type for a response was incorrect or the payload was malformed."
+            }
+            DapProblemType::UnrecognizedTask => {
+                "An endpoint received a message with an unknown task ID."
+            }
+            DapProblemType::MissingTaskId => {
+                "HPKE configuration was requested without specifying a task ID."
+            }
+            DapProblemType::UnrecognizedAggregationJob => {
+                "An endpoint received a message with an unknown aggregation job ID."
+            }
+            DapProblemType::OutdatedConfig => {
+                "The message was generated using an outdated configuration."
+            }
+            DapProblemType::ReportTooLate => {
+                "Report could not be processed because it arrived too late."
+            }
+            DapProblemType::ReportTooEarly => {
+                "Report could not be processed because it arrived too early."
+            }
+            DapProblemType::BatchInvalid => "The batch implied by the query is invalid.",
+            DapProblemType::InvalidBatchSize => {
+                "The number of reports included in the batch is invalid."
+            }
+            DapProblemType::BatchQueriedTooManyTimes => {
+                "The batch described by the query has been queried too many times."
+            }
+            DapProblemType::BatchMismatch => {
+                "Leader and helper disagree on reports aggregated in a batch."
+            }
+            DapProblemType::UnauthorizedRequest => "The request's authorization is not valid.",
+            DapProblemType::BatchOverlap => {
+                "The queried batch overlaps with a previously queried batch."
+            }
+        }
+    }
+}
+
+/// An error indicating a problem type URI was not recognized as a DAP problem type.
+#[derive(Debug)]
+pub struct DapProblemTypeParseError;
+
+impl FromStr for DapProblemType {
+    type Err = DapProblemTypeParseError;
+
+    fn from_str(value: &str) -> Result<DapProblemType, DapProblemTypeParseError> {
+        match value {
+            "urn:ietf:params:ppm:dap:error:unrecognizedMessage" => {
+                Ok(DapProblemType::UnrecognizedMessage)
+            }
+            "urn:ietf:params:ppm:dap:error:unrecognizedTask" => {
+                Ok(DapProblemType::UnrecognizedTask)
+            }
+            "urn:ietf:params:ppm:dap:error:missingTaskID" => Ok(DapProblemType::MissingTaskId),
+            "urn:ietf:params:ppm:dap:error:unrecognizedAggregationJob" => {
+                Ok(DapProblemType::UnrecognizedAggregationJob)
+            }
+            "urn:ietf:params:ppm:dap:error:outdatedConfig" => Ok(DapProblemType::OutdatedConfig),
+            "urn:ietf:params:ppm:dap:error:reportTooLate" => Ok(DapProblemType::ReportTooLate),
+            "urn:ietf:params:ppm:dap:error:reportTooEarly" => Ok(DapProblemType::ReportTooEarly),
+            "urn:ietf:params:ppm:dap:error:batchInvalid" => Ok(DapProblemType::BatchInvalid),
+            "urn:ietf:params:ppm:dap:error:invalidBatchSize" => {
+                Ok(DapProblemType::InvalidBatchSize)
+            }
+            "urn:ietf:params:ppm:dap:error:batchQueriedTooManyTimes" => {
+                Ok(DapProblemType::BatchQueriedTooManyTimes)
+            }
+            "urn:ietf:params:ppm:dap:error:batchMismatch" => Ok(DapProblemType::BatchMismatch),
+            "urn:ietf:params:ppm:dap:error:unauthorizedRequest" => {
+                Ok(DapProblemType::UnauthorizedRequest)
+            }
+            "urn:ietf:params:ppm:dap:error:batchOverlap" => Ok(DapProblemType::BatchOverlap),
+            _ => Err(DapProblemTypeParseError),
+        }
+    }
+}


### PR DESCRIPTION
This PR makes the following changes:

- Moves the enum `DapProblemType` from `janus_aggregator` to `janus_messages` so it can be reused. (One method is left behind in an extension trait, but this will go away as part of DAP-03, see #705)
- Stores a parsed `DapProblemType` in the collector library's `Error::Http` variant, similar to that in the aggregator module.

Closes #763.