### PR TITLE
Add per-task configuration for Daphne compatibility

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1323,7 +1323,7 @@ impl VdafOps {
                 report.task_id(),
                 report.metadata(),
                 report.public_share(),
-                task.input_share_aad_tweak(),
+                task.input_share_aad_public_share_length_prefix(),
             ),
         ) {
             Ok(leader_decrypted_input_share) => leader_decrypted_input_share,
@@ -1502,7 +1502,7 @@ impl VdafOps {
                         task.id(),
                         report_share.metadata(),
                         report_share.public_share(),
-                        task.input_share_aad_tweak(),
+                        task.input_share_aad_public_share_length_prefix(),
                     ),
                 )
                 .map_err(|error| {

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1323,6 +1323,7 @@ impl VdafOps {
                 report.task_id(),
                 report.metadata(),
                 report.public_share(),
+                task.input_share_aad_tweak(),
             ),
         ) {
             Ok(leader_decrypted_input_share) => leader_decrypted_input_share,
@@ -1501,6 +1502,7 @@ impl VdafOps {
                         task.id(),
                         report_share.metadata(),
                         report_share.public_share(),
+                        task.input_share_aad_tweak(),
                     ),
                 )
                 .map_err(|error| {
@@ -3500,6 +3502,7 @@ mod tests {
             task.id(),
             &report_metadata,
             &public_share.get_encoded(),
+            false,
         );
 
         let leader_ciphertext = hpke::seal(
@@ -4318,8 +4321,12 @@ mod tests {
         );
         let mut input_share_bytes = input_share.get_encoded();
         input_share_bytes.push(0); // can no longer be decoded.
-        let aad =
-            associated_data_for_report_share(task.id(), &report_metadata_2, &encoded_public_share);
+        let aad = associated_data_for_report_share(
+            task.id(),
+            &report_metadata_2,
+            &encoded_public_share,
+            false,
+        );
         let report_share_2 = generate_helper_report_share_for_plaintext(
             report_metadata_2,
             &hpke_key.0,
@@ -4415,7 +4422,8 @@ mod tests {
                 .unwrap(),
             Vec::new(),
         );
-        let aad = associated_data_for_report_share(task.id(), &report_metadata_6, &public_share_6);
+        let aad =
+            associated_data_for_report_share(task.id(), &report_metadata_6, &public_share_6, false);
         let report_share_6 = generate_helper_report_share_for_plaintext(
             report_metadata_6,
             &hpke_key.0,
@@ -7940,8 +7948,12 @@ mod tests {
         for<'a> &'a V::AggregateShare: Into<Vec<u8>>,
     {
         let encoded_public_share = public_share.get_encoded();
-        let associated_data =
-            associated_data_for_report_share(task_id, report_metadata, &encoded_public_share);
+        let associated_data = associated_data_for_report_share(
+            task_id,
+            report_metadata,
+            &encoded_public_share,
+            false,
+        );
         generate_helper_report_share_for_plaintext(
             report_metadata.clone(),
             cfg,

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -2199,6 +2199,7 @@ mod tests {
                 task_id,
                 report_metadata,
                 &public_share.get_encoded(),
+                false,
             ),
         )
         .unwrap();

--- a/aggregator/src/datastore.rs
+++ b/aggregator/src/datastore.rs
@@ -291,7 +291,8 @@ impl<C: Clock> Transaction<'_, C> {
             .prepare_cached(
                 "INSERT INTO tasks (task_id, aggregator_role, aggregator_endpoints, query_type,
                     vdaf, max_batch_query_count, task_expiration, min_batch_size, time_precision,
-                    tolerable_clock_skew, collector_hpke_config, input_share_aad_tweak)
+                    tolerable_clock_skew, collector_hpke_config,
+                    input_share_aad_public_share_length_prefix)
                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
             )
             .await?;
@@ -313,7 +314,8 @@ impl<C: Clock> Transaction<'_, C> {
                     /* tolerable_clock_skew */
                     &i64::try_from(task.tolerable_clock_skew().as_seconds())?,
                     /* collector_hpke_config */ &task.collector_hpke_config().get_encoded(),
-                    /* input_share_aad_tweak */ &task.input_share_aad_tweak(),
+                    /* input_share_aad_public_share_length_prefix */
+                    &task.input_share_aad_public_share_length_prefix(),
                 ],
             )
             .await?;
@@ -518,7 +520,8 @@ impl<C: Clock> Transaction<'_, C> {
             .prepare_cached(
                 "SELECT aggregator_role, aggregator_endpoints, query_type, vdaf,
                     max_batch_query_count, task_expiration, min_batch_size, time_precision,
-                    tolerable_clock_skew, collector_hpke_config, input_share_aad_tweak
+                    tolerable_clock_skew, collector_hpke_config,
+                    input_share_aad_public_share_length_prefix
                 FROM tasks WHERE task_id = $1",
             )
             .await?;
@@ -595,7 +598,8 @@ impl<C: Clock> Transaction<'_, C> {
             .prepare_cached(
                 "SELECT task_id, aggregator_role, aggregator_endpoints, query_type, vdaf,
                     max_batch_query_count, task_expiration, min_batch_size, time_precision,
-                    tolerable_clock_skew, collector_hpke_config, input_share_aad_tweak
+                    tolerable_clock_skew, collector_hpke_config,
+                    input_share_aad_public_share_length_prefix
                 FROM tasks",
             )
             .await?;
@@ -742,7 +746,8 @@ impl<C: Clock> Transaction<'_, C> {
         let tolerable_clock_skew =
             Duration::from_seconds(row.get_bigint_and_convert("tolerable_clock_skew")?);
         let collector_hpke_config = HpkeConfig::get_decoded(row.get("collector_hpke_config"))?;
-        let input_share_aad_tweak = row.get("input_share_aad_tweak");
+        let input_share_aad_public_share_length_prefix =
+            row.get("input_share_aad_public_share_length_prefix");
 
         // Aggregator authentication tokens.
         let mut aggregator_auth_tokens = Vec::new();
@@ -829,7 +834,7 @@ impl<C: Clock> Transaction<'_, C> {
             aggregator_auth_tokens,
             collector_auth_tokens,
             hpke_configs,
-            input_share_aad_tweak,
+            input_share_aad_public_share_length_prefix,
         )?)
     }
 

--- a/aggregator/src/datastore.rs
+++ b/aggregator/src/datastore.rs
@@ -291,8 +291,8 @@ impl<C: Clock> Transaction<'_, C> {
             .prepare_cached(
                 "INSERT INTO tasks (task_id, aggregator_role, aggregator_endpoints, query_type,
                     vdaf, max_batch_query_count, task_expiration, min_batch_size, time_precision,
-                    tolerable_clock_skew, collector_hpke_config)
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
+                    tolerable_clock_skew, collector_hpke_config, input_share_aad_tweak)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
             )
             .await?;
         self.tx
@@ -313,6 +313,7 @@ impl<C: Clock> Transaction<'_, C> {
                     /* tolerable_clock_skew */
                     &i64::try_from(task.tolerable_clock_skew().as_seconds())?,
                     /* collector_hpke_config */ &task.collector_hpke_config().get_encoded(),
+                    /* input_share_aad_tweak */ &task.input_share_aad_tweak(),
                 ],
             )
             .await?;
@@ -517,7 +518,7 @@ impl<C: Clock> Transaction<'_, C> {
             .prepare_cached(
                 "SELECT aggregator_role, aggregator_endpoints, query_type, vdaf,
                     max_batch_query_count, task_expiration, min_batch_size, time_precision,
-                    tolerable_clock_skew, collector_hpke_config
+                    tolerable_clock_skew, collector_hpke_config, input_share_aad_tweak
                 FROM tasks WHERE task_id = $1",
             )
             .await?;
@@ -594,7 +595,7 @@ impl<C: Clock> Transaction<'_, C> {
             .prepare_cached(
                 "SELECT task_id, aggregator_role, aggregator_endpoints, query_type, vdaf,
                     max_batch_query_count, task_expiration, min_batch_size, time_precision,
-                    tolerable_clock_skew, collector_hpke_config
+                    tolerable_clock_skew, collector_hpke_config, input_share_aad_tweak
                 FROM tasks",
             )
             .await?;
@@ -741,6 +742,7 @@ impl<C: Clock> Transaction<'_, C> {
         let tolerable_clock_skew =
             Duration::from_seconds(row.get_bigint_and_convert("tolerable_clock_skew")?);
         let collector_hpke_config = HpkeConfig::get_decoded(row.get("collector_hpke_config"))?;
+        let input_share_aad_tweak = row.get("input_share_aad_tweak");
 
         // Aggregator authentication tokens.
         let mut aggregator_auth_tokens = Vec::new();
@@ -827,6 +829,7 @@ impl<C: Clock> Transaction<'_, C> {
             aggregator_auth_tokens,
             collector_auth_tokens,
             hpke_configs,
+            input_share_aad_tweak,
         )?)
     }
 

--- a/aggregator/src/task.rs
+++ b/aggregator/src/task.rs
@@ -112,7 +112,7 @@ pub struct Task {
     /// HPKE configurations & private keys used by this aggregator to decrypt client reports.
     hpke_keys: HashMap<HpkeConfigId, (HpkeConfig, HpkePrivateKey)>,
     /// Configuration option to add a length prefix for the public share in the input share AAD.
-    input_share_aad_tweak: bool,
+    input_share_aad_public_share_length_prefix: bool,
 }
 
 impl Task {
@@ -133,7 +133,7 @@ impl Task {
         aggregator_auth_tokens: Vec<AuthenticationToken>,
         collector_auth_tokens: Vec<AuthenticationToken>,
         hpke_keys: I,
-        input_share_aad_tweak: bool,
+        input_share_aad_public_share_length_prefix: bool,
     ) -> Result<Self, Error> {
         // Ensure provided aggregator endpoints end with a slash, as we will be joining additional
         // path segments into these endpoints & the Url::join implementation is persnickety about
@@ -164,7 +164,7 @@ impl Task {
             aggregator_auth_tokens,
             collector_auth_tokens,
             hpke_keys,
-            input_share_aad_tweak,
+            input_share_aad_public_share_length_prefix,
         };
         task.validate()?;
         Ok(task)
@@ -338,8 +338,8 @@ impl Task {
 
     /// Fetch the configuration setting specifying whether an additional length prefix should be
     /// added to the input share AAD, before the public share.
-    pub fn input_share_aad_tweak(&self) -> bool {
-        self.input_share_aad_tweak
+    pub fn input_share_aad_public_share_length_prefix(&self) -> bool {
+        self.input_share_aad_public_share_length_prefix
     }
 }
 
@@ -370,7 +370,7 @@ struct SerializedTask {
     aggregator_auth_tokens: Vec<String>, // in unpadded base64url
     collector_auth_tokens: Vec<String>,  // in unpadded base64url
     hpke_keys: Vec<SerializedHpkeKeypair>, // in unpadded base64url
-    input_share_aad_tweak: bool,
+    input_share_aad_public_share_length_prefix: bool,
 }
 
 impl Serialize for Task {
@@ -413,7 +413,8 @@ impl Serialize for Task {
             aggregator_auth_tokens,
             collector_auth_tokens,
             hpke_keys,
-            input_share_aad_tweak: self.input_share_aad_tweak,
+            input_share_aad_public_share_length_prefix: self
+                .input_share_aad_public_share_length_prefix,
         }
         .serialize(serializer)
     }
@@ -494,7 +495,7 @@ impl<'de> Deserialize<'de> for Task {
             aggregator_auth_tokens,
             collector_auth_tokens,
             hpke_keys,
-            serialized_task.input_share_aad_tweak,
+            serialized_task.input_share_aad_public_share_length_prefix,
         )
         .map_err(D::Error::custom)
     }
@@ -756,9 +757,12 @@ pub mod test_util {
         }
 
         /// Selects the input share AAD format.
-        pub fn with_input_share_aad_tweak(self, input_share_aad_tweak: bool) -> Self {
+        pub fn with_input_share_aad_public_share_length_prefix(
+            self,
+            input_share_aad_public_share_length_prefix: bool,
+        ) -> Self {
             Self(Task {
-                input_share_aad_tweak,
+                input_share_aad_public_share_length_prefix,
                 ..self.0
             })
         }
@@ -801,7 +805,7 @@ mod tests {
         )
         .build();
         roundtrip_encoding(task.clone());
-        task.input_share_aad_tweak = true;
+        task.input_share_aad_public_share_length_prefix = true;
         roundtrip_encoding(task);
     }
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -67,7 +67,7 @@ pub struct ClientParameters {
     http_request_retry_parameters: ExponentialBackoff,
     /// Configuration setting to add an additional length prefix to the input share AAD, before
     /// the public share.
-    input_share_aad_tweak: bool,
+    input_share_aad_public_share_length_prefix: bool,
 }
 
 impl ClientParameters {
@@ -76,13 +76,13 @@ impl ClientParameters {
         task_id: TaskId,
         aggregator_endpoints: Vec<Url>,
         time_precision: Duration,
-        input_share_aad_tweak: bool,
+        input_share_aad_public_share_length_prefix: bool,
     ) -> Self {
         Self::new_with_backoff(
             task_id,
             aggregator_endpoints,
             time_precision,
-            input_share_aad_tweak,
+            input_share_aad_public_share_length_prefix,
             http_request_exponential_backoff(),
         )
     }
@@ -92,7 +92,7 @@ impl ClientParameters {
         task_id: TaskId,
         mut aggregator_endpoints: Vec<Url>,
         time_precision: Duration,
-        input_share_aad_tweak: bool,
+        input_share_aad_public_share_length_prefix: bool,
         http_request_retry_parameters: ExponentialBackoff,
     ) -> Self {
         // Ensure provided aggregator endpoints end with a slash, as we will be joining additional
@@ -107,7 +107,7 @@ impl ClientParameters {
             aggregator_endpoints,
             time_precision,
             http_request_retry_parameters,
-            input_share_aad_tweak,
+            input_share_aad_public_share_length_prefix,
         }
     }
 
@@ -233,7 +233,7 @@ where
             &self.parameters.task_id,
             &report_metadata,
             &public_share,
-            self.parameters.input_share_aad_tweak,
+            self.parameters.input_share_aad_public_share_length_prefix,
         );
 
         let encrypted_input_shares: Vec<HpkeCiphertext> = [

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -65,15 +65,24 @@ pub struct ClientParameters {
     time_precision: Duration,
     /// Parameters to use when retrying HTTP requests.
     http_request_retry_parameters: ExponentialBackoff,
+    /// Configuration setting to add an additional length prefix to the input share AAD, before
+    /// the public share.
+    input_share_aad_tweak: bool,
 }
 
 impl ClientParameters {
     /// Creates a new set of client task parameters.
-    pub fn new(task_id: TaskId, aggregator_endpoints: Vec<Url>, time_precision: Duration) -> Self {
+    pub fn new(
+        task_id: TaskId,
+        aggregator_endpoints: Vec<Url>,
+        time_precision: Duration,
+        input_share_aad_tweak: bool,
+    ) -> Self {
         Self::new_with_backoff(
             task_id,
             aggregator_endpoints,
             time_precision,
+            input_share_aad_tweak,
             http_request_exponential_backoff(),
         )
     }
@@ -83,6 +92,7 @@ impl ClientParameters {
         task_id: TaskId,
         mut aggregator_endpoints: Vec<Url>,
         time_precision: Duration,
+        input_share_aad_tweak: bool,
         http_request_retry_parameters: ExponentialBackoff,
     ) -> Self {
         // Ensure provided aggregator endpoints end with a slash, as we will be joining additional
@@ -97,6 +107,7 @@ impl ClientParameters {
             aggregator_endpoints,
             time_precision,
             http_request_retry_parameters,
+            input_share_aad_tweak,
         }
     }
 
@@ -222,6 +233,7 @@ where
             &self.parameters.task_id,
             &report_metadata,
             &public_share,
+            self.parameters.input_share_aad_tweak,
         );
 
         let encrypted_input_shares: Vec<HpkeCiphertext> = [
@@ -305,6 +317,7 @@ mod tests {
                 random(),
                 Vec::from([server_url.clone(), server_url]),
                 Duration::from_seconds(1),
+                false,
                 test_http_request_exponential_backoff(),
             ),
             vdaf_client,
@@ -324,6 +337,7 @@ mod tests {
                 "http://helper_endpoint".parse().unwrap(),
             ]),
             Duration::from_seconds(1),
+            false,
         );
 
         assert_eq!(
@@ -424,7 +438,7 @@ mod tests {
         install_test_trace_subscriber();
 
         let client_parameters =
-            ClientParameters::new(random(), Vec::new(), Duration::from_seconds(0));
+            ClientParameters::new(random(), Vec::new(), Duration::from_seconds(0), false);
         let client = Client::new(
             client_parameters,
             Prio3::new_aes128_count(2).unwrap(),

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -22,7 +22,8 @@ CREATE TABLE tasks(
     min_batch_size         BIGINT NOT NULL,           -- the minimum number of reports in a batch to allow it to be collected
     time_precision         BIGINT NOT NULL,           -- the duration to which clients are expected to round their report timestamps, in seconds
     tolerable_clock_skew   BIGINT NOT NULL,           -- the maximum acceptable clock skew to allow between client and aggregator, in seconds
-    collector_hpke_config  BYTEA NOT NULL             -- the HPKE config of the collector (encoded HpkeConfig message)
+    collector_hpke_config  BYTEA NOT NULL,            -- the HPKE config of the collector (encoded HpkeConfig message)
+    input_share_aad_tweak  BOOLEAN NOT NULL DEFAULT false -- selects which input share AAD format should be used (true: includes a length prefix for the public share, akin to DAP-03, false: no length prefix for the public share)
 );
 
 -- The aggregator authentication tokens used by a given task.

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -11,19 +11,19 @@ CREATE TYPE AGGREGATOR_ROLE AS ENUM(
 
 -- Corresponds to a DAP task, containing static data associated with the task.
 CREATE TABLE tasks(
-    id                     BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,  -- artificial ID, internal-only
-    task_id                BYTEA UNIQUE NOT NULL,     -- 32-byte TaskID as defined by the DAP specification
-    aggregator_role        AGGREGATOR_ROLE NOT NULL,  -- the role of this aggregator for this task
-    aggregator_endpoints   TEXT[] NOT NULL,           -- aggregator HTTPS endpoints, leader first
-    query_type             JSONB NOT NULL,            -- the query type in use for this task, along with its parameters
-    vdaf                   JSON NOT NULL,             -- the VDAF instance in use for this task, along with its parameters
-    max_batch_query_count  BIGINT NOT NULL,           -- the maximum number of times a given batch may be collected
-    task_expiration        TIMESTAMP NOT NULL,        -- the time after which client reports are no longer accepted
-    min_batch_size         BIGINT NOT NULL,           -- the minimum number of reports in a batch to allow it to be collected
-    time_precision         BIGINT NOT NULL,           -- the duration to which clients are expected to round their report timestamps, in seconds
-    tolerable_clock_skew   BIGINT NOT NULL,           -- the maximum acceptable clock skew to allow between client and aggregator, in seconds
-    collector_hpke_config  BYTEA NOT NULL,            -- the HPKE config of the collector (encoded HpkeConfig message)
-    input_share_aad_tweak  BOOLEAN NOT NULL DEFAULT false -- selects which input share AAD format should be used (true: includes a length prefix for the public share, akin to DAP-03, false: no length prefix for the public share)
+    id                     BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,    -- artificial ID, internal-only
+    task_id                BYTEA UNIQUE NOT NULL,                              -- 32-byte TaskID as defined by the DAP specification
+    aggregator_role        AGGREGATOR_ROLE NOT NULL,                           -- the role of this aggregator for this task
+    aggregator_endpoints   TEXT[] NOT NULL,                                    -- aggregator HTTPS endpoints, leader first
+    query_type             JSONB NOT NULL,                                     -- the query type in use for this task, along with its parameters
+    vdaf                   JSON NOT NULL,                                      -- the VDAF instance in use for this task, along with its parameters
+    max_batch_query_count  BIGINT NOT NULL,                                    -- the maximum number of times a given batch may be collected
+    task_expiration        TIMESTAMP NOT NULL,                                 -- the time after which client reports are no longer accepted
+    min_batch_size         BIGINT NOT NULL,                                    -- the minimum number of reports in a batch to allow it to be collected
+    time_precision         BIGINT NOT NULL,                                    -- the duration to which clients are expected to round their report timestamps, in seconds
+    tolerable_clock_skew   BIGINT NOT NULL,                                    -- the maximum acceptable clock skew to allow between client and aggregator, in seconds
+    collector_hpke_config  BYTEA NOT NULL,                                     -- the HPKE config of the collector (encoded HpkeConfig message)
+    input_share_aad_public_share_length_prefix  BOOLEAN NOT NULL DEFAULT false -- selects which input share AAD format should be used (true: includes a length prefix for the public share, akin to DAP-03, false: no length prefix for the public share)
 );
 
 -- The aggregator authentication tokens used by a given task.

--- a/integration_tests/src/client.rs
+++ b/integration_tests/src/client.rs
@@ -218,8 +218,12 @@ where
         aggregator_endpoints: Vec<Url>,
         vdaf: V,
     ) -> Result<ClientImplementation<'static, V>, janus_client::Error> {
-        let client_parameters =
-            ClientParameters::new(*task.id(), aggregator_endpoints, *task.time_precision());
+        let client_parameters = ClientParameters::new(
+            *task.id(),
+            aggregator_endpoints,
+            *task.time_precision(),
+            task.input_share_aad_tweak(),
+        );
         let http_client = default_http_client()?;
         let leader_config =
             aggregator_hpke_config(&client_parameters, &Role::Leader, task.id(), &http_client)

--- a/integration_tests/src/client.rs
+++ b/integration_tests/src/client.rs
@@ -222,7 +222,7 @@ where
             *task.id(),
             aggregator_endpoints,
             *task.time_precision(),
-            task.input_share_aad_tweak(),
+            task.input_share_aad_public_share_length_prefix(),
         );
         let http_client = default_http_client()?;
         let leader_config =

--- a/integration_tests/tests/common/mod.rs
+++ b/integration_tests/tests/common/mod.rs
@@ -25,6 +25,7 @@ use tokio::time::{self, sleep};
 pub fn test_task_builders(
     vdaf: VdafInstance,
     query_type: QueryType,
+    input_share_aad_tweak: bool,
 ) -> (HpkePrivateKey, TaskBuilder, TaskBuilder) {
     let endpoint_random_value = hex::encode(random::<[u8; 4]>());
     let (collector_hpke_config, collector_private_key) =
@@ -35,6 +36,7 @@ pub fn test_task_builders(
             Url::parse(&format!("http://helper-{endpoint_random_value}:8080/")).unwrap(),
         ]))
         .with_query_type(query_type)
+        .with_input_share_aad_tweak(input_share_aad_tweak)
         .with_min_batch_size(46)
         .with_collector_hpke_config(collector_hpke_config);
     let helper_task = leader_task

--- a/integration_tests/tests/common/mod.rs
+++ b/integration_tests/tests/common/mod.rs
@@ -25,7 +25,7 @@ use tokio::time::{self, sleep};
 pub fn test_task_builders(
     vdaf: VdafInstance,
     query_type: QueryType,
-    input_share_aad_tweak: bool,
+    input_share_aad_public_share_length_prefix: bool,
 ) -> (HpkePrivateKey, TaskBuilder, TaskBuilder) {
     let endpoint_random_value = hex::encode(random::<[u8; 4]>());
     let (collector_hpke_config, collector_private_key) =
@@ -36,7 +36,7 @@ pub fn test_task_builders(
             Url::parse(&format!("http://helper-{endpoint_random_value}:8080/")).unwrap(),
         ]))
         .with_query_type(query_type)
-        .with_input_share_aad_tweak(input_share_aad_tweak)
+        .with_input_share_aad_public_share_length_prefix(input_share_aad_public_share_length_prefix)
         .with_min_batch_size(46)
         .with_collector_hpke_config(collector_hpke_config);
     let helper_task = leader_task

--- a/integration_tests/tests/divviup_ts.rs
+++ b/integration_tests/tests/divviup_ts.rs
@@ -17,7 +17,7 @@ use common::{submit_measurements_and_verify_aggregate, test_task_builders};
 
 async fn run_divviup_ts_integration_test(container_client: &Cli, vdaf: VdafInstance) {
     let (collector_private_key, leader_task, helper_task) =
-        test_task_builders(vdaf, janus_aggregator::task::QueryType::TimeInterval);
+        test_task_builders(vdaf, janus_aggregator::task::QueryType::TimeInterval, false);
     let leader_task = leader_task.build();
     let network = generate_network_name();
     let leader = Janus::new_in_container(container_client, &network, &leader_task).await;

--- a/integration_tests/tests/janus.rs
+++ b/integration_tests/tests/janus.rs
@@ -52,10 +52,10 @@ impl<'a> JanusPair<'a> {
         container_client: &'a Cli,
         vdaf: VdafInstance,
         query_type: QueryType,
-        input_share_aad_tweak: bool,
+        input_share_aad_public_share_length_prefix: bool,
     ) -> JanusPair<'a> {
         let (collector_private_key, leader_task, helper_task) =
-            test_task_builders(vdaf, query_type, input_share_aad_tweak);
+            test_task_builders(vdaf, query_type, input_share_aad_public_share_length_prefix);
 
         // The environment variables should either all be present, or all be absent
         let (leader_task, leader, helper) = match (
@@ -290,7 +290,9 @@ async fn janus_janus_aad_tweak() {
         true,
     )
     .await;
-    assert!(janus_pair.leader_task.input_share_aad_tweak());
+    assert!(janus_pair
+        .leader_task
+        .input_share_aad_public_share_length_prefix());
 
     // Run the behavioral test.
     submit_measurements_and_verify_aggregate(

--- a/integration_tests/tests/janus.rs
+++ b/integration_tests/tests/janus.rs
@@ -52,9 +52,10 @@ impl<'a> JanusPair<'a> {
         container_client: &'a Cli,
         vdaf: VdafInstance,
         query_type: QueryType,
+        input_share_aad_tweak: bool,
     ) -> JanusPair<'a> {
         let (collector_private_key, leader_task, helper_task) =
-            test_task_builders(vdaf, query_type);
+            test_task_builders(vdaf, query_type, input_share_aad_tweak);
 
         // The environment variables should either all be present, or all be absent
         let (leader_task, leader, helper) = match (
@@ -153,6 +154,7 @@ async fn janus_janus_count() {
         &container_client,
         VdafInstance::Prio3Aes128Count,
         QueryType::TimeInterval,
+        false,
     )
     .await;
 
@@ -178,6 +180,7 @@ async fn janus_janus_sum_16() {
         &container_client,
         VdafInstance::Prio3Aes128Sum { bits: 16 },
         QueryType::TimeInterval,
+        false,
     )
     .await;
 
@@ -205,6 +208,7 @@ async fn janus_janus_histogram_4_buckets() {
         &container_client,
         VdafInstance::Prio3Aes128Histogram { buckets },
         QueryType::TimeInterval,
+        false,
     )
     .await;
 
@@ -230,6 +234,7 @@ async fn janus_janus_count_vec_15() {
         &container_client,
         VdafInstance::Prio3Aes128CountVec { length: 15 },
         QueryType::TimeInterval,
+        false,
     )
     .await;
 
@@ -255,8 +260,37 @@ async fn janus_janus_fixed_size() {
         &container_client,
         VdafInstance::Prio3Aes128Count,
         QueryType::FixedSize { max_batch_size: 50 },
+        false,
     )
     .await;
+
+    // Run the behavioral test.
+    submit_measurements_and_verify_aggregate(
+        (janus_pair.leader.port(), janus_pair.helper.port()),
+        &janus_pair.leader_task,
+        &janus_pair.collector_private_key,
+        &ClientBackend::InProcess,
+        janus_pair.leader.batch_discovery(),
+    )
+    .await;
+}
+
+/// This test runs an aggregation using an alternate input share AAD construction in both the
+/// client and the aggregators.
+#[tokio::test(flavor = "multi_thread")]
+async fn janus_janus_aad_tweak() {
+    install_test_trace_subscriber();
+
+    // Start servers.
+    let container_client = container_client();
+    let janus_pair = JanusPair::new(
+        &container_client,
+        VdafInstance::Prio3Aes128Count,
+        QueryType::TimeInterval,
+        true,
+    )
+    .await;
+    assert!(janus_pair.leader_task.input_share_aad_tweak());
 
     // Run the behavioral test.
     submit_measurements_and_verify_aggregate(

--- a/interop_binaries/src/bin/janus_interop_aggregator.rs
+++ b/interop_binaries/src/bin/janus_interop_aggregator.rs
@@ -141,6 +141,7 @@ async fn handle_add_task(
         Vec::from([leader_authentication_token]),
         collector_authentication_tokens,
         [(hpke_config, private_key)],
+        request.input_share_aad_tweak,
     )
     .context("error constructing task")?;
 

--- a/interop_binaries/src/bin/janus_interop_aggregator.rs
+++ b/interop_binaries/src/bin/janus_interop_aggregator.rs
@@ -141,7 +141,7 @@ async fn handle_add_task(
         Vec::from([leader_authentication_token]),
         collector_authentication_tokens,
         [(hpke_config, private_key)],
-        request.input_share_aad_tweak,
+        request.input_share_aad_public_share_length_prefix,
     )
     .context("error constructing task")?;
 

--- a/interop_binaries/src/bin/janus_interop_client.rs
+++ b/interop_binaries/src/bin/janus_interop_client.rs
@@ -89,6 +89,7 @@ where
         task_id,
         Vec::<Url>::from([request.leader, request.helper]),
         time_precision,
+        false,
     );
 
     let leader_hpke_config = janus_client::aggregator_hpke_config(

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -198,7 +198,7 @@ pub struct AggregatorAddTaskRequest {
     pub collector_hpke_config: String, // in unpadded base64url
     pub task_expiration: u64,          // in seconds since the epoch
     #[serde(default)]
-    pub input_share_aad_tweak: bool,
+    pub input_share_aad_public_share_length_prefix: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -248,7 +248,8 @@ impl From<Task> for AggregatorAddTaskRequest {
                 URL_SAFE_NO_PAD,
             ),
             task_expiration: task.task_expiration().as_seconds_since_epoch(),
-            input_share_aad_tweak: task.input_share_aad_tweak(),
+            input_share_aad_public_share_length_prefix: task
+                .input_share_aad_public_share_length_prefix(),
         }
     }
 }

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -197,6 +197,8 @@ pub struct AggregatorAddTaskRequest {
     pub time_precision: u64,           // in seconds
     pub collector_hpke_config: String, // in unpadded base64url
     pub task_expiration: u64,          // in seconds since the epoch
+    #[serde(default)]
+    pub input_share_aad_tweak: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -246,6 +248,7 @@ impl From<Task> for AggregatorAddTaskRequest {
                 URL_SAFE_NO_PAD,
             ),
             task_expiration: task.task_expiration().as_seconds_since_epoch(),
+            input_share_aad_tweak: task.input_share_aad_tweak(),
         }
     }
 }


### PR DESCRIPTION
This adds a new task parameter, `input_share_aad_tweak` which changes how we build the input share AAD. This affects both the client and the aggregator. This is a 0.2-only change, since this compatibility issue is only relevant when targeting DAP-02. I added an integration test to confirm that aggregation works with this new mode.

We will likely need to do a manual schema migration in our dap-02 deployment. The following statement will suffice:

```sql
ALTER TABLE tasks ADD COLUMN input_share_aad_tweak BOOLEAN NOT NULL DEFAULT false;
```