### PR TITLE
Revert "Add dry run mode to `Datastore`"

### DIFF
--- a/aggregator/src/bin/janus_cli.rs
+++ b/aggregator/src/bin/janus_cli.rs
@@ -119,7 +119,6 @@ impl Command {
                     &kubernetes_secret_options
                         .datastore_keys(common_options, kube_client)
                         .await?,
-                    config.common_config().database.dry_run_mode,
                 )?;
 
                 let written_tasks =

--- a/aggregator/src/binary_utils.rs
+++ b/aggregator/src/binary_utils.rs
@@ -128,7 +128,6 @@ pub fn datastore<C: Clock>(
     pool: Pool,
     clock: C,
     datastore_keys: &[String],
-    dry_run_mode: bool,
 ) -> Result<Datastore<C>> {
     let datastore_keys = datastore_keys
         .iter()
@@ -148,12 +147,7 @@ pub fn datastore<C: Clock>(
         return Err(anyhow!("datastore_keys is empty"));
     }
 
-    Ok(Datastore::new(
-        pool,
-        Crypter::new(datastore_keys),
-        clock,
-        dry_run_mode,
-    ))
+    Ok(Datastore::new(pool, Crypter::new(datastore_keys), clock))
 }
 
 /// Options for Janus binaries.
@@ -280,7 +274,6 @@ where
         pool,
         clock.clone(),
         &options.common_options().datastore_keys,
-        config.common_config().database.dry_run_mode,
     )
     .context("couldn't create datastore")?;
 

--- a/aggregator/src/config.rs
+++ b/aggregator/src/config.rs
@@ -67,11 +67,6 @@ pub struct DbConfig {
     /// `deadpool_postgres::Timeouts` value.
     #[serde(default = "DbConfig::default_connection_pool_timeout")]
     pub connection_pool_timeouts_secs: u64,
-    /// When in dry-run mode, all database transactions will be rolled back
-    /// instead of being completed. Database queries will otherwise mostly but
-    /// not perfectly correct results.
-    #[serde(default)]
-    pub dry_run_mode: bool,
     // TODO(#231): add option for connecting to database over TLS, if necessary
 }
 
@@ -149,7 +144,6 @@ pub mod test_util {
         DbConfig {
             url: Url::parse("postgres://postgres:postgres@localhost:5432/postgres").unwrap(),
             connection_pool_timeouts_secs: 60,
-            dry_run_mode: false,
         }
     }
 

--- a/aggregator/src/datastore.rs
+++ b/aggregator/src/datastore.rs
@@ -39,7 +39,6 @@ use std::{
     ops::RangeInclusive, pin::Pin,
 };
 use tokio_postgres::{error::SqlState, row::RowIndex, IsolationLevel, Row};
-use tracing::info;
 use url::Url;
 use uuid::Uuid;
 
@@ -128,7 +127,6 @@ pub struct Datastore<C: Clock> {
     pool: deadpool_postgres::Pool,
     crypter: Crypter,
     clock: C,
-    dry_run: bool,
     transaction_status_counter: Counter<u64>,
     rollback_error_counter: Counter<u64>,
 }
