### PR TITLE
replace `generate_vdaf_values` with `run_vdaf`

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -3344,7 +3344,7 @@ mod tests {
         vdaf::{
             self,
             prio3::{Prio3, Prio3Aes128Count},
-            AggregateShare, Aggregator as _, Client as VdafClient, PrepareTransition,
+            AggregateShare, Aggregator as _, Client as VdafClient,
         },
     };
     use rand::random;
@@ -4881,16 +4881,7 @@ mod tests {
             report_metadata_0.id(),
             &0,
         );
-        let prep_state_0 = assert_matches!(
-            &transcript_0.prepare_transitions[1][0],
-            PrepareTransition::<Prio3Aes128Count, PRIO3_AES128_VERIFY_KEY_LENGTH>::Continue(prep_state, _)
-            => prep_state.clone()
-        );
-        let out_share_0 = assert_matches!(
-            &transcript_0.prepare_transitions[1][1],
-            PrepareTransition::<Prio3Aes128Count, PRIO3_AES128_VERIFY_KEY_LENGTH>::Finish(out_share)
-            => out_share.clone()
-        );
+        let prep_state_0 = transcript_0.prep_state(0, Role::Helper);
         let prep_msg_0 = transcript_0.prepare_messages[0].clone();
         let report_share_0 = generate_helper_report_share::<Prio3Aes128Count>(
             *task.id(),
@@ -4916,7 +4907,7 @@ mod tests {
             report_metadata_1.id(),
             &0,
         );
-        let prep_state_1 = assert_matches!(&transcript_1.prepare_transitions[1][0], PrepareTransition::<Prio3Aes128Count, PRIO3_AES128_VERIFY_KEY_LENGTH>::Continue(prep_state, _) => prep_state.clone());
+        let prep_state_1 = transcript_1.prep_state(0, Role::Helper);
         let report_share_1 = generate_helper_report_share::<Prio3Aes128Count>(
             *task.id(),
             report_metadata_1.clone(),
@@ -4944,7 +4935,7 @@ mod tests {
             report_metadata_2.id(),
             &0,
         );
-        let prep_state_2 = assert_matches!(&transcript_2.prepare_transitions[1][0], PrepareTransition::<Prio3Aes128Count, PRIO3_AES128_VERIFY_KEY_LENGTH>::Continue(prep_state, _) => prep_state.clone());
+        let prep_state_2 = transcript_2.prep_state(0, Role::Helper);
         let prep_msg_2 = transcript_2.prepare_messages[0].clone();
         let report_share_2 = generate_helper_report_share::<Prio3Aes128Count>(
             *task.id(),
@@ -5143,7 +5134,9 @@ mod tests {
                     *report_metadata_0.id(),
                     *report_metadata_0.time(),
                     0,
-                    ReportAggregationState::Finished(out_share_0.clone()),
+                    ReportAggregationState::Finished(
+                        transcript_0.output_share(Role::Helper).clone()
+                    ),
                 ),
                 ReportAggregation::new(
                     *task.id(),
@@ -5207,8 +5200,8 @@ mod tests {
             report_metadata_0.id(),
             &0,
         );
-        let prep_state_0 = assert_matches!(&transcript_0.prepare_transitions[1][0], PrepareTransition::<Prio3Aes128Count, PRIO3_AES128_VERIFY_KEY_LENGTH>::Continue(prep_state, _) => prep_state.clone());
-        let out_share_0 = assert_matches!(&transcript_0.prepare_transitions[1][1], PrepareTransition::<Prio3Aes128Count, PRIO3_AES128_VERIFY_KEY_LENGTH>::Finish(out_share) => out_share.clone());
+        let prep_state_0 = transcript_0.prep_state(0, Role::Helper);
+        let out_share_0 = transcript_0.output_share(Role::Helper);
         let prep_msg_0 = transcript_0.prepare_messages[0].clone();
         let report_share_0 = generate_helper_report_share::<Prio3Aes128Count>(
             *task.id(),
@@ -5235,8 +5228,8 @@ mod tests {
             report_metadata_1.id(),
             &0,
         );
-        let prep_state_1 = assert_matches!(&transcript_1.prepare_transitions[1][0], PrepareTransition::<Prio3Aes128Count, PRIO3_AES128_VERIFY_KEY_LENGTH>::Continue(prep_state, _) => prep_state.clone());
-        let out_share_1 = assert_matches!(&transcript_1.prepare_transitions[1][1], PrepareTransition::<Prio3Aes128Count, PRIO3_AES128_VERIFY_KEY_LENGTH>::Finish(out_share) => out_share.clone());
+        let prep_state_1 = transcript_1.prep_state(0, Role::Helper);
+        let out_share_1 = transcript_1.output_share(Role::Helper);
         let prep_msg_1 = transcript_1.prepare_messages[0].clone();
         let report_share_1 = generate_helper_report_share::<Prio3Aes128Count>(
             *task.id(),
@@ -5262,8 +5255,8 @@ mod tests {
             report_metadata_2.id(),
             &0,
         );
-        let prep_state_2 = assert_matches!(&transcript_2.prepare_transitions[1][0], PrepareTransition::<Prio3Aes128Count, PRIO3_AES128_VERIFY_KEY_LENGTH>::Continue(prep_state, _) => prep_state.clone());
-        let out_share_2 = assert_matches!(&transcript_2.prepare_transitions[1][1], PrepareTransition::<Prio3Aes128Count, PRIO3_AES128_VERIFY_KEY_LENGTH>::Finish(out_share) => out_share.clone());
+        let prep_state_2 = transcript_2.prep_state(0, Role::Helper);
+        let out_share_2 = transcript_2.output_share(Role::Helper);
         let prep_msg_2 = transcript_2.prepare_messages[0].clone();
         let report_share_2 = generate_helper_report_share::<Prio3Aes128Count>(
             *task.id(),
@@ -5495,8 +5488,8 @@ mod tests {
             report_metadata_3.id(),
             &0,
         );
-        let prep_state_3 = assert_matches!(&transcript_3.prepare_transitions[1][0], PrepareTransition::<Prio3Aes128Count, PRIO3_AES128_VERIFY_KEY_LENGTH>::Continue(prep_state, _) => prep_state.clone());
-        let out_share_3 = assert_matches!(&transcript_3.prepare_transitions[1][1], PrepareTransition::<Prio3Aes128Count, PRIO3_AES128_VERIFY_KEY_LENGTH>::Finish(out_share) => out_share.clone());
+        let prep_state_3 = transcript_3.prep_state(0, Role::Helper);
+        let out_share_3 = transcript_3.output_share(Role::Helper);
         let prep_msg_3 = transcript_3.prepare_messages[0].clone();
         let report_share_3 = generate_helper_report_share::<Prio3Aes128Count>(
             *task.id(),
@@ -5522,8 +5515,8 @@ mod tests {
             report_metadata_4.id(),
             &0,
         );
-        let prep_state_4 = assert_matches!(&transcript_4.prepare_transitions[1][0], PrepareTransition::<Prio3Aes128Count, PRIO3_AES128_VERIFY_KEY_LENGTH>::Continue(prep_state, _) => prep_state.clone());
-        let out_share_4 = assert_matches!(&transcript_4.prepare_transitions[1][1], PrepareTransition::<Prio3Aes128Count, PRIO3_AES128_VERIFY_KEY_LENGTH>::Finish(out_share) => out_share.clone());
+        let prep_state_4 = transcript_4.prep_state(0, Role::Helper);
+        let out_share_4 = transcript_4.output_share(Role::Helper);
         let prep_msg_4 = transcript_4.prepare_messages[0].clone();
         let report_share_4 = generate_helper_report_share::<Prio3Aes128Count>(
             *task.id(),
@@ -5549,8 +5542,8 @@ mod tests {
             report_metadata_5.id(),
             &0,
         );
-        let prep_state_5 = assert_matches!(&transcript_5.prepare_transitions[1][0], PrepareTransition::<Prio3Aes128Count, PRIO3_AES128_VERIFY_KEY_LENGTH>::Continue(prep_state, _) => prep_state.clone());
-        let out_share_5 = assert_matches!(&transcript_5.prepare_transitions[1][1], PrepareTransition::<Prio3Aes128Count, PRIO3_AES128_VERIFY_KEY_LENGTH>::Finish(out_share) => out_share.clone());
+        let prep_state_5 = transcript_5.prep_state(0, Role::Helper);
+        let out_share_5 = transcript_5.output_share(Role::Helper);
         let prep_msg_5 = transcript_5.prepare_messages[0].clone();
         let report_share_5 = generate_helper_report_share::<Prio3Aes128Count>(
             *task.id(),
@@ -5711,14 +5704,20 @@ mod tests {
             .unwrap();
 
         let first_aggregate_share = vdaf
-            .aggregate(&(), [out_share_0, out_share_1, out_share_3])
+            .aggregate(
+                &(),
+                [out_share_0, out_share_1, out_share_3].into_iter().cloned(),
+            )
             .unwrap();
         let first_checksum = ReportIdChecksum::for_report_id(report_metadata_0.id())
             .updated_with(report_metadata_1.id())
             .updated_with(report_metadata_3.id());
 
         let second_aggregate_share = vdaf
-            .aggregate(&(), [out_share_2, out_share_4, out_share_5])
+            .aggregate(
+                &(),
+                [out_share_2, out_share_4, out_share_5].into_iter().cloned(),
+            )
             .unwrap();
         let second_checksum = ReportIdChecksum::for_report_id(report_metadata_2.id())
             .updated_with(report_metadata_4.id())


### PR DESCRIPTION
The tests in mod `datastore` defined a mechanism for running a VDAF and recording a transcript, which is redundant given `run_vdaf` and `VdafTranscript` in `janus_core`. This commit moves `datastore` tests to `run_vdaf`. Additionally, `VdafTranscript` now has convenience methods for getting preparation state and output shares, which absolves its clients of writing gnarly `assert_matches!` macros that get so long that `rustfmt` gives up on tidying them up.

---

I'm working on the changes needed to implement DAP-04 in https://github.com/divviup/janus/pull/731. Since DAP-04 isn't ready yet and in order to reduce the size of the eventual PR wiring up the new HTTP API, I'm teasing out some independent pieces into more digestible PRs.