### PR TITLE
Fix building `janus_core` alone

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -76,6 +76,8 @@ jobs:
         key: ${{ steps.os-version.outputs.release }}
     - name: Build minimal janus_messages
       run: cargo build --package janus_messages --no-default-features
+    - name: Build janus_core
+      run: cargo build --package janus_core
     # Note: keep Build & Test steps consecutive, and match flags other than `--no-run`.
     - name: Build
       run: cargo test --no-run --locked --all-targets

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -32,7 +32,7 @@ test-util = [
 [dependencies]
 backoff = { version = "0.4.0", features = ["tokio"] }
 base64 = "0.21.0"
-chrono.workspace = true
+chrono = { workspace = true, features = ["clock"] }
 derivative = "2.2.0"
 futures = "0.3.26"
 hex = "0.4"


### PR DESCRIPTION
This enables the `clock` feature on chrono when building `janus_core`, which is necessary for `RealClock::now()`. Our usual builds are unaffected because dependencies from other workspace crates turn on this feature, and those get unified together.