### PR TITLE
Implement garbage collection.

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -5,6 +5,7 @@ pub mod aggregate_share;
 pub mod aggregation_job_creator;
 pub mod aggregation_job_driver;
 pub mod collect_job_driver;
+pub mod garbage_collector;
 pub mod query_type;
 
 use crate::{
@@ -4599,7 +4600,7 @@ mod tests {
             .run_tx(|tx| {
                 let task = task.clone();
                 Box::pin(async move {
-                    tx.get_aggregation_jobs_for_task_id::<
+                    tx.get_aggregation_jobs_for_task::<
                         PRIO3_AES128_VERIFY_KEY_LENGTH,
                         TimeInterval,
                         Prio3Aes128Count,

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -1486,7 +1486,7 @@ mod tests {
     {
         gather_errors(
             join_all(
-                tx.get_aggregation_jobs_for_task_id::<L, Q, A>(task_id)
+                tx.get_aggregation_jobs_for_task::<L, Q, A>(task_id)
                     .await
                     .unwrap()
                     .into_iter()

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -909,7 +909,7 @@ mod tests {
         AggregateContinueReq, AggregateContinueResp, AggregateInitializeReq,
         AggregateInitializeResp, Duration, Extension, ExtensionType, HpkeConfig, InputShareAad,
         Interval, PartialBatchSelector, PlaintextInputShare, PrepareStep, PrepareStepResult,
-        ReportIdChecksum, ReportMetadata, ReportShare, ReportShareError, Role, TaskId,
+        ReportIdChecksum, ReportMetadata, ReportShare, ReportShareError, Role, TaskId, Time,
     };
     use mockito::mock;
     use opentelemetry::global::meter;
@@ -996,6 +996,8 @@ mod tests {
                     aggregation_job_id,
                     Some(batch_interval),
                     (),
+                    Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
+                        .unwrap(),
                     AggregationJobState::InProgress,
                 ))
                 .await?;
@@ -1097,6 +1099,8 @@ mod tests {
                 aggregation_job_id,
                 Some(batch_interval),
                 (),
+                Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
+                    .unwrap(),
                 AggregationJobState::Finished,
             );
         let leader_output_share = assert_matches!(
@@ -1226,6 +1230,8 @@ mod tests {
                         aggregation_job_id,
                         Some(batch_interval),
                         (),
+                        Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
+                            .unwrap(),
                         AggregationJobState::InProgress,
                     ))
                     .await?;
@@ -1337,6 +1343,8 @@ mod tests {
                 aggregation_job_id,
                 Some(batch_interval),
                 (),
+                Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
+                    .unwrap(),
                 AggregationJobState::InProgress,
             );
         let leader_prep_state = assert_matches!(
@@ -1466,6 +1474,8 @@ mod tests {
                         aggregation_job_id,
                         Some(batch_id),
                         (),
+                        Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
+                            .unwrap(),
                         AggregationJobState::InProgress,
                     ))
                     .await?;
@@ -1565,6 +1575,8 @@ mod tests {
                 aggregation_job_id,
                 Some(batch_id),
                 (),
+                Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
+                    .unwrap(),
                 AggregationJobState::InProgress,
             );
         let leader_prep_state = assert_matches!(
@@ -1692,6 +1704,8 @@ mod tests {
                         aggregation_job_id,
                         Some(batch_interval),
                         (),
+                        Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
+                            .unwrap(),
                         AggregationJobState::InProgress,
                     ))
                     .await?;
@@ -1782,6 +1796,8 @@ mod tests {
                 aggregation_job_id,
                 Some(batch_interval),
                 (),
+                Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
+                    .unwrap(),
                 AggregationJobState::Finished,
             );
         let leader_output_share = assert_matches!(
@@ -1935,6 +1951,8 @@ mod tests {
                         aggregation_job_id,
                         Some(batch_id),
                         (),
+                        Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
+                            .unwrap(),
                         AggregationJobState::InProgress,
                     ))
                     .await?;
@@ -2025,6 +2043,8 @@ mod tests {
                 aggregation_job_id,
                 Some(batch_id),
                 (),
+                Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
+                    .unwrap(),
                 AggregationJobState::Finished,
             );
         let leader_output_share = assert_matches!(
@@ -2143,6 +2163,8 @@ mod tests {
                 aggregation_job_id,
                 Some(batch_interval),
                 (),
+                Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
+                    .unwrap(),
                 AggregationJobState::InProgress,
             );
         let report_aggregation =
@@ -2339,6 +2361,8 @@ mod tests {
                     aggregation_job_id,
                     Some(batch_interval),
                     (),
+                    Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
+                        .unwrap(),
                     AggregationJobState::InProgress,
                 ))
                 .await?;
@@ -2454,6 +2478,8 @@ mod tests {
                 aggregation_job_id,
                 Some(batch_interval),
                 (),
+                Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
+                    .unwrap(),
                 AggregationJobState::Abandoned,
             ),
         );

--- a/aggregator/src/aggregator/collect_job_driver.rs
+++ b/aggregator/src/aggregator/collect_job_driver.rs
@@ -610,7 +610,7 @@ mod tests {
     };
     use janus_messages::{
         query_type::TimeInterval, AggregateShareReq, AggregateShareResp, BatchSelector, Duration,
-        HpkeCiphertext, HpkeConfigId, Interval, ReportIdChecksum, Role,
+        HpkeCiphertext, HpkeConfigId, Interval, ReportIdChecksum, Role, Time,
     };
     use mockito::mock;
     use opentelemetry::global::meter;
@@ -664,6 +664,11 @@ mod tests {
                             aggregation_job_id,
                             Some(batch_interval),
                             aggregation_param,
+                            Interval::new(
+                                Time::from_seconds_since_epoch(0),
+                                Duration::from_seconds(1),
+                            )
+                            .unwrap(),
                             AggregationJobState::Finished,
                         ),
                     )
@@ -784,6 +789,11 @@ mod tests {
                             aggregation_job_id,
                             Some(batch_interval),
                             aggregation_param,
+                            Interval::new(
+                                Time::from_seconds_since_epoch(0),
+                                Duration::from_seconds(1),
+                            )
+                            .unwrap(),
                             AggregationJobState::Finished,
                         ),
                     )

--- a/aggregator/src/aggregator/garbage_collector.rs
+++ b/aggregator/src/aggregator/garbage_collector.rs
@@ -1,8 +1,4 @@
-use crate::{
-    datastore::Datastore,
-    messages::TimeExt,
-    task::{QueryType, Task},
-};
+use crate::{datastore::Datastore, messages::TimeExt, task::Task};
 use anyhow::{anyhow, Context, Result};
 use futures::future::join_all;
 use janus_core::time::Clock;
@@ -46,9 +42,10 @@ impl<C: Clock> GarbageCollector<C> {
     async fn gc_task(&self, task: Arc<Task>) -> Result<()> {
         let oldest_allowed_report_timestamp =
             if let Some(report_expiry_age) = task.report_expiry_age() {
-                if task.role() != &Role::Leader || task.query_type() != &QueryType::TimeInterval {
+                // XXX: handle helper tasks
+                if task.role() != &Role::Leader {
                     return Err(anyhow!(
-                        "garbage collection is implemented only for leader, time-interval tasks"
+                        "garbage collection is implemented only for leader tasks"
                     ));
                 }
                 self.clock.now().sub(report_expiry_age)?
@@ -86,8 +83,6 @@ impl<C: Clock> GarbageCollector<C> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use super::GarbageCollector;
     use crate::{
         datastore::{
@@ -108,12 +103,16 @@ mod tests {
         },
         time::{Clock, MockClock},
     };
-    use janus_messages::{query_type::TimeInterval, Duration, Interval, Role, Time};
+    use janus_messages::{
+        query_type::{FixedSize, TimeInterval},
+        Duration, Interval, Role,
+    };
     use rand::random;
+    use std::sync::Arc;
     use uuid::Uuid;
 
     #[tokio::test]
-    async fn gc_task() {
+    async fn gc_task_time_interval() {
         install_test_trace_subscriber();
 
         let clock = MockClock::default();
@@ -193,7 +192,7 @@ mod tests {
         // Verify.
         let (client_reports, aggregation_jobs, report_aggregations, collect_jobs) = ds
             .run_tx(|tx| {
-                let (clock, vdaf, task) = (clock.clone(), vdaf.clone(), Arc::clone(&task));
+                let (vdaf, task) = (vdaf.clone(), Arc::clone(&task));
                 Box::pin(async move {
                     let client_reports = tx
                         .get_client_reports_for_task::<0, dummy_vdaf::Vdaf>(&vdaf, task.id())
@@ -211,14 +210,122 @@ mod tests {
                         )
                         .await?;
                     let collect_jobs = tx
-                        .get_collect_jobs_intersecting_interval::<0, dummy_vdaf::Vdaf>(
+                        .get_collect_jobs_for_task::<0, TimeInterval, dummy_vdaf::Vdaf>(task.id())
+                        .await?;
+
+                    Ok((
+                        client_reports,
+                        aggregation_jobs,
+                        report_aggregations,
+                        collect_jobs,
+                    ))
+                })
+            })
+            .await
+            .unwrap();
+        assert!(client_reports.is_empty());
+        assert!(aggregation_jobs.is_empty());
+        assert!(report_aggregations.is_empty());
+        assert!(collect_jobs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn gc_task_fixed_size() {
+        install_test_trace_subscriber();
+
+        let clock = MockClock::default();
+        let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
+        let ds = Arc::new(ds);
+        let vdaf = dummy_vdaf::Vdaf::new();
+
+        // Setup.
+        let task = ds
+            .run_tx(|tx| {
+                let clock = clock.clone();
+                Box::pin(async move {
+                    const REPORT_EXPIRY_AGE: Duration = Duration::from_seconds(3600);
+                    let task = TaskBuilder::new(
+                        task::QueryType::FixedSize { max_batch_size: 10 },
+                        VdafInstance::Fake,
+                        Role::Leader,
+                    )
+                    .with_report_expiry_age(Some(REPORT_EXPIRY_AGE))
+                    .build();
+                    tx.put_task(&task).await?;
+
+                    let client_timestamp = clock
+                        .now()
+                        .sub(&REPORT_EXPIRY_AGE)
+                        .unwrap()
+                        .sub(&Duration::from_seconds(1))
+                        .unwrap();
+                    let report = LeaderStoredReport::new_dummy(*task.id(), client_timestamp);
+                    tx.put_client_report(&report).await.unwrap();
+
+                    let batch_identifier = random();
+                    let aggregation_job = AggregationJob::<0, FixedSize, dummy_vdaf::Vdaf>::new(
+                        *task.id(),
+                        random(),
+                        Some(batch_identifier),
+                        AggregationParam(0),
+                        AggregationJobState::InProgress,
+                    );
+                    tx.put_aggregation_job(&aggregation_job).await.unwrap();
+
+                    let report_aggregation = ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
+                        *task.id(),
+                        *aggregation_job.id(),
+                        *report.metadata().id(),
+                        client_timestamp,
+                        0,
+                        ReportAggregationState::Start,
+                    );
+                    tx.put_report_aggregation(&report_aggregation)
+                        .await
+                        .unwrap();
+
+                    let collect_job = CollectJob::<0, FixedSize, dummy_vdaf::Vdaf>::new(
+                        *task.id(),
+                        Uuid::new_v4(),
+                        batch_identifier,
+                        AggregationParam(0),
+                        CollectJobState::Start,
+                    );
+                    tx.put_collect_job(&collect_job).await.unwrap();
+
+                    Ok(task)
+                })
+            })
+            .await
+            .unwrap();
+
+        // Run.
+        let task = Arc::new(task);
+        GarbageCollector::new(Arc::clone(&ds), clock.clone())
+            .gc_task(Arc::clone(&task))
+            .await
+            .unwrap();
+
+        // Verify.
+        let (client_reports, aggregation_jobs, report_aggregations, collect_jobs) = ds
+            .run_tx(|tx| {
+                let (vdaf, task) = (vdaf.clone(), Arc::clone(&task));
+                Box::pin(async move {
+                    let client_reports = tx
+                        .get_client_reports_for_task::<0, dummy_vdaf::Vdaf>(&vdaf, task.id())
+                        .await?;
+                    let aggregation_jobs = tx
+                        .get_aggregation_jobs_for_task::<0, FixedSize, dummy_vdaf::Vdaf>(task.id())
+                        .await?;
+                    let report_aggregations = tx
+                        .get_report_aggregations_for_task::<0, dummy_vdaf::Vdaf>(
+                            &vdaf,
+                            &Role::Leader,
                             task.id(),
-                            &Interval::new(
-                                Time::from_seconds_since_epoch(0),
-                                Duration::from_seconds(clock.now().as_seconds_since_epoch()),
-                            )
-                            .unwrap(),
                         )
+                        .await?;
+                    let collect_jobs = tx
+                        .get_collect_jobs_for_task::<0, FixedSize, dummy_vdaf::Vdaf>(task.id())
                         .await?;
 
                     Ok((

--- a/aggregator/src/aggregator/garbage_collector.rs
+++ b/aggregator/src/aggregator/garbage_collector.rs
@@ -1,0 +1,239 @@
+use crate::{
+    datastore::Datastore,
+    messages::TimeExt,
+    task::{QueryType, Task},
+};
+use anyhow::{anyhow, Context, Result};
+use futures::future::join_all;
+use janus_core::time::Clock;
+use janus_messages::Role;
+use std::sync::Arc;
+use tracing::error;
+
+pub struct GarbageCollector<C: Clock> {
+    // Dependencies.
+    datastore: Arc<Datastore<C>>,
+    clock: C,
+}
+
+impl<C: Clock> GarbageCollector<C> {
+    pub fn new(datastore: Arc<Datastore<C>>, clock: C) -> Self {
+        Self { datastore, clock }
+    }
+
+    #[tracing::instrument(skip(self))]
+    pub async fn run(&self) -> Result<()> {
+        // TODO(#224): add support for handling only a subset of tasks in a single job (i.e. sharding).
+
+        // Retrieve tasks.
+        let tasks = self
+            .datastore
+            .run_tx(|tx| Box::pin(async move { tx.get_tasks().await }))
+            .await
+            .context("couldn't retrieve tasks")?;
+
+        // Run GC for each task.
+        join_all(tasks.into_iter().map(|task| async move {
+            let task = Arc::new(task);
+            if let Err(err) = self.gc_task(Arc::clone(&task)).await {
+                error!(task_id = ?task.id(), ?err, "Couldn't GC task");
+            }
+        }))
+        .await;
+        Ok(())
+    }
+
+    async fn gc_task(&self, task: Arc<Task>) -> Result<()> {
+        let oldest_allowed_report_timestamp =
+            if let Some(report_expiry_age) = task.report_expiry_age() {
+                if task.role() != &Role::Leader || task.query_type() != &QueryType::TimeInterval {
+                    return Err(anyhow!(
+                        "garbage collection is implemented only for leader, time-interval tasks"
+                    ));
+                }
+                self.clock.now().sub(report_expiry_age)?
+            } else {
+                // No configured report expiry age -- nothing to GC.
+                return Ok(());
+            };
+
+        self.datastore
+            .run_tx(|tx| {
+                let task = Arc::clone(&task);
+                Box::pin(async move {
+                    // Find and delete old collect jobs.
+                    tx.delete_expired_collect_artifacts(task.id(), oldest_allowed_report_timestamp)
+                        .await?;
+
+                    // Find and delete old aggregation jobs/report aggregations/batch aggregations.
+                    tx.delete_expired_aggregation_artifacts(
+                        task.id(),
+                        oldest_allowed_report_timestamp,
+                    )
+                    .await?;
+
+                    // Find and delete old client reports.
+                    tx.delete_expired_client_reports(task.id(), oldest_allowed_report_timestamp)
+                        .await?;
+
+                    Ok(())
+                })
+            })
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::GarbageCollector;
+    use crate::{
+        datastore::{
+            models::{
+                AggregationJob, AggregationJobState, CollectJob, CollectJobState,
+                LeaderStoredReport, ReportAggregation, ReportAggregationState,
+            },
+            test_util::ephemeral_datastore,
+        },
+        messages::TimeExt,
+        task::{self, test_util::TaskBuilder},
+    };
+    use janus_core::{
+        task::VdafInstance,
+        test_util::{
+            dummy_vdaf::{self, AggregationParam},
+            install_test_trace_subscriber,
+        },
+        time::{Clock, MockClock},
+    };
+    use janus_messages::{query_type::TimeInterval, Duration, Interval, Role, Time};
+    use rand::random;
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn gc_task() {
+        install_test_trace_subscriber();
+
+        let clock = MockClock::default();
+        let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
+        let ds = Arc::new(ds);
+        let vdaf = dummy_vdaf::Vdaf::new();
+
+        // Setup.
+        let task = ds
+            .run_tx(|tx| {
+                let clock = clock.clone();
+                Box::pin(async move {
+                    const REPORT_EXPIRY_AGE: Duration = Duration::from_seconds(3600);
+                    let task = TaskBuilder::new(
+                        task::QueryType::TimeInterval,
+                        VdafInstance::Fake,
+                        Role::Leader,
+                    )
+                    .with_report_expiry_age(Some(REPORT_EXPIRY_AGE))
+                    .build();
+                    tx.put_task(&task).await?;
+
+                    let client_timestamp = clock
+                        .now()
+                        .sub(&REPORT_EXPIRY_AGE)
+                        .unwrap()
+                        .sub(&Duration::from_seconds(1))
+                        .unwrap();
+                    let report = LeaderStoredReport::new_dummy(*task.id(), client_timestamp);
+                    tx.put_client_report(&report).await.unwrap();
+
+                    let batch_identifier =
+                        Interval::new(client_timestamp, Duration::from_seconds(1)).unwrap();
+                    let aggregation_job = AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
+                        *task.id(),
+                        random(),
+                        Some(batch_identifier),
+                        AggregationParam(0),
+                        AggregationJobState::InProgress,
+                    );
+                    tx.put_aggregation_job(&aggregation_job).await.unwrap();
+
+                    let report_aggregation = ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
+                        *task.id(),
+                        *aggregation_job.id(),
+                        *report.metadata().id(),
+                        client_timestamp,
+                        0,
+                        ReportAggregationState::Start,
+                    );
+                    tx.put_report_aggregation(&report_aggregation)
+                        .await
+                        .unwrap();
+
+                    let collect_job = CollectJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
+                        *task.id(),
+                        Uuid::new_v4(),
+                        batch_identifier,
+                        AggregationParam(0),
+                        CollectJobState::Start,
+                    );
+                    tx.put_collect_job(&collect_job).await.unwrap();
+
+                    Ok(task)
+                })
+            })
+            .await
+            .unwrap();
+
+        // Run.
+        let task = Arc::new(task);
+        GarbageCollector::new(Arc::clone(&ds), clock.clone())
+            .gc_task(Arc::clone(&task))
+            .await
+            .unwrap();
+
+        // Verify.
+        let (client_reports, aggregation_jobs, report_aggregations, collect_jobs) = ds
+            .run_tx(|tx| {
+                let (clock, vdaf, task) = (clock.clone(), vdaf.clone(), Arc::clone(&task));
+                Box::pin(async move {
+                    let client_reports = tx
+                        .get_client_reports_for_task::<0, dummy_vdaf::Vdaf>(&vdaf, task.id())
+                        .await?;
+                    let aggregation_jobs = tx
+                        .get_aggregation_jobs_for_task::<0, TimeInterval, dummy_vdaf::Vdaf>(
+                            task.id(),
+                        )
+                        .await?;
+                    let report_aggregations = tx
+                        .get_report_aggregations_for_task::<0, dummy_vdaf::Vdaf>(
+                            &vdaf,
+                            &Role::Leader,
+                            task.id(),
+                        )
+                        .await?;
+                    let collect_jobs = tx
+                        .get_collect_jobs_intersecting_interval::<0, dummy_vdaf::Vdaf>(
+                            task.id(),
+                            &Interval::new(
+                                Time::from_seconds_since_epoch(0),
+                                Duration::from_seconds(clock.now().as_seconds_since_epoch()),
+                            )
+                            .unwrap(),
+                        )
+                        .await?;
+
+                    Ok((
+                        client_reports,
+                        aggregation_jobs,
+                        report_aggregations,
+                        collect_jobs,
+                    ))
+                })
+            })
+            .await
+            .unwrap();
+        assert!(client_reports.is_empty());
+        assert!(aggregation_jobs.is_empty());
+        assert!(report_aggregations.is_empty());
+        assert!(collect_jobs.is_empty());
+    }
+}

--- a/aggregator/src/bin/garbage_collector.rs
+++ b/aggregator/src/bin/garbage_collector.rs
@@ -1,0 +1,68 @@
+use clap::Parser;
+use janus_aggregator::{
+    aggregator::garbage_collector::GarbageCollector,
+    binary_utils::{janus_main, BinaryOptions, CommonBinaryOptions},
+    config::{BinaryConfig, CommonConfig},
+};
+use janus_core::time::RealClock;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    janus_main::<_, Options, Config, _, _>(RealClock::default(), |ctx| async move {
+        GarbageCollector::new(Arc::new(ctx.datastore), ctx.clock)
+            .run()
+            .await
+    })
+    .await
+}
+
+#[derive(Debug, Parser)]
+#[clap(
+    name = "janus-collect-job-driver",
+    about = "Janus collect job driver",
+    rename_all = "kebab-case",
+    version = env!("CARGO_PKG_VERSION"),
+)]
+struct Options {
+    #[clap(flatten)]
+    common: CommonBinaryOptions,
+}
+
+impl BinaryOptions for Options {
+    fn common_options(&self) -> &CommonBinaryOptions {
+        &self.common
+    }
+}
+
+/// Non-secret configuration options for Janus Garbage Collector jobs.
+///
+/// # Examples
+///
+/// ```
+/// let yaml_config = r#"
+/// ---
+/// database:
+///   url: "postgres://postgres:postgres@localhost:5432/postgres"
+/// logging_config: # logging_config is optional
+///   force_json_output: true
+/// "#;
+///
+/// let _decoded: Config = serde_yaml::from_str(yaml_config).unwrap();
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct Config {
+    #[serde(flatten)]
+    common_config: CommonConfig,
+}
+
+impl BinaryConfig for Config {
+    fn common_config(&self) -> &CommonConfig {
+        &self.common_config
+    }
+
+    fn common_config_mut(&mut self) -> &mut CommonConfig {
+        &mut self.common_config
+    }
+}

--- a/aggregator/src/bin/garbage_collector.rs
+++ b/aggregator/src/bin/garbage_collector.rs
@@ -20,8 +20,8 @@ async fn main() -> anyhow::Result<()> {
 
 #[derive(Debug, Parser)]
 #[clap(
-    name = "janus-collect-job-driver",
-    about = "Janus collect job driver",
+    name = "janus-garbage-collector",
+    about = "Janus garbage collector",
     rename_all = "kebab-case",
     version = env!("CARGO_PKG_VERSION"),
 )]

--- a/aggregator/src/datastore.rs
+++ b/aggregator/src/datastore.rs
@@ -3542,9 +3542,8 @@ impl RowExt for Row {
         for<'a> <T as TryFrom<&'a [u8]>>::Error: std::fmt::Debug,
     {
         let encoded: Vec<u8> = self.try_get(idx)?;
-        T::try_from(&encoded).map_err(|err| {
-            Error::DbState(format!("{} stored in database is invalid: {:?}", idx, err))
-        })
+        T::try_from(&encoded)
+            .map_err(|err| Error::DbState(format!("{idx} stored in database is invalid: {err:?}")))
     }
 }
 

--- a/aggregator/src/datastore.rs
+++ b/aggregator/src/datastore.rs
@@ -3300,8 +3300,8 @@ ORDER BY id DESC
                             AND NOT EXISTS (
                                 SELECT id FROM collect_jobs
                                 WHERE batch_aggregations.task_id = collect_jobs.task_id
-                                  AND (batch_aggregations.batch_identifier = batch_aggregations.batch_identifier
-                                    OR batch_aggregations.batch_interval <@ batch_aggregations.batch_interval))
+                                  AND (batch_aggregations.batch_identifier = collect_jobs.batch_identifier
+                                    OR batch_aggregations.batch_interval <@ collect_jobs.batch_interval))
                             AND NOT EXISTS (
                                 SELECT id FROM aggregate_share_jobs
                                 WHERE batch_aggregations.task_id = aggregate_share_jobs.task_id

--- a/aggregator/src/datastore.rs
+++ b/aggregator/src/datastore.rs
@@ -937,15 +937,15 @@ impl<C: Clock> Transaction<'_, C> {
             .tx
             .prepare_cached(
                 "SELECT
-                client_reports.report_id,
-                client_reports.client_timestamp,
-                client_reports.extensions,
-                client_reports.public_share,
-                client_reports.leader_input_share,
-                client_reports.helper_encrypted_input_share
-            FROM client_reports
-            JOIN tasks ON tasks.id = client_reports.task_id
-            WHERE tasks.task_id = $1",
+                    client_reports.report_id,
+                    client_reports.client_timestamp,
+                    client_reports.extensions,
+                    client_reports.public_share,
+                    client_reports.leader_input_share,
+                    client_reports.helper_encrypted_input_share
+                FROM client_reports
+                JOIN tasks ON tasks.id = client_reports.task_id
+                WHERE tasks.task_id = $1",
             )
             .await?;
         self.tx
@@ -9615,7 +9615,7 @@ mod tests {
                     let mut batch_identifiers = HashSet::new();
                     let mut all_report_ids = HashSet::new();
 
-                    // Leader, time-interval aggregation job job with old reports [GC'ed].
+                    // Leader, time-interval aggregation job with old reports [GC'ed].
                     write_aggregation_artifacts::<TimeInterval>(
                         tx,
                         leader_time_interval_task.id(),
@@ -9780,7 +9780,7 @@ mod tests {
                     batch_identifiers.insert(batch_identifier.get_encoded());
                     all_report_ids.extend(report_ids);
 
-                    // Leader, fixed-size aggregation job job with old reports [GC'ed].
+                    // Leader, fixed-size aggregation job with old reports [GC'ed].
                     write_aggregation_artifacts::<FixedSize>(
                         tx,
                         leader_fixed_size_task.id(),

--- a/aggregator/src/datastore.rs
+++ b/aggregator/src/datastore.rs
@@ -290,10 +290,11 @@ impl<C: Clock> Transaction<'_, C> {
         let stmt = self
             .tx
             .prepare_cached(
-                "INSERT INTO tasks (task_id, aggregator_role, aggregator_endpoints, query_type,
-                    vdaf, max_batch_query_count, task_expiration, min_batch_size, time_precision,
-                    tolerable_clock_skew, collector_hpke_config)
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
+                "INSERT INTO tasks (
+                    task_id, aggregator_role, aggregator_endpoints, query_type, vdaf,
+                    max_batch_query_count, task_expiration, report_expiry_age, min_batch_size,
+                    time_precision, tolerable_clock_skew, collector_hpke_config)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
             )
             .await?;
         self.tx
@@ -308,6 +309,12 @@ impl<C: Clock> Transaction<'_, C> {
                     /* max_batch_query_count */
                     &i64::try_from(task.max_batch_query_count())?,
                     /* task_expiration */ &task.task_expiration().as_naive_date_time()?,
+                    /* report_expiry_age */
+                    &task
+                        .report_expiry_age()
+                        .map(Duration::as_seconds)
+                        .map(i64::try_from)
+                        .transpose()?,
                     /* min_batch_size */ &i64::try_from(task.min_batch_size())?,
                     /* time_precision */
                     &i64::try_from(task.time_precision().as_seconds())?,
@@ -518,8 +525,8 @@ impl<C: Clock> Transaction<'_, C> {
             .tx
             .prepare_cached(
                 "SELECT aggregator_role, aggregator_endpoints, query_type, vdaf,
-                    max_batch_query_count, task_expiration, min_batch_size, time_precision,
-                    tolerable_clock_skew, collector_hpke_config
+                    max_batch_query_count, task_expiration, report_expiry_age, min_batch_size,
+                    time_precision, tolerable_clock_skew, collector_hpke_config
                 FROM tasks WHERE task_id = $1",
             )
             .await?;
@@ -595,8 +602,8 @@ impl<C: Clock> Transaction<'_, C> {
             .tx
             .prepare_cached(
                 "SELECT task_id, aggregator_role, aggregator_endpoints, query_type, vdaf,
-                    max_batch_query_count, task_expiration, min_batch_size, time_precision,
-                    tolerable_clock_skew, collector_hpke_config
+                    max_batch_query_count, task_expiration, report_expiry_age, min_batch_size,
+                    time_precision, tolerable_clock_skew, collector_hpke_config
                 FROM tasks",
             )
             .await?;
@@ -738,6 +745,9 @@ impl<C: Clock> Transaction<'_, C> {
         let vdaf = row.try_get::<_, Json<VdafInstance>>("vdaf")?.0;
         let max_batch_query_count = row.get_bigint_and_convert("max_batch_query_count")?;
         let task_expiration = Time::from_naive_date_time(&row.get("task_expiration"));
+        let report_expiry_age = row
+            .get_nullable_bigint_and_convert("report_expiry_age")?
+            .map(Duration::from_seconds);
         let min_batch_size = row.get_bigint_and_convert("min_batch_size")?;
         let time_precision = Duration::from_seconds(row.get_bigint_and_convert("time_precision")?);
         let tolerable_clock_skew =
@@ -822,6 +832,7 @@ impl<C: Clock> Transaction<'_, C> {
             vdaf_verify_keys,
             max_batch_query_count,
             task_expiration,
+            report_expiry_age,
             min_batch_size,
             time_precision,
             tolerable_clock_skew,
@@ -834,7 +845,7 @@ impl<C: Clock> Transaction<'_, C> {
 
     /// get_client_report retrieves a client report by ID.
     #[tracing::instrument(skip(self), err)]
-    pub(crate) async fn get_client_report<const L: usize, A>(
+    pub async fn get_client_report<const L: usize, A>(
         &self,
         vdaf: &A,
         task_id: &TaskId,
@@ -869,37 +880,89 @@ impl<C: Clock> Transaction<'_, C> {
                 ],
             )
             .await?
-            .map(|row| {
-                let time = Time::from_naive_date_time(&row.get("client_timestamp"));
-
-                let encoded_extensions: Vec<u8> = row.get("extensions");
-                let extensions: Vec<Extension> =
-                    decode_u16_items(&(), &mut Cursor::new(&encoded_extensions))?;
-
-                let encoded_public_share: Vec<u8> = row.get("public_share");
-                let public_share =
-                    A::PublicShare::get_decoded_with_param(&vdaf, &encoded_public_share)?;
-
-                let encoded_leader_input_share: Vec<u8> = row.get("leader_input_share");
-                let leader_input_share = A::InputShare::get_decoded_with_param(
-                    &(vdaf, Role::Leader.index().unwrap()),
-                    &encoded_leader_input_share,
-                )?;
-
-                let encoded_helper_input_share: Vec<u8> = row.get("helper_encrypted_input_share");
-                let helper_encrypted_input_share =
-                    HpkeCiphertext::get_decoded(&encoded_helper_input_share)?;
-
-                Ok(LeaderStoredReport::new(
-                    *task_id,
-                    ReportMetadata::new(*report_id, time),
-                    public_share,
-                    extensions,
-                    leader_input_share,
-                    helper_encrypted_input_share,
-                ))
-            })
+            .map(|row| Self::client_report_from_row(vdaf, *task_id, *report_id, row))
             .transpose()
+    }
+
+    #[cfg(feature = "test-util")]
+    pub async fn get_client_reports_for_task<const L: usize, A: vdaf::Aggregator<L>>(
+        &self,
+        vdaf: &A,
+        task_id: &TaskId,
+    ) -> Result<Vec<LeaderStoredReport<L, A>>, Error>
+    where
+        A::InputShare: PartialEq,
+        A::PublicShare: PartialEq,
+        for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
+    {
+        let stmt = self
+            .tx
+            .prepare_cached(
+                "SELECT
+                client_reports.report_id,
+                client_reports.client_timestamp,
+                client_reports.extensions,
+                client_reports.public_share,
+                client_reports.leader_input_share,
+                client_reports.helper_encrypted_input_share
+            FROM client_reports
+            JOIN tasks ON tasks.id = client_reports.task_id
+            WHERE tasks.task_id = $1",
+            )
+            .await?;
+        self.tx
+            .query(&stmt, &[/* task_id */ &task_id.as_ref()])
+            .await?
+            .into_iter()
+            .map(|row| {
+                Self::client_report_from_row(
+                    vdaf,
+                    *task_id,
+                    row.get_bytea_and_convert::<ReportId>("report_id")?,
+                    row,
+                )
+            })
+            .collect()
+    }
+
+    fn client_report_from_row<const L: usize, A: vdaf::Aggregator<L>>(
+        vdaf: &A,
+        task_id: TaskId,
+        report_id: ReportId,
+        row: Row,
+    ) -> Result<LeaderStoredReport<L, A>, Error>
+    where
+        A::InputShare: PartialEq,
+        A::PublicShare: PartialEq,
+        for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
+    {
+        let time = Time::from_naive_date_time(&row.get("client_timestamp"));
+
+        let encoded_extensions: Vec<u8> = row.get("extensions");
+        let extensions: Vec<Extension> =
+            decode_u16_items(&(), &mut Cursor::new(&encoded_extensions))?;
+
+        let encoded_public_share: Vec<u8> = row.get("public_share");
+        let public_share = A::PublicShare::get_decoded_with_param(&vdaf, &encoded_public_share)?;
+
+        let encoded_leader_input_share: Vec<u8> = row.get("leader_input_share");
+        let leader_input_share = A::InputShare::get_decoded_with_param(
+            &(vdaf, Role::Leader.index().unwrap()),
+            &encoded_leader_input_share,
+        )?;
+
+        let encoded_helper_input_share: Vec<u8> = row.get("helper_encrypted_input_share");
+        let helper_encrypted_input_share =
+            HpkeCiphertext::get_decoded(&encoded_helper_input_share)?;
+
+        Ok(LeaderStoredReport::new(
+            task_id,
+            ReportMetadata::new(report_id, time),
+            public_share,
+            extensions,
+            leader_input_share,
+            helper_encrypted_input_share,
+        ))
     }
 
     /// `get_unaggregated_client_report_ids_for_task` returns some report IDs corresponding to
@@ -937,13 +1000,7 @@ impl<C: Clock> Transaction<'_, C> {
 
         rows.into_iter()
             .map(|row| {
-                let report_id_bytes: [u8; ReportId::LEN] = row
-                    .get::<_, Vec<u8>>("report_id")
-                    .try_into()
-                    .map_err(|err| {
-                        Error::DbState(format!("couldn't convert report_id value: {err:?}"))
-                    })?;
-                let report_id = ReportId::from(report_id_bytes);
+                let report_id = row.get_bytea_and_convert::<ReportId>("report_id")?;
                 let time = Time::from_naive_date_time(&row.get("client_timestamp"));
                 Ok((report_id, time))
             })
@@ -999,13 +1056,7 @@ impl<C: Clock> Transaction<'_, C> {
 
         rows.into_iter()
             .map(|row| {
-                let report_id_bytes: [u8; ReportId::LEN] = row
-                    .get::<_, Vec<u8>>("report_id")
-                    .try_into()
-                    .map_err(|err| {
-                        Error::DbState(format!("couldn't convert report_id value: {0:?}", err))
-                    })?;
-                let report_id = ReportId::from(report_id_bytes);
+                let report_id = row.get_bytea_and_convert::<ReportId>("report_id")?;
                 let time = Time::from_naive_date_time(&row.get("client_timestamp"));
                 let agg_param = A::AggregationParam::get_decoded(row.get("aggregation_param"))?;
                 Ok((report_id, time, agg_param))
@@ -1230,11 +1281,11 @@ impl<C: Clock> Transaction<'_, C> {
             .transpose()
     }
 
-    /// get_aggregation_jobs_for_task_id returns all aggregation jobs for a given task ID.
+    /// get_aggregation_jobs_for_task returns all aggregation jobs for a given task ID.
     #[cfg(feature = "test-util")]
     #[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
     #[tracing::instrument(skip(self), err)]
-    pub async fn get_aggregation_jobs_for_task_id<
+    pub async fn get_aggregation_jobs_for_task<
         const L: usize,
         Q: AccumulableQueryType,
         A: vdaf::Aggregator<L>,
@@ -1342,11 +1393,7 @@ impl<C: Clock> Transaction<'_, C> {
                     AggregationJobId::get_decoded(row.get("aggregation_job_id"))?;
                 let query_type = row.try_get::<_, Json<task::QueryType>>("query_type")?.0;
                 let vdaf = row.try_get::<_, Json<VdafInstance>>("vdaf")?.0;
-                let lease_token_bytes: [u8; LeaseToken::LEN] = row
-                    .get::<_, Vec<u8>>("lease_token")
-                    .try_into()
-                    .map_err(|err| Error::DbState(format!("lease_token invalid: {:?}", err)))?;
-                let lease_token = LeaseToken::from(lease_token_bytes);
+                let lease_token = row.get_bytea_and_convert::<LeaseToken>("lease_token")?;
                 let lease_attempts = row.get_bigint_and_convert("lease_attempts")?;
                 Ok(Lease::new(
                     AcquiredAggregationJob::new(task_id, aggregation_job_id, query_type, vdaf),
@@ -1585,19 +1632,58 @@ impl<C: Clock> Transaction<'_, C> {
             .await?
             .into_iter()
             .map(|row| {
-                let report_id_bytes: [u8; ReportId::LEN] = row
-                    .get::<_, Vec<u8>>("report_id")
-                    .try_into()
-                    .map_err(|err| {
-                        Error::DbState(format!("couldn't convert report_id value: {err:?}"))
-                    })?;
-                let report_id = ReportId::from(report_id_bytes);
                 Self::report_aggregation_from_row(
                     vdaf,
                     role,
                     task_id,
                     aggregation_job_id,
-                    &report_id,
+                    &row.get_bytea_and_convert::<ReportId>("report_id")?,
+                    &row,
+                )
+            })
+            .collect()
+    }
+
+    /// get_report_aggregations_for_task retrieves all report aggregations associated with a given
+    /// task.
+    #[cfg(feature = "test-util")]
+    pub async fn get_report_aggregations_for_task<const L: usize, A: vdaf::Aggregator<L>>(
+        &self,
+        vdaf: &A,
+        role: &Role,
+        task_id: &TaskId,
+    ) -> Result<Vec<ReportAggregation<L, A>>, Error>
+    where
+        for<'a> A::PrepareState: ParameterizedDecode<(&'a A, usize)>,
+        A::OutputShare: for<'a> TryFrom<&'a [u8]>,
+        for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
+    {
+        let stmt = self
+            .tx
+            .prepare_cached(
+                "SELECT
+                    aggregation_jobs.aggregation_job_id, client_reports.report_id,
+                    client_reports.client_timestamp, report_aggregations.ord,
+                    report_aggregations.state, report_aggregations.prep_state,
+                    report_aggregations.prep_msg, report_aggregations.out_share,
+                    report_aggregations.error_code
+                FROM report_aggregations
+                JOIN client_reports ON client_reports.id = report_aggregations.client_report_id
+                JOIN aggregation_jobs ON aggregation_jobs.id = report_aggregations.aggregation_job_id
+                WHERE aggregation_jobs.task_id = (SELECT id FROM tasks WHERE task_id = $1)",
+            )
+            .await?;
+        self.tx
+            .query(&stmt, &[/* task_id */ &task_id.as_ref()])
+            .await?
+            .into_iter()
+            .map(|row| {
+                Self::report_aggregation_from_row(
+                    vdaf,
+                    role,
+                    task_id,
+                    &row.get_bytea_and_convert::<AggregationJobId>("aggregation_job_id")?,
+                    &row.get_bytea_and_convert::<ReportId>("report_id")?,
                     &row,
                 )
             })
@@ -2190,11 +2276,7 @@ ORDER BY id DESC
                 let collect_job_id = row.get("collect_job_id");
                 let query_type = row.try_get::<_, Json<task::QueryType>>("query_type")?.0;
                 let vdaf = row.try_get::<_, Json<VdafInstance>>("vdaf")?.0;
-                let lease_token_bytes: [u8; LeaseToken::LEN] = row
-                    .get::<_, Vec<u8>>("lease_token")
-                    .try_into()
-                    .map_err(|err| Error::DbState(format!("lease_token invalid: {:?}", err)))?;
-                let lease_token = LeaseToken::from(lease_token_bytes);
+                let lease_token = row.get_bytea_and_convert::<LeaseToken>("lease_token")?;
                 let lease_attempts = row.get_bigint_and_convert("lease_attempts")?;
                 Ok(Lease::new(
                     AcquiredCollectJob::new(task_id, collect_job_id, query_type, vdaf),
@@ -2274,11 +2356,7 @@ ORDER BY id DESC
                 let collect_job_id = row.get("collect_job_id");
                 let query_type = row.try_get::<_, Json<task::QueryType>>("query_type")?.0;
                 let vdaf = row.try_get::<_, Json<VdafInstance>>("vdaf")?.0;
-                let lease_token_bytes: [u8; LeaseToken::LEN] = row
-                    .get::<_, Vec<u8>>("lease_token")
-                    .try_into()
-                    .map_err(|err| Error::DbState(format!("lease_token invalid: {:?}", err)))?;
-                let lease_token = LeaseToken::from(lease_token_bytes);
+                let lease_token = row.get_bytea_and_convert::<LeaseToken>("lease_token")?;
                 let lease_attempts = row.get_bigint_and_convert("lease_attempts")?;
                 Ok(Lease::new(
                     AcquiredCollectJob::new(task_id, collect_job_id, query_type, vdaf),
@@ -2416,20 +2494,76 @@ ORDER BY id DESC
             )
             .await?
             .map(|row| {
-                let aggregate_share = row.get_bytea_and_convert("aggregate_share")?;
-                let report_count = row.get_bigint_and_convert("report_count")?;
-                let checksum = ReportIdChecksum::get_decoded(row.get("checksum"))?;
-
-                Ok(BatchAggregation::new(
+                Self::batch_aggregation_from_row(
                     *task_id,
                     batch_identifier.clone(),
                     aggregation_parameter.clone(),
-                    aggregate_share,
-                    report_count,
-                    checksum,
-                ))
+                    row,
+                )
             })
             .transpose()
+    }
+
+    #[cfg(feature = "test-util")]
+    pub async fn get_batch_aggregations_for_task<
+        const L: usize,
+        Q: QueryType,
+        A: vdaf::Aggregator<L>,
+    >(
+        &self,
+        task_id: &TaskId,
+    ) -> Result<Vec<BatchAggregation<L, Q, A>>, Error>
+    where
+        for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Debug,
+        for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
+    {
+        let stmt = self
+            .tx
+            .prepare_cached(
+                "SELECT
+                    batch_identifier, aggregation_param, aggregate_share, report_count, checksum
+                FROM batch_aggregations
+                WHERE task_id = (SELECT id FROM tasks WHERE task_id = $1)",
+            )
+            .await?;
+
+        self.tx
+            .query(&stmt, &[/* task_id */ &task_id.as_ref()])
+            .await?
+            .into_iter()
+            .map(|row| {
+                let batch_identifier =
+                    Q::BatchIdentifier::get_decoded(row.get("batch_identifier"))?;
+                let aggregation_param =
+                    A::AggregationParam::get_decoded(row.get("aggregation_param"))?;
+
+                Self::batch_aggregation_from_row(*task_id, batch_identifier, aggregation_param, row)
+            })
+            .collect()
+    }
+
+    fn batch_aggregation_from_row<const L: usize, Q: QueryType, A: vdaf::Aggregator<L>>(
+        task_id: TaskId,
+        batch_identifier: Q::BatchIdentifier,
+        aggregation_parameter: A::AggregationParam,
+        row: Row,
+    ) -> Result<BatchAggregation<L, Q, A>, Error>
+    where
+        for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Debug,
+        for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
+    {
+        let aggregate_share = row.get_bytea_and_convert("aggregate_share")?;
+        let report_count = row.get_bigint_and_convert("report_count")?;
+        let checksum = ReportIdChecksum::get_decoded(row.get("checksum"))?;
+
+        Ok(BatchAggregation::new(
+            task_id,
+            batch_identifier,
+            aggregation_parameter,
+            aggregate_share,
+            report_count,
+            checksum,
+        ))
     }
 
     /// Store a new `batch_aggregations` row in the datastore.
@@ -2948,6 +3082,155 @@ ORDER BY id DESC
             .map(|row| Ok(BatchId::get_decoded(row.get("batch_id"))?))
             .transpose()
     }
+
+    /// Deletes old client reports for a given task, that is, client reports whose timestamp is
+    /// older than a given timestamp which are not included in any report aggregations.
+    #[tracing::instrument(skip(self), err)]
+    pub async fn delete_expired_client_reports(
+        &self,
+        task_id: &TaskId,
+        oldest_allowed_report_timestamp: Time,
+    ) -> Result<(), Error> {
+        let stmt = self
+            .tx
+            .prepare_cached(
+                "DELETE FROM client_reports
+                WHERE task_id = (SELECT id FROM tasks WHERE task_id = $1) AND client_timestamp < $2
+                AND NOT EXISTS(
+                    SELECT FROM report_aggregations
+                    WHERE report_aggregations.client_report_id = client_reports.id)",
+            )
+            .await?;
+        self.tx
+            .execute(
+                &stmt,
+                &[
+                    /* task_id */ &task_id.get_encoded(),
+                    /* client_timestamp */
+                    &oldest_allowed_report_timestamp.as_naive_date_time()?,
+                ],
+            )
+            .await?;
+        Ok(())
+    }
+
+    /// Deletes old aggregation artifacts (aggregation jobs/report aggregations/batch aggregations)
+    /// for a given task, that is, aggregation artifacts for which all associated client reports
+    /// have timestamps older than a given timestamp, and which are not included in any collection
+    /// artifacts.
+    ///
+    /// Only implemented for leader tasks with the time-interval query type.
+    ///
+    /// After calling this function, delete_expired_client_reports must be called in the same
+    /// transaction to avoid re-aggregating client reports.
+    #[tracing::instrument(skip(self), err)]
+    pub async fn delete_expired_aggregation_artifacts(
+        &self,
+        task_id: &TaskId,
+        oldest_allowed_report_timestamp: Time,
+    ) -> Result<(), Error> {
+        let stmt = self
+            .tx
+            .prepare_cached(
+                "WITH aggregation_jobs_to_delete AS (
+                    SELECT id FROM aggregation_jobs
+                    JOIN (
+                        SELECT
+                            report_aggregations.aggregation_job_id,
+                            MAX(client_reports.client_timestamp) AS max_timestamp
+                        FROM report_aggregations
+                        JOIN client_reports
+                            ON client_reports.id = report_aggregations.client_report_id
+                        GROUP BY report_aggregations.aggregation_job_id
+                    ) report_max_timestamps
+                        ON report_max_timestamps.aggregation_job_id = aggregation_jobs.id
+                    WHERE aggregation_jobs.task_id = (SELECT id FROM tasks WHERE task_id = $1)
+                      AND report_max_timestamps.max_timestamp < $2
+                      AND NOT EXISTS (
+                          SELECT id FROM collect_jobs
+                          WHERE aggregation_jobs.task_id = collect_jobs.task_id
+                            AND aggregation_jobs.batch_interval <@ collect_jobs.batch_interval)
+                ),
+                deleted_report_aggregations AS (
+                    DELETE FROM report_aggregations
+                    WHERE report_aggregations.aggregation_job_id IN (
+                        SELECT id FROM aggregation_jobs_to_delete)
+                ),
+                deleted_batch_aggregations AS (
+                    DELETE FROM batch_aggregations
+                    WHERE batch_aggregations.batch_identifier IN (
+                        SELECT batch_identifier FROM aggregation_jobs
+                        WHERE aggregation_jobs.id IN (SELECT id FROM aggregation_jobs_to_delete))
+                )
+                DELETE FROM aggregation_jobs
+                WHERE id IN (SELECT id FROM aggregation_jobs_to_delete)",
+            )
+            .await?;
+        self.tx
+            .execute(
+                &stmt,
+                &[
+                    /* task_id */ &task_id.get_encoded(),
+                    /* client_timestamp */
+                    &oldest_allowed_report_timestamp.as_naive_date_time()?,
+                ],
+            )
+            .await?;
+        Ok(())
+    }
+
+    /// Deletes old collection artifacts (collect jobs/aggregate share jobs/outstanding batches) for
+    /// a given task, that is, collection artifacts for which all associated client reports have
+    /// timestamps older than a given timestamp.
+    ///
+    /// Only implemented for leader tasks with the time-interval query type.
+    ///
+    /// After calling this function, delete_expired_aggregation_artifacts must be called in the same
+    /// transaction to avoid re-collecting old aggregations.
+    #[tracing::instrument(skip(self), err)]
+    pub async fn delete_expired_collect_artifacts(
+        &self,
+        task_id: &TaskId,
+        oldest_allowed_report_timestamp: Time,
+    ) -> Result<(), Error> {
+        let stmt = self
+            .tx
+            .prepare_cached(
+                "WITH collect_jobs_to_delete AS (
+                    SELECT id FROM collect_jobs
+                    JOIN (
+                        SELECT
+                            collect_jobs.id AS collect_job_id,
+                            MAX(client_reports.client_timestamp) AS max_timestamp
+                        FROM collect_jobs
+                        JOIN aggregation_jobs
+                            ON aggregation_jobs.task_id = collect_jobs.task_id
+                           AND aggregation_jobs.batch_interval <@ collect_jobs.batch_interval
+                           JOIN report_aggregations
+                           ON report_aggregations.aggregation_job_id = aggregation_jobs.id
+                       JOIN client_reports
+                           ON client_reports.id = report_aggregations.client_report_id
+                       GROUP BY collect_jobs.id
+                   ) report_max_timestamps
+                       ON report_max_timestamps.collect_job_id = collect_jobs.id
+                   WHERE collect_jobs.task_id = (SELECT id FROM tasks WHERE task_id = $1)
+                       AND report_max_timestamps.max_timestamp < $2
+               )
+               DELETE FROM collect_jobs WHERE id IN (SELECT id FROM collect_jobs_to_delete)",
+            )
+            .await?;
+        self.tx
+            .execute(
+                &stmt,
+                &[
+                    /* task_id */ &task_id.get_encoded(),
+                    /* client_timestamp */
+                    &oldest_allowed_report_timestamp.as_naive_date_time()?,
+                ],
+            )
+            .await?;
+        Ok(())
+    }
 }
 
 fn check_single_row_mutation(row_count: u64) -> Result<(), Error> {
@@ -2987,8 +3270,8 @@ trait RowExt {
     /// Get a PostgreSQL `BYTEA` from the row and attempt to convert it to `T`.
     fn get_bytea_and_convert<T>(&self, idx: &'static str) -> Result<T, Error>
     where
-        for<'a> <T as TryFrom<&'a [u8]>>::Error: std::fmt::Debug,
-        for<'a> T: TryFrom<&'a [u8]>;
+        for<'a> T: TryFrom<&'a [u8]>,
+        for<'a> <T as TryFrom<&'a [u8]>>::Error: std::fmt::Debug;
 }
 
 impl RowExt for Row {
@@ -3028,14 +3311,13 @@ impl RowExt for Row {
 
     fn get_bytea_and_convert<T>(&self, idx: &'static str) -> Result<T, Error>
     where
-        for<'a> <T as TryFrom<&'a [u8]>>::Error: std::fmt::Debug,
         for<'a> T: TryFrom<&'a [u8]>,
+        for<'a> <T as TryFrom<&'a [u8]>>::Error: std::fmt::Debug,
     {
         let encoded: Vec<u8> = self.try_get(idx)?;
-        let decoded = T::try_from(&encoded).map_err(|err| {
+        T::try_from(&encoded).map_err(|err| {
             Error::DbState(format!("{} stored in database is invalid: {:?}", idx, err))
-        })?;
-        Ok(decoded)
+        })
     }
 }
 
@@ -3602,6 +3884,19 @@ pub mod models {
     impl From<[u8; Self::LEN]> for LeaseToken {
         fn from(lease_token: [u8; Self::LEN]) -> Self {
             Self(lease_token)
+        }
+    }
+
+    impl<'a> TryFrom<&'a [u8]> for LeaseToken {
+        type Error = Error;
+
+        fn try_from(lease_token: &[u8]) -> Result<Self, Self::Error> {
+            let lease_token: [u8; Self::LEN] = lease_token.try_into().map_err(|_| {
+                Error::Message(janus_messages::Error::InvalidParameter(
+                    "LeaseToken length incorrect",
+                ))
+            })?;
+            Ok(Self::from(lease_token))
         }
     }
 
@@ -4871,7 +5166,7 @@ mod tests {
                 OutstandingBatch, ReportAggregation, ReportAggregationState, SqlInterval,
             },
             test_util::{ephemeral_datastore, generate_aead_key},
-            Crypter, Error,
+            Crypter, Error, Transaction,
         },
         messages::{DurationExt, TimeExt},
         task::{self, test_util::TaskBuilder, Task, PRIO3_AES128_VERIFY_KEY_LENGTH},
@@ -4890,9 +5185,9 @@ mod tests {
     };
     use janus_messages::{
         query_type::{FixedSize, QueryType, TimeInterval},
-        AggregateShareAad, BatchSelector, Duration, Extension, ExtensionType, HpkeCiphertext,
-        HpkeConfigId, Interval, ReportId, ReportIdChecksum, ReportMetadata, ReportShare,
-        ReportShareError, Role, TaskId, Time,
+        AggregateShareAad, AggregationJobId, BatchSelector, Duration, Extension, ExtensionType,
+        HpkeCiphertext, HpkeConfigId, Interval, ReportId, ReportIdChecksum, ReportMetadata,
+        ReportShare, ReportShareError, Role, TaskId, Time,
     };
     use prio::{
         codec::{Decode, Encode},
@@ -4947,7 +5242,9 @@ mod tests {
             (VdafInstance::Poplar1 { bits: 8 }, Role::Helper),
             (VdafInstance::Poplar1 { bits: 64 }, Role::Helper),
         ] {
-            let task = TaskBuilder::new(task::QueryType::TimeInterval, vdaf, role).build();
+            let task = TaskBuilder::new(task::QueryType::TimeInterval, vdaf, role)
+                .with_report_expiry_age(Some(Duration::from_seconds(3600)))
+                .build();
             want_tasks.insert(*task.id(), task.clone());
 
             let err = ds
@@ -6244,7 +6541,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_aggregation_jobs_for_task_id() {
+    async fn get_aggregation_jobs_for_task() {
         // Setup.
         install_test_trace_subscriber();
         let (ds, _db_handle) = ephemeral_datastore(MockClock::default()).await;
@@ -6311,7 +6608,7 @@ mod tests {
         let mut got_agg_jobs = ds
             .run_tx(|tx| {
                 let task = task.clone();
-                Box::pin(async move { tx.get_aggregation_jobs_for_task_id(task.id()).await })
+                Box::pin(async move { tx.get_aggregation_jobs_for_task(task.id()).await })
             })
             .await
             .unwrap();
@@ -8707,6 +9004,642 @@ mod tests {
             .await
             .unwrap();
         assert!(outstanding_batches.is_empty());
+    }
+
+    #[tokio::test]
+    async fn delete_expired_client_reports() {
+        install_test_trace_subscriber();
+
+        let clock = MockClock::default();
+        let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
+        let vdaf = dummy_vdaf::Vdaf::new();
+
+        // Setup.
+        const OLDEST_ALLOWED_REPORT_TIMESTAMP: Time = Time::from_seconds_since_epoch(1000);
+        let (task_id, new_report_id, attached_report_id, other_task_id, other_task_report_id) = ds
+            .run_tx(|tx| {
+                Box::pin(async move {
+                    let task = TaskBuilder::new(
+                        task::QueryType::TimeInterval,
+                        VdafInstance::Fake,
+                        Role::Leader,
+                    )
+                    .build();
+                    let other_task = TaskBuilder::new(
+                        task::QueryType::TimeInterval,
+                        VdafInstance::Fake,
+                        Role::Leader,
+                    )
+                    .build();
+                    tx.put_task(&task).await?;
+                    tx.put_task(&other_task).await?;
+
+                    let old_report = LeaderStoredReport::new_dummy(
+                        *task.id(),
+                        OLDEST_ALLOWED_REPORT_TIMESTAMP
+                            .sub(&Duration::from_seconds(1))
+                            .unwrap(),
+                    );
+                    let new_report =
+                        LeaderStoredReport::new_dummy(*task.id(), OLDEST_ALLOWED_REPORT_TIMESTAMP);
+                    let attached_report = LeaderStoredReport::new_dummy(
+                        *task.id(),
+                        OLDEST_ALLOWED_REPORT_TIMESTAMP
+                            .sub(&Duration::from_seconds(1))
+                            .unwrap(),
+                    );
+                    let other_task_report = LeaderStoredReport::new_dummy(
+                        *other_task.id(),
+                        OLDEST_ALLOWED_REPORT_TIMESTAMP
+                            .sub(&Duration::from_seconds(1))
+                            .unwrap(),
+                    );
+                    tx.put_client_report(&old_report).await?;
+                    tx.put_client_report(&new_report).await?;
+                    tx.put_client_report(&attached_report).await?;
+                    tx.put_client_report(&other_task_report).await?;
+
+                    let aggregation_job = AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
+                        *task.id(),
+                        random(),
+                        None,
+                        AggregationParam(0),
+                        AggregationJobState::InProgress,
+                    );
+                    let report_aggregation = ReportAggregation::new(
+                        *task.id(),
+                        *aggregation_job.id(),
+                        *attached_report.metadata().id(),
+                        *attached_report.metadata().time(),
+                        0,
+                        ReportAggregationState::<0, dummy_vdaf::Vdaf>::Start,
+                    );
+
+                    tx.put_aggregation_job(&aggregation_job).await?;
+                    tx.put_report_aggregation(&report_aggregation).await?;
+
+                    Ok((
+                        *task.id(),
+                        *new_report.metadata().id(),
+                        *attached_report.metadata().id(),
+                        *other_task.id(),
+                        *other_task_report.metadata().id(),
+                    ))
+                })
+            })
+            .await
+            .unwrap();
+
+        // Run.
+        ds.run_tx(|tx| {
+            Box::pin(async move {
+                tx.delete_expired_client_reports(&task_id, OLDEST_ALLOWED_REPORT_TIMESTAMP)
+                    .await
+            })
+        })
+        .await
+        .unwrap();
+
+        // Verify.
+        let want_report_ids =
+            HashSet::from([new_report_id, attached_report_id, other_task_report_id]);
+        let got_report_ids = ds
+            .run_tx(|tx| {
+                let vdaf = vdaf.clone();
+                Box::pin(async move {
+                    let task_client_reports =
+                        tx.get_client_reports_for_task(&vdaf, &task_id).await?;
+                    let other_task_client_reports = tx
+                        .get_client_reports_for_task(&vdaf, &other_task_id)
+                        .await?;
+                    Ok(HashSet::from_iter(
+                        task_client_reports
+                            .into_iter()
+                            .chain(other_task_client_reports)
+                            .map(|report| *report.metadata().id()),
+                    ))
+                })
+            })
+            .await
+            .unwrap();
+        assert_eq!(want_report_ids, got_report_ids);
+    }
+
+    #[tokio::test]
+    async fn delete_expired_aggregation_artifacts() {
+        install_test_trace_subscriber();
+
+        let clock = MockClock::default();
+        let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
+        let vdaf = dummy_vdaf::Vdaf::new();
+
+        // Setup.
+        async fn write_aggregation_artifacts(
+            tx: &Transaction<'_, MockClock>,
+            task_id: &TaskId,
+            client_timestamps: &[Time],
+        ) -> (AggregationJobId, Interval, Vec<ReportId>) {
+            // The batch identifier is somewhat arbitrary: in reality, it would match a batch
+            // interval (based on the task's time precision). Instead, we generate an interval that
+            // covers all of the report timestamps. It is up to the test to avoid creating multiple
+            // aggregation artifacts with the same batch identifier.
+            let min_client_timestamp = *client_timestamps.iter().min().unwrap();
+            let max_client_timestamp = *client_timestamps.iter().max().unwrap();
+            let batch_identifier = Interval::new(
+                min_client_timestamp,
+                Duration::from_seconds(
+                    max_client_timestamp
+                        .difference(&min_client_timestamp)
+                        .unwrap()
+                        .as_seconds()
+                        + 1,
+                ),
+            )
+            .unwrap();
+
+            let mut report_ids_and_timestamps = Vec::new();
+            for client_timestamp in client_timestamps {
+                let report = LeaderStoredReport::new_dummy(*task_id, *client_timestamp);
+                tx.put_client_report(&report).await.unwrap();
+                report_ids_and_timestamps.push((*report.metadata().id(), *client_timestamp));
+            }
+
+            let aggregation_job = AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
+                *task_id,
+                random(),
+                Some(batch_identifier),
+                AggregationParam(0),
+                AggregationJobState::InProgress,
+            );
+            tx.put_aggregation_job(&aggregation_job).await.unwrap();
+
+            for (ord, (report_id, client_timestamp)) in report_ids_and_timestamps.iter().enumerate()
+            {
+                let report_aggregation = ReportAggregation::new(
+                    *task_id,
+                    *aggregation_job.id(),
+                    *report_id,
+                    *client_timestamp,
+                    ord.try_into().unwrap(),
+                    ReportAggregationState::<0, dummy_vdaf::Vdaf>::Start,
+                );
+                tx.put_report_aggregation(&report_aggregation)
+                    .await
+                    .unwrap();
+            }
+
+            let batch_aggregation = BatchAggregation::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
+                *task_id,
+                batch_identifier,
+                AggregationParam(0),
+                AggregateShare(0),
+                0,
+                ReportIdChecksum::default(),
+            );
+            tx.put_batch_aggregation(&batch_aggregation).await.unwrap();
+
+            (
+                *aggregation_job.id(),
+                batch_identifier,
+                report_ids_and_timestamps
+                    .into_iter()
+                    .map(|(report_id, _)| report_id)
+                    .collect(),
+            )
+        }
+
+        const OLDEST_ALLOWED_REPORT_TIMESTAMP: Time = Time::from_seconds_since_epoch(1000);
+        let (
+            task_id,
+            other_task_id,
+            want_aggregation_job_ids,
+            want_batch_identifiers,
+            want_report_ids,
+        ) = ds
+            .run_tx(|tx| {
+                Box::pin(async move {
+                    let task = TaskBuilder::new(
+                        task::QueryType::TimeInterval,
+                        VdafInstance::Fake,
+                        Role::Leader,
+                    )
+                    .build();
+                    let other_task = TaskBuilder::new(
+                        task::QueryType::TimeInterval,
+                        VdafInstance::Fake,
+                        Role::Leader,
+                    )
+                    .build();
+                    tx.put_task(&task).await?;
+                    tx.put_task(&other_task).await?;
+
+                    let mut aggregation_job_ids = HashSet::new();
+                    let mut batch_identifiers = HashSet::new();
+                    let mut all_report_ids = HashSet::new();
+
+                    // Aggregation job job with old reports [GC'ed].
+                    write_aggregation_artifacts(
+                        tx,
+                        task.id(),
+                        &[
+                            OLDEST_ALLOWED_REPORT_TIMESTAMP
+                                .sub(&Duration::from_seconds(10))
+                                .unwrap(),
+                            OLDEST_ALLOWED_REPORT_TIMESTAMP
+                                .sub(&Duration::from_seconds(9))
+                                .unwrap(),
+                        ],
+                    )
+                    .await;
+
+                    // Aggregation job with old & new reports [not GC'ed].
+                    let (aggregation_job_id, batch_identifier, report_ids) =
+                        write_aggregation_artifacts(
+                            tx,
+                            task.id(),
+                            &[
+                                OLDEST_ALLOWED_REPORT_TIMESTAMP
+                                    .sub(&Duration::from_seconds(5))
+                                    .unwrap(),
+                                OLDEST_ALLOWED_REPORT_TIMESTAMP
+                                    .add(&Duration::from_seconds(5))
+                                    .unwrap(),
+                            ],
+                        )
+                        .await;
+                    aggregation_job_ids.insert(aggregation_job_id);
+                    batch_identifiers.insert(batch_identifier);
+                    all_report_ids.extend(report_ids);
+
+                    // Aggregation job with new reports [not GC'ed].
+                    let (aggregation_job_id, batch_identifier, report_ids) =
+                        write_aggregation_artifacts(
+                            tx,
+                            task.id(),
+                            &[
+                                OLDEST_ALLOWED_REPORT_TIMESTAMP
+                                    .add(&Duration::from_seconds(9))
+                                    .unwrap(),
+                                OLDEST_ALLOWED_REPORT_TIMESTAMP
+                                    .add(&Duration::from_seconds(10))
+                                    .unwrap(),
+                            ],
+                        )
+                        .await;
+                    aggregation_job_ids.insert(aggregation_job_id);
+                    batch_identifiers.insert(batch_identifier);
+                    all_report_ids.extend(report_ids);
+
+                    // Aggregation job with attached collect job [not GC'ed].
+                    let (aggregation_job_id, batch_identifier, report_ids) =
+                        write_aggregation_artifacts(
+                            tx,
+                            task.id(),
+                            &[
+                                OLDEST_ALLOWED_REPORT_TIMESTAMP
+                                    .sub(&Duration::from_seconds(9))
+                                    .unwrap(),
+                                OLDEST_ALLOWED_REPORT_TIMESTAMP
+                                    .sub(&Duration::from_seconds(8))
+                                    .unwrap(),
+                            ],
+                        )
+                        .await;
+                    tx.put_collect_job(&CollectJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
+                        *task.id(),
+                        Uuid::new_v4(),
+                        batch_identifier,
+                        AggregationParam(0),
+                        CollectJobState::Start,
+                    ))
+                    .await
+                    .unwrap();
+                    aggregation_job_ids.insert(aggregation_job_id);
+                    batch_identifiers.insert(batch_identifier);
+                    all_report_ids.extend(report_ids);
+
+                    // Aggregation job for a different task [not GC'ed].
+                    let (aggregation_job_id, batch_identifier, report_ids) =
+                        write_aggregation_artifacts(
+                            tx,
+                            other_task.id(),
+                            &[
+                                OLDEST_ALLOWED_REPORT_TIMESTAMP
+                                    .sub(&Duration::from_seconds(8))
+                                    .unwrap(),
+                                OLDEST_ALLOWED_REPORT_TIMESTAMP
+                                    .sub(&Duration::from_seconds(7))
+                                    .unwrap(),
+                            ],
+                        )
+                        .await;
+                    aggregation_job_ids.insert(aggregation_job_id);
+                    batch_identifiers.insert(batch_identifier);
+                    all_report_ids.extend(report_ids);
+
+                    Ok((
+                        *task.id(),
+                        *other_task.id(),
+                        aggregation_job_ids,
+                        batch_identifiers,
+                        all_report_ids,
+                    ))
+                })
+            })
+            .await
+            .unwrap();
+
+        // Run.
+        ds.run_tx(|tx| {
+            Box::pin(async move {
+                tx.delete_expired_aggregation_artifacts(&task_id, OLDEST_ALLOWED_REPORT_TIMESTAMP)
+                    .await
+            })
+        })
+        .await
+        .unwrap();
+
+        // Verify.
+        let (got_aggregation_job_ids, got_batch_identifiers, got_report_ids) = ds
+            .run_tx(|tx| {
+                let vdaf = vdaf.clone();
+                Box::pin(async move {
+                    let task_aggregation_jobs = tx
+                        .get_aggregation_jobs_for_task::<0, TimeInterval, dummy_vdaf::Vdaf>(
+                            &task_id,
+                        )
+                        .await
+                        .unwrap();
+                    let other_task_aggregation_jobs = tx
+                        .get_aggregation_jobs_for_task::<0, TimeInterval, dummy_vdaf::Vdaf>(
+                            &other_task_id,
+                        )
+                        .await
+                        .unwrap();
+                    let got_aggregation_job_ids = task_aggregation_jobs
+                        .into_iter()
+                        .chain(other_task_aggregation_jobs.into_iter())
+                        .map(|aggregation_job| *aggregation_job.id())
+                        .collect();
+
+                    let task_batch_aggregations = tx
+                        .get_batch_aggregations_for_task::<0, TimeInterval, dummy_vdaf::Vdaf>(
+                            &task_id,
+                        )
+                        .await
+                        .unwrap();
+                    let other_task_batch_aggregations = tx
+                        .get_batch_aggregations_for_task::<0, TimeInterval, dummy_vdaf::Vdaf>(
+                            &other_task_id,
+                        )
+                        .await
+                        .unwrap();
+                    let got_batch_identifiers = task_batch_aggregations
+                        .into_iter()
+                        .chain(other_task_batch_aggregations.into_iter())
+                        .map(|batch_aggregation| *batch_aggregation.batch_identifier())
+                        .collect();
+
+                    let task_report_aggregations = tx
+                        .get_report_aggregations_for_task::<0, dummy_vdaf::Vdaf>(
+                            &vdaf,
+                            &Role::Leader,
+                            &task_id,
+                        )
+                        .await
+                        .unwrap();
+                    let other_task_report_aggregations = tx
+                        .get_report_aggregations_for_task::<0, dummy_vdaf::Vdaf>(
+                            &vdaf,
+                            &Role::Leader,
+                            &other_task_id,
+                        )
+                        .await
+                        .unwrap();
+                    let got_report_ids = task_report_aggregations
+                        .into_iter()
+                        .chain(other_task_report_aggregations.into_iter())
+                        .map(|report_aggregation| *report_aggregation.report_id())
+                        .collect();
+
+                    Ok((
+                        got_aggregation_job_ids,
+                        got_batch_identifiers,
+                        got_report_ids,
+                    ))
+                })
+            })
+            .await
+            .unwrap();
+        assert_eq!(want_aggregation_job_ids, got_aggregation_job_ids);
+        assert_eq!(want_batch_identifiers, got_batch_identifiers);
+        assert_eq!(want_report_ids, got_report_ids);
+    }
+
+    #[tokio::test]
+    async fn delete_expired_collect_artifacts() {
+        install_test_trace_subscriber();
+
+        let clock = MockClock::default();
+        let (ds, _db_handle) = ephemeral_datastore(clock.clone()).await;
+
+        // Setup.
+        async fn write_collect_artifacts(
+            tx: &Transaction<'_, MockClock>,
+            task_id: &TaskId,
+            client_timestamps: &[Time],
+        ) -> Uuid {
+            for client_timestamp in client_timestamps {
+                let report = LeaderStoredReport::new_dummy(*task_id, *client_timestamp);
+                tx.put_client_report(&report).await.unwrap();
+
+                let batch_identifier =
+                    Interval::new(*client_timestamp, Duration::from_seconds(1)).unwrap();
+                let aggregation_job = AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
+                    *task_id,
+                    random(),
+                    Some(batch_identifier),
+                    AggregationParam(0),
+                    AggregationJobState::InProgress,
+                );
+                tx.put_aggregation_job(&aggregation_job).await.unwrap();
+
+                let report_aggregation = ReportAggregation::new(
+                    *task_id,
+                    *aggregation_job.id(),
+                    *report.metadata().id(),
+                    *client_timestamp,
+                    0,
+                    ReportAggregationState::<0, dummy_vdaf::Vdaf>::Start,
+                );
+                tx.put_report_aggregation(&report_aggregation)
+                    .await
+                    .unwrap();
+            }
+
+            let min_client_timestamp = *client_timestamps.iter().min().unwrap();
+            let max_client_timestamp = *client_timestamps.iter().max().unwrap();
+            let batch_identifier = Interval::new(
+                min_client_timestamp,
+                Duration::from_seconds(
+                    max_client_timestamp
+                        .difference(&min_client_timestamp)
+                        .unwrap()
+                        .as_seconds()
+                        + 1,
+                ),
+            )
+            .unwrap();
+            let collect_job = CollectJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
+                *task_id,
+                Uuid::new_v4(),
+                batch_identifier,
+                AggregationParam(0),
+                CollectJobState::Start,
+            );
+            tx.put_collect_job(&collect_job).await.unwrap();
+
+            *collect_job.collect_job_id()
+        }
+
+        const OLDEST_ALLOWED_REPORT_TIMESTAMP: Time = Time::from_seconds_since_epoch(1000);
+        let (task_id, other_task_id, want_collect_job_ids) = ds
+            .run_tx(|tx| {
+                Box::pin(async move {
+                    let task = TaskBuilder::new(
+                        task::QueryType::TimeInterval,
+                        VdafInstance::Fake,
+                        Role::Leader,
+                    )
+                    .build();
+                    let other_task = TaskBuilder::new(
+                        task::QueryType::TimeInterval,
+                        VdafInstance::Fake,
+                        Role::Leader,
+                    )
+                    .build();
+                    tx.put_task(&task).await?;
+                    tx.put_task(&other_task).await?;
+
+                    let mut collect_job_ids = HashSet::new();
+
+                    // Collect job with old reports. [GC'ed]
+                    write_collect_artifacts(
+                        tx,
+                        task.id(),
+                        &[
+                            OLDEST_ALLOWED_REPORT_TIMESTAMP
+                                .sub(&Duration::from_seconds(10))
+                                .unwrap(),
+                            OLDEST_ALLOWED_REPORT_TIMESTAMP
+                                .sub(&Duration::from_seconds(9))
+                                .unwrap(),
+                        ],
+                    )
+                    .await;
+
+                    // Collect job with old & new reports. [not GC'ed]
+                    let collect_job_id = write_collect_artifacts(
+                        tx,
+                        task.id(),
+                        &[
+                            OLDEST_ALLOWED_REPORT_TIMESTAMP
+                                .sub(&Duration::from_seconds(5))
+                                .unwrap(),
+                            OLDEST_ALLOWED_REPORT_TIMESTAMP
+                                .add(&Duration::from_seconds(5))
+                                .unwrap(),
+                        ],
+                    )
+                    .await;
+                    collect_job_ids.insert(collect_job_id);
+
+                    // Collect job with new reports. [not GC'ed]
+                    let collect_job_id = write_collect_artifacts(
+                        tx,
+                        task.id(),
+                        &[
+                            OLDEST_ALLOWED_REPORT_TIMESTAMP
+                                .add(&Duration::from_seconds(9))
+                                .unwrap(),
+                            OLDEST_ALLOWED_REPORT_TIMESTAMP
+                                .add(&Duration::from_seconds(10))
+                                .unwrap(),
+                        ],
+                    )
+                    .await;
+                    collect_job_ids.insert(collect_job_id);
+
+                    // Collect job for different task. [not GC'ed]
+                    let collect_job_id = write_collect_artifacts(
+                        tx,
+                        other_task.id(),
+                        &[
+                            OLDEST_ALLOWED_REPORT_TIMESTAMP
+                                .sub(&Duration::from_seconds(9))
+                                .unwrap(),
+                            OLDEST_ALLOWED_REPORT_TIMESTAMP
+                                .sub(&Duration::from_seconds(8))
+                                .unwrap(),
+                        ],
+                    )
+                    .await;
+                    collect_job_ids.insert(collect_job_id);
+
+                    Ok((*task.id(), *other_task.id(), collect_job_ids))
+                })
+            })
+            .await
+            .unwrap();
+
+        // Run.
+        ds.run_tx(|tx| {
+            Box::pin(async move {
+                tx.delete_expired_collect_artifacts(&task_id, OLDEST_ALLOWED_REPORT_TIMESTAMP)
+                    .await
+            })
+        })
+        .await
+        .unwrap();
+
+        // Verify.
+        let got_collect_job_ids = ds
+            .run_tx(|tx| {
+                Box::pin(async move {
+                    let task_collect_jobs = tx
+                        .get_collect_jobs_intersecting_interval::<0, dummy_vdaf::Vdaf>(
+                            &task_id,
+                            &Interval::new(
+                                Time::from_seconds_since_epoch(0),
+                                Duration::from_seconds(2000),
+                            )
+                            .unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                    let other_task_collect_jobs = tx
+                        .get_collect_jobs_intersecting_interval::<0, dummy_vdaf::Vdaf>(
+                            &other_task_id,
+                            &Interval::new(
+                                Time::from_seconds_since_epoch(0),
+                                Duration::from_seconds(2000),
+                            )
+                            .unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                    let got_collect_job_ids = task_collect_jobs
+                        .into_iter()
+                        .chain(other_task_collect_jobs.into_iter())
+                        .map(|collect_job| *collect_job.collect_job_id())
+                        .collect();
+
+                    Ok(got_collect_job_ids)
+                })
+            })
+            .await
+            .unwrap();
+        assert_eq!(want_collect_job_ids, got_collect_job_ids);
     }
 
     /// generate_vdaf_values generates some arbitrary VDAF values for use in testing. It is cribbed

--- a/aggregator/src/messages.rs
+++ b/aggregator/src/messages.rs
@@ -8,6 +8,9 @@ const USEC_PER_SEC: u64 = 1_000_000;
 
 /// Extension methods on [`Duration`].
 pub trait DurationExt: Sized {
+    /// Add this duration with another duration.
+    fn add(&self, duration: &Duration) -> Result<Self, Error>;
+
     /// Create a duration from a number of microseconds. The time will be rounded down to the next
     /// second.
     fn from_microseconds(microseconds: u64) -> Self;
@@ -24,6 +27,13 @@ pub trait DurationExt: Sized {
 }
 
 impl DurationExt for Duration {
+    fn add(&self, other: &Duration) -> Result<Self, Error> {
+        self.as_seconds()
+            .checked_add(other.as_seconds())
+            .ok_or(Error::IllegalTimeArithmetic("operation would overflow"))
+            .map(Duration::from_seconds)
+    }
+
     fn from_microseconds(microseconds: u64) -> Self {
         Self::from_seconds(microseconds / USEC_PER_SEC)
     }

--- a/aggregator/src/task.rs
+++ b/aggregator/src/task.rs
@@ -93,6 +93,9 @@ pub struct Task {
     max_batch_query_count: u64,
     /// The time after which the task is considered invalid.
     task_expiration: Time,
+    /// The age after which a report is considered to be "expired" and will be considered a
+    /// candidate for garbage collection.
+    report_expiry_age: Option<Duration>,
     /// The minimum number of reports in a batch to allow it to be collected.
     min_batch_size: u64,
     /// The duration to which clients should round their reported timestamps to. For time-interval
@@ -124,6 +127,7 @@ impl Task {
         vdaf_verify_keys: Vec<SecretBytes>,
         max_batch_query_count: u64,
         task_expiration: Time,
+        report_expiry_age: Option<Duration>,
         min_batch_size: u64,
         time_precision: Duration,
         tolerable_clock_skew: Duration,
@@ -154,6 +158,7 @@ impl Task {
             vdaf_verify_keys,
             max_batch_query_count,
             task_expiration,
+            report_expiry_age,
             min_batch_size,
             time_precision,
             tolerable_clock_skew,
@@ -229,6 +234,11 @@ impl Task {
     /// Retrieves the task expiration associated with this task.
     pub fn task_expiration(&self) -> &Time {
         &self.task_expiration
+    }
+
+    /// Retrieves the report expiry age associated with this task.
+    pub fn report_expiry_age(&self) -> Option<&Duration> {
+        self.report_expiry_age.as_ref()
     }
 
     /// Retrieves the min batch size parameter associated with this task.
@@ -353,6 +363,7 @@ pub struct SerializedTask {
     vdaf_verify_keys: Vec<String>, // in unpadded base64url
     max_batch_query_count: u64,
     task_expiration: Time,
+    report_expiry_age: Option<Duration>,
     min_batch_size: u64,
     time_precision: Duration,
     tolerable_clock_skew: Duration,
@@ -445,6 +456,7 @@ impl Serialize for Task {
             vdaf_verify_keys,
             max_batch_query_count: self.max_batch_query_count,
             task_expiration: self.task_expiration,
+            report_expiry_age: self.report_expiry_age,
             min_batch_size: self.min_batch_size,
             time_precision: self.time_precision,
             tolerable_clock_skew: self.tolerable_clock_skew,
@@ -496,6 +508,7 @@ impl TryFrom<SerializedTask> for Task {
             vdaf_verify_keys,
             serialized_task.max_batch_query_count,
             serialized_task.task_expiration,
+            serialized_task.report_expiry_age,
             serialized_task.min_batch_size,
             serialized_task.time_precision,
             serialized_task.tolerable_clock_skew,
@@ -511,7 +524,6 @@ impl<'de> Deserialize<'de> for Task {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         // Deserialize into intermediate representation.
         let serialized_task = SerializedTask::deserialize(deserializer)?;
-
         Task::try_from(serialized_task).map_err(D::Error::custom)
     }
 }
@@ -593,6 +605,7 @@ pub mod test_util {
                     Vec::from([vdaf_verify_key]),
                     1,
                     Time::distant_future(),
+                    None,
                     0,
                     Duration::from_hours(8).unwrap(),
                     Duration::from_minutes(10).unwrap(),
@@ -698,6 +711,14 @@ pub mod test_util {
             })
         }
 
+        /// Sets the report expiry age.
+        pub fn with_report_expiry_age(self, report_expiry_age: Option<Duration>) -> Self {
+            Self(Task {
+                report_expiry_age,
+                ..self.0
+            })
+        }
+
         /// Sets the task query type
         pub fn with_query_type(self, query_type: QueryType) -> Self {
             Self(Task {
@@ -772,6 +793,7 @@ mod tests {
             Vec::from([SecretBytes::new([0; PRIO3_AES128_VERIFY_KEY_LENGTH].into())]),
             0,
             Time::from_seconds_since_epoch(u64::MAX),
+            None,
             0,
             Duration::from_hours(8).unwrap(),
             Duration::from_minutes(10).unwrap(),
@@ -795,6 +817,7 @@ mod tests {
             Vec::from([SecretBytes::new([0; PRIO3_AES128_VERIFY_KEY_LENGTH].into())]),
             0,
             Time::from_seconds_since_epoch(u64::MAX),
+            None,
             0,
             Duration::from_hours(8).unwrap(),
             Duration::from_minutes(10).unwrap(),
@@ -818,6 +841,7 @@ mod tests {
             Vec::from([SecretBytes::new([0; PRIO3_AES128_VERIFY_KEY_LENGTH].into())]),
             0,
             Time::from_seconds_since_epoch(u64::MAX),
+            None,
             0,
             Duration::from_hours(8).unwrap(),
             Duration::from_minutes(10).unwrap(),
@@ -841,6 +865,7 @@ mod tests {
             Vec::from([SecretBytes::new([0; PRIO3_AES128_VERIFY_KEY_LENGTH].into())]),
             0,
             Time::from_seconds_since_epoch(u64::MAX),
+            None,
             0,
             Duration::from_hours(8).unwrap(),
             Duration::from_minutes(10).unwrap(),
@@ -866,6 +891,7 @@ mod tests {
             Vec::from([SecretBytes::new([0; PRIO3_AES128_VERIFY_KEY_LENGTH].into())]),
             0,
             Time::from_seconds_since_epoch(u64::MAX),
+            None,
             0,
             Duration::from_hours(8).unwrap(),
             Duration::from_minutes(10).unwrap(),
@@ -900,6 +926,7 @@ mod tests {
                 Vec::from([SecretBytes::new(b"1234567812345678".to_vec())]),
                 1,
                 Time::distant_future(),
+                None,
                 10,
                 Duration::from_seconds(3600),
                 Duration::from_seconds(60),
@@ -927,7 +954,7 @@ mod tests {
             &[
                 Token::Struct {
                     name: "SerializedTask",
-                    len: 15,
+                    len: 16,
                 },
                 Token::Str("task_id"),
                 Token::Some,
@@ -961,6 +988,8 @@ mod tests {
                 Token::Str("task_expiration"),
                 Token::NewtypeStruct { name: "Time" },
                 Token::U64(9000000000),
+                Token::Str("report_expiry_age"),
+                Token::None,
                 Token::Str("min_batch_size"),
                 Token::U64(10),
                 Token::Str("time_precision"),
@@ -1060,6 +1089,7 @@ mod tests {
                 Vec::from([SecretBytes::new(b"1234567812345678".to_vec())]),
                 1,
                 Time::distant_future(),
+                Some(Duration::from_seconds(1800)),
                 10,
                 Duration::from_seconds(3600),
                 Duration::from_seconds(60),
@@ -1087,7 +1117,7 @@ mod tests {
             &[
                 Token::Struct {
                     name: "SerializedTask",
-                    len: 15,
+                    len: 16,
                 },
                 Token::Str("task_id"),
                 Token::Some,
@@ -1129,6 +1159,10 @@ mod tests {
                 Token::Str("task_expiration"),
                 Token::NewtypeStruct { name: "Time" },
                 Token::U64(9000000000),
+                Token::Str("report_expiry_age"),
+                Token::Some,
+                Token::NewtypeStruct { name: "Duration" },
+                Token::U64(1800),
                 Token::Str("min_batch_size"),
                 Token::U64(10),
                 Token::Str("time_precision"),

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -19,6 +19,7 @@ CREATE TABLE tasks(
     vdaf                   JSON NOT NULL,             -- the VDAF instance in use for this task, along with its parameters
     max_batch_query_count  BIGINT NOT NULL,           -- the maximum number of times a given batch may be collected
     task_expiration        TIMESTAMP NOT NULL,        -- the time after which client reports are no longer accepted
+    report_expiry_age      BIGINT,                    -- the maximum age of a report before it is considered expired (and acceptable for garbage collection), in seconds. NULL means that GC is disabled.
     min_batch_size         BIGINT NOT NULL,           -- the minimum number of reports in a batch to allow it to be collected
     time_precision         BIGINT NOT NULL,           -- the duration to which clients are expected to round their report timestamps, in seconds
     tolerable_clock_skew   BIGINT NOT NULL,           -- the maximum acceptable clock skew to allow between client and aggregator, in seconds

--- a/interop_binaries/src/bin/janus_interop_aggregator.rs
+++ b/interop_binaries/src/bin/janus_interop_aggregator.rs
@@ -86,6 +86,7 @@ async fn handle_add_task(
         Vec::from([vdaf_verify_key]),
         request.max_batch_query_count,
         Time::from_seconds_since_epoch(request.task_expiration),
+        None,
         request.min_batch_size,
         time_precision,
         // We can be strict about clock skew since this executable is only intended for use with

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -28,6 +28,9 @@ pub mod problem_type;
 /// Errors returned by functions and methods in this module
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    /// An invalid parameter was passed.
+    #[error("{0}")]
+    InvalidParameter(&'static str),
     /// An illegal arithmetic operation on a [`Time`] or [`Duration`].
     #[error("{0}")]
     IllegalTimeArithmetic(&'static str),
@@ -49,7 +52,7 @@ impl Duration {
     }
 
     /// Get the number of seconds this duration represents.
-    pub fn as_seconds(self) -> u64 {
+    pub fn as_seconds(&self) -> u64 {
         self.0
     }
 }
@@ -240,6 +243,17 @@ impl ReportId {
 impl From<[u8; Self::LEN]> for ReportId {
     fn from(report_id: [u8; Self::LEN]) -> Self {
         Self(report_id)
+    }
+}
+
+impl<'a> TryFrom<&'a [u8]> for ReportId {
+    type Error = Error;
+
+    fn try_from(report_id: &[u8]) -> Result<Self, Self::Error> {
+        let report_id: [u8; Self::LEN] = report_id
+            .try_into()
+            .map_err(|_| Error::InvalidParameter("ReportId length incorrect"))?;
+        Ok(Self::from(report_id))
     }
 }
 
@@ -1835,6 +1849,23 @@ pub struct AggregationJobId([u8; Self::LEN]);
 impl AggregationJobId {
     /// LEN is the length of an aggregation job ID in bytes.
     pub const LEN: usize = 32;
+}
+
+impl From<[u8; Self::LEN]> for AggregationJobId {
+    fn from(aggregation_job_id: [u8; Self::LEN]) -> Self {
+        Self(aggregation_job_id)
+    }
+}
+
+impl<'a> TryFrom<&'a [u8]> for AggregationJobId {
+    type Error = Error;
+
+    fn try_from(aggregation_job_id: &[u8]) -> Result<Self, Self::Error> {
+        let aggregation_job_id: [u8; Self::LEN] = aggregation_job_id
+            .try_into()
+            .map_err(|_| Error::InvalidParameter("AggregationJobId length incorrect"))?;
+        Ok(Self::from(aggregation_job_id))
+    }
 }
 
 impl AsRef<[u8; Self::LEN]> for AggregationJobId {

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -346,6 +346,13 @@ impl Decode for ReportIdChecksum {
     }
 }
 
+#[cfg(feature = "test-util")]
+impl Distribution<ReportIdChecksum> for Standard {
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> ReportIdChecksum {
+        ReportIdChecksum(rng.gen())
+    }
+}
+
 /// DAP protocol message representing the different roles that participants can adopt.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, TryFromPrimitive, Serialize, Deserialize)]
 #[repr(u8)]


### PR DESCRIPTION
This PR is huge, but is mostly straightforward. Over-and-above the 0.2 version of this functionality, this PR includes:

* Support for fixed-size tasks. This is relatively straightforward--no new data needs to be stored, only the relevant expiry SQL queries needed to be updated.
* Support for helper tasks. This is trickier: to support time-interval helper tasks, we need to compute & store the interval of contained reports, as otherwise we do not have a fast (indexed) way to associate collection artifacts with the relevant aggregation jobs since time-interval helper tasks do not store the interval of the aggregation job (nor could they, as this information is not transmitted from the leader). However, we have to be careful to only use the client timestamp interval for time-interval tasks, as fixed-size tasks do not correlate collection artifacts to aggregation jobs in this way.

Please review the tests carefully; I made them as realistic as possible given that this functionality involves the deletion of data. The `garbage_collector.rs` tests are higher-level tests that the individual datastore operations interact as expected; the `datastore.rs` tests verify the various corner cases of the individual datastore operations.

Closes #313.