### PR TITLE
Add a name to transactions for metrics, 0.2 backport

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -130,7 +130,9 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
             let start = Instant::now();
             let tasks = self
                 .datastore
-                .run_tx(|tx| Box::pin(async move { tx.get_tasks().await }))
+                .run_tx_with_name("aggregation_job_creator_get_tasks", |tx| {
+                    Box::pin(async move { tx.get_tasks().await })
+                })
                 .await;
             let tasks = match tasks {
                 Ok(tasks) => tasks
@@ -303,7 +305,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
     {
         Ok(self
             .datastore
-            .run_tx(|tx| {
+            .run_tx_with_name("aggregation_job_creator_time_no_param", |tx| {
                 let (this, task) = (Arc::clone(&self), Arc::clone(&task));
                 Box::pin(async move {
                     let current_batch_start = this
@@ -413,7 +415,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
         );
         Ok(self
             .datastore
-            .run_tx(|tx| {
+            .run_tx_with_name("aggregation_job_creator_fixed_no_param", |tx| {
                 let (this, task) = (Arc::clone(&self), Arc::clone(&task));
                 Box::pin(async move {
                     // Find unaggregated client reports & existing unfilled batches.
@@ -584,7 +586,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
         let max_aggregation_job_size = self.max_aggregation_job_size;
 
         self.datastore
-            .run_tx(|tx| {
+            .run_tx_with_name("aggregation_job_creator_time_with_param", |tx| {
                 let task = Arc::clone(&task);
                 Box::pin(async move {
                     // Find some client reports that are covered by a collect request, but haven't

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -168,7 +168,7 @@ impl AggregationJobDriver {
     {
         // Read all information about the aggregation job.
         let (task, aggregation_job, report_aggregations, client_reports, verify_key) = datastore
-            .run_tx(|tx| {
+            .run_tx_with_name("step_aggregation_job_1", |tx| {
                 let (lease, vdaf) = (Arc::clone(&lease), Arc::clone(&vdaf));
                 Box::pin(async move {
                     let task = tx
@@ -659,7 +659,7 @@ impl AggregationJobDriver {
         let aggregation_job_to_write = Arc::new(aggregation_job_to_write);
         let accumulator = Arc::new(accumulator);
         datastore
-            .run_tx(|tx| {
+            .run_tx_with_name("step_aggregation_job_2", |tx| {
                 let (report_aggregations_to_write, aggregation_job_to_write, accumulator, lease) = (
                     Arc::clone(&report_aggregations_to_write),
                     Arc::clone(&aggregation_job_to_write),
@@ -763,7 +763,7 @@ impl AggregationJobDriver {
     {
         let lease = Arc::new(lease);
         datastore
-            .run_tx(|tx| {
+            .run_tx_with_name("cancel_aggregation_job", |tx| {
                 let lease = Arc::clone(&lease);
                 Box::pin(async move {
                     let aggregation_job = tx
@@ -809,7 +809,7 @@ impl AggregationJobDriver {
             let datastore = Arc::clone(&datastore);
             Box::pin(async move {
                 datastore
-                    .run_tx(|tx| {
+                    .run_tx_with_name("acquire_aggregation_jobs", |tx| {
                         Box::pin(async move {
                             tx.acquire_incomplete_aggregation_jobs(
                                 &lease_duration,

--- a/aggregator/src/aggregator/collect_job_driver.rs
+++ b/aggregator/src/aggregator/collect_job_driver.rs
@@ -183,7 +183,7 @@ impl CollectJobDriver {
         for<'a> &'a A::OutputShare: Into<Vec<u8>>,
     {
         let (task, collect_job, batch_aggregations) = datastore
-            .run_tx(|tx| {
+            .run_tx_with_name("step_collect_job_1", |tx| {
                 let lease = Arc::clone(&lease);
                 Box::pin(async move {
                     // TODO(#224): Consider fleshing out `AcquiredCollectJob` to include a `Task`,
@@ -265,7 +265,7 @@ impl CollectJobDriver {
             }),
         );
         datastore
-            .run_tx(|tx| {
+            .run_tx_with_name("step_collect_job_2", |tx| {
                 let (lease, collect_job) = (Arc::clone(&lease), Arc::clone(&collect_job));
                 let metrics = self.metrics.clone();
 
@@ -429,7 +429,7 @@ impl CollectJobDriver {
     {
         let lease = Arc::new(lease);
         datastore
-            .run_tx(|tx| {
+            .run_tx_with_name("abandon_collect_job", |tx| {
                 let lease = Arc::clone(&lease);
                 Box::pin(async move {
                     let collect_job = tx
@@ -463,7 +463,7 @@ impl CollectJobDriver {
             let datastore = Arc::clone(&datastore);
             Box::pin(async move {
                 datastore
-                    .run_tx(|tx| {
+                    .run_tx_with_name("acquire_collect_jobs", |tx| {
                         Box::pin(async move {
                             let (time_interval_jobs, fixed_size_jobs) = try_join!(
                                 tx.acquire_incomplete_time_interval_collect_jobs(

--- a/aggregator/src/aggregator/garbage_collector.rs
+++ b/aggregator/src/aggregator/garbage_collector.rs
@@ -29,7 +29,9 @@ impl<C: Clock> GarbageCollector<C> {
         // Retrieve tasks.
         let tasks = self
             .datastore
-            .run_tx(|tx| Box::pin(async move { tx.get_tasks().await }))
+            .run_tx_with_name("garbage_collector_get_tasks", |tx| {
+                Box::pin(async move { tx.get_tasks().await })
+            })
             .await
             .context("couldn't retrieve tasks")?;
 
@@ -59,7 +61,7 @@ impl<C: Clock> GarbageCollector<C> {
             };
 
         self.datastore
-            .run_tx(|tx| {
+            .run_tx_with_name("gc_task", |tx| {
                 let task = Arc::clone(&task);
                 Box::pin(async move {
                     // Find and delete old collect jobs.


### PR DESCRIPTION
This backports #937 to the 0.2 release branch. I'm backporting this because I'd like to see this metrics refinement in load tests of 0.2.