### PR TITLE
`integration_tests`: don't panic in panic handler

### DIFF
--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -197,7 +197,7 @@ impl<'a> Drop for Janus<'a> {
             }
             if let Some(mut destination_path) = log_export_path() {
                 destination_path.push(format!("{}-{}", role, container.id()));
-                let docker_cp_status = Command::new("docker")
+                if let Ok(docker_cp_status) = Command::new("docker")
                     .args([
                         "cp",
                         &format!("{}:logs/", container.id()),
@@ -207,11 +207,13 @@ impl<'a> Drop for Janus<'a> {
                     .stdout(Stdio::null())
                     .stderr(Stdio::null())
                     .status()
-                    .expect("Failed to execute `docker cp`");
-                assert!(
-                    docker_cp_status.success(),
-                    "`docker cp` failed with status {docker_cp_status:?}"
-                );
+                {
+                    if !docker_cp_status.success() {
+                        println!("`docker cp` failed with status {docker_cp_status:?}");
+                    }
+                } else {
+                    println!("Failed to execute `docker cp`");
+                }
             }
         }
     }


### PR DESCRIPTION
The `Drop` implementation on `integration_tests::janus::Janus` tries to copy logs out of interop test containers using `docker cp`. It would panic if that failed, which would result in a double panic (because test failures in `cargo test` are panics), and that would cause output from failing tests to be lost, making it hard to diagnose failures.

With this change, we no longer panic if either we can't `exec(2)` `docker` or if `docker cp` fails. Instead, the errors get printed to stdout so at least they will appear in GitHub Actions logs, as will some information about the test that failed.

Example test failure _without_ this change:
https://github.com/divviup/janus/actions/runs/4010819099/jobs/6887739020

Example test failure _with_ this change:
https://github.com/divviup/janus/actions/runs/4011174836/jobs/6888472737