### PR TITLE
`janus_cli`: add dry-run mode

### DIFF
--- a/interop_binaries/config/supervisord.conf
+++ b/interop_binaries/config/supervisord.conf
@@ -50,5 +50,6 @@ stderr_logfile=/logs/postgres_stderr.log
 command=/usr/local/bin/setup.sh
 autostart=true
 autorestart=false
+environment=RUST_LOG=info
 stdout_logfile=/logs/setup_stdout.log
 stderr_logfile=/logs/setup_stderr.log

--- a/interop_binaries/setup.sh
+++ b/interop_binaries/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-/usr/local/bin/janus_cli write-schema --config-file /etc/janus/janus_cli.yaml
+/usr/local/bin/janus_cli --config-file /etc/janus/janus_cli.yaml write-schema
 /usr/bin/supervisorctl -c /etc/janus/supervisord.conf start janus_interop_aggregator
 /usr/bin/supervisorctl -c /etc/janus/supervisord.conf start aggregation_job_creator
 /usr/bin/supervisorctl -c /etc/janus/supervisord.conf start aggregation_job_driver


### PR DESCRIPTION
Building on the previously introduced dry-run support in `Datastore`, `janus_cli` can now be run with a `--dry-run` flag. In this mode, no real modifications to the datastore (in the case of `write-schema` or `provision-tasks`) or Kubernetes secrets (in the case of `create-datastore-key`) are made.

We also refactor some of the command line option and configuration file handling to reduce code duplication in `Command::execute`.

Resolves #529