### PR TITLE
Implement garbage collection. [0.2]

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -5,6 +5,7 @@ pub mod aggregate_share;
 pub mod aggregation_job_creator;
 pub mod aggregation_job_driver;
 pub mod collect_job_driver;
+pub mod garbage_collector;
 pub mod query_type;
 
 use crate::{
@@ -4554,7 +4555,7 @@ mod tests {
             .run_tx(|tx| {
                 let task = task.clone();
                 Box::pin(async move {
-                    tx.get_aggregation_jobs_for_task_id::<
+                    tx.get_aggregation_jobs_for_task::<
                         PRIO3_AES128_VERIFY_KEY_LENGTH,
                         TimeInterval,
                         Prio3Aes128Count,

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -1486,7 +1486,7 @@ mod tests {
     {
         gather_errors(
             join_all(
-                tx.get_aggregation_jobs_for_task_id::<L, Q, A>(task_id)
+                tx.get_aggregation_jobs_for_task::<L, Q, A>(task_id)
                     .await
                     .unwrap()
                     .into_iter()

--- a/aggregator/src/aggregator/garbage_collector.rs
+++ b/aggregator/src/aggregator/garbage_collector.rs
@@ -1,0 +1,240 @@
+use std::sync::Arc;
+
+use crate::{
+    datastore::Datastore,
+    messages::TimeExt,
+    task::{QueryType, Task},
+};
+use anyhow::{anyhow, Context, Result};
+use futures::future::join_all;
+use janus_core::time::Clock;
+use janus_messages::Role;
+use tracing::error;
+
+pub struct GarbageCollector<C: Clock> {
+    // Dependencies.
+    datastore: Arc<Datastore<C>>,
+    clock: C,
+}
+
+impl<C: Clock> GarbageCollector<C> {
+    pub fn new(datastore: Arc<Datastore<C>>, clock: C) -> Self {
+        Self { datastore, clock }
+    }
+
+    #[tracing::instrument(skip(self))]
+    pub async fn run(&self) -> Result<()> {
+        // TODO(#224): add support for handling only a subset of tasks in a single job (i.e. sharding).
+
+        // Retrieve tasks.
+        let tasks = self
+            .datastore
+            .run_tx(|tx| Box::pin(async move { tx.get_tasks().await }))
+            .await;
+        let tasks = match tasks {
+            Ok(tasks) => tasks,
+            Err(error) => return Err(error).context("couldn't retrieve tasks"),
+        };
+
+        // Run GC for each task.
+        join_all(tasks.into_iter().map(|task| async move {
+            let task = Arc::new(task);
+            if let Err(err) = self.gc_task(Arc::clone(&task)).await {
+                error!(task_id = ?task.id(), ?err, "Couldn't GC task");
+            }
+        }))
+        .await;
+        Ok(())
+    }
+
+    async fn gc_task(&self, task: Arc<Task>) -> Result<()> {
+        let oldest_allowed_report_timestamp =
+            if let Some(report_expiry_age) = task.report_expiry_age() {
+                if task.role() != &Role::Leader || task.query_type() != &QueryType::TimeInterval {
+                    return Err(anyhow!(
+                        "garbage collection is implemented only for leader, time-interval tasks"
+                    ));
+                }
+                self.clock.now().sub(report_expiry_age)?
+            } else {
+                // No configured report expiry age -- nothing to GC.
+                return Ok(());
+            };
+
+        self.datastore
+            .run_tx(|tx| {
+                let task = Arc::clone(&task);
+                Box::pin(async move {
+                    // Find and delete old collect jobs.
+                    tx.delete_old_collect_artifacts(task.id(), oldest_allowed_report_timestamp)
+                        .await?;
+
+                    // Find and delete old aggregation jobs/report aggregations/batch aggregations.
+                    tx.delete_old_aggregation_artifacts(task.id(), oldest_allowed_report_timestamp)
+                        .await?;
+
+                    // Find and delete old client reports.
+                    tx.delete_old_client_reports(task.id(), oldest_allowed_report_timestamp)
+                        .await?;
+
+                    Ok(())
+                })
+            })
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::GarbageCollector;
+    use crate::{
+        datastore::{
+            models::{
+                AggregationJob, AggregationJobState, CollectJob, CollectJobState,
+                LeaderStoredReport, ReportAggregation, ReportAggregationState,
+            },
+            test_util::ephemeral_datastore,
+        },
+        messages::TimeExt,
+        task::{self, test_util::TaskBuilder},
+    };
+    use janus_core::{
+        task::VdafInstance,
+        test_util::{
+            dummy_vdaf::{self, AggregationParam},
+            install_test_trace_subscriber,
+        },
+        time::{Clock, MockClock},
+    };
+    use janus_messages::{query_type::TimeInterval, Duration, Interval, Role, Time};
+    use rand::random;
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn gc_task() {
+        install_test_trace_subscriber();
+
+        let clock = MockClock::default();
+        let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
+        let ds = Arc::new(ds);
+        let vdaf = dummy_vdaf::Vdaf::new();
+
+        // Setup.
+        let task = ds
+            .run_tx(|tx| {
+                let clock = clock.clone();
+                Box::pin(async move {
+                    const REPORT_EXPIRY_AGE: Duration = Duration::from_seconds(3600);
+                    let task = TaskBuilder::new(
+                        task::QueryType::TimeInterval,
+                        VdafInstance::Fake,
+                        Role::Leader,
+                    )
+                    .with_report_expiry_age(Some(REPORT_EXPIRY_AGE))
+                    .build();
+                    tx.put_task(&task).await?;
+
+                    let client_timestamp = clock
+                        .now()
+                        .sub(&REPORT_EXPIRY_AGE)
+                        .unwrap()
+                        .sub(&Duration::from_seconds(1))
+                        .unwrap();
+                    let report = LeaderStoredReport::new_dummy(*task.id(), client_timestamp);
+                    tx.put_client_report(&report).await.unwrap();
+
+                    let batch_identifier =
+                        Interval::new(client_timestamp, Duration::from_seconds(1)).unwrap();
+                    let aggregation_job = AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
+                        *task.id(),
+                        random(),
+                        Some(batch_identifier),
+                        AggregationParam(0),
+                        AggregationJobState::InProgress,
+                    );
+                    tx.put_aggregation_job(&aggregation_job).await.unwrap();
+
+                    let report_aggregation = ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
+                        *task.id(),
+                        *aggregation_job.id(),
+                        *report.metadata().id(),
+                        client_timestamp,
+                        0,
+                        ReportAggregationState::Start,
+                    );
+                    tx.put_report_aggregation(&report_aggregation)
+                        .await
+                        .unwrap();
+
+                    let collect_job = CollectJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
+                        *task.id(),
+                        Uuid::new_v4(),
+                        batch_identifier,
+                        AggregationParam(0),
+                        CollectJobState::Start,
+                    );
+                    tx.put_collect_job(&collect_job).await.unwrap();
+
+                    Ok(task)
+                })
+            })
+            .await
+            .unwrap();
+
+        // Run.
+        let task = Arc::new(task);
+        GarbageCollector::new(Arc::clone(&ds), clock.clone())
+            .gc_task(Arc::clone(&task))
+            .await
+            .unwrap();
+
+        // Verify.
+        let (client_reports, aggregation_jobs, report_aggregations, collect_jobs) = ds
+            .run_tx(|tx| {
+                let (clock, vdaf, task) = (clock.clone(), vdaf.clone(), Arc::clone(&task));
+                Box::pin(async move {
+                    let client_reports = tx
+                        .get_client_reports_for_task::<0, dummy_vdaf::Vdaf>(&vdaf, task.id())
+                        .await?;
+                    let aggregation_jobs = tx
+                        .get_aggregation_jobs_for_task::<0, TimeInterval, dummy_vdaf::Vdaf>(
+                            task.id(),
+                        )
+                        .await?;
+                    let report_aggregations = tx
+                        .get_report_aggregations_for_task::<0, dummy_vdaf::Vdaf>(
+                            &vdaf,
+                            &Role::Leader,
+                            task.id(),
+                        )
+                        .await?;
+                    let collect_jobs = tx
+                        .get_collect_jobs_intersecting_interval::<0, dummy_vdaf::Vdaf>(
+                            task.id(),
+                            &Interval::new(
+                                Time::from_seconds_since_epoch(0),
+                                Duration::from_seconds(clock.now().as_seconds_since_epoch()),
+                            )
+                            .unwrap(),
+                        )
+                        .await?;
+
+                    Ok((
+                        client_reports,
+                        aggregation_jobs,
+                        report_aggregations,
+                        collect_jobs,
+                    ))
+                })
+            })
+            .await
+            .unwrap();
+        assert!(client_reports.is_empty());
+        assert!(aggregation_jobs.is_empty());
+        assert!(report_aggregations.is_empty());
+        assert!(collect_jobs.is_empty());
+    }
+}

--- a/aggregator/src/aggregator/garbage_collector.rs
+++ b/aggregator/src/aggregator/garbage_collector.rs
@@ -30,11 +30,8 @@ impl<C: Clock> GarbageCollector<C> {
         let tasks = self
             .datastore
             .run_tx(|tx| Box::pin(async move { tx.get_tasks().await }))
-            .await;
-        let tasks = match tasks {
-            Ok(tasks) => tasks,
-            Err(error) => return Err(error).context("couldn't retrieve tasks"),
-        };
+            .await
+            .context("couldn't retrieve tasks")?;
 
         // Run GC for each task.
         join_all(tasks.into_iter().map(|task| async move {

--- a/aggregator/src/aggregator/garbage_collector.rs
+++ b/aggregator/src/aggregator/garbage_collector.rs
@@ -63,15 +63,18 @@ impl<C: Clock> GarbageCollector<C> {
                 let task = Arc::clone(&task);
                 Box::pin(async move {
                     // Find and delete old collect jobs.
-                    tx.delete_old_collect_artifacts(task.id(), oldest_allowed_report_timestamp)
+                    tx.delete_expired_collect_artifacts(task.id(), oldest_allowed_report_timestamp)
                         .await?;
 
                     // Find and delete old aggregation jobs/report aggregations/batch aggregations.
-                    tx.delete_old_aggregation_artifacts(task.id(), oldest_allowed_report_timestamp)
-                        .await?;
+                    tx.delete_expired_aggregation_artifacts(
+                        task.id(),
+                        oldest_allowed_report_timestamp,
+                    )
+                    .await?;
 
                     // Find and delete old client reports.
-                    tx.delete_old_client_reports(task.id(), oldest_allowed_report_timestamp)
+                    tx.delete_expired_client_reports(task.id(), oldest_allowed_report_timestamp)
                         .await?;
 
                     Ok(())

--- a/aggregator/src/bin/garbage_collector.rs
+++ b/aggregator/src/bin/garbage_collector.rs
@@ -1,0 +1,68 @@
+use clap::Parser;
+use janus_aggregator::{
+    aggregator::garbage_collector::GarbageCollector,
+    binary_utils::{janus_main, BinaryOptions, CommonBinaryOptions},
+    config::{BinaryConfig, CommonConfig},
+};
+use janus_core::time::RealClock;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    janus_main::<_, Options, Config, _, _>(RealClock::default(), |ctx| async move {
+        GarbageCollector::new(Arc::new(ctx.datastore), ctx.clock)
+            .run()
+            .await
+    })
+    .await
+}
+
+#[derive(Debug, Parser)]
+#[clap(
+    name = "janus-collect-job-driver",
+    about = "Janus collect job driver",
+    rename_all = "kebab-case",
+    version = env!("CARGO_PKG_VERSION"),
+)]
+struct Options {
+    #[clap(flatten)]
+    common: CommonBinaryOptions,
+}
+
+impl BinaryOptions for Options {
+    fn common_options(&self) -> &CommonBinaryOptions {
+        &self.common
+    }
+}
+
+/// Non-secret configuration options for Janus Garbage Collector jobs.
+///
+/// # Examples
+///
+/// ```
+/// let yaml_config = r#"
+/// ---
+/// database:
+///   url: "postgres://postgres:postgres@localhost:5432/postgres"
+/// logging_config: # logging_config is optional
+///   force_json_output: true
+/// "#;
+///
+/// let _decoded: Config = serde_yaml::from_str(yaml_config).unwrap();
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct Config {
+    #[serde(flatten)]
+    common_config: CommonConfig,
+}
+
+impl BinaryConfig for Config {
+    fn common_config(&self) -> &CommonConfig {
+        &self.common_config
+    }
+
+    fn common_config_mut(&mut self) -> &mut CommonConfig {
+        &mut self.common_config
+    }
+}

--- a/aggregator/src/datastore.rs
+++ b/aggregator/src/datastore.rs
@@ -3022,7 +3022,7 @@ ORDER BY id DESC
     /// Deletes old client reports for a given task, that is, client reports whose timestamp is
     /// older than a given timestamp which are not included in any report aggregations.
     #[tracing::instrument(skip(self), err)]
-    pub async fn delete_old_client_reports(
+    pub async fn delete_expired_client_reports(
         &self,
         task_id: &TaskId,
         oldest_allowed_report_timestamp: Time,
@@ -3057,10 +3057,10 @@ ORDER BY id DESC
     ///
     /// Only implemented for leader tasks with the time-interval query type.
     ///
-    /// After calling this function, delete_old_client_reports must be called in the same
+    /// After calling this function, delete_expired_client_reports must be called in the same
     /// transaction to avoid re-aggregating client reports.
     #[tracing::instrument(skip(self), err)]
-    pub async fn delete_old_aggregation_artifacts(
+    pub async fn delete_expired_aggregation_artifacts(
         &self,
         task_id: &TaskId,
         oldest_allowed_report_timestamp: Time,
@@ -3121,10 +3121,10 @@ ORDER BY id DESC
     ///
     /// Only implemented for leader tasks with the time-interval query type.
     ///
-    /// After calling this function, delete_old_aggregation_artifacts must be called in the same
+    /// After calling this function, delete_expired_aggregation_artifacts must be called in the same
     /// transaction to avoid re-collecting old aggregations.
     #[tracing::instrument(skip(self), err)]
-    pub async fn delete_old_collect_artifacts(
+    pub async fn delete_expired_collect_artifacts(
         &self,
         task_id: &TaskId,
         oldest_allowed_report_timestamp: Time,
@@ -8907,7 +8907,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_old_client_reports() {
+    async fn delete_expired_client_reports() {
         install_test_trace_subscriber();
 
         let clock = MockClock::default();
@@ -8993,7 +8993,7 @@ mod tests {
         // Run.
         ds.run_tx(|tx| {
             Box::pin(async move {
-                tx.delete_old_client_reports(&task_id, OLDEST_ALLOWED_REPORT_TIMESTAMP)
+                tx.delete_expired_client_reports(&task_id, OLDEST_ALLOWED_REPORT_TIMESTAMP)
                     .await
             })
         })
@@ -9026,7 +9026,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_old_aggregation_artifacts() {
+    async fn delete_expired_aggregation_artifacts() {
         install_test_trace_subscriber();
 
         let clock = MockClock::default();
@@ -9252,7 +9252,7 @@ mod tests {
         // Run.
         ds.run_tx(|tx| {
             Box::pin(async move {
-                tx.delete_old_aggregation_artifacts(&task_id, OLDEST_ALLOWED_REPORT_TIMESTAMP)
+                tx.delete_expired_aggregation_artifacts(&task_id, OLDEST_ALLOWED_REPORT_TIMESTAMP)
                     .await
             })
         })
@@ -9337,7 +9337,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_old_collect_artifacts() {
+    async fn delete_expired_collect_artifacts() {
         install_test_trace_subscriber();
 
         let clock = MockClock::default();
@@ -9495,7 +9495,7 @@ mod tests {
         // Run.
         ds.run_tx(|tx| {
             Box::pin(async move {
-                tx.delete_old_collect_artifacts(&task_id, OLDEST_ALLOWED_REPORT_TIMESTAMP)
+                tx.delete_expired_collect_artifacts(&task_id, OLDEST_ALLOWED_REPORT_TIMESTAMP)
                     .await
             })
         })

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -19,6 +19,7 @@ CREATE TABLE tasks(
     vdaf                   JSON NOT NULL,                                      -- the VDAF instance in use for this task, along with its parameters
     max_batch_query_count  BIGINT NOT NULL,                                    -- the maximum number of times a given batch may be collected
     task_expiration        TIMESTAMP NOT NULL,                                 -- the time after which client reports are no longer accepted
+    report_expiry_age      BIGINT,                                             -- the maximum age of a report before it is considered expired (and acceptable for garbage collection), in seconds
     min_batch_size         BIGINT NOT NULL,                                    -- the minimum number of reports in a batch to allow it to be collected
     time_precision         BIGINT NOT NULL,                                    -- the duration to which clients are expected to round their report timestamps, in seconds
     tolerable_clock_skew   BIGINT NOT NULL,                                    -- the maximum acceptable clock skew to allow between client and aggregator, in seconds

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -19,7 +19,7 @@ CREATE TABLE tasks(
     vdaf                   JSON NOT NULL,                                      -- the VDAF instance in use for this task, along with its parameters
     max_batch_query_count  BIGINT NOT NULL,                                    -- the maximum number of times a given batch may be collected
     task_expiration        TIMESTAMP NOT NULL,                                 -- the time after which client reports are no longer accepted
-    report_expiry_age      BIGINT,                                             -- the maximum age of a report before it is considered expired (and acceptable for garbage collection), in seconds
+    report_expiry_age      BIGINT,                                             -- the maximum age of a report before it is considered expired (and acceptable for garbage collection), in seconds. NULL means that GC is disabled.
     min_batch_size         BIGINT NOT NULL,                                    -- the minimum number of reports in a batch to allow it to be collected
     time_precision         BIGINT NOT NULL,                                    -- the duration to which clients are expected to round their report timestamps, in seconds
     tolerable_clock_skew   BIGINT NOT NULL,                                    -- the maximum acceptable clock skew to allow between client and aggregator, in seconds

--- a/interop_binaries/src/bin/janus_interop_aggregator.rs
+++ b/interop_binaries/src/bin/janus_interop_aggregator.rs
@@ -135,6 +135,7 @@ async fn handle_add_task(
         Vec::from([verify_key]),
         request.max_batch_query_count,
         Time::from_seconds_since_epoch(request.task_expiration),
+        None,
         request.min_batch_size,
         time_precision,
         // We can be strict about clock skew since this executable is only intended for use with

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -247,6 +247,17 @@ impl From<[u8; Self::LEN]> for ReportId {
     }
 }
 
+impl<'a> TryFrom<&'a [u8]> for ReportId {
+    type Error = Error;
+
+    fn try_from(report_id: &[u8]) -> Result<Self, Self::Error> {
+        let report_id: [u8; Self::LEN] = report_id
+            .try_into()
+            .map_err(|_| Error::InvalidParameter("ReportId length incorrect"))?;
+        Ok(Self::from(report_id))
+    }
+}
+
 impl AsRef<[u8; Self::LEN]> for ReportId {
     fn as_ref(&self) -> &[u8; Self::LEN] {
         &self.0
@@ -1524,6 +1535,17 @@ impl AggregationJobId {
 impl From<[u8; Self::LEN]> for AggregationJobId {
     fn from(aggregation_job_id: [u8; Self::LEN]) -> Self {
         Self(aggregation_job_id)
+    }
+}
+
+impl<'a> TryFrom<&'a [u8]> for AggregationJobId {
+    type Error = Error;
+
+    fn try_from(aggregation_job_id: &[u8]) -> Result<Self, Self::Error> {
+        let aggregation_job_id: [u8; Self::LEN] = aggregation_job_id
+            .try_into()
+            .map_err(|_| Error::InvalidParameter("AggregationJobId length incorrect"))?;
+        Ok(Self::from(aggregation_job_id))
     }
 }
 

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -53,7 +53,7 @@ impl Duration {
     }
 
     /// Get the number of seconds this duration represents.
-    pub fn as_seconds(self) -> u64 {
+    pub fn as_seconds(&self) -> u64 {
         self.0
     }
 }
@@ -1519,6 +1519,12 @@ pub struct AggregationJobId([u8; Self::LEN]);
 impl AggregationJobId {
     /// LEN is the length of an aggregation job ID in bytes.
     pub const LEN: usize = 32;
+}
+
+impl From<[u8; Self::LEN]> for AggregationJobId {
+    fn from(aggregation_job_id: [u8; Self::LEN]) -> Self {
+        Self(aggregation_job_id)
+    }
 }
 
 impl AsRef<[u8; Self::LEN]> for AggregationJobId {


### PR DESCRIPTION
The 0.2 version of this functionality only supports leader tasks with time-interval query types. This is because supporting helper tasks would require a schema change & backfill, and because fixed-size query types are not deployable in DAP-02 due to the lack of current-batch support.