### PR TITLE
Interop API: rename parameter to vdaf_verify_key

### DIFF
--- a/interop_binaries/src/bin/janus_interop_aggregator.rs
+++ b/interop_binaries/src/bin/janus_interop_aggregator.rs
@@ -38,9 +38,9 @@ async fn handle_add_task(
     let vdaf = request.vdaf.into();
     let leader_authentication_token =
         AuthenticationToken::from(request.leader_authentication_token.into_bytes());
-    let verify_key = SecretBytes::new(
-        base64::decode_engine(request.verify_key, &URL_SAFE_NO_PAD)
-            .context("invalid base64url content in \"verify_key\"")?,
+    let vdaf_verify_key = SecretBytes::new(
+        base64::decode_engine(request.vdaf_verify_key, &URL_SAFE_NO_PAD)
+            .context("invalid base64url content in \"vdaf_verify_key\"")?,
     );
     let time_precision = Duration::from_seconds(request.time_precision);
     let collector_hpke_config_bytes =
@@ -85,7 +85,7 @@ async fn handle_add_task(
         query_type,
         vdaf,
         request.role.into(),
-        Vec::from([verify_key]),
+        Vec::from([vdaf_verify_key]),
         request.max_batch_query_count,
         Time::from_seconds_since_epoch(request.task_expiration),
         request.min_batch_size,

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -192,7 +192,7 @@ pub struct AggregatorAddTaskRequest {
     #[serde(default)]
     pub collector_authentication_token: Option<String>,
     pub role: AggregatorRole,
-    pub verify_key: String, // in unpadded base64url
+    pub vdaf_verify_key: String, // in unpadded base64url
     pub max_batch_query_count: u64,
     pub query_type: u8,
     pub min_batch_size: u64,
@@ -235,7 +235,7 @@ impl From<Task> for AggregatorAddTaskRequest {
                 None
             },
             role: (*task.role()).try_into().unwrap(),
-            verify_key: base64::encode_engine(
+            vdaf_verify_key: base64::encode_engine(
                 task.vdaf_verify_keys().first().unwrap().as_ref(),
                 &URL_SAFE_NO_PAD,
             ),

--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -109,10 +109,10 @@ async fn run(
     let task_id: TaskId = random();
     let aggregator_auth_token = base64::encode_engine(random::<[u8; 16]>(), &URL_SAFE_NO_PAD);
     let collector_auth_token = base64::encode_engine(random::<[u8; 16]>(), &URL_SAFE_NO_PAD);
-    let verify_key = rand::random::<[u8; PRIO3_AES128_VERIFY_KEY_LENGTH]>();
+    let vdaf_verify_key = rand::random::<[u8; PRIO3_AES128_VERIFY_KEY_LENGTH]>();
 
     let task_id_encoded = base64::encode_engine(task_id.get_encoded(), &URL_SAFE_NO_PAD);
-    let verify_key_encoded = base64::encode_engine(verify_key, &URL_SAFE_NO_PAD);
+    let vdaf_verify_key_encoded = base64::encode_engine(vdaf_verify_key, &URL_SAFE_NO_PAD);
 
     // Endpoints, from the POV of this test (i.e. the Docker host).
     let local_client_endpoint = Url::parse(&format!("http://127.0.0.1:{client_port}/")).unwrap();
@@ -264,7 +264,7 @@ async fn run(
         "leader_authentication_token": aggregator_auth_token,
         "collector_authentication_token": collector_auth_token,
         "role": "leader",
-        "verify_key": verify_key_encoded,
+        "vdaf_verify_key": vdaf_verify_key_encoded,
         "max_batch_query_count": 1,
         "query_type": query_type_json,
         "min_batch_size": 1,
@@ -317,7 +317,7 @@ async fn run(
         "vdaf": vdaf_object,
         "leader_authentication_token": aggregator_auth_token,
         "role": "helper",
-        "verify_key": verify_key_encoded,
+        "vdaf_verify_key": vdaf_verify_key_encoded,
         "max_batch_query_count": 1,
         "query_type": query_type_json,
         "min_batch_size": 1,


### PR DESCRIPTION
This updates the interoperation test API support, renaming the `verify_key` attribute to `vdaf_verify_key`, to reflect the latest editor's copy. This rename is being done for clarity, but it got delayed until now so it could ride along with other breaking changes (for DAP-03 support).