### PR TITLE
Check for retryable errors at tokio_postgres boundary.

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -17,7 +17,6 @@ use crate::{
     },
     messages::{DurationExt, IntervalExt, TimeExt},
     task::{self, Task, VerifyKey, PRIO3_AES128_VERIFY_KEY_LENGTH},
-    try_join,
 };
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use bytes::Bytes;
@@ -71,7 +70,7 @@ use std::{
     sync::Arc,
     time::{Duration as StdDuration, Instant},
 };
-use tokio::sync::Mutex;
+use tokio::{sync::Mutex, try_join};
 use tracing::{debug, error, info, warn};
 use url::Url;
 use warp::{cors::Cors, filters::BoxedFilter, reply::Response, trace, Filter, Rejection, Reply};

--- a/aggregator/src/aggregator/accumulator.rs
+++ b/aggregator/src/aggregator/accumulator.rs
@@ -2,11 +2,11 @@
 
 use super::{query_type::AccumulableQueryType, Error};
 use crate::{
-    datastore::{self, gather_errors, models::BatchAggregation, Transaction},
+    datastore::{self, models::BatchAggregation, Transaction},
     task::Task,
 };
 use derivative::Derivative;
-use futures::future::join_all;
+use futures::future::try_join_all;
 use janus_core::{report_id::ReportIdChecksumExt, time::Clock};
 use janus_messages::{ReportId, ReportIdChecksum, Time};
 use prio::vdaf::{self, Aggregatable};
@@ -77,42 +77,40 @@ where
         &self,
         tx: &Transaction<'_, C>,
     ) -> Result<(), datastore::Error> {
-        gather_errors(
-            join_all(self.accumulations.iter().map(
-                |(batch_identifier, accumulation)| async move {
-                    let batch_aggregation = tx
-                        .get_batch_aggregation::<L, Q, A>(
-                            self.task.id(),
-                            batch_identifier,
-                            &self.aggregation_param,
-                        )
+        try_join_all(self.accumulations.iter().map(
+            |(batch_identifier, accumulation)| async move {
+                let batch_aggregation = tx
+                    .get_batch_aggregation::<L, Q, A>(
+                        self.task.id(),
+                        batch_identifier,
+                        &self.aggregation_param,
+                    )
+                    .await?;
+                match batch_aggregation {
+                    Some(batch_aggregation) => {
+                        tx.update_batch_aggregation(&batch_aggregation.merged_with(
+                            &accumulation.aggregate_share,
+                            accumulation.report_count,
+                            &accumulation.checksum,
+                        )?)
                         .await?;
-                    match batch_aggregation {
-                        Some(batch_aggregation) => {
-                            tx.update_batch_aggregation(&batch_aggregation.merged_with(
-                                &accumulation.aggregate_share,
-                                accumulation.report_count,
-                                &accumulation.checksum,
-                            )?)
-                            .await?;
-                        }
-                        None => {
-                            tx.put_batch_aggregation(&BatchAggregation::<L, Q, A>::new(
-                                *self.task.id(),
-                                batch_identifier.clone(),
-                                self.aggregation_param.clone(),
-                                accumulation.aggregate_share.clone(),
-                                accumulation.report_count,
-                                accumulation.checksum,
-                            ))
-                            .await?;
-                        }
                     }
-                    Ok::<(), datastore::Error>(())
-                },
-            ))
-            .await,
-        )?;
+                    None => {
+                        tx.put_batch_aggregation(&BatchAggregation::<L, Q, A>::new(
+                            *self.task.id(),
+                            batch_identifier.clone(),
+                            self.aggregation_param.clone(),
+                            accumulation.aggregate_share.clone(),
+                            accumulation.report_count,
+                            accumulation.checksum,
+                        ))
+                        .await?;
+                    }
+                }
+                Ok::<(), datastore::Error>(())
+            },
+        ))
+        .await?;
         Ok(())
     }
 }

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -12,7 +12,6 @@ use crate::{
         Datastore,
     },
     task::{self, PRIO3_AES128_VERIFY_KEY_LENGTH},
-    try_join,
 };
 use derivative::Derivative;
 #[cfg(feature = "fpvec_bounded_l2")]
@@ -45,6 +44,7 @@ use prio::{
 };
 use reqwest::Method;
 use std::{sync::Arc, time::Duration};
+use tokio::try_join;
 use tracing::{info, warn};
 
 /// Drives a collection job.

--- a/aggregator/src/aggregator/report_writer.rs
+++ b/aggregator/src/aggregator/report_writer.rs
@@ -123,23 +123,7 @@ impl<C: Clock> ReportWriteBatcher<C> {
             .run_tx_with_name("upload", |tx| {
                 let report_writers = Arc::clone(&report_writers);
                 Box::pin(async move {
-                    let mut rslts =
-                        join_all(report_writers.iter().map(|rw| rw.write_report(tx))).await;
-
-                    // Hack: look for a retryable error, and return it if we find one. (This is a
-                    // hack because we want to replace the retry-detection logic to be fully
-                    // included in Datastore & Transaction, rather than pushed out to authors of
-                    // Datastore transaction callbacks.)
-                    for rslt in &mut rslts {
-                        if let Err(err) = rslt {
-                            if err.is_serialization_failure() || err.is_deadlock_failure() {
-                                // The replacement error is arbitrary as we are going to throw rslts away.
-                                return Err(replace(err, datastore::Error::Crypt));
-                            }
-                        }
-                    }
-
-                    Ok(rslts)
+                    Ok(join_all(report_writers.iter().map(|rw| rw.write_report(tx))).await)
                 })
             })
             .await;


### PR DESCRIPTION
Previously, we checked for retryable errors at the point they were returned from the user-supplied callback. This sorta works, but expects every callback to be smart enough to propagate serialization errors appropriately -- which has proven to be error-prone, and required some clever (and complex) code to get right.

Now, we check each tokio_postgres::Transaction operation for a retryable failure. No matter what the return value from the user-supplied callback is, if we ever observed a retryable failure, we retry the transaction. The user-supplied callback no longer needs to be involved in the retry process.