### PR TITLE
Update divviup-ts container used in local tests

### DIFF
--- a/integration_tests/src/client.rs
+++ b/integration_tests/src/client.rs
@@ -114,7 +114,7 @@ impl InteropClient {
         } else {
             InteropClient {
                 name: "us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-ts/divviup_ts_interop_client".to_string(),
-                tag: "dap-draft-03@sha256:b03102a4e8eb9e1abf879940aa89d6a04e4a8229a215c715a4c92a0aec4b3be7".to_string(),
+                tag: "dap-draft-04@sha256:ad6fa3f6fa6f732ccf8291692e250ffa0cc50acd31bb393d98ebaec0f1d2f48c".to_string(),
             }
         }
     }


### PR DESCRIPTION
This is a follow-up to #936 to update the divviup-ts container used in local tests, following the change in the `ci-build` workflow.