### PR TITLE
`janus_cli`: task parameter generation

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -3302,8 +3302,7 @@ mod tests {
         },
         messages::{DurationExt, TimeExt},
         task::{
-            test_util::{generate_auth_token, TaskBuilder},
-            QueryType, Task, VerifyKey, PRIO3_AES128_VERIFY_KEY_LENGTH,
+            test_util::TaskBuilder, QueryType, Task, VerifyKey, PRIO3_AES128_VERIFY_KEY_LENGTH,
         },
     };
     use assert_matches::assert_matches;
@@ -4215,7 +4214,7 @@ mod tests {
         let (parts, body) = warp::test::request()
             .method("POST")
             .path("/aggregate")
-            .header("DAP-Auth-Token", generate_auth_token().as_bytes())
+            .header("DAP-Auth-Token", random::<AuthenticationToken>().as_bytes())
             .header(
                 CONTENT_TYPE,
                 AggregateInitializeReq::<TimeInterval>::MEDIA_TYPE,
@@ -6457,7 +6456,7 @@ mod tests {
         let (parts, body) = warp::test::request()
             .method("POST")
             .path("/collect")
-            .header("DAP-Auth-Token", generate_auth_token().as_bytes())
+            .header("DAP-Auth-Token", random::<AuthenticationToken>().as_bytes())
             .header(CONTENT_TYPE, CollectReq::<TimeInterval>::MEDIA_TYPE)
             .body(request.get_encoded())
             .filter(&filter)
@@ -6691,7 +6690,7 @@ mod tests {
         let mut response = warp::test::request()
             .method("POST")
             .path("/collect")
-            .header("DAP-Auth-Token", generate_auth_token().as_bytes())
+            .header("DAP-Auth-Token", random::<AuthenticationToken>().as_bytes())
             .header(CONTENT_TYPE, CollectReq::<TimeInterval>::MEDIA_TYPE)
             .body(req.get_encoded())
             .filter(&filter)
@@ -6830,7 +6829,7 @@ mod tests {
         let mut response = warp::test::request()
             .method("GET")
             .path(&format!("/collect_jobs/{}", collect_job_id))
-            .header("DAP-Auth-Token", generate_auth_token().as_bytes())
+            .header("DAP-Auth-Token", random::<AuthenticationToken>().as_bytes())
             .filter(&filter)
             .await
             .unwrap()

--- a/aggregator/src/bin/janus_cli.rs
+++ b/aggregator/src/bin/janus_cli.rs
@@ -10,7 +10,7 @@ use janus_aggregator::{
     config::{BinaryConfig, CommonConfig},
     datastore::{self, Datastore},
     metrics::install_metrics_exporter,
-    task::Task,
+    task::{SerializedTask, Task},
     trace::install_trace_subscriber,
 };
 use janus_core::time::{Clock, RealClock};
@@ -58,6 +58,14 @@ enum Command {
         /// A YAML file containing a list of tasks to be written. Existing tasks (matching by task
         /// ID) will be overwritten.
         tasks_file: PathBuf,
+
+        /// If true, task parameters omitted from the YAML tasks file will be randomly generated.
+        #[clap(long, default_value = "false")]
+        generate_missing_parameters: bool,
+
+        /// Write the YAML representation of the tasks that are written to stdout.
+        #[clap(long, default_value = "false")]
+        echo_tasks: bool,
     },
 
     /// Create a datastore key and write it to a Kubernetes secret.
@@ -91,6 +99,8 @@ impl Command {
                 common_options,
                 kubernetes_secret_options,
                 tasks_file,
+                generate_missing_parameters,
+                echo_tasks,
             } => {
                 let kube_client = kube::Client::try_default()
                     .await
@@ -111,7 +121,16 @@ impl Command {
                         .await?,
                 )?;
 
-                provision_tasks(&datastore, tasks_file).await
+                let written_tasks =
+                    provision_tasks(&datastore, tasks_file, *generate_missing_parameters).await?;
+
+                if *echo_tasks {
+                    let tasks_yaml = serde_yaml::to_string(&written_tasks)
+                        .context("couldn't serialize tasks to YAML")?;
+                    println!("{tasks_yaml}");
+                }
+
+                Ok(())
             }
 
             Command::CreateDatastoreKey {
@@ -158,10 +177,13 @@ async fn write_schema(pool: &Pool) -> Result<()> {
     Ok(())
 }
 
-async fn provision_tasks<C: Clock>(datastore: &Datastore<C>, tasks_file: &Path) -> Result<()> {
+async fn provision_tasks<C: Clock>(
+    datastore: &Datastore<C>,
+    tasks_file: &Path,
+    generate_missing_parameters: bool,
+) -> Result<Vec<Task>> {
     // Read tasks file.
-    info!("Reading tasks file");
-    let tasks: Vec<Task> = {
+    let tasks: Vec<SerializedTask> = {
         let task_file_contents = fs::read_to_string(tasks_file)
             .await
             .with_context(|| format!("couldn't read tasks file {:?}", tasks_file))?;
@@ -169,28 +191,48 @@ async fn provision_tasks<C: Clock>(datastore: &Datastore<C>, tasks_file: &Path) 
             .with_context(|| format!("couldn't parse tasks file {:?}", tasks_file))?
     };
 
-    // Write all tasks requested.
+    let tasks: Vec<Task> = tasks
+        .into_iter()
+        .map(|mut task| {
+            if generate_missing_parameters {
+                task.generate_missing_fields();
+            }
+
+            Task::try_from(task)
+        })
+        .collect::<Result<_, _>>()?;
+
     let tasks = Arc::new(tasks);
+
+    // Write all tasks requested.
     info!(task_count = %tasks.len(), "Writing tasks");
-    datastore
+    let written_tasks = datastore
         .run_tx(|tx| {
             let tasks = Arc::clone(&tasks);
             Box::pin(async move {
+                let mut written_tasks = Vec::new();
                 for task in tasks.iter() {
                     // We attempt to delete the task, but ignore "task not found" errors since
                     // the task not existing is an OK outcome too.
                     match tx.delete_task(task.id()).await {
-                        Ok(_) | Err(datastore::Error::MutationTargetNotFound) => (),
+                        Ok(()) => {
+                            info!(task_id = %task.id(), "replacing existing task");
+                        }
+                        Err(datastore::Error::MutationTargetNotFound) => (),
                         err => err?,
                     }
 
                     tx.put_task(task).await?;
+
+                    written_tasks.push(task.clone());
                 }
-                Ok(())
+                Ok(written_tasks)
             })
         })
         .await
-        .context("couldn't write tasks")
+        .context("couldn't write tasks")?;
+
+    Ok(written_tasks)
 }
 
 async fn fetch_datastore_keys(
@@ -363,10 +405,10 @@ mod tests {
         },
         config::CommonConfig,
         datastore::test_util::{ephemeral_datastore, ephemeral_db_handle},
-        task::{test_util::TaskBuilder, QueryType},
+        task::{test_util::TaskBuilder, QueryType, Task},
     };
     use janus_core::{task::VdafInstance, test_util::kubernetes, time::RealClock};
-    use janus_messages::Role;
+    use janus_messages::{Role, TaskId};
     use ring::aead::{UnboundKey, AES_128_GCM};
     use std::{
         collections::HashMap,
@@ -463,6 +505,10 @@ mod tests {
             .unwrap();
     }
 
+    fn task_hashmap_from_slice(tasks: Vec<Task>) -> HashMap<TaskId, Task> {
+        tasks.into_iter().map(|task| (*task.id(), task)).collect()
+    }
+
     #[tokio::test]
     async fn provision_tasks() {
         let tasks = Vec::from([
@@ -490,18 +536,191 @@ mod tests {
         let tasks_path = tasks_file.into_temp_path();
 
         // Run the program logic.
-        super::provision_tasks(&ds, &tasks_path).await.unwrap();
+        let written_tasks = super::provision_tasks(&ds, &tasks_path, false)
+            .await
+            .unwrap();
 
         // Verify that the expected tasks were written.
-        let want_tasks: HashMap<_, _> = tasks.into_iter().map(|task| (*task.id(), task)).collect();
+        let want_tasks = task_hashmap_from_slice(tasks);
+        let written_tasks = task_hashmap_from_slice(written_tasks);
+        let got_tasks = task_hashmap_from_slice(
+            ds.run_tx(|tx| Box::pin(async move { tx.get_tasks().await }))
+                .await
+                .unwrap(),
+        );
+        assert_eq!(want_tasks, got_tasks);
+        assert_eq!(want_tasks, written_tasks);
+    }
+
+    #[tokio::test]
+    async fn replace_task() {
+        let tasks = Vec::from([
+            TaskBuilder::new(
+                QueryType::TimeInterval,
+                VdafInstance::Prio3Aes128Count,
+                Role::Leader,
+            )
+            .build(),
+            TaskBuilder::new(
+                QueryType::TimeInterval,
+                VdafInstance::Prio3Aes128Sum { bits: 64 },
+                Role::Helper,
+            )
+            .build(),
+        ]);
+
+        let (ds, _db_handle) = ephemeral_datastore(RealClock::default()).await;
+
+        let mut tasks_file = NamedTempFile::new().unwrap();
+        tasks_file
+            .write_all(serde_yaml::to_string(&tasks).unwrap().as_ref())
+            .unwrap();
+
+        super::provision_tasks(&ds, &tasks_file.into_temp_path(), false)
+            .await
+            .unwrap();
+
+        // Construct a "new" task with a previously existing ID.
+        let replacement_task = TaskBuilder::new(
+            QueryType::FixedSize {
+                max_batch_size: 100,
+            },
+            VdafInstance::Prio3Aes128CountVec { length: 4 },
+            Role::Leader,
+        )
+        .with_id(*tasks[0].id())
+        .build();
+
+        let mut replacement_tasks_file = NamedTempFile::new().unwrap();
+        replacement_tasks_file
+            .write_all(
+                serde_yaml::to_string(&[&replacement_task])
+                    .unwrap()
+                    .as_ref(),
+            )
+            .unwrap();
+
+        let written_tasks =
+            super::provision_tasks(&ds, &replacement_tasks_file.into_temp_path(), false)
+                .await
+                .unwrap();
+        assert_eq!(written_tasks.len(), 1);
+        assert_eq!(written_tasks[0].id(), tasks[0].id());
+
+        // Verify that the expected tasks were written.
+        let got_tasks = task_hashmap_from_slice(
+            ds.run_tx(|tx| Box::pin(async move { tx.get_tasks().await }))
+                .await
+                .unwrap(),
+        );
+        let want_tasks = HashMap::from([
+            (*replacement_task.id(), replacement_task),
+            (*tasks[1].id(), tasks[1].clone()),
+        ]);
+
+        assert_eq!(want_tasks, got_tasks);
+    }
+
+    #[tokio::test]
+    async fn provision_task_with_generated_values() {
+        // YAML contains no task ID, VDAF verify keys, aggregator auth tokens, collector auth tokens
+        // or HPKE keys.
+        let serialized_task_yaml = r#"
+- aggregator_endpoints:
+  - https://leader
+  - https://helper
+  query_type: TimeInterval
+  vdaf: !Prio3Aes128Sum
+    bits: 2
+  role: Leader
+  vdaf_verify_keys:
+  max_batch_query_count: 1
+  task_expiration: 9000000000
+  min_batch_size: 10
+  time_precision: 300
+  tolerable_clock_skew: 600
+  input_share_aad_public_share_length_prefix: false
+  collector_hpke_config:
+    id: 23
+    kem_id: X25519HkdfSha256
+    kdf_id: HkdfSha256
+    aead_id: Aes128Gcm
+    public_key: 8lAqZ7OfNV2Gi_9cNE6J9WRmPbO-k1UPtu2Bztd0-yc
+  aggregator_auth_tokens: []
+  collector_auth_tokens: []
+  hpke_keys: []
+- aggregator_endpoints:
+  - https://leader
+  - https://helper
+  query_type: TimeInterval
+  vdaf: !Prio3Aes128Sum
+    bits: 2
+  role: Helper
+  vdaf_verify_keys:
+  max_batch_query_count: 1
+  task_expiration: 9000000000
+  min_batch_size: 10
+  time_precision: 300
+  tolerable_clock_skew: 600
+  input_share_aad_public_share_length_prefix: false
+  collector_hpke_config:
+    id: 23
+    kem_id: X25519HkdfSha256
+    kdf_id: HkdfSha256
+    aead_id: Aes128Gcm
+    public_key: 8lAqZ7OfNV2Gi_9cNE6J9WRmPbO-k1UPtu2Bztd0-yc
+  aggregator_auth_tokens: []
+  collector_auth_tokens: []
+  hpke_keys: []
+"#;
+
+        let (ds, _db_handle) = ephemeral_datastore(RealClock::default()).await;
+
+        let mut tasks_file = NamedTempFile::new().unwrap();
+        tasks_file
+            .write_all(serialized_task_yaml.as_bytes())
+            .unwrap();
+        let tasks_file_path = tasks_file.into_temp_path();
+
+        super::provision_tasks(
+            &ds,
+            &tasks_file_path,
+            // do not generate missing parameters
+            false,
+        )
+        .await
+        // Should fail because parameters are omitted from task YAML
+        .unwrap_err();
+
+        let written_tasks = super::provision_tasks(
+            &ds,
+            &tasks_file_path,
+            // generate missing parameters
+            true,
+        )
+        .await
+        .unwrap();
+
+        // Verify that the expected tasks were written.
         let got_tasks = ds
             .run_tx(|tx| Box::pin(async move { tx.get_tasks().await }))
             .await
-            .unwrap()
-            .into_iter()
-            .map(|task| (*task.id(), task))
-            .collect();
-        assert_eq!(want_tasks, got_tasks);
+            .unwrap();
+
+        assert_eq!(got_tasks.len(), 2);
+
+        for task in &got_tasks {
+            match task.role() {
+                Role::Leader => assert_eq!(task.collector_auth_tokens().len(), 1),
+                Role::Helper => assert!(task.collector_auth_tokens().is_empty()),
+                role => panic!("unexpected role {role}"),
+            }
+        }
+
+        assert_eq!(
+            task_hashmap_from_slice(written_tasks),
+            task_hashmap_from_slice(got_tasks)
+        );
     }
 
     #[tokio::test]

--- a/core/src/task.rs
+++ b/core/src/task.rs
@@ -1,9 +1,14 @@
+use crate::URL_SAFE_NO_PAD;
+use rand::{distributions::Standard, prelude::Distribution};
 use reqwest::Url;
 use ring::constant_time;
 use serde::{Deserialize, Serialize};
 
 /// HTTP header where auth tokens are provided in messages between participants.
 pub const DAP_AUTH_HEADER: &str = "DAP-Auth-Token";
+
+/// The length of the verify key parameter for Prio3 AES-128 VDAF instantiations.
+pub const PRIO3_AES128_VERIFY_KEY_LENGTH: usize = 16;
 
 /// Identifiers for supported VDAFs, corresponding to definitions in
 /// [draft-irtf-cfrg-vdaf-03][1] and implementations in [`prio::vdaf::prio3`].
@@ -29,6 +34,22 @@ pub enum VdafInstance {
     FakeFailsPrepInit,
     #[cfg(feature = "test-util")]
     FakeFailsPrepStep,
+}
+
+impl VdafInstance {
+    /// Returns the expected length of a VDAF verification key for a VDAF of this type.
+    pub fn verify_key_length(&self) -> usize {
+        match self {
+            #[cfg(feature = "test-util")]
+            VdafInstance::Fake
+            | VdafInstance::FakeFailsPrepInit
+            | VdafInstance::FakeFailsPrepStep => 0,
+
+            // All "real" VDAFs use a verify key of length 16 currently. (Poplar1 may not, but it's
+            // not yet done being specified, so choosing 16 bytes is fine for testing.)
+            _ => PRIO3_AES128_VERIFY_KEY_LENGTH,
+        }
+    }
 }
 
 /// An authentication (bearer) token used by aggregators for aggregator-to-aggregator and
@@ -60,6 +81,15 @@ impl PartialEq for AuthenticationToken {
 }
 
 impl Eq for AuthenticationToken {}
+
+impl Distribution<AuthenticationToken> for Standard {
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> AuthenticationToken {
+        let buf: [u8; 16] = rng.gen();
+        base64::encode_engine(buf, &URL_SAFE_NO_PAD)
+            .into_bytes()
+            .into()
+    }
+}
 
 /// Modifies a [`Url`] in place to ensure it ends with a slash.
 ///

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -443,6 +443,12 @@ impl From<HpkeConfigId> for u8 {
     }
 }
 
+impl Distribution<HpkeConfigId> for Standard {
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> HpkeConfigId {
+        HpkeConfigId(rng.gen())
+    }
+}
+
 /// DAP protocol message representing an identifier for a DAP task.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct TaskId([u8; Self::LEN]);


### PR DESCRIPTION
`janus_cli provision-tasks` can now generate task IDs, VDAF verify keys, authentication tokens for aggregators and collectors and aggregator HPKE keypairs, if those values are not present in the task YAML. We also add an `--echo-tasks` flag so that the tool prints the YAML encoding of provisioned tasks to stdout.

Resolves #528