### PR TITLE
Add tests for collection job idempotence

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -92,6 +92,8 @@ pub mod aggregate_share;
 pub mod aggregation_job_creator;
 pub mod aggregation_job_driver;
 pub mod collection_job_driver;
+#[cfg(test)]
+mod collection_job_tests;
 pub mod garbage_collector;
 pub mod query_type;
 pub mod report_writer;
@@ -4537,8 +4539,10 @@ mod tests {
     use crate::{
         aggregator::{
             aggregate_init_tests::{put_aggregation_job, setup_aggregate_init_test},
-            aggregator_filter, error_handler, send_request_to_helper, Aggregator, BatchMismatch,
-            CollectableQueryType, Config, Error,
+            aggregator_filter,
+            collection_job_tests::setup_collection_job_test_case,
+            error_handler, send_request_to_helper, Aggregator, BatchMismatch, CollectableQueryType,
+            Config, Error,
         },
         datastore::{
             models::{
@@ -7960,38 +7964,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn collect_request_to_helper() {
-        install_test_trace_subscriber();
-
-        // Prepare parameters.
-        let task =
-            TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Helper).build();
-        let clock = MockClock::default();
-        let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = ephemeral_datastore.datastore(clock.clone());
-
-        datastore.put_task(&task).await.unwrap();
-
-        let filter = aggregator_filter(Arc::new(datastore), clock, Config::default()).unwrap();
+    async fn collection_job_put_request_to_helper() {
+        let test_case = setup_collection_job_test_case(Role::Helper, QueryType::TimeInterval).await;
 
         let collection_job_id: CollectionJobId = random();
         let request = CollectionReq::new(
             Query::new_time_interval(
-                Interval::new(Time::from_seconds_since_epoch(0), *task.time_precision()).unwrap(),
+                Interval::new(
+                    Time::from_seconds_since_epoch(0),
+                    *test_case.task.time_precision(),
+                )
+                .unwrap(),
             ),
-            Vec::new(),
+            dummy_vdaf::AggregationParam::default().get_encoded(),
         );
 
-        let (parts, body) = warp::test::request()
-            .method("PUT")
-            .path(task.collection_job_uri(&collection_job_id).unwrap().path())
-            .header("DAP-Auth-Token", random::<AuthenticationToken>().as_bytes())
-            .header(CONTENT_TYPE, CollectionReq::<TimeInterval>::MEDIA_TYPE)
-            .body(request.get_encoded())
-            .filter(&filter)
+        let (parts, body) = test_case
+            .put_collection_job_with_auth_token(&collection_job_id, &request, Some(&random()))
             .await
-            .unwrap()
-            .into_response()
             .into_parts();
 
         assert_eq!(parts.status, StatusCode::BAD_REQUEST);
@@ -8003,25 +7993,14 @@ mod tests {
                 "status": StatusCode::BAD_REQUEST.as_u16(),
                 "type": "urn:ietf:params:ppm:dap:error:unrecognizedTask",
                 "title": "An endpoint received a message with an unknown task ID.",
-                "taskid": format!("{}", task.id()),
+                "taskid": format!("{}", test_case.task.id()),
             })
         );
     }
 
     #[tokio::test]
-    async fn collect_request_invalid_batch_interval() {
-        install_test_trace_subscriber();
-
-        // Prepare parameters.
-        let task =
-            TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Leader).build();
-        let clock = MockClock::default();
-        let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = ephemeral_datastore.datastore(clock.clone());
-
-        datastore.put_task(&task).await.unwrap();
-
-        let filter = aggregator_filter(Arc::new(datastore), clock, Config::default()).unwrap();
+    async fn collection_job_put_request_invalid_batch_interval() {
+        let test_case = setup_collection_job_test_case(Role::Leader, QueryType::TimeInterval).await;
 
         let collection_job_id: CollectionJobId = random();
         let request = CollectionReq::new(
@@ -8029,26 +8008,16 @@ mod tests {
                 Interval::new(
                     Time::from_seconds_since_epoch(0),
                     // Collect request will be rejected because batch interval is too small
-                    Duration::from_seconds(task.time_precision().as_seconds() - 1),
+                    Duration::from_seconds(test_case.task.time_precision().as_seconds() - 1),
                 )
                 .unwrap(),
             ),
-            dummy_vdaf::AggregationParam(0).get_encoded(),
+            dummy_vdaf::AggregationParam::default().get_encoded(),
         );
 
-        let (parts, body) = warp::test::request()
-            .method("PUT")
-            .path(task.collection_job_uri(&collection_job_id).unwrap().path())
-            .header(
-                "DAP-Auth-Token",
-                task.primary_collector_auth_token().as_bytes(),
-            )
-            .header(CONTENT_TYPE, CollectionReq::<TimeInterval>::MEDIA_TYPE)
-            .body(request.get_encoded())
-            .filter(&filter)
+        let (parts, body) = test_case
+            .put_collection_job(&collection_job_id, &request)
             .await
-            .unwrap()
-            .into_response()
             .into_parts();
 
         assert_eq!(parts.status, StatusCode::BAD_REQUEST);
@@ -8060,53 +8029,32 @@ mod tests {
                 "status": StatusCode::BAD_REQUEST.as_u16(),
                 "type": "urn:ietf:params:ppm:dap:error:batchInvalid",
                 "title": "The batch implied by the query is invalid.",
-                "taskid": format!("{}", task.id()),
+                "taskid": format!("{}", test_case.task.id()),
             })
         );
     }
 
     #[tokio::test]
