### PR TITLE
Idempotent report uploads

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1971,7 +1971,7 @@ impl VdafOps {
         );
 
         report_writer
-            .write_report(WritableReport::<L, Q, A>::new(report))
+            .write_report(WritableReport::<L, Q, A>::new(vdaf, report))
             .await
     }
 
@@ -4606,12 +4606,12 @@ mod tests {
         );
     }
 
-    fn create_report(task: &Task, report_timestamp: Time) -> Report {
+    fn create_report_with_id(task: &Task, report_timestamp: Time, id: ReportId) -> Report {
         assert_eq!(task.vdaf(), &VdafInstance::Prio3Aes128Count);
 
         let vdaf = Prio3Aes128Count::new_aes128_count(2).unwrap();
         let hpke_key = current_hpke_key(task.hpke_keys());
-        let report_metadata = ReportMetadata::new(random(), report_timestamp);
+        let report_metadata = ReportMetadata::new(id, report_timestamp);
 
         let (public_share, measurements) = vdaf.shard(&1).unwrap();
 
@@ -4643,6 +4643,10 @@ mod tests {
         )
     }
 
+    fn create_report(task: &Task, report_timestamp: Time) -> Report {
+        create_report_with_id(task, report_timestamp, random())
+    }
+
     /// Convenience method to handle interaction with `warp::test` for typical DAP requests.
     async fn drive_filter(
         method: Method,
@@ -4662,6 +4666,28 @@ mod tests {
 
     #[tokio::test]
     async fn upload_filter() {
+        async fn check_response(
+            response: &mut Response,
+            desired_status: StatusCode,
+            desired_type: &str,
+            desired_title: &str,
+            desired_task_id: &TaskId,
+        ) {
+            assert_eq!(response.status(), desired_status);
+            let problem_details: serde_json::Value =
+                serde_json::from_slice(&body::to_bytes(response.body_mut()).await.unwrap())
+                    .unwrap();
+            assert_eq!(
+                problem_details,
+                json!({
+                    "status": desired_status.as_u16(),
+                    "type": format!("urn:ietf:params:ppm:dap:error:{desired_type}"),
+                    "title": desired_title,
+                    "taskid": format!("{desired_task_id}"),
+                }),
+            )
+        }
+
         install_test_trace_subscriber();
 
         const REPORT_EXPIRY_AGE: u64 = 1_000_000;
@@ -4681,42 +4707,44 @@ mod tests {
         let filter =
             aggregator_filter(Arc::clone(&datastore), clock.clone(), Config::default()).unwrap();
 
-        let response = drive_filter(
-            Method::PUT,
-            task.report_upload_uri().unwrap().path(),
-            &report.get_encoded(),
-            &filter,
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(response.status(), StatusCode::OK);
-        assert!(body::to_bytes(response.into_body())
+        // Upload a report. Do this twice to prove that PUT is idempotent.
+        for _ in 0..2 {
+            let response = drive_filter(
+                Method::PUT,
+                task.report_upload_uri().unwrap().path(),
+                &report.get_encoded(),
+                &filter,
+            )
             .await
-            .unwrap()
-            .is_empty());
+            .unwrap();
 
-        // Verify that we reject duplicate reports with the reportRejected type.
+            assert_eq!(response.status(), StatusCode::OK);
+            assert!(body::to_bytes(response.into_body())
+                .await
+                .unwrap()
+                .is_empty());
+        }
+
+        let accepted_report_id = report.metadata().id();
+
+        // Verify that new reports using an existing report ID are rejected with reportRejected
+        let duplicate_id_report = create_report_with_id(&task, clock.now(), *accepted_report_id);
         let mut response = drive_filter(
             Method::PUT,
             task.report_upload_uri().unwrap().path(),
-            &report.get_encoded(),
+            &duplicate_id_report.get_encoded(),
             &filter,
         )
         .await
         .unwrap();
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        let problem_details: serde_json::Value =
-            serde_json::from_slice(&body::to_bytes(response.body_mut()).await.unwrap()).unwrap();
-        assert_eq!(
-            problem_details,
-            json!({
-                "status": 400u16,
-                "type": "urn:ietf:params:ppm:dap:error:reportRejected",
-                "title": "Report could not be processed.",
-                "taskid": format!("{}", task.id()),
-            })
-        );
+        check_response(
+            &mut response,
+            StatusCode::BAD_REQUEST,
+            "reportRejected",
+            "Report could not be processed.",
+            task.id(),
+        )
+        .await;
 
         // Verify that reports older than the report expiry age are rejected with the reportRejected
         // error type.
@@ -4739,18 +4767,14 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        let problem_details: serde_json::Value =
-            serde_json::from_slice(&body::to_bytes(response.body_mut()).await.unwrap()).unwrap();
-        assert_eq!(
-            problem_details,
-            json!({
-                "status": 400u16,
-                "type": "urn:ietf:params:ppm:dap:error:reportRejected",
-                "title": "Report could not be processed.",
-                "taskid": format!("{}", task.id()),
-            })
-        );
+        check_response(
+            &mut response,
+            StatusCode::BAD_REQUEST,
+            "reportRejected",
+            "Report could not be processed.",
+            task.id(),
+        )
+        .await;
 
         // should reject a report with only one share with the unrecognizedMessage type.
         let bad_report = Report::new(
@@ -4766,18 +4790,14 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        let problem_details: serde_json::Value =
-            serde_json::from_slice(&body::to_bytes(response.body_mut()).await.unwrap()).unwrap();
-        assert_eq!(
-            problem_details,
-            json!({
-                "status": 400u16,
-                "type": "urn:ietf:params:ppm:dap:error:unrecognizedMessage",
-                "title": "The message type for a response was incorrect or the payload was malformed.",
-                "taskid": format!("{}", task.id()),
-            })
-        );
+        check_response(
+            &mut response,
+            StatusCode::BAD_REQUEST,
+            "unrecognizedMessage",
+            "The message type for a response was incorrect or the payload was malformed.",
+            task.id(),
+        )
+        .await;
 
         // should reject a report using the wrong HPKE config for the leader, and reply with
         // the error type outdatedConfig.
@@ -4807,18 +4827,14 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        let problem_details: serde_json::Value =
-            serde_json::from_slice(&body::to_bytes(response.body_mut()).await.unwrap()).unwrap();
-        assert_eq!(
-            problem_details,
-            json!({
-                "status": 400u16,
-                "type": "urn:ietf:params:ppm:dap:error:outdatedConfig",
-                "title": "The message was generated using an outdated configuration.",
-                "taskid": format!("{}", task.id()),
-            })
-        );
+        check_response(
+            &mut response,
+            StatusCode::BAD_REQUEST,
+            "outdatedConfig",
+            "The message was generated using an outdated configuration.",
+            task.id(),
+        )
+        .await;
 
         // Reports from the future should be rejected.
         let bad_report_time = clock
@@ -4840,18 +4856,14 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        let problem_details: serde_json::Value =
-            serde_json::from_slice(&body::to_bytes(response.body_mut()).await.unwrap()).unwrap();
-        assert_eq!(
-            problem_details,
-            json!({
-                "status": 400u16,
-                "type": "urn:ietf:params:ppm:dap:error:reportTooEarly",
-                "title": "Report could not be processed because it arrived too early.",
-                "taskid": format!("{}", task.id()),
-            })
-        );
+        check_response(
+            &mut response,
+            StatusCode::BAD_REQUEST,
+            "reportTooEarly",
+            "Report could not be processed because it arrived too early.",
+            task.id(),
+        )
+        .await;
 
         // Reports with timestamps past the task's expiration should be rejected.
         let task_expire_soon = TaskBuilder::new(
@@ -4874,18 +4886,14 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        let problem_details: serde_json::Value =
-            serde_json::from_slice(&body::to_bytes(response.body_mut()).await.unwrap()).unwrap();
-        assert_eq!(
-            problem_details,
-            json!({
-                "status": 400u16,
-                "type": "urn:ietf:params:ppm:dap:error:reportRejected",
-                "title": "Report could not be processed.",
-                "taskid": format!("{}", task_expire_soon.id()),
-            })
-        );
+        check_response(
+            &mut response,
+            StatusCode::BAD_REQUEST,
+            "reportRejected",
+            "Report could not be processed.",
+            task_expire_soon.id(),
+        )
+        .await;
 
         // Check for appropriate CORS headers in response to a preflight request.
         let response = warp::test::request()
@@ -5070,11 +5078,22 @@ mod tests {
         assert_eq!(task.id(), got_report.task_id());
         assert_eq!(report.metadata(), got_report.metadata());
 
-        // should reject duplicate reports.
-        assert_matches!(aggregator.handle_upload(task.id(),&report.get_encoded()).await.unwrap_err().as_ref(), Error::ReportRejected(task_id, stale_report_id, stale_time) => {
+        // Report uploads are idempotent
+        aggregator
+            .handle_upload(task.id(), &report.get_encoded())
+            .await
+            .unwrap();
+
+        // Reports may not be mutated
+        let mutated_report = create_report_with_id(&task, clock.now(), *report.metadata().id());
+        let error = aggregator
+            .handle_upload(task.id(), &mutated_report.get_encoded())
+            .await
+            .unwrap_err();
+        assert_matches!(error.as_ref(), Error::ReportRejected(task_id, report_id, timestamp) => {
             assert_eq!(task.id(), task_id);
-            assert_eq!(report.metadata().id(), stale_report_id);
-            assert_eq!(report.metadata().time(), stale_time);
+            assert_eq!(mutated_report.metadata().id(), report_id);
+            assert_eq!(mutated_report.metadata().time(), timestamp);
         });
     }
 

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -1021,7 +1021,7 @@ mod tests {
     };
     use rand::random;
     use reqwest::Url;
-    use std::{str, sync::Arc, time::Duration as StdDuration};
+    use std::{borrow::Borrow, str, sync::Arc, time::Duration as StdDuration};
 
     #[tokio::test]
     async fn aggregation_job_driver() {
@@ -1079,10 +1079,10 @@ mod tests {
         let aggregation_job_id = random();
 
         ds.run_tx(|tx| {
-            let (task, report) = (task.clone(), report.clone());
+            let (vdaf, task, report) = (vdaf.clone(), task.clone(), report.clone());
             Box::pin(async move {
                 tx.put_task(&task).await?;
-                tx.put_client_report(&report).await?;
+                tx.put_client_report(vdaf.borrow(), &report).await?;
 
                 tx.put_aggregation_job(&AggregationJob::<
                     PRIO3_AES128_VERIFY_KEY_LENGTH,
@@ -1311,15 +1311,17 @@ mod tests {
 
         let lease = ds
             .run_tx(|tx| {
-                let (task, report, repeated_extension_report) = (
+                let (vdaf, task, report, repeated_extension_report) = (
+                    vdaf.clone(),
                     task.clone(),
                     report.clone(),
                     repeated_extension_report.clone(),
                 );
                 Box::pin(async move {
                     tx.put_task(&task).await?;
-                    tx.put_client_report(&report).await?;
-                    tx.put_client_report(&repeated_extension_report).await?;
+                    tx.put_client_report(vdaf.borrow(), &report).await?;
+                    tx.put_client_report(vdaf.borrow(), &repeated_extension_report)
+                        .await?;
 
                     tx.put_aggregation_job(&AggregationJob::<
                         PRIO3_AES128_VERIFY_KEY_LENGTH,
@@ -1564,10 +1566,10 @@ mod tests {
 
         let lease = ds
             .run_tx(|tx| {
-                let (task, report) = (task.clone(), report.clone());
+                let (vdaf, task, report) = (vdaf.clone(), task.clone(), report.clone());
                 Box::pin(async move {
                     tx.put_task(&task).await?;
-                    tx.put_client_report(&report).await?;
+                    tx.put_client_report(vdaf.borrow(), &report).await?;
 
                     tx.put_aggregation_job(&AggregationJob::<
                         PRIO3_AES128_VERIFY_KEY_LENGTH,
@@ -1790,7 +1792,8 @@ mod tests {
 
         let lease = ds
             .run_tx(|tx| {
-                let (task, report, leader_prep_state, prep_msg) = (
+                let (vdaf, task, report, leader_prep_state, prep_msg) = (
+                    vdaf.clone(),
                     task.clone(),
                     report.clone(),
                     leader_prep_state.clone(),
@@ -1798,7 +1801,7 @@ mod tests {
                 );
                 Box::pin(async move {
                     tx.put_task(&task).await?;
-                    tx.put_client_report(&report).await?;
+                    tx.put_client_report(vdaf.borrow(), &report).await?;
 
                     tx.put_aggregation_job(&AggregationJob::<
                         PRIO3_AES128_VERIFY_KEY_LENGTH,
@@ -2037,7 +2040,8 @@ mod tests {
 
         let lease = ds
             .run_tx(|tx| {
-                let (task, report, leader_prep_state, prep_msg) = (
+                let (vdaf, task, report, leader_prep_state, prep_msg) = (
+                    vdaf.clone(),
                     task.clone(),
                     report.clone(),
                     leader_prep_state.clone(),
@@ -2045,7 +2049,7 @@ mod tests {
                 );
                 Box::pin(async move {
                     tx.put_task(&task).await?;
-                    tx.put_client_report(&report).await?;
+                    tx.put_client_report(vdaf.borrow(), &report).await?;
 
                     tx.put_aggregation_job(&AggregationJob::<
                         PRIO3_AES128_VERIFY_KEY_LENGTH,
@@ -2287,7 +2291,8 @@ mod tests {
 
         let lease = ds
             .run_tx(|tx| {
-                let (task, report, aggregation_job, report_aggregation) = (
+                let (vdaf, task, report, aggregation_job, report_aggregation) = (
+                    vdaf.clone(),
                     task.clone(),
                     report.clone(),
                     aggregation_job.clone(),
@@ -2295,7 +2300,7 @@ mod tests {
                 );
                 Box::pin(async move {
                     tx.put_task(&task).await?;
-                    tx.put_client_report(&report).await?;
+                    tx.put_client_report(vdaf.borrow(), &report).await?;
                     tx.put_aggregation_job(&aggregation_job).await?;
                     tx.put_report_aggregation(&report_aggregation).await?;
 
@@ -2450,6 +2455,7 @@ mod tests {
 
         // Set up fixtures in the database.
         ds.run_tx(|tx| {
+            let vdaf = vdaf.clone();
             let task = task.clone();
             let report = report.clone();
             Box::pin(async move {
@@ -2457,7 +2463,7 @@ mod tests {
 
                 // We need to store a well-formed report, as it will get parsed by the leader and
                 // run through initial VDAF preparation before sending a request to the helper.
-                tx.put_client_report(&report).await?;
+                tx.put_client_report(&vdaf, &report).await?;
 
                 tx.put_aggregation_job(&AggregationJob::<
                     PRIO3_AES128_VERIFY_KEY_LENGTH,

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -797,7 +797,8 @@ mod tests {
 
                     let report = LeaderStoredReport::new_dummy(*task.id(), report_timestamp);
 
-                    tx.put_client_report(&report).await?;
+                    tx.put_client_report(&dummy_vdaf::Vdaf::new(), &report)
+                        .await?;
 
                     tx.put_report_aggregation(&ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
                         *task.id(),
@@ -918,7 +919,8 @@ mod tests {
 
                     let report = LeaderStoredReport::new_dummy(*task.id(), report_timestamp);
 
-                    tx.put_client_report(&report).await?;
+                    tx.put_client_report(&dummy_vdaf::Vdaf::new(), &report)
+                        .await?;
 
                     tx.put_report_aggregation(&ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
                         *task.id(),

--- a/aggregator/src/aggregator/garbage_collector.rs
+++ b/aggregator/src/aggregator/garbage_collector.rs
@@ -119,7 +119,7 @@ mod tests {
         // Setup.
         let task = ds
             .run_tx(|tx| {
-                let clock = clock.clone();
+                let (clock, vdaf) = (clock.clone(), vdaf.clone());
                 Box::pin(async move {
                     const REPORT_EXPIRY_AGE: Duration = Duration::from_seconds(3600);
                     let task = TaskBuilder::new(
@@ -138,7 +138,7 @@ mod tests {
                         .sub(&Duration::from_seconds(1))
                         .unwrap();
                     let report = LeaderStoredReport::new_dummy(*task.id(), client_timestamp);
-                    tx.put_client_report(&report).await.unwrap();
+                    tx.put_client_report(&vdaf, &report).await.unwrap();
 
                     let batch_identifier =
                         Interval::new(client_timestamp, Duration::from_seconds(1)).unwrap();
@@ -428,7 +428,7 @@ mod tests {
         // Setup.
         let task = ds
             .run_tx(|tx| {
-                let clock = clock.clone();
+                let (clock, vdaf) = (clock.clone(), vdaf.clone());
                 Box::pin(async move {
                     const REPORT_EXPIRY_AGE: Duration = Duration::from_seconds(3600);
                     let task = TaskBuilder::new(
@@ -447,7 +447,7 @@ mod tests {
                         .sub(&Duration::from_seconds(1))
                         .unwrap();
                     let report = LeaderStoredReport::new_dummy(*task.id(), client_timestamp);
-                    tx.put_client_report(&report).await.unwrap();
+                    tx.put_client_report(&vdaf, &report).await.unwrap();
 
                     let batch_identifier = random();
                     let aggregation_job = AggregationJob::<0, FixedSize, dummy_vdaf::Vdaf>::new(

--- a/aggregator/src/aggregator/report_writer.rs
+++ b/aggregator/src/aggregator/report_writer.rs
@@ -168,6 +168,7 @@ where
     for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     Q: UploadableQueryType,
 {
+    vdaf: Arc<A>,
     report: LeaderStoredReport<L, A>,
     _phantom_q: PhantomData<Q>,
 }
@@ -183,8 +184,9 @@ where
     for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     Q: UploadableQueryType,
 {
-    pub fn new(report: LeaderStoredReport<L, A>) -> Self {
+    pub fn new(vdaf: Arc<A>, report: LeaderStoredReport<L, A>) -> Self {
         Self {
+            vdaf,
             report,
             _phantom_q: PhantomData::<Q>,
         }
@@ -208,7 +210,7 @@ where
         Q::validate_uploaded_report(tx, &self.report).await?;
 
         // Store the report.
-        match tx.put_client_report::<L, A>(&self.report).await {
+        match tx.put_client_report::<L, A>(&self.vdaf, &self.report).await {
             Ok(()) => Ok(()),
 
             // Reject reports whose report IDs have been seen before.


### PR DESCRIPTION
Uploading reports to the leader should be idempotent, meaning:
    
 - repeated requests to upload the same report (same ID and contents) should succeed
 - PUT with a repeated report ID by varying contents should fail
    
Part of #998
