### PR TITLE
DAP-03: adopt `reportRejected` error

### DIFF
--- a/messages/src/problem_type.rs
+++ b/messages/src/problem_type.rs
@@ -8,7 +8,7 @@ pub enum DapProblemType {
     MissingTaskId,
     UnrecognizedAggregationJob,
     OutdatedConfig,
-    ReportTooLate,
+    ReportRejected,
     ReportTooEarly,
     BatchInvalid,
     InvalidBatchSize,
@@ -31,7 +31,7 @@ impl DapProblemType {
                 "urn:ietf:params:ppm:dap:error:unrecognizedAggregationJob"
             }
             DapProblemType::OutdatedConfig => "urn:ietf:params:ppm:dap:error:outdatedConfig",
-            DapProblemType::ReportTooLate => "urn:ietf:params:ppm:dap:error:reportTooLate",
+            DapProblemType::ReportRejected => "urn:ietf:params:ppm:dap:error:reportRejected",
             DapProblemType::ReportTooEarly => "urn:ietf:params:ppm:dap:error:reportTooEarly",
             DapProblemType::BatchInvalid => "urn:ietf:params:ppm:dap:error:batchInvalid",
             DapProblemType::InvalidBatchSize => "urn:ietf:params:ppm:dap:error:invalidBatchSize",
@@ -64,9 +64,7 @@ impl DapProblemType {
             DapProblemType::OutdatedConfig => {
                 "The message was generated using an outdated configuration."
             }
-            DapProblemType::ReportTooLate => {
-                "Report could not be processed because it arrived too late."
-            }
+            DapProblemType::ReportRejected => "Report could not be processed.",
             DapProblemType::ReportTooEarly => {
                 "Report could not be processed because it arrived too early."
             }
@@ -108,7 +106,7 @@ impl FromStr for DapProblemType {
                 Ok(DapProblemType::UnrecognizedAggregationJob)
             }
             "urn:ietf:params:ppm:dap:error:outdatedConfig" => Ok(DapProblemType::OutdatedConfig),
-            "urn:ietf:params:ppm:dap:error:reportTooLate" => Ok(DapProblemType::ReportTooLate),
+            "urn:ietf:params:ppm:dap:error:reportRejected" => Ok(DapProblemType::ReportRejected),
             "urn:ietf:params:ppm:dap:error:reportTooEarly" => Ok(DapProblemType::ReportTooEarly),
             "urn:ietf:params:ppm:dap:error:batchInvalid" => Ok(DapProblemType::BatchInvalid),
             "urn:ietf:params:ppm:dap:error:invalidBatchSize" => {


### PR DESCRIPTION
DAP-03 replaces the `reportTooLate` message with a generic `reportRejected` and notes two places ([1], [2]) where it should be used.

[1]: https://datatracker.ietf.org/doc/html/draft-ietf-ppm-dap-03#section-4.3.2-16 [2]: https://datatracker.ietf.org/doc/html/draft-ietf-ppm-dap-03#section-4.3.2-17

Resolves #34