### PR TITLE
Create aggregation jobs with arbitrary reports.

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1971,8 +1971,6 @@ impl VdafOps {
         }
 
         // Store data to datastore.
-        let batch_identifier_opt =
-            Q::upgrade_partial_batch_identifier(req.batch_selector().batch_identifier()).cloned();
         let req = Arc::new(req);
         let min_client_timestamp = req
             .report_shares()
@@ -1995,8 +1993,8 @@ impl VdafOps {
         let aggregation_job = Arc::new(AggregationJob::<L, Q, A>::new(
             *task.id(),
             *req.job_id(),
-            batch_identifier_opt,
             agg_param,
+            req.batch_selector().batch_identifier().clone(),
             client_timestamp_interval,
             if saw_continue {
                 AggregationJobState::InProgress
@@ -2071,7 +2069,7 @@ impl VdafOps {
                             share_data.agg_state
                         {
                             accumulator.update(
-                                aggregation_job.partial_batch_identifier()?,
+                                aggregation_job.partial_batch_identifier(),
                                 share_data.report_share.metadata().id(),
                                 share_data.report_share.metadata().time(),
                                 output_share,
@@ -2223,7 +2221,7 @@ impl VdafOps {
                             Ok(PrepareTransition::Finish(output_share)) => {
                                 saw_finish = true;
                                 accumulator.update(
-                                    aggregation_job.partial_batch_identifier()?,
+                                    aggregation_job.partial_batch_identifier(),
                                     prep_step.report_id(),
                                     report_aggregation.time(),
                                     &output_share,
@@ -5394,7 +5392,7 @@ mod tests {
         assert_eq!(aggregation_jobs.len(), 1);
         assert_eq!(aggregation_jobs[0].task_id(), task.id());
         assert_eq!(aggregation_jobs[0].id(), request.job_id());
-        assert!(aggregation_jobs[0].batch_identifier().is_none());
+        assert_eq!(aggregation_jobs[0].partial_batch_identifier(), &());
         assert_eq!(
             aggregation_jobs[0].state(),
             &AggregationJobState::InProgress
@@ -5761,7 +5759,7 @@ mod tests {
                     >::new(
                         *task.id(),
                         aggregation_job_id,
-                        None,
+                        (),
                         (),
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1)).unwrap(),
                         AggregationJobState::InProgress,
@@ -5903,7 +5901,7 @@ mod tests {
             Some(AggregationJob::new(
                 *task.id(),
                 aggregation_job_id,
-                None,
+                (),
                 (),
                 Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                     .unwrap(),
@@ -6085,7 +6083,7 @@ mod tests {
                     >::new(
                         *task.id(),
                         aggregation_job_id_0,
-                        None,
+                        (),
                         (),
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
@@ -6372,7 +6370,7 @@ mod tests {
                     >::new(
                         *task.id(),
                         aggregation_job_id_1,
-                        None,
+                        (),
                         (),
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
@@ -6603,8 +6601,8 @@ mod tests {
                     >::new(
                         *task.id(),
                         aggregation_job_id,
-                        None,
                         dummy_vdaf::AggregationParam(0),
+                        (),
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,
@@ -6717,8 +6715,8 @@ mod tests {
                     >::new(
                         *task.id(),
                         aggregation_job_id,
-                        None,
                         dummy_vdaf::AggregationParam(0),
+                        (),
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,
@@ -6815,8 +6813,8 @@ mod tests {
             Some(AggregationJob::new(
                 *task.id(),
                 aggregation_job_id,
-                None,
                 dummy_vdaf::AggregationParam(0),
+                (),
                 Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                     .unwrap(),
                 AggregationJobState::Finished,
@@ -6878,8 +6876,8 @@ mod tests {
                     >::new(
                         *task.id(),
                         aggregation_job_id,
-                        None,
                         dummy_vdaf::AggregationParam(0),
+                        (),
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,
@@ -7013,8 +7011,8 @@ mod tests {
                     >::new(
                         *task.id(),
                         aggregation_job_id,
-                        None,
                         dummy_vdaf::AggregationParam(0),
+                        (),
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,
@@ -7142,8 +7140,8 @@ mod tests {
                     >::new(
                         *task.id(),
                         aggregation_job_id,
-                        None,
                         dummy_vdaf::AggregationParam(0),
+                        (),
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -464,7 +464,7 @@ impl AggregationJobDriver {
             *task.id(),
             *aggregation_job.id(),
             aggregation_job.aggregation_parameter().get_encoded(),
-            PartialBatchSelector::new(aggregation_job.partial_batch_identifier()?.clone()),
+            PartialBatchSelector::new(aggregation_job.partial_batch_identifier().clone()),
             report_shares,
         );
 
@@ -685,7 +685,7 @@ impl AggregationJobDriver {
                     // If the leader didn't finish too, we transition to INVALID.
                     if let PrepareTransition::Finish(out_share) = leader_transition {
                         match accumulator.update(
-                            aggregation_job.partial_batch_identifier()?,
+                            aggregation_job.partial_batch_identifier(),
                             report_aggregation.report_id(),
                             report_aggregation.time(),
                             out_share,
@@ -1080,7 +1080,6 @@ mod tests {
         );
 
         let aggregation_job_id = random();
-        let batch_interval = Interval::new(time, *task.time_precision()).unwrap();
 
         ds.run_tx(|tx| {
             let (task, report) = (task.clone(), report.clone());
@@ -1095,7 +1094,7 @@ mod tests {
                 >::new(
                     *task.id(),
                     aggregation_job_id,
-                    Some(batch_interval),
+                    (),
                     (),
                     Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                         .unwrap(),
@@ -1196,7 +1195,7 @@ mod tests {
             AggregationJob::<PRIO3_AES128_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>::new(
                 *task.id(),
                 aggregation_job_id,
-                Some(batch_interval),
+                (),
                 (),
                 Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                     .unwrap(),
@@ -1303,7 +1302,6 @@ mod tests {
                 transcript.input_shares.clone(),
             );
         let aggregation_job_id = random();
-        let batch_interval = Interval::new(time, *task.time_precision()).unwrap();
 
         let lease = ds
             .run_tx(|tx| {
@@ -1324,7 +1322,7 @@ mod tests {
                     >::new(
                         *task.id(),
                         aggregation_job_id,
-                        Some(batch_interval),
+                        (),
                         (),
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
@@ -1435,7 +1433,7 @@ mod tests {
             AggregationJob::<PRIO3_AES128_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>::new(
                 *task.id(),
                 aggregation_job_id,
-                Some(batch_interval),
+                (),
                 (),
                 Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                     .unwrap(),
@@ -1564,8 +1562,8 @@ mod tests {
                     >::new(
                         *task.id(),
                         aggregation_job_id,
-                        Some(batch_id),
                         (),
+                        batch_id,
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,
@@ -1663,8 +1661,8 @@ mod tests {
             AggregationJob::<PRIO3_AES128_VERIFY_KEY_LENGTH, FixedSize, Prio3Aes128Count>::new(
                 *task.id(),
                 aggregation_job_id,
-                Some(batch_id),
                 (),
+                batch_id,
                 Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                     .unwrap(),
                 AggregationJobState::InProgress,
@@ -1761,7 +1759,6 @@ mod tests {
             transcript.input_shares.clone(),
         );
         let aggregation_job_id = random();
-        let batch_interval = Interval::new(time, *task.time_precision()).unwrap();
 
         let leader_prep_state = transcript.prep_state(0, Role::Leader);
         let leader_aggregate_share = vdaf
@@ -1788,7 +1785,7 @@ mod tests {
                     >::new(
                         *task.id(),
                         aggregation_job_id,
-                        Some(batch_interval),
+                        (),
                         (),
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
@@ -1880,7 +1877,7 @@ mod tests {
             AggregationJob::<PRIO3_AES128_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>::new(
                 *task.id(),
                 aggregation_job_id,
-                Some(batch_interval),
+                (),
                 (),
                 Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                     .unwrap(),
@@ -2029,8 +2026,8 @@ mod tests {
                     >::new(
                         *task.id(),
                         aggregation_job_id,
-                        Some(batch_id),
                         (),
+                        batch_id,
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,
@@ -2121,8 +2118,8 @@ mod tests {
             AggregationJob::<PRIO3_AES128_VERIFY_KEY_LENGTH, FixedSize, Prio3Aes128Count>::new(
                 *task.id(),
                 aggregation_job_id,
-                Some(batch_id),
                 (),
+                batch_id,
                 Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                     .unwrap(),
                 AggregationJobState::Finished,
@@ -2233,13 +2230,12 @@ mod tests {
             transcript.input_shares,
         );
         let aggregation_job_id = random();
-        let batch_interval = Interval::new(time, *task.time_precision()).unwrap();
 
         let aggregation_job =
             AggregationJob::<PRIO3_AES128_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>::new(
                 *task.id(),
                 aggregation_job_id,
-                Some(batch_interval),
+                (),
                 (),
                 Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                     .unwrap(),
@@ -2417,7 +2413,6 @@ mod tests {
             Vec::new(),
             transcript.input_shares,
         );
-        let batch_interval = Interval::new(time, *task.time_precision()).unwrap();
 
         // Set up fixtures in the database.
         ds.run_tx(|tx| {
@@ -2437,7 +2432,7 @@ mod tests {
                 >::new(
                     *task.id(),
                     aggregation_job_id,
-                    Some(batch_interval),
+                    (),
                     (),
                     Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                         .unwrap(),
@@ -2554,7 +2549,7 @@ mod tests {
             AggregationJob::<PRIO3_AES128_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>::new(
                 *task.id(),
                 aggregation_job_id,
-                Some(batch_interval),
+                (),
                 (),
                 Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                     .unwrap(),

--- a/aggregator/src/aggregator/collect_job_driver.rs
+++ b/aggregator/src/aggregator/collect_job_driver.rs
@@ -724,7 +724,7 @@ mod tests {
     };
     use janus_messages::{
         query_type::TimeInterval, AggregateShareReq, AggregateShareResp, BatchSelector, Duration,
-        HpkeCiphertext, HpkeConfigId, Interval, ReportIdChecksum, Role, Time,
+        HpkeCiphertext, HpkeConfigId, Interval, ReportIdChecksum, Role,
     };
     use mockito::mock;
     use opentelemetry::global::meter;
@@ -772,29 +772,23 @@ mod tests {
                         .await?;
 
                     let aggregation_job_id = random();
+                    let report_timestamp = clock
+                        .now()
+                        .to_batch_interval_start(task.time_precision())
+                        .unwrap();
                     tx.put_aggregation_job(
                         &AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
                             *task.id(),
                             aggregation_job_id,
-                            Some(batch_interval),
                             aggregation_param,
-                            Interval::new(
-                                Time::from_seconds_since_epoch(0),
-                                Duration::from_seconds(1),
-                            )
-                            .unwrap(),
+                            (),
+                            Interval::new(report_timestamp, Duration::from_seconds(1)).unwrap(),
                             AggregationJobState::Finished,
                         ),
                     )
                     .await?;
 
-                    let report = LeaderStoredReport::new_dummy(
-                        *task.id(),
-                        clock
-                            .now()
-                            .to_batch_interval_start(task.time_precision())
-                            .unwrap(),
-                    );
+                    let report = LeaderStoredReport::new_dummy(*task.id(), report_timestamp);
 
                     tx.put_client_report(&report).await?;
 
@@ -897,29 +891,23 @@ mod tests {
                     .await?;
 
                     let aggregation_job_id = random();
+                    let report_timestamp = clock
+                        .now()
+                        .to_batch_interval_start(task.time_precision())
+                        .unwrap();
                     tx.put_aggregation_job(
                         &AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
                             *task.id(),
                             aggregation_job_id,
-                            Some(batch_interval),
                             aggregation_param,
-                            Interval::new(
-                                Time::from_seconds_since_epoch(0),
-                                Duration::from_seconds(1),
-                            )
-                            .unwrap(),
+                            (),
+                            Interval::new(report_timestamp, Duration::from_seconds(1)).unwrap(),
                             AggregationJobState::Finished,
                         ),
                     )
                     .await?;
 
-                    let report = LeaderStoredReport::new_dummy(
-                        *task.id(),
-                        clock
-                            .now()
-                            .to_batch_interval_start(task.time_precision())
-                            .unwrap(),
-                    );
+                    let report = LeaderStoredReport::new_dummy(*task.id(), report_timestamp);
 
                     tx.put_client_report(&report).await?;
 

--- a/aggregator/src/aggregator/garbage_collector.rs
+++ b/aggregator/src/aggregator/garbage_collector.rs
@@ -146,9 +146,9 @@ mod tests {
                     let aggregation_job = AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
                         *task.id(),
                         random(),
-                        Some(batch_identifier),
                         AggregationParam(0),
-                        Interval::new(client_timestamp, Duration::from_seconds(1)).unwrap(),
+                        (),
+                        batch_identifier,
                         AggregationJobState::InProgress,
                     );
                     tx.put_aggregation_job(&aggregation_job).await.unwrap();
@@ -300,9 +300,9 @@ mod tests {
                     let aggregation_job = AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
                         *task.id(),
                         random(),
-                        Some(batch_identifier),
                         AggregationParam(0),
-                        Interval::new(client_timestamp, Duration::from_seconds(1)).unwrap(),
+                        (),
+                        batch_identifier,
                         AggregationJobState::InProgress,
                     );
                     tx.put_aggregation_job(&aggregation_job).await.unwrap();
@@ -452,8 +452,8 @@ mod tests {
                     let aggregation_job = AggregationJob::<0, FixedSize, dummy_vdaf::Vdaf>::new(
                         *task.id(),
                         random(),
-                        Some(batch_identifier),
                         AggregationParam(0),
+                        batch_identifier,
                         Interval::new(client_timestamp, Duration::from_seconds(1)).unwrap(),
                         AggregationJobState::InProgress,
                     );
@@ -610,8 +610,8 @@ mod tests {
                     let aggregation_job = AggregationJob::<0, FixedSize, dummy_vdaf::Vdaf>::new(
                         *task.id(),
                         random(),
-                        Some(batch_identifier),
                         AggregationParam(0),
+                        batch_identifier,
                         Interval::new(client_timestamp, Duration::from_seconds(1)).unwrap(),
                         AggregationJobState::InProgress,
                     );

--- a/aggregator/src/bin/aggregation_job_creator.rs
+++ b/aggregator/src/bin/aggregation_job_creator.rs
@@ -20,7 +20,6 @@ async fn main() -> anyhow::Result<()> {
         // Start creating aggregation jobs.
         let aggregation_job_creator = Arc::new(AggregationJobCreator::new(
             ctx.datastore,
-            ctx.clock,
             Duration::from_secs(ctx.config.tasks_update_frequency_secs),
             Duration::from_secs(ctx.config.aggregation_job_creation_interval_secs),
             ctx.config.min_aggregation_job_size,

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -99,9 +99,8 @@ CREATE TABLE aggregation_jobs(
     id                        BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY, -- artificial ID, internal-only
     task_id                   BIGINT NOT NULL,                 -- ID of related task
     aggregation_job_id        BYTEA NOT NULL,                  -- 32-byte AggregationJobID as defined by the DAP specification
-    batch_identifier          BYTEA,                           -- encoded query-type-specific batch identifier (corresponds to identifier in BatchSelector; present for leader tasks and fixed size tasks, NULL otherwise)
-    batch_interval            TSRANGE,                         -- batch interval, as a TSRANGE, populated only for leader time-interval tasks. (will match batch_identifier when present)
     aggregation_param         BYTEA NOT NULL,                  -- encoded aggregation parameter (opaque VDAF message)
+    batch_id                  BYTEA NOT NULL,                  -- batch ID (fixed-size only; corresponds to identifier in BatchSelector)
     client_timestamp_interval TSRANGE NOT NULL,                -- the minimal interval containing all of client timestamps included in this aggregation job
     state                     AGGREGATION_JOB_STATE NOT NULL,  -- current state of the aggregation job
 
@@ -113,8 +112,7 @@ CREATE TABLE aggregation_jobs(
     CONSTRAINT fk_task_id FOREIGN KEY(task_id) REFERENCES tasks(id)
 );
 CREATE INDEX aggregation_jobs_state_and_lease_expiry ON aggregation_jobs(state, lease_expiry) WHERE state = 'IN_PROGRESS';
-CREATE INDEX aggregation_jobs_task_and_batch_id ON aggregation_jobs(task_id, batch_identifier);
-CREATE INDEX aggregation_jobs_task_and_batch_interval ON aggregation_jobs USING gist (task_id, batch_interval) WHERE batch_interval IS NOT NULL;
+CREATE INDEX aggregation_jobs_task_and_batch_id ON aggregation_jobs(task_id, batch_id);
 CREATE INDEX aggregation_jobs_task_and_client_timestamp_interval ON aggregation_jobs USING gist (task_id, client_timestamp_interval);
 
 -- Specifies the possible state of aggregating a single report.


### PR DESCRIPTION
Aggregation jobs for time-interval tasks were previously created with reports in a single "batch unit" (i.e. an interval of time aligned with & as long as the time precision of the task). Now, aggregation jobs for time-interval tasks are created with arbitrary reports.

This allows us to stop ordering the reports we read, which will hopefully improve DB performance as we no longer need to read (and therefore predicate-lock) all reports for a given task.

This implied a schema change: previously, aggregation_jobs tracked the batch_identifier. Now, for time-interval tasks there is no batch_identifier to record. This column (and the equivalent batch_interval) are now removed; instead, client_timestamp_interval & the new batch_id column are used where batch_identifier previously would have been used.