### PR TITLE
Add `interval` field to collections

### DIFF
--- a/aggregator/src/aggregator/aggregate_init_tests.rs
+++ b/aggregator/src/aggregator/aggregate_init_tests.rs
@@ -208,7 +208,6 @@ async fn aggregation_job_mutation_report_shares() {
             PartialBatchSelector::new_time_interval(),
             mutated_report_shares,
         );
-        tracing::error!("putting {mutated_aggregation_job_init_req:?}");
         let response = put_aggregation_job(
             &test_case.task,
             &test_case.aggregation_job_id,
@@ -216,7 +215,6 @@ async fn aggregation_job_mutation_report_shares() {
             &test_case.filter,
         )
         .await;
-        tracing::error!(?response);
         assert_eq!(response.status(), StatusCode::CONFLICT);
     }
 }

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -1013,7 +1013,7 @@ mod tests {
         report_id::ReportIdChecksumExt,
         task::{VdafInstance, PRIO3_AES128_VERIFY_KEY_LENGTH},
         test_util::{install_test_trace_subscriber, run_vdaf, runtime::TestRuntimeManager},
-        time::{Clock, MockClock, TimeExt},
+        time::{Clock, IntervalExt, MockClock, TimeExt},
         Runtime,
     };
     use janus_messages::{
@@ -1970,6 +1970,7 @@ mod tests {
             0,
             leader_aggregate_share,
             1,
+            Interval::from_time(report.metadata().time()).unwrap(),
             ReportIdChecksum::for_report_id(report.metadata().id()),
         )]);
 
@@ -2019,6 +2020,7 @@ mod tests {
                     0,
                     agg.aggregate_share().clone(),
                     agg.report_count(),
+                    *agg.client_timestamp_interval(),
                     *agg.checksum(),
                 )
             })
@@ -2236,6 +2238,7 @@ mod tests {
             0,
             leader_aggregate_share,
             1,
+            Interval::from_time(report.metadata().time()).unwrap(),
             ReportIdChecksum::for_report_id(report.metadata().id()),
         )]);
 
@@ -2283,6 +2286,7 @@ mod tests {
                     0,
                     agg.aggregate_share().clone(),
                     agg.report_count(),
+                    *agg.client_timestamp_interval(),
                     *agg.checksum(),
                 )
             })

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -727,7 +727,7 @@ mod tests {
             install_test_trace_subscriber,
             runtime::TestRuntimeManager,
         },
-        time::{Clock, MockClock, TimeExt},
+        time::{Clock, IntervalExt, MockClock, TimeExt},
         Runtime,
     };
     use janus_messages::{
@@ -791,7 +791,7 @@ mod tests {
                             aggregation_job_id,
                             aggregation_param,
                             (),
-                            Interval::new(report_timestamp, Duration::from_seconds(1)).unwrap(),
+                            Interval::from_time(&report_timestamp).unwrap(),
                             AggregationJobState::Finished,
                         ),
                     )
@@ -820,6 +820,7 @@ mod tests {
                             0,
                             dummy_vdaf::AggregateShare(0),
                             5,
+                            Interval::from_time(&report_timestamp).unwrap(),
                             ReportIdChecksum::get_decoded(&[3; 32]).unwrap(),
                         ),
                     )
@@ -836,6 +837,7 @@ mod tests {
                             0,
                             dummy_vdaf::AggregateShare(0),
                             5,
+                            Interval::from_time(&report_timestamp).unwrap(),
                             ReportIdChecksum::get_decoded(&[2; 32]).unwrap(),
                         ),
                     )