@@ -136,12 +134,7 @@ pub struct Datastore<C: Clock> {
 impl<C: Clock> Datastore<C> {
     /// new creates a new Datastore using the given Client for backing storage. It is assumed that
     /// the Client is connected to a database with a compatible version of the Janus database schema.
-    pub fn new(
-        pool: deadpool_postgres::Pool,
-        crypter: Crypter,
-        clock: C,
-        dry_run: bool,
-    ) -> Datastore<C> {
+    pub fn new(pool: deadpool_postgres::Pool, crypter: Crypter, clock: C) -> Datastore<C> {
         let meter = opentelemetry::global::meter("janus_aggregator");
         let transaction_status_counter = meter
             .u64_counter("janus_database_transactions_total")
@@ -165,15 +158,10 @@ impl<C: Clock> Datastore<C> {
             );
         }
 
-        if dry_run {
-            info!("DRY RUN: All database transactions run through this datastore will be rolled back.")
-        }
-
         Self {
             pool,
             crypter,
             clock,
-            dry_run,
             transaction_status_counter,
             rollback_error_counter,
         }
@@ -244,12 +232,8 @@ impl<C: Clock> Datastore<C> {
         // Run user-provided function with the transaction.
         match f(&tx).await {
             Ok(rslt) => {
-                if self.dry_run {
-                    tx.tx.rollback().await?;
-                } else {
-                    // Commit.
-                    tx.tx.commit().await?;
-                }
+                // Commit.
+                tx.tx.commit().await?;
                 Ok(rslt)
             }
             Err(error) => match tx.tx.rollback().await {
@@ -4713,16 +4697,12 @@ pub mod test_util {
     impl DbHandle {
         /// Retrieve a datastore attached to the ephemeral database.
         pub fn datastore<C: Clock>(&self, clock: C) -> Datastore<C> {
-            self.datastore_with_dry_run(clock, false)
-        }
-
-        pub fn datastore_with_dry_run<C: Clock>(&self, clock: C, dry_run: bool) -> Datastore<C> {
             // Create a crypter based on the generated key bytes.
             let datastore_key =
                 LessSafeKey::new(UnboundKey::new(&AES_128_GCM, &self.datastore_key_bytes).unwrap());
             let crypter = Crypter::new(Vec::from([datastore_key]));
 
-            Datastore::new(self.pool(), crypter, clock, dry_run)
+            Datastore::new(self.pool(), crypter, clock)
         }
 
         /// Retrieve a Postgres connection pool attached to the ephemeral database.
@@ -4860,17 +4840,10 @@ pub mod test_util {
     ///
     /// Dropping the second return value causes the database to be shut down & cleaned up.
     pub async fn ephemeral_datastore<C: Clock>(clock: C) -> (Datastore<C>, DbHandle) {
-        ephemeral_datastore_with_dry_run(clock, false).await
-    }
-
-    pub async fn ephemeral_datastore_with_dry_run<C: Clock>(
-        clock: C,
-        dry_run: bool,
-    ) -> (Datastore<C>, DbHandle) {
         let db_handle = ephemeral_db_handle();
         let client = db_handle.pool().get().await.unwrap();
         client.batch_execute(SCHEMA).await.unwrap();
-        (db_handle.datastore_with_dry_run(clock, dry_run), db_handle)
+        (db_handle.datastore(clock), db_handle)
     }
 
     pub fn generate_aead_key_bytes() -> Vec<u8> {
@@ -4938,37 +4911,7 @@ mod tests {
     };
     use uuid::Uuid;
 
-    use super::{
-        models::AcquiredCollectJob, test_util::ephemeral_datastore_with_dry_run, Datastore,
-    };
-
-    #[tokio::test]
-    async fn dry_run_datastore() {
-        install_test_trace_subscriber();
-
-        let (ds, _db_handle) = ephemeral_datastore_with_dry_run(MockClock::default(), true).await;
-
-        let task = TaskBuilder::new(
-            task::QueryType::TimeInterval,
-            VdafInstance::Prio3Aes128Count,
-            Role::Leader,
-        )
-        .build();
-
-        // Write the task in one transaction. It should not be visible to a subsequent transaction.
-        ds.put_task(&task).await.unwrap();
-
-        ds.run_tx(|tx| {
-            Box::pin(async move {
-                let got_tasks = tx.get_tasks().await.unwrap();
-                assert!(got_tasks.is_empty());
-
-                Ok(())
-            })
-        })
-        .await
-        .unwrap();
-    }
+    use super::{models::AcquiredCollectJob, Datastore};
 
     #[tokio::test]
     async fn roundtrip_task() {

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -159,7 +159,6 @@ impl Janus<'static> {
                 ))
                 .unwrap(),
                 connection_pool_timeouts_secs: 60,
-                dry_run_mode: false,
             },
             None,
         )
@@ -171,7 +170,7 @@ impl Janus<'static> {
         // depends on this task being defined will likely time out or otherwise fail.
         // This should become more robust in the future when we implement dynamic task provisioning
         // (#44).
-        let datastore = datastore(pool, RealClock::default(), &[datastore_key], false).unwrap();
+        let datastore = datastore(pool, RealClock::default(), &[datastore_key]).unwrap();
         datastore.put_task(task).await.unwrap();
 
         let aggregator_port_forward = cluster


### PR DESCRIPTION
Reverts divviup/janus#843

Per discussion around #848, we agreed that the dry run mode implemented by #843 is too risky and not valuable enough to keep around.