### PR TITLE
Use current batch query in interop binaries and integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1641,7 +1641,6 @@ name = "janus_integration_tests"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "backoff",
  "base64 0.20.0",
  "futures",
@@ -1660,7 +1659,6 @@ dependencies = [
  "prio",
  "rand",
  "reqwest",
- "serde",
  "serde_json",
  "tempfile",
  "testcontainers",

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -13,7 +13,6 @@ kube-openssl = ["kube/openssl-tls"]
 
 [dependencies]
 anyhow = "1"
-async-trait = "0.1"
 backoff = { version = "0.4", features = ["tokio"] }
 base64 = "0.20.0"
 futures = "0.3.25"
@@ -29,7 +28,6 @@ portpicker = "0.1"
 prio = { version = "0.10.0", features = ["multithreaded"] }
 rand = "0.8"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
-serde = "1.0.151"
 serde_json = "1.0.91"
 testcontainers = "0.14.0"
 tokio = { version = "1", features = ["full", "tracing"] }

--- a/integration_tests/src/client.rs
+++ b/integration_tests/src/client.rs
@@ -19,7 +19,7 @@ use testcontainers::{clients::Cli, core::WaitFor, Image, RunnableImage};
 use url::Url;
 
 /// Extension trait to encode measurements for VDAFs as JSON objects, according to
-/// draft-dcook-ppm-dap-interop-test-design-02.
+/// draft-dcook-ppm-dap-interop-test-design.
 pub trait InteropClientEncoding: vdaf::Client
 where
     for<'a> Vec<u8>: From<&'a Self::AggregateShare>,
@@ -86,7 +86,7 @@ fn json_encode_vdaf(vdaf: &VdafInstance) -> Value {
 }
 
 /// This represents a container image that implements the client role of
-/// draft-dcook-ppm-dap-interop-test-design-02, for use with [`testcontainers`].
+/// draft-dcook-ppm-dap-interop-test-design, for use with [`testcontainers`].
 #[derive(Clone)]
 pub struct InteropClient {
     name: String,
@@ -141,7 +141,7 @@ pub enum ClientBackend<'a> {
     /// Uploads reports using `janus-client` as a library.
     InProcess,
     /// Uploads reports by starting a containerized client implementation, and sending it requests
-    /// using draft-dcook-ppm-dap-interop-test-design-02.
+    /// using draft-dcook-ppm-dap-interop-test-design.
     Container {
         container_client: &'a Cli,
         container_image: InteropClient,

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -4,19 +4,10 @@ use base64::{
     alphabet::URL_SAFE,
     engine::fast_portable::{FastPortable, NO_PAD},
 };
-use janus_messages::{BatchId, TaskId};
 
 pub mod client;
 #[cfg(feature = "daphne")]
 pub mod daphne;
 pub mod janus;
-
-/// Provides access to find which batch identifiers have been assigned in a fixed-size task.
-///
-/// Note that this will be made obsolete by "current_batch" requests in DAP-03.
-#[async_trait::async_trait]
-pub trait BatchDiscovery {
-    async fn get_batch_ids(&self, task_id: &TaskId) -> anyhow::Result<Vec<BatchId>>;
-}
 
 const URL_SAFE_NO_PAD: FastPortable = FastPortable::from(&URL_SAFE, NO_PAD);

--- a/integration_tests/tests/divviup_ts.rs
+++ b/integration_tests/tests/divviup_ts.rs
@@ -33,7 +33,6 @@ async fn run_divviup_ts_integration_test(container_client: &Cli, vdaf: VdafInsta
         &leader_task,
         &collector_private_key,
         &client_backend,
-        leader.batch_discovery(),
     )
     .await;
 }

--- a/integration_tests/tests/janus.rs
+++ b/integration_tests/tests/janus.rs
@@ -162,7 +162,6 @@ async fn janus_janus_count() {
         &janus_pair.leader_task,
         &janus_pair.collector_private_key,
         &ClientBackend::InProcess,
-        janus_pair.leader.batch_discovery(),
     )
     .await;
 }
@@ -187,7 +186,6 @@ async fn janus_janus_sum_16() {
         &janus_pair.leader_task,
         &janus_pair.collector_private_key,
         &ClientBackend::InProcess,
-        janus_pair.leader.batch_discovery(),
     )
     .await;
 }
@@ -214,7 +212,6 @@ async fn janus_janus_histogram_4_buckets() {
         &janus_pair.leader_task,
         &janus_pair.collector_private_key,
         &ClientBackend::InProcess,
-        janus_pair.leader.batch_discovery(),
     )
     .await;
 }
@@ -239,7 +236,6 @@ async fn janus_janus_count_vec_15() {
         &janus_pair.leader_task,
         &janus_pair.collector_private_key,
         &ClientBackend::InProcess,
-        janus_pair.leader.batch_discovery(),
     )
     .await;
 }
@@ -264,7 +260,6 @@ async fn janus_janus_fixed_size() {
         &janus_pair.leader_task,
         &janus_pair.collector_private_key,
         &ClientBackend::InProcess,
-        janus_pair.leader.batch_discovery(),
     )
     .await;
 }


### PR DESCRIPTION
This rips out `/internal/test/fetch_batch_ids`, updates the interop test API based on https://github.com/divergentdave/draft-dcook-ppm-dap-interop-test-design/pull/33, and uses "current_batch" queries in fixed size tests instead.