### PR TITLE
Dispatch to VDAF instances using macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,6 +1768,7 @@ dependencies = [
  "base64 0.21.0",
  "chrono",
  "derivative",
+ "fixed",
  "futures",
  "hex",
  "hpke-dispatch",

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -3,11 +3,6 @@ use crate::aggregator::{
 };
 use anyhow::{anyhow, Context as _, Result};
 use derivative::Derivative;
-#[cfg(feature = "fpvec_bounded_l2")]
-use fixed::{
-    types::extra::{U15, U31, U63},
-    FixedI16, FixedI32, FixedI64,
-};
 use futures::future::{try_join_all, BoxFuture, FutureExt};
 use janus_aggregator_core::{
     datastore::{
@@ -21,11 +16,7 @@ use janus_aggregator_core::{
     query_type::AccumulableQueryType,
     task::{self, Task, VerifyKey},
 };
-use janus_core::{
-    task::{VdafInstance, PRIO3_AES128_VERIFY_KEY_LENGTH},
-    time::Clock,
-    vdaf_dispatch,
-};
+use janus_core::{time::Clock, vdaf_dispatch};
 use janus_messages::{
     query_type::{FixedSize, TimeInterval},
     AggregationJobContinueReq, AggregationJobInitializeReq, AggregationJobResp,
@@ -35,18 +26,9 @@ use opentelemetry::{
     metrics::{Counter, Histogram, Meter, Unit},
     Context, KeyValue,
 };
-#[cfg(feature = "fpvec_bounded_l2")]
-use prio::vdaf::prio3::Prio3Aes128FixedPointBoundedL2VecSum;
 use prio::{
     codec::{Decode, Encode, ParameterizedDecode},
-    vdaf::{
-        self,
-        prio3::{
-            Prio3Aes128Count, Prio3Aes128CountVecMultithreaded, Prio3Aes128Histogram,
-            Prio3Aes128Sum,
-        },
-        PrepareTransition,
-    },
+    vdaf::{self, PrepareTransition},
 };
 use reqwest::Method;
 use std::{collections::HashSet, fmt, sync::Arc, time::Duration};
@@ -690,84 +672,29 @@ impl AggregationJobDriver {
         datastore: Arc<Datastore<C>>,
         lease: Lease<AcquiredAggregationJob>,
     ) -> Result<()> {
-        match (lease.leased().query_type(), lease.leased().vdaf()) {
-            (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128Count) => {
-                self.cancel_aggregation_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, TimeInterval, Prio3Aes128Count>(datastore, lease)
+        match lease.leased().query_type() {
+            task::QueryType::TimeInterval => {
+                vdaf_dispatch!(lease.leased().vdaf(), (_, VdafType, VERIFY_KEY_LENGTH) => {
+                    self.cancel_aggregation_job_generic::<
+                        VERIFY_KEY_LENGTH,
+                        C,
+                        TimeInterval,
+                        VdafType,
+                    >(datastore, lease)
                     .await
+                })
             }
-
-            (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128CountVec { .. }) => {
-                self.cancel_aggregation_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, TimeInterval, Prio3Aes128CountVecMultithreaded>(datastore, lease)
+            task::QueryType::FixedSize { .. } => {
+                vdaf_dispatch!(lease.leased().vdaf(), (_, VdafType, VERIFY_KEY_LENGTH) => {
+                    self.cancel_aggregation_job_generic::<
+                        VERIFY_KEY_LENGTH,
+                        C,
+                        FixedSize,
+                        VdafType,
+                    >(datastore, lease)
                     .await
+                })
             }
-
-            (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128Sum { .. }) => {
-                self.cancel_aggregation_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, TimeInterval, Prio3Aes128Sum>(datastore, lease)
-                    .await
-            }
-
-            (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128Histogram { .. }) => {
-                self.cancel_aggregation_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, TimeInterval, Prio3Aes128Histogram>(datastore, lease)
-                    .await
-            }
-
-#[cfg(feature = "fpvec_bounded_l2")]
-            (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128FixedPoint16BitBoundedL2VecSum { .. }) => {
-                self.cancel_aggregation_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, TimeInterval, Prio3Aes128FixedPointBoundedL2VecSum<FixedI16<U15>>>(datastore, lease)
-                    .await
-            }
-
-#[cfg(feature = "fpvec_bounded_l2")]
-            (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128FixedPoint32BitBoundedL2VecSum { .. }) => {
-                self.cancel_aggregation_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, TimeInterval, Prio3Aes128FixedPointBoundedL2VecSum<FixedI32<U31>>>(datastore, lease)
-                    .await
-            }
-
-#[cfg(feature = "fpvec_bounded_l2")]
-            (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128FixedPoint64BitBoundedL2VecSum { .. }) => {
-                self.cancel_aggregation_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, TimeInterval, Prio3Aes128FixedPointBoundedL2VecSum<FixedI64<U63>>>(datastore, lease)
-                    .await
-            }
-
-            (task::QueryType::FixedSize{..}, VdafInstance::Prio3Aes128Count) => {
-                self.cancel_aggregation_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, FixedSize, Prio3Aes128Count>(datastore, lease)
-                    .await
-            }
-
-            (task::QueryType::FixedSize{..}, VdafInstance::Prio3Aes128CountVec { .. }) => {
-                self.cancel_aggregation_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, FixedSize, Prio3Aes128CountVecMultithreaded>(datastore, lease)
-                    .await
-            }
-
-            (task::QueryType::FixedSize{..}, VdafInstance::Prio3Aes128Sum { .. }) => {
-                self.cancel_aggregation_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, FixedSize, Prio3Aes128Sum>(datastore, lease)
-                    .await
-            }
-
-            (task::QueryType::FixedSize{..}, VdafInstance::Prio3Aes128Histogram { .. }) => {
-                self.cancel_aggregation_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, FixedSize, Prio3Aes128Histogram>(datastore, lease)
-                    .await
-            }
-
-#[cfg(feature = "fpvec_bounded_l2")]
-            (task::QueryType::FixedSize { .. }, VdafInstance::Prio3Aes128FixedPoint16BitBoundedL2VecSum { .. }) => {
-                self.cancel_aggregation_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, FixedSize, Prio3Aes128FixedPointBoundedL2VecSum<FixedI16<U15>>>(datastore, lease)
-                    .await
-            }
-
-#[cfg(feature = "fpvec_bounded_l2")]
-            (task::QueryType::FixedSize { .. }, VdafInstance::Prio3Aes128FixedPoint32BitBoundedL2VecSum { .. }) => {
-                self.cancel_aggregation_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, FixedSize, Prio3Aes128FixedPointBoundedL2VecSum<FixedI32<U31>>>(datastore, lease)
-                    .await
-            }
-
-#[cfg(feature = "fpvec_bounded_l2")]
-            (task::QueryType::FixedSize { .. }, VdafInstance::Prio3Aes128FixedPoint64BitBoundedL2VecSum { .. }) => {
-                self.cancel_aggregation_job_generic::<PRIO3_AES128_VERIFY_KEY_LENGTH, C, FixedSize, Prio3Aes128FixedPointBoundedL2VecSum<FixedI64<U63>>>(datastore, lease)
-                    .await
-            }
-
-            _ => panic!("Query type/VDAF {:?}/{:?} is not yet supported", lease.leased().query_type(), lease.leased().vdaf()),
         }
     }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -59,6 +59,7 @@ tracing-log = { version = "0.1.3", optional = true }
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt"], optional = true }
 
 [dev-dependencies]
+fixed = "1.23"
 hex = { version = "0.4", features = ["serde"] }  # ensure this remains compatible with the non-dev dependency
 janus_core = { workspace = true, features = ["test-util"] }
 # Enable `kube`'s `openssl-tls` feature (which takes precedence over the

--- a/core/src/task.rs
+++ b/core/src/task.rs
@@ -75,7 +75,7 @@ impl VdafInstance {
 macro_rules! vdaf_dispatch_impl_base {
     // TODO: check if the type can be inferred, and the type argument and type alias can be dropped,
     // after upgrading to prio 0.11 and getting rid of `TryFrom<&'a [u8]>::Error: Debug` bounds.
-    (impl match base $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident) => $body:tt) => {
+    (impl match base $vdaf_instance:expr, ($vdaf:pat_param, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident) => $body:tt) => {
         match $vdaf_instance {
             ::janus_core::task::VdafInstance::Prio3Aes128Count => {
                 let $vdaf = ::prio::vdaf::prio3::Prio3::new_aes128_count(2)?;
@@ -119,7 +119,7 @@ macro_rules! vdaf_dispatch_impl_base {
 #[cfg(feature = "fpvec_bounded_l2")]
 #[macro_export]
 macro_rules! vdaf_dispatch_impl_fpvec_bounded_l2 {
-    (impl match fpvec_bounded_l2 $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident) => $body:tt) => {
+    (impl match fpvec_bounded_l2 $vdaf_instance:expr, ($vdaf:pat_param, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident) => $body:tt) => {
         match $vdaf_instance {
             ::janus_core::task::VdafInstance::Prio3Aes128FixedPoint16BitBoundedL2VecSum {
                 length,
@@ -172,7 +172,7 @@ macro_rules! vdaf_dispatch_impl_fpvec_bounded_l2 {
 #[cfg(feature = "fpvec_bounded_l2")]
 #[macro_export]
 macro_rules! vdaf_dispatch_impl {
-    (impl match all $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident) => $body:tt) => {
+    (impl match all $vdaf_instance:expr, ($vdaf:pat_param, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident) => $body:tt) => {
         match $vdaf_instance {
             ::janus_core::task::VdafInstance::Prio3Aes128Count
             | ::janus_core::task::VdafInstance::Prio3Aes128CountVec { .. }
@@ -196,7 +196,7 @@ macro_rules! vdaf_dispatch_impl {
 #[cfg(not(feature = "fpvec_bounded_l2"))]
 #[macro_export]
 macro_rules! vdaf_dispatch_impl {
-    (impl match all $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident) => $body:tt) => {
+    (impl match all $vdaf_instance:expr, ($vdaf:pat_param, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident) => $body:tt) => {
         match $vdaf_instance {
             ::janus_core::task::VdafInstance::Prio3Aes128Count
             | ::janus_core::task::VdafInstance::Prio3Aes128CountVec { .. }
@@ -237,7 +237,7 @@ macro_rules! vdaf_dispatch_impl {
 /// ```
 #[macro_export]
 macro_rules! vdaf_dispatch {
-    ($vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident) => $body:tt) => {
+    ($vdaf_instance:expr, ($vdaf:pat_param, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident) => $body:tt) => {
         ::janus_core::vdaf_dispatch_impl!(impl match all $vdaf_instance, ($vdaf, $Vdaf, $VERIFY_KEY_LENGTH) => $body)
     };
 }


### PR DESCRIPTION
This closes #1040. I've defined macros for `VdafInstance` and `VdafOps`. I had to get a little creative with syntax, because the different generated match arm bodies need to use different types when calling generic functions. Thus, the macro sets up a type alias and a const, using passed-in identifiers as names, which can then be used in the rest of the block to explicitly specify types in turbofishes. (Once we define a macro for query types, it will have to do the same thing, creating different type aliases with the same macro parameter name in each match arm)