### PR TITLE
Miscellaneous query type-related cleanups

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1056,7 +1056,7 @@ impl VdafOps {
 
             #[cfg(feature = "test-util")]
             (task::QueryType::FixedSize { .. }, VdafOps::Fake(vdaf)) => {
-                Self::handle_aggregate_init_generic::<0, TimeInterval, dummy_vdaf::Vdaf, _>(
+                Self::handle_aggregate_init_generic::<0, FixedSize, dummy_vdaf::Vdaf, _>(
                     datastore,
                     vdaf,
                     aggregate_step_failure_counter,

--- a/aggregator/src/task.rs
+++ b/aggregator/src/task.rs
@@ -698,14 +698,6 @@ pub mod test_util {
             })
         }
 
-        /// Sets the task query type
-        pub fn with_query_type(self, query_type: QueryType) -> Self {
-            Self(Task {
-                query_type,
-                ..self.0
-            })
-        }
-
         /// Sets the task HPKE keys
         pub fn with_hpke_keys(self, hpke_keys: Vec<HpkeKeypair>) -> Self {
             let hpke_keys = hpke_keys

--- a/integration_tests/tests/common/mod.rs
+++ b/integration_tests/tests/common/mod.rs
@@ -29,12 +29,11 @@ pub fn test_task_builders(
 ) -> (HpkePrivateKey, TaskBuilder, TaskBuilder) {
     let endpoint_random_value = hex::encode(random::<[u8; 4]>());
     let collector_keypair = generate_test_hpke_config_and_private_key();
-    let leader_task = TaskBuilder::new(QueryType::TimeInterval, vdaf, Role::Leader)
+    let leader_task = TaskBuilder::new(query_type, vdaf, Role::Leader)
         .with_aggregator_endpoints(Vec::from([
             Url::parse(&format!("http://leader-{endpoint_random_value}:8080/")).unwrap(),
             Url::parse(&format!("http://helper-{endpoint_random_value}:8080/")).unwrap(),
         ]))
-        .with_query_type(query_type)
         .with_min_batch_size(46)
         .with_collector_hpke_config(collector_keypair.config().clone());
     let helper_task = leader_task

--- a/messages/src/bin/dap_decode.rs
+++ b/messages/src/bin/dap_decode.rs
@@ -33,50 +33,70 @@ fn decode_dap_message(message_file: &str, media_type: &MediaType) -> Result<Box<
     let mut message_buf = Vec::new();
     reader.read_to_end(&mut message_buf)?;
 
-    let decoded = match media_type {
-        MediaType::HpkeConfig => Box::new(HpkeConfig::get_decoded(&message_buf)?) as Box<dyn Debug>,
-        MediaType::Report => Box::new(Report::get_decoded(&message_buf)?) as Box<dyn Debug>,
+    let decoded: Box<dyn Debug> = match media_type {
+        MediaType::HpkeConfig => {
+            let message: HpkeConfig = HpkeConfig::get_decoded(&message_buf)?;
+            Box::new(message)
+        }
+        MediaType::Report => {
+            let message: Report = Report::get_decoded(&message_buf)?;
+            Box::new(message)
+        }
         MediaType::AggregateInitializeReq => {
             if let Ok(decoded) = AggregateInitializeReq::<TimeInterval>::get_decoded(&message_buf) {
-                Box::new(decoded) as Box<dyn Debug>
+                let message: AggregateInitializeReq<TimeInterval> = decoded;
+                Box::new(message)
             } else {
-                Box::new(AggregateInitializeReq::<FixedSize>::get_decoded(
-                    &message_buf,
-                )?) as Box<dyn Debug>
+                let message: AggregateInitializeReq<FixedSize> =
+                    AggregateInitializeReq::<FixedSize>::get_decoded(&message_buf)?;
+                Box::new(message)
             }
         }
         MediaType::AggregateInitializeResp => {
-            Box::new(AggregateInitializeResp::get_decoded(&message_buf)?) as Box<dyn Debug>
+            let message: AggregateInitializeResp =
+                AggregateInitializeResp::get_decoded(&message_buf)?;
+            Box::new(message)
         }
         MediaType::AggregateContinueReq => {
-            Box::new(AggregateContinueReq::get_decoded(&message_buf)?) as Box<dyn Debug>
+            let message: AggregateContinueReq = AggregateContinueReq::get_decoded(&message_buf)?;
+            Box::new(message)
         }
         MediaType::AggregateContinueResp => {
-            Box::new(AggregateContinueResp::get_decoded(&message_buf)?) as Box<dyn Debug>
+            let message: AggregateContinueResp = AggregateContinueResp::get_decoded(&message_buf)?;
+            Box::new(message)
         }
         MediaType::AggregateShareReq => {
             if let Ok(decoded) = AggregateShareReq::<TimeInterval>::get_decoded(&message_buf) {
-                Box::new(decoded) as Box<dyn Debug>
+                let message: AggregateShareReq<TimeInterval> = decoded;
+                Box::new(message)
             } else {
-                Box::new(AggregateShareReq::<FixedSize>::get_decoded(&message_buf)?)
-                    as Box<dyn Debug>
+                let message: AggregateShareReq<FixedSize> =
+                    AggregateShareReq::<FixedSize>::get_decoded(&message_buf)?;
+                Box::new(message)
             }
         }
         MediaType::AggregateShareResp => {
-            Box::new(AggregateShareResp::get_decoded(&message_buf)?) as Box<dyn Debug>
+            let message: AggregateShareResp = AggregateShareResp::get_decoded(&message_buf)?;
+            Box::new(message)
         }
         MediaType::CollectReq => {
             if let Ok(decoded) = CollectReq::<TimeInterval>::get_decoded(&message_buf) {
-                Box::new(decoded) as Box<dyn Debug>
+                let message: CollectReq<TimeInterval> = decoded;
+                Box::new(message)
             } else {
-                Box::new(CollectReq::<FixedSize>::get_decoded(&message_buf)?) as Box<dyn Debug>
+                let message: CollectReq<FixedSize> =
+                    CollectReq::<FixedSize>::get_decoded(&message_buf)?;
+                Box::new(message)
             }
         }
         MediaType::CollectResp => {
             if let Ok(decoded) = CollectResp::<TimeInterval>::get_decoded(&message_buf) {
-                Box::new(decoded) as Box<dyn Debug>
+                let message: CollectResp<TimeInterval> = decoded;
+                Box::new(message)
             } else {
-                Box::new(CollectResp::<FixedSize>::get_decoded(&message_buf)?) as Box<dyn Debug>
+                let message: CollectResp<FixedSize> =
+                    CollectResp::<FixedSize>::get_decoded(&message_buf)?;
+                Box::new(message)
             }
         }
     };

--- a/messages/src/bin/dap_decode.rs
+++ b/messages/src/bin/dap_decode.rs
@@ -58,7 +58,7 @@ fn decode_dap_message(message_file: &str, media_type: &MediaType) -> Result<Box<
             if let Ok(decoded) = AggregateShareReq::<TimeInterval>::get_decoded(&message_buf) {
                 Box::new(decoded) as Box<dyn Debug>
             } else {
-                Box::new(AggregateShareReq::<FixedSize>::get_decoded(&message_buf))
+                Box::new(AggregateShareReq::<FixedSize>::get_decoded(&message_buf)?)
                     as Box<dyn Debug>
             }
         }


### PR DESCRIPTION
I reviewed the codebase to check that we have parity between the two query types, and I came up with three small cleanups to make.

- `/aggregate` was broken for fixed size queries with the dummy VDAF.
- `test_task_builders()` can be slightly simplified now that `TaskBuilder::new()` takes the query type.
- `dap_decode` would have output an extra `Ok(...)` around one particular message type.