### PR TITLE
Make READMEs consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The `main` branch is under continuous development and will usually be partway be
 | ---------- | ------------- | --------------------- | ------ |
 | `release/0.1` | [`draft-ietf-ppm-dap-01`](https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/01/) | Yes | Unmaintained as of December 7, 2022 |
 | `release/0.2` | [`draft-ietf-ppm-dap-02`](https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/02/) | Yes | Supported |
-| `main` | `draft-ietf-ppm-dap-03` (forthcoming) | Partially | Supported |
+| `main` | [`draft-ietf-ppm-dap-03`](https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/03/) | [Partially](https://github.com/divviup/janus/milestone/2) | Supported |
 
 ## Building
 

--- a/client/README.md
+++ b/client/README.md
@@ -8,4 +8,4 @@
 [docs badge]: https://img.shields.io/badge/docs.rs-rustdoc-green
 [docs.rs]: https://docs.rs/janus_client/
 
-`janus_client` is a self-contained client for Janus and [Divvi Up](https://divviup.org), [ISRG](https://abetterinternet.org)'s privacy-respecting metrics service. `janus_client` is published to crates.io by a GitHub Action that runs when a `janus` release is created.
+`janus_client` is a self-contained implementation of the [Distributed Aggregation Protocol](https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/)'s client role. It is intended for use with [Janus](https://github.com/divviup/janus) and [Divvi Up](https://divviup.org), [ISRG](https://abetterinternet.org)'s privacy-respecting metrics service. `janus_client` is published to crates.io by a GitHub Action that runs when a `janus` release is created.

--- a/collector/README.md
+++ b/collector/README.md
@@ -1,0 +1,12 @@
+# `janus_collector`
+[![Build Status]][actions] [![latest version]][crates.io] [![docs badge]][docs.rs]
+
+[Build Status]: https://github.com/divviup/janus/workflows/ci-build/badge.svg
+[actions]: https://github.com/divviup/janus/actions?query=branch%3Amain
+[latest version]: https://img.shields.io/crates/v/janus_collector.svg
+[crates.io]: https://crates.io/crates/janus_collector
+[docs badge]: https://img.shields.io/badge/docs.rs-rustdoc-green
+[docs.rs]: https://docs.rs/janus_collector/
+
+`janus_collector` is a self-contained implementation of the [Distributed Aggregation Protocol](https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/)'s collector role. It is intended for use with [Janus](https://github.com/divviup/janus) and [Divvi Up](https://divviup.org), [ISRG](https://abetterinternet.org)'s privacy-respecting metrics service. `janus_collector` is published to crates.io by a GitHub Action that runs when a `janus` release is created.
+

--- a/core/README.md
+++ b/core/README.md
@@ -8,4 +8,4 @@
 [docs badge]: https://img.shields.io/badge/docs.rs-rustdoc-green
 [docs.rs]: https://docs.rs/janus_core/
 
-`janus_core` contains type definitions and support code used in various Janus targets. It should not be depended on directly. `janus_core` is published to crates.io by a GitHub Action that runs when a `janus` release is created.
+`janus_core` contains type definitions and support code used in various [Janus](https://github.com/divviup/janus) targets. It should not be depended on directly. `janus_core` is published to crates.io by a GitHub Action that runs when a `janus` release is created.

--- a/messages/README.md
+++ b/messages/README.md
@@ -1,3 +1,11 @@
 # `janus_messages`
+[![Build Status]][actions] [![latest version]][crates.io] [![docs badge]][docs.rs]
 
-This crate provides structures representing the various messages defined by the [Distributed Aggregation Protocol](https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/).
+[Build Status]: https://github.com/divviup/janus/workflows/ci-build/badge.svg
+[actions]: https://github.com/divviup/janus/actions?query=branch%3Amain
+[latest version]: https://img.shields.io/crates/v/janus_messages.svg
+[crates.io]: https://crates.io/crates/janus_messages
+[docs badge]: https://img.shields.io/badge/docs.rs-rustdoc-green
+[docs.rs]: https://docs.rs/janus_messages/
+
+`janus_messages` crate provides structures representing the various messages defined by the [Distributed Aggregation Protocol](https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/).


### PR DESCRIPTION
 - add `collector/README.md`
 - display badges for CI status, crates.io and docs.rs in all crate READMEs
 - update `README.md` with current links for DAP-03

Resolves #649