### PR TITLE
Remove janus_message time types from job drivers

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -23,8 +23,7 @@ use janus_core::{task::VdafInstance, time::Clock};
 use janus_messages::{
     query_type::{FixedSize, TimeInterval},
     AggregateContinueReq, AggregateContinueResp, AggregateInitializeReq, AggregateInitializeResp,
-    Duration, PartialBatchSelector, PrepareStep, PrepareStepResult, ReportShare, ReportShareError,
-    Role,
+    PartialBatchSelector, PrepareStep, PrepareStepResult, ReportShare, ReportShareError, Role,
 };
 use opentelemetry::{
     metrics::{Counter, Histogram, Meter, Unit},
@@ -43,7 +42,7 @@ use prio::{
         PrepareTransition,
     },
 };
-use std::{collections::HashSet, fmt, sync::Arc};
+use std::{collections::HashSet, fmt, sync::Arc, time::Duration};
 use tracing::{info, warn};
 
 #[derive(Derivative)]
@@ -1025,7 +1024,7 @@ mod tests {
     };
     use rand::random;
     use reqwest::Url;
-    use std::{str, sync::Arc};
+    use std::{str, sync::Arc, time::Duration as StdDuration};
 
     #[tokio::test]
     async fn aggregation_job_driver() {
@@ -1164,13 +1163,13 @@ mod tests {
             clock,
             runtime_manager.with_label("stepper"),
             meter,
-            Duration::from_seconds(1),
-            Duration::from_seconds(1),
+            StdDuration::from_secs(1),
+            StdDuration::from_secs(1),
             10,
-            Duration::from_seconds(60),
+            StdDuration::from_secs(60),
             aggregation_job_driver.make_incomplete_job_acquirer_callback(
                 Arc::clone(&ds),
-                Duration::from_seconds(600),
+                StdDuration::from_secs(600),
             ),
             aggregation_job_driver.make_job_stepper_callback(Arc::clone(&ds), 5),
         ));
@@ -1352,7 +1351,7 @@ mod tests {
                     .await?;
 
                     Ok(tx
-                        .acquire_incomplete_aggregation_jobs(&Duration::from_seconds(60), 1)
+                        .acquire_incomplete_aggregation_jobs(&StdDuration::from_secs(60), 1)
                         .await?
                         .remove(0))
                 })
@@ -1576,7 +1575,7 @@ mod tests {
                     .await?;
 
                     Ok(tx
-                        .acquire_incomplete_aggregation_jobs(&Duration::from_seconds(60), 1)
+                        .acquire_incomplete_aggregation_jobs(&StdDuration::from_secs(60), 1)
                         .await?
                         .remove(0))
                 })
@@ -1796,7 +1795,7 @@ mod tests {
                     .await?;
 
                     Ok(tx
-                        .acquire_incomplete_aggregation_jobs(&Duration::from_seconds(60), 1)
+                        .acquire_incomplete_aggregation_jobs(&StdDuration::from_secs(60), 1)
                         .await?
                         .remove(0))
                 })
@@ -2033,7 +2032,7 @@ mod tests {
                     .await?;
 
                     Ok(tx
-                        .acquire_incomplete_aggregation_jobs(&Duration::from_seconds(60), 1)
+                        .acquire_incomplete_aggregation_jobs(&StdDuration::from_secs(60), 1)
                         .await?
                         .remove(0))
                 })
@@ -2249,7 +2248,7 @@ mod tests {
                     tx.put_report_aggregation(&report_aggregation).await?;
 
                     Ok(tx
-                        .acquire_incomplete_aggregation_jobs(&Duration::from_seconds(60), 1)
+                        .acquire_incomplete_aggregation_jobs(&StdDuration::from_secs(60), 1)
                         .await?
                         .remove(0))
                 })
