### PR TITLE
DAP-03: move extensions to ciphertext.

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1249,8 +1249,6 @@ impl VdafOps {
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
         C: Clock,
     {
-        // XXX: update
-
         // The leader's report is the first one.
         // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-02.html#section-4.3.2
         if report.encrypted_input_shares().len() != 2 {

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -44,9 +44,9 @@ use janus_messages::{
     query_type::{FixedSize, QueryType, TimeInterval},
     AggregateContinueReq, AggregateContinueResp, AggregateInitializeReq, AggregateInitializeResp,
     AggregateShareReq, AggregateShareResp, AggregationJobId, CollectReq, CollectResp,
-    HpkeCiphertext, HpkeConfig, HpkeConfigId, Interval, PartialBatchSelector, PrepareStep,
-    PrepareStepResult, Report, ReportId, ReportIdChecksum, ReportShare, ReportShareError, Role,
-    TaskId, Time,
+    HpkeCiphertext, HpkeConfig, HpkeConfigId, Interval, PartialBatchSelector, PlaintextInputShare,
+    PrepareStep, PrepareStepResult, Report, ReportId, ReportIdChecksum, ReportShare,
+    ReportShareError, Role, TaskId, Time,
 };
 use opentelemetry::{
     metrics::{Counter, Histogram, Meter, Unit},
@@ -1249,6 +1249,8 @@ impl VdafOps {
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
         C: Clock,
     {
+        // XXX: update
+
         // The leader's report is the first one.
         // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-02.html#section-4.3.2
         if report.encrypted_input_shares().len() != 2 {
@@ -1314,7 +1316,7 @@ impl VdafOps {
                 }
             };
 
-        let leader_decrypted_input_share = match hpke::open(
+        let encoded_leader_plaintext_input_share = match hpke::open(
             hpke_config,
             hpke_private_key,
             &HpkeApplicationInfo::new(&Label::InputShare, &Role::Client, task.role()),
@@ -1325,7 +1327,7 @@ impl VdafOps {
                 report.public_share(),
             ),
         ) {
-            Ok(leader_decrypted_input_share) => leader_decrypted_input_share,
+            Ok(encoded_leader_plaintext_input_share) => encoded_leader_plaintext_input_share,
             Err(error) => {
                 info!(
                     report.task_id = %report.task_id(),
@@ -1338,9 +1340,12 @@ impl VdafOps {
             }
         };
 
+        let leader_plaintext_input_share =
+            PlaintextInputShare::get_decoded(&encoded_leader_plaintext_input_share)?;
+
         let leader_input_share = match A::InputShare::get_decoded_with_param(
             &(vdaf, Role::Leader.index().unwrap()),
-            &leader_decrypted_input_share,
+            leader_plaintext_input_share.payload(),
         ) {
             Ok(leader_input_share) => leader_input_share,
             Err(err) => {
@@ -1362,6 +1367,7 @@ impl VdafOps {
             *report.task_id(),
             report.metadata().clone(),
             public_share,
+            Vec::from(leader_plaintext_input_share.extensions()),
             leader_input_share,
             helper_encrypted_input_share.clone(),
         );
@@ -3287,8 +3293,9 @@ mod tests {
         AggregateContinueReq, AggregateContinueResp, AggregateInitializeReq,
         AggregateInitializeResp, AggregateShareReq, AggregateShareResp, BatchSelector, CollectReq,
         CollectResp, Duration, HpkeCiphertext, HpkeConfig, HpkeConfigId, Interval,
-        PartialBatchSelector, PrepareStep, PrepareStepResult, Query, Report, ReportId,
-        ReportIdChecksum, ReportMetadata, ReportShare, ReportShareError, Role, TaskId, Time,
+        PartialBatchSelector, PlaintextInputShare, PrepareStep, PrepareStepResult, Query, Report,
+        ReportId, ReportIdChecksum, ReportMetadata, ReportShare, ReportShareError, Role, TaskId,
+        Time,
     };
     use mockito::mock;
     use opentelemetry::global::meter;
@@ -3492,7 +3499,7 @@ mod tests {
 
         let vdaf = Prio3Aes128Count::new_aes128_count(2).unwrap();
         let hpke_key = current_hpke_key(task.hpke_keys());
-        let report_metadata = ReportMetadata::new(random(), report_timestamp, Vec::new());
+        let report_metadata = ReportMetadata::new(random(), report_timestamp);
 
         let (public_share, measurements) = vdaf.shard(&1).unwrap();
 
@@ -3505,14 +3512,14 @@ mod tests {
         let leader_ciphertext = hpke::seal(
             &hpke_key.0,
             &HpkeApplicationInfo::new(&Label::InputShare, &Role::Client, &Role::Leader),
-            &measurements[0].get_encoded(),
+            &PlaintextInputShare::new(Vec::new(), measurements[0].get_encoded()).get_encoded(),
             &associated_data,
         )
         .unwrap();
         let helper_ciphertext = hpke::seal(
             &hpke_key.0,
             &HpkeApplicationInfo::new(&Label::InputShare, &Role::Client, &Role::Helper),
-            &measurements[1].get_encoded(),
+            &PlaintextInputShare::new(Vec::new(), measurements[1].get_encoded()).get_encoded(),
             &associated_data,
         )
         .unwrap();
@@ -3664,11 +3671,7 @@ mod tests {
             .unwrap();
         let bad_report = Report::new(
             *report.task_id(),
-            ReportMetadata::new(
-                *report.metadata().id(),
-                bad_report_time,
-                report.metadata().extensions().to_vec(),
-            ),
+            ReportMetadata::new(*report.metadata().id(), bad_report_time),
             report.public_share().to_vec(),
             report.encrypted_input_shares().to_vec(),
         );
@@ -3762,7 +3765,6 @@ mod tests {
                             .now()
                             .to_batch_interval_start(task.time_precision())
                             .unwrap(),
-                        Vec::new(),
                     ),
                     report.public_share().to_vec(),
                     report.encrypted_input_shares().to_vec(),
@@ -4264,7 +4266,6 @@ mod tests {
                 .now()
                 .to_batch_interval_start(task.time_precision())
                 .unwrap(),
-            Vec::new(),
         );
         let transcript = run_vdaf(
             &vdaf,
@@ -4289,7 +4290,6 @@ mod tests {
                 .now()
                 .to_batch_interval_start(task.time_precision())
                 .unwrap(),
-            Vec::new(),
         );
         let encrypted_input_share = report_share_0.encrypted_input_share();
         let mut corrupted_payload = encrypted_input_share.payload().to_vec();
@@ -4314,7 +4314,6 @@ mod tests {
                 .now()
                 .to_batch_interval_start(task.time_precision())
                 .unwrap(),
-            Vec::new(),
         );
         let mut input_share_bytes = input_share.get_encoded();
         input_share_bytes.push(0); // can no longer be decoded.
@@ -4335,7 +4334,6 @@ mod tests {
                 .now()
                 .to_batch_interval_start(task.time_precision())
                 .unwrap(),
-            Vec::new(),
         );
         let wrong_hpke_config = loop {
             let hpke_config = generate_test_hpke_config_and_private_key().0;
@@ -4359,7 +4357,6 @@ mod tests {
                 .now()
                 .to_batch_interval_start(task.time_precision())
                 .unwrap(),
-            Vec::new(),
         );
         let transcript = run_vdaf(
             &vdaf,
@@ -4387,7 +4384,6 @@ mod tests {
                 .now()
                 .to_batch_interval_start(task.time_precision())
                 .unwrap(),
-            Vec::new(),
         );
         let transcript = run_vdaf(
             &vdaf,
@@ -4413,7 +4409,6 @@ mod tests {
                 .now()
                 .to_batch_interval_start(task.time_precision())
                 .unwrap(),
-            Vec::new(),
         );
         let aad = associated_data_for_report_share(task.id(), &report_metadata_6, &public_share_6);
         let report_share_6 = generate_helper_report_share_for_plaintext(
@@ -4592,7 +4587,6 @@ mod tests {
                     .now()
                     .to_batch_interval_start(task.time_precision())
                     .unwrap(),
-                Vec::new(),
             ),
             &hpke_key.0,
             &(),
@@ -4669,7 +4663,6 @@ mod tests {
                     .now()
                     .to_batch_interval_start(task.time_precision())
                     .unwrap(),
-                Vec::new(),
             ),
             &hpke_key.0,
             &(),
@@ -4740,7 +4733,6 @@ mod tests {
             ReportMetadata::new(
                 ReportId::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
                 Time::from_seconds_since_epoch(54321),
-                Vec::new(),
             ),
             Vec::from("PUBLIC"),
             HpkeCiphertext::new(
@@ -4824,7 +4816,6 @@ mod tests {
                 .now()
                 .to_batch_interval_start(task.time_precision())
                 .unwrap(),
-            Vec::new(),
         );
         let transcript_0 = run_vdaf(
             vdaf.as_ref(),
@@ -4859,7 +4850,6 @@ mod tests {
                 .now()
                 .to_batch_interval_start(task.time_precision())
                 .unwrap(),
-            Vec::new(),
         );
         let transcript_1 = run_vdaf(
             vdaf.as_ref(),
@@ -4887,7 +4877,6 @@ mod tests {
                 .now()
                 .to_batch_interval_start(task.time_precision())
                 .unwrap(),
-            Vec::new(),
         );
         let transcript_2 = run_vdaf(
             vdaf.as_ref(),
@@ -5150,7 +5139,6 @@ mod tests {
                 .now()
                 .to_batch_interval_start(task.time_precision())
                 .unwrap(),
-            Vec::new(),
         );
         let transcript_0 = run_vdaf(
             &vdaf,
@@ -5178,7 +5166,6 @@ mod tests {
                 .now()
                 .to_batch_interval_start(task.time_precision())
                 .unwrap(),
-            Vec::new(),
         );
         let transcript_1 = run_vdaf(
             &vdaf,
@@ -5205,7 +5192,6 @@ mod tests {
                 .now()
                 .to_batch_interval_start(task.time_precision())
                 .unwrap(),
-            Vec::new(),
         );
         let transcript_2 = run_vdaf(
             &vdaf,
@@ -5438,7 +5424,6 @@ mod tests {
                 .now()
                 .to_batch_interval_start(task.time_precision())
                 .unwrap(),
-            Vec::new(),
         );
         let transcript_3 = run_vdaf(
             &vdaf,
@@ -5465,7 +5450,6 @@ mod tests {
                 .now()
                 .to_batch_interval_start(task.time_precision())
                 .unwrap(),
-            Vec::new(),
         );
         let transcript_4 = run_vdaf(
             &vdaf,
@@ -5492,7 +5476,6 @@ mod tests {
                 .now()
                 .to_batch_interval_start(task.time_precision())
                 .unwrap(),
-            Vec::new(),
         );
         let transcript_5 = run_vdaf(
             &vdaf,
@@ -5734,7 +5717,6 @@ mod tests {
         let report_metadata = ReportMetadata::new(
             ReportId::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
             Time::from_seconds_since_epoch(54321),
-            Vec::new(),
         );
         let clock = MockClock::default();
         let (datastore, _db_handle) = ephemeral_datastore(clock.clone()).await;
@@ -5849,7 +5831,6 @@ mod tests {
         let report_metadata = ReportMetadata::new(
             ReportId::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
             Time::from_seconds_since_epoch(54321),
-            Vec::new(),
         );
         let clock = MockClock::default();
         let (datastore, _db_handle) = ephemeral_datastore(clock.clone()).await;
@@ -6008,7 +5989,6 @@ mod tests {
         let report_metadata = ReportMetadata::new(
             ReportId::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
             Time::from_seconds_since_epoch(54321),
-            Vec::new(),
         );
         let clock = MockClock::default();
         let (datastore, _db_handle) = ephemeral_datastore(clock.clone()).await;
@@ -6120,12 +6100,10 @@ mod tests {
         let report_metadata_0 = ReportMetadata::new(
             ReportId::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
             Time::from_seconds_since_epoch(54321),
-            Vec::new(),
         );
         let report_metadata_1 = ReportMetadata::new(
             ReportId::from([16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]),
             Time::from_seconds_since_epoch(54321),
-            Vec::new(),
         );
 
         let clock = MockClock::default();
@@ -6275,7 +6253,6 @@ mod tests {
         let report_metadata = ReportMetadata::new(
             ReportId::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
             Time::from_seconds_since_epoch(54321),
-            Vec::new(),
         );
 
         let clock = MockClock::default();

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -890,8 +890,9 @@ mod tests {
     use janus_messages::{
         query_type::{FixedSize, TimeInterval},
         AggregateContinueReq, AggregateContinueResp, AggregateInitializeReq,
-        AggregateInitializeResp, Duration, HpkeConfig, Interval, PartialBatchSelector, PrepareStep,
-        PrepareStepResult, ReportIdChecksum, ReportMetadata, ReportShare, Role, TaskId,
+        AggregateInitializeResp, Duration, HpkeConfig, Interval, PartialBatchSelector,
+        PlaintextInputShare, PrepareStep, PrepareStepResult, ReportIdChecksum, ReportMetadata,
+        ReportShare, Role, TaskId,
     };
     use mockito::mock;
     use opentelemetry::global::meter;
@@ -2189,10 +2190,14 @@ mod tests {
         let encrypted_helper_input_share = hpke::seal(
             helper_hpke_config,
             &HpkeApplicationInfo::new(&Label::InputShare, &Role::Client, &Role::Helper),
-            &input_shares
-                .get(Role::Helper.index().unwrap())
-                .unwrap()
-                .get_encoded(),
+            &PlaintextInputShare::new(
+                Vec::new(),
+                input_shares
+                    .get(Role::Helper.index().unwrap())
+                    .unwrap()
+                    .get_encoded(),
+            )
+            .get_encoded(),
             &associated_data_for_report_share(
                 task_id,
                 report_metadata,

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -937,7 +937,7 @@ mod tests {
             .now()
             .to_batch_interval_start(task.time_precision())
             .unwrap();
-        let report_metadata = ReportMetadata::new(random(), time, Vec::new());
+        let report_metadata = ReportMetadata::new(random(), time);
         let verify_key: VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH> =
             task.primary_vdaf_verify_key().unwrap();
 
@@ -1150,7 +1150,7 @@ mod tests {
             .now()
             .to_batch_interval_start(task.time_precision())
             .unwrap();
-        let report_metadata = ReportMetadata::new(random(), time, Vec::new());
+        let report_metadata = ReportMetadata::new(random(), time);
         let verify_key: VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH> =
             task.primary_vdaf_verify_key().unwrap();
 
@@ -1364,7 +1364,6 @@ mod tests {
                 .now()
                 .to_batch_interval_start(task.time_precision())
                 .unwrap(),
-            Vec::new(),
         );
         let verify_key: VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH> =
             task.primary_vdaf_verify_key().unwrap();
@@ -1577,7 +1576,7 @@ mod tests {
             .now()
             .to_batch_interval_start(task.time_precision())
             .unwrap();
-        let report_metadata = ReportMetadata::new(random(), time, Vec::new());
+        let report_metadata = ReportMetadata::new(random(), time);
         let verify_key: VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH> =
             task.primary_vdaf_verify_key().unwrap();
 
@@ -1820,7 +1819,6 @@ mod tests {
                 .now()
                 .to_batch_interval_start(task.time_precision())
                 .unwrap(),
-            Vec::new(),
         );
         let verify_key: VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH> =
             task.primary_vdaf_verify_key().unwrap();
@@ -2054,7 +2052,7 @@ mod tests {
             .now()
             .to_batch_interval_start(task.time_precision())
             .unwrap();
-        let report_metadata = ReportMetadata::new(random(), time, Vec::new());
+        let report_metadata = ReportMetadata::new(random(), time);
         let verify_key: VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH> =
             task.primary_vdaf_verify_key().unwrap();
 
@@ -2207,6 +2205,7 @@ mod tests {
             *task_id,
             report_metadata.clone(),
             public_share.clone(),
+            Vec::new(),
             input_shares
                 .get(Role::Leader.index().unwrap())
                 .unwrap()
@@ -2245,7 +2244,7 @@ mod tests {
             .now()
             .to_batch_interval_start(task.time_precision())
             .unwrap();
-        let report_metadata = ReportMetadata::new(random(), time, Vec::new());
+        let report_metadata = ReportMetadata::new(random(), time);
         let transcript = run_vdaf(&vdaf, verify_key.as_bytes(), &(), report_metadata.id(), &0);
         let report: LeaderStoredReport<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count> =
             generate_report(

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -866,15 +866,15 @@ impl Decode for ReportMetadata {
     }
 }
 
-// XXX: documentation
-// XXX: tests
+/// DAP protocol message representing the plaintext of an input share.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PlaintextInputShare {
     extensions: Vec<Extension>,
     payload: Vec<u8>,
 }
 
 impl PlaintextInputShare {
-    // XXX: documentation
+    /// Construct a plaintext input share from its components.
     pub fn new(extensions: Vec<Extension>, payload: Vec<u8>) -> Self {
         Self {
             extensions,
@@ -882,12 +882,12 @@ impl PlaintextInputShare {
         }
     }
 
-    // XXX: documentation
+    /// Retrieve the extensions from this plaintext input share.
     pub fn extensions(&self) -> &[Extension] {
         &self.extensions
     }
 
-    // XXX: documentation
+    /// Retrieve the payload from this plaintext input share.
     pub fn payload(&self) -> &[u8] {
         &self.payload
     }
@@ -1361,7 +1361,6 @@ pub mod query_type {
 }
 
 /// DAP protocol message representing one aggregator's share of a single client report.
-// XXX: does this need to include extensions? (since they have been removed from ReportMetadata)
 #[derive(Derivative, Clone, PartialEq, Eq)]
 #[derivative(Debug)]
 pub struct ReportShare {
@@ -2002,8 +2001,9 @@ mod tests {
         AggregateInitializeResp, AggregateShareReq, AggregateShareResp, AggregationJobId, BatchId,
         BatchSelector, CollectReq, CollectResp, Duration, Extension, ExtensionType, HpkeAeadId,
         HpkeCiphertext, HpkeConfig, HpkeConfigId, HpkeKdfId, HpkeKemId, HpkePublicKey, Interval,
-        PartialBatchSelector, PrepareStep, PrepareStepResult, Query, Report, ReportId,
-        ReportIdChecksum, ReportMetadata, ReportShare, ReportShareError, Role, TaskId, Time,
+        PartialBatchSelector, PlaintextInputShare, PrepareStep, PrepareStepResult, Query, Report,
+        ReportId, ReportIdChecksum, ReportMetadata, ReportShare, ReportShareError, Role, TaskId,
+        Time,
     };
     use assert_matches::assert_matches;
     use prio::codec::{CodecError, Decode, Encode};
@@ -2247,7 +2247,7 @@ mod tests {
                 concat!(
                     "0A", // config_id
                     concat!(
-                        // encapsulated_context
+                        // encapsulated_key
                         "0004",     // length
                         "30313233", // opaque data
                     ),
@@ -2263,7 +2263,7 @@ mod tests {
                 concat!(
                     "0C", // config_id
                     concat!(
-                        // encapsulated_context
+                        // encapsulated_key
                         "0005",       // length
                         "3031323334", // opaque data
                     ),
@@ -2364,6 +2364,51 @@ mod tests {
                 concat!(
                     "100F0E0D0C0B0A090807060504030201", // report_id
                     "000000000000D431",                 // time
+                ),
+            ),
+        ])
+    }
+
+    #[test]
+    fn roundtrip_plaintext_input_share() {
+        roundtrip_encoding(&[
+            (
+                PlaintextInputShare::new(Vec::new(), Vec::from("0123")),
+                concat!(
+                    concat!(
+                        // extensions
+                        "0000", // length
+                    ),
+                    concat!(
+                        // payload
+                        "00000004", // length
+                        "30313233", // opaque data
+                    )
+                ),
+            ),
+            (
+                PlaintextInputShare::new(
+                    Vec::from([Extension::new(ExtensionType::Tbd, Vec::from("0123"))]),
+                    Vec::from("4567"),
+                ),
+                concat!(
+                    concat!(
+                        // extensions
+                        "0008", // length
+                        concat!(
+                            "0000", // extension_type
+                            concat!(
+                                // extension_data
+                                "0004",     // length
+                                "30313233", // opaque data
+                            ),
+                        ),
+                    ),
+                    concat!(
+                        // payload
+                        "00000004", // length
+                        "34353637", // opaque data
+                    ),
                 ),
             ),
         ])


### PR DESCRIPTION
This commit introduces the PlaintextInputShare structure used for input shares in DAP-03.

Part of #761.