### PR TITLE
Update Kind and Kubernetes versions used in tests

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -61,7 +61,7 @@ jobs:
       # We should always make sure that the `kind` CLI we install is from the
       # same release as the node image version used by
       # `janus_core::test_util::kubernetes::EphemeralCluster`
-      run: go install sigs.k8s.io/kind@v0.14.0
+      run: go install sigs.k8s.io/kind@v0.17.0
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@master
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ janus_core = { version = "0.3", path = "core" }
 janus_integration_tests = { version = "0.3", path = "integration_tests" }
 janus_interop_binaries = { version = "0.3", path = "interop_binaries" }
 janus_messages = { version = "0.3", path = "messages" }
-k8s-openapi = { version = "0.16.0", features = ["v1_20"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
+k8s-openapi = { version = "0.16.0", features = ["v1_24"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
 kube = { version = "0.75.0", default-features = false, features = ["client"] }
 
 [profile.dev]

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ components; see `.github/workflows/ci-build.yml` for example Docker invocations.
 
 ## Running tests
 
-Tests require that [`docker`](https://www.docker.com) & [`kind`](https://kind.sigs.k8s.io) be installed on the machine running the tests and in the `PATH` of the test-runner's environment. The `docker` daemon must be running. CI tests currently use [`kind` 0.14.0](https://github.com/kubernetes-sigs/kind/releases/tag/v0.14.0) and the corresponding [Kubernetes 1.22 node image](kindest/node:v1.22.9@sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105) and using the same versions for local development is recommended.
+Tests require that [`docker`](https://www.docker.com) & [`kind`](https://kind.sigs.k8s.io) be installed on the machine running the tests and in the `PATH` of the test-runner's environment. The `docker` daemon must be running. CI tests currently use [`kind` 0.17.0](https://github.com/kubernetes-sigs/kind/releases/tag/v0.17.0) and the corresponding Kubernetes 1.24 node image (kindest/node:v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315) and using the same versions for local development is recommended.
 
 To run Janus tests, execute `cargo test`.
 

--- a/core/src/test_util/kubernetes.rs
+++ b/core/src/test_util/kubernetes.rs
@@ -124,10 +124,10 @@ impl EphemeralCluster {
         // Choose a cluster name.
         let kind_cluster_name = format!("janus-ephemeral-{}", hex::encode(random::<[u8; 4]>()));
 
-        // Use kind to start the cluster, with the node image from kind v0.14.0 for Kubernetes 1.22,
+        // Use kind to start the cluster, with the node image from kind v0.17.0 for Kubernetes 1.24,
         // matching current regular GKE release channel. This image version should be bumped in
         // lockstep with the version of kind installed by the ci-build workflow.
-        // https://github.com/kubernetes-sigs/kind/releases/tag/v0.14.0
+        // https://github.com/kubernetes-sigs/kind/releases/tag/v0.17.0
         // https://cloud.google.com/kubernetes-engine/docs/release-notes#regular-channel
         assert!(Command::new("kind")
             .args([
@@ -138,7 +138,7 @@ impl EphemeralCluster {
                 "--name",
                 &kind_cluster_name,
                 "--image",
-                "kindest/node:v1.22.9@sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105",
+                "kindest/node:v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315",
             ])
             .stdin(Stdio::null())
             .stdout(Stdio::null())


### PR DESCRIPTION
This updates the Kind and Kubernetes versions we test against, to keep up with our deployment code.