### PR TITLE
cargo clippy --fix, 1.67, 0.2 backport

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -2744,7 +2744,7 @@ fn build_problem_details_response(error_type: DapProblemType, task_id: Option<Ta
                 // the instance member, thus ".." will always refer to the aggregator's endpoint,
                 // as required by §3.2.
                 "instance": "..",
-                "taskid": task_id.map(|tid| format!("{}", tid)),
+                "taskid": task_id.map(|tid| format!("{tid}")),
             })),
             http::header::CONTENT_TYPE,
             PROBLEM_DETAILS_JSON_MEDIA_TYPE,
@@ -2945,7 +2945,7 @@ pub fn aggregator_filter<C: Clock>(
                     .header(CACHE_CONTROL, "max-age=86400")
                     .header(CONTENT_TYPE, HpkeConfig::MEDIA_TYPE)
                     .body(hpke_config_bytes)
-                    .map_err(|err| Error::Internal(format!("couldn't produce response: {}", err)))
+                    .map_err(|err| Error::Internal(format!("couldn't produce response: {err}")))
             },
         );
     let hpke_config_endpoint = compose_common_wrappers(
@@ -3011,7 +3011,7 @@ pub fn aggregator_filter<C: Clock>(
                         .status(StatusCode::UNSUPPORTED_MEDIA_TYPE)
                         .body(Vec::new()),
                 }
-                .map_err(|err| Error::Internal(format!("couldn't produce response: {}", err)))
+                .map_err(|err| Error::Internal(format!("couldn't produce response: {err}")))
             },
         );
     let aggregate_endpoint = compose_common_wrappers(
@@ -3069,7 +3069,7 @@ pub fn aggregator_filter<C: Clock>(
                             .status(StatusCode::ACCEPTED)
                             .body(Vec::new()),
                     }
-                    .map_err(|err| Error::Internal(format!("couldn't produce response: {}", err)))
+                    .map_err(|err| Error::Internal(format!("couldn't produce response: {err}")))
                 },
             );
     let collect_jobs_get_endpoint = compose_common_wrappers(
@@ -3118,7 +3118,7 @@ pub fn aggregator_filter<C: Clock>(
                 http::Response::builder()
                     .header(CONTENT_TYPE, AggregateShareResp::MEDIA_TYPE)
                     .body(resp_bytes)
-                    .map_err(|err| Error::Internal(format!("couldn't produce response: {}", err)))
+                    .map_err(|err| Error::Internal(format!("couldn't produce response: {err}")))
             },
         );
     let aggregate_share_endpoint = compose_common_wrappers(
@@ -6832,7 +6832,7 @@ mod tests {
         // Incorrect authentication token.
         let mut response = warp::test::request()
             .method("GET")
-            .path(&format!("/collect_jobs/{}", collect_job_id))
+            .path(&format!("/collect_jobs/{collect_job_id}"))
             .header("DAP-Auth-Token", random::<AuthenticationToken>().as_bytes())
             .filter(&filter)
             .await
@@ -6858,7 +6858,7 @@ mod tests {
         // Aggregator authentication token.
         let mut response = warp::test::request()
             .method("GET")
-            .path(&format!("/collect_jobs/{}", collect_job_id))
+            .path(&format!("/collect_jobs/{collect_job_id}"))
             .header(
                 "DAP-Auth-Token",
                 task.primary_aggregator_auth_token().as_bytes(),
@@ -6887,7 +6887,7 @@ mod tests {
         // Missing authentication token.
         let mut response = warp::test::request()
             .method("GET")
-            .path(&format!("/collect_jobs/{}", collect_job_id))
+            .path(&format!("/collect_jobs/{collect_job_id}"))
             .filter(&filter)
             .await
             .unwrap()
@@ -6970,7 +6970,7 @@ mod tests {
 
         let collect_job_response = warp::test::request()
             .method("GET")
-            .path(&format!("/collect_jobs/{}", collect_job_id))
+            .path(&format!("/collect_jobs/{collect_job_id}"))
             .header(
                 "DAP-Auth-Token",
                 task.primary_collector_auth_token().as_bytes(),
@@ -7029,7 +7029,7 @@ mod tests {
 
         let (parts, body) = warp::test::request()
             .method("GET")
-            .path(&format!("/collect_jobs/{}", collect_job_id))
+            .path(&format!("/collect_jobs/{collect_job_id}"))
             .header(
                 "DAP-Auth-Token",
                 task.primary_collector_auth_token().as_bytes(),
@@ -7838,16 +7838,12 @@ mod tests {
                 assert_eq!(
                     parts.status,
                     StatusCode::OK,
-                    "test case: {:?}, iteration: {}",
-                    label,
-                    iteration
+                    "test case: {label:?}, iteration: {iteration}"
                 );
                 assert_eq!(
                     parts.headers.get(CONTENT_TYPE).unwrap(),
                     AggregateShareResp::MEDIA_TYPE,
-                    "test case: {:?}, iteration: {}",
-                    label,
-                    iteration
+                    "test case: {label:?}, iteration: {iteration}"
                 );
                 let body_bytes = body::to_bytes(body).await.unwrap();
                 let aggregate_share_resp = AggregateShareResp::get_decoded(&body_bytes).unwrap();
@@ -7873,8 +7869,7 @@ mod tests {
                     dummy_vdaf::AggregateShare::try_from(aggregate_share.as_ref()).unwrap();
                 assert_eq!(
                     decoded_aggregate_share, expected_result,
-                    "test case: {:?}, iteration: {}",
-                    label, iteration
+                    "test case: {label:?}, iteration: {iteration}"
                 );
             }
         }

--- a/aggregator/src/bin/janus_cli.rs
+++ b/aggregator/src/bin/janus_cli.rs
@@ -183,9 +183,9 @@ async fn provision_tasks<C: Clock>(
     let tasks: Vec<SerializedTask> = {
         let task_file_contents = fs::read_to_string(tasks_file)
             .await
-            .with_context(|| format!("couldn't read tasks file {:?}", tasks_file))?;
+            .with_context(|| format!("couldn't read tasks file {tasks_file:?}"))?;
         serde_yaml::from_str(&task_file_contents)
-            .with_context(|| format!("couldn't parse tasks file {:?}", tasks_file))?
+            .with_context(|| format!("couldn't parse tasks file {tasks_file:?}"))?
     };
 
     let tasks: Vec<Task> = tasks

--- a/aggregator/src/datastore.rs
+++ b/aggregator/src/datastore.rs
@@ -1717,10 +1717,10 @@ impl<C: Clock> Transaction<'_, C> {
         let error_code = match error_code {
             Some(c) => {
                 let c: u8 = c.try_into().map_err(|err| {
-                    Error::DbState(format!("couldn't convert error_code value: {0}", err))
+                    Error::DbState(format!("couldn't convert error_code value: {err}"))
                 })?;
                 Some(c.try_into().map_err(|err| {
-                    Error::DbState(format!("couldn't convert error_code value: {0}", err))
+                    Error::DbState(format!("couldn't convert error_code value: {err}"))
                 })?)
             }
             None => None,
@@ -2141,8 +2141,7 @@ impl<C: Clock> Transaction<'_, C> {
                 )
                 .map_err(|err| {
                     Error::DbState(format!(
-                        "leader_aggregate_share stored in database is invalid: {:?}",
-                        err
+                        "leader_aggregate_share stored in database is invalid: {err:?}"
                     ))
                 })?;
                 CollectJobState::Finished {
@@ -3174,8 +3173,7 @@ fn check_single_row_mutation(row_count: u64) -> Result<(), Error> {
         0 => Err(Error::MutationTargetNotFound),
         1 => Ok(()),
         _ => panic!(
-            "update which should have affected at most one row instead affected {} rows",
-            row_count
+            "update which should have affected at most one row instead affected {row_count} rows"
         ),
     }
 }
@@ -3251,9 +3249,8 @@ impl RowExt for Row {
         for<'a> <T as TryFrom<&'a [u8]>>::Error: std::fmt::Debug,
     {
         let encoded: Vec<u8> = self.try_get(idx)?;
-        T::try_from(&encoded).map_err(|err| {
-            Error::DbState(format!("{} stored in database is invalid: {:?}", idx, err))
-        })
+        T::try_from(&encoded)
+            .map_err(|err| Error::DbState(format!("{idx} stored in database is invalid: {err:?}")))
     }
 }
 
@@ -5039,10 +5036,8 @@ pub mod test_util {
         // Compute the Postgres connection string.
         const POSTGRES_DEFAULT_PORT: u16 = 5432;
         let port_number = db_container.get_host_port_ipv4(POSTGRES_DEFAULT_PORT);
-        let connection_string = format!(
-            "postgres://postgres:postgres@127.0.0.1:{}/postgres",
-            port_number,
-        );
+        let connection_string =
+            format!("postgres://postgres:postgres@127.0.0.1:{port_number}/postgres");
         trace!("Postgres container is up with URL {}", connection_string);
 
         // Create a random (ephemeral) key.
@@ -8489,7 +8484,7 @@ mod tests {
                     )
                     .await?;
 
-                assert_eq!(batch_aggregations.len(), 3, "{:#?}", batch_aggregations);
+                assert_eq!(batch_aggregations.len(), 3, "{batch_aggregations:#?}");
                 for batch_aggregation in [
                     &first_batch_aggregation,
                     &second_batch_aggregation,
@@ -8497,8 +8492,7 @@ mod tests {
                 ] {
                     assert!(
                         batch_aggregations.contains(batch_aggregation),
-                        "{:#?}",
-                        batch_aggregations
+                        "{batch_aggregations:#?}"
                     );
                 }
 
@@ -8531,7 +8525,7 @@ mod tests {
                     )
                     .await?;
 
-                assert_eq!(batch_aggregations.len(), 3, "{:#?}", batch_aggregations);
+                assert_eq!(batch_aggregations.len(), 3, "{batch_aggregations:#?}");
                 for batch_aggregation in [
                     &first_batch_aggregation,
                     &second_batch_aggregation,
@@ -8539,8 +8533,7 @@ mod tests {
                 ] {
                     assert!(
                         batch_aggregations.contains(batch_aggregation),
-                        "{:#?}",
-                        batch_aggregations
+                        "{batch_aggregations:#?}"
                     );
                 }
 

--- a/aggregator/src/task.rs
+++ b/aggregator/src/task.rs
@@ -359,7 +359,7 @@ impl Task {
 fn fmt_vector_of_urls(urls: &Vec<Url>, f: &mut Formatter<'_>) -> fmt::Result {
     let mut list = f.debug_list();
     for url in urls {
-        list.entry(&format!("{}", url));
+        list.entry(&format!("{url}"));
     }
     list.finish()
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -135,7 +135,7 @@ impl ClientParameters {
 fn fmt_vector_of_urls(urls: &Vec<Url>, f: &mut Formatter<'_>) -> fmt::Result {
     let mut list = f.debug_list();
     for url in urls {
-        list.entry(&format!("{}", url));
+        list.entry(&format!("{url}"));
     }
     list.finish()
 }

--- a/integration_tests/src/client.rs
+++ b/integration_tests/src/client.rs
@@ -81,7 +81,7 @@ fn json_encode_vdaf(vdaf: &VdafInstance) -> Value {
                 "buckets": buckets,
             })
         }
-        _ => panic!("VDAF {:?} is not yet supported", vdaf),
+        _ => panic!("VDAF {vdaf:?} is not yet supported"),
     }
 }
 

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -77,7 +77,7 @@ impl<'a> Janus<'a> {
         // Write the given task to the Janus instance we started.
         let http_client = reqwest::Client::default();
         let resp = http_client
-            .post(Url::parse(&format!("http://127.0.0.1:{}/internal/test/add_task", port)).unwrap())
+            .post(Url::parse(&format!("http://127.0.0.1:{port}/internal/test/add_task")).unwrap())
             .json(&AggregatorAddTaskRequest::from(task.clone()))
             .send()
             .await
@@ -92,8 +92,7 @@ impl<'a> Janus<'a> {
         );
 
         let fetch_batch_ids_url = Url::parse(&format!(
-            "http://127.0.0.1:{}/internal/test/fetch_batch_ids",
-            port
+            "http://127.0.0.1:{port}/internal/test/fetch_batch_ids"
         ))
         .unwrap();
         let batch_discovery = Arc::new(JanusContainerBatchFetch {

--- a/interop_binaries/src/bin/janus_interop_aggregator.rs
+++ b/interop_binaries/src/bin/janus_interop_aggregator.rs
@@ -228,7 +228,7 @@ fn make_filter(
                     },
                     Err(e) => AddTaskResponse {
                         status: ERROR.to_string(),
-                        error: Some(format!("{:?}", e)),
+                        error: Some(format!("{e:?}")),
                     },
                 };
                 warp::reply::with_status(warp::reply::json(&response), StatusCode::OK)
@@ -255,7 +255,7 @@ fn make_filter(
                         },
                         Err(e) => FetchBatchIdsResponse {
                             status: ERROR,
-                            error: Some(format!("{:?}", e)),
+                            error: Some(format!("{e:?}")),
                             batch_ids: None,
                         },
                     };

--- a/interop_binaries/src/bin/janus_interop_client.rs
+++ b/interop_binaries/src/bin/janus_interop_client.rs
@@ -177,7 +177,7 @@ async fn handle_upload(
             handle_upload_generic(http_client, vdaf_client, request, measurement).await?;
         }
 
-        _ => panic!("Unsupported VDAF: {:?}", vdaf_instance),
+        _ => panic!("Unsupported VDAF: {vdaf_instance:?}"),
     }
     Ok(())
 }
@@ -202,7 +202,7 @@ fn make_filter() -> anyhow::Result<impl Filter<Extract = (Response,)> + Clone> {
                         },
                         Err(e) => UploadResponse {
                             status: ERROR,
-                            error: Some(format!("{:?}", e)),
+                            error: Some(format!("{e:?}")),
                         },
                     };
                     warp::reply::with_status(warp::reply::json(&response), StatusCode::OK)

--- a/interop_binaries/src/bin/janus_interop_collector.rs
+++ b/interop_binaries/src/bin/janus_interop_collector.rs
@@ -394,7 +394,7 @@ async fn handle_collect_start(
             .await?
         }
 
-        (_, vdaf_instance) => panic!("Unsupported VDAF: {:?}", vdaf_instance),
+        (_, vdaf_instance) => panic!("Unsupported VDAF: {vdaf_instance:?}"),
     };
 
     let mut collect_jobs_guard = collect_jobs.lock().await;
@@ -488,7 +488,7 @@ fn make_filter() -> anyhow::Result<impl Filter<Extract = (Response,)> + Clone> {
                     },
                     Err(e) => AddTaskResponse {
                         status: ERROR,
-                        error: Some(format!("{:?}", e)),
+                        error: Some(format!("{e:?}")),
                         collector_hpke_config: None,
                     },
                 };
@@ -517,7 +517,7 @@ fn make_filter() -> anyhow::Result<impl Filter<Extract = (Response,)> + Clone> {
                             },
                             Err(e) => CollectStartResponse {
                                 status: ERROR,
-                                error: Some(format!("{:?}", e)),
+                                error: Some(format!("{e:?}")),
                                 handle: None,
                             },
                         };
@@ -545,7 +545,7 @@ fn make_filter() -> anyhow::Result<impl Filter<Extract = (Response,)> + Clone> {
                     },
                     Err(e) => CollectPollResponse {
                         status: ERROR,
-                        error: Some(format!("{:?}", e)),
+                        error: Some(format!("{e:?}")),
                         report_count: None,
                         result: None,
                     },

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -93,7 +93,7 @@ where
     {
         let number = value
             .parse()
-            .map_err(|err| E::custom(format!("string could not be parsed into number: {}", err)))?;
+            .map_err(|err| E::custom(format!("string could not be parsed into number: {err}")))?;
         Ok(NumberAsString(number))
     }
 }
@@ -124,7 +124,7 @@ impl From<VdafInstance> for VdafObject {
                 buckets: buckets.iter().copied().map(NumberAsString).collect(),
             },
 
-            _ => panic!("Unsupported VDAF: {:?}", vdaf),
+            _ => panic!("Unsupported VDAF: {vdaf:?}"),
         }
     }
 }
@@ -361,7 +361,7 @@ impl<'d, I: Image> Drop for ContainerLogsDropGuard<'d, I> {
 
             let copy_status = Command::new("docker")
                 .arg("cp")
-                .arg(format!("{}:/logs", id))
+                .arg(format!("{id}:/logs"))
                 .arg(destination)
                 .status()
                 .expect("running `docker cp` failed");


### PR DESCRIPTION
This makes some mechanical changes to format strings, to fix clippy lints.