### PR TITLE
Improvements to dap-decode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,6 +1747,7 @@ dependencies = [
  "thiserror",
  "tracing-log",
  "tracing-subscriber",
+ "trycmd",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,15 +72,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,21 +354,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim 0.8.0",
- "textwrap",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
 version = "4.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0acbd8d28a0a60d7108d7ae850af6ba34cf2d1257fc646980e5f97ce14275966"
@@ -387,7 +363,7 @@ dependencies = [
  "clap_lex",
  "is-terminal",
  "once_cell",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
 ]
 
@@ -397,7 +373,7 @@ version = "4.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
 dependencies = [
- "heck 0.4.0",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -663,7 +639,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn",
 ]
 
@@ -1165,15 +1141,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
@@ -1515,7 +1482,7 @@ dependencies = [
  "base64",
  "bytes",
  "chrono",
- "clap 4.0.27",
+ "clap",
  "console-subscriber",
  "deadpool",
  "deadpool-postgres",
@@ -1607,7 +1574,7 @@ dependencies = [
  "backoff",
  "base64",
  "chrono",
- "clap 4.0.27",
+ "clap",
  "derivative",
  "http-api-problem",
  "janus_collector",
@@ -1701,7 +1668,7 @@ dependencies = [
  "anyhow",
  "backoff",
  "base64",
- "clap 4.0.27",
+ "clap",
  "futures",
  "hex",
  "janus_aggregator",
@@ -1737,13 +1704,13 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "base64",
+ "clap",
  "derivative",
  "hex",
  "num_enum",
  "prio",
  "rand",
  "serde",
- "structopt",
  "thiserror",
  "tracing-log",
  "tracing-subscriber",
@@ -2629,7 +2596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f835c582e6bd972ba8347313300219fed5bfa52caf175298d860b61ff6069bb"
 dependencies = [
  "bytes",
- "heck 0.4.0",
+ "heck",
  "itertools",
  "lazy_static",
  "log",
@@ -3311,39 +3278,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "subtle"
@@ -3418,15 +3355,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -3993,18 +3921,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4070,12 +3986,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -10,19 +10,19 @@ rust-version.workspace = true
 version.workspace = true
 
 [features]
-dap-decode-bin = ["dep:structopt"]
+dap-decode-bin = ["dep:clap"]
 test-util = []
 
 [dependencies]
 anyhow = "1"
 base64 = "0.13.1"
+clap = { version = "4.0.27", features = ["cargo", "derive"], optional = true }
 derivative = "2.2.0"
 hex = "0.4"
 num_enum = "0.5.6"
 prio = { version = "0.10.0", default-features = false } # important: do not enable prio/crypto-dependencies by default!
 rand = "0.8"
 serde = { version = "1.0.148", features = ["derive"] }
-structopt = { version = "0.3.26", optional = true }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -29,6 +29,7 @@ thiserror = "1.0"
 assert_matches = "1"
 tracing-log = "0.1.3"
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt"] }
+trycmd = "0.14.5"
 
 [[bin]]
 name = "dap-decode"

--- a/messages/tests/cli.rs
+++ b/messages/tests/cli.rs
@@ -1,0 +1,4 @@
+#[test]
+fn cli_tests() {
+    trycmd::TestCases::new().case("tests/cmd/*.trycmd").run();
+}

--- a/messages/tests/cmd/dap_decode.trycmd
+++ b/messages/tests/cmd/dap_decode.trycmd
@@ -1,0 +1,22 @@
+```
+$ dap-decode --help
+dap-decode 0.3.0
+Distributed Aggregation Protocol message decoder
+
+USAGE:
+    dap-decode <message-file> --media-type <media-type>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -t, --media-type <media-type>    Media type of the message to decode [possible values: hpke-config, report,
+                                     aggregate-initialize-req, aggregate-initialize-resp, aggregate-continue-req,
+                                     aggregate-continue-resp, aggregate-share-req, aggregate-share-resp, collect-req,
+                                     collect-resp]
+
+ARGS:
+    <message-file>    Path to file containing message to decode. Pass "-" to read from stdin
+
+```

--- a/messages/tests/cmd/dap_decode.trycmd
+++ b/messages/tests/cmd/dap_decode.trycmd
@@ -1,22 +1,15 @@
 ```
 $ dap-decode --help
-dap-decode 0.3.0
 Distributed Aggregation Protocol message decoder
 
-USAGE:
-    dap-decode <message-file> --media-type <media-type>
+Usage: dap-decode --media-type <MEDIA_TYPE> <MESSAGE_FILE>
 
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+Arguments:
+  <MESSAGE_FILE>  Path to file containing message to decode. Pass "-" to read from stdin
 
-OPTIONS:
-    -t, --media-type <media-type>    Media type of the message to decode [possible values: hpke-config, report,
-                                     aggregate-initialize-req, aggregate-initialize-resp, aggregate-continue-req,
-                                     aggregate-continue-resp, aggregate-share-req, aggregate-share-resp, collect-req,
-                                     collect-resp]
-
-ARGS:
-    <message-file>    Path to file containing message to decode. Pass "-" to read from stdin
+Options:
+  -t, --media-type <MEDIA_TYPE>  Media type of the message to decode [possible values: hpke-config, report, aggregate-initialize-req, aggregate-initialize-resp, aggregate-continue-req, aggregate-continue-resp, aggregate-share-req, aggregate-share-resp, collect-req, collect-resp]
+  -h, --help                     Print help information
+  -V, --version                  Print version information
 
 ```


### PR DESCRIPTION
This upgrades `dap-decode` to clap v4, and adds support for decoding messages with fixed-size query types. 