### PR TITLE
Extend retry timeout in tests

### DIFF
--- a/core/src/retries.rs
+++ b/core/src/retries.rs
@@ -45,7 +45,7 @@ pub fn test_http_request_exponential_backoff() -> ExponentialBackoff {
         initial_interval: Duration::from_nanos(1),
         max_interval: Duration::from_nanos(30),
         multiplier: 2.0,
-        max_elapsed_time: Some(Duration::from_millis(10)),
+        max_elapsed_time: Some(Duration::from_millis(30)),
         ..Default::default()
     }
 }


### PR DESCRIPTION
I've been seeing some local test flakiness from the one `janus_collector` test that checks retry behavior. Presumably this is linked to the recent `mockito` rewrite. This PR extends the retry timeout used in tests, and it seems to solve the issue.