### PR TITLE
Tracing cleanup

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -2471,7 +2471,7 @@ impl VdafOps {
         }
     }
 
-    #[tracing::instrument(skip(datastore, req_bytes), err)]
+    #[tracing::instrument(skip(datastore, task, req_bytes), fields(task_id = ?task.id()), err)]
     async fn handle_collect_generic<
         const L: usize,
         Q: CollectableQueryType,

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -2471,7 +2471,7 @@ impl VdafOps {
         }
     }
 
-    #[tracing::instrument(skip(datastore), err)]
+    #[tracing::instrument(skip(datastore, req_bytes), err)]
     async fn handle_collect_generic<
         const L: usize,
         Q: CollectableQueryType,

--- a/aggregator/src/aggregator/aggregate_share.rs
+++ b/aggregator/src/aggregator/aggregate_share.rs
@@ -10,7 +10,7 @@ use prio::vdaf::{self, Aggregatable};
 /// The assumption is that all aggregation jobs contributing to those batch aggregations have
 /// been driven to completion, and that the query count requirements have been validated for the
 /// included batches.
-#[tracing::instrument(err)]
+#[tracing::instrument(skip(task), fields(task_id = ?task.id()), err)]
 pub(crate) async fn compute_aggregate_share<const L: usize, Q: QueryType, A: vdaf::Aggregator<L>>(
     task: &Task,
     batch_aggregations: &[BatchAggregation<L, Q, A>],

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -233,7 +233,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
         }
     }
 
-    #[tracing::instrument(skip(self), err)]
+    #[tracing::instrument(skip(self, task), fields(task_id = ?task.id()), err)]
     async fn create_aggregation_jobs_for_task(
         self: Arc<Self>,
         task: Arc<Task>,
@@ -333,7 +333,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
         }
     }
 
-    #[tracing::instrument(skip(self), err)]
+    #[tracing::instrument(skip(self, task), fields(task_id = ?task.id()), err)]
     async fn create_aggregation_jobs_for_time_interval_task_no_param<
         const L: usize,
         A: vdaf::Aggregator<L, AggregationParam = ()>,
@@ -439,7 +439,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
             .await?)
     }
 
-    #[tracing::instrument(skip(self), err)]
+    #[tracing::instrument(skip(self, task), fields(task_id = ?task.id()), err)]
     async fn create_aggregation_jobs_for_fixed_size_task_no_param<
         const L: usize,
         A: vdaf::Aggregator<L, AggregationParam = ()>,
@@ -645,7 +645,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
     /// be used with VDAFs that have non-unit type aggregation parameters.
     // This is only used in tests thus far.
     #[cfg(test)]
-    #[tracing::instrument(skip(self), err)]
+    #[tracing::instrument(skip(self, task), fields(task_id = ?task.id()), err)]
     async fn create_aggregation_jobs_for_task_with_param<const L: usize, A>(
         self: Arc<Self>,
         task: Arc<Task>,

--- a/aggregator/src/datastore.rs
+++ b/aggregator/src/datastore.rs
@@ -316,7 +316,7 @@ pub struct Transaction<'a, C: Clock> {
 
 impl<C: Clock> Transaction<'_, C> {
     /// Writes a task into the datastore.
-    #[tracing::instrument(skip(self), err)]
+    #[tracing::instrument(skip(self, task), fields(task_id = ?task.id()), err)]
     pub async fn put_task(&self, task: &Task) -> Result<(), Error> {
         let endpoints: Vec<_> = task
             .aggregator_endpoints()

--- a/aggregator/src/datastore.rs
+++ b/aggregator/src/datastore.rs
@@ -1118,7 +1118,7 @@ impl<C: Clock> Transaction<'_, C> {
     /// should generally only be called on report IDs returned from
     /// `get_unaggregated_client_report_ids_for_task`, as part of the same transaction, for any
     /// client reports that are not added to an aggregation job.
-    #[tracing::instrument(skip(self), err)]
+    #[tracing::instrument(skip(self, report_ids), err)]
     pub async fn mark_reports_unaggregated(
         &self,
         task_id: &TaskId,

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -375,7 +375,7 @@ where
     }
 
     /// Send a collect request to the leader aggregator.
-    #[tracing::instrument(err)]
+    #[tracing::instrument(skip(aggregation_parameter), err)]
     async fn start_collection<Q: QueryType>(
         &self,
         query: Query<Q>,


### PR DESCRIPTION
This removes some large arguments from tracing spans. The chief change here is to only log a `TaskId` in place of a `Task`, which takes up 900+ characters with debug formatting. I also removed three other arguments on account of them being large, unhelpful, and/or sensitive.

I needed the Task change to get tracing over the UDP jaeger-agent protocol to work, but I think we'll want this same conciseness for TCP OTLP tracing setups, and even stdout logging.