### PR TITLE
Bump crate versions to 0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1501,7 +1501,7 @@ checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "janus_aggregator"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1566,14 +1566,14 @@ dependencies = [
 
 [[package]]
 name = "janus_build_script_utils"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "janus_client"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -1596,7 +1596,7 @@ dependencies = [
 
 [[package]]
 name = "janus_collector"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "janus_core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -1660,7 +1660,7 @@ dependencies = [
 
 [[package]]
 name = "janus_integration_tests"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "janus_interop_binaries"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "backoff",
@@ -1729,7 +1729,7 @@ dependencies = [
 
 [[package]]
 name = "janus_messages"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ homepage = "https://divviup.org"
 license = "MPL-2.0"
 repository = "https://github.com/divviup/janus"
 rust-version = "1.65.0"
-version = "0.2.2"
+version = "0.2.3"
 
 [workspace.dependencies]
 k8s-openapi = { version = "0.16.0", features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`


### PR DESCRIPTION
This prepares crate metadata for the next release.