@@ -2297,7 +2296,7 @@ mod tests {
                         .await?
                         .unwrap();
                     let leases = tx
-                        .acquire_incomplete_aggregation_jobs(&Duration::from_seconds(60), 1)
+                        .acquire_incomplete_aggregation_jobs(&StdDuration::from_secs(60), 1)
                         .await?;
                     Ok((aggregation_job, report_aggregation, leases))
                 })
@@ -2449,13 +2448,13 @@ mod tests {
             clock.clone(),
             runtime_manager.with_label("stepper"),
             meter,
-            Duration::from_seconds(1),
-            Duration::from_seconds(1),
+            StdDuration::from_secs(1),
+            StdDuration::from_secs(1),
             10,
-            Duration::from_seconds(60),
+            StdDuration::from_secs(60),
             aggregation_job_driver.make_incomplete_job_acquirer_callback(
                 Arc::clone(&ds),
-                Duration::from_seconds(600),
+                StdDuration::from_secs(600),
             ),
             aggregation_job_driver.make_job_stepper_callback(Arc::clone(&ds), 3),
         ));

--- a/aggregator/src/aggregator/collect_job_driver.rs
+++ b/aggregator/src/aggregator/collect_job_driver.rs
@@ -23,7 +23,7 @@ use janus_core::test_util::dummy_vdaf;
 use janus_core::{task::VdafInstance, time::Clock};
 use janus_messages::{
     query_type::{FixedSize, QueryType, TimeInterval},
-    AggregateShareReq, AggregateShareResp, BatchSelector, Duration, Role,
+    AggregateShareReq, AggregateShareResp, BatchSelector, Role,
 };
 use opentelemetry::{
     metrics::{Counter, Histogram, Meter, Unit},
@@ -41,7 +41,7 @@ use prio::{
         },
     },
 };
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 use tracing::{info, warn};
 
 /// Drives a collect job.
