### PR TITLE
Hoist `prio` dependency into workspace `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ janus_interop_binaries = { version = "0.3", path = "interop_binaries" }
 janus_messages = { version = "0.3", path = "messages" }
 k8s-openapi = { version = "0.16.0", features = ["v1_24"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
 kube = { version = "0.75.0", default-features = false, features = ["client"] }
+prio = { version = "0.10.0", features = ["multithreaded"] }
 
 [profile.dev]
 # Disabling debug info improves build speeds & reduces build artifact sizes, which helps CI caching.

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -67,7 +67,7 @@ opentelemetry-prometheus = { version = "0.11", optional = true }
 opentelemetry-semantic-conventions = { version = "0.10", optional = true }
 postgres-protocol = "0.6.4"
 postgres-types = { version = "0.2.4", features = ["derive", "array-impls"] }
-prio = { version = "0.10.0", features = ["multithreaded"] }
+prio.workspace = true
 prometheus = { version = "0.13.3", optional = true }
 rand = { version = "0.8", features = ["min_const_gen"] }
 regex = "1"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -16,7 +16,7 @@ http = "0.2.9"
 http-api-problem = "0.56.0"
 janus_core.workspace = true
 janus_messages.workspace = true
-prio = { version = "0.10.0", features = ["multithreaded"] }
+prio.workspace = true
 rand = "0.8"
 reqwest = { version = "0.11.14", default-features = false, features = ["rustls-tls", "json"] }
 thiserror = "1.0"

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -25,7 +25,7 @@ janus_core.workspace = true
 janus_messages.workspace = true
 fixed = { version = "1.23", optional = true }
 fixed-macro = { version = "1.1.1", optional = true }
-prio = "0.10.0"
+prio.workspace = true
 rand = { version = "0.8", features = ["min_const_gen"] }
 reqwest = { version = "0.11.14", default-features = false, features = ["rustls-tls", "json"] }
 retry-after = "0.3.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -41,7 +41,7 @@ http-api-problem = "0.56.0"
 janus_messages.workspace = true
 kube = { workspace = true, optional = true, features = ["rustls-tls"] }
 k8s-openapi = { workspace = true, optional = true }
-prio = { version = "0.10.0", features = ["multithreaded"] }
+prio.workspace = true
 rand = "0.8"
 reqwest = { version = "0.11.14", default-features = false, features = ["rustls-tls", "json"] }
 ring = "0.16.20"

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -25,7 +25,7 @@ janus_messages.workspace = true
 k8s-openapi.workspace = true
 kube.workspace = true
 portpicker = "0.1"
-prio = { version = "0.10.0", features = ["multithreaded"] }
+prio.workspace = true
 rand = "0.8"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
 serde_json = "1.0.93"

--- a/interop_binaries/Cargo.toml
+++ b/interop_binaries/Cargo.toml
@@ -38,7 +38,7 @@ janus_collector.workspace = true
 janus_core.workspace = true
 janus_messages.workspace = true
 opentelemetry = { version = "0.18", features = ["metrics"] }
-prio = { version = "0.10.0", features = ["multithreaded"] }
+prio.workspace = true
 rand = "0.8"
 regex = { version = "1", optional = true }
 reqwest = { version = "0.11.14", default-features = false, features = ["rustls-tls"] }

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -20,7 +20,9 @@ clap = { version = "4.1.6", features = ["cargo", "derive"], optional = true }
 derivative = "2.2.0"
 hex = "0.4"
 num_enum = "0.5.10"
-prio = { version = "0.10.0", default-features = false } # important: do not enable prio/crypto-dependencies by default!
+# We can't pull prio in from the workspace because that would enable default features, and we do not
+# want prio/crypto-dependencies
+prio = { version = "0.10.0", default-features = false }
 rand = "0.8"
 serde = { version = "1.0.152", features = ["derive"] }
 thiserror = "1.0"


### PR DESCRIPTION
Except in `janus_messages`, because if we pull in the dependency from the workspace, then default features are enabled.