-    async fn collect_request_invalid_aggregation_parameter() {
-        install_test_trace_subscriber();
-
-        // Prepare parameters.
-        let task =
-            TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Leader).build();
-        let clock = MockClock::default();
-        let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = ephemeral_datastore.datastore(clock.clone());
-
-        datastore.put_task(&task).await.unwrap();
-
-        let filter = aggregator_filter(Arc::new(datastore), clock, Config::default()).unwrap();
+    async fn collection_job_put_request_invalid_aggregation_parameter() {
+        let test_case = setup_collection_job_test_case(Role::Leader, QueryType::TimeInterval).await;
 
         let collection_job_id: CollectionJobId = random();
         let request = CollectionReq::new(
             Query::new_time_interval(
                 Interval::new(
                     Time::from_seconds_since_epoch(0),
-                    Duration::from_seconds(task.time_precision().as_seconds()),
+                    Duration::from_seconds(test_case.task.time_precision().as_seconds()),
                 )
                 .unwrap(),
             ),
             // dummy_vdaf::AggregationParam is a tuple struct wrapping a u8, so this is not a valid
             // encoding of an aggregation parameter.
-            Vec::new(),
+            Vec::from([0u8, 0u8]),
         );
 
-        let (parts, body) = warp::test::request()
-            .method("PUT")
-            .path(task.collection_job_uri(&collection_job_id).unwrap().path())
-            .header(
-                "DAP-Auth-Token",
-                task.primary_collector_auth_token().as_bytes(),
-            )
-            .header(CONTENT_TYPE, CollectionReq::<TimeInterval>::MEDIA_TYPE)
-            .body(request.get_encoded())
-            .filter(&filter)
+        let (parts, body) = test_case
+            .put_collection_job(&collection_job_id, &request)
             .await
-            .unwrap()
-            .into_response()
             .into_parts();
 
         // Collect request will be rejected because the aggregation parameter can't be decoded
@@ -8124,7 +8072,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn collect_request_invalid_batch_size() {
+    async fn collection_job_put_request_invalid_batch_size() {
         install_test_trace_subscriber();
 
         // Prepare parameters.
@@ -8148,7 +8096,7 @@ mod tests {
                 )
                 .unwrap(),
             ),
-            dummy_vdaf::AggregationParam(0).get_encoded(),
+            dummy_vdaf::AggregationParam::default().get_encoded(),
         );
 
         let (parts, body) = warp::test::request()
@@ -8182,41 +8130,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn collect_request_unauthenticated() {
-        install_test_trace_subscriber();
+    async fn collection_job_put_request_unauthenticated() {
+        let test_case = setup_collection_job_test_case(Role::Leader, QueryType::TimeInterval).await;
 
-        // Prepare parameters.
-        let task = TaskBuilder::new(
-            QueryType::TimeInterval,
-            VdafInstance::Prio3Aes128Count,
-            Role::Leader,
+        let batch_interval = Interval::new(
+            Time::from_seconds_since_epoch(0),
+            *test_case.task.time_precision(),
         )
-        .build();
-        let batch_interval =
-            Interval::new(Time::from_seconds_since_epoch(0), *task.time_precision()).unwrap();
-
-        let clock = MockClock::default();
-        let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()));
-
-        datastore.put_task(&task).await.unwrap();
-
-        let filter = aggregator_filter(Arc::clone(&datastore), clock, Config::default()).unwrap();
-
+        .unwrap();
         let collection_job_id: CollectionJobId = random();
-        let req = CollectionReq::new(Query::new_time_interval(batch_interval), Vec::new());
+        let req = CollectionReq::new(
+            Query::new_time_interval(batch_interval),
+            dummy_vdaf::AggregationParam::default().get_encoded(),
+        );
 
         // Incorrect authentication token.
-        let mut response = warp::test::request()
-            .method("PUT")
-            .path(task.collection_job_uri(&collection_job_id).unwrap().path())
-            .header("DAP-Auth-Token", random::<AuthenticationToken>().as_bytes())
-            .header(CONTENT_TYPE, CollectionReq::<TimeInterval>::MEDIA_TYPE)
-            .body(req.get_encoded())
-            .filter(&filter)
-            .await
-            .unwrap()
-            .into_response();
+        let mut response = test_case
+            .put_collection_job_with_auth_token(&collection_job_id, &req, Some(&random()))
+            .await;
 
         let want_status = StatusCode::BAD_REQUEST;
         let problem_details: serde_json::Value =
@@ -8227,25 +8158,19 @@ mod tests {
                 "status": want_status.as_u16(),
                 "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
                 "title": "The request's authorization is not valid.",
-                "taskid": format!("{}", task.id()),
+                "taskid": format!("{}", test_case.task.id()),
             })
         );
         assert_eq!(want_status, response.status());
 
         // Aggregator authentication token.
-        let mut response = warp::test::request()
-            .method("PUT")
-            .path(task.collection_job_uri(&collection_job_id).unwrap().path())
-            .header(
-                "DAP-Auth-Token",
-                task.primary_aggregator_auth_token().as_bytes(),
+        let mut response = test_case
+            .put_collection_job_with_auth_token(
+                &collection_job_id,
+                &req,
+                Some(test_case.task.primary_aggregator_auth_token()),
             )
-            .header(CONTENT_TYPE, CollectionReq::<TimeInterval>::MEDIA_TYPE)
-            .body(req.get_encoded())
-            .filter(&filter)
-            .await
-            .unwrap()
-            .into_response();
+            .await;
 
         let want_status = StatusCode::BAD_REQUEST;
         let problem_details: serde_json::Value =
@@ -8256,21 +8181,15 @@ mod tests {
                 "status": want_status.as_u16(),
                 "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
                 "title": "The request's authorization is not valid.",
-                "taskid": format!("{}", task.id()),
+                "taskid": format!("{}", test_case.task.id()),
             })
         );
         assert_eq!(want_status, response.status());
 
         // Missing authentication token.
-        let mut response = warp::test::request()
-            .method("PUT")
-            .path(task.collection_job_uri(&collection_job_id).unwrap().path())
-            .header(CONTENT_TYPE, CollectionReq::<TimeInterval>::MEDIA_TYPE)
-            .body(req.get_encoded())
-            .filter(&filter)
-            .await
-            .unwrap()
-            .into_response();
+        let mut response = test_case
+            .put_collection_job_with_auth_token(&collection_job_id, &req, None)
+            .await;
 
         let want_status = StatusCode::BAD_REQUEST;
         let problem_details: serde_json::Value =
@@ -8281,62 +8200,39 @@ mod tests {
                 "status": want_status.as_u16(),
                 "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
                 "title": "The request's authorization is not valid.",
-                "taskid": format!("{}", task.id()),
+                "taskid": format!("{}", test_case.task.id()),
             })
         );
         assert_eq!(want_status, response.status());
     }
 
     #[tokio::test]
-    async fn collect_request_unauthenticated_collection_jobs() {
-        install_test_trace_subscriber();
+    async fn collection_job_post_request_unauthenticated_collection_jobs() {
+        let test_case = setup_collection_job_test_case(Role::Leader, QueryType::TimeInterval).await;
 
-        // Prepare parameters.
-        let task = TaskBuilder::new(
-            QueryType::TimeInterval,
-            VdafInstance::Prio3Aes128Count,
-            Role::Leader,
+        let batch_interval = Interval::new(
+            Time::from_seconds_since_epoch(0),
+            *test_case.task.time_precision(),
         )
-        .build();
-        let batch_interval =
-            Interval::new(Time::from_seconds_since_epoch(0), *task.time_precision()).unwrap();
-
-        let clock = MockClock::default();
-        let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()));
-
-        datastore.put_task(&task).await.unwrap();
-
-        let filter = aggregator_filter(Arc::clone(&datastore), clock, Config::default()).unwrap();
+        .unwrap();
 
         let collection_job_id: CollectionJobId = random();
-        let request = CollectionReq::new(Query::new_time_interval(batch_interval), Vec::new());
+        let request = CollectionReq::new(
+            Query::new_time_interval(batch_interval),
+            dummy_vdaf::AggregationParam::default().get_encoded(),
+        );
 
-        let response = warp::test::request()
-            .method("PUT")
-            .path(task.collection_job_uri(&collection_job_id).unwrap().path())
-            .header(
-                "DAP-Auth-Token",
-                task.primary_collector_auth_token().as_bytes(),
-            )
-            .header(CONTENT_TYPE, CollectionReq::<TimeInterval>::MEDIA_TYPE)
-            .body(request.get_encoded())
-            .filter(&filter)
+        let response = test_case
+            .put_collection_job(&collection_job_id, &request)
             .await
-            .unwrap()
             .into_response();
 
         assert_eq!(response.status(), StatusCode::CREATED);
 
         // Incorrect authentication token.
-        let mut response = warp::test::request()
-            .method("POST")
-            .path(task.collection_job_uri(&collection_job_id).unwrap().path())
-            .header("DAP-Auth-Token", random::<AuthenticationToken>().as_bytes())
-            .filter(&filter)
-            .await
-            .unwrap()
-            .into_response();
+        let mut response = test_case
+            .post_collection_job_with_auth_token(&collection_job_id, Some(&random()))
+            .await;
 
         let want_status = StatusCode::BAD_REQUEST;
         let problem_details: serde_json::Value =
@@ -8347,23 +8243,18 @@ mod tests {
                 "status": want_status.as_u16(),
                 "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
                 "title": "The request's authorization is not valid.",
-                "taskid": format!("{}", task.id()),
+                "taskid": format!("{}", test_case.task.id()),
             })
         );
         assert_eq!(want_status, response.status());
 
         // Aggregator authentication token.
