### PR TITLE
Add HpkeConfigList to dap-decode

### DIFF
--- a/messages/src/bin/dap_decode.rs
+++ b/messages/src/bin/dap_decode.rs
@@ -3,7 +3,7 @@ use clap::{Parser, ValueEnum};
 use janus_messages::{
     query_type::{FixedSize, TimeInterval},
     AggregateShare, AggregateShareReq, AggregationJobContinueReq, AggregationJobInitializeReq,
-    AggregationJobResp, Collection, CollectionReq, HpkeConfig, Report,
+    AggregationJobResp, Collection, CollectionReq, HpkeConfig, HpkeConfigList, Report,
 };
 use prio::codec::Decode;
 use std::{
@@ -36,6 +36,10 @@ fn decode_dap_message(message_file: &str, media_type: &MediaType) -> Result<Box<
     let decoded: Box<dyn Debug> = match media_type {
         MediaType::HpkeConfig => {
             let message: HpkeConfig = HpkeConfig::get_decoded(&message_buf)?;
+            Box::new(message)
+        }
+        MediaType::HpkeConfigList => {
+            let message: HpkeConfigList = HpkeConfigList::get_decoded(&message_buf)?;
             Box::new(message)
         }
         MediaType::Report => {
@@ -107,6 +111,8 @@ fn decode_dap_message(message_file: &str, media_type: &MediaType) -> Result<Box<
 enum MediaType {
     #[value(name = "hpke-config")]
     HpkeConfig,
+    #[value(name = "hpke-config-list")]
+    HpkeConfigList,
     #[value(name = "report")]
     Report,
     #[value(name = "aggregation-job-init-req")]

--- a/messages/tests/cmd/dap_decode.trycmd
+++ b/messages/tests/cmd/dap_decode.trycmd
@@ -8,7 +8,7 @@ Arguments:
   <MESSAGE_FILE>  Path to file containing message to decode. Pass "-" to read from stdin
 
 Options:
-  -t, --media-type <MEDIA_TYPE>  Media type of the message to decode [possible values: hpke-config, report, aggregation-job-init-req, aggregation-job, aggregate-share-req, aggregate-share, collect-req, collection]
+  -t, --media-type <MEDIA_TYPE>  Media type of the message to decode [possible values: hpke-config, hpke-config-list, report, aggregation-job-init-req, aggregation-job-resp, aggregation-job-continue-req, aggregate-share-req, aggregate-share, collect-req, collection]
   -h, --help                     Print help
   -V, --version                  Print version
 


### PR DESCRIPTION
This adds support for HpkeConfigList to dap-decode. I decided to leave in HpkeConfig, even though it no longer has its own media type in the latest draft, for convenience. Example:

```
$ cargo run -p janus_messages --features dap-decode-bin --bin dap-decode -- --media-type hpke-config-list <(curl -s https://helper1.dap.cloudflareresearch.com/v03/hpke_config)
HpkeConfigList(
    [
        HpkeConfig {
            id: HpkeConfigId(
                118,
            ),
            kem_id: X25519HkdfSha256,
            kdf_id: HkdfSha256,
            aead_id: Aes128Gcm,
            public_key: b15c780bcec0aa5229866e6481942ed87af922e7fac9b54bc0b316b76c32b476,
        },
    ],
)

$ cargo run -p janus_messages --features dap-decode-bin --bin dap-decode -- --media-type hpke-config <(curl -s https://helper1.dap.cloudflareresearch.com/v02/hpke_config)
HpkeConfig {
    id: HpkeConfigId(
        118,
    ),
    kem_id: X25519HkdfSha256,
    kdf_id: HkdfSha256,
    aead_id: Aes128Gcm,
    public_key: b15c780bcec0aa5229866e6481942ed87af922e7fac9b54bc0b316b76c32b476,
}
```