### PR TITLE
Refactor base64url-encoded fields in serde implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1712,6 +1712,7 @@ dependencies = [
  "prio",
  "rand",
  "serde",
+ "serde_test",
  "thiserror",
  "tracing-log",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1600,6 +1600,7 @@ version = "0.3.0"
 dependencies = [
  "assert_matches",
  "backoff",
+ "base64",
  "chrono",
  "derivative",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1514,6 +1514,7 @@ dependencies = [
  "ring",
  "serde",
  "serde_json",
+ "serde_test",
  "serde_yaml 0.9.14",
  "signal-hook",
  "signal-hook-tokio",

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -93,6 +93,7 @@ hyper = "0.14.23"
 # used in unit tests.
 janus_aggregator = { workspace = true, features = ["kube-openssl", "test-util"] }
 mockito = "0.31.0"
+serde_test = "1.0.148"
 tempfile = "3.3.0"
 tokio = { version = "1", features = ["test-util"] }  # ensure this remains compatible with the non-dev dependency
 trycmd = "0.14.5"

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -969,11 +969,11 @@ mod tests {
         );
 
         let agg_auth_token = task.primary_aggregator_auth_token().clone();
-        let (helper_hpke_config, _) = generate_test_hpke_config_and_private_key();
+        let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
         let report = generate_report::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
             *task.id(),
             report_metadata,
-            &helper_hpke_config,
+            helper_hpke_keypair.config(),
             (),
             Vec::new(),
             transcript.input_shares,
@@ -1182,11 +1182,11 @@ mod tests {
         );
 
         let agg_auth_token = task.primary_aggregator_auth_token();
-        let (helper_hpke_config, _) = generate_test_hpke_config_and_private_key();
+        let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
         let report = generate_report::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
             *task.id(),
             report_metadata,
-            &helper_hpke_config,
+            helper_hpke_keypair.config(),
             (),
             Vec::new(),
             transcript.input_shares.clone(),
@@ -1195,7 +1195,7 @@ mod tests {
             generate_report::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
                 *task.id(),
                 ReportMetadata::new(random(), time),
-                &helper_hpke_config,
+                helper_hpke_keypair.config(),
                 (),
                 Vec::from([
                     Extension::new(ExtensionType::Tbd, Vec::new()),
@@ -1439,11 +1439,11 @@ mod tests {
         );
 
         let agg_auth_token = task.primary_aggregator_auth_token();
-        let (helper_hpke_config, _) = generate_test_hpke_config_and_private_key();
+        let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
         let report = generate_report::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
             *task.id(),
             report_metadata,
-            &helper_hpke_config,
+            helper_hpke_keypair.config(),
             (),
             Vec::new(),
             transcript.input_shares,
@@ -1651,11 +1651,11 @@ mod tests {
         );
 
         let agg_auth_token = task.primary_aggregator_auth_token();
-        let (helper_hpke_config, _) = generate_test_hpke_config_and_private_key();
+        let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
         let report = generate_report::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
             *task.id(),
             report_metadata,
-            &helper_hpke_config,
+            helper_hpke_keypair.config(),
             (),
             Vec::new(),
             transcript.input_shares,
@@ -1894,11 +1894,11 @@ mod tests {
         );
 
         let agg_auth_token = task.primary_aggregator_auth_token();
-        let (helper_hpke_config, _) = generate_test_hpke_config_and_private_key();
+        let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
         let report = generate_report::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
             *task.id(),
             report_metadata,
-            &helper_hpke_config,
+            helper_hpke_keypair.config(),
             (),
             Vec::new(),
             transcript.input_shares,
@@ -2126,11 +2126,11 @@ mod tests {
             &0,
         );
 
-        let (helper_hpke_config, _) = generate_test_hpke_config_and_private_key();
+        let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
         let report = generate_report::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
             *task.id(),
             report_metadata,
-            &helper_hpke_config,
+            helper_hpke_keypair.config(),
             (),
             Vec::new(),
             transcript.input_shares,
@@ -2304,7 +2304,7 @@ mod tests {
         let verify_key: VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH> =
             task.primary_vdaf_verify_key().unwrap();
 
-        let (helper_hpke_config, _) = generate_test_hpke_config_and_private_key();
+        let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
 
         let vdaf = Prio3::new_aes128_count(2).unwrap();
         let time = clock
@@ -2316,7 +2316,7 @@ mod tests {
         let report = generate_report::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
             *task.id(),
             report_metadata,
-            &helper_hpke_config,
+            helper_hpke_keypair.config(),
             (),
             Vec::new(),
             transcript.input_shares,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -312,8 +312,8 @@ mod tests {
             vdaf_client,
             MockClock::default(),
             &default_http_client().unwrap(),
-            generate_test_hpke_config_and_private_key().0,
-            generate_test_hpke_config_and_private_key().0,
+            generate_test_hpke_config_and_private_key().config().clone(),
+            generate_test_hpke_config_and_private_key().config().clone(),
         )
     }
 
@@ -432,8 +432,8 @@ mod tests {
             Prio3::new_aes128_count(2).unwrap(),
             MockClock::default(),
             &default_http_client().unwrap(),
-            generate_test_hpke_config_and_private_key().0,
-            generate_test_hpke_config_and_private_key().0,
+            generate_test_hpke_config_and_private_key().config().clone(),
+            generate_test_hpke_config_and_private_key().config().clone(),
         );
         let result = client.upload(&1).await;
         assert_matches!(result, Err(Error::InvalidParameter(_)));

--- a/collector/examples/collect.rs
+++ b/collector/examples/collect.rs
@@ -467,9 +467,11 @@ mod tests {
 
     #[tokio::test]
     async fn argument_handling() {
-        let (hpke_config, hpke_private_key) = generate_test_hpke_config_and_private_key();
-        let encoded_hpke_config = base64::encode_config(hpke_config.get_encoded(), URL_SAFE_NO_PAD);
-        let encoded_private_key = base64::encode_config(hpke_private_key.as_ref(), URL_SAFE_NO_PAD);
+        let hpke_keypair = generate_test_hpke_config_and_private_key();
+        let encoded_hpke_config =
+            base64::encode_config(hpke_keypair.config().get_encoded(), URL_SAFE_NO_PAD);
+        let encoded_private_key =
+            base64::encode_config(hpke_keypair.private_key().as_ref(), URL_SAFE_NO_PAD);
 
         let task_id = random();
         let leader = Url::parse("https://example.com/dap/").unwrap();
@@ -479,8 +481,8 @@ mod tests {
             task_id,
             leader: leader.clone(),
             auth_token: auth_token.clone(),
-            hpke_config: hpke_config.clone(),
-            hpke_private_key: hpke_private_key.clone(),
+            hpke_config: hpke_keypair.config().clone(),
+            hpke_private_key: hpke_keypair.private_key().clone(),
             vdaf: VdafType::Count,
             length: None,
             bits: None,
@@ -653,8 +655,8 @@ mod tests {
             task_id,
             leader: leader.clone(),
             auth_token,
-            hpke_config,
-            hpke_private_key,
+            hpke_config: hpke_keypair.config().clone(),
+            hpke_private_key: hpke_keypair.private_key().clone(),
             vdaf: VdafType::Count,
             length: None,
             bits: None,

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -20,7 +20,7 @@
 //! # async fn run() {
 //! // Supply DAP task paramenters.
 //! let task_id = random();
-//! let (hpke_config, private_key) = janus_core::hpke::generate_hpke_config_and_private_key(
+//! let hpke_keypair = janus_core::hpke::generate_hpke_config_and_private_key(
 //!     HpkeConfigId::from(0),
 //!     HpkeKemId::X25519HkdfSha256,
 //!     HpkeKdfId::HkdfSha256,
@@ -31,8 +31,8 @@
 //!     task_id,
 //!     "https://example.com/dap/".parse().unwrap(),
 //!     authentication_token,
-//!     hpke_config,
-//!     private_key,
+//!     hpke_keypair.config().clone(),
+//!     hpke_keypair.private_key().clone(),
 //! );
 //!
 //! // Supply a VDAF implementation, corresponding to this task.
@@ -642,13 +642,13 @@ mod tests {
         for<'a> Vec<u8>: From<&'a V::AggregateShare>,
     {
         let server_url = Url::parse(&mockito::server_url()).unwrap();
-        let (hpke_config, hpke_private_key) = generate_test_hpke_config_and_private_key();
+        let hpke_keypair = generate_test_hpke_config_and_private_key();
         let parameters = CollectorParameters::new(
             random(),
             server_url,
             AuthenticationToken::from(b"token".to_vec()),
-            hpke_config,
-            hpke_private_key,
+            hpke_keypair.config().clone(),
+            hpke_keypair.private_key().clone(),
         )
         .with_http_request_backoff(test_http_request_exponential_backoff())
         .with_collect_poll_backoff(test_http_request_exponential_backoff());
@@ -743,13 +743,13 @@ mod tests {
 
     #[test]
     fn leader_endpoint_end_in_slash() {
-        let (hpke_config, hpke_private_key) = generate_test_hpke_config_and_private_key();
+        let hpke_keypair = generate_test_hpke_config_and_private_key();
         let collector_parameters = CollectorParameters::new(
             random(),
             "http://example.com/dap".parse().unwrap(),
             AuthenticationToken::from(b"token".to_vec()),
-            hpke_config.clone(),
-            hpke_private_key.clone(),
+            hpke_keypair.config().clone(),
+            hpke_keypair.private_key().clone(),
         );
 
         assert_eq!(
@@ -761,8 +761,8 @@ mod tests {
             random(),
             "http://example.com".parse().unwrap(),
             AuthenticationToken::from(b"token".to_vec()),
-            hpke_config,
-            hpke_private_key,
+            hpke_keypair.config().clone(),
+            hpke_keypair.private_key().clone(),
         );
 
         assert_eq!(

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,6 +26,7 @@ test-util = [
 
 [dependencies]
 backoff = { version = "0.4.0", features = ["tokio"] }
+base64 = "0.13.1"
 chrono = "0.4"
 derivative = "2.2.0"
 futures = "0.3.25"

--- a/core/src/hpke.rs
+++ b/core/src/hpke.rs
@@ -253,6 +253,7 @@ pub fn generate_hpke_config_and_private_key(
     )
 }
 
+/// An HPKE configuration and its corresponding private key.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HpkeKeypair {
     config: HpkeConfig,
@@ -260,6 +261,7 @@ pub struct HpkeKeypair {
 }
 
 impl HpkeKeypair {
+    /// Construct a keypair from its two halves.
     pub fn new(config: HpkeConfig, private_key: HpkePrivateKey) -> HpkeKeypair {
         HpkeKeypair {
             config,
@@ -267,10 +269,12 @@ impl HpkeKeypair {
         }
     }
 
+    /// Retrieve the HPKE configuration from this keypair.
     pub fn config(&self) -> &HpkeConfig {
         &self.config
     }
 
+    /// Retrieve the HPKE private key from this keypair.
     pub fn private_key(&self) -> &HpkePrivateKey {
         &self.private_key
     }

--- a/integration_tests/tests/common/mod.rs
+++ b/integration_tests/tests/common/mod.rs
@@ -27,8 +27,7 @@ pub fn test_task_builders(
     query_type: QueryType,
 ) -> (HpkePrivateKey, TaskBuilder, TaskBuilder) {
     let endpoint_random_value = hex::encode(random::<[u8; 4]>());
-    let (collector_hpke_config, collector_private_key) =
-        generate_test_hpke_config_and_private_key();
+    let collector_keypair = generate_test_hpke_config_and_private_key();
     let leader_task = TaskBuilder::new(QueryType::TimeInterval, vdaf, Role::Leader)
         .with_aggregator_endpoints(Vec::from([
             Url::parse(&format!("http://leader-{endpoint_random_value}:8080/")).unwrap(),
@@ -36,13 +35,17 @@ pub fn test_task_builders(
         ]))
         .with_query_type(query_type)
         .with_min_batch_size(46)
-        .with_collector_hpke_config(collector_hpke_config);
+        .with_collector_hpke_config(collector_keypair.config().clone());
     let helper_task = leader_task
         .clone()
         .with_role(Role::Helper)
         .with_collector_auth_tokens(Vec::new());
 
-    (collector_private_key, leader_task, helper_task)
+    (
+        collector_keypair.private_key().clone(),
+        leader_task,
+        helper_task,
+    )
 }
 
 pub fn translate_url_for_external_access(url: &Url, external_port: u16) -> Url {

--- a/interop_binaries/src/bin/janus_interop_aggregator.rs
+++ b/interop_binaries/src/bin/janus_interop_aggregator.rs
@@ -103,7 +103,7 @@ async fn handle_add_task(
             (AggregatorRole::Helper, _) => Vec::new(),
         };
 
-    let (hpke_config, private_key) = keyring.lock().await.get_random_keypair();
+    let hpke_keypair = keyring.lock().await.get_random_keypair();
 
     let query_type = match request.query_type {
         1 => janus_aggregator::task::QueryType::TimeInterval,
@@ -137,7 +137,7 @@ async fn handle_add_task(
         collector_hpke_config,
         Vec::from([leader_authentication_token]),
         collector_authentication_tokens,
-        [(hpke_config, private_key)],
+        [hpke_keypair],
     )
     .context("error constructing task")?;
 

--- a/interop_binaries/src/bin/janus_interop_aggregator.rs
+++ b/interop_binaries/src/bin/janus_interop_aggregator.rs
@@ -76,9 +76,6 @@ async fn handle_add_task(
     keyring: &Mutex<HpkeConfigRegistry>,
     request: AggregatorAddTaskRequest,
 ) -> anyhow::Result<()> {
-    let task_id_bytes = base64::decode_config(request.task_id, URL_SAFE_NO_PAD)
-        .context("invalid base64url content in \"task_id\"")?;
-    let task_id = TaskId::get_decoded(&task_id_bytes).context("invalid length of TaskId")?;
     let vdaf = request.vdaf.into();
     let leader_authentication_token =
         AuthenticationToken::from(request.leader_authentication_token.into_bytes());
@@ -124,7 +121,7 @@ async fn handle_add_task(
     };
 
     let task = Task::new(
-        task_id,
+        request.task_id,
         Vec::from([request.leader, request.helper]),
         query_type,
         vdaf,

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -6,7 +6,7 @@ use janus_core::{
 };
 use janus_messages::{
     query_type::{FixedSize, QueryType as _, TimeInterval},
-    HpkeAeadId, HpkeConfig, HpkeConfigId, HpkeKdfId, HpkeKemId, Role,
+    HpkeAeadId, HpkeConfig, HpkeConfigId, HpkeKdfId, HpkeKemId, Role, TaskId,
 };
 use prio::codec::Encode;
 use rand::random;
@@ -181,7 +181,7 @@ impl From<AggregatorRole> for Role {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AggregatorAddTaskRequest {
-    pub task_id: String, // in unpadded base64url
+    pub task_id: TaskId, // uses unpadded base64url
     pub leader: Url,
     pub helper: Url,
     pub vdaf: VdafObject,
@@ -215,7 +215,7 @@ impl From<Task> for AggregatorAddTaskRequest {
             }
         };
         Self {
-            task_id: base64::encode_config(task.id().as_ref(), URL_SAFE_NO_PAD),
+            task_id: *task.id(),
             leader: task.aggregator_url(&Role::Leader).unwrap().clone(),
             helper: task.aggregator_url(&Role::Helper).unwrap().clone(),
             vdaf: task.vdaf().clone().into(),

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -1,12 +1,12 @@
 use base64::URL_SAFE_NO_PAD;
 use janus_aggregator::task::{QueryType, Task};
 use janus_core::{
-    hpke::{generate_hpke_config_and_private_key, HpkePrivateKey},
+    hpke::{generate_hpke_config_and_private_key, HpkeKeypair},
     task::VdafInstance,
 };
 use janus_messages::{
     query_type::{FixedSize, QueryType as _, TimeInterval},
-    HpkeAeadId, HpkeConfig, HpkeConfigId, HpkeKdfId, HpkeKemId, Role, TaskId,
+    HpkeAeadId, HpkeConfigId, HpkeKdfId, HpkeKemId, Role, TaskId,
 };
 use prio::codec::Encode;
 use rand::random;
@@ -272,7 +272,7 @@ pub fn install_tracing_subscriber() -> anyhow::Result<()> {
 /// [`HpkeConfigId`].
 #[derive(Default)]
 pub struct HpkeConfigRegistry {
-    keypairs: HashMap<HpkeConfigId, (HpkeConfig, HpkePrivateKey)>,
+    keypairs: HashMap<HpkeConfigId, HpkeKeypair>,
 }
 
 impl HpkeConfigRegistry {
@@ -281,7 +281,7 @@ impl HpkeConfigRegistry {
     }
 
     /// Get the keypair associated with a given ID.
-    pub fn fetch_keypair(&mut self, id: HpkeConfigId) -> (HpkeConfig, HpkePrivateKey) {
+    pub fn fetch_keypair(&mut self, id: HpkeConfigId) -> HpkeKeypair {
         self.keypairs
             .entry(id)
             .or_insert_with(|| {
@@ -298,7 +298,7 @@ impl HpkeConfigRegistry {
     }
 
     /// Choose a random [`HpkeConfigId`], and then get the keypair associated with that ID.
-    pub fn get_random_keypair(&mut self) -> (HpkeConfig, HpkePrivateKey) {
+    pub fn get_random_keypair(&mut self) -> HpkeKeypair {
         self.fetch_keypair(random::<u8>().into())
     }
 }

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -27,6 +27,7 @@ thiserror = "1.0"
 
 [dev-dependencies]
 assert_matches = "1"
+serde_test = "1.0.148"
 tracing-log = "0.1.3"
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt"] }
 trycmd = "0.14.5"

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -445,7 +445,7 @@ impl From<HpkeConfigId> for u8 {
 }
 
 /// DAP protocol message representing an identifier for a DAP task.
-#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct TaskId([u8; Self::LEN]);
 
 impl TaskId {
@@ -717,7 +717,7 @@ impl Decode for HpkeCiphertext {
 
 /// DAP protocol message representing an HPKE public key.
 // TODO(#230): refactor HpkePublicKey & HpkeConfig to simplify usage
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct HpkePublicKey(Vec<u8>);
 
 impl From<Vec<u8>> for HpkePublicKey {
@@ -752,7 +752,7 @@ impl Debug for HpkePublicKey {
 }
 
 /// DAP protocol message representing an HPKE config.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HpkeConfig {
     id: HpkeConfigId,
     kem_id: HpkeKemId,


### PR DESCRIPTION
This refactors parts of our task YAML serialization code out into serde trait implementations on individual types. Hoisting HPKE key YAML serialization from `janus_aggregator` to `janus_core` is a prerequisite for #801.  This PR makes the following changes:

- Move base64url-encoding of `TaskId`, `HpkePublicKey`, and `HpkePrivateKey` into custom serde trait implementations on the types themselves. (out of implementations on various serialization helper types)
- Remove `SerializedHpkeConfig`, and use `HpkeConfig` directly in types with serde derive macros applied.
- Replace `(HpkeConfig, HpkePrivateKey)` tuples with a new struct type, `HpkeKeypair`.
- Remove `SerializedHpkeKeypair`, and derive serde traits on `HpkeKeypair` directly.
- Add a `serde_test` test for the `Task` serialization format. The only changes to this test throughout the above refactor were struct names, which don't appear in the output when using `serde_yaml`.