@@ -730,7 +730,7 @@ mod tests {
     use opentelemetry::global::meter;
     use prio::codec::{Decode, Encode};
     use rand::random;
-    use std::{str, sync::Arc};
+    use std::{str, sync::Arc, time::Duration as StdDuration};
     use url::Url;
     use uuid::Uuid;
 
@@ -833,7 +833,7 @@ mod tests {
                     if acquire_lease {
                         let lease = tx
                             .acquire_incomplete_time_interval_collect_jobs(
-                                &Duration::from_seconds(100),
+                                &StdDuration::from_secs(100),
                                 1,
                             )
                             .await?
@@ -925,7 +925,7 @@ mod tests {
 
                     let lease = Arc::new(
                         tx.acquire_incomplete_time_interval_collect_jobs(
-                            &Duration::from_seconds(100),
+                            &StdDuration::from_secs(100),
                             1,
                         )
                         .await?
@@ -1138,7 +1138,7 @@ mod tests {
 
                     let leases = tx
                         .acquire_incomplete_time_interval_collect_jobs(
-                            &Duration::from_seconds(100),
+                            &StdDuration::from_secs(100),
                             1,
                         )
                         .await?;
@@ -1173,13 +1173,13 @@ mod tests {
             clock.clone(),
             runtime_manager.with_label("stepper"),
             meter,
-            Duration::from_seconds(1),
-            Duration::from_seconds(1),
+            StdDuration::from_secs(1),
+            StdDuration::from_secs(1),
             10,
-            Duration::from_seconds(60),
+            StdDuration::from_secs(60),
             collect_job_driver.make_incomplete_job_acquirer_callback(
                 Arc::clone(&ds),
-                Duration::from_seconds(600),
+                StdDuration::from_secs(600),
             ),
             collect_job_driver.make_job_stepper_callback(Arc::clone(&ds), 3),
         ));
@@ -1305,7 +1305,7 @@ mod tests {
                 assert_eq!(collect_job.state(), &CollectJobState::Deleted);
 
                 let leases = tx
-                    .acquire_incomplete_time_interval_collect_jobs(&Duration::from_seconds(100), 1)
+                    .acquire_incomplete_time_interval_collect_jobs(&StdDuration::from_secs(100), 1)
                     .await
                     .unwrap();
 

--- a/aggregator/src/bin/aggregation_job_driver.rs
+++ b/aggregator/src/bin/aggregation_job_driver.rs
@@ -8,9 +8,8 @@ use janus_aggregator::{
     config::{BinaryConfig, CommonConfig, JobDriverConfig},
 };
 use janus_core::{time::RealClock, TokioRuntime};
-use janus_messages::Duration;
 use serde::{Deserialize, Serialize};
-use std::{fmt::Debug, sync::Arc};
+use std::{fmt::Debug, sync::Arc, time::Duration};
 use tokio::select;
 
 #[tokio::main]
@@ -33,7 +32,7 @@ async fn main() -> anyhow::Result<()> {
             &meter,
         ));
         let lease_duration =
-            Duration::from_seconds(ctx.config.job_driver_config.worker_lease_duration_secs);
+            Duration::from_secs(ctx.config.job_driver_config.worker_lease_duration_secs);
         let shutdown_signal =
             setup_signal_handler().context("failed to register SIGTERM signal handler")?;
 
@@ -42,10 +41,10 @@ async fn main() -> anyhow::Result<()> {
             ctx.clock,
             TokioRuntime,
             meter,
-            Duration::from_seconds(ctx.config.job_driver_config.min_job_discovery_delay_secs),
-            Duration::from_seconds(ctx.config.job_driver_config.max_job_discovery_delay_secs),
+            Duration::from_secs(ctx.config.job_driver_config.min_job_discovery_delay_secs),
+            Duration::from_secs(ctx.config.job_driver_config.max_job_discovery_delay_secs),
             ctx.config.job_driver_config.max_concurrent_job_workers,
-            Duration::from_seconds(
+            Duration::from_secs(
                 ctx.config
                     .job_driver_config
                     .worker_lease_clock_skew_allowance_secs,

--- a/aggregator/src/bin/collect_job_driver.rs
+++ b/aggregator/src/bin/collect_job_driver.rs
@@ -8,9 +8,8 @@ use janus_aggregator::{
     config::{BinaryConfig, CommonConfig, JobDriverConfig},
 };
 use janus_core::{time::RealClock, TokioRuntime};
-use janus_messages::Duration;
 use serde::{Deserialize, Serialize};
-use std::{fmt::Debug, sync::Arc};
+use std::{fmt::Debug, sync::Arc, time::Duration};
 use tokio::select;
 
 #[tokio::main]
@@ -33,7 +32,7 @@ async fn main() -> anyhow::Result<()> {
             &meter,
         ));
         let lease_duration =
-            Duration::from_seconds(ctx.config.job_driver_config.worker_lease_duration_secs);
+            Duration::from_secs(ctx.config.job_driver_config.worker_lease_duration_secs);
         let shutdown_signal =
             setup_signal_handler().context("failed to register SIGTERM signal handler")?;
 
@@ -42,10 +41,10 @@ async fn main() -> anyhow::Result<()> {
             ctx.clock,
             TokioRuntime,
             meter,
-            Duration::from_seconds(ctx.config.job_driver_config.min_job_discovery_delay_secs),
-            Duration::from_seconds(ctx.config.job_driver_config.max_job_discovery_delay_secs),
+            Duration::from_secs(ctx.config.job_driver_config.min_job_discovery_delay_secs),
+            Duration::from_secs(ctx.config.job_driver_config.max_job_discovery_delay_secs),
             ctx.config.job_driver_config.max_concurrent_job_workers,
-            Duration::from_seconds(
+            Duration::from_secs(
                 ctx.config
                     .job_driver_config
                     .worker_lease_clock_skew_allowance_secs,


### PR DESCRIPTION
This changes job driver delays, lease durations, and lease expirations to use `std::time::Duration` and `chrono::NaiveDateTime` instead.

This is part of #445.