### PR TITLE
Introduce client_reports.aggregation_started flag.

### DIFF
--- a/aggregator/src/datastore.rs
+++ b/aggregator/src/datastore.rs
@@ -1006,7 +1006,7 @@ impl<C: Clock> Transaction<'_, C> {
     /// `get_unaggregated_client_report_ids_for_task` returns some report IDs corresponding to
     /// unaggregated client reports for the task identified by the given task ID. Returned client
     /// reports are marked as aggregation-started: the caller must either create an aggregation job
-    /// with, or call `mark_reports_unaggregated` on, each returned report as part of the same
+    /// with, or call `mark_reports_unaggregated` on each returned report as part of the same
     /// transaction.
     ///
     /// This should only be used with VDAFs that have an aggregation parameter of the unit type. It

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -74,17 +74,19 @@ CREATE TABLE task_vdaf_verify_keys(
 -- Individual reports received from clients.
 CREATE TABLE client_reports(
     id                              BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY, -- artificial ID, internal-only
-    task_id                         BIGINT NOT NULL,     -- task ID the report is associated with
-    report_id                       BYTEA NOT NULL,      -- 16-byte ReportID as defined by the DAP specification
-    client_timestamp                TIMESTAMP NOT NULL,  -- report timestamp, from client
-    extensions                      BYTEA,               -- encoded sequence of Extension messages (populated for leader only)
-    public_share                    BYTEA,               -- encoded public share (opaque VDAF message, populated for leader only)
-    leader_input_share              BYTEA,               -- encoded, decrypted leader input share (populated for leader only)
-    helper_encrypted_input_share    BYTEA,               -- encdoed HpkeCiphertext message containing the helper's input share (populated for leader only)
+    task_id                         BIGINT NOT NULL,                 -- task ID the report is associated with
+    report_id                       BYTEA NOT NULL,                  -- 16-byte ReportID as defined by the DAP specification
+    client_timestamp                TIMESTAMP NOT NULL,              -- report timestamp, from client
+    extensions                      BYTEA,                           -- encoded sequence of Extension messages (populated for leader only)
+    public_share                    BYTEA,                           -- encoded public share (opaque VDAF message, populated for leader only)
+    leader_input_share              BYTEA,                           -- encoded, decrypted leader input share (populated for leader only)
+    helper_encrypted_input_share    BYTEA,                           -- encoded HpkeCiphertext message containing the helper's input share (populated for leader only)
+    aggregation_started             BOOLEAN NOT NULL DEFAULT FALSE,  -- has this client report been associated with an aggregation job?
 
     CONSTRAINT client_reports_unique_task_id_and_report_id UNIQUE(task_id, report_id),
     CONSTRAINT fk_task_id FOREIGN KEY(task_id) REFERENCES tasks(id)
 );
+CREATE INDEX client_reports_task_unaggregated ON client_reports(task_id) WHERE aggregation_started = FALSE;
 CREATE INDEX client_reports_task_and_timestamp_index ON client_reports(task_id, client_timestamp);
 
 -- Specifies the possible state of an aggregation job.


### PR DESCRIPTION
This new flag is used to track which client reports have been attached to an aggregation, allowing us to create aggregation jobs without needing to consult the report_aggregations table. Hopefully, this will reduce the amount of contention between aggregation job creation & other datastore operations in the system.

Note that we set the flag for both VDAFs without an aggregation parameter, and VDAFs with an aggregation parameter. However, it's only effectively used by VDAFs without an aggregation parameter. Still, the flag is set for consistency.