### PR TITLE
Add metric with build-time version information

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -142,11 +142,12 @@ jobs:
       DOCKER_BUILDKIT: 1
     steps:
     - uses: actions/checkout@v3
-    - run: docker build --tag janus_aggregator .
-    - run: docker build --tag janus_aggregation_job_creator --build-arg BINARY=aggregation_job_creator .
-    - run: docker build --tag janus_aggregation_job_driver --build-arg BINARY=aggregation_job_driver .
-    - run: docker build --tag janus_collection_job_driver --build-arg BINARY=collection_job_driver .
-    - run: docker build --tag janus_cli --build-arg BINARY=janus_cli .
+    - run: echo "GIT_REVISION=$(git describe --always --dirty=-modified)" >> $GITHUB_ENV
+    - run: docker build --tag janus_aggregator --build-arg GIT_REVISION=${GIT_REVISION} .
+    - run: docker build --tag janus_aggregation_job_creator --build-arg BINARY=aggregation_job_creator --build-arg GIT_REVISION=${GIT_REVISION} .
+    - run: docker build --tag janus_aggregation_job_driver --build-arg BINARY=aggregation_job_driver --build-arg GIT_REVISION=${GIT_REVISION} .
+    - run: docker build --tag janus_collection_job_driver --build-arg BINARY=collection_job_driver --build-arg GIT_REVISION=${GIT_REVISION} .
+    - run: docker build --tag janus_cli --build-arg BINARY=janus_cli --build-arg GIT_REVISION=${GIT_REVISION} .
     - run: docker run --rm janus_aggregator --help
     - run: docker run --rm janus_aggregation_job_creator --help
     - run: docker run --rm janus_aggregation_job_driver --help

--- a/.github/workflows/push-docker-images-release.yml
+++ b/.github/workflows/push-docker-images-release.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - run: echo "GIT_REVISION=$(git describe --always --dirty=-modified)" >> $GITHUB_ENV
     # See https://github.com/google-github-actions/auth#authenticating-to-container-registry-and-artifact-registry
     - id: "gcp-auth-private"
       name: "Authenticate to GCP (private repositories)"
@@ -48,6 +49,7 @@ jobs:
         docker build \
           --tag us-west2-docker.pkg.dev/janus-artifacts/janus/janus_aggregator:${{ steps.get_version.outputs.VERSION }} \
           --tag us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_aggregator:${{ steps.get_version.outputs.VERSION }} \
+          --build-arg GIT_REVISION=${GIT_REVISION} \
           .
     - run: docker push us-west2-docker.pkg.dev/janus-artifacts/janus/janus_aggregator:${{ steps.get_version.outputs.VERSION }}
     - run: |-
@@ -55,6 +57,7 @@ jobs:
           --tag us-west2-docker.pkg.dev/janus-artifacts/janus/janus_aggregation_job_creator:${{ steps.get_version.outputs.VERSION }} \
           --tag us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_aggregation_job_creator:${{ steps.get_version.outputs.VERSION }} \
           --build-arg BINARY=aggregation_job_creator \
+          --build-arg GIT_REVISION=${GIT_REVISION} \
           .
     - run: docker push us-west2-docker.pkg.dev/janus-artifacts/janus/janus_aggregation_job_creator:${{ steps.get_version.outputs.VERSION }}
     - run: |-
@@ -62,6 +65,7 @@ jobs:
           --tag us-west2-docker.pkg.dev/janus-artifacts/janus/janus_aggregation_job_driver:${{ steps.get_version.outputs.VERSION }} \
           --tag us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_aggregation_job_driver:${{ steps.get_version.outputs.VERSION }} \
           --build-arg BINARY=aggregation_job_driver \
+          --build-arg GIT_REVISION=${GIT_REVISION} \
           .
     - run: docker push us-west2-docker.pkg.dev/janus-artifacts/janus/janus_aggregation_job_driver:${{ steps.get_version.outputs.VERSION }}
     - run: |-
@@ -69,6 +73,7 @@ jobs:
           --tag us-west2-docker.pkg.dev/janus-artifacts/janus/janus_collection_job_driver:${{ steps.get_version.outputs.VERSION }} \
           --tag us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_collection_job_driver:${{ steps.get_version.outputs.VERSION }} \
           --build-arg BINARY=collection_job_driver \
+          --build-arg GIT_REVISION=${GIT_REVISION} \
           .
     - run: docker push us-west2-docker.pkg.dev/janus-artifacts/janus/janus_collection_job_driver:${{ steps.get_version.outputs.VERSION }}
     - run: |-
@@ -76,6 +81,7 @@ jobs:
           --tag us-west2-docker.pkg.dev/janus-artifacts/janus/janus_cli:${{ steps.get_version.outputs.VERSION }} \
           --tag us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_cli:${{ steps.get_version.outputs.VERSION }} \
           --build-arg BINARY=janus_cli \
+          --build-arg GIT_REVISION=${GIT_REVISION} \
           .
     - run: docker push us-west2-docker.pkg.dev/janus-artifacts/janus/janus_cli:${{ steps.get_version.outputs.VERSION }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,6 +1134,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-version"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b0decc02f4636b9ccad390dcbe77b722a77efedfa393caf8379a51d5c61899"
+dependencies = [
+ "git-version-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe69f1cbdb6e28af2bac214e943b99ce8a0a06b447d15d3e61161b0423139f3f"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1582,6 +1604,7 @@ dependencies = [
  "derivative",
  "fixed",
  "futures",
+ "git-version",
  "hex",
  "http",
  "http-api-problem",
@@ -1607,6 +1630,7 @@ dependencies = [
  "regex",
  "reqwest",
  "ring",
+ "rustc_version",
  "serde",
  "serde_json",
  "serde_test",
@@ -2680,6 +2704,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2964,6 +2994,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3128,6 +3167,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "serde"

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,targe
 
 FROM alpine:3.17.1
 ARG BINARY=aggregator
+ARG GIT_REVISION=unknown
+LABEL revision ${GIT_REVISION}
 COPY --from=builder /src/db/schema.sql /db/schema.sql
 COPY --from=builder /$BINARY /$BINARY
 # Store the build argument in an environment variable so we can reference it

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM rust:1.67.0-alpine as builder
 ARG BINARY=aggregator
+ARG GIT_REVISION=unknown
 RUN apk add libc-dev protobuf-dev protoc
 WORKDIR /src
 COPY Cargo.toml /src/Cargo.toml
@@ -13,6 +14,7 @@ COPY db /src/db
 COPY integration_tests /src/integration_tests
 COPY interop_binaries /src/interop_binaries
 COPY messages /src/messages
+ENV GIT_REVISION ${GIT_REVISION}
 RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,target=/src/target cargo build --release -p janus_aggregator --bin $BINARY --features=prometheus && cp /src/target/release/$BINARY /$BINARY
 
 FROM alpine:3.17.1

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -49,6 +49,7 @@ deadpool-postgres = "0.10.5"
 derivative = "2.2.0"
 futures = "0.3.26"
 fixed = { version = "1.23", optional = true }
+git-version = "0.3.5"
 hex = { version = "0.4.3", features = ["serde"], optional = true }
 http = "0.2.8"
 http-api-problem = "0.56.0"
@@ -106,3 +107,6 @@ tempfile = "3.3.0"
 tokio = { version = "1", features = ["test-util"] }  # ensure this remains compatible with the non-dev dependency
 trycmd = "0.14.11"
 wait-timeout = "0.2.0"
+
+[build-dependencies]
+rustc_version = "0.4.0"

--- a/aggregator/build.rs
+++ b/aggregator/build.rs
@@ -1,0 +1,6 @@
+use rustc_version::version;
+
+fn main() {
+    let rustc_semver = version().expect("could not parse rustc version");
+    println!("cargo:rustc-env=RUSTC_SEMVER={rustc_semver}");
+}


### PR DESCRIPTION
This adds a gauge metric with version information, to make it easier to identify what version of software a running instance was built from. The Cargo package version is included via a Cargo environment variable, the rustc version is included by using the `rustc_version` crate in a build script, and the git commit is included using a procedural macro from the `git-version` crate, or via an environment variable for builds inside a Docker container, which don't have the git binary or the .git directory available. (if neither is available, "unknown" is reported instead, to avoid getting in the way of manual container builds)

Sample output:
```
# HELP janus_build_info A metric with a constant '1' value labeled with build-time version information.
# TYPE janus_build_info gauge
janus_build_info{revision="02bd25a",rust_version="1.67.1",service_name="janus_aggregator",version="0.3.0"} 1
```