### PR TITLE
DAP-03: implement current-batch functionality in Aggregator.

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -24,6 +24,7 @@ use crate::{
     task::{self, Task, VerifyKey, PRIO3_AES128_VERIFY_KEY_LENGTH},
     try_join,
 };
+use anyhow::anyhow;
 use bytes::Bytes;
 use http::{
     header::{CACHE_CONTROL, CONTENT_TYPE, LOCATION},
@@ -38,7 +39,7 @@ use janus_core::{
 };
 use janus_messages::{
     problem_type::DapProblemType,
-    query_type::{FixedSize, QueryType, TimeInterval},
+    query_type::{FixedSize, TimeInterval},
     AggregateContinueReq, AggregateContinueResp, AggregateInitializeReq, AggregateInitializeResp,
     AggregateShareAad, AggregateShareReq, AggregateShareResp, AggregationJobId, BatchSelector,
     CollectReq, CollectResp, HpkeCiphertext, HpkeConfig, HpkeConfigId, InputShareAad, Interval,
@@ -758,7 +759,7 @@ impl TaskAggregator {
         collect_job_id: Uuid,
     ) -> Result<Option<Vec<u8>>, Error> {
         self.vdaf_ops
-            .handle_get_collect_job(datastore, &self.task, Arc::new(collect_job_id))
+            .handle_get_collect_job(datastore, Arc::clone(&self.task), Arc::new(collect_job_id))
             .await
     }
 
@@ -768,7 +769,7 @@ impl TaskAggregator {
         collect_job_id: Uuid,
     ) -> Result<(), Error> {
         self.vdaf_ops
-            .handle_delete_collect_job(datastore, &self.task, collect_job_id)
+            .handle_delete_collect_job(datastore, Arc::clone(&self.task), Arc::new(collect_job_id))
             .await
     }
 
@@ -2024,29 +2025,36 @@ impl VdafOps {
         // that the task IDs match as this should be guaranteed by the caller.
         let req = Arc::new(CollectReq::<Q>::get_decoded(req_bytes)?);
         assert_eq!(req.task_id(), task.id());
-
-        let aggregation_param =
-            A::AggregationParam::get_decoded(req.as_ref().aggregation_parameter())?;
-
-        // Check that the batch interval is valid for the task
-        // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-02.html#section-4.5.6.1.1
-        if !Q::validate_collect_identifier(&task, req.query().batch_identifier()) {
-            return Err(Error::BatchInvalid(
-                *task.id(),
-                format!("{}", req.query().batch_identifier()),
-            ));
-        }
+        let aggregation_param = Arc::new(A::AggregationParam::get_decoded(
+            req.as_ref().aggregation_parameter(),
+        )?);
 
         Ok(datastore
             .run_tx(move |tx| {
-                let aggregation_param = aggregation_param.clone();
-                let task = task.clone();
-                let req = req.clone();
+                let (task, req, aggregation_param) = (
+                    Arc::clone(&task),
+                    Arc::clone(&req),
+                    Arc::clone(&aggregation_param),
+                );
                 Box::pin(async move {
+                    let batch_identifier = Q::batch_identifier_for_query(tx, &task, req.query())
+                        .await?
+                        .ok_or_else(|| {
+                            datastore::Error::User(anyhow!("No batch ready for collection").into())
+                        })?;
+
+                    // Check that the batch interval is valid for the task
+                    // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-02.html#section-4.5.6.1.1
+                    if !Q::validate_collect_identifier(&task, &batch_identifier) {
+                        return Err(datastore::Error::User(
+                            Error::BatchInvalid(*task.id(), format!("{}", batch_identifier)).into(),
+                        ));
+                    }
+
                     if let Some(collect_job_id) = tx
                         .get_collect_job_id::<L, Q, A>(
                             task.id(),
-                            req.query().batch_identifier(),
+                            &batch_identifier,
                             &aggregation_param,
                         )
                         .await?
@@ -2057,12 +2065,8 @@ impl VdafOps {
 
                     debug!(collect_request = ?req, "Cache miss, creating new collect job UUID");
                     let (_, report_count) = try_join!(
-                        Q::validate_query_count::<L, C, A>(
-                            tx,
-                            &task,
-                            req.query().batch_identifier(),
-                        ),
-                        Q::count_client_reports(tx, &task, req.query().batch_identifier()),
+                        Q::validate_query_count::<L, C, A>(tx, &task, &batch_identifier),
+                        Q::count_client_reports(tx, &task, &batch_identifier),
                     )?;
 
                     // Batch size must be validated while handling CollectReq and hence before
@@ -2078,8 +2082,8 @@ impl VdafOps {
                     tx.put_collect_job(&CollectJob::<L, Q, A>::new(
                         *req.task_id(),
                         collect_job_id,
-                        req.query().batch_identifier().clone(),
-                        aggregation_param,
+                        batch_identifier,
+                        aggregation_param.as_ref().clone(),
                         CollectJobState::<L, A>::Start,
                     ))
                     .await?;
@@ -2095,7 +2099,7 @@ impl VdafOps {
     async fn handle_get_collect_job<C: Clock>(
         &self,
         datastore: &Datastore<C>,
-        task: &Task,
+        task: Arc<Task>,
         collect_job_id: Arc<Uuid>,
     ) -> Result<Option<Vec<u8>>, Error> {
         match (task.query_type(), self) {
@@ -2204,12 +2208,12 @@ impl VdafOps {
     // return value is an encoded CollectResp<Q>
     async fn handle_get_collect_job_generic<
         const L: usize,
-        Q: QueryType,
+        Q: CollectableQueryType,
         A: vdaf::Aggregator<L>,
         C: Clock,
     >(
         datastore: &Datastore<C>,
-        task: &Task,
+        task: Arc<Task>,
         collect_job_id: Arc<Uuid>,
     ) -> Result<Option<Vec<u8>>, Error>
     where
@@ -2220,15 +2224,19 @@ impl VdafOps {
     {
         let collect_job = datastore
             .run_tx(|tx| {
-                let collect_job_id = Arc::clone(&collect_job_id);
+                let (task, collect_job_id) = (Arc::clone(&task), Arc::clone(&collect_job_id));
                 Box::pin(async move {
-                    tx.get_collect_job::<L, Q, A>(&collect_job_id)
+                    let collect_job = tx
+                        .get_collect_job::<L, Q, A>(&collect_job_id)
                         .await?
                         .ok_or_else(|| {
                             datastore::Error::User(
                                 Error::UnrecognizedCollectJob(*collect_job_id).into(),
                             )
-                        })
+                        })?;
+                    Q::acknowledge_collection(tx, task.id(), collect_job.batch_identifier())
+                        .await?;
+                    Ok(collect_job)
                 })
             })
             .await?;
@@ -2306,8 +2314,8 @@ impl VdafOps {
     async fn handle_delete_collect_job<C: Clock>(
         &self,
         datastore: &Datastore<C>,
-        task: &Task,
-        collect_job_id: Uuid,
+        task: Arc<Task>,
+        collect_job_id: Arc<Uuid>,
     ) -> Result<(), Error> {
         match (task.query_type(), self) {
             (task::QueryType::TimeInterval, VdafOps::Prio3Aes128Count(_, _)) => {
@@ -2316,7 +2324,7 @@ impl VdafOps {
                     TimeInterval,
                     Prio3Aes128Count,
                     _,
-                >(datastore, collect_job_id)
+                >(datastore, task, collect_job_id)
                 .await
             }
 
@@ -2326,7 +2334,7 @@ impl VdafOps {
                     TimeInterval,
                     Prio3Aes128CountVecMultithreaded,
                     _,
-                >(datastore, collect_job_id)
+                >(datastore, task, collect_job_id)
                 .await
             }
 
@@ -2336,7 +2344,7 @@ impl VdafOps {
                     TimeInterval,
                     Prio3Aes128Sum,
                     _,
-                >(datastore, collect_job_id)
+                >(datastore, task, collect_job_id)
                 .await
             }
 
@@ -2346,7 +2354,7 @@ impl VdafOps {
                     TimeInterval,
                     Prio3Aes128Histogram,
                     _,
-                >(datastore, collect_job_id)
+                >(datastore, task, collect_job_id)
                 .await
             }
 
@@ -2354,6 +2362,7 @@ impl VdafOps {
             (task::QueryType::TimeInterval, VdafOps::Fake(_)) => {
                 Self::handle_delete_collect_job_generic::<0, TimeInterval, dummy_vdaf::Vdaf, _>(
                     datastore,
+                    task,
                     collect_job_id,
                 )
                 .await
@@ -2365,7 +2374,7 @@ impl VdafOps {
                     FixedSize,
                     Prio3Aes128Count,
                     _,
-                >(datastore, collect_job_id)
+                >(datastore, task, collect_job_id)
                 .await
             }
 
@@ -2375,7 +2384,7 @@ impl VdafOps {
                     FixedSize,
                     Prio3Aes128CountVecMultithreaded,
                     _,
-                >(datastore, collect_job_id)
+                >(datastore, task, collect_job_id)
                 .await
             }
 
@@ -2385,7 +2394,7 @@ impl VdafOps {
                     FixedSize,
                     Prio3Aes128Sum,
                     _,
-                >(datastore, collect_job_id)
+                >(datastore, task, collect_job_id)
                 .await
             }
 
@@ -2395,7 +2404,7 @@ impl VdafOps {
                     FixedSize,
                     Prio3Aes128Histogram,
                     _,
-                >(datastore, collect_job_id)
+                >(datastore, task, collect_job_id)
                 .await
             }
 
@@ -2403,6 +2412,7 @@ impl VdafOps {
             (task::QueryType::FixedSize { .. }, VdafOps::Fake(_)) => {
                 Self::handle_delete_collect_job_generic::<0, FixedSize, dummy_vdaf::Vdaf, _>(
                     datastore,
+                    task,
                     collect_job_id,
                 )
                 .await
@@ -2412,12 +2422,13 @@ impl VdafOps {
 
     async fn handle_delete_collect_job_generic<
         const L: usize,
-        Q: QueryType,
+        Q: CollectableQueryType,
         A: vdaf::Aggregator<L>,
         C: Clock,
     >(
         datastore: &Datastore<C>,
-        collect_job_id: Uuid,
+        task: Arc<Task>,
+        collect_job_id: Arc<Uuid>,
     ) -> Result<(), Error>
     where
         A::AggregationParam: Send + Sync,
@@ -2427,16 +2438,18 @@ impl VdafOps {
     {
         datastore
             .run_tx(move |tx| {
+                let (task, collect_job_id) = (Arc::clone(&task), Arc::clone(&collect_job_id));
                 Box::pin(async move {
                     let collect_job = tx
                         .get_collect_job::<L, Q, A>(&collect_job_id)
                         .await?
                         .ok_or_else(|| {
                             datastore::Error::User(
-                                Error::UnrecognizedCollectJob(collect_job_id).into(),
+                                Error::UnrecognizedCollectJob(*collect_job_id).into(),
                             )
                         })?;
-
+                    Q::acknowledge_collection(tx, task.id(), collect_job.batch_identifier())
+                        .await?;
                     if collect_job.state() != &CollectJobState::Deleted {
                         tx.update_collect_job::<L, Q, A>(
                             &collect_job.with_state(CollectJobState::Deleted),

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -24,7 +24,6 @@ use crate::{
     task::{self, Task, VerifyKey, PRIO3_AES128_VERIFY_KEY_LENGTH},
     try_join, URL_SAFE_NO_PAD,
 };
-use anyhow::anyhow;
 use bytes::Bytes;
 use http::{
     header::{CACHE_CONTROL, CONTENT_TYPE, LOCATION},
@@ -2040,7 +2039,13 @@ impl VdafOps {
                     let batch_identifier = Q::batch_identifier_for_query(tx, &task, req.query())
                         .await?
                         .ok_or_else(|| {
-                            datastore::Error::User(anyhow!("No batch ready for collection").into())
+                            datastore::Error::User(
+                                Error::BatchInvalid(
+                                    *task.id(),
+                                    "no batch ready for collection".to_string(),
+                                )
+                                .into(),
+                            )
                         })?;
 
                     // Check that the batch interval is valid for the task

--- a/aggregator/src/aggregator/query_type.rs
+++ b/aggregator/src/aggregator/query_type.rs
@@ -248,6 +248,10 @@ pub trait CollectableQueryType: AccumulableQueryType {
         Ok(batch_aggregations.into_iter().flatten().collect::<Vec<_>>())
     }
 
+    /// Acknowledges that a collection attempt has been made, allowing any query-type specific
+    /// updates to be made. For exmaple, a task using fixed-size queries might remove the given
+    /// batch to be removed from the list of batches ready to be returned by a `current-batch`
+    /// query.
     async fn acknowledge_collection<C: Clock>(
         tx: &Transaction<'_, C>,
         task_id: &TaskId,

--- a/collector/examples/collect.rs
+++ b/collector/examples/collect.rs
@@ -8,7 +8,8 @@ use derivative::Derivative;
 use janus_collector::{default_http_client, Collector, CollectorParameters};
 use janus_core::{hpke::HpkePrivateKey, task::AuthenticationToken};
 use janus_messages::{
-    query_type::QueryType, BatchId, Duration, HpkeConfig, Interval, Query, TaskId, Time,
+    query_type::QueryType, BatchId, Duration, FixedSizeQuery, HpkeConfig, Interval, Query, TaskId,
+    Time,
 };
 use prio::{
     codec::Decode,
@@ -356,7 +357,11 @@ async fn run(options: Options) -> Result<(), Error> {
         }
         (None, None, Some(batch_id)) => {
             let batch_id = *batch_id;
-            run_with_query(options, Query::new_fixed_size(batch_id)).await
+            run_with_query(
+                options,
+                Query::new_fixed_size(FixedSizeQuery::ByBatchId { batch_id }),
+            )
+            .await
         }
         _ => unreachable!(),
     }

--- a/integration_tests/tests/common/mod.rs
+++ b/integration_tests/tests/common/mod.rs
@@ -14,7 +14,9 @@ use janus_integration_tests::{
     client::{ClientBackend, ClientImplementation, InteropClientEncoding},
     BatchDiscovery,
 };
-use janus_messages::{problem_type::DapProblemType, query_type, Duration, Interval, Query, Role};
+use janus_messages::{
+    problem_type::DapProblemType, query_type, Duration, FixedSizeQuery, Interval, Query, Role,
+};
 use prio::vdaf::{self, prio3::Prio3};
 use rand::{random, thread_rng, Rng};
 use reqwest::Url;
@@ -192,7 +194,7 @@ pub async fn submit_measurements_and_verify_aggregate_generic<'a, V>(
             let batch_id = batch_ids[0];
             collect_generic(
                 &collector,
-                Query::new_fixed_size(batch_id),
+                Query::new_fixed_size(FixedSizeQuery::ByBatchId { batch_id }),
                 &test_case.aggregation_parameter,
                 "127.0.0.1",
                 forwarded_port,

--- a/interop_binaries/src/bin/janus_interop_collector.rs
+++ b/interop_binaries/src/bin/janus_interop_collector.rs
@@ -13,7 +13,8 @@ use janus_interop_binaries::{
     HpkeConfigRegistry, NumberAsString, VdafObject,
 };
 use janus_messages::{
-    query_type::QueryType, BatchId, Duration, HpkeConfig, Interval, Query, TaskId, Time,
+    query_type::QueryType, BatchId, Duration, FixedSizeQuery, HpkeConfig, Interval, Query, TaskId,
+    Time,
 };
 use prio::{
     codec::{Decode, Encode},
@@ -340,7 +341,7 @@ async fn handle_collect_start(
             handle_collect_generic(
                 http_client,
                 collector_params,
-                Query::new_fixed_size(batch_id),
+                Query::new_fixed_size(FixedSizeQuery::ByBatchId { batch_id }),
                 vdaf,
                 &agg_param,
                 |result| AggregationResult::Number(NumberAsString((*result).into())),
@@ -354,7 +355,7 @@ async fn handle_collect_start(
             handle_collect_generic(
                 http_client,
                 collector_params,
-                Query::new_fixed_size(batch_id),
+                Query::new_fixed_size(FixedSizeQuery::ByBatchId { batch_id }),
                 vdaf,
                 &agg_param,
                 |result| {
@@ -371,7 +372,7 @@ async fn handle_collect_start(
             handle_collect_generic(
                 http_client,
                 collector_params,
-                Query::new_fixed_size(batch_id),
+                Query::new_fixed_size(FixedSizeQuery::ByBatchId { batch_id }),
                 vdaf,
                 &agg_param,
                 |result| AggregationResult::Number(NumberAsString(*result)),
@@ -385,7 +386,7 @@ async fn handle_collect_start(
             handle_collect_generic(
                 http_client,
                 collector_params,
-                Query::new_fixed_size(batch_id),
+                Query::new_fixed_size(FixedSizeQuery::ByBatchId { batch_id }),
                 vdaf,
                 &agg_param,
                 |result| {

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -1108,7 +1108,7 @@ impl Decode for FixedSizeQuery {
             }
             1 => Ok(FixedSizeQuery::CurrentBatch),
             _ => Err(CodecError::Other(
-                anyhow!("unexpected FixedSizeQueryTypevalue {}", query_type).into(),
+                anyhow!("unexpected FixedSizeQueryType value {}", query_type).into(),
             )),
         }
     }


### PR DESCRIPTION
The logic for deciding which batch to return for current-batch is currently very simple: we let Postgres decide which of the eligible batches to return. We may well need to tweak this approach later (e.g. to always return the least-recently-returned eligible batch), but this should be fine for a first pass.

Part of #706.