### PR TITLE
Rename PRIO3_AES128_VERIFY_KEY_LENGTH

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -35,7 +35,7 @@ use janus_core::test_util::dummy_vdaf;
 use janus_core::{
     hpke::{self, HpkeApplicationInfo, Label},
     http::response_to_problem_details,
-    task::{AuthenticationToken, VdafInstance, DAP_AUTH_HEADER, PRIO3_AES128_VERIFY_KEY_LENGTH},
+    task::{AuthenticationToken, VdafInstance, DAP_AUTH_HEADER, PRIO3_VERIFY_KEY_LENGTH},
     time::{Clock, DurationExt, IntervalExt, TimeExt},
 };
 use janus_messages::{
@@ -879,36 +879,30 @@ impl<C: Clock> TaskAggregator<C> {
 /// VdafOps stores VDAF-specific operations for a TaskAggregator in a non-generic way.
 #[allow(clippy::enum_variant_names)]
 enum VdafOps {
-    Prio3Aes128Count(
-        Arc<Prio3Aes128Count>,
-        VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH>,
-    ),
+    Prio3Aes128Count(Arc<Prio3Aes128Count>, VerifyKey<PRIO3_VERIFY_KEY_LENGTH>),
     Prio3Aes128CountVec(
         Arc<Prio3Aes128CountVecMultithreaded>,
-        VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH>,
+        VerifyKey<PRIO3_VERIFY_KEY_LENGTH>,
     ),
-    Prio3Aes128Sum(
-        Arc<Prio3Aes128Sum>,
-        VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH>,
-    ),
+    Prio3Aes128Sum(Arc<Prio3Aes128Sum>, VerifyKey<PRIO3_VERIFY_KEY_LENGTH>),
     Prio3Aes128Histogram(
         Arc<Prio3Aes128Histogram>,
-        VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH>,
+        VerifyKey<PRIO3_VERIFY_KEY_LENGTH>,
     ),
     #[cfg(feature = "fpvec_bounded_l2")]
     Prio3Aes128FixedPoint16BitBoundedL2VecSum(
         Arc<Prio3Aes128FixedPointBoundedL2VecSum<FixedI16<U15>>>,
-        VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH>,
+        VerifyKey<PRIO3_VERIFY_KEY_LENGTH>,
     ),
     #[cfg(feature = "fpvec_bounded_l2")]
     Prio3Aes128FixedPoint32BitBoundedL2VecSum(
         Arc<Prio3Aes128FixedPointBoundedL2VecSum<FixedI32<U31>>>,
-        VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH>,
+        VerifyKey<PRIO3_VERIFY_KEY_LENGTH>,
     ),
     #[cfg(feature = "fpvec_bounded_l2")]
     Prio3Aes128FixedPoint64BitBoundedL2VecSum(
         Arc<Prio3Aes128FixedPointBoundedL2VecSum<FixedI64<U63>>>,
-        VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH>,
+        VerifyKey<PRIO3_VERIFY_KEY_LENGTH>,
     ),
 
     #[cfg(feature = "test-util")]
@@ -927,8 +921,7 @@ macro_rules! vdaf_ops_dispatch {
                 let $vdaf = vdaf;
                 let $verify_key = verify_key;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128Count;
-                const $VERIFY_KEY_LENGTH: usize =
-                    ::janus_core::task::PRIO3_AES128_VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
@@ -936,8 +929,7 @@ macro_rules! vdaf_ops_dispatch {
                 let $vdaf = vdaf;
                 let $verify_key = verify_key;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128CountVecMultithreaded;
-                const $VERIFY_KEY_LENGTH: usize =
-                    ::janus_core::task::PRIO3_AES128_VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
@@ -945,8 +937,7 @@ macro_rules! vdaf_ops_dispatch {
                 let $vdaf = vdaf;
                 let $verify_key = verify_key;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128Sum;
-                const $VERIFY_KEY_LENGTH: usize =
-                    ::janus_core::task::PRIO3_AES128_VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
@@ -954,8 +945,7 @@ macro_rules! vdaf_ops_dispatch {
                 let $vdaf = vdaf;
                 let $verify_key = verify_key;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128Histogram;
-                const $VERIFY_KEY_LENGTH: usize =
-                    ::janus_core::task::PRIO3_AES128_VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
@@ -968,8 +958,7 @@ macro_rules! vdaf_ops_dispatch {
                 let $verify_key = verify_key;
                 type $Vdaf =
                     ::prio::vdaf::prio3::Prio3Aes128FixedPointBoundedL2VecSum<FixedI16<U15>>;
-                const $VERIFY_KEY_LENGTH: usize =
-                    ::janus_core::task::PRIO3_AES128_VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
@@ -982,8 +971,7 @@ macro_rules! vdaf_ops_dispatch {
                 let $verify_key = verify_key;
                 type $Vdaf =
                     ::prio::vdaf::prio3::Prio3Aes128FixedPointBoundedL2VecSum<FixedI32<U31>>;
-                const $VERIFY_KEY_LENGTH: usize =
-                    ::janus_core::task::PRIO3_AES128_VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
@@ -996,8 +984,7 @@ macro_rules! vdaf_ops_dispatch {
                 let $verify_key = verify_key;
                 type $Vdaf =
                     ::prio::vdaf::prio3::Prio3Aes128FixedPointBoundedL2VecSum<FixedI64<U63>>;
-                const $VERIFY_KEY_LENGTH: usize =
-                    ::janus_core::task::PRIO3_AES128_VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
@@ -3252,7 +3239,7 @@ mod tests {
             self, test_util::generate_test_hpke_config_and_private_key, HpkeApplicationInfo, Label,
         },
         report_id::ReportIdChecksumExt,
-        task::{AuthenticationToken, VdafInstance, PRIO3_AES128_VERIFY_KEY_LENGTH},
+        task::{AuthenticationToken, VdafInstance, PRIO3_VERIFY_KEY_LENGTH},
         test_util::{dummy_vdaf, install_test_trace_subscriber, run_vdaf},
         time::{Clock, DurationExt, MockClock, RealClock, TimeExt},
     };
@@ -4146,7 +4133,7 @@ mod tests {
                 let task = task.clone();
                 Box::pin(async move {
                     tx.put_collection_job(&CollectionJob::<
-                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        PRIO3_VERIFY_KEY_LENGTH,
                         TimeInterval,
                         Prio3Aes128Count,
                     >::new(
@@ -5093,7 +5080,7 @@ mod tests {
         let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()));
 
         let vdaf = Arc::new(Prio3::new_aes128_count(2).unwrap());
-        let verify_key: VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH> =
+        let verify_key: VerifyKey<PRIO3_VERIFY_KEY_LENGTH> =
             task.primary_vdaf_verify_key().unwrap();
         let hpke_key = task.current_hpke_key();
 
@@ -5204,7 +5191,7 @@ mod tests {
                     tx.put_report_share(task.id(), &report_share_2).await?;
 
                     tx.put_aggregation_job(&AggregationJob::<
-                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        PRIO3_VERIFY_KEY_LENGTH,
                         TimeInterval,
                         Prio3Aes128Count,
                     >::new(
@@ -5217,7 +5204,7 @@ mod tests {
                     ))
                     .await?;
 
-                    tx.put_report_aggregation::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                    tx.put_report_aggregation::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
                         &ReportAggregation::new(
                             *task.id(),
                             aggregation_job_id,
@@ -5228,7 +5215,7 @@ mod tests {
                         ),
                     )
                     .await?;
-                    tx.put_report_aggregation::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                    tx.put_report_aggregation::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
                         &ReportAggregation::new(
                             *task.id(),
                             aggregation_job_id,
@@ -5239,7 +5226,7 @@ mod tests {
                         ),
                     )
                     .await?;
-                    tx.put_report_aggregation::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+                    tx.put_report_aggregation::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
                         &ReportAggregation::new(
                             *task.id(),
                             aggregation_job_id,
@@ -5251,7 +5238,7 @@ mod tests {
                     )
                     .await?;
 
-                    tx.put_aggregate_share_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>(
+                    tx.put_aggregate_share_job::<PRIO3_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>(
                         &AggregateShareJob::new(
                             *task.id(),
                             Interval::new(
@@ -5329,7 +5316,7 @@ mod tests {
                 let (vdaf, task) = (Arc::clone(&vdaf), task.clone());
                 Box::pin(async move {
                     let aggregation_job = tx
-                        .get_aggregation_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>(
+                        .get_aggregation_job::<PRIO3_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>(
                             task.id(),
                             &aggregation_job_id,
                         )
@@ -5416,7 +5403,7 @@ mod tests {
         );
 
         let vdaf = Prio3::new_aes128_count(2).unwrap();
-        let verify_key: VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH> =
+        let verify_key: VerifyKey<PRIO3_VERIFY_KEY_LENGTH> =
             task.primary_vdaf_verify_key().unwrap();
         let hpke_key = task.current_hpke_key();
 
@@ -5529,7 +5516,7 @@ mod tests {
                     tx.put_report_share(task.id(), &report_share_2).await?;
 
                     tx.put_aggregation_job(&AggregationJob::<
-                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        PRIO3_VERIFY_KEY_LENGTH,
                         TimeInterval,
                         Prio3Aes128Count,
                     >::new(
@@ -5544,7 +5531,7 @@ mod tests {
                     .await?;
 
                     tx.put_report_aggregation(&ReportAggregation::<
-                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        PRIO3_VERIFY_KEY_LENGTH,
                         Prio3Aes128Count,
                     >::new(
                         *task.id(),
@@ -5556,7 +5543,7 @@ mod tests {
                     ))
                     .await?;
                     tx.put_report_aggregation(&ReportAggregation::<
-                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        PRIO3_VERIFY_KEY_LENGTH,
                         Prio3Aes128Count,
                     >::new(
                         *task.id(),
@@ -5568,7 +5555,7 @@ mod tests {
                     ))
                     .await?;
                     tx.put_report_aggregation(&ReportAggregation::<
-                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        PRIO3_VERIFY_KEY_LENGTH,
                         Prio3Aes128Count,
                     >::new(
                         *task.id(),
@@ -5640,7 +5627,7 @@ mod tests {
                 let (task, report_metadata_0) = (task.clone(), report_metadata_0.clone());
                 Box::pin(async move {
                     TimeInterval::get_batch_aggregations_for_collect_identifier::<
-                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        PRIO3_VERIFY_KEY_LENGTH,
                         Prio3Aes128Count,
                         _,
                     >(
@@ -5664,7 +5651,7 @@ mod tests {
             .unwrap()
             .into_iter()
             .map(|agg| {
-                BatchAggregation::<PRIO3_AES128_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>::new(
+                BatchAggregation::<PRIO3_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>::new(
                     *agg.task_id(),
                     *agg.batch_identifier(),
                     (),
@@ -5828,7 +5815,7 @@ mod tests {
                     tx.put_report_share(task.id(), &report_share_5).await?;
 
                     tx.put_aggregation_job(&AggregationJob::<
-                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        PRIO3_VERIFY_KEY_LENGTH,
                         TimeInterval,
                         Prio3Aes128Count,
                     >::new(
@@ -5843,7 +5830,7 @@ mod tests {
                     .await?;
 
                     tx.put_report_aggregation(&ReportAggregation::<
-                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        PRIO3_VERIFY_KEY_LENGTH,
                         Prio3Aes128Count,
                     >::new(
                         *task.id(),
@@ -5855,7 +5842,7 @@ mod tests {
                     ))
                     .await?;
                     tx.put_report_aggregation(&ReportAggregation::<
-                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        PRIO3_VERIFY_KEY_LENGTH,
                         Prio3Aes128Count,
                     >::new(
                         *task.id(),
@@ -5867,7 +5854,7 @@ mod tests {
                     ))
                     .await?;
                     tx.put_report_aggregation(&ReportAggregation::<
-                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        PRIO3_VERIFY_KEY_LENGTH,
                         Prio3Aes128Count,
                     >::new(
                         *task.id(),
@@ -5939,7 +5926,7 @@ mod tests {
                 let (task, report_metadata_0) = (task.clone(), report_metadata_0.clone());
                 Box::pin(async move {
                     TimeInterval::get_batch_aggregations_for_collect_identifier::<
-                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        PRIO3_VERIFY_KEY_LENGTH,
                         Prio3Aes128Count,
                         _,
                     >(
@@ -5963,7 +5950,7 @@ mod tests {
             .unwrap()
             .into_iter()
             .map(|agg| {
-                BatchAggregation::<PRIO3_AES128_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>::new(
+                BatchAggregation::<PRIO3_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>::new(
                     *agg.task_id(),
                     *agg.batch_identifier(),
                     (),

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -12,7 +12,7 @@ use janus_aggregator_core::{
     task::{self, Task},
 };
 use janus_core::{
-    task::{VdafInstance, PRIO3_AES128_VERIFY_KEY_LENGTH},
+    task::{VdafInstance, PRIO3_VERIFY_KEY_LENGTH},
     time::{Clock, DurationExt as _, TimeExt as _},
 };
 use janus_messages::{
@@ -235,89 +235,89 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
     ) -> anyhow::Result<bool> {
         match (task.query_type(), task.vdaf()) {
             (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128Count) => {
-                self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(task)
+                self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Count>(task)
                     .await
             }
 
             (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128CountVec { .. }) => {
                 self.create_aggregation_jobs_for_time_interval_task_no_param::<
-                    PRIO3_AES128_VERIFY_KEY_LENGTH,
+                    PRIO3_VERIFY_KEY_LENGTH,
                     Prio3Aes128CountVecMultithreaded
                 >(task).await
             }
 
             (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128Sum { .. }) => {
-                self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Sum>(task)
+                self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Sum>(task)
                     .await
             }
 
             (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128Histogram { .. }) => {
-                self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Histogram>(task)
+                self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Histogram>(task)
                     .await
             }
 
             #[cfg(feature = "fpvec_bounded_l2")]
             (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128FixedPoint16BitBoundedL2VecSum { .. }) => {
-                self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128FixedPointBoundedL2VecSum<FixedI16<U15>>>(task)
+                self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128FixedPointBoundedL2VecSum<FixedI16<U15>>>(task)
                     .await
             }
 
             #[cfg(feature = "fpvec_bounded_l2")]
             (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128FixedPoint32BitBoundedL2VecSum { .. }) => {
-                self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128FixedPointBoundedL2VecSum<FixedI32<U31>>>(task)
+                self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128FixedPointBoundedL2VecSum<FixedI32<U31>>>(task)
                     .await
             }
 
             #[cfg(feature = "fpvec_bounded_l2")]
             (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128FixedPoint64BitBoundedL2VecSum { .. }) => {
-                self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128FixedPointBoundedL2VecSum<FixedI64<U63>>>(task)
+                self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128FixedPointBoundedL2VecSum<FixedI64<U63>>>(task)
                     .await
             }
 
             (task::QueryType::FixedSize{max_batch_size}, VdafInstance::Prio3Aes128Count) => {
                 let max_batch_size = *max_batch_size;
-                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(task, max_batch_size)
+                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Count>(task, max_batch_size)
                     .await
             }
 
             (task::QueryType::FixedSize{max_batch_size}, VdafInstance::Prio3Aes128CountVec { .. }) => {
                 let max_batch_size = *max_batch_size;
                 self.create_aggregation_jobs_for_fixed_size_task_no_param::<
-                    PRIO3_AES128_VERIFY_KEY_LENGTH,
+                    PRIO3_VERIFY_KEY_LENGTH,
                     Prio3Aes128CountVecMultithreaded
                 >(task, max_batch_size).await
             }
 
             (task::QueryType::FixedSize{max_batch_size}, VdafInstance::Prio3Aes128Sum { .. }) => {
                 let max_batch_size = *max_batch_size;
-                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Sum>(task, max_batch_size)
+                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Sum>(task, max_batch_size)
                     .await
             }
 
             (task::QueryType::FixedSize{max_batch_size}, VdafInstance::Prio3Aes128Histogram { .. }) => {
                 let max_batch_size = *max_batch_size;
-                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Histogram>(task, max_batch_size)
+                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Histogram>(task, max_batch_size)
                     .await
             }
 
             #[cfg(feature = "fpvec_bounded_l2")]
             (task::QueryType::FixedSize{max_batch_size}, VdafInstance::Prio3Aes128FixedPoint16BitBoundedL2VecSum { .. }) => {
                 let max_batch_size = *max_batch_size;
-                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128FixedPointBoundedL2VecSum<FixedI16<U15>>>(task, max_batch_size)
+                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128FixedPointBoundedL2VecSum<FixedI16<U15>>>(task, max_batch_size)
                     .await
             }
 
             #[cfg(feature = "fpvec_bounded_l2")]
             (task::QueryType::FixedSize{max_batch_size}, VdafInstance::Prio3Aes128FixedPoint32BitBoundedL2VecSum { .. }) => {
                 let max_batch_size = *max_batch_size;
-                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128FixedPointBoundedL2VecSum<FixedI32<U31>>>(task, max_batch_size)
+                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128FixedPointBoundedL2VecSum<FixedI32<U31>>>(task, max_batch_size)
                     .await
             }
 
             #[cfg(feature = "fpvec_bounded_l2")]
             (task::QueryType::FixedSize{max_batch_size}, VdafInstance::Prio3Aes128FixedPoint64BitBoundedL2VecSum { .. }) => {
                 let max_batch_size = *max_batch_size;
-                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128FixedPointBoundedL2VecSum<FixedI64<U63>>>(task, max_batch_size)
+                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128FixedPointBoundedL2VecSum<FixedI64<U63>>>(task, max_batch_size)
                     .await
             }
 
@@ -759,7 +759,7 @@ mod tests {
         task::{test_util::TaskBuilder, QueryType as TaskQueryType},
     };
     use janus_core::{
-        task::{VdafInstance, PRIO3_AES128_VERIFY_KEY_LENGTH},
+        task::{VdafInstance, PRIO3_VERIFY_KEY_LENGTH},
         test_util::{
             dummy_vdaf::{self, AggregationParam},
             install_test_trace_subscriber,
@@ -1460,18 +1460,14 @@ mod tests {
     ) -> HashMap<
         AggregationJobId,
         (
-            AggregationJob<PRIO3_AES128_VERIFY_KEY_LENGTH, Q, Prio3Aes128Count>,
+            AggregationJob<PRIO3_VERIFY_KEY_LENGTH, Q, Prio3Aes128Count>,
             T,
         ),
     > {
         let vdaf = Prio3::new_aes128_count(2).unwrap();
-        read_aggregate_jobs_for_task_generic::<
-            PRIO3_AES128_VERIFY_KEY_LENGTH,
-            Q,
-            Prio3Aes128Count,
-            T,
-            C,
-        >(tx, task_id, &vdaf)
+        read_aggregate_jobs_for_task_generic::<PRIO3_VERIFY_KEY_LENGTH, Q, Prio3Aes128Count, T, C>(
+            tx, task_id, &vdaf,
+        )
         .await
         .map(|(agg_job, report_id)| (*agg_job.id(), (agg_job, report_id)))
         .collect()

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -836,7 +836,7 @@ mod tests {
             self, test_util::generate_test_hpke_config_and_private_key, HpkeApplicationInfo, Label,
         },
         report_id::ReportIdChecksumExt,
-        task::{VdafInstance, PRIO3_AES128_VERIFY_KEY_LENGTH},
+        task::{VdafInstance, PRIO3_VERIFY_KEY_LENGTH},
         test_util::{install_test_trace_subscriber, run_vdaf, runtime::TestRuntimeManager},
         time::{Clock, MockClock, TimeExt},
         Runtime,
@@ -893,7 +893,7 @@ mod tests {
             .to_batch_interval_start(task.time_precision())
             .unwrap();
         let report_metadata = ReportMetadata::new(random(), time);
-        let verify_key: VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH> =
+        let verify_key: VerifyKey<PRIO3_VERIFY_KEY_LENGTH> =
             task.primary_vdaf_verify_key().unwrap();
 
         let transcript = run_vdaf(
@@ -906,7 +906,7 @@ mod tests {
 
         let agg_auth_token = task.primary_aggregator_auth_token().clone();
         let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
-        let report = generate_report::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+        let report = generate_report::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
             *task.id(),
             report_metadata,
             helper_hpke_keypair.config(),
@@ -924,7 +924,7 @@ mod tests {
                 tx.put_client_report(vdaf.borrow(), &report).await?;
 
                 tx.put_aggregation_job(&AggregationJob::<
-                    PRIO3_AES128_VERIFY_KEY_LENGTH,
+                    PRIO3_VERIFY_KEY_LENGTH,
                     TimeInterval,
                     Prio3Aes128Count,
                 >::new(
@@ -938,7 +938,7 @@ mod tests {
                 ))
                 .await?;
                 tx.put_report_aggregation(&ReportAggregation::<
-                    PRIO3_AES128_VERIFY_KEY_LENGTH,
+                    PRIO3_VERIFY_KEY_LENGTH,
                     Prio3Aes128Count,
                 >::new(
                     *task.id(),
@@ -1039,7 +1039,7 @@ mod tests {
         }
 
         let want_aggregation_job =
-            AggregationJob::<PRIO3_AES128_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>::new(
+            AggregationJob::<PRIO3_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>::new(
                 *task.id(),
                 aggregation_job_id,
                 (),
@@ -1049,7 +1049,7 @@ mod tests {
                 AggregationJobState::Finished,
             );
         let want_report_aggregation =
-            ReportAggregation::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>::new(
+            ReportAggregation::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Count>::new(
                 *task.id(),
                 aggregation_job_id,
                 *report.metadata().id(),
@@ -1064,7 +1064,7 @@ mod tests {
                     (Arc::clone(&vdaf), task.clone(), *report.metadata().id());
                 Box::pin(async move {
                     let aggregation_job = tx
-                        .get_aggregation_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>(
+                        .get_aggregation_job::<PRIO3_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>(
                             task.id(),
                             &aggregation_job_id,
                         )
@@ -1116,7 +1116,7 @@ mod tests {
             .to_batch_interval_start(task.time_precision())
             .unwrap();
         let report_metadata = ReportMetadata::new(random(), time);
-        let verify_key: VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH> =
+        let verify_key: VerifyKey<PRIO3_VERIFY_KEY_LENGTH> =
             task.primary_vdaf_verify_key().unwrap();
 
         let transcript = run_vdaf(
@@ -1129,7 +1129,7 @@ mod tests {
 
         let agg_auth_token = task.primary_aggregator_auth_token();
         let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
-        let report = generate_report::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+        let report = generate_report::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
             *task.id(),
             report_metadata,
             helper_hpke_keypair.config(),
@@ -1137,18 +1137,17 @@ mod tests {
             Vec::new(),
             transcript.input_shares.clone(),
         );
-        let repeated_extension_report =
-            generate_report::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
-                *task.id(),
-                ReportMetadata::new(random(), time),
-                helper_hpke_keypair.config(),
-                (),
-                Vec::from([
-                    Extension::new(ExtensionType::Tbd, Vec::new()),
-                    Extension::new(ExtensionType::Tbd, Vec::new()),
-                ]),
-                transcript.input_shares.clone(),
-            );
+        let repeated_extension_report = generate_report::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+            *task.id(),
+            ReportMetadata::new(random(), time),
+            helper_hpke_keypair.config(),
+            (),
+            Vec::from([
+                Extension::new(ExtensionType::Tbd, Vec::new()),
+                Extension::new(ExtensionType::Tbd, Vec::new()),
+            ]),
+            transcript.input_shares.clone(),
+        );
         let aggregation_job_id = random();
 
         let lease = ds
@@ -1166,7 +1165,7 @@ mod tests {
                         .await?;
 
                     tx.put_aggregation_job(&AggregationJob::<
-                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        PRIO3_VERIFY_KEY_LENGTH,
                         TimeInterval,
                         Prio3Aes128Count,
                     >::new(
@@ -1180,7 +1179,7 @@ mod tests {
                     ))
                     .await?;
                     tx.put_report_aggregation(&ReportAggregation::<
-                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        PRIO3_VERIFY_KEY_LENGTH,
                         Prio3Aes128Count,
                     >::new(
                         *task.id(),
@@ -1192,7 +1191,7 @@ mod tests {
                     ))
                     .await?;
                     tx.put_report_aggregation(&ReportAggregation::<
-                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        PRIO3_VERIFY_KEY_LENGTH,
                         Prio3Aes128Count,
                     >::new(
                         *task.id(),
@@ -1292,7 +1291,7 @@ mod tests {
         mocked_aggregate_success.assert_async().await;
 
         let want_aggregation_job =
-            AggregationJob::<PRIO3_AES128_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>::new(
+            AggregationJob::<PRIO3_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>::new(
                 *task.id(),
                 aggregation_job_id,
                 (),
@@ -1304,7 +1303,7 @@ mod tests {
         let leader_prep_state = transcript.prep_state(0, Role::Leader).clone();
         let prep_msg = transcript.prepare_messages[0].clone();
         let want_report_aggregation =
-            ReportAggregation::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>::new(
+            ReportAggregation::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Count>::new(
                 *task.id(),
                 aggregation_job_id,
                 *report.metadata().id(),
@@ -1313,7 +1312,7 @@ mod tests {
                 ReportAggregationState::Waiting(leader_prep_state, Some(prep_msg)),
             );
         let want_repeated_extension_report_aggregation =
-            ReportAggregation::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>::new(
+            ReportAggregation::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Count>::new(
                 *task.id(),
                 aggregation_job_id,
                 *repeated_extension_report.metadata().id(),
@@ -1328,7 +1327,7 @@ mod tests {
                     (Arc::clone(&vdaf), task.clone(), *report.metadata().id(), *repeated_extension_report.metadata().id());
                 Box::pin(async move {
                     let aggregation_job = tx
-                        .get_aggregation_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>(
+                        .get_aggregation_job::<PRIO3_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>(
                             task.id(),
                             &aggregation_job_id,
                         )
@@ -1387,7 +1386,7 @@ mod tests {
                 .to_batch_interval_start(task.time_precision())
                 .unwrap(),
         );
-        let verify_key: VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH> =
+        let verify_key: VerifyKey<PRIO3_VERIFY_KEY_LENGTH> =
             task.primary_vdaf_verify_key().unwrap();
 
         let transcript = run_vdaf(
@@ -1400,7 +1399,7 @@ mod tests {
 
         let agg_auth_token = task.primary_aggregator_auth_token();
         let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
-        let report = generate_report::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+        let report = generate_report::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
             *task.id(),
             report_metadata,
             helper_hpke_keypair.config(),
@@ -1419,7 +1418,7 @@ mod tests {
                     tx.put_client_report(vdaf.borrow(), &report).await?;
 
                     tx.put_aggregation_job(&AggregationJob::<
-                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        PRIO3_VERIFY_KEY_LENGTH,
                         FixedSize,
                         Prio3Aes128Count,
                     >::new(
@@ -1433,7 +1432,7 @@ mod tests {
                     ))
                     .await?;
                     tx.put_report_aggregation(&ReportAggregation::<
-                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        PRIO3_VERIFY_KEY_LENGTH,
                         Prio3Aes128Count,
                     >::new(
                         *task.id(),
@@ -1533,7 +1532,7 @@ mod tests {
         mocked_aggregate_success.assert_async().await;
 
         let want_aggregation_job =
-            AggregationJob::<PRIO3_AES128_VERIFY_KEY_LENGTH, FixedSize, Prio3Aes128Count>::new(
+            AggregationJob::<PRIO3_VERIFY_KEY_LENGTH, FixedSize, Prio3Aes128Count>::new(
                 *task.id(),
                 aggregation_job_id,
                 (),
@@ -1543,7 +1542,7 @@ mod tests {
                 AggregationJobState::InProgress,
             );
         let want_report_aggregation =
-            ReportAggregation::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>::new(
+            ReportAggregation::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Count>::new(
                 *task.id(),
                 aggregation_job_id,
                 *report.metadata().id(),
@@ -1561,7 +1560,7 @@ mod tests {
                     (Arc::clone(&vdaf), task.clone(), *report.metadata().id());
                 Box::pin(async move {
                     let aggregation_job = tx
-                        .get_aggregation_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, FixedSize, Prio3Aes128Count>(
+                        .get_aggregation_job::<PRIO3_VERIFY_KEY_LENGTH, FixedSize, Prio3Aes128Count>(
                             task.id(),
                             &aggregation_job_id,
                         )
@@ -1613,7 +1612,7 @@ mod tests {
             .to_batch_interval_start(task.time_precision())
             .unwrap();
         let report_metadata = ReportMetadata::new(random(), time);
-        let verify_key: VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH> =
+        let verify_key: VerifyKey<PRIO3_VERIFY_KEY_LENGTH> =
             task.primary_vdaf_verify_key().unwrap();
 
         let transcript = run_vdaf(
@@ -1626,7 +1625,7 @@ mod tests {
 
         let agg_auth_token = task.primary_aggregator_auth_token();
         let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
-        let report = generate_report::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+        let report = generate_report::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
             *task.id(),
             report_metadata,
             helper_hpke_keypair.config(),
@@ -1656,7 +1655,7 @@ mod tests {
                     tx.put_client_report(vdaf.borrow(), &report).await?;
 
                     tx.put_aggregation_job(&AggregationJob::<
-                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        PRIO3_VERIFY_KEY_LENGTH,
                         TimeInterval,
                         Prio3Aes128Count,
                     >::new(
@@ -1670,7 +1669,7 @@ mod tests {
                     ))
                     .await?;
                     tx.put_report_aggregation(&ReportAggregation::<
-                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        PRIO3_VERIFY_KEY_LENGTH,
                         Prio3Aes128Count,
                     >::new(
                         *task.id(),
@@ -1761,7 +1760,7 @@ mod tests {
         mocked_aggregate_success.assert_async().await;
 
         let want_aggregation_job =
-            AggregationJob::<PRIO3_AES128_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>::new(
+            AggregationJob::<PRIO3_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>::new(
                 *task.id(),
                 aggregation_job_id,
                 (),
@@ -1771,7 +1770,7 @@ mod tests {
                 AggregationJobState::Finished,
             );
         let want_report_aggregation =
-            ReportAggregation::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>::new(
+            ReportAggregation::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Count>::new(
                 *task.id(),
                 aggregation_job_id,
                 *report.metadata().id(),
@@ -1785,7 +1784,7 @@ mod tests {
             .to_batch_interval_start(task.time_precision())
             .unwrap();
         let want_batch_aggregations = Vec::from([BatchAggregation::<
-            PRIO3_AES128_VERIFY_KEY_LENGTH,
+            PRIO3_VERIFY_KEY_LENGTH,
             TimeInterval,
             Prio3Aes128Count,
         >::new(
@@ -1803,7 +1802,7 @@ mod tests {
                 let (vdaf, task, report_metadata) = (Arc::clone(&vdaf), task.clone(), report.metadata().clone());
                 Box::pin(async move {
                     let aggregation_job = tx
-                        .get_aggregation_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>(
+                        .get_aggregation_job::<PRIO3_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>(
                             task.id(),
                             &aggregation_job_id,
                         )
@@ -1819,7 +1818,7 @@ mod tests {
                         )
                         .await?
                         .unwrap();
-                    let batch_aggregations = TimeInterval::get_batch_aggregations_for_collect_identifier::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count, _>(
+                    let batch_aggregations = TimeInterval::get_batch_aggregations_for_collect_identifier::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Count, _>(
                         tx,
                         &task,
                         &Interval::new(
@@ -1882,7 +1881,7 @@ mod tests {
                 .to_batch_interval_start(task.time_precision())
                 .unwrap(),
         );
-        let verify_key: VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH> =
+        let verify_key: VerifyKey<PRIO3_VERIFY_KEY_LENGTH> =
             task.primary_vdaf_verify_key().unwrap();
 
         let transcript = run_vdaf(
@@ -1895,7 +1894,7 @@ mod tests {
 
         let agg_auth_token = task.primary_aggregator_auth_token();
         let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
-        let report = generate_report::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+        let report = generate_report::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
             *task.id(),
             report_metadata,
             helper_hpke_keypair.config(),
@@ -1926,7 +1925,7 @@ mod tests {
                     tx.put_client_report(vdaf.borrow(), &report).await?;
 
                     tx.put_aggregation_job(&AggregationJob::<
-                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        PRIO3_VERIFY_KEY_LENGTH,
                         FixedSize,
                         Prio3Aes128Count,
                     >::new(
@@ -1940,7 +1939,7 @@ mod tests {
                     ))
                     .await?;
                     tx.put_report_aggregation(&ReportAggregation::<
-                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        PRIO3_VERIFY_KEY_LENGTH,
                         Prio3Aes128Count,
                     >::new(
                         *task.id(),
@@ -2031,7 +2030,7 @@ mod tests {
         mocked_aggregate_success.assert_async().await;
 
         let want_aggregation_job =
-            AggregationJob::<PRIO3_AES128_VERIFY_KEY_LENGTH, FixedSize, Prio3Aes128Count>::new(
+            AggregationJob::<PRIO3_VERIFY_KEY_LENGTH, FixedSize, Prio3Aes128Count>::new(
                 *task.id(),
                 aggregation_job_id,
                 (),
@@ -2042,7 +2041,7 @@ mod tests {
             );
         let leader_output_share = transcript.output_share(Role::Leader);
         let want_report_aggregation =
-            ReportAggregation::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>::new(
+            ReportAggregation::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Count>::new(
                 *task.id(),
                 aggregation_job_id,
                 *report.metadata().id(),
@@ -2051,7 +2050,7 @@ mod tests {
                 ReportAggregationState::Finished(leader_output_share.clone()),
             );
         let want_batch_aggregations = Vec::from([BatchAggregation::<
-            PRIO3_AES128_VERIFY_KEY_LENGTH,
+            PRIO3_VERIFY_KEY_LENGTH,
             FixedSize,
             Prio3Aes128Count,
         >::new(
@@ -2069,7 +2068,7 @@ mod tests {
                 let (vdaf, task, report_metadata) = (Arc::clone(&vdaf), task.clone(), report.metadata().clone());
                 Box::pin(async move {
                     let aggregation_job = tx
-                        .get_aggregation_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, FixedSize, Prio3Aes128Count>(
+                        .get_aggregation_job::<PRIO3_VERIFY_KEY_LENGTH, FixedSize, Prio3Aes128Count>(
                             task.id(),
                             &aggregation_job_id,
                         )
@@ -2085,7 +2084,7 @@ mod tests {
                         )
                         .await?
                         .unwrap();
-                    let batch_aggregations = FixedSize::get_batch_aggregations_for_collect_identifier::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count, _>(
+                    let batch_aggregations = FixedSize::get_batch_aggregations_for_collect_identifier::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Count, _>(
                         tx,
                         &task,
                         &batch_id,
@@ -2138,7 +2137,7 @@ mod tests {
             .to_batch_interval_start(task.time_precision())
             .unwrap();
         let report_metadata = ReportMetadata::new(random(), time);
-        let verify_key: VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH> =
+        let verify_key: VerifyKey<PRIO3_VERIFY_KEY_LENGTH> =
             task.primary_vdaf_verify_key().unwrap();
 
         let transcript = run_vdaf(
@@ -2150,7 +2149,7 @@ mod tests {
         );
 
         let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
-        let report = generate_report::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+        let report = generate_report::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
             *task.id(),
             report_metadata,
             helper_hpke_keypair.config(),
@@ -2161,7 +2160,7 @@ mod tests {
         let aggregation_job_id = random();
 
         let aggregation_job =
-            AggregationJob::<PRIO3_AES128_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>::new(
+            AggregationJob::<PRIO3_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>::new(
                 *task.id(),
                 aggregation_job_id,
                 (),
@@ -2171,7 +2170,7 @@ mod tests {
                 AggregationJobState::InProgress,
             );
         let report_aggregation =
-            ReportAggregation::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>::new(
+            ReportAggregation::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Count>::new(
                 *task.id(),
                 aggregation_job_id,
                 *report.metadata().id(),
@@ -2227,7 +2226,7 @@ mod tests {
                     (Arc::clone(&vdaf), task.clone(), *report.metadata().id());
                 Box::pin(async move {
                     let aggregation_job = tx
-                        .get_aggregation_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>(
+                        .get_aggregation_job::<PRIO3_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>(
                             task.id(),
                             &aggregation_job_id,
                         )
@@ -2324,7 +2323,7 @@ mod tests {
         .build();
         let agg_auth_token = task.primary_aggregator_auth_token();
         let aggregation_job_id = random();
-        let verify_key: VerifyKey<PRIO3_AES128_VERIFY_KEY_LENGTH> =
+        let verify_key: VerifyKey<PRIO3_VERIFY_KEY_LENGTH> =
             task.primary_vdaf_verify_key().unwrap();
 
         let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
@@ -2336,7 +2335,7 @@ mod tests {
             .unwrap();
         let report_metadata = ReportMetadata::new(random(), time);
         let transcript = run_vdaf(&vdaf, verify_key.as_bytes(), &(), report_metadata.id(), &0);
-        let report = generate_report::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
+        let report = generate_report::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Count>(
             *task.id(),
             report_metadata,
             helper_hpke_keypair.config(),
@@ -2358,7 +2357,7 @@ mod tests {
                 tx.put_client_report(&vdaf, &report).await?;
 
                 tx.put_aggregation_job(&AggregationJob::<
-                    PRIO3_AES128_VERIFY_KEY_LENGTH,
+                    PRIO3_VERIFY_KEY_LENGTH,
                     TimeInterval,
                     Prio3Aes128Count,
                 >::new(
@@ -2373,7 +2372,7 @@ mod tests {
                 .await?;
 
                 tx.put_report_aggregation(&ReportAggregation::<
-                    PRIO3_AES128_VERIFY_KEY_LENGTH,
+                    PRIO3_VERIFY_KEY_LENGTH,
                     Prio3Aes128Count,
                 >::new(
                     *task.id(),
@@ -2483,7 +2482,7 @@ mod tests {
             .run_tx(|tx| {
                 let task = task.clone();
                 Box::pin(async move {
-                    tx.get_aggregation_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>(
+                    tx.get_aggregation_job::<PRIO3_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>(
                         task.id(),
                         &aggregation_job_id,
                     )
@@ -2495,7 +2494,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             aggregation_job_after,
-            AggregationJob::<PRIO3_AES128_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>::new(
+            AggregationJob::<PRIO3_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>::new(
                 *task.id(),
                 aggregation_job_id,
                 (),

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -5122,7 +5122,7 @@ mod tests {
     use futures::future::try_join_all;
     use janus_core::{
         hpke::{self, HpkeApplicationInfo, Label},
-        task::{VdafInstance, PRIO3_AES128_VERIFY_KEY_LENGTH},
+        task::{VdafInstance, PRIO3_VERIFY_KEY_LENGTH},
         test_util::{
             dummy_vdaf::{self, AggregateShare, AggregationParam},
             install_test_trace_subscriber, run_vdaf,
@@ -6318,7 +6318,7 @@ mod tests {
                 tx.put_task(&task).await?;
                 for aggregation_job_id in aggregation_job_ids {
                     tx.put_aggregation_job(&AggregationJob::<
-                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        PRIO3_VERIFY_KEY_LENGTH,
                         TimeInterval,
                         Prio3Aes128Count,
                     >::new(
@@ -6335,7 +6335,7 @@ mod tests {
 
                 // Write an aggregation job that is finished. We don't want to retrieve this one.
                 tx.put_aggregation_job(&AggregationJob::<
-                    PRIO3_AES128_VERIFY_KEY_LENGTH,
+                    PRIO3_VERIFY_KEY_LENGTH,
                     TimeInterval,
                     Prio3Aes128Count,
                 >::new(
@@ -6359,7 +6359,7 @@ mod tests {
                 .build();
                 tx.put_task(&helper_task).await?;
                 tx.put_aggregation_job(&AggregationJob::<
-                    PRIO3_AES128_VERIFY_KEY_LENGTH,
+                    PRIO3_VERIFY_KEY_LENGTH,
                     TimeInterval,
                     Prio3Aes128Count,
                 >::new(
@@ -6583,7 +6583,7 @@ mod tests {
         let rslt = ds
             .run_tx(|tx| {
                 Box::pin(async move {
-                    tx.get_aggregation_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>(
+                    tx.get_aggregation_job::<PRIO3_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>(
                         &random(),
                         &random(),
                     )
@@ -6597,7 +6597,7 @@ mod tests {
         let rslt = ds
             .run_tx(|tx| {
                 Box::pin(async move {
-                    tx.update_aggregation_job::<PRIO3_AES128_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>(
+                    tx.update_aggregation_job::<PRIO3_VERIFY_KEY_LENGTH, TimeInterval, Prio3Aes128Count>(
                         &AggregationJob::new(
                             random(),
                             random(),
@@ -6705,12 +6705,12 @@ mod tests {
 
         let report_id = ReportId::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
         let vdaf = Arc::new(Prio3::new_aes128_count(2).unwrap());
-        let verify_key: [u8; PRIO3_AES128_VERIFY_KEY_LENGTH] = random();
+        let verify_key: [u8; PRIO3_VERIFY_KEY_LENGTH] = random();
         let vdaf_transcript = run_vdaf(vdaf.as_ref(), &verify_key, &(), &report_id, &0);
         let prep_state = vdaf_transcript.prep_state(0, Role::Leader);
 
         for (ord, state) in [
-            ReportAggregationState::<PRIO3_AES128_VERIFY_KEY_LENGTH, Prio3Aes128Count>::Start,
+            ReportAggregationState::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Count>::Start,
             ReportAggregationState::Waiting(prep_state.clone(), None),
             ReportAggregationState::Waiting(
                 prep_state.clone(),
@@ -6739,7 +6739,7 @@ mod tests {
                     Box::pin(async move {
                         tx.put_task(&task).await?;
                         tx.put_aggregation_job(&AggregationJob::<
-                            PRIO3_AES128_VERIFY_KEY_LENGTH,
+                            PRIO3_VERIFY_KEY_LENGTH,
                             TimeInterval,
                             Prio3Aes128Count,
                         >::new(
@@ -7012,7 +7012,7 @@ mod tests {
 
         let report_id = ReportId::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
         let vdaf = Arc::new(Prio3::new_aes128_count(2).unwrap());
-        let verify_key: [u8; PRIO3_AES128_VERIFY_KEY_LENGTH] = random();
+        let verify_key: [u8; PRIO3_VERIFY_KEY_LENGTH] = random();
         let vdaf_transcript = run_vdaf(vdaf.as_ref(), &verify_key, &(), &report_id, &0);
 
         let task = TaskBuilder::new(
@@ -7035,7 +7035,7 @@ mod tests {
                 Box::pin(async move {
                     tx.put_task(&task).await?;
                     tx.put_aggregation_job(&AggregationJob::<
-                        PRIO3_AES128_VERIFY_KEY_LENGTH,
+                        PRIO3_VERIFY_KEY_LENGTH,
                         TimeInterval,
                         Prio3Aes128Count,
                     >::new(
@@ -7050,20 +7050,16 @@ mod tests {
                     .await?;
 
                     let mut report_aggregations = Vec::new();
-                    for (ord, state) in
-                        [
-                            ReportAggregationState::<
-                                PRIO3_AES128_VERIFY_KEY_LENGTH,
-                                Prio3Aes128Count,
-                            >::Start,
-                            ReportAggregationState::Waiting(prep_state.clone(), None),
-                            ReportAggregationState::Waiting(prep_state, Some(prep_msg)),
-                            ReportAggregationState::Finished(output_share),
-                            ReportAggregationState::Failed(ReportShareError::VdafPrepError),
-                            ReportAggregationState::Invalid,
-                        ]
-                        .iter()
-                        .enumerate()
+                    for (ord, state) in [
+                        ReportAggregationState::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Count>::Start,
+                        ReportAggregationState::Waiting(prep_state.clone(), None),
+                        ReportAggregationState::Waiting(prep_state, Some(prep_msg)),
+                        ReportAggregationState::Finished(output_share),
+                        ReportAggregationState::Failed(ReportShareError::VdafPrepError),
+                        ReportAggregationState::Invalid,
+                    ]
+                    .iter()
+                    .enumerate()
                     {
                         let report_id = ReportId::from((ord as u128).to_be_bytes());
                         tx.put_report_share(

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -602,7 +602,7 @@ pub mod test_util {
     };
     use janus_core::{
         hpke::{test_util::generate_test_hpke_config_and_private_key, HpkeKeypair},
-        task::{AuthenticationToken, VdafInstance, PRIO3_AES128_VERIFY_KEY_LENGTH},
+        task::{AuthenticationToken, VdafInstance, PRIO3_VERIFY_KEY_LENGTH},
         time::DurationExt,
     };
     use janus_messages::{Duration, HpkeConfig, HpkeConfigId, Role, TaskId, Time};
@@ -618,7 +618,7 @@ pub mod test_util {
 
             // All "real" VDAFs use a verify key of length 16 currently. (Poplar1 may not, but it's
             // not yet done being specified, so choosing 16 bytes is fine for testing.)
-            _ => PRIO3_AES128_VERIFY_KEY_LENGTH,
+            _ => PRIO3_VERIFY_KEY_LENGTH,
         }
     }
 
@@ -816,7 +816,7 @@ mod tests {
     use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
     use janus_core::{
         hpke::{test_util::generate_test_hpke_config_and_private_key, HpkeKeypair, HpkePrivateKey},
-        task::{AuthenticationToken, PRIO3_AES128_VERIFY_KEY_LENGTH},
+        task::{AuthenticationToken, PRIO3_VERIFY_KEY_LENGTH},
         test_util::roundtrip_encoding,
         time::DurationExt,
     };
@@ -857,7 +857,7 @@ mod tests {
             QueryType::TimeInterval,
             VdafInstance::Prio3Aes128Count,
             Role::Leader,
-            Vec::from([SecretBytes::new([0; PRIO3_AES128_VERIFY_KEY_LENGTH].into())]),
+            Vec::from([SecretBytes::new([0; PRIO3_VERIFY_KEY_LENGTH].into())]),
             0,
             Time::from_seconds_since_epoch(u64::MAX),
             None,
@@ -881,7 +881,7 @@ mod tests {
             QueryType::TimeInterval,
             VdafInstance::Prio3Aes128Count,
             Role::Leader,
-            Vec::from([SecretBytes::new([0; PRIO3_AES128_VERIFY_KEY_LENGTH].into())]),
+            Vec::from([SecretBytes::new([0; PRIO3_VERIFY_KEY_LENGTH].into())]),
             0,
             Time::from_seconds_since_epoch(u64::MAX),
             None,
@@ -905,7 +905,7 @@ mod tests {
             QueryType::TimeInterval,
             VdafInstance::Prio3Aes128Count,
             Role::Helper,
-            Vec::from([SecretBytes::new([0; PRIO3_AES128_VERIFY_KEY_LENGTH].into())]),
+            Vec::from([SecretBytes::new([0; PRIO3_VERIFY_KEY_LENGTH].into())]),
             0,
             Time::from_seconds_since_epoch(u64::MAX),
             None,
@@ -929,7 +929,7 @@ mod tests {
             QueryType::TimeInterval,
             VdafInstance::Prio3Aes128Count,
             Role::Helper,
-            Vec::from([SecretBytes::new([0; PRIO3_AES128_VERIFY_KEY_LENGTH].into())]),
+            Vec::from([SecretBytes::new([0; PRIO3_VERIFY_KEY_LENGTH].into())]),
             0,
             Time::from_seconds_since_epoch(u64::MAX),
             None,
@@ -955,7 +955,7 @@ mod tests {
             QueryType::TimeInterval,
             VdafInstance::Prio3Aes128Count,
             Role::Leader,
-            Vec::from([SecretBytes::new([0; PRIO3_AES128_VERIFY_KEY_LENGTH].into())]),
+            Vec::from([SecretBytes::new([0; PRIO3_VERIFY_KEY_LENGTH].into())]),
             0,
             Time::from_seconds_since_epoch(u64::MAX),
             None,

--- a/core/src/task.rs
+++ b/core/src/task.rs
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize};
 /// HTTP header where auth tokens are provided in messages between participants.
 pub const DAP_AUTH_HEADER: &str = "DAP-Auth-Token";
 
-/// The length of the verify key parameter for Prio3 AES-128 VDAF instantiations.
-pub const PRIO3_AES128_VERIFY_KEY_LENGTH: usize = 16;
+/// The length of the verify key parameter for Prio3 VDAF instantiations.
+pub const PRIO3_VERIFY_KEY_LENGTH: usize = 16;
 
 /// Identifiers for supported VDAFs, corresponding to definitions in
 /// [draft-irtf-cfrg-vdaf-03][1] and implementations in [`prio::vdaf::prio3`].
@@ -65,7 +65,7 @@ impl VdafInstance {
 
             // All "real" VDAFs use a verify key of length 16 currently. (Poplar1 may not, but it's
             // not yet done being specified, so choosing 16 bytes is fine for testing.)
-            _ => PRIO3_AES128_VERIFY_KEY_LENGTH,
+            _ => PRIO3_VERIFY_KEY_LENGTH,
         }
     }
 }
@@ -78,29 +78,25 @@ macro_rules! vdaf_dispatch_impl_base {
         match $vdaf_instance {
             ::janus_core::task::VdafInstance::Prio3Aes128Count => {
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128Count;
-                const $VERIFY_KEY_LENGTH: usize =
-                    ::janus_core::task::PRIO3_AES128_VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
             ::janus_core::task::VdafInstance::Prio3Aes128CountVec { length } => {
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128CountVecMultithreaded;
-                const $VERIFY_KEY_LENGTH: usize =
-                    ::janus_core::task::PRIO3_AES128_VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
             ::janus_core::task::VdafInstance::Prio3Aes128Sum { bits } => {
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128Sum;
-                const $VERIFY_KEY_LENGTH: usize =
-                    ::janus_core::task::PRIO3_AES128_VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
             ::janus_core::task::VdafInstance::Prio3Aes128Histogram { buckets } => {
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128Histogram;
-                const $VERIFY_KEY_LENGTH: usize =
-                    ::janus_core::task::PRIO3_AES128_VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
@@ -114,8 +110,7 @@ macro_rules! vdaf_dispatch_impl_base {
             ::janus_core::task::VdafInstance::Prio3Aes128Count => {
                 let $vdaf = ::prio::vdaf::prio3::Prio3::new_aes128_count(2)?;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128Count;
-                const $VERIFY_KEY_LENGTH: usize =
-                    ::janus_core::task::PRIO3_AES128_VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
@@ -123,24 +118,21 @@ macro_rules! vdaf_dispatch_impl_base {
                 let $vdaf =
                     ::prio::vdaf::prio3::Prio3::new_aes128_count_vec_multithreaded(2, *length)?;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128CountVecMultithreaded;
-                const $VERIFY_KEY_LENGTH: usize =
-                    ::janus_core::task::PRIO3_AES128_VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
             ::janus_core::task::VdafInstance::Prio3Aes128Sum { bits } => {
                 let $vdaf = ::prio::vdaf::prio3::Prio3::new_aes128_sum(2, *bits)?;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128Sum;
-                const $VERIFY_KEY_LENGTH: usize =
-                    ::janus_core::task::PRIO3_AES128_VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
             ::janus_core::task::VdafInstance::Prio3Aes128Histogram { buckets } => {
                 let $vdaf = ::prio::vdaf::prio3::Prio3::new_aes128_histogram(2, buckets)?;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128Histogram;
-                const $VERIFY_KEY_LENGTH: usize =
-                    ::janus_core::task::PRIO3_AES128_VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
@@ -162,8 +154,7 @@ macro_rules! vdaf_dispatch_impl_fpvec_bounded_l2 {
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128FixedPointBoundedL2VecSumMultithreaded<
                     ::fixed::FixedI16<::fixed::types::extra::U15>,
                 >;
-                const $VERIFY_KEY_LENGTH: usize =
-                    ::janus_core::task::PRIO3_AES128_VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
@@ -173,8 +164,7 @@ macro_rules! vdaf_dispatch_impl_fpvec_bounded_l2 {
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128FixedPointBoundedL2VecSumMultithreaded<
                     ::fixed::FixedI32<::fixed::types::extra::U31>,
                 >;
-                const $VERIFY_KEY_LENGTH: usize =
-                    ::janus_core::task::PRIO3_AES128_VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
@@ -184,8 +174,7 @@ macro_rules! vdaf_dispatch_impl_fpvec_bounded_l2 {
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128FixedPointBoundedL2VecSumMultithreaded<
                     ::fixed::FixedI64<::fixed::types::extra::U63>,
                 >;
-                const $VERIFY_KEY_LENGTH: usize =
-                    ::janus_core::task::PRIO3_AES128_VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
@@ -205,8 +194,7 @@ macro_rules! vdaf_dispatch_impl_fpvec_bounded_l2 {
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128FixedPointBoundedL2VecSumMultithreaded<
                     ::fixed::FixedI16<::fixed::types::extra::U15>,
                 >;
-                const $VERIFY_KEY_LENGTH: usize =
-                    ::janus_core::task::PRIO3_AES128_VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
@@ -219,8 +207,7 @@ macro_rules! vdaf_dispatch_impl_fpvec_bounded_l2 {
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128FixedPointBoundedL2VecSumMultithreaded<
                     ::fixed::FixedI32<::fixed::types::extra::U31>,
                 >;
-                const $VERIFY_KEY_LENGTH: usize =
-                    ::janus_core::task::PRIO3_AES128_VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
@@ -233,8 +220,7 @@ macro_rules! vdaf_dispatch_impl_fpvec_bounded_l2 {
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128FixedPointBoundedL2VecSumMultithreaded<
                     ::fixed::FixedI64<::fixed::types::extra::U63>,
                 >;
-                const $VERIFY_KEY_LENGTH: usize =
-                    ::janus_core::task::PRIO3_AES128_VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 

--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -2,7 +2,7 @@ use backoff::{backoff::Backoff, ExponentialBackoffBuilder};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use futures::future::join_all;
 use janus_core::{
-    task::PRIO3_AES128_VERIFY_KEY_LENGTH,
+    task::PRIO3_VERIFY_KEY_LENGTH,
     test_util::{install_test_trace_subscriber, testcontainers::container_client},
     time::{Clock, RealClock, TimeExt},
 };
@@ -109,7 +109,7 @@ async fn run(
     let task_id: TaskId = random();
     let aggregator_auth_token = URL_SAFE_NO_PAD.encode(random::<[u8; 16]>());
     let collector_auth_token = URL_SAFE_NO_PAD.encode(random::<[u8; 16]>());
-    let vdaf_verify_key = rand::random::<[u8; PRIO3_AES128_VERIFY_KEY_LENGTH]>();
+    let vdaf_verify_key = rand::random::<[u8; PRIO3_VERIFY_KEY_LENGTH]>();
 
     let task_id_encoded = URL_SAFE_NO_PAD.encode(task_id.get_encoded());
     let vdaf_verify_key_encoded = URL_SAFE_NO_PAD.encode(vdaf_verify_key);


### PR DESCRIPTION
This renames `PRIO3_AES128_VERIFY_KEY_LENGTH` to `PRIO3_VERIFY_KEY_LENGTH`, to help prepare for the prio 0.11.0 upgrade.