### PR TITLE
Update CI build script to keep Build & Test steps consecutive.

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -74,16 +74,17 @@ jobs:
       uses: Swatinem/rust-cache@v2
       with:
         key: ${{ steps.os-version.outputs.release }}
-    - name: Build
-      run: cargo test --no-run --locked --all-targets
     - name: Build minimal janus_messages
       run: cargo build --package janus_messages --no-default-features
+    # Note: keep Build & Test steps consecutive, and match flags other than `--no-run`.
+    - name: Build
+      run: cargo test --no-run --locked --all-targets
     - name: Test
       id: test
       env:
         JANUS_E2E_LOGS_PATH: ${{ github.workspace }}/test-logs
         DIVVIUP_TS_INTEROP_CONTAINER: ${{ steps.default-input-values.outputs.divviup_ts_interop_container }}
-      run: cargo test --all-targets
+      run: cargo test --locked --all-targets
       # Continue on error so we can upload logs
       continue-on-error: true
     - name: Upload container logs


### PR DESCRIPTION
Also, tweak flags so that the test step uses all the same flags as the Build step, except for the `--no-run` flag that keeps the Build step from actually running tests.

(I noticed in CI that our test step was building a few crates: I'm not sure if this is due to the `janus_messages` build between Build & Test, or if it's due to the difference in flags, but ultimately there should be no building required to start running tests.)