### PR TITLE
Add dry run mode to `Datastore`

### DIFF
--- a/aggregator/src/bin/janus_cli.rs
+++ b/aggregator/src/bin/janus_cli.rs
@@ -119,6 +119,7 @@ impl Command {
                     &kubernetes_secret_options
                         .datastore_keys(common_options, kube_client)
                         .await?,
+                    config.common_config().database.dry_run_mode,
                 )?;
 
                 let written_tasks =

--- a/aggregator/src/binary_utils.rs
+++ b/aggregator/src/binary_utils.rs
@@ -128,6 +128,7 @@ pub fn datastore<C: Clock>(
     pool: Pool,
     clock: C,
     datastore_keys: &[String],
+    dry_run_mode: bool,
 ) -> Result<Datastore<C>> {
     let datastore_keys = datastore_keys
         .iter()
@@ -147,7 +148,12 @@ pub fn datastore<C: Clock>(
         return Err(anyhow!("datastore_keys is empty"));
     }
 
-    Ok(Datastore::new(pool, Crypter::new(datastore_keys), clock))
+    Ok(Datastore::new(
+        pool,
+        Crypter::new(datastore_keys),
+        clock,
+        dry_run_mode,
+    ))
 }
 
 /// Options for Janus binaries.
@@ -274,6 +280,7 @@ where
         pool,
         clock.clone(),
         &options.common_options().datastore_keys,
+        config.common_config().database.dry_run_mode,
     )
     .context("couldn't create datastore")?;
 

--- a/aggregator/src/config.rs
+++ b/aggregator/src/config.rs
@@ -67,6 +67,11 @@ pub struct DbConfig {
     /// `deadpool_postgres::Timeouts` value.
     #[serde(default = "DbConfig::default_connection_pool_timeout")]
     pub connection_pool_timeouts_secs: u64,
+    /// When in dry-run mode, all database transactions will be rolled back
+    /// instead of being completed. Database queries will otherwise mostly but
+    /// not perfectly correct results.
+    #[serde(default)]
+    pub dry_run_mode: bool,
     // TODO(#231): add option for connecting to database over TLS, if necessary
 }
 
@@ -143,6 +148,7 @@ pub mod test_util {
         DbConfig {
             url: Url::parse("postgres://postgres:postgres@localhost:5432/postgres").unwrap(),
             connection_pool_timeouts_secs: 60,
+            dry_run_mode: false,
         }
     }
 

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -191,6 +191,7 @@ impl Janus<'static> {
                 ))
                 .unwrap(),
                 connection_pool_timeouts_secs: 60,
+                dry_run_mode: false,
             },
             None,
         )
@@ -202,7 +203,7 @@ impl Janus<'static> {
         // depends on this task being defined will likely time out or otherwise fail.
         // This should become more robust in the future when we implement dynamic task provisioning
         // (#44).
-        let datastore = datastore(pool, RealClock::default(), &[datastore_key]).unwrap();
+        let datastore = datastore(pool, RealClock::default(), &[datastore_key], false).unwrap();
         datastore.put_task(task).await.unwrap();
 
         let batch_discovery = Arc::new(JanusClusterBatchFetch {


### PR DESCRIPTION
Adds a configuration option for Janus binaries to instantiate a `janus_aggregator::datastore::Datastore` in dry-run mode. This is implemented by having `Datastore::run_tx_once` call `Transaction::rollback` instead of `::commit` after a successful database transaction. This in turn allows us to implement things like a `--dry-run` flag on `janus_cli`, so that operators can convince themselves they've correctly set up a task being provisioned before making real changes to a live production database.

Part of #529