-        let mut response = warp::test::request()
-            .method("POST")
-            .path(task.collection_job_uri(&collection_job_id).unwrap().path())
-            .header(
-                "DAP-Auth-Token",
-                task.primary_aggregator_auth_token().as_bytes(),
+        let mut response = test_case
+            .post_collection_job_with_auth_token(
+                &collection_job_id,
+                Some(test_case.task.primary_aggregator_auth_token()),
             )
-            .filter(&filter)
-            .await
-            .unwrap()
-            .into_response();
+            .await;
 
         let want_status = StatusCode::BAD_REQUEST;
         let problem_details: serde_json::Value =
@@ -8374,19 +8265,15 @@ mod tests {
                 "status": want_status.as_u16(),
                 "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
                 "title": "The request's authorization is not valid.",
-                "taskid": format!("{}", task.id()),
+                "taskid": format!("{}", test_case.task.id()),
             })
         );
         assert_eq!(want_status, response.status());
 
         // Missing authentication token.
-        let mut response = warp::test::request()
-            .method("POST")
-            .path(task.collection_job_uri(&collection_job_id).unwrap().path())
-            .filter(&filter)
-            .await
-            .unwrap()
-            .into_response();
+        let mut response = test_case
+            .post_collection_job_with_auth_token(&collection_job_id, None)
+            .await;
 
         let want_status = StatusCode::BAD_REQUEST;
         let problem_details: serde_json::Value =
@@ -8397,75 +8284,46 @@ mod tests {
                 "status": want_status.as_u16(),
                 "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
                 "title": "The request's authorization is not valid.",
-                "taskid": format!("{}", task.id()),
+                "taskid": format!("{}", test_case.task.id()),
             })
         );
         assert_eq!(want_status, response.status());
     }
 
     #[tokio::test]
-    async fn collect_request() {
-        install_test_trace_subscriber();
+    async fn collection_job_success_time_interval() {
+        let test_case = setup_collection_job_test_case(Role::Leader, QueryType::TimeInterval).await;
 
-        // Prepare parameters.
-        let collector_hpke_keypair = generate_test_hpke_config_and_private_key();
-        let task = TaskBuilder::new(
-            QueryType::TimeInterval,
-            VdafInstance::Prio3Aes128Count,
-            Role::Leader,
+        let batch_interval = Interval::new(
+            Time::from_seconds_since_epoch(0),
+            *test_case.task.time_precision(),
         )
-        .with_collector_hpke_config(collector_hpke_keypair.config().clone())
-        .build();
-        let batch_interval =
-            Interval::new(Time::from_seconds_since_epoch(0), *task.time_precision()).unwrap();
+        .unwrap();
 
-        let leader_aggregate_share = AggregateShare::from(Vec::from([Field64::from(64)]));
-        let helper_aggregate_share = AggregateShare::from(Vec::from([Field64::from(32)]));
-
-        let clock = MockClock::default();
-        let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()));
-
-        datastore.put_task(&task).await.unwrap();
-
-        let filter = aggregator_filter(Arc::clone(&datastore), clock, Config::default()).unwrap();
+        let leader_aggregate_share = dummy_vdaf::AggregateShare(0);
+        let helper_aggregate_share = dummy_vdaf::AggregateShare(1);
 
         let collection_job_id: CollectionJobId = random();
-        let request = CollectionReq::new(Query::new_time_interval(batch_interval), Vec::new());
+        let request = CollectionReq::new(
+            Query::new_time_interval(batch_interval),
+            dummy_vdaf::AggregationParam::default().get_encoded(),
+        );
 
-        let response = warp::test::request()
-            .method("PUT")
-            .path(task.collection_job_uri(&collection_job_id).unwrap().path())
-            .header(
-                "DAP-Auth-Token",
-                task.primary_collector_auth_token().as_bytes(),
-            )
-            .header(CONTENT_TYPE, CollectionReq::<TimeInterval>::MEDIA_TYPE)
-            .body(request.get_encoded())
-            .filter(&filter)
+        let response = test_case
+            .put_collection_job(&collection_job_id, &request)
             .await
-            .unwrap()
             .into_response();
 
         assert_eq!(response.status(), StatusCode::CREATED);
 
-        let collection_job_response = warp::test::request()
-            .method("POST")
-            .path(task.collection_job_uri(&collection_job_id).unwrap().path())
-            .header(
-                "DAP-Auth-Token",
-                task.primary_collector_auth_token().as_bytes(),
-            )
-            .filter(&filter)
-            .await
-            .unwrap()
-            .into_response();
+        let collection_job_response = test_case.post_collection_job(&collection_job_id).await;
         assert_eq!(collection_job_response.status(), StatusCode::ACCEPTED);
 
         // Update the collection job with the aggregate shares. collection job should now be complete.
-        datastore
+        test_case
+            .datastore
             .run_tx(|tx| {
-                let task = task.clone();
+                let task = test_case.task.clone();
                 let helper_aggregate_share_bytes: Vec<u8> = (&helper_aggregate_share).into();
                 let leader_aggregate_share = leader_aggregate_share.clone();
                 Box::pin(async move {
@@ -8477,14 +8335,16 @@ mod tests {
                             &Role::Collector,
                         ),
                         &helper_aggregate_share_bytes,
-                        &AggregateShareAad::new(*task.id(), BatchSelector::new_time_interval(batch_interval)).get_encoded(),
+                        &AggregateShareAad::new(
+                            *task.id(),
+                            BatchSelector::new_time_interval(batch_interval),
+                        )
+                        .get_encoded(),
                     )
                     .unwrap();
 
                     let collection_job = tx
-                        .get_collection_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>(
-                            &collection_job_id,
-                        )
+                        .get_collection_job::<0, TimeInterval, dummy_vdaf::Vdaf>(&collection_job_id)
                         .await
                         .unwrap()
                         .unwrap()
@@ -8494,28 +8354,18 @@ mod tests {
                             leader_aggregate_share,
                         });
 
-                    tx.update_collection_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>(
-                        &collection_job,
-                    )
-                    .await
-                    .unwrap();
+                    tx.update_collection_job::<0, TimeInterval, dummy_vdaf::Vdaf>(&collection_job)
+                        .await
+                        .unwrap();
                     Ok(())
                 })
             })
             .await
             .unwrap();
 
-        let (parts, body) = warp::test::request()
-            .method("POST")
-            .path(task.collection_job_uri(&collection_job_id).unwrap().path())
-            .header(
-                "DAP-Auth-Token",
-                task.primary_collector_auth_token().as_bytes(),
-            )
-            .filter(&filter)
+        let (parts, body) = test_case
+            .post_collection_job(&collection_job_id)
             .await
-            .unwrap()
-            .into_response()
             .into_parts();
 
         assert_eq!(parts.status, StatusCode::OK);
