### PR TITLE
Aggregation job creator: add locking clause to report-finder query.

### DIFF
--- a/aggregator/src/datastore.rs
+++ b/aggregator/src/datastore.rs
@@ -1025,6 +1025,7 @@ impl<C: Clock> Transaction<'_, C> {
                     SELECT id FROM client_reports
                     WHERE task_id = (SELECT id FROM tasks WHERE task_id = $1)
                       AND aggregation_started = FALSE
+                    FOR UPDATE SKIP LOCKED
                     LIMIT 5000
                 )
                 RETURNING report_id, client_timestamp",
@@ -1062,6 +1063,7 @@ impl<C: Clock> Transaction<'_, C> {
         A: vdaf::Aggregator<L> + VdafHasAggregationParameter,
         for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
     {
+        // TODO(#224): lock retrieved client_reports rows
         // TODO(#269): allow the number of returned results to be controlled?
         let stmt = self
             .prepare_cached(


### PR DESCRIPTION
This allows us to efficiently run multiple replicas of the aggregation job creator -- without the locking clauses, concurrent attempts to create aggregation jobs would almost certainly conflict, requiring retries & actually-serial execution.

Note I don't update
`get_unaggregated_client_report_ids_by_collect_for_task`: locking clauses don't work when DISTINCT is set. We'd need to do a larger update to this query. Thankfully, this query is test-only code (and only required for Poplar1 or other VDAFs with a nontrivial aggregation parameter).