### PR TITLE
store helper's `A::PrepareShare` in the database

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -23,8 +23,8 @@ use janus_aggregator_core::{
         self,
         models::{
             AggregateShareJob, AggregationJob, AggregationJobState, BatchAggregation,
-            CollectionJob, CollectionJobState, LeaderStoredReport, ReportAggregation,
-            ReportAggregationState,
+            CollectionJob, CollectionJobState, LeaderStoredReport, PrepareMessageOrShare,
+            ReportAggregation, ReportAggregationState,
         },
         Datastore, Transaction,
     },
@@ -1327,6 +1327,7 @@ impl VdafOps {
         A::AggregationParam: Send + Sync + PartialEq,
         A::AggregateShare: Send + Sync,
         A::PrepareMessage: Send + Sync + PartialEq,
+        A::PrepareShare: Send + Sync + PartialEq,
         for<'a> A::PrepareState:
             Send + Sync + Encode + ParameterizedDecode<(&'a A, usize)> + PartialEq,
         A::OutputShare: Send + Sync + PartialEq,
@@ -1410,6 +1411,7 @@ impl VdafOps {
         A::AggregationParam: Send + Sync + PartialEq,
         A::AggregateShare: Send + Sync,
         A::PrepareMessage: Send + Sync + PartialEq,
+        A::PrepareShare: Send + Sync + PartialEq,
         for<'a> A::PrepareState:
             Send + Sync + Encode + ParameterizedDecode<(&'a A, usize)> + PartialEq,
         A::OutputShare: Send + Sync + PartialEq,
@@ -1543,6 +1545,8 @@ impl VdafOps {
             report_share_data.push(match init_rslt {
                 Ok((prep_state, prep_share)) => {
                     saw_continue = true;
+
+                    let encoded_prep_share = prep_share.get_encoded();
                     ReportShareData::new(
                         report_share.clone(),
                         ReportAggregation::<L, A>::new(
@@ -1551,9 +1555,12 @@ impl VdafOps {
                             *report_share.metadata().id(),
                             *report_share.metadata().time(),
                             ord.try_into()?,
-                            ReportAggregationState::<L, A>::Waiting(prep_state, None),
+                            ReportAggregationState::<L, A>::Waiting(
+                                prep_state,
+                                PrepareMessageOrShare::Helper(prep_share),
+                            ),
                         ),
-                        PrepareStepResult::Continued(prep_share.get_encoded()),
+                        PrepareStepResult::Continued(encoded_prep_share),
                     )
                 }
 
@@ -1865,7 +1872,7 @@ impl VdafOps {
                                     *prep_step.report_id(),
                                     PrepareStepResult::Continued(prep_share.get_encoded()),
                                 ));
-                                ReportAggregationState::Waiting(prep_state, None)
+                                ReportAggregationState::Waiting(prep_state, PrepareMessageOrShare::Helper(prep_share))
                             }
 
                             Ok(PrepareTransition::Finish(output_share)) => {
@@ -3238,7 +3245,8 @@ mod tests {
         datastore::{
             models::{
                 AggregateShareJob, AggregationJob, AggregationJobState, BatchAggregation,
-                CollectionJob, CollectionJobState, ReportAggregation, ReportAggregationState,
+                CollectionJob, CollectionJobState, PrepareMessageOrShare, ReportAggregation,
+                ReportAggregationState,
             },
             test_util::{ephemeral_datastore, EphemeralDatastore},
             Datastore,
@@ -5110,7 +5118,7 @@ mod tests {
             report_metadata_0.id(),
             &0,
         );
-        let (prep_state_0, _) = transcript_0.helper_prep_state(0);
+        let (prep_state_0, prep_share_0) = transcript_0.helper_prep_state(0);
         let prep_msg_0 = transcript_0.prepare_messages[0].clone();
         let report_share_0 = generate_helper_report_share::<Prio3Count>(
             *task.id(),
@@ -5136,7 +5144,8 @@ mod tests {
             report_metadata_1.id(),
             &0,
         );
-        let (prep_state_1, _) = transcript_1.helper_prep_state(0);
+
+        let (prep_state_1, prep_share_1) = transcript_1.helper_prep_state(0);
         let report_share_1 = generate_helper_report_share::<Prio3Count>(
             *task.id(),
             report_metadata_1.clone(),
@@ -5164,7 +5173,7 @@ mod tests {
             report_metadata_2.id(),
             &0,
         );
-        let (prep_state_2, _) = transcript_2.helper_prep_state(0);
+        let (prep_state_2, prep_share_2) = transcript_2.helper_prep_state(0);
         let prep_msg_2 = transcript_2.prepare_messages[0].clone();
         let report_share_2 = generate_helper_report_share::<Prio3Count>(
             *task.id(),
@@ -5182,6 +5191,11 @@ mod tests {
                     report_share_0.clone(),
                     report_share_1.clone(),
                     report_share_2.clone(),
+                );
+                let (prep_share_0, prep_share_1, prep_share_2) = (
+                    prep_share_0.clone(),
+                    prep_share_1.clone(),
+                    prep_share_2.clone(),
                 );
                 let (prep_state_0, prep_state_1, prep_state_2) = (
                     prep_state_0.clone(),
@@ -5223,7 +5237,10 @@ mod tests {
                             *report_metadata_0.id(),
                             *report_metadata_0.time(),
                             0,
-                            ReportAggregationState::Waiting(prep_state_0, None),
+                            ReportAggregationState::Waiting(
+                                prep_state_0,
+                                PrepareMessageOrShare::Helper(prep_share_0),
+                            ),
                         ),
                     )
                     .await?;
@@ -5234,7 +5251,10 @@ mod tests {
                             *report_metadata_1.id(),
                             *report_metadata_1.time(),
                             1,
-                            ReportAggregationState::Waiting(prep_state_1, None),
+                            ReportAggregationState::Waiting(
+                                prep_state_1,
+                                PrepareMessageOrShare::Helper(prep_share_1),
+                            ),
                         ),
                     )
                     .await?;
@@ -5245,7 +5265,10 @@ mod tests {
                             *report_metadata_2.id(),
                             *report_metadata_2.time(),
                             2,
-                            ReportAggregationState::Waiting(prep_state_2, None),
+                            ReportAggregationState::Waiting(
+                                prep_state_2,
+                                PrepareMessageOrShare::Helper(prep_share_2),
+                            ),
                         ),
                     )
                     .await?;
@@ -5434,7 +5457,7 @@ mod tests {
             report_metadata_0.id(),
             &0,
         );
-        let (prep_state_0, _) = transcript_0.helper_prep_state(0);
+        let (prep_state_0, prep_share_0) = transcript_0.helper_prep_state(0);
         let out_share_0 = transcript_0.output_share(Role::Helper);
         let prep_msg_0 = transcript_0.prepare_messages[0].clone();
         let report_share_0 = generate_helper_report_share::<Prio3Count>(
@@ -5462,7 +5485,7 @@ mod tests {
             report_metadata_1.id(),
             &0,
         );
-        let (prep_state_1, _) = transcript_1.helper_prep_state(0);
+        let (prep_state_1, prep_share_1) = transcript_1.helper_prep_state(0);
         let out_share_1 = transcript_1.output_share(Role::Helper);
         let prep_msg_1 = transcript_1.prepare_messages[0].clone();
         let report_share_1 = generate_helper_report_share::<Prio3Count>(
@@ -5489,7 +5512,7 @@ mod tests {
             report_metadata_2.id(),
             &0,
         );
-        let (prep_state_2, _) = transcript_2.helper_prep_state(0);
+        let (prep_state_2, prep_share_2) = transcript_2.helper_prep_state(0);
         let out_share_2 = transcript_2.output_share(Role::Helper);
         let prep_msg_2 = transcript_2.prepare_messages[0].clone();
         let report_share_2 = generate_helper_report_share::<Prio3Count>(
@@ -5508,6 +5531,11 @@ mod tests {
                     report_share_0.clone(),
                     report_share_1.clone(),
                     report_share_2.clone(),
+                );
+                let (prep_share_0, prep_share_1, prep_share_2) = (
+                    prep_share_0.clone(),
+                    prep_share_1.clone(),
+                    prep_share_2.clone(),
                 );
                 let (prep_state_0, prep_state_1, prep_state_2) = (
                     prep_state_0.clone(),
@@ -5551,7 +5579,10 @@ mod tests {
                         *report_metadata_0.id(),
                         *report_metadata_0.time(),
                         0,
-                        ReportAggregationState::Waiting(prep_state_0, None),
+                        ReportAggregationState::Waiting(
+                            prep_state_0,
+                            PrepareMessageOrShare::Helper(prep_share_0),
+                        ),
                     ))
                     .await?;
                     tx.put_report_aggregation(&ReportAggregation::<
@@ -5563,7 +5594,10 @@ mod tests {
                         *report_metadata_1.id(),
                         *report_metadata_1.time(),
                         1,
-                        ReportAggregationState::Waiting(prep_state_1, None),
+                        ReportAggregationState::Waiting(
+                            prep_state_1,
+                            PrepareMessageOrShare::Helper(prep_share_1),
+                        ),
                     ))
                     .await?;
                     tx.put_report_aggregation(&ReportAggregation::<
@@ -5575,7 +5609,10 @@ mod tests {
                         *report_metadata_2.id(),
                         *report_metadata_2.time(),
                         2,
-                        ReportAggregationState::Waiting(prep_state_2, None),
+                        ReportAggregationState::Waiting(
+                            prep_state_2,
+                            PrepareMessageOrShare::Helper(prep_share_2),
+                        ),
                     ))
                     .await?;
 
@@ -5741,7 +5778,7 @@ mod tests {
             report_metadata_3.id(),
             &0,
         );
-        let (prep_state_3, _) = transcript_3.helper_prep_state(0);
+        let (prep_state_3, prep_share_3) = transcript_3.helper_prep_state(0);
         let out_share_3 = transcript_3.output_share(Role::Helper);
         let prep_msg_3 = transcript_3.prepare_messages[0].clone();
         let report_share_3 = generate_helper_report_share::<Prio3Count>(
@@ -5768,7 +5805,7 @@ mod tests {
             report_metadata_4.id(),
             &0,
         );
-        let (prep_state_4, _) = transcript_4.helper_prep_state(0);
+        let (prep_state_4, prep_share_4) = transcript_4.helper_prep_state(0);
         let out_share_4 = transcript_4.output_share(Role::Helper);
         let prep_msg_4 = transcript_4.prepare_messages[0].clone();
         let report_share_4 = generate_helper_report_share::<Prio3Count>(
@@ -5795,7 +5832,7 @@ mod tests {
             report_metadata_5.id(),
             &0,
         );
-        let (prep_state_5, _) = transcript_5.helper_prep_state(0);
+        let (prep_state_5, prep_share_5) = transcript_5.helper_prep_state(0);
         let out_share_5 = transcript_5.output_share(Role::Helper);
         let prep_msg_5 = transcript_5.prepare_messages[0].clone();
         let report_share_5 = generate_helper_report_share::<Prio3Count>(
@@ -5814,6 +5851,11 @@ mod tests {
                     report_share_3.clone(),
                     report_share_4.clone(),
                     report_share_5.clone(),
+                );
+                let (prep_share_3, prep_share_4, prep_share_5) = (
+                    prep_share_3.clone(),
+                    prep_share_4.clone(),
+                    prep_share_5.clone(),
                 );
                 let (prep_state_3, prep_state_4, prep_state_5) = (
                     prep_state_3.clone(),
@@ -5855,7 +5897,10 @@ mod tests {
                         *report_metadata_3.id(),
                         *report_metadata_3.time(),
                         3,
-                        ReportAggregationState::Waiting(prep_state_3, None),
+                        ReportAggregationState::Waiting(
+                            prep_state_3,
+                            PrepareMessageOrShare::Helper(prep_share_3),
+                        ),
                     ))
                     .await?;
                     tx.put_report_aggregation(&ReportAggregation::<
@@ -5867,7 +5912,10 @@ mod tests {
                         *report_metadata_4.id(),
                         *report_metadata_4.time(),
                         4,
-                        ReportAggregationState::Waiting(prep_state_4, None),
+                        ReportAggregationState::Waiting(
+                            prep_state_4,
+                            PrepareMessageOrShare::Helper(prep_share_4),
+                        ),
                     ))
                     .await?;
                     tx.put_report_aggregation(&ReportAggregation::<
@@ -5879,7 +5927,10 @@ mod tests {
                         *report_metadata_5.id(),
                         *report_metadata_5.time(),
                         5,
-                        ReportAggregationState::Waiting(prep_state_5, None),
+                        ReportAggregationState::Waiting(
+                            prep_state_5,
+                            PrepareMessageOrShare::Helper(prep_share_5),
+                        ),
                     ))
                     .await?;
 
@@ -6107,7 +6158,10 @@ mod tests {
                         *report_metadata.id(),
                         *report_metadata.time(),
                         0,
-                        ReportAggregationState::Waiting(dummy_vdaf::PrepareState::default(), None),
+                        ReportAggregationState::Waiting(
+                            dummy_vdaf::PrepareState::default(),
+                            PrepareMessageOrShare::Helper(()),
+                        ),
                     ))
                     .await
                 })
@@ -6222,7 +6276,10 @@ mod tests {
                         *report_metadata.id(),
                         *report_metadata.time(),
                         0,
-                        ReportAggregationState::Waiting(dummy_vdaf::PrepareState::default(), None),
+                        ReportAggregationState::Waiting(
+                            dummy_vdaf::PrepareState::default(),
+                            PrepareMessageOrShare::Helper(()),
+                        ),
                     ))
                     .await
                 })
@@ -6385,7 +6442,10 @@ mod tests {
                         *report_metadata.id(),
                         *report_metadata.time(),
                         0,
-                        ReportAggregationState::Waiting(dummy_vdaf::PrepareState::default(), None),
+                        ReportAggregationState::Waiting(
+                            dummy_vdaf::PrepareState::default(),
+                            PrepareMessageOrShare::Helper(()),
+                        ),
                     ))
                     .await
                 })
@@ -6523,7 +6583,10 @@ mod tests {
                         *report_metadata_0.id(),
                         *report_metadata_0.time(),
                         0,
-                        ReportAggregationState::Waiting(dummy_vdaf::PrepareState::default(), None),
+                        ReportAggregationState::Waiting(
+                            dummy_vdaf::PrepareState::default(),
+                            PrepareMessageOrShare::Helper(()),
+                        ),
                     ))
                     .await?;
                     tx.put_report_aggregation(&ReportAggregation::<
@@ -6535,7 +6598,10 @@ mod tests {
                         *report_metadata_1.id(),
                         *report_metadata_1.time(),
                         1,
-                        ReportAggregationState::Waiting(dummy_vdaf::PrepareState::default(), None),
+                        ReportAggregationState::Waiting(
+                            dummy_vdaf::PrepareState::default(),
+                            PrepareMessageOrShare::Helper(()),
+                        ),
                     ))
                     .await
                 })

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -5110,7 +5110,7 @@ mod tests {
             report_metadata_0.id(),
             &0,
         );
-        let prep_state_0 = transcript_0.prep_state(0, Role::Helper);
+        let (prep_state_0, _) = transcript_0.helper_prep_state(0);
         let prep_msg_0 = transcript_0.prepare_messages[0].clone();
         let report_share_0 = generate_helper_report_share::<Prio3Count>(
             *task.id(),
@@ -5136,7 +5136,7 @@ mod tests {
             report_metadata_1.id(),
             &0,
         );
-        let prep_state_1 = transcript_1.prep_state(0, Role::Helper);
+        let (prep_state_1, _) = transcript_1.helper_prep_state(0);
         let report_share_1 = generate_helper_report_share::<Prio3Count>(
             *task.id(),
             report_metadata_1.clone(),
@@ -5164,7 +5164,7 @@ mod tests {
             report_metadata_2.id(),
             &0,
         );
-        let prep_state_2 = transcript_2.prep_state(0, Role::Helper);
+        let (prep_state_2, _) = transcript_2.helper_prep_state(0);
         let prep_msg_2 = transcript_2.prepare_messages[0].clone();
         let report_share_2 = generate_helper_report_share::<Prio3Count>(
             *task.id(),
@@ -5434,7 +5434,7 @@ mod tests {
             report_metadata_0.id(),
             &0,
         );
-        let prep_state_0 = transcript_0.prep_state(0, Role::Helper);
+        let (prep_state_0, _) = transcript_0.helper_prep_state(0);
         let out_share_0 = transcript_0.output_share(Role::Helper);
         let prep_msg_0 = transcript_0.prepare_messages[0].clone();
         let report_share_0 = generate_helper_report_share::<Prio3Count>(
@@ -5462,7 +5462,7 @@ mod tests {
             report_metadata_1.id(),
             &0,
         );
-        let prep_state_1 = transcript_1.prep_state(0, Role::Helper);
+        let (prep_state_1, _) = transcript_1.helper_prep_state(0);
         let out_share_1 = transcript_1.output_share(Role::Helper);
         let prep_msg_1 = transcript_1.prepare_messages[0].clone();
         let report_share_1 = generate_helper_report_share::<Prio3Count>(
@@ -5489,7 +5489,7 @@ mod tests {
             report_metadata_2.id(),
             &0,
         );
-        let prep_state_2 = transcript_2.prep_state(0, Role::Helper);
+        let (prep_state_2, _) = transcript_2.helper_prep_state(0);
         let out_share_2 = transcript_2.output_share(Role::Helper);
         let prep_msg_2 = transcript_2.prepare_messages[0].clone();
         let report_share_2 = generate_helper_report_share::<Prio3Count>(
@@ -5741,7 +5741,7 @@ mod tests {
             report_metadata_3.id(),
             &0,
         );
-        let prep_state_3 = transcript_3.prep_state(0, Role::Helper);
+        let (prep_state_3, _) = transcript_3.helper_prep_state(0);
         let out_share_3 = transcript_3.output_share(Role::Helper);
         let prep_msg_3 = transcript_3.prepare_messages[0].clone();
         let report_share_3 = generate_helper_report_share::<Prio3Count>(
@@ -5768,7 +5768,7 @@ mod tests {
             report_metadata_4.id(),
             &0,
         );
-        let prep_state_4 = transcript_4.prep_state(0, Role::Helper);
+        let (prep_state_4, _) = transcript_4.helper_prep_state(0);
         let out_share_4 = transcript_4.output_share(Role::Helper);
         let prep_msg_4 = transcript_4.prepare_messages[0].clone();
         let report_share_4 = generate_helper_report_share::<Prio3Count>(
@@ -5795,7 +5795,7 @@ mod tests {
             report_metadata_5.id(),
             &0,
         );
-        let prep_state_5 = transcript_5.prep_state(0, Role::Helper);
+        let (prep_state_5, _) = transcript_5.helper_prep_state(0);
         let out_share_5 = transcript_5.output_share(Role::Helper);
         let prep_msg_5 = transcript_5.prepare_messages[0].clone();
         let report_share_5 = generate_helper_report_share::<Prio3Count>(

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -335,6 +335,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
     ) -> anyhow::Result<bool>
     where
         A::PrepareMessage: Send + Sync,
+        A::PrepareShare: Send + Sync,
         A::PrepareState: Send + Sync + Encode,
         A::OutputShare: Send + Sync,
     {
@@ -436,6 +437,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
     ) -> anyhow::Result<bool>
     where
         A::PrepareMessage: Send + Sync,
+        A::PrepareShare: Send + Sync,
         A::PrepareState: Send + Sync + Encode,
         A::OutputShare: Send + Sync,
     {
@@ -633,6 +635,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
     where
         A: vdaf::Aggregator<L, 16> + janus_aggregator_core::VdafHasAggregationParameter,
         A::PrepareMessage: Send + Sync,
+        A::PrepareShare: Send + Sync,
         A::PrepareState: Send + Sync + Encode,
         A::OutputShare: Send + Sync,
         A::AggregationParam: Send + Sync + Eq + std::hash::Hash,

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -945,7 +945,7 @@ mod tests {
         .unwrap();
 
         // Setup: prepare mocked HTTP responses.
-        let helper_vdaf_msg = transcript.helper_prep_share(0);
+        let (_, helper_vdaf_msg) = transcript.helper_prep_state(0);
         let helper_responses = Vec::from([
             (
                 "PUT",
@@ -1216,7 +1216,7 @@ mod tests {
                 report.helper_encrypted_input_share().clone(),
             )]),
         );
-        let helper_vdaf_msg = transcript.helper_prep_share(0);
+        let (_, helper_vdaf_msg) = transcript.helper_prep_state(0);
         let helper_response = AggregationJobResp::new(Vec::from([PrepareStep::new(
             *report.metadata().id(),
             PrepareStepResult::Continued(helper_vdaf_msg.get_encoded()),
@@ -1289,7 +1289,7 @@ mod tests {
                     .unwrap(),
                 AggregationJobState::InProgress,
             );
-        let leader_prep_state = transcript.prep_state(0, Role::Leader).clone();
+        let leader_prep_state = transcript.leader_prep_state(0).clone();
         let prep_msg = transcript.prepare_messages[0].clone();
         let want_report_aggregation = ReportAggregation::<PRIO3_VERIFY_KEY_LENGTH, Prio3Count>::new(
             *task.id(),
@@ -1477,7 +1477,7 @@ mod tests {
                 report.helper_encrypted_input_share().clone(),
             )]),
         );
-        let helper_vdaf_msg = transcript.helper_prep_share(0);
+        let (_, helper_vdaf_msg) = transcript.helper_prep_state(0);
         let helper_response = AggregationJobResp::new(Vec::from([PrepareStep::new(
             *report.metadata().id(),
             PrepareStepResult::Continued(helper_vdaf_msg.get_encoded()),
@@ -1557,7 +1557,7 @@ mod tests {
             *report.metadata().time(),
             0,
             ReportAggregationState::Waiting(
-                transcript.prep_state(0, Role::Leader).clone(),
+                transcript.leader_prep_state(0).clone(),
                 Some(transcript.prepare_messages[0].clone()),
             ),
         );
@@ -1643,7 +1643,7 @@ mod tests {
         );
         let aggregation_job_id = random();
 
-        let leader_prep_state = transcript.prep_state(0, Role::Leader);
+        let leader_prep_state = transcript.leader_prep_state(0);
         let leader_aggregate_share = vdaf
             .aggregate(&(), [transcript.output_share(Role::Leader).clone()])
             .unwrap();
@@ -1927,8 +1927,7 @@ mod tests {
         );
         let batch_id = random();
         let aggregation_job_id = random();
-
-        let leader_prep_state = transcript.prep_state(0, Role::Leader);
+        let leader_prep_state = transcript.leader_prep_state(0);
         let leader_aggregate_share = vdaf
             .aggregate(&(), [transcript.output_share(Role::Leader).clone()])
             .unwrap();

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -6645,7 +6645,7 @@ mod tests {
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
         let verify_key: [u8; PRIO3_VERIFY_KEY_LENGTH] = random();
         let vdaf_transcript = run_vdaf(vdaf.as_ref(), &verify_key, &(), &report_id, &0);
-        let prep_state = vdaf_transcript.prep_state(0, Role::Leader);
+        let prep_state = vdaf_transcript.leader_prep_state(0);
 
         for (ord, state) in [
             ReportAggregationState::<PRIO3_VERIFY_KEY_LENGTH, Prio3Count>::Start,
@@ -6967,7 +6967,7 @@ mod tests {
                 let (task, prep_msg, prep_state, output_share) = (
                     task.clone(),
                     vdaf_transcript.prepare_messages[0].clone(),
-                    vdaf_transcript.prep_state(0, Role::Leader).clone(),
+                    vdaf_transcript.leader_prep_state(0).clone(),
                     vdaf_transcript.output_share(Role::Leader).clone(),
                 );
                 Box::pin(async move {

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -3,8 +3,8 @@
 use self::models::{
     AcquiredAggregationJob, AcquiredCollectionJob, AggregateShareJob, AggregationJob,
     AggregatorRole, BatchAggregation, CollectionJob, CollectionJobState, CollectionJobStateCode,
-    LeaderStoredReport, Lease, LeaseToken, OutstandingBatch, ReportAggregation,
-    ReportAggregationState, ReportAggregationStateCode, SqlInterval,
+    LeaderStoredReport, Lease, LeaseToken, OutstandingBatch, PrepareMessageOrShare,
+    ReportAggregation, ReportAggregationState, ReportAggregationStateCode, SqlInterval,
 };
 #[cfg(feature = "test-util")]
 use crate::VdafHasAggregationParameter;
@@ -1825,9 +1825,21 @@ impl<C: Clock> Transaction<'_, C> {
                         )
                     })?,
                 )?;
-                let prep_msg = prep_msg_bytes
-                    .map(|bytes| A::PrepareMessage::get_decoded_with_param(&prep_state, &bytes))
-                    .transpose()?;
+                let prep_msg_bytes = prep_msg_bytes.ok_or_else(|| {
+                    Error::DbState(
+                        "report aggregation in state WAITING but prep_msg is NULL".to_string(),
+                    )
+                })?;
+                let prep_msg = match role {
+                    Role::Leader => PrepareMessageOrShare::Leader(
+                        A::PrepareMessage::get_decoded_with_param(&prep_state, &prep_msg_bytes)?,
+                    ),
+                    Role::Helper => PrepareMessageOrShare::Helper(
+                        A::PrepareShare::get_decoded_with_param(&prep_state, &prep_msg_bytes)?,
+                    ),
+                    _ => return Err(Error::DbState(format!("unexpected role {role}"))),
+                };
+
                 ReportAggregationState::Waiting(prep_state, prep_msg)
             }
             ReportAggregationStateCode::Finished => {
@@ -4266,6 +4278,7 @@ pub mod models {
     where
         A::PrepareState: PartialEq,
         A::PrepareMessage: PartialEq,
+        A::PrepareShare: PartialEq,
         A::OutputShare: PartialEq,
     {
         fn eq(&self, other: &Self) -> bool {
@@ -4282,7 +4295,77 @@ pub mod models {
     where
         A::PrepareState: Eq,
         A::PrepareMessage: Eq,
+        A::PrepareShare: Eq,
         A::OutputShare: Eq,
+    {
+    }
+
+    /// Represents either a preprocessed VDAF preparation message (for the leader) or a VDAF
+    /// preparation message share (for the helper).
+    #[derive(Clone, Derivative)]
+    #[derivative(Debug)]
+    pub enum PrepareMessageOrShare<const L: usize, A: vdaf::Aggregator<L, 16>> {
+        /// The helper stores a prepare message share
+        Helper(#[derivative(Debug = "ignore")] A::PrepareShare),
+        /// The leader stores a combined prepare message
+        Leader(#[derivative(Debug = "ignore")] A::PrepareMessage),
+    }
+
+    impl<const L: usize, A: vdaf::Aggregator<L, 16>> PrepareMessageOrShare<L, A> {
+        /// Get the leader's preprocessed prepare message, or an error if this is a helper's prepare
+        /// share.
+        pub fn get_leader_prepare_message(&self) -> Result<&A::PrepareMessage, Error>
+        where
+            A::PrepareMessage: Encode,
+        {
+            if let Self::Leader(prep_msg) = self {
+                Ok(prep_msg)
+            } else {
+                Err(Error::InvalidParameter(
+                    "does not contain a prepare message",
+                ))
+            }
+        }
+
+        /// Get the helper's prepare share, or an error if this is a leader's preprocessed prepare
+        /// message.
+        #[cfg(test)]
+        pub(crate) fn get_helper_prepare_share(&self) -> Result<&A::PrepareShare, Error>
+        where
+            A::PrepareShare: Encode,
+        {
+            if let Self::Helper(prep_share) = self {
+                Ok(prep_share)
+            } else {
+                Err(Error::InvalidParameter("does not contain a prepare share"))
+            }
+        }
+    }
+
+    impl<const L: usize, A> PartialEq for PrepareMessageOrShare<L, A>
+    where
+        A: vdaf::Aggregator<L, 16>,
+        A::PrepareShare: PartialEq,
+        A::PrepareMessage: PartialEq,
+    {
+        fn eq(&self, other: &Self) -> bool {
+            match (self, other) {
+                (Self::Helper(self_prep_share), Self::Helper(other_prep_share)) => {
+                    self_prep_share.eq(other_prep_share)
+                }
+                (Self::Leader(self_prep_msg), Self::Leader(other_prep_msg)) => {
+                    self_prep_msg.eq(other_prep_msg)
+                }
+                _ => false,
+            }
+        }
+    }
+
+    impl<const L: usize, A> Eq for PrepareMessageOrShare<L, A>
+    where
+        A: vdaf::Aggregator<L, 16>,
+        A::PrepareShare: Eq,
+        A::PrepareMessage: Eq,
     {
     }
 
@@ -4294,7 +4377,7 @@ pub mod models {
         Start,
         Waiting(
             #[derivative(Debug = "ignore")] A::PrepareState,
-            #[derivative(Debug = "ignore")] Option<A::PrepareMessage>,
+            #[derivative(Debug = "ignore")] PrepareMessageOrShare<L, A>,
         ),
         Finished(#[derivative(Debug = "ignore")] A::OutputShare),
         Failed(ReportShareError),
@@ -4321,12 +4404,18 @@ pub mod models {
         {
             let (prep_state, prep_msg, output_share, report_share_err) = match self {
                 ReportAggregationState::Start => (None, None, None, None),
-                ReportAggregationState::Waiting(prep_state, prep_msg) => (
-                    Some(prep_state.get_encoded()),
-                    prep_msg.as_ref().map(|msg| msg.get_encoded()),
-                    None,
-                    None,
-                ),
+                ReportAggregationState::Waiting(prep_state, prep_msg) => {
+                    let encoded_msg = match prep_msg {
+                        PrepareMessageOrShare::Leader(prep_msg) => prep_msg.get_encoded(),
+                        PrepareMessageOrShare::Helper(prep_share) => prep_share.get_encoded(),
+                    };
+                    (
+                        Some(prep_state.get_encoded()),
+                        Some(encoded_msg),
+                        None,
+                        None,
+                    )
+                }
                 ReportAggregationState::Finished(output_share) => {
                     (None, None, Some(output_share.get_encoded()), None)
                 }
@@ -4374,6 +4463,7 @@ pub mod models {
     where
         A::PrepareState: PartialEq,
         A::PrepareMessage: PartialEq,
+        A::PrepareShare: PartialEq,
         A::OutputShare: PartialEq,
     {
         fn eq(&self, other: &Self) -> bool {
@@ -4397,6 +4487,7 @@ pub mod models {
     where
         A::PrepareState: Eq,
         A::PrepareMessage: Eq,
+        A::PrepareShare: Eq,
         A::OutputShare: Eq,
     {
     }
@@ -5047,8 +5138,8 @@ mod tests {
             models::{
                 AcquiredAggregationJob, AcquiredCollectionJob, AggregateShareJob, AggregationJob,
                 AggregationJobState, BatchAggregation, CollectionJob, CollectionJobState,
-                LeaderStoredReport, Lease, OutstandingBatch, ReportAggregation,
-                ReportAggregationState, SqlInterval,
+                LeaderStoredReport, Lease, OutstandingBatch, PrepareMessageOrShare,
+                ReportAggregation, ReportAggregationState, SqlInterval,
             },
             test_util::{ephemeral_datastore, generate_aead_key},
             Crypter, Datastore, Error, Transaction,
@@ -6645,18 +6736,39 @@ mod tests {
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
         let verify_key: [u8; PRIO3_VERIFY_KEY_LENGTH] = random();
         let vdaf_transcript = run_vdaf(vdaf.as_ref(), &verify_key, &(), &report_id, &0);
-        let prep_state = vdaf_transcript.leader_prep_state(0);
+        let (helper_prep_state, helper_prep_share) = vdaf_transcript.helper_prep_state(0);
+        let leader_prep_state = vdaf_transcript.leader_prep_state(0);
 
-        for (ord, state) in [
-            ReportAggregationState::<PRIO3_VERIFY_KEY_LENGTH, Prio3Count>::Start,
-            ReportAggregationState::Waiting(prep_state.clone(), None),
-            ReportAggregationState::Waiting(
-                prep_state.clone(),
-                Some(vdaf_transcript.prepare_messages[0].clone()),
+        for (ord, (role, state)) in [
+            (
+                Role::Leader,
+                ReportAggregationState::<PRIO3_VERIFY_KEY_LENGTH, Prio3Count>::Start,
             ),
-            ReportAggregationState::Finished(vdaf_transcript.output_share(Role::Leader).clone()),
-            ReportAggregationState::Failed(ReportShareError::VdafPrepError),
-            ReportAggregationState::Invalid,
+            (
+                Role::Helper,
+                ReportAggregationState::Waiting(
+                    helper_prep_state.clone(),
+                    PrepareMessageOrShare::Helper(helper_prep_share.clone()),
+                ),
+            ),
+            (
+                Role::Leader,
+                ReportAggregationState::Waiting(
+                    leader_prep_state.clone(),
+                    PrepareMessageOrShare::Leader(vdaf_transcript.prepare_messages[0].clone()),
+                ),
+            ),
+            (
+                Role::Leader,
+                ReportAggregationState::Finished(
+                    vdaf_transcript.output_share(Role::Leader).clone(),
+                ),
+            ),
+            (
+                Role::Leader,
+                ReportAggregationState::Failed(ReportShareError::VdafPrepError),
+            ),
+            (Role::Leader, ReportAggregationState::Invalid),
         ]
         .into_iter()
         .enumerate()
@@ -6664,7 +6776,7 @@ mod tests {
             let task = TaskBuilder::new(
                 task::QueryType::TimeInterval,
                 VdafInstance::Prio3Count,
-                Role::Leader,
+                role,
             )
             .build();
             let aggregation_job_id = random();
@@ -6728,7 +6840,7 @@ mod tests {
                     Box::pin(async move {
                         tx.get_report_aggregation(
                             vdaf.as_ref(),
-                            &Role::Leader,
+                            &role,
                             task.id(),
                             &aggregation_job_id,
                             &report_id,
@@ -6737,8 +6849,23 @@ mod tests {
                     })
                 })
                 .await
+                .unwrap()
                 .unwrap();
-            assert_eq!(Some(&report_aggregation), got_report_aggregation.as_ref());
+            assert_eq!(report_aggregation, got_report_aggregation);
+
+            if let ReportAggregationState::Waiting(_, message) = got_report_aggregation.state() {
+                match role {
+                    Role::Leader => {
+                        assert!(message.get_leader_prepare_message().is_ok());
+                        assert!(message.get_helper_prepare_share().is_err());
+                    }
+                    Role::Helper => {
+                        assert!(message.get_helper_prepare_share().is_ok());
+                        assert!(message.get_leader_prepare_message().is_err());
+                    }
+                    _ => panic!("unexpected role"),
+                }
+            }
 
             let new_report_aggregation = ReportAggregation::new(
                 *report_aggregation.task_id(),
@@ -6761,7 +6888,7 @@ mod tests {
                     Box::pin(async move {
                         tx.get_report_aggregation(
                             vdaf.as_ref(),
-                            &Role::Leader,
+                            &role,
                             task.id(),
                             &aggregation_job_id,
                             &report_id,
@@ -6990,8 +7117,10 @@ mod tests {
                     let mut report_aggregations = Vec::new();
                     for (ord, state) in [
                         ReportAggregationState::<PRIO3_VERIFY_KEY_LENGTH, Prio3Count>::Start,
-                        ReportAggregationState::Waiting(prep_state.clone(), None),
-                        ReportAggregationState::Waiting(prep_state, Some(prep_msg)),
+                        ReportAggregationState::Waiting(
+                            prep_state.clone(),
+                            PrepareMessageOrShare::Leader(prep_msg),
+                        ),
                         ReportAggregationState::Finished(output_share),
                         ReportAggregationState::Failed(ReportShareError::VdafPrepError),
                         ReportAggregationState::Invalid,
@@ -8824,7 +8953,7 @@ mod tests {
                         1,
                         ReportAggregationState::Waiting(
                             dummy_vdaf::PrepareState::default(),
-                            Some(()),
+                            PrepareMessageOrShare::Leader(()),
                         ), // Counted among max_size.
                     );
                     let report_aggregation_0_2 = ReportAggregation::<0, dummy_vdaf::Vdaf>::new(

--- a/core/src/test_util/mod.rs
+++ b/core/src/test_util/mod.rs
@@ -34,19 +34,19 @@ impl<const L: usize, V> VdafTranscript<L, V>
 where
     V: vdaf::Aggregator<L, 16>,
 {
-    /// Get the VDAF preparation state for the requested round and aggregator.
-    pub fn prep_state(&self, round: usize, role: Role) -> &V::PrepareState {
+    /// Get the leader's preparation state at the requested round.
+    pub fn leader_prep_state(&self, round: usize) -> &V::PrepareState {
         assert_matches!(
-            &self.prepare_transitions[role.index().unwrap()][round],
+            &self.prepare_transitions[Role::Leader.index().unwrap()][round],
             PrepareTransition::<V, L, 16>::Continue(prep_state, _) => prep_state
         )
     }
 
-    /// Get the helper's prepare share at the requested round.
-    pub fn helper_prep_share(&self, round: usize) -> &V::PrepareShare {
+    /// Get the helper's preparation state and prepare share at the requested round.
+    pub fn helper_prep_state(&self, round: usize) -> (&V::PrepareState, &V::PrepareShare) {
         assert_matches!(
             &self.prepare_transitions[Role::Helper.index().unwrap()][round],
-            PrepareTransition::<V, L, 16>::Continue(_, prep_share) => prep_share
+            PrepareTransition::<V, L, 16>::Continue(prep_state, prep_share) => (prep_state, prep_share)
         )
     }
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -136,7 +136,9 @@ CREATE TABLE report_aggregations(
     ord                 BIGINT NOT NULL,                    -- a value used to specify the ordering of client reports in the aggregation job
     state               REPORT_AGGREGATION_STATE NOT NULL,  -- the current state of this report aggregation
     prep_state          BYTEA,                              -- the current preparation state (opaque VDAF message, only if in state WAITING)
-    prep_msg            BYTEA,                              -- the next preparation message to be sent to the helper (opaque VDAF message, only if in state WAITING if this aggregator is the leader)
+    prep_msg            BYTEA,                              -- for the leader, the next preparation message to be sent to the helper (opaque VDAF message)
+                                                            -- for the helper, the next preparation share to be sent to the leader (opaque VDAF message)
+                                                            -- only non-NULL if in state WAITING
     out_share           BYTEA,                              -- the output share (opaque VDAF message, only if in state FINISHED)
     error_code          SMALLINT,                           -- error code corresponding to a DAP ReportShareError value; null if in a state other than FAILED
 


### PR DESCRIPTION
DAP-04 introduces protocol affordances for recovering from round skew. To that end, the helper needs to store the prepare shares from its current round so that it can service replayed aggregation job continuation requests from the leader.

---

I'm working on the changes needed to implement DAP-04 in https://github.com/divviup/janus/pull/731. Since DAP-04 isn't ready yet and in order to reduce the size of the eventual PR wiring up the new HTTP API, I'm teasing out some independent pieces into more digestible PRs.