@@ -8528,46 +8378,45 @@ mod tests {
         assert_eq!(collect_resp.encrypted_aggregate_shares().len(), 2);
 
         let decrypted_leader_aggregate_share = hpke::open(
-            task.collector_hpke_config(),
-            collector_hpke_keypair.private_key(),
+            test_case.task.collector_hpke_config(),
+            test_case.collector_hpke_keypair.private_key(),
             &HpkeApplicationInfo::new(&Label::AggregateShare, &Role::Leader, &Role::Collector),
             &collect_resp.encrypted_aggregate_shares()[0],
-            &AggregateShareAad::new(*task.id(), BatchSelector::new_time_interval(batch_interval))
-                .get_encoded(),
+            &AggregateShareAad::new(
+                *test_case.task.id(),
+                BatchSelector::new_time_interval(batch_interval),
+            )
+            .get_encoded(),
         )
         .unwrap();
         assert_eq!(
             leader_aggregate_share,
-            AggregateShare::try_from(decrypted_leader_aggregate_share.as_ref()).unwrap()
+            dummy_vdaf::AggregateShare::try_from(decrypted_leader_aggregate_share.as_ref())
+                .unwrap()
         );
 
         let decrypted_helper_aggregate_share = hpke::open(
-            task.collector_hpke_config(),
-            collector_hpke_keypair.private_key(),
+            test_case.task.collector_hpke_config(),
+            test_case.collector_hpke_keypair.private_key(),
             &HpkeApplicationInfo::new(&Label::AggregateShare, &Role::Helper, &Role::Collector),
             &collect_resp.encrypted_aggregate_shares()[1],
-            &AggregateShareAad::new(*task.id(), BatchSelector::new_time_interval(batch_interval))
-                .get_encoded(),
+            &AggregateShareAad::new(
+                *test_case.task.id(),
+                BatchSelector::new_time_interval(batch_interval),
+            )
+            .get_encoded(),
         )
         .unwrap();
         assert_eq!(
             helper_aggregate_share,
-            AggregateShare::try_from(decrypted_helper_aggregate_share.as_ref()).unwrap()
+            dummy_vdaf::AggregateShare::try_from(decrypted_helper_aggregate_share.as_ref())
+                .unwrap()
         );
     }
 
     #[tokio::test]
