### PR TITLE
Reject uploaded reports past expiry age (0.2)

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1297,6 +1297,18 @@ impl VdafOps {
             ));
         }
 
+        // Reject reports that would be eligible for garbage collection, to prevent replay attacks.
+        if let Some(report_expiry_age) = task.report_expiry_age() {
+            let report_expiry_time = report.metadata().time().add(report_expiry_age)?;
+            if clock.now().is_after(&report_expiry_time) {
+                return Err(Error::ReportTooLate(
+                    *report.task_id(),
+                    *report.metadata().id(),
+                    *report.metadata().time(),
+                ));
+            }
+        }
+
         // Decode (and in the case of the leader input share, decrypt) the remaining fields of the
         // report before storing them in the datastore. The spec does not require the /upload
         // handler to do this, but it exercises HPKE decryption, saves us the trouble of storing
@@ -3551,11 +3563,13 @@ mod tests {
     async fn upload_filter() {
         install_test_trace_subscriber();
 
+        const REPORT_EXPIRY_AGE: u64 = 1_000_000;
         let task = TaskBuilder::new(
             QueryType::TimeInterval,
             VdafInstance::Prio3Aes128Count,
             Role::Leader,
         )
+        .with_report_expiry_age(Some(Duration::from_seconds(REPORT_EXPIRY_AGE)))
         .build();
         let clock = MockClock::default();
         let (datastore, _db_handle) = ephemeral_datastore(clock.clone()).await;
@@ -3579,6 +3593,44 @@ mod tests {
         let mut response = drive_filter(Method::POST, "/upload", &report.get_encoded(), &filter)
             .await
             .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let problem_details: serde_json::Value =
+            serde_json::from_slice(&body::to_bytes(response.body_mut()).await.unwrap()).unwrap();
+        assert_eq!(
+            problem_details,
+            json!({
+                "status": 400u16,
+                "type": "urn:ietf:params:ppm:dap:error:reportTooLate",
+                "title": "Report could not be processed because it arrived too late.",
+                "detail": "Report could not be processed because it arrived too late.",
+                "instance": "..",
+                "taskid": format!("{}", report.task_id()),
+            })
+        );
+
+        // Confirm that reports older than the report expiry age are rejected with the
+        // reportTooLate error type.
+        let gc_eligible_report = Report::new(
+            *report.task_id(),
+            ReportMetadata::new(
+                random(),
+                clock
+                    .now()
+                    .sub(&Duration::from_seconds(REPORT_EXPIRY_AGE + 30000))
+                    .unwrap(),
+                Vec::new(),
+            ),
+            report.public_share().to_vec(),
+            report.encrypted_input_shares().to_vec(),
+        );
+        let mut response = drive_filter(
+            Method::POST,
+            "/upload",
+            &gc_eligible_report.get_encoded(),
+            &filter,
+        )
+        .await
+        .unwrap();
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         let problem_details: serde_json::Value =
             serde_json::from_slice(&body::to_bytes(response.body_mut()).await.unwrap()).unwrap();


### PR DESCRIPTION
This is a follow-up to #894, changing `/upload` to reject reports with `...:reportTooLate` if the given task has a report expiry age configured, and the report is older than that age. We need to check for this because otherwise an attacker could re-upload the same report multiple times once it's old enough to be garbage collected, and race collections against the garbage collector to get around anti-replay protections.