### PR TITLE
Fix flaky test by changing number of retries

### DIFF
--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -836,7 +836,7 @@ mod tests {
                 CollectReq::<TimeInterval>::MEDIA_TYPE,
             )
             .with_status(500)
-            .expect(3)
+            .expect(1)
             .create();
         let mocked_collect_start_success = mock("POST", "/collect")
             .match_header(
@@ -849,7 +849,7 @@ mod tests {
             .create();
         let mocked_collect_error = mock("GET", "/collect_job/1")
             .with_status(500)
-            .expect(3)
+            .expect(1)
             .create();
         let mocked_collect_accepted = mock("GET", "/collect_job/1")
             .with_status(202)


### PR DESCRIPTION
Mocked responses for two APIs in this test previously returned three errors before returning a successful response. On rare occasions, the 10ms maximum elapsed time limit from `test_http_request_exponential_backoff()` would be exceeded on the third error, and the test would fail. This PR changes the mocks to only return one error before succeeding, which should give us plenty of buffer.