-    async fn no_such_collection_job() {
-        install_test_trace_subscriber();
-        let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = ephemeral_datastore.datastore(MockClock::default());
-        let task =
-            TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Leader).build();
-
-        datastore.put_task(&task).await.unwrap();
-        let filter =
-            aggregator_filter(Arc::new(datastore), MockClock::default(), Config::default())
-                .unwrap();
+    async fn collection_job_post_request_no_such_collection_job() {
+        let test_case = setup_collection_job_test_case(Role::Leader, QueryType::TimeInterval).await;
 
         let no_such_collection_job_id: CollectionJobId = random();
 
@@ -8575,13 +8424,13 @@ mod tests {
             .method("POST")
             .path(&format!(
                 "/tasks/{}/collection_jobs/{no_such_collection_job_id}",
-                task.id(),
+                test_case.task.id(),
             ))
             .header(
                 "DAP-Auth-Token",
-                task.primary_collector_auth_token().as_bytes(),
+                test_case.task.primary_collector_auth_token().as_bytes(),
             )
-            .filter(&filter)
+            .filter(&test_case.filter)
             .await
             .unwrap()
             .into_response();
@@ -8589,21 +8438,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn collect_request_batch_queried_too_many_times() {
-        install_test_trace_subscriber();
+    async fn collection_job_put_request_batch_queried_too_many_times() {
+        let test_case = setup_collection_job_test_case(Role::Leader, QueryType::TimeInterval).await;
 
-        let task =
-            TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Leader).build();
-
-        let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = ephemeral_datastore.datastore(MockClock::default());
-
-        datastore
+        test_case
+            .datastore
             .run_tx(|tx| {
-                let task = task.clone();
+                let task = test_case.task.clone();
                 Box::pin(async move {
-                    tx.put_task(&task).await?;
-
                     tx.put_batch_aggregation(&BatchAggregation::<
                         DUMMY_VERIFY_KEY_LENGTH,
                         TimeInterval,
@@ -8623,55 +8465,37 @@ mod tests {
             .await
             .unwrap();
 
-        let filter =
-            aggregator_filter(Arc::new(datastore), MockClock::default(), Config::default())
-                .unwrap();
-
         // Sending this request will consume a query for [0, time_precision).
         let request = CollectionReq::new(
             Query::new_time_interval(
-                Interval::new(Time::from_seconds_since_epoch(0), *task.time_precision()).unwrap(),
+                Interval::new(
+                    Time::from_seconds_since_epoch(0),
+                    *test_case.task.time_precision(),
+                )
+                .unwrap(),
             ),
             dummy_vdaf::AggregationParam(0).get_encoded(),
         );
 
-        let response = warp::test::request()
-            .method("PUT")
-            .path(task.collection_job_uri(&random()).unwrap().path())
-            .header(
-                "DAP-Auth-Token",
-                task.primary_collector_auth_token().as_bytes(),
-            )
-            .header(CONTENT_TYPE, CollectionReq::<TimeInterval>::MEDIA_TYPE)
-            .body(request.get_encoded())
-            .filter(&filter)
-            .await
-            .unwrap()
-            .into_response();
+        let response = test_case.put_collection_job(&random(), &request).await;
 
         assert_eq!(response.status(), StatusCode::CREATED);
 
         // This request will not be allowed due to the query count already being consumed.
         let invalid_request = CollectionReq::new(
             Query::new_time_interval(
-                Interval::new(Time::from_seconds_since_epoch(0), *task.time_precision()).unwrap(),
+                Interval::new(
+                    Time::from_seconds_since_epoch(0),
+                    *test_case.task.time_precision(),
+                )
+                .unwrap(),
             ),
             dummy_vdaf::AggregationParam(1).get_encoded(),
         );
 
-        let (parts, body) = warp::test::request()
-            .method("PUT")
-            .path(task.collection_job_uri(&random()).unwrap().path())
-            .header(
-                "DAP-Auth-Token",
-                task.primary_collector_auth_token().as_bytes(),
-            )
-            .header(CONTENT_TYPE, CollectionReq::<TimeInterval>::MEDIA_TYPE)
-            .body(invalid_request.get_encoded())
-            .filter(&filter)
+        let (parts, body) = test_case
+            .put_collection_job(&random(), &invalid_request)
             .await
-            .unwrap()
-            .into_response()
             .into_parts();
         assert_eq!(parts.status, StatusCode::BAD_REQUEST);
         let problem_details: serde_json::Value =
@@ -8682,27 +8506,20 @@ mod tests {
                 "status": StatusCode::BAD_REQUEST.as_u16(),
                 "type": "urn:ietf:params:ppm:dap:error:batchQueriedTooManyTimes",
                 "title": "The batch described by the query has been queried too many times.",
-                "taskid": format!("{}", task.id()),
+                "taskid": format!("{}", test_case.task.id()),
             })
         );
     }
 
     #[tokio::test]
-    async fn collect_request_batch_overlap() {
-        install_test_trace_subscriber();
+    async fn collection_job_put_request_batch_overlap() {
+        let test_case = setup_collection_job_test_case(Role::Leader, QueryType::TimeInterval).await;
 
-        let task =
-            TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Leader).build();
-
-        let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = ephemeral_datastore.datastore(MockClock::default());
-
-        datastore
+        test_case
+            .datastore
             .run_tx(|tx| {
-                let task = task.clone();
+                let task = test_case.task.clone();
                 Box::pin(async move {
-                    tx.put_task(&task).await?;
-
                     tx.put_batch_aggregation(&BatchAggregation::<
                         DUMMY_VERIFY_KEY_LENGTH,
                         TimeInterval,
@@ -8722,17 +8539,13 @@ mod tests {
             .await
             .unwrap();
 
-        let filter =
-            aggregator_filter(Arc::new(datastore), MockClock::default(), Config::default())
-                .unwrap();
-
         // Sending this request will consume a query for [0, 2 * time_precision).
         let request = CollectionReq::new(
             Query::new_time_interval(
                 Interval::new(
                     Time::from_seconds_since_epoch(0),
                     Duration::from_microseconds(
-                        2 * task.time_precision().as_microseconds().unwrap(),
+                        2 * test_case.task.time_precision().as_microseconds().unwrap(),
                     ),
                 )
                 .unwrap(),
@@ -8740,19 +8553,7 @@ mod tests {
             dummy_vdaf::AggregationParam(0).get_encoded(),
         );
 
-        let response = warp::test::request()
-            .method("PUT")
-            .path(task.collection_job_uri(&random()).unwrap().path())
-            .header(
-                "DAP-Auth-Token",
-                task.primary_collector_auth_token().as_bytes(),
-            )
-            .header(CONTENT_TYPE, CollectionReq::<TimeInterval>::MEDIA_TYPE)
-            .body(request.get_encoded())
-            .filter(&filter)
-            .await
-            .unwrap()
-            .into_response();
+        let response = test_case.put_collection_job(&random(), &request).await;
 
         assert_eq!(response.status(), StatusCode::CREATED);
 
@@ -8761,28 +8562,18 @@ mod tests {
             Query::new_time_interval(
                 Interval::new(
                     Time::from_seconds_since_epoch(0)
-                        .add(task.time_precision())
+                        .add(test_case.task.time_precision())
                         .unwrap(),
-                    *task.time_precision(),
+                    *test_case.task.time_precision(),
                 )
                 .unwrap(),
             ),
             dummy_vdaf::AggregationParam(1).get_encoded(),
         );
 
-        let (parts, body) = warp::test::request()
-            .method("PUT")
-            .path(task.collection_job_uri(&random()).unwrap().path())
-            .header(
-                "DAP-Auth-Token",
-                task.primary_collector_auth_token().as_bytes(),
-            )
-            .header(CONTENT_TYPE, CollectionReq::<TimeInterval>::MEDIA_TYPE)
-            .body(invalid_request.get_encoded())
-            .filter(&filter)
+        let (parts, body) = test_case
+            .put_collection_job(&random(), &invalid_request)
             .await
-            .unwrap()
-            .into_response()
             .into_parts();
         assert_eq!(parts.status, StatusCode::BAD_REQUEST);
         let problem_details: serde_json::Value =
@@ -8793,93 +8584,76 @@ mod tests {
                 "status": StatusCode::BAD_REQUEST.as_u16(),
                 "type": "urn:ietf:params:ppm:dap:error:batchOverlap",
                 "title": "The queried batch overlaps with a previously queried batch.",
-                "taskid": format!("{}", task.id()),
+                "taskid": format!("{}", test_case.task.id()),
             })
         );
     }
 
     #[tokio::test]
     async fn delete_collection_job() {
-        install_test_trace_subscriber();
-
-        // Prepare parameters.
-        let task = TaskBuilder::new(
-            QueryType::TimeInterval,
-            VdafInstance::Prio3Aes128Count,
-            Role::Leader,
+        let test_case = setup_collection_job_test_case(Role::Leader, QueryType::TimeInterval).await;
+        let batch_interval = Interval::new(
+            Time::from_seconds_since_epoch(0),
+            *test_case.task.time_precision(),
         )
-        .build();
-        let batch_interval =
-            Interval::new(Time::from_seconds_since_epoch(0), *task.time_precision()).unwrap();
+        .unwrap();
 
-        let clock = MockClock::default();
-        let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()));
-
-        datastore.put_task(&task).await.unwrap();
-
-        let filter = aggregator_filter(Arc::clone(&datastore), clock, Config::default()).unwrap();
         let collection_job_id: CollectionJobId = random();
 
         // Try to delete a collection job that doesn't exist
         let delete_job_response = warp::test::request()
             .method("DELETE")
-            .path(task.collection_job_uri(&collection_job_id).unwrap().path())
+            .path(
+                test_case
+                    .task
+                    .collection_job_uri(&collection_job_id)
+                    .unwrap()
+                    .path(),
+            )
             .header(
                 "DAP-Auth-Token",
-                task.primary_collector_auth_token().as_bytes(),
+                test_case.task.primary_collector_auth_token().as_bytes(),
             )
-            .filter(&filter)
+            .filter(&test_case.filter)
             .await
             .unwrap()
             .into_response();
         assert_eq!(delete_job_response.status(), StatusCode::NOT_FOUND);
 
         // Create a collection job
-        let request = CollectionReq::new(Query::new_time_interval(batch_interval), Vec::new());
+        let request = CollectionReq::new(
+            Query::new_time_interval(batch_interval),
+            dummy_vdaf::AggregationParam::default().get_encoded(),
+        );
 
-        let collect_response = warp::test::request()
-            .method("PUT")
-            .path(task.collection_job_uri(&collection_job_id).unwrap().path())
-            .header(
-                "DAP-Auth-Token",
-                task.primary_collector_auth_token().as_bytes(),
-            )
-            .header(CONTENT_TYPE, CollectionReq::<TimeInterval>::MEDIA_TYPE)
-            .body(request.get_encoded())
-            .filter(&filter)
-            .await
-            .unwrap()
-            .into_response();
+        let collect_response = test_case
+            .put_collection_job(&collection_job_id, &request)
+            .await;
 
         assert_eq!(collect_response.status(), StatusCode::CREATED);
 
         // Cancel the job
         let delete_job_response = warp::test::request()
             .method("DELETE")
-            .path(task.collection_job_uri(&collection_job_id).unwrap().path())
+            .path(
+                test_case
+                    .task
+                    .collection_job_uri(&collection_job_id)
+                    .unwrap()
+                    .path(),
+            )
             .header(
                 "DAP-Auth-Token",
-                task.primary_collector_auth_token().as_bytes(),
+                test_case.task.primary_collector_auth_token().as_bytes(),
             )
-            .filter(&filter)
+            .filter(&test_case.filter)
             .await
             .unwrap()
             .into_response();
         assert_eq!(delete_job_response.status(), StatusCode::NO_CONTENT);
 
         // Get the job again
-        let get_response = warp::test::request()
-            .method("POST")
-            .path(task.collection_job_uri(&collection_job_id).unwrap().path())
-            .header(
-                "DAP-Auth-Token",
-                task.primary_collector_auth_token().as_bytes(),
-            )
-            .filter(&filter)
-            .await
-            .unwrap()
-            .into_response();
+        let get_response = test_case.post_collection_job(&collection_job_id).await;
         assert_eq!(get_response.status(), StatusCode::NO_CONTENT);
     }
 

--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -1,0 +1,651 @@
+use crate::{
+    aggregator::{aggregator_filter, Config},
+    datastore::{
+        models::{
+            AggregationJob, AggregationJobState, CollectionJobState, LeaderStoredReport,
+            ReportAggregation, ReportAggregationState,
+        },
+        test_util::{ephemeral_datastore, EphemeralDatastore},
+        Datastore,
+    },
+    task::{test_util::TaskBuilder, QueryType, Task},
+};
+use http::{header::CONTENT_TYPE, StatusCode};
+use hyper::body;
+use janus_core::{
+    hpke::{
+        self, test_util::generate_test_hpke_config_and_private_key, HpkeApplicationInfo,
+        HpkeKeypair, Label,
+    },
+    task::{AuthenticationToken, VdafInstance},
+    test_util::{dummy_vdaf, install_test_trace_subscriber},
+    time::{Clock, MockClock},
+};
+use janus_messages::{
+    query_type::{FixedSize, QueryType as QueryTypeTrait, TimeInterval},
+    AggregateShareAad, BatchId, BatchSelector, Collection, CollectionJobId, CollectionReq,
+    FixedSizeQuery, Interval, Query, Role, Time,
+};
+use prio::codec::{Decode, Encode};
+use rand::random;
+use serde_json::json;
+use std::sync::Arc;
+use warp::{
+    filters::BoxedFilter,
+    reply::{Reply, Response},
+};
+
+pub(crate) struct CollectionJobTestCase<R> {
+    pub(super) task: Task,
+    clock: MockClock,
+    pub(super) collector_hpke_keypair: HpkeKeypair,
+    pub(super) filter: BoxedFilter<(R,)>,
+    pub(super) datastore: Arc<Datastore<MockClock>>,
+    _ephemeral_datastore: EphemeralDatastore,
+}
+
+impl<R: Reply + 'static> CollectionJobTestCase<R> {
+    pub(super) async fn put_collection_job_with_auth_token<Q: QueryTypeTrait>(
+        &self,
+        collection_job_id: &CollectionJobId,
+        request: &CollectionReq<Q>,
+        auth_token: Option<&AuthenticationToken>,
+    ) -> Response {
+        let mut builder = warp::test::request().method("PUT").path(
+            self.task
+                .collection_job_uri(collection_job_id)
+                .unwrap()
+                .path(),
+        );
+        if let Some(token) = auth_token {
+            builder = builder.header("DAP-Auth-Token", token.as_bytes())
+        }
+
+        builder
+            .header(CONTENT_TYPE, CollectionReq::<TimeInterval>::MEDIA_TYPE)
+            .body(request.get_encoded())
+            .filter(&self.filter)
+            .await
+            .unwrap()
+            .into_response()
+    }
+
+    pub(super) async fn put_collection_job<Q: QueryTypeTrait>(
+        &self,
+        collection_job_id: &CollectionJobId,
+        request: &CollectionReq<Q>,
+    ) -> Response {
+        self.put_collection_job_with_auth_token(
+            collection_job_id,
+            request,
+            Some(self.task.primary_collector_auth_token()),
+        )
+        .await
+    }
+
+    pub(super) async fn post_collection_job_with_auth_token(
+        &self,
+        collection_job_id: &CollectionJobId,
+        auth_token: Option<&AuthenticationToken>,
+    ) -> Response {
+        let mut builder = warp::test::request().method("POST").path(
+            self.task
+                .collection_job_uri(collection_job_id)
+                .unwrap()
+                .path(),
+        );
+        if let Some(token) = auth_token {
+            builder = builder.header("DAP-Auth-Token", token.as_bytes())
+        }
+        builder.filter(&self.filter).await.unwrap().into_response()
+    }
+
+    pub(super) async fn post_collection_job(
+        &self,
+        collection_job_id: &CollectionJobId,
+    ) -> Response {
+        self.post_collection_job_with_auth_token(
+            collection_job_id,
+            Some(self.task.primary_collector_auth_token()),
+        )
+        .await
+    }
+}
+
+pub(crate) async fn setup_collection_job_test_case(
+    role: Role,
+    query_type: QueryType,
+) -> CollectionJobTestCase<impl Reply + 'static> {
+    install_test_trace_subscriber();
+
+    let collector_hpke_keypair = generate_test_hpke_config_and_private_key();
+    let task = TaskBuilder::new(query_type, VdafInstance::Fake, role)
+        .with_collector_hpke_config(collector_hpke_keypair.config().clone())
+        .build();
+    let clock = MockClock::default();
+    let ephemeral_datastore = ephemeral_datastore().await;
+    let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()));
+
+    datastore.put_task(&task).await.unwrap();
+
+    let filter =
+        aggregator_filter(Arc::clone(&datastore), clock.clone(), Config::default()).unwrap();
+
+    CollectionJobTestCase {
+        task,
+        clock,
+        collector_hpke_keypair,
+        filter,
+        datastore,
+        _ephemeral_datastore: ephemeral_datastore,
+    }
+}
+
+async fn setup_fixed_size_current_batch_collection_job_test_case() -> (
+    CollectionJobTestCase<impl Reply + 'static>,
+    BatchId,
+    BatchId,
+) {
+    let test_case =
+        setup_collection_job_test_case(Role::Leader, QueryType::FixedSize { max_batch_size: 10 })
+            .await;
+
+    // Fill the datastore with the necessary data so that there is are two outstanding batches to be
+    // collected.
+    let batch_id_1 = random();
+    let batch_id_2 = random();
+    let time = test_case.clock.now();
+    let interval = Interval::new(time, *test_case.task.time_precision()).unwrap();
+
+    test_case
+        .datastore
+        .run_tx(|tx| {
+            let task = test_case.task.clone();
+            Box::pin(async move {
+                for batch_id in [batch_id_1, batch_id_2] {
+                    let aggregation_job_id = random();
+                    tx.put_aggregation_job::<0, FixedSize, dummy_vdaf::Vdaf>(&AggregationJob::new(
+                        *task.id(),
+                        aggregation_job_id,
+                        dummy_vdaf::AggregationParam::default(),
+                        batch_id,
+                        interval,
+                        AggregationJobState::Finished,
+                    ))
+                    .await
+                    .unwrap();
+
+                    for ord in 0..task.min_batch_size() + 1 {
+                        let report = LeaderStoredReport::new_dummy(*task.id(), time);
+                        tx.put_client_report(&dummy_vdaf::Vdaf::new(), &report)
+                            .await
+                            .unwrap();
+
+                        tx.put_report_aggregation::<0, dummy_vdaf::Vdaf>(&ReportAggregation::new(
+                            *task.id(),
+                            aggregation_job_id,
+                            *report.metadata().id(),
+                            time,
+                            ord as i64,
+                            ReportAggregationState::Finished(dummy_vdaf::OutputShare()),
+                        ))
+                        .await
+                        .unwrap();
+                    }
+
+                    tx.put_outstanding_batch(task.id(), &batch_id)
+                        .await
+                        .unwrap();
+                }
+
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
+
+    (test_case, batch_id_1, batch_id_2)
+}
+
+#[tokio::test]
+async fn collection_job_success_fixed_size() {
+    // This test drives two current batch collection jobs to completion, verifying that distinct
+    // batch IDs are collected each time. Then, we attempt to collect another current batch, which
+    // must fail as there are no more outstanding batches.
+    let (test_case, batch_id_1, batch_id_2) =
+        setup_fixed_size_current_batch_collection_job_test_case().await;
+
+    let mut saw_batch_id_1 = false;
+    let mut saw_batch_id_2 = false;
+    let leader_aggregate_share = dummy_vdaf::AggregateShare(0);
+    let helper_aggregate_share = dummy_vdaf::AggregateShare(1);
+    let request = CollectionReq::new(
+        Query::new_fixed_size(FixedSizeQuery::CurrentBatch),
+        dummy_vdaf::AggregationParam::default().get_encoded(),
+    );
+
+    for _ in 0..2 {
+        let collection_job_id: CollectionJobId = random();
+
+        let response = test_case
+            .put_collection_job(&collection_job_id, &request)
+            .await
+            .into_response();
+        assert_eq!(response.status(), StatusCode::CREATED);
+
+        let collection_job_response = test_case.post_collection_job(&collection_job_id).await;
+        assert_eq!(collection_job_response.status(), StatusCode::ACCEPTED);
+
+        // Update the collection job with the aggregate shares. collection job should now be complete.
+        let batch_id = test_case
+            .datastore
+            .run_tx(|tx| {
+                let task = test_case.task.clone();
+                let helper_aggregate_share_bytes: Vec<u8> = (&helper_aggregate_share).into();
+                let leader_aggregate_share = leader_aggregate_share.clone();
+                Box::pin(async move {
+                    let collection_job = tx
+                        .get_collection_job::<0, FixedSize, dummy_vdaf::Vdaf>(&collection_job_id)
+                        .await
+                        .unwrap()
+                        .unwrap();
+                    let batch_id = *collection_job.batch_identifier();
+
+                    let encrypted_helper_aggregate_share = hpke::seal(
+                        task.collector_hpke_config(),
+                        &HpkeApplicationInfo::new(
+                            &Label::AggregateShare,
+                            &Role::Helper,
+                            &Role::Collector,
+                        ),
+                        &helper_aggregate_share_bytes,
+                        &AggregateShareAad::new(
+                            *task.id(),
+                            BatchSelector::new_fixed_size(batch_id),
+                        )
+                        .get_encoded(),
+                    )
+                    .unwrap();
+
+                    tx.update_collection_job::<0, FixedSize, dummy_vdaf::Vdaf>(
+                        &collection_job.with_state(CollectionJobState::Finished {
+                            report_count: task.min_batch_size() + 1,
+                            encrypted_helper_aggregate_share,
+                            leader_aggregate_share,
+                        }),
+                    )
+                    .await
+                    .unwrap();
+
+                    Ok(batch_id)
+                })
+            })
+            .await
+            .unwrap();
+
+        if batch_id.eq(&batch_id_1) {
+            saw_batch_id_1 = true;
+        } else if batch_id.eq(&batch_id_2) {
+            saw_batch_id_2 = true;
+        } else {
+            panic!("unexpected batch ID");
+        }
+
+        let (parts, body) = test_case
+            .post_collection_job(&collection_job_id)
+            .await
+            .into_parts();
+
+        assert_eq!(parts.status, StatusCode::OK);
+        assert_eq!(
+            parts.headers.get(CONTENT_TYPE).unwrap(),
+            Collection::<FixedSize>::MEDIA_TYPE
+        );
+        let body_bytes = body::to_bytes(body).await.unwrap();
+        let collect_resp = Collection::<FixedSize>::get_decoded(body_bytes.as_ref()).unwrap();
+        assert_eq!(collect_resp.encrypted_aggregate_shares().len(), 2);
+
+        let decrypted_leader_aggregate_share = hpke::open(
+            test_case.task.collector_hpke_config(),
+            test_case.collector_hpke_keypair.private_key(),
+            &HpkeApplicationInfo::new(&Label::AggregateShare, &Role::Leader, &Role::Collector),
+            &collect_resp.encrypted_aggregate_shares()[0],
+            &AggregateShareAad::new(
+                *test_case.task.id(),
+                BatchSelector::new_fixed_size(batch_id),
+            )
+            .get_encoded(),
+        )
+        .unwrap();
+        assert_eq!(
+            leader_aggregate_share,
+            dummy_vdaf::AggregateShare::try_from(decrypted_leader_aggregate_share.as_ref())
+                .unwrap()
+        );
+
+        let decrypted_helper_aggregate_share = hpke::open(
+            test_case.task.collector_hpke_config(),
+            test_case.collector_hpke_keypair.private_key(),
+            &HpkeApplicationInfo::new(&Label::AggregateShare, &Role::Helper, &Role::Collector),
+            &collect_resp.encrypted_aggregate_shares()[1],
+            &AggregateShareAad::new(
+                *test_case.task.id(),
+                BatchSelector::new_fixed_size(batch_id),
+            )
+            .get_encoded(),
+        )
+        .unwrap();
+        assert_eq!(
+            helper_aggregate_share,
+            dummy_vdaf::AggregateShare::try_from(decrypted_helper_aggregate_share.as_ref())
+                .unwrap()
+        );
+    }
+
+    assert!(saw_batch_id_1 && saw_batch_id_2);
+
+    // We have run the two ready batches to completion. Further attempts to collect current batch
+    // ought to fail.
+    let collection_job_id: CollectionJobId = random();
+
+    let mut response = test_case
+        .put_collection_job(&collection_job_id, &request)
+        .await
+        .into_response();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let problem_details: serde_json::Value =
+        serde_json::from_slice(&body::to_bytes(response.body_mut()).await.unwrap()).unwrap();
+    assert_eq!(
+        problem_details,
+        json!({
+            "status": StatusCode::BAD_REQUEST.as_u16(),
+            "type": "urn:ietf:params:ppm:dap:error:batchInvalid",
+            "title": "The batch implied by the query is invalid.",
+            "taskid": format!("{}", test_case.task.id()),
+        }),
+    );
+}
+
+#[tokio::test]
+async fn collection_job_put_idempotence_time_interval() {
+    let test_case = setup_collection_job_test_case(Role::Leader, QueryType::TimeInterval).await;
+
+    let collection_job_id = random();
+    let request = CollectionReq::new(
+        Query::new_time_interval(
+            Interval::new(
+                Time::from_seconds_since_epoch(0),
+                *test_case.task.time_precision(),
+            )
+            .unwrap(),
+        ),
+        dummy_vdaf::AggregationParam::default().get_encoded(),
+    );
+
+    for _ in 0..2 {
+        let response = test_case
+            .put_collection_job(&collection_job_id, &request)
+            .await;
+        assert_eq!(response.status(), StatusCode::CREATED);
+    }
+
+    // There should only be a single collection job despite two successful PUTs
+    test_case
+        .datastore
+        .run_tx(|tx| {
+            let task_id = *test_case.task.id();
+            Box::pin(async move {
+                let collection_jobs = tx
+                    .get_collection_jobs_for_task::<0, TimeInterval, dummy_vdaf::Vdaf>(&task_id)
+                    .await
+                    .unwrap();
+                assert_eq!(collection_jobs.len(), 1);
+                assert_eq!(collection_jobs[0].collection_job_id(), &collection_job_id);
+
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn collection_job_put_idempotence_time_interval_mutate_time_interval() {
+    let test_case = setup_collection_job_test_case(Role::Leader, QueryType::TimeInterval).await;
+
+    let collection_job_id = random();
+    let request = CollectionReq::new(
+        Query::new_time_interval(
+            Interval::new(
+                Time::from_seconds_since_epoch(0),
+                *test_case.task.time_precision(),
+            )
+            .unwrap(),
+        ),
+        dummy_vdaf::AggregationParam::default().get_encoded(),
+    );
+
+    let response = test_case
+        .put_collection_job(&collection_job_id, &request)
+        .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let mutated_request = CollectionReq::new(
+        Query::new_time_interval(
+            Interval::new(
+                Time::from_seconds_since_epoch(test_case.task.time_precision().as_seconds()),
+                *test_case.task.time_precision(),
+            )
+            .unwrap(),
+        ),
+        dummy_vdaf::AggregationParam::default().get_encoded(),
+    );
+
+    let response = test_case
+        .put_collection_job(&collection_job_id, &mutated_request)
+        .await;
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn collection_job_put_idempotence_time_interval_mutate_aggregation_param() {
+    let test_case = setup_collection_job_test_case(Role::Leader, QueryType::TimeInterval).await;
+
+    let collection_job_id = random();
+    let request = CollectionReq::new(
+        Query::new_time_interval(
+            Interval::new(
+                Time::from_seconds_since_epoch(0),
+                *test_case.task.time_precision(),
+            )
+            .unwrap(),
+        ),
+        dummy_vdaf::AggregationParam(0).get_encoded(),
+    );
+
+    let response = test_case
+        .put_collection_job(&collection_job_id, &request)
+        .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let mutated_request = CollectionReq::new(
+        Query::new_time_interval(
+            Interval::new(
+                Time::from_seconds_since_epoch(0),
+                *test_case.task.time_precision(),
+            )
+            .unwrap(),
+        ),
+        dummy_vdaf::AggregationParam(1).get_encoded(),
+    );
+
+    let response = test_case
+        .put_collection_job(&collection_job_id, &mutated_request)
+        .await;
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn collection_job_put_idempotence_fixed_size_current_batch() {
+    let (test_case, batch_id_1, batch_id_2) =
+        setup_fixed_size_current_batch_collection_job_test_case().await;
+
+    let collection_job_id = random();
+    let request = CollectionReq::new(
+        Query::new_fixed_size(FixedSizeQuery::CurrentBatch),
+        dummy_vdaf::AggregationParam(0).get_encoded(),
+    );
+    let mut seen_batch_id = None;
+
+    for _ in 0..2 {
+        let response = test_case
+            .put_collection_job(&collection_job_id, &request)
+            .await;
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+
+        // Make sure that there is only ever a single collection job, and that it uses the same
+        // batch ID after each PUT
+        let batch_id = test_case
+            .datastore
+            .run_tx(|tx| {
+                let task_id = *test_case.task.id();
+                Box::pin(async move {
+                    let collection_jobs = tx
+                        .get_collection_jobs_for_task::<0, FixedSize, dummy_vdaf::Vdaf>(&task_id)
+                        .await
+                        .unwrap();
+                    assert_eq!(collection_jobs.len(), 1);
+                    assert_eq!(collection_jobs[0].collection_job_id(), &collection_job_id);
+                    assert!(
+                        collection_jobs[0].batch_identifier().eq(&batch_id_1)
+                            || collection_jobs[0].batch_identifier().eq(&batch_id_2)
+                    );
+
+                    Ok(*collection_jobs[0].batch_identifier())
+                })
+            })
+            .await
+            .unwrap();
+        match seen_batch_id {
+            None => seen_batch_id = Some(batch_id),
+            Some(seen_batch_id) => assert_eq!(seen_batch_id, batch_id),
+        }
+    }
+}
+
+#[tokio::test]
+async fn collection_job_put_idempotence_fixed_size_current_batch_mutate_aggregation_param() {
+    let (test_case, _, _) = setup_fixed_size_current_batch_collection_job_test_case().await;
+
+    let collection_job_id = random();
+    let request = CollectionReq::new(
+        Query::new_fixed_size(FixedSizeQuery::CurrentBatch),
+        dummy_vdaf::AggregationParam(0).get_encoded(),
+    );
+
+    let response = test_case
+        .put_collection_job(&collection_job_id, &request)
+        .await;
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let mutated_request = CollectionReq::new(
+        Query::new_fixed_size(FixedSizeQuery::CurrentBatch),
+        dummy_vdaf::AggregationParam(1).get_encoded(),
+    );
+
+    let response = test_case
+        .put_collection_job(&collection_job_id, &mutated_request)
+        .await;
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn collection_job_put_idempotence_fixed_size_by_batch_id() {
+    let test_case =
+        setup_collection_job_test_case(Role::Leader, QueryType::FixedSize { max_batch_size: 10 })
+            .await;
+
+    let collection_job_id = random();
+    let request = CollectionReq::new(
+        Query::new_fixed_size(FixedSizeQuery::ByBatchId {
+            batch_id: BatchId::try_from([1u8; 32]).unwrap(),
+        }),
+        dummy_vdaf::AggregationParam(0).get_encoded(),
+    );
+
+    for _ in 0..2 {
+        let response = test_case
+            .put_collection_job(&collection_job_id, &request)
+            .await;
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+    }
+}
+
+#[tokio::test]
+async fn collection_job_put_idempotence_fixed_size_by_batch_id_mutate_batch_id() {
+    let test_case =
+        setup_collection_job_test_case(Role::Leader, QueryType::FixedSize { max_batch_size: 10 })
+            .await;
+
+    let collection_job_id = random();
+    let request = CollectionReq::new(
+        Query::new_fixed_size(FixedSizeQuery::ByBatchId {
+            batch_id: BatchId::try_from([1u8; 32]).unwrap(),
+        }),
+        dummy_vdaf::AggregationParam(0).get_encoded(),
+    );
+
+    let response = test_case
+        .put_collection_job(&collection_job_id, &request)
+        .await;
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let mutated_request = CollectionReq::new(
+        Query::new_fixed_size(FixedSizeQuery::ByBatchId {
+            batch_id: BatchId::try_from([2u8; 32]).unwrap(),
+        }),
+        dummy_vdaf::AggregationParam(0).get_encoded(),
+    );
+
+    let response = test_case
+        .put_collection_job(&collection_job_id, &mutated_request)
+        .await;
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn collection_job_put_idempotence_fixed_size_by_batch_id_mutate_aggregation_param() {
+    let test_case =
+        setup_collection_job_test_case(Role::Leader, QueryType::FixedSize { max_batch_size: 10 })
+            .await;
+
+    let collection_job_id = random();
+    let request = CollectionReq::new(
+        Query::new_fixed_size(FixedSizeQuery::ByBatchId {
+            batch_id: BatchId::try_from([1u8; 32]).unwrap(),
+        }),
+        dummy_vdaf::AggregationParam(0).get_encoded(),
+    );
+
+    let response = test_case
+        .put_collection_job(&collection_job_id, &request)
+        .await;
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let mutated_request = CollectionReq::new(
+        Query::new_fixed_size(FixedSizeQuery::ByBatchId {
+            batch_id: BatchId::try_from([1u8; 32]).unwrap(),
+        }),
+        dummy_vdaf::AggregationParam(1).get_encoded(),
+    );
+
+    let response = test_case
+        .put_collection_job(&collection_job_id, &mutated_request)
+        .await;
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+}

--- a/core/src/test_util/dummy_vdaf.rs
+++ b/core/src/test_util/dummy_vdaf.rs
@@ -163,7 +163,7 @@ impl Decode for InputShare {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AggregationParam(pub u8);
 
 impl Encode for AggregationParam {


### PR DESCRIPTION
Adds new tests to verify that PUT and POST to collection jobs has the
expected idempotence semantics:

 - PUT to a collection job is idempotent
 - POST to a collection job allows the leader to update what "current
   batch" means in a fixed size task

As it turns out, our existing implementation already satisfied these
requirements, so this only adds test coverage. New tests and support
code are introduced in a new `collection_job_tests` module, to avoid
unnecessarily growing `aggregator/src/aggregator.rs`.

Existing tests on collection jobs defined in that file are renamed to
all start with `collection_job`, which makes it easier to run just those
tests that pertain to collection jobs. We could (should) move those
tests to the new module, but that would make this PR unnecessarily noisy
and would obscure the real changes it introduces.

Part of https://github.com/divviup/janus/issues/998