### PR TITLE
workaround for cargo dev-dependencies problem

### DIFF
--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -39,7 +39,7 @@ assert_matches = "1"
 base64 = "0.21.0"
 chrono = "0.4"
 clap = { version = "4.1.4", features = ["derive", "env"] }
-janus_collector = { workspace = true, features = ["fpvec_bounded_l2", "test-util"] }
+janus_collector = { path = ".", features = ["fpvec_bounded_l2", "test-util"] }
 janus_core = { workspace = true, features = ["fpvec_bounded_l2", "test-util"] }
 mockito = "0.31.1"
 rand = "0.8"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -61,7 +61,7 @@ tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt"],
 
 [dev-dependencies]
 hex = { version = "0.4", features = ["serde"] }  # ensure this remains compatible with the non-dev dependency
-janus_core = { workspace = true, features = ["fpvec_bounded_l2", "test-util"] }
+janus_core = { path = ".", features = ["fpvec_bounded_l2", "test-util"] }
 # Enable `kube`'s `openssl-tls` feature (which takes precedence over the
 # `rustls-tls` feature when creating a default client) to work around rustls's
 # lack of support for connecting to servers by IP addresses, which affects many

--- a/interop_binaries/Cargo.toml
+++ b/interop_binaries/Cargo.toml
@@ -55,7 +55,7 @@ warp = "0.3"
 zstd = { version = "0.12", optional = true }
 
 [dev-dependencies]
-janus_interop_binaries = { workspace = true, features = ["fpvec_bounded_l2", "testcontainer", "test-util"] }
+janus_interop_binaries = { path = ".", features = ["fpvec_bounded_l2", "testcontainer", "test-util"] }
 janus_core = { workspace = true, features = ["test-util", "fpvec_bounded_l2"] }
 reqwest = { version = "0.11.14", default-features = false, features = ["json"] }
 


### PR DESCRIPTION
To work around a known issue with `cargo publish` ([1}), update all self-dependencies under dev-dependencies to use `path = "."` instead of a versioned crate, as `publish` insists on fetching from crates.io, despite a correctly versioned crate being available locally.

[1]: https://github.com/rust-lang/cargo/issues/4242