@@ -886,10 +888,14 @@ mod tests {
         let agg_auth_token = task.primary_aggregator_auth_token();
         let batch_interval = Interval::new(clock.now(), Duration::from_seconds(2000)).unwrap();
         let aggregation_param = AggregationParam(0);
+        let report_timestamp = clock
+            .now()
+            .to_batch_interval_start(task.time_precision())
+            .unwrap();
 
         let (collection_job_id, lease) = ds
             .run_tx(|tx| {
-                let (clock, task) = (clock.clone(), task.clone());
+                let task = task.clone();
                 Box::pin(async move {
                     tx.put_task(&task).await?;
 
@@ -906,17 +912,13 @@ mod tests {
                     .await?;
 
                     let aggregation_job_id = random();
-                    let report_timestamp = clock
-                        .now()
-                        .to_batch_interval_start(task.time_precision())
-                        .unwrap();
                     tx.put_aggregation_job(
                         &AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
                             *task.id(),
                             aggregation_job_id,
                             aggregation_param,
                             (),
-                            Interval::new(report_timestamp, Duration::from_seconds(1)).unwrap(),
+                            Interval::from_time(&report_timestamp).unwrap(),
                             AggregationJobState::Finished,
                         ),
                     )
@@ -980,6 +982,7 @@ mod tests {
                         0,
                         dummy_vdaf::AggregateShare(0),
                         5,
+                        Interval::from_time(&report_timestamp).unwrap(),
                         ReportIdChecksum::get_decoded(&[3; 32]).unwrap(),
                     ),
                 )
@@ -997,6 +1000,7 @@ mod tests {
                         0,
                         dummy_vdaf::AggregateShare(0),
                         5,
+                        Interval::from_time(&report_timestamp).unwrap(),
                         ReportIdChecksum::get_decoded(&[2; 32]).unwrap(),
                     ),
                 )

--- a/aggregator/src/aggregator/garbage_collector.rs
+++ b/aggregator/src/aggregator/garbage_collector.rs
@@ -97,7 +97,7 @@ mod tests {
             dummy_vdaf::{self, AggregateShare, AggregationParam},
             install_test_trace_subscriber,
         },
-        time::{Clock, MockClock, TimeExt},
+        time::{Clock, IntervalExt, MockClock, TimeExt},
     };
     use janus_messages::{
         query_type::{FixedSize, TimeInterval},
@@ -170,6 +170,7 @@ mod tests {
                         0,
                         AggregateShare(11),
                         1,
+                        Interval::from_time(&client_timestamp).unwrap(),
                         random(),
                     );
                     tx.put_batch_aggregation::<0, TimeInterval, dummy_vdaf::Vdaf>(
@@ -327,6 +328,7 @@ mod tests {
                         0,
                         AggregateShare(11),
                         1,
+                        Interval::from_time(&client_timestamp).unwrap(),
                         random(),
                     );
                     tx.put_batch_aggregation::<0, TimeInterval, dummy_vdaf::Vdaf>(
@@ -480,6 +482,7 @@ mod tests {
                         0,
                         AggregateShare(11),
                         1,
+                        Interval::from_time(&client_timestamp).unwrap(),
                         random(),
                     );
                     tx.put_batch_aggregation::<0, FixedSize, dummy_vdaf::Vdaf>(&batch_aggregation)
@@ -639,6 +642,7 @@ mod tests {
                         0,
                         AggregateShare(11),
                         1,
+                        Interval::from_time(&client_timestamp).unwrap(),
                         random(),
                     );
                     tx.put_batch_aggregation::<0, FixedSize, dummy_vdaf::Vdaf>(&batch_aggregation)

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -19,6 +19,7 @@ test-util = []
 
 [dependencies]
 backoff = { version = "0.4.0", features = ["tokio"] }
+chrono.workspace = true
 derivative = "2.2.0"
 http-api-problem = "0.56.0"
 janus_core.workspace = true
@@ -36,7 +37,6 @@ url = "2.3.1"
 
 [dev-dependencies]
 assert_matches = "1"
-chrono.workspace = true
 janus_collector = { path = ".", features = ["fpvec_bounded_l2", "test-util"] }
 janus_core = { workspace = true, features = ["fpvec_bounded_l2", "test-util"] }
 mockito = "0.32.3"

--- a/core/src/test_util/dummy_vdaf.rs
+++ b/core/src/test_util/dummy_vdaf.rs
@@ -178,7 +178,7 @@ impl Decode for AggregationParam {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct OutputShare();
 
 impl TryFrom<&[u8]> for OutputShare {
@@ -210,7 +210,7 @@ impl Decode for PrepareState {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AggregateShare(pub u64);
 
 impl Aggregatable for AggregateShare {

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -158,6 +158,7 @@ CREATE TABLE batch_aggregations(
     ord                   BIGINT NOT NULL,     -- the index of this batch aggregation shard, over (task ID, batch_identifier, aggregation_param).
     aggregate_share       BYTEA NOT NULL,      -- the (possibly-incremental) aggregate share
     report_count          BIGINT NOT NULL,     -- the (possibly-incremental) client report count
+    client_timestamp_interval TSRANGE NOT NULL, -- the minimal interval containing all of client timestamps included in this batch aggregation
     checksum              BYTEA NOT NULL,      -- the (possibly-incremental) checksum
 
     CONSTRAINT batch_aggregations_unique_task_id_batch_id_aggregation_param UNIQUE(task_id, batch_identifier, aggregation_param, ord),

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -501,6 +501,11 @@ where
         );
     }
     println!("Number of reports: {}", collection.report_count());
+    println!(
+        "Spanned interval: start: {} length: {}",
+        collection.interval().0,
+        collection.interval().1
+    );
     println!("Aggregation result: {:?}", collection.aggregate_result());
     Ok(())
 }


### PR DESCRIPTION
Add `interval` field to collections

In DAP-04, the `Collection` message which conveys aggregate shares to the collector now includes an `Interval` representing the exact interval of time spanned by the reports included in the collection.

When servicing a GET request on a finished collection job, Janus now queries the constituent aggregation jobs and merges their `client_report_interval`s together (we were already recording the exact interval spanned by aggregation jobs). `janus_collector::Collection` adds a field `interval: (chrono::DateTime<Utc>, chrono::Duration)` to represent this interval.

Resolves #990
