### PR TITLE
Fix panic in ReportWriter if upload request is cancelled(?).

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -134,7 +134,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
 
         loop {
             tasks_update_ticker.tick().await;
-            info!("Updating tasks");
+            debug!("Updating tasks");
             let start = Instant::now();
             let tasks = self
                 .datastore
@@ -217,7 +217,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
         loop {
             select! {
                 _ = aggregation_job_creation_ticker.tick() => {
-                    info!(task_id = %task.id(), "Creating aggregation jobs for task");
+                    debug!(task_id = %task.id(), "Creating aggregation jobs for task");
                     let (start, mut status) = (Instant::now(), "success");
                     if let Err(error) = Arc::clone(&self).create_aggregation_jobs_for_task(Arc::clone(&task)).await {
                         error!(task_id = %task.id(), %error, "Couldn't create aggregation jobs for task");

--- a/aggregator/src/aggregator/report_writer.rs
+++ b/aggregator/src/aggregator/report_writer.rs
@@ -133,18 +133,14 @@ impl<C: Clock> ReportWriteBatcher<C> {
                 // Individual, per-request results.
                 assert_eq!(result_txs.len(), rslts.len()); // sanity check: should be guaranteed.
                 for (rslt_tx, rslt) in result_txs.into_iter().zip(rslts.into_iter()) {
-                    // Unwrap safety: rslt_rx is not closed or dropped until rslt_tx is sent on.
-                    rslt_tx
-                        .send(rslt.map_err(|err| Arc::new(Error::from(err))))
-                        .unwrap();
+                    let _ = rslt_tx.send(rslt.map_err(|err| Arc::new(Error::from(err))));
                 }
             }
             Err(err) => {
                 // Total-transaction failures are given to all waiting report uploaders.
                 let err = Arc::new(Error::from(err));
                 for rslt_tx in result_txs.into_iter() {
-                    // Unwrap safety: rslt_rx is not closed or dropped until rslt_tx is sent on.
-                    rslt_tx.send(Err(Arc::clone(&err))).unwrap();
+                    let _ = rslt_tx.send(Err(Arc::clone(&err)));
                 }
             }
         };


### PR DESCRIPTION
The response-receiver could be dropped if the entire upload future was dropped, which I think corresponds to a cancelled request handling. This would cause the attempt to send the response to panic, which would cause all other waiting response-receivers to panic themselves when the respense-sender was dropped. I saw a few instances of this in the logs from the latest load test:

```
thread 'tokio-runtime-worker' panicked at 'called `Result::unwrap()` on an `Err` value: Ok(())', /src/aggregator/src/aggregator/report_writer.rs:139:26
thread 'tokio-runtime-worker' panicked at 'called `Result::unwrap()` on an `Err` value: RecvError(())', /src/aggregator/src/aggregator/report_writer.rs:56:23
```

With this change, any responses whose receivers have been dropped will simply be dropped.

Also, lower the level of a few spammy-but-less-useful log messages.