### PR TITLE
Update supported release branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "main"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 20
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -19,20 +19,20 @@ updates:
       interval: "weekly"
     target-branch: "main"
 
-  # Manage dependencies on the release/0.1 branch
+  # Manage dependencies on the release/0.2 branch
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "release/0.1"
-    open-pull-requests-limit: 10
+    target-branch: "release/0.2"
+    open-pull-requests-limit: 20
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "release/0.1"
+    target-branch: "release/0.2"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "release/0.1"
+    target-branch: "release/0.2"

--- a/README.md
+++ b/README.md
@@ -5,9 +5,19 @@
 [actions]: https://github.com/divviup/janus/actions?query=branch%3Amain
 
 Janus is an experimental implementation of the
-[Distributed Aggregation Protocol (DAP) specification](https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap).
+[Distributed Aggregation Protocol (DAP) specification](https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/).
 
 Janus is currently in active development.
+
+## Draft versions and release branches
+
+The `main` branch is under continuous development and will usually be partway between DAP drafts. Janus uses stable release branches to maintain implementations of different DAP draft versions. Rust crates and container images with versions `x.y.z` are released from a corresponding `release/x.y` branch.
+
+| Git branch | Draft version | Conforms to protocol? | Status |
+| ---------- | ------------- | --------------------- | ------ |
+| `release/0.1` | [`draft-ietf-ppm-dap-01`](https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/01/) | Yes | Unmaintained as of December 7, 2022 |
+| `release/0.2` | [`draft-ietf-ppm-dap-02`](https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/02/) | Yes | Supported |
+| `main` | `draft-ietf-ppm-dap-03` (forthcoming) | Partially | Supported |
 
 ## Building
 


### PR DESCRIPTION
- Configure dependabot to manage `release/0.2`
- Stop taking dependabot changes to `release/0.1`
- Bump open dependabot PR limit to 20 to avoid annoying phenomenon where you get multiple waves of PRs to deal with
- Document release branches and their status in README.md