### PR TITLE
Fix report replay check in aggregation job init

### DIFF
--- a/aggregator/src/datastore.rs
+++ b/aggregator/src/datastore.rs
@@ -919,6 +919,30 @@ impl<C: Clock> Transaction<'_, C> {
     }
 
     #[cfg(feature = "test-util")]
+    pub async fn get_report_metadatas_for_task(
+        &self,
+        task_id: &TaskId,
+    ) -> Result<Vec<ReportMetadata>, Error> {
+        let stmt = self
+            .prepare_cached(
+                "SELECT client_reports.report_id, client_reports.client_timestamp
+                FROM client_reports
+                JOIN tasks ON tasks.id = client_reports.task_id WHERE tasks.task_id = $1",
+            )
+            .await?;
+        self.query(&stmt, &[&task_id.as_ref()])
+            .await?
+            .into_iter()
+            .map(|row| {
+                Ok(ReportMetadata::new(
+                    row.get_bytea_and_convert::<ReportId>("report_id")?,
+                    Time::from_naive_date_time(&row.get("client_timestamp")),
+                ))
+            })
+            .collect()
+    }
+
+    #[cfg(feature = "test-util")]
     pub async fn get_client_reports_for_task<const L: usize, A: vdaf::Aggregator<L>>(
         &self,
         vdaf: &A,
@@ -1300,64 +1324,50 @@ impl<C: Clock> Transaction<'_, C> {
         Ok(())
     }
 
-    /// check_report_share_exists checks if a report share has been recorded in the datastore, given
-    /// its associated task ID & report ID.
-    ///
-    /// This method is intended for use by aggregators acting in the helper role.
-    #[tracing::instrument(skip(self), err)]
-    pub async fn check_report_share_exists(
-        &self,
-        task_id: &TaskId,
-        report_id: &ReportId,
-    ) -> Result<bool, Error> {
-        let stmt = self
-            .prepare_cached(
-                "SELECT 1 FROM client_reports JOIN tasks ON tasks.id = client_reports.task_id
-                WHERE tasks.task_id = $1
-                  AND client_reports.report_id = $2",
-            )
-            .await?;
-        Ok(self
-            .query_opt(
-                &stmt,
-                &[
-                    /* task_id */ &task_id.as_ref(),
-                    /* report_id */ &report_id.as_ref(),
-                ],
-            )
-            .await
-            .map(|row| row.is_some())?)
-    }
-
     /// put_report_share stores a report share, given its associated task ID.
     ///
     /// This method is intended for use by aggregators acting in the helper role; notably, it does
     /// not store extensions, public_share, or input_shares, as these are not required to be stored
     /// for the helper workflow (and the helper never observes the entire set of encrypted input
     /// shares, so it could not record the full client report in any case).
+    ///
+    /// Returns `Err(Error::MutationTargetAlreadyExisted)` if an attempt to mutate an existing row
+    /// (e.g., changing the timestamp for a known report ID) is detected.
     #[tracing::instrument(skip(self), err)]
     pub async fn put_report_share(
         &self,
         task_id: &TaskId,
         report_share: &ReportShare,
     ) -> Result<(), Error> {
+        // On conflict, we update the row, but only if the incoming client timestamp (excluded)
+        // matches the existing one. This lets us detect whether there's a row with a mismatching
+        // timestamp through the number of rows modified by the statement.
         let stmt = self
             .prepare_cached(
                 "INSERT INTO client_reports (task_id, report_id, client_timestamp)
-                VALUES ((SELECT id FROM tasks WHERE task_id = $1), $2, $3)",
+                VALUES ((SELECT id FROM tasks WHERE task_id = $1), $2, $3)
+                ON CONFLICT (task_id, report_id) DO UPDATE
+                  SET client_timestamp = client_reports.client_timestamp
+                    WHERE excluded.client_timestamp = client_reports.client_timestamp",
             )
             .await?;
-        self.execute(
-            &stmt,
-            &[
-                /* task_id */ &task_id.get_encoded(),
-                /* report_id */ &report_share.metadata().id().as_ref(),
-                /* client_timestamp */
-                &report_share.metadata().time().as_naive_date_time()?,
-            ],
-        )
-        .await?;
-        Ok(())
+        let rows_modified = self
+            .execute(
+                &stmt,
+                &[
+                    /* task_id */ &task_id.get_encoded(),
+                    /* report_id */ &report_share.metadata().id().as_ref(),
+                    /* client_timestamp */
+                    &report_share.metadata().time().as_naive_date_time()?,
+                ],
+            )
+            .await?;
+
+        if rows_modified == 0 {
+            Err(Error::MutationTargetAlreadyExisted)
+        } else {
+            Ok(())
+        }
     }
 
     /// get_aggregation_job retrieves an aggregation job by ID.
@@ -1613,6 +1623,40 @@ impl<C: Clock> Transaction<'_, C> {
             )
             .await?,
         )
+    }
+
+    /// Check whether the report has ever been aggregated with the given parameter.
+    #[tracing::instrument(skip(self), err)]
+    pub async fn check_report_aggregation_exists<const L: usize, A>(
+        &self,
+        task_id: &TaskId,
+        report_id: &ReportId,
+        aggregation_param: &A::AggregationParam,
+    ) -> Result<bool, Error>
+    where
+        A: vdaf::Aggregator<L>,
+        for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
+    {
+        let stmt = self.prepare_cached(
+            "SELECT 1 FROM report_aggregations
+                JOIN client_reports ON client_reports.id = report_aggregations.client_report_id
+                JOIN aggregation_jobs ON aggregation_jobs.id = report_aggregations.aggregation_job_id
+                WHERE client_reports.task_id = (SELECT id FROM tasks WHERE task_id = $1)
+                    AND client_reports.report_id = $2
+                    AND aggregation_jobs.aggregation_param = $3"
+            )
+        .await?;
+        Ok(self
+            .query_opt(
+                &stmt,
+                &[
+                    /* task_id */ &task_id.as_ref(),
+                    /* report_id */ &report_id.as_ref(),
+                    /* aggregation_param */ &aggregation_param.get_encoded(),
+                ],
+            )
+            .await
+            .map(|row| row.is_some())?)
     }
 
     /// get_report_aggregation gets a report aggregation by ID.
@@ -5962,35 +6006,22 @@ mod tests {
             ),
         );
 
-        let got_report_share_exists = ds
-            .run_tx(|tx| {
-                let (task, report_share) = (task.clone(), report_share.clone());
-                Box::pin(async move {
-                    tx.put_task(&task).await?;
-                    let report_share_exists = tx
-                        .check_report_share_exists(task.id(), report_share.metadata().id())
-                        .await?;
-                    tx.put_report_share(task.id(), &report_share).await?;
-                    Ok(report_share_exists)
-                })
-            })
-            .await
-            .unwrap();
-        assert!(!got_report_share_exists);
+        ds.run_tx(|tx| {
+            let (task, report_share) = (task.clone(), report_share.clone());
+            Box::pin(async move {
+                tx.put_task(&task).await?;
+                tx.put_report_share(task.id(), &report_share).await?;
 
-        let (
-            got_report_share_exists,
-            got_task_id,
-            got_extensions,
-            got_leader_input_share,
-            got_helper_input_share,
-        ) = ds
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
+
+        let (got_task_id, got_extensions, got_leader_input_share, got_helper_input_share) = ds
             .run_tx(|tx| {
-                let (task, report_share_metadata) = (task.clone(), report_share.metadata().clone());
+                let report_share_metadata = report_share.metadata().clone();
                 Box::pin(async move {
-                    let report_share_exists = tx
-                        .check_report_share_exists(task.id(), report_share_metadata.id())
-                        .await?;
                     let row = tx
                         .query_one(
                             "SELECT
@@ -6018,7 +6049,6 @@ mod tests {
                         row.get("helper_encrypted_input_share");
 
                     Ok((
-                        report_share_exists,
                         task_id,
                         maybe_extensions,
                         maybe_leader_input_share,
@@ -6029,11 +6059,22 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(got_report_share_exists);
         assert_eq!(task.id(), &got_task_id);
         assert!(got_extensions.is_none());
         assert!(got_leader_input_share.is_none());
         assert!(got_helper_input_share.is_none());
+
+        // Put the same report share again. This should not cause an error.
+        ds.run_tx(|tx| {
+            let (task_id, report_share) = (*task.id(), report_share.clone());
+            Box::pin(async move {
+                tx.put_report_share(&task_id, &report_share).await.unwrap();
+
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
     }
 
     #[tokio::test]
@@ -6695,6 +6736,114 @@ mod tests {
                 .unwrap();
             assert_eq!(Some(new_report_aggregation), got_report_aggregation);
         }
+    }
+
+    #[tokio::test]
+    async fn check_report_aggregation_exists() {
+        install_test_trace_subscriber();
+        let ephemeral_datastore = ephemeral_datastore().await;
+        let ds = ephemeral_datastore.datastore(MockClock::default());
+        let task = TaskBuilder::new(
+            task::QueryType::TimeInterval,
+            VdafInstance::Fake,
+            Role::Helper,
+        )
+        .build();
+
+        ds.put_task(&task).await.unwrap();
+
+        let aggregation_job_id = random();
+        let report_id = ReportId::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+
+        ds.run_tx(|tx| {
+            let task_id = *task.id();
+            Box::pin(async move {
+                tx.put_aggregation_job(&AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
+                    task_id,
+                    aggregation_job_id,
+                    dummy_vdaf::AggregationParam(0),
+                    (),
+                    Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
+                        .unwrap(),
+                    AggregationJobState::InProgress,
+                ))
+                .await?;
+                tx.put_report_share(
+                    &task_id,
+                    &ReportShare::new(
+                        ReportMetadata::new(report_id, Time::from_seconds_since_epoch(12345)),
+                        Vec::from("public_share"),
+                        HpkeCiphertext::new(
+                            HpkeConfigId::from(12),
+                            Vec::from("encapsulated_context_0"),
+                            Vec::from("payload_0"),
+                        ),
+                    ),
+                )
+                .await?;
+
+                let report_aggregation = ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
+                    task_id,
+                    aggregation_job_id,
+                    report_id,
+                    Time::from_seconds_since_epoch(12345),
+                    0,
+                    ReportAggregationState::Start,
+                );
+                tx.put_report_aggregation(&report_aggregation).await?;
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
+
+        ds.run_tx(|tx| {
+            let task_id = *task.id();
+            Box::pin(async move {
+                assert!(tx
+                    .check_report_aggregation_exists::<0, dummy_vdaf::Vdaf>(
+                        &task_id,
+                        &report_id,
+                        &dummy_vdaf::AggregationParam(0),
+                    )
+                    .await
+                    .unwrap());
+
+                // Wrong task ID
+                assert!(!tx
+                    .check_report_aggregation_exists::<0, dummy_vdaf::Vdaf>(
+                        &random(),
+                        &report_id,
+                        &dummy_vdaf::AggregationParam(0),
+                    )
+                    .await
+                    .unwrap());
+
+                // Wrong report ID
+                assert!(!tx
+                    .check_report_aggregation_exists::<0, dummy_vdaf::Vdaf>(
+                        &task_id,
+                        &random(),
+                        &dummy_vdaf::AggregationParam(0),
+                    )
+                    .await
+                    .unwrap());
+
+                // Wrong aggregation param
+                assert!(!tx
+                    .check_report_aggregation_exists::<0, dummy_vdaf::Vdaf>(
+                        &task_id,
+                        &report_id,
+                        &dummy_vdaf::AggregationParam(1),
+                    )
+                    .await
+                    .unwrap());
+
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
`handle_aggregate_init_generic` was checking if any of the report shares in an `AggregationJobInitReq` already occurred in the `client_reports` table, and would refuse to begin preparing an input share if so, producing a `report_replayed` error.

However, this is not what DAP requires ([1]):

> Check if the report has already been aggregated *with this aggregation
> parameter*. If this check fails, the input share MUST be marked as invalid
> with the error `report_replayed`. This is the case if the report was used in
> a previous aggregate request and is therefore a replay.

We now check whether there's a `report_aggregations` row for the `ReportId` and whether its corresponding aggregation job uses the same aggregation parameter as the incoming aggregation job. Additionally, we allow `put_report_share` to write the same report twice, because that's perfectly OK for a VDAF like Poplar1.

[1]: https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/blob/89e5dc32be05ebd4eb032c7f6d0aaa7074c69b08/draft-ietf-ppm-dap.md?plain=1#L1331