### PR TITLE
Interop binaries: defer parsing measurements

### DIFF
--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -663,26 +663,26 @@ async fn e2e_prio3_fixed16vec() {
         QueryKind::TimeInterval,
         json!({"type": "Prio3Aes128FixedPoint16BitBoundedL2VecSum", "length": "3"}),
         &[
-            json!({"type": "Fixed16", "vec": [
+            json!([
                 fp16_4_inv.to_string(),
                 fp16_8_inv.to_string(),
                 fp16_8_inv.to_string()
-            ]}),
-            json!({"type" : "Fixed16", "vec":[
+            ]),
+            json!([
                 fp16_16_inv.to_string(),
                 fp16_8_inv.to_string(),
                 fp16_16_inv.to_string()
-            ]}),
-            json!({"type" : "Fixed16", "vec":[
+            ]),
+            json!([
                 fp16_8_inv.to_string(),
                 fp16_8_inv.to_string(),
                 fp16_4_inv.to_string()
-            ]}),
-            json!({"type" : "Fixed16", "vec":[
+            ]),
+            json!([
                 fp16_16_inv.to_string(),
                 fp16_8_inv.to_string(),
                 fp16_4_inv.to_string()
-            ]}),
+            ]),
         ],
         b"",
     )
@@ -699,26 +699,26 @@ async fn e2e_prio3_fixed32vec() {
         QueryKind::TimeInterval,
         json!({"type": "Prio3Aes128FixedPoint32BitBoundedL2VecSum", "length": "3"}),
         &[
-            json!({"type": "Fixed32", "vec": [
+            json!([
                 fp32_4_inv.to_string(),
                 fp32_8_inv.to_string(),
                 fp32_8_inv.to_string()
-            ]}),
-            json!({"type" : "Fixed32", "vec":[
+            ]),
+            json!([
                 fp32_16_inv.to_string(),
                 fp32_8_inv.to_string(),
                 fp32_16_inv.to_string()
-            ]}),
-            json!({"type" : "Fixed32", "vec":[
+            ]),
+            json!([
                 fp32_8_inv.to_string(),
                 fp32_8_inv.to_string(),
                 fp32_4_inv.to_string()
-            ]}),
-            json!({"type" : "Fixed32", "vec":[
+            ]),
+            json!([
                 fp32_16_inv.to_string(),
                 fp32_8_inv.to_string(),
                 fp32_4_inv.to_string()
-            ]}),
+            ]),
         ],
         b"",
     )
@@ -735,26 +735,26 @@ async fn e2e_prio3_fixed64vec() {
         QueryKind::TimeInterval,
         json!({"type": "Prio3Aes128FixedPoint64BitBoundedL2VecSum", "length": "3"}),
         &[
-            json!({"type": "Fixed64", "vec": [
+            json!([
                 fp64_4_inv.to_string(),
                 fp64_8_inv.to_string(),
                 fp64_8_inv.to_string()
-            ]}),
-            json!({"type" : "Fixed64", "vec":[
+            ]),
+            json!([
                 fp64_16_inv.to_string(),
                 fp64_8_inv.to_string(),
                 fp64_16_inv.to_string()
-            ]}),
-            json!({"type" : "Fixed64", "vec":[
+            ]),
+            json!([
                 fp64_8_inv.to_string(),
                 fp64_8_inv.to_string(),
                 fp64_4_inv.to_string()
-            ]}),
-            json!({"type" : "Fixed64", "vec":[
+            ]),
+            json!([
                 fp64_16_inv.to_string(),
                 fp64_8_inv.to_string(),
                 fp64_4_inv.to_string()
-            ]}),
+            ]),
         ],
         b"",
     )
@@ -771,26 +771,26 @@ async fn e2e_prio3_fixed16vec_fixed_size() {
         QueryKind::FixedSize,
         json!({"type": "Prio3Aes128FixedPoint16BitBoundedL2VecSum", "length": "3"}),
         &[
-            json!({"type": "Fixed16", "vec": [
+            json!([
                 fp16_4_inv.to_string(),
                 fp16_8_inv.to_string(),
                 fp16_8_inv.to_string()
-            ]}),
-            json!({"type" : "Fixed16", "vec":[
+            ]),
+            json!([
                 fp16_16_inv.to_string(),
                 fp16_8_inv.to_string(),
                 fp16_16_inv.to_string()
-            ]}),
-            json!({"type" : "Fixed16", "vec":[
+            ]),
+            json!([
                 fp16_8_inv.to_string(),
                 fp16_8_inv.to_string(),
                 fp16_4_inv.to_string()
-            ]}),
-            json!({"type" : "Fixed16", "vec":[
+            ]),
+            json!([
                 fp16_16_inv.to_string(),
                 fp16_8_inv.to_string(),
                 fp16_4_inv.to_string()
-            ]}),
+            ]),
         ],
         b"",
     )
@@ -807,26 +807,26 @@ async fn e2e_prio3_fixed32vec_fixed_size() {
         QueryKind::FixedSize,
         json!({"type": "Prio3Aes128FixedPoint32BitBoundedL2VecSum", "length": "3"}),
         &[
-            json!({"type": "Fixed32", "vec": [
+            json!([
                 fp32_4_inv.to_string(),
                 fp32_8_inv.to_string(),
                 fp32_8_inv.to_string()
-            ]}),
-            json!({"type" : "Fixed32", "vec":[
+            ]),
+            json!([
                 fp32_16_inv.to_string(),
                 fp32_8_inv.to_string(),
                 fp32_16_inv.to_string()
-            ]}),
-            json!({"type" : "Fixed32", "vec":[
+            ]),
+            json!([
                 fp32_8_inv.to_string(),
                 fp32_8_inv.to_string(),
                 fp32_4_inv.to_string()
-            ]}),
-            json!({"type" : "Fixed32", "vec":[
+            ]),
+            json!([
                 fp32_16_inv.to_string(),
                 fp32_8_inv.to_string(),
                 fp32_4_inv.to_string()
-            ]}),
+            ]),
         ],
         b"",
     )
@@ -843,26 +843,26 @@ async fn e2e_prio3_fixed64vec_fixed_size() {
         QueryKind::FixedSize,
         json!({"type": "Prio3Aes128FixedPoint64BitBoundedL2VecSum", "length": "3"}),
         &[
-            json!({"type": "Fixed64", "vec": [
+            json!([
                 fp64_4_inv.to_string(),
                 fp64_8_inv.to_string(),
                 fp64_8_inv.to_string()
-            ]}),
-            json!({"type" : "Fixed64", "vec":[
+            ]),
+            json!([
                 fp64_16_inv.to_string(),
                 fp64_8_inv.to_string(),
                 fp64_16_inv.to_string()
-            ]}),
-            json!({"type" : "Fixed64", "vec":[
+            ]),
+            json!([
                 fp64_8_inv.to_string(),
                 fp64_8_inv.to_string(),
                 fp64_4_inv.to_string()
-            ]}),
-            json!({"type" : "Fixed64", "vec":[
+            ]),
+            json!([
                 fp64_16_inv.to_string(),
                 fp64_8_inv.to_string(),
                 fp64_4_inv.to_string()
-            ]}),
+            ]),
         ],
         b"",
     )


### PR DESCRIPTION
This changes how the interop test client parses upload requests. In the first pass, it now only parses measurements to a JSON AST, and then after switching on the VDAF type, it finishes parsing the measurement. This allows for removing two helper enums, and simplifying how fixed point number vectors are encoded.