### PR TITLE
Fixes for Rust 1.66

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -13,33 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    # We retry crate publishing to allow the newly published janus_messages to be visible on
-    # crates.io when we get around to publishing janus_core, janus_client and janus_collector.
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
     - name: "Publish janus_messages"
-      uses: nick-fields/retry@v2
-      with:
-        timeout_minutes: 10
-        max_attempts: 5
-        polling_interval_seconds: 30
-        command: cargo publish -p janus_messages
+      run: cargo publish --package janus_messages
     - name: "Publish janus_core"
-      uses: nick-fields/retry@v2
-      with:
-        timeout_minutes: 10
-        max_attempts: 5
-        polling_interval_seconds: 30
-        command: cargo publish -p janus_core
+      run: cargo publish --package janus_core
     - name: "Publish janus_client"
-      uses: nick-fields/retry@v2
-      with:
-        timeout_minutes: 10
-        max_attempts: 5
-        polling_interval_seconds: 30
-        command: cargo publish -p janus_client
+      run: cargo publish --package janus_client
     - name: "Publish janus_collector"
-      uses: nick-fields/retry@v2
-      with:
-        timeout_minutes: 10
-        max_attempts: 5
-        polling_interval_seconds: 30
-        command: cargo publish -p janus_collector
+      run: cargo publish --package janus_collector

--- a/integration_tests/src/client.rs
+++ b/integration_tests/src/client.rs
@@ -275,7 +275,7 @@ where
             }
             ClientImplementation::Container(inner) => {
                 let task_id_encoded =
-                    base64::encode_engine(&inner.task_id.get_encoded(), &URL_SAFE_NO_PAD);
+                    base64::encode_engine(inner.task_id.get_encoded(), &URL_SAFE_NO_PAD);
                 let upload_response = inner
                     .http_client
                     .post(format!(

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -274,7 +274,7 @@ struct JanusContainerBatchFetch {
 #[async_trait]
 impl BatchDiscovery for JanusContainerBatchFetch {
     async fn get_batch_ids(&self, task_id: &TaskId) -> anyhow::Result<Vec<BatchId>> {
-        let task_id_encoded = base64::encode_engine(&task_id.get_encoded(), &URL_SAFE_NO_PAD);
+        let task_id_encoded = base64::encode_engine(task_id.get_encoded(), &URL_SAFE_NO_PAD);
         let response = self
             .http_client
             .post(self.fetch_batch_ids_url.clone())

--- a/integration_tests/tests/common/mod.rs
+++ b/integration_tests/tests/common/mod.rs
@@ -270,7 +270,7 @@ pub async fn submit_measurements_and_verify_aggregate(
         VdafInstance::Prio3Aes128Sum { bits } => {
             let vdaf = Prio3::new_aes128_sum(2, *bits).unwrap();
 
-            let measurements = iter::repeat_with(|| (random::<u128>() as u128) >> (128 - bits))
+            let measurements = iter::repeat_with(|| (random::<u128>()) >> (128 - bits))
                 .take(total_measurements)
                 .collect::<Vec<_>>();
             let aggregate_result = measurements.iter().sum();

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -245,7 +245,7 @@ impl From<Task> for AggregatorAddTaskRequest {
             max_batch_size,
             time_precision: task.time_precision().as_seconds(),
             collector_hpke_config: base64::encode_engine(
-                &task.collector_hpke_config().get_encoded(),
+                task.collector_hpke_config().get_encoded(),
                 &URL_SAFE_NO_PAD,
             ),
             task_expiration: task.task_expiration().as_seconds_since_epoch(),

--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -112,7 +112,7 @@ async fn run(
     let collector_auth_token = base64::encode_engine(random::<[u8; 16]>(), &URL_SAFE_NO_PAD);
     let verify_key = rand::random::<[u8; PRIO3_AES128_VERIFY_KEY_LENGTH]>();
 
-    let task_id_encoded = base64::encode_engine(&task_id.get_encoded(), &URL_SAFE_NO_PAD);
+    let task_id_encoded = base64::encode_engine(task_id.get_encoded(), &URL_SAFE_NO_PAD);
     let verify_key_encoded = base64::encode_engine(verify_key, &URL_SAFE_NO_PAD);
 
     // Endpoints, from the POV of this test (i.e. the Docker host).


### PR DESCRIPTION
 - Fix `clippy` warnings for unnecessary dereferences
 - Fix `clippy` warnings for unnecessary `u128 -> u128` cast
 - [`cargo publish` now blocks until it sees the published package in the index][1], so we can remove the retry loop from our crate publishing action.

[1]: https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-166-2022-12-15