### PR TITLE
Document `test-util` items

### DIFF
--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -8,6 +8,10 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 default = ["kube-rustls"]
 tokio-console = ["dep:console-subscriber"]

--- a/aggregator/src/config.rs
+++ b/aggregator/src/config.rs
@@ -125,6 +125,7 @@ pub struct JobDriverConfig {
 }
 
 #[cfg(feature = "test-util")]
+#[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
 pub mod test_util {
     use super::DbConfig;
     use crate::{

--- a/aggregator/src/datastore.rs
+++ b/aggregator/src/datastore.rs
@@ -275,6 +275,7 @@ impl<C: Clock> Datastore<C> {
 
     /// Write a task into the datastore.
     #[cfg(feature = "test-util")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
     pub async fn put_task(&self, task: &Task) -> Result<(), Error> {
         self.run_tx(|tx| {
             let task = task.clone();
@@ -1247,6 +1248,7 @@ impl<C: Clock> Transaction<'_, C> {
 
     /// get_aggregation_jobs_for_task_id returns all aggregation jobs for a given task ID.
     #[cfg(feature = "test-util")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
     #[tracing::instrument(skip(self), err)]
     pub async fn get_aggregation_jobs_for_task_id<
         const L: usize,
@@ -4674,6 +4676,7 @@ pub mod models {
 }
 
 #[cfg(feature = "test-util")]
+#[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
 pub mod test_util {
     use super::{Crypter, Datastore};
     use deadpool_postgres::{Manager, Pool};

--- a/aggregator/src/lib.rs
+++ b/aggregator/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::too_many_arguments)]
 
 use base64::{

--- a/aggregator/src/task.rs
+++ b/aggregator/src/task.rs
@@ -539,6 +539,7 @@ impl<'de> Deserialize<'de> for Task {
 
 // This is public to allow use in integration tests.
 #[cfg(feature = "test-util")]
+#[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
 pub mod test_util {
     use super::{
         AuthenticationToken, QueryType, SecretBytes, Task, VdafInstance,

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -9,6 +9,10 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 test-util = []
 

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -52,6 +52,8 @@
 //! # }
 //! ```
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 use backoff::{backoff::Backoff, ExponentialBackoff};
 use derivative::Derivative;
 use http_api_problem::HttpApiProblem;
@@ -288,6 +290,7 @@ impl<T> Collection<T> {
 }
 
 #[cfg(feature = "test-util")]
+#[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
 impl<T> Collection<T> {
     /// Creates a new [`Collection`].
     pub fn new(report_count: u64, aggregate_result: T) -> Self {
@@ -580,6 +583,7 @@ where
 }
 
 #[cfg(feature = "test-util")]
+#[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
 pub mod test_util {
     use crate::{Collection, Collector, Error};
     use janus_messages::{query_type::QueryType, Query};

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,6 +9,10 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 test-util = [
     "dep:assert_matches",

--- a/core/src/hpke.rs
+++ b/core/src/hpke.rs
@@ -254,6 +254,7 @@ impl HpkeKeypair {
 }
 
 #[cfg(feature = "test-util")]
+#[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
 pub mod test_util {
     use super::{generate_hpke_config_and_private_key, HpkeKeypair};
     use janus_messages::{HpkeAeadId, HpkeConfigId, HpkeKdfId, HpkeKemId};

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 use base64::{
     alphabet::URL_SAFE,
     engine::fast_portable::{FastPortable, NO_PAD},
@@ -11,6 +13,7 @@ pub mod report_id;
 pub mod retries;
 pub mod task;
 #[cfg(feature = "test-util")]
+#[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
 pub mod test_util;
 pub mod time;
 

--- a/core/src/retries.rs
+++ b/core/src/retries.rs
@@ -39,6 +39,7 @@ pub fn http_request_exponential_backoff() -> ExponentialBackoff {
 /// An [`ExponentialBackoff`] with parameters tuned for tests where we don't want to be retrying
 /// for 10 minutes.
 #[cfg(feature = "test-util")]
+#[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
 pub fn test_http_request_exponential_backoff() -> ExponentialBackoff {
     ExponentialBackoff {
         initial_interval: Duration::from_nanos(1),

--- a/core/src/task.rs
+++ b/core/src/task.rs
@@ -28,11 +28,17 @@ pub enum VdafInstance {
     /// The `poplar1` VDAF. Support for this VDAF is experimental.
     Poplar1 { bits: usize },
 
+    /// A fake, no-op VDAF.
     #[cfg(feature = "test-util")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
     Fake,
+    /// A fake, no-op VDAF that always fails during initialization of input preparation.
     #[cfg(feature = "test-util")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
     FakeFailsPrepInit,
+    /// A fake, no-op VDAF that always fails when stepping input preparation.
     #[cfg(feature = "test-util")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
     FakeFailsPrepStep,
 }
 


### PR DESCRIPTION
Annotates items across the `janus_core`, `janus_collector` and `janus_aggregator` crates that are gated on the `test-util` feature so that they get documented by `cargo doc`.

Resolves #309