### PR TITLE
Upgrade prio to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,6 +919,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fiat-crypto"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b2f3c51e4dd999930845da5d10a48775b8fe4ca9f4f9ec1f9161f334da5dfe"
+
+[[package]]
 name = "filetime"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,6 +1028,12 @@ checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1957,6 +1981,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
 name = "kube"
 version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2724,20 +2757,24 @@ dependencies = [
 
 [[package]]
 name = "prio"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0453e1ec5f2f48af9a67aab1d812f9aec48619dda0d9a59e2f79ebd235448ec"
+checksum = "4223a3572e19886b36122fe471b99a06684776cc8e827adefc6bb3890b29e9bf"
 dependencies = [
  "aes",
- "base64 0.13.1",
+ "base64 0.21.0",
+ "bitvec",
  "byteorder",
  "cmac",
  "ctr",
+ "fiat-crypto",
  "fixed",
  "getrandom",
  "rayon",
  "serde",
+ "sha3",
  "static_assertions",
+ "subtle",
  "thiserror",
 ]
 
@@ -2881,6 +2918,12 @@ checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -3391,6 +3434,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
+dependencies = [
+ "digest 0.10.6",
+ "keccak",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3563,6 +3616,12 @@ dependencies = [
  "syn",
  "unicode-xid",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -4544,6 +4603,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ janus_interop_binaries = { version = "0.3", path = "interop_binaries" }
 janus_messages = { version = "0.3", path = "messages" }
 k8s-openapi = { version = "0.16.0", features = ["v1_24"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
 kube = { version = "0.75.0", default-features = false, features = ["client"] }
-prio = { version = "0.10.0", features = ["multithreaded"] }
+prio = { version = "0.11.0", features = ["multithreaded"] }
 
 [profile.dev]
 # Disabling debug info improves build speeds & reduces build artifact sizes, which helps CI caching.

--- a/aggregator/src/aggregator/aggregate_share.rs
+++ b/aggregator/src/aggregator/aggregate_share.rs
@@ -11,14 +11,14 @@ use prio::vdaf::{self, Aggregatable};
 /// been driven to completion, and that the query count requirements have been validated for the
 /// included batches.
 #[tracing::instrument(skip(task), fields(task_id = ?task.id()), err)]
-pub(crate) async fn compute_aggregate_share<const L: usize, Q: QueryType, A: vdaf::Aggregator<L>>(
+pub(crate) async fn compute_aggregate_share<
+    const L: usize,
+    Q: QueryType,
+    A: vdaf::Aggregator<L, 16>,
+>(
     task: &Task,
     batch_aggregations: &[BatchAggregation<L, Q, A>],
-) -> Result<(A::AggregateShare, u64, ReportIdChecksum), Error>
-where
-    Vec<u8>: for<'a> From<&'a A::AggregateShare>,
-    for<'a> <A::AggregateShare as TryFrom<&'a [u8]>>::Error: std::fmt::Debug,
-{
+) -> Result<(A::AggregateShare, u64, ReportIdChecksum), Error> {
     // At the moment we construct an aggregate share (either handling AggregateShareReq in the
     // helper or driving a collection job in the leader), there could be some incomplete aggregation
     // jobs whose results not been accumulated into the batch aggregations we just queried from the

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -24,15 +24,12 @@ use opentelemetry::{
     Context, KeyValue,
 };
 #[cfg(feature = "fpvec_bounded_l2")]
-use prio::vdaf::prio3::Prio3Aes128FixedPointBoundedL2VecSum;
+use prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded;
 use prio::{
     codec::Encode,
     vdaf::{
         self,
-        prio3::{
-            Prio3Aes128Count, Prio3Aes128CountVecMultithreaded, Prio3Aes128Histogram,
-            Prio3Aes128Sum,
-        },
+        prio3::{Prio3Count, Prio3Histogram, Prio3Sum, Prio3SumVecMultithreaded},
     },
 };
 use rand::{random, thread_rng, Rng};
@@ -234,90 +231,90 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
         task: Arc<Task>,
     ) -> anyhow::Result<bool> {
         match (task.query_type(), task.vdaf()) {
-            (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128Count) => {
-                self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Count>(task)
+            (task::QueryType::TimeInterval, VdafInstance::Prio3Count) => {
+                self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Count>(task)
                     .await
             }
 
-            (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128CountVec { .. }) => {
+            (task::QueryType::TimeInterval, VdafInstance::Prio3CountVec { .. }) => {
                 self.create_aggregation_jobs_for_time_interval_task_no_param::<
                     PRIO3_VERIFY_KEY_LENGTH,
-                    Prio3Aes128CountVecMultithreaded
+                    Prio3SumVecMultithreaded
                 >(task).await
             }
 
-            (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128Sum { .. }) => {
-                self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Sum>(task)
+            (task::QueryType::TimeInterval, VdafInstance::Prio3Sum { .. }) => {
+                self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Sum>(task)
                     .await
             }
 
-            (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128Histogram { .. }) => {
-                self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Histogram>(task)
-                    .await
-            }
-
-            #[cfg(feature = "fpvec_bounded_l2")]
-            (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128FixedPoint16BitBoundedL2VecSum { .. }) => {
-                self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128FixedPointBoundedL2VecSum<FixedI16<U15>>>(task)
+            (task::QueryType::TimeInterval, VdafInstance::Prio3Histogram { .. }) => {
+                self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Histogram>(task)
                     .await
             }
 
             #[cfg(feature = "fpvec_bounded_l2")]
-            (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128FixedPoint32BitBoundedL2VecSum { .. }) => {
-                self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128FixedPointBoundedL2VecSum<FixedI32<U31>>>(task)
+            (task::QueryType::TimeInterval, VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { .. }) => {
+                self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>>>(task)
                     .await
             }
 
             #[cfg(feature = "fpvec_bounded_l2")]
-            (task::QueryType::TimeInterval, VdafInstance::Prio3Aes128FixedPoint64BitBoundedL2VecSum { .. }) => {
-                self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128FixedPointBoundedL2VecSum<FixedI64<U63>>>(task)
+            (task::QueryType::TimeInterval, VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { .. }) => {
+                self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>>>(task)
                     .await
             }
 
-            (task::QueryType::FixedSize{max_batch_size}, VdafInstance::Prio3Aes128Count) => {
+            #[cfg(feature = "fpvec_bounded_l2")]
+            (task::QueryType::TimeInterval, VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { .. }) => {
+                self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>>>(task)
+                    .await
+            }
+
+            (task::QueryType::FixedSize{max_batch_size}, VdafInstance::Prio3Count) => {
                 let max_batch_size = *max_batch_size;
-                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Count>(task, max_batch_size)
+                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Count>(task, max_batch_size)
                     .await
             }
 
-            (task::QueryType::FixedSize{max_batch_size}, VdafInstance::Prio3Aes128CountVec { .. }) => {
+            (task::QueryType::FixedSize{max_batch_size}, VdafInstance::Prio3CountVec { .. }) => {
                 let max_batch_size = *max_batch_size;
                 self.create_aggregation_jobs_for_fixed_size_task_no_param::<
                     PRIO3_VERIFY_KEY_LENGTH,
-                    Prio3Aes128CountVecMultithreaded
+                    Prio3SumVecMultithreaded
                 >(task, max_batch_size).await
             }
 
-            (task::QueryType::FixedSize{max_batch_size}, VdafInstance::Prio3Aes128Sum { .. }) => {
+            (task::QueryType::FixedSize{max_batch_size}, VdafInstance::Prio3Sum { .. }) => {
                 let max_batch_size = *max_batch_size;
-                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Sum>(task, max_batch_size)
+                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Sum>(task, max_batch_size)
                     .await
             }
 
-            (task::QueryType::FixedSize{max_batch_size}, VdafInstance::Prio3Aes128Histogram { .. }) => {
+            (task::QueryType::FixedSize{max_batch_size}, VdafInstance::Prio3Histogram { .. }) => {
                 let max_batch_size = *max_batch_size;
-                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128Histogram>(task, max_batch_size)
-                    .await
-            }
-
-            #[cfg(feature = "fpvec_bounded_l2")]
-            (task::QueryType::FixedSize{max_batch_size}, VdafInstance::Prio3Aes128FixedPoint16BitBoundedL2VecSum { .. }) => {
-                let max_batch_size = *max_batch_size;
-                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128FixedPointBoundedL2VecSum<FixedI16<U15>>>(task, max_batch_size)
+                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Histogram>(task, max_batch_size)
                     .await
             }
 
             #[cfg(feature = "fpvec_bounded_l2")]
-            (task::QueryType::FixedSize{max_batch_size}, VdafInstance::Prio3Aes128FixedPoint32BitBoundedL2VecSum { .. }) => {
+            (task::QueryType::FixedSize{max_batch_size}, VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { .. }) => {
                 let max_batch_size = *max_batch_size;
-                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128FixedPointBoundedL2VecSum<FixedI32<U31>>>(task, max_batch_size)
+                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>>>(task, max_batch_size)
                     .await
             }
 
             #[cfg(feature = "fpvec_bounded_l2")]
-            (task::QueryType::FixedSize{max_batch_size}, VdafInstance::Prio3Aes128FixedPoint64BitBoundedL2VecSum { .. }) => {
+            (task::QueryType::FixedSize{max_batch_size}, VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { .. }) => {
                 let max_batch_size = *max_batch_size;
-                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Aes128FixedPointBoundedL2VecSum<FixedI64<U63>>>(task, max_batch_size)
+                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>>>(task, max_batch_size)
+                    .await
+            }
+
+            #[cfg(feature = "fpvec_bounded_l2")]
+            (task::QueryType::FixedSize{max_batch_size}, VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { .. }) => {
+                let max_batch_size = *max_batch_size;
+                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>>>(task, max_batch_size)
                     .await
             }
 
@@ -331,17 +328,15 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
     #[tracing::instrument(skip(self, task), fields(task_id = ?task.id()), err)]
     async fn create_aggregation_jobs_for_time_interval_task_no_param<
         const L: usize,
-        A: vdaf::Aggregator<L, AggregationParam = ()>,
+        A: vdaf::Aggregator<L, 16, AggregationParam = ()>,
     >(
         self: Arc<Self>,
         task: Arc<Task>,
     ) -> anyhow::Result<bool>
     where
-        for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
         A::PrepareMessage: Send + Sync,
         A::PrepareState: Send + Sync + Encode,
         A::OutputShare: Send + Sync,
-        for<'a> &'a A::OutputShare: Into<Vec<u8>>,
     {
         Ok(self
             .datastore
@@ -433,18 +428,16 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
     #[tracing::instrument(skip(self, task), fields(task_id = ?task.id()), err)]
     async fn create_aggregation_jobs_for_fixed_size_task_no_param<
         const L: usize,
-        A: vdaf::Aggregator<L, AggregationParam = ()>,
+        A: vdaf::Aggregator<L, 16, AggregationParam = ()>,
     >(
         self: Arc<Self>,
         task: Arc<Task>,
         task_max_batch_size: u64,
     ) -> anyhow::Result<bool>
     where
-        for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
         A::PrepareMessage: Send + Sync,
         A::PrepareState: Send + Sync + Encode,
         A::OutputShare: Send + Sync,
-        for<'a> &'a A::OutputShare: Into<Vec<u8>>,
     {
         let (task_min_batch_size, task_max_batch_size) = (
             usize::try_from(task.min_batch_size())?,
@@ -638,12 +631,10 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
         task: Arc<Task>,
     ) -> anyhow::Result<bool>
     where
-        A: vdaf::Aggregator<L> + janus_aggregator_core::VdafHasAggregationParameter,
-        for<'a> &'a A::AggregateShare: Into<Vec<u8>>,
+        A: vdaf::Aggregator<L, 16> + janus_aggregator_core::VdafHasAggregationParameter,
         A::PrepareMessage: Send + Sync,
         A::PrepareState: Send + Sync + Encode,
         A::OutputShare: Send + Sync,
-        for<'a> &'a A::OutputShare: Into<Vec<u8>>,
         A::AggregationParam: Send + Sync + Eq + std::hash::Hash,
     {
         use itertools::Itertools;
@@ -773,8 +764,8 @@ mod tests {
     use prio::{
         codec::ParameterizedDecode,
         vdaf::{
-            prio3::{Prio3, Prio3Aes128Count},
-            Aggregator, Vdaf,
+            prio3::{Prio3, Prio3Count},
+            Aggregator,
         },
     };
     use rand::random;
@@ -808,7 +799,7 @@ mod tests {
         let report_time = Time::from_seconds_since_epoch(0);
         let leader_task = TaskBuilder::new(
             TaskQueryType::TimeInterval,
-            VdafInstance::Prio3Aes128Count,
+            VdafInstance::Prio3Count,
             Role::Leader,
         )
         .build();
@@ -816,7 +807,7 @@ mod tests {
 
         let helper_task = TaskBuilder::new(
             TaskQueryType::TimeInterval,
-            VdafInstance::Prio3Aes128Count,
+            VdafInstance::Prio3Count,
             Role::Helper,
         )
         .build();
@@ -913,7 +904,7 @@ mod tests {
         let task = Arc::new(
             TaskBuilder::new(
                 TaskQueryType::TimeInterval,
-                VdafInstance::Prio3Aes128Count,
+                VdafInstance::Prio3Count,
                 Role::Leader,
             )
             .build(),
@@ -1004,7 +995,7 @@ mod tests {
         let task = Arc::new(
             TaskBuilder::new(
                 TaskQueryType::TimeInterval,
-                VdafInstance::Prio3Aes128Count,
+                VdafInstance::Prio3Count,
                 Role::Leader,
             )
             .build(),
@@ -1124,7 +1115,7 @@ mod tests {
                 TaskQueryType::FixedSize {
                     max_batch_size: MAX_BATCH_SIZE as u64,
                 },
-                VdafInstance::Prio3Aes128Count,
+                VdafInstance::Prio3Count,
                 Role::Leader,
             )
             .with_min_batch_size(MIN_BATCH_SIZE as u64)
@@ -1447,8 +1438,8 @@ mod tests {
     }
 
     /// Test helper function that reads all aggregation jobs for a given task ID, with VDAF
-    /// Prio3Aes128Count, returning a map from aggregation job ID to the report IDs included in
-    /// the aggregation job. The container used to store the report IDs is up to the caller; ordered
+    /// Prio3Count, returning a map from aggregation job ID to the report IDs included in the
+    /// aggregation job. The container used to store the report IDs is up to the caller; ordered
     /// containers will store report IDs in the order they are included in the aggregate job.
     async fn read_aggregate_jobs_for_task_prio3_count<
         Q: AccumulableQueryType,
@@ -1457,15 +1448,10 @@ mod tests {
     >(
         tx: &Transaction<'_, C>,
         task_id: &TaskId,
-    ) -> HashMap<
-        AggregationJobId,
-        (
-            AggregationJob<PRIO3_VERIFY_KEY_LENGTH, Q, Prio3Aes128Count>,
-            T,
-        ),
-    > {
-        let vdaf = Prio3::new_aes128_count(2).unwrap();
-        read_aggregate_jobs_for_task_generic::<PRIO3_VERIFY_KEY_LENGTH, Q, Prio3Aes128Count, T, C>(
+    ) -> HashMap<AggregationJobId, (AggregationJob<PRIO3_VERIFY_KEY_LENGTH, Q, Prio3Count>, T)>
+    {
+        let vdaf = Prio3::new_count(2).unwrap();
+        read_aggregate_jobs_for_task_generic::<PRIO3_VERIFY_KEY_LENGTH, Q, Prio3Count, T, C>(
             tx, task_id, &vdaf,
         )
         .await
@@ -1491,10 +1477,8 @@ mod tests {
     ) -> impl Iterator<Item = (AggregationJob<L, Q, A>, T)>
     where
         T: FromIterator<(Time, ReportId)>,
-        A: Aggregator<L>,
-        for<'a> Vec<u8>: From<&'a <A as Vdaf>::AggregateShare>,
-        <A as Aggregator<L>>::PrepareState: for<'a> ParameterizedDecode<(&'a A, usize)>,
-        for<'a> <A as Vdaf>::OutputShare: TryFrom<&'a [u8]>,
+        A: Aggregator<L, 16>,
+        <A as Aggregator<L, 16>>::PrepareState: for<'a> ParameterizedDecode<(&'a A, usize)>,
     {
         try_join_all(
             tx.get_aggregation_jobs_for_task::<L, Q, A>(task_id)

--- a/aggregator/src/aggregator/garbage_collector.rs
+++ b/aggregator/src/aggregator/garbage_collector.rs
@@ -229,11 +229,13 @@ mod tests {
                         .await?;
                     let batch_aggregations = tx
                         .get_batch_aggregations_for_task::<0, TimeInterval, dummy_vdaf::Vdaf>(
+                            &vdaf,
                             task.id(),
                         )
                         .await?;
                     let collection_jobs = tx
                         .get_collection_jobs_for_task::<0, TimeInterval, dummy_vdaf::Vdaf>(
+                            &vdaf,
                             task.id(),
                         )
                         .await?;
@@ -392,11 +394,13 @@ mod tests {
                         .await?;
                     let batch_aggregations = tx
                         .get_batch_aggregations_for_task::<0, TimeInterval, dummy_vdaf::Vdaf>(
+                            &vdaf,
                             task.id(),
                         )
                         .await?;
                     let aggregate_share_jobs = tx
                         .get_aggregate_share_jobs_for_task::<0, TimeInterval, dummy_vdaf::Vdaf>(
+                            &vdaf,
                             task.id(),
                         )
                         .await?;
@@ -542,11 +546,15 @@ mod tests {
                         .await?;
                     let batch_aggregations = tx
                         .get_batch_aggregations_for_task::<0, FixedSize, dummy_vdaf::Vdaf>(
+                            &vdaf,
                             task.id(),
                         )
                         .await?;
                     let collection_jobs = tx
-                        .get_collection_jobs_for_task::<0, FixedSize, dummy_vdaf::Vdaf>(task.id())
+                        .get_collection_jobs_for_task::<0, FixedSize, dummy_vdaf::Vdaf>(
+                            &vdaf,
+                            task.id(),
+                        )
                         .await?;
                     let outstanding_batches =
                         tx.get_outstanding_batches_for_task(task.id()).await?;
@@ -702,11 +710,13 @@ mod tests {
                         .await?;
                     let batch_aggregations = tx
                         .get_batch_aggregations_for_task::<0, FixedSize, dummy_vdaf::Vdaf>(
+                            &vdaf,
                             task.id(),
                         )
                         .await?;
                     let aggregate_share_jobs = tx
                         .get_aggregate_share_jobs_for_task::<0, FixedSize, dummy_vdaf::Vdaf>(
+                            &vdaf,
                             task.id(),
                         )
                         .await?;

--- a/aggregator/src/bin/janus_cli.rs
+++ b/aggregator/src/bin/janus_cli.rs
@@ -617,13 +617,13 @@ mod tests {
         let tasks = Vec::from([
             TaskBuilder::new(
                 QueryType::TimeInterval,
-                VdafInstance::Prio3Aes128Count,
+                VdafInstance::Prio3Count,
                 Role::Leader,
             )
             .build(),
             TaskBuilder::new(
                 QueryType::TimeInterval,
-                VdafInstance::Prio3Aes128Sum { bits: 64 },
+                VdafInstance::Prio3Sum { bits: 64 },
                 Role::Helper,
             )
             .build(),
@@ -650,7 +650,7 @@ mod tests {
 
         let tasks = Vec::from([TaskBuilder::new(
             QueryType::TimeInterval,
-            VdafInstance::Prio3Aes128Count,
+            VdafInstance::Prio3Count,
             Role::Leader,
         )
         .build()]);
@@ -673,13 +673,13 @@ mod tests {
         let tasks = Vec::from([
             TaskBuilder::new(
                 QueryType::TimeInterval,
-                VdafInstance::Prio3Aes128Count,
+                VdafInstance::Prio3Count,
                 Role::Leader,
             )
             .build(),
             TaskBuilder::new(
                 QueryType::TimeInterval,
-                VdafInstance::Prio3Aes128Sum { bits: 64 },
+                VdafInstance::Prio3Sum { bits: 64 },
                 Role::Helper,
             )
             .build(),
@@ -702,7 +702,7 @@ mod tests {
             QueryType::FixedSize {
                 max_batch_size: 100,
             },
-            VdafInstance::Prio3Aes128CountVec { length: 4 },
+            VdafInstance::Prio3CountVec { length: 4 },
             Role::Leader,
         )
         .with_id(*tasks[0].id())
@@ -747,7 +747,7 @@ mod tests {
   - https://leader
   - https://helper
   query_type: TimeInterval
-  vdaf: !Prio3Aes128Sum
+  vdaf: !Prio3Sum
     bits: 2
   role: Leader
   vdaf_verify_keys:
@@ -770,7 +770,7 @@ mod tests {
   - https://leader
   - https://helper
   query_type: TimeInterval
-  vdaf: !Prio3Aes128Sum
+  vdaf: !Prio3Sum
     bits: 2
   role: Helper
   vdaf_verify_keys:

--- a/aggregator/tests/graceful_shutdown.rs
+++ b/aggregator/tests/graceful_shutdown.rs
@@ -126,7 +126,7 @@ async fn graceful_shutdown(binary: &Path, mut config: Mapping) {
 
     let task = TaskBuilder::new(
         QueryType::TimeInterval,
-        VdafInstance::Prio3Aes128Count,
+        VdafInstance::Prio3Count,
         Role::Leader,
     )
     .build();

--- a/aggregator_core/Cargo.toml
+++ b/aggregator_core/Cargo.toml
@@ -41,7 +41,7 @@ lazy_static = { version = "1", optional = true }
 opentelemetry = { version = "0.18", features = ["metrics", "rt-tokio"] }
 postgres-protocol = "0.6.4"
 postgres-types = { version = "0.2.4", features = ["derive", "array-impls"] }
-prio.workspace = true
+prio = { workspace = true, features = ["experimental"] }
 rand = { version = "0.8", features = ["min_const_gen"] }
 regex = "1"
 reqwest = { version = "0.11.14", default-features = false, features = ["rustls-tls", "json"] }

--- a/aggregator_core/src/lib.rs
+++ b/aggregator_core/src/lib.rs
@@ -27,7 +27,7 @@ impl AsRef<[u8]> for SecretBytes {
 /// A marker trait for VDAFs that have an aggregation parameter other than the unit type.
 pub trait VdafHasAggregationParameter {}
 
-impl<I, P, const L: usize> VdafHasAggregationParameter for prio::vdaf::poplar1::Poplar1<I, P, L> {}
+impl<P, const L: usize> VdafHasAggregationParameter for prio::vdaf::poplar1::Poplar1<P, L> {}
 
 #[cfg(feature = "test-util")]
 impl VdafHasAggregationParameter for dummy_vdaf::Vdaf {}

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -833,7 +833,7 @@ mod tests {
         roundtrip_encoding(
             TaskBuilder::new(
                 QueryType::TimeInterval,
-                VdafInstance::Prio3Aes128Count,
+                VdafInstance::Prio3Count,
                 Role::Leader,
             )
             .build(),
@@ -855,7 +855,7 @@ mod tests {
                 "http://helper_endpoint".parse().unwrap(),
             ]),
             QueryType::TimeInterval,
-            VdafInstance::Prio3Aes128Count,
+            VdafInstance::Prio3Count,
             Role::Leader,
             Vec::from([SecretBytes::new([0; PRIO3_VERIFY_KEY_LENGTH].into())]),
             0,
@@ -879,7 +879,7 @@ mod tests {
                 "http://helper_endpoint".parse().unwrap(),
             ]),
             QueryType::TimeInterval,
-            VdafInstance::Prio3Aes128Count,
+            VdafInstance::Prio3Count,
             Role::Leader,
             Vec::from([SecretBytes::new([0; PRIO3_VERIFY_KEY_LENGTH].into())]),
             0,
@@ -903,7 +903,7 @@ mod tests {
                 "http://helper_endpoint".parse().unwrap(),
             ]),
             QueryType::TimeInterval,
-            VdafInstance::Prio3Aes128Count,
+            VdafInstance::Prio3Count,
             Role::Helper,
             Vec::from([SecretBytes::new([0; PRIO3_VERIFY_KEY_LENGTH].into())]),
             0,
@@ -927,7 +927,7 @@ mod tests {
                 "http://helper_endpoint".parse().unwrap(),
             ]),
             QueryType::TimeInterval,
-            VdafInstance::Prio3Aes128Count,
+            VdafInstance::Prio3Count,
             Role::Helper,
             Vec::from([SecretBytes::new([0; PRIO3_VERIFY_KEY_LENGTH].into())]),
             0,
@@ -953,7 +953,7 @@ mod tests {
                 "http://helper_endpoint".parse().unwrap(),
             ]),
             QueryType::TimeInterval,
-            VdafInstance::Prio3Aes128Count,
+            VdafInstance::Prio3Count,
             Role::Leader,
             Vec::from([SecretBytes::new([0; PRIO3_VERIFY_KEY_LENGTH].into())]),
             0,
@@ -985,7 +985,7 @@ mod tests {
                 "",
                 TaskBuilder::new(
                     QueryType::TimeInterval,
-                    VdafInstance::Prio3Aes128Count,
+                    VdafInstance::Prio3Count,
                     Role::Leader,
                 )
                 .build(),
@@ -994,7 +994,7 @@ mod tests {
                 "/prefix",
                 TaskBuilder::new(
                     QueryType::TimeInterval,
-                    VdafInstance::Prio3Aes128Count,
+                    VdafInstance::Prio3Count,
                     Role::Leader,
                 )
                 .with_aggregator_endpoints(Vec::from([
@@ -1033,7 +1033,7 @@ mod tests {
                     "https://example.net/".parse().unwrap(),
                 ]),
                 QueryType::TimeInterval,
-                VdafInstance::Prio3Aes128Count,
+                VdafInstance::Prio3Count,
                 Role::Leader,
                 Vec::from([SecretBytes::new(b"1234567812345678".to_vec())]),
                 1,
@@ -1084,7 +1084,7 @@ mod tests {
                 Token::Str("vdaf"),
                 Token::UnitVariant {
                     name: "VdafInstance",
-                    variant: "Prio3Aes128Count",
+                    variant: "Prio3Count",
                 },
                 Token::Str("role"),
                 Token::UnitVariant {
@@ -1196,7 +1196,7 @@ mod tests {
                     "https://example.net/".parse().unwrap(),
                 ]),
                 QueryType::FixedSize { max_batch_size: 10 },
-                VdafInstance::Prio3Aes128CountVec { length: 8 },
+                VdafInstance::Prio3CountVec { length: 8 },
                 Role::Helper,
                 Vec::from([SecretBytes::new(b"1234567812345678".to_vec())]),
                 1,
@@ -1251,7 +1251,7 @@ mod tests {
                 Token::Str("vdaf"),
                 Token::StructVariant {
                     name: "VdafInstance",
-                    variant: "Prio3Aes128CountVec",
+                    variant: "Prio3CountVec",
                     len: 1,
                 },
                 Token::Str("length"),
@@ -1373,7 +1373,7 @@ mod tests {
                 "https://www.example.net/".parse().unwrap(),
             ]),
             query_type: QueryType::TimeInterval,
-            vdaf: VdafInstance::Prio3Aes128Count,
+            vdaf: VdafInstance::Prio3Count,
             role: Role::Helper,
             vdaf_verify_keys: Vec::from([]),
             max_batch_query_count: 1,
@@ -1399,7 +1399,7 @@ mod tests {
                 "https://www.example.net/".parse().unwrap(),
             ]),
             query_type: QueryType::TimeInterval,
-            vdaf: VdafInstance::Prio3Aes128Count,
+            vdaf: VdafInstance::Prio3Count,
             role: Role::Leader,
             vdaf_verify_keys: Vec::from([]),
             max_batch_query_count: 1,

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -14,7 +14,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-fpvec_bounded_l2 = ["dep:fixed", "dep:fixed-macro", "janus_core/fpvec_bounded_l2"]
+fpvec_bounded_l2 = ["dep:fixed", "dep:fixed-macro", "janus_core/fpvec_bounded_l2", "prio/experimental"]
 test-util = []
 
 [dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,7 +14,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-fpvec_bounded_l2 = []
+fpvec_bounded_l2 = ["prio/experimental"]
 test-util = [
     "dep:assert_matches",
     "dep:lazy_static",

--- a/core/src/task.rs
+++ b/core/src/task.rs
@@ -17,26 +17,23 @@ pub const PRIO3_VERIFY_KEY_LENGTH: usize = 16;
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum VdafInstance {
-    /// A `prio3` counter using the AES 128 pseudorandom generator.
-    Prio3Aes128Count,
-    /// A vector of `prio3` counters using the AES 128 pseudorandom generator.
-    Prio3Aes128CountVec { length: usize },
-    /// A `prio3` sum using the AES 128 pseudorandom generator.
-    Prio3Aes128Sum { bits: u32 },
-    /// A `prio3` histogram using the AES 128 pseudorandom generator.
-    Prio3Aes128Histogram { buckets: Vec<u64> },
-    /// A `prio3` 16-bit fixedpoint vector sum with bounded L2 norm using the AES
-    /// 128 pseudorandom generator.
+    /// A `Prio3` counter.
+    Prio3Count,
+    /// A vector of `Prio3` counters.
+    Prio3CountVec { length: usize },
+    /// A `Prio3` sum.
+    Prio3Sum { bits: u32 },
+    /// A `Prio3` histogram.
+    Prio3Histogram { buckets: Vec<u64> },
+    /// A `Prio3` 16-bit fixed point vector sum with bounded L2 norm.
     #[cfg(feature = "fpvec_bounded_l2")]
-    Prio3Aes128FixedPoint16BitBoundedL2VecSum { length: usize },
-    /// A `prio3` 32-bit fixedpoint vector sum with bounded L2 norm using the AES
-    /// 128 pseudorandom generator.
+    Prio3FixedPoint16BitBoundedL2VecSum { length: usize },
+    /// A `Prio3` 32-bit fixed point vector sum with bounded L2 norm.
     #[cfg(feature = "fpvec_bounded_l2")]
-    Prio3Aes128FixedPoint32BitBoundedL2VecSum { length: usize },
-    /// A `prio3` 64-bit fixedpoint vector sum with bounded L2 norm using the AES
-    /// 128 pseudorandom generator.
+    Prio3FixedPoint32BitBoundedL2VecSum { length: usize },
+    /// A `Prio3` 64-bit fixedpoint vector sum with bounded L2 norm.
     #[cfg(feature = "fpvec_bounded_l2")]
-    Prio3Aes128FixedPoint64BitBoundedL2VecSum { length: usize },
+    Prio3FixedPoint64BitBoundedL2VecSum { length: usize },
     /// The `poplar1` VDAF. Support for this VDAF is experimental.
     Poplar1 { bits: usize },
 
@@ -76,26 +73,26 @@ macro_rules! vdaf_dispatch_impl_base {
     // Provide the dispatched type only, don't construct a VDAF instance.
     (impl match base $vdaf_instance:expr, (_, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident) => $body:tt) => {
         match $vdaf_instance {
-            ::janus_core::task::VdafInstance::Prio3Aes128Count => {
-                type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128Count;
+            ::janus_core::task::VdafInstance::Prio3Count => {
+                type $Vdaf = ::prio::vdaf::prio3::Prio3Count;
                 const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
-            ::janus_core::task::VdafInstance::Prio3Aes128CountVec { length } => {
-                type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128CountVecMultithreaded;
+            ::janus_core::task::VdafInstance::Prio3CountVec { length } => {
+                type $Vdaf = ::prio::vdaf::prio3::Prio3SumVecMultithreaded;
                 const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
-            ::janus_core::task::VdafInstance::Prio3Aes128Sum { bits } => {
-                type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128Sum;
+            ::janus_core::task::VdafInstance::Prio3Sum { bits } => {
+                type $Vdaf = ::prio::vdaf::prio3::Prio3Sum;
                 const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
-            ::janus_core::task::VdafInstance::Prio3Aes128Histogram { buckets } => {
-                type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128Histogram;
+            ::janus_core::task::VdafInstance::Prio3Histogram { buckets } => {
+                type $Vdaf = ::prio::vdaf::prio3::Prio3Histogram;
                 const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
@@ -107,31 +104,30 @@ macro_rules! vdaf_dispatch_impl_base {
     // Construct a VDAF instance, and provide that to the block as well.
     (impl match base $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident) => $body:tt) => {
         match $vdaf_instance {
-            ::janus_core::task::VdafInstance::Prio3Aes128Count => {
-                let $vdaf = ::prio::vdaf::prio3::Prio3::new_aes128_count(2)?;
-                type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128Count;
+            ::janus_core::task::VdafInstance::Prio3Count => {
+                let $vdaf = ::prio::vdaf::prio3::Prio3::new_count(2)?;
+                type $Vdaf = ::prio::vdaf::prio3::Prio3Count;
                 const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
-            ::janus_core::task::VdafInstance::Prio3Aes128CountVec { length } => {
-                let $vdaf =
-                    ::prio::vdaf::prio3::Prio3::new_aes128_count_vec_multithreaded(2, *length)?;
-                type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128CountVecMultithreaded;
+            ::janus_core::task::VdafInstance::Prio3CountVec { length } => {
+                let $vdaf = ::prio::vdaf::prio3::Prio3::new_sum_vec_multithreaded(2, 1, *length)?;
+                type $Vdaf = ::prio::vdaf::prio3::Prio3SumVecMultithreaded;
                 const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
-            ::janus_core::task::VdafInstance::Prio3Aes128Sum { bits } => {
-                let $vdaf = ::prio::vdaf::prio3::Prio3::new_aes128_sum(2, *bits)?;
-                type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128Sum;
+            ::janus_core::task::VdafInstance::Prio3Sum { bits } => {
+                let $vdaf = ::prio::vdaf::prio3::Prio3::new_sum(2, *bits)?;
+                type $Vdaf = ::prio::vdaf::prio3::Prio3Sum;
                 const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
-            ::janus_core::task::VdafInstance::Prio3Aes128Histogram { buckets } => {
-                let $vdaf = ::prio::vdaf::prio3::Prio3::new_aes128_histogram(2, buckets)?;
-                type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128Histogram;
+            ::janus_core::task::VdafInstance::Prio3Histogram { buckets } => {
+                let $vdaf = ::prio::vdaf::prio3::Prio3::new_histogram(2, buckets)?;
+                type $Vdaf = ::prio::vdaf::prio3::Prio3Histogram;
                 const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
@@ -145,33 +141,27 @@ macro_rules! vdaf_dispatch_impl_base {
 #[cfg(feature = "fpvec_bounded_l2")]
 #[macro_export]
 macro_rules! vdaf_dispatch_impl_fpvec_bounded_l2 {
-     // Provide the dispatched type only, don't construct a VDAF instance.
-     (impl match fpvec_bounded_l2 $vdaf_instance:expr, (_, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident) => $body:tt) => {
+    // Provide the dispatched type only, don't construct a VDAF instance.
+    (impl match fpvec_bounded_l2 $vdaf_instance:expr, (_, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident) => $body:tt) => {
         match $vdaf_instance {
-            ::janus_core::task::VdafInstance::Prio3Aes128FixedPoint16BitBoundedL2VecSum {
-                length,
-            } => {
-                type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128FixedPointBoundedL2VecSumMultithreaded<
+            ::janus_core::task::VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { length } => {
+                type $Vdaf = ::prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded<
                     ::fixed::FixedI16<::fixed::types::extra::U15>,
                 >;
                 const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
-            ::janus_core::task::VdafInstance::Prio3Aes128FixedPoint32BitBoundedL2VecSum {
-                length,
-            } => {
-                type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128FixedPointBoundedL2VecSumMultithreaded<
+            ::janus_core::task::VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { length } => {
+                type $Vdaf = ::prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded<
                     ::fixed::FixedI32<::fixed::types::extra::U31>,
                 >;
                 const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
-            ::janus_core::task::VdafInstance::Prio3Aes128FixedPoint64BitBoundedL2VecSum {
-                length,
-            } => {
-                type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128FixedPointBoundedL2VecSumMultithreaded<
+            ::janus_core::task::VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { length } => {
+                type $Vdaf = ::prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded<
                     ::fixed::FixedI64<::fixed::types::extra::U63>,
                 >;
                 const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
@@ -185,39 +175,36 @@ macro_rules! vdaf_dispatch_impl_fpvec_bounded_l2 {
     // Construct a VDAF instance, and provide that to the block as well.
     (impl match fpvec_bounded_l2 $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident) => $body:tt) => {
         match $vdaf_instance {
-            ::janus_core::task::VdafInstance::Prio3Aes128FixedPoint16BitBoundedL2VecSum {
-                length,
-            } => {
-                let $vdaf = ::prio::vdaf::prio3::Prio3::new_aes128_fixedpoint_boundedl2_vec_sum_multithreaded(
-                    2, *length,
-                )?;
-                type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128FixedPointBoundedL2VecSumMultithreaded<
+            ::janus_core::task::VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { length } => {
+                let $vdaf =
+                    ::prio::vdaf::prio3::Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
+                        2, *length,
+                    )?;
+                type $Vdaf = ::prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded<
                     ::fixed::FixedI16<::fixed::types::extra::U15>,
                 >;
                 const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
-            ::janus_core::task::VdafInstance::Prio3Aes128FixedPoint32BitBoundedL2VecSum {
-                length,
-            } => {
-                let $vdaf = ::prio::vdaf::prio3::Prio3::new_aes128_fixedpoint_boundedl2_vec_sum_multithreaded(
-                    2, *length,
-                )?;
-                type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128FixedPointBoundedL2VecSumMultithreaded<
+            ::janus_core::task::VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { length } => {
+                let $vdaf =
+                    ::prio::vdaf::prio3::Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
+                        2, *length,
+                    )?;
+                type $Vdaf = ::prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded<
                     ::fixed::FixedI32<::fixed::types::extra::U31>,
                 >;
                 const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
                 $body
             }
 
-            ::janus_core::task::VdafInstance::Prio3Aes128FixedPoint64BitBoundedL2VecSum {
-                length,
-            } => {
-                let $vdaf = ::prio::vdaf::prio3::Prio3::new_aes128_fixedpoint_boundedl2_vec_sum_multithreaded(
-                    2, *length,
-                )?;
-                type $Vdaf = ::prio::vdaf::prio3::Prio3Aes128FixedPointBoundedL2VecSumMultithreaded<
+            ::janus_core::task::VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { length } => {
+                let $vdaf =
+                    ::prio::vdaf::prio3::Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
+                        2, *length,
+                    )?;
+                type $Vdaf = ::prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded<
                     ::fixed::FixedI64<::fixed::types::extra::U63>,
                 >;
                 const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::PRIO3_VERIFY_KEY_LENGTH;
@@ -284,7 +271,7 @@ macro_rules! vdaf_dispatch_impl_test_util {
             ::janus_core::task::VdafInstance::FakeFailsPrepStep => {
                 let $vdaf = ::janus_core::test_util::dummy_vdaf::Vdaf::new().with_prep_step_fn(
                     || -> Result<
-                        ::prio::vdaf::PrepareTransition<::janus_core::test_util::dummy_vdaf::Vdaf, 0>,
+                        ::prio::vdaf::PrepareTransition<::janus_core::test_util::dummy_vdaf::Vdaf, 0, 16>,
                         ::prio::vdaf::VdafError,
                     > {
                         ::std::result::Result::Err(::prio::vdaf::VdafError::Uncategorized(
@@ -309,16 +296,16 @@ macro_rules! vdaf_dispatch_impl {
     // Provide the dispatched type only, don't construct a VDAF instance.
     (impl match all $vdaf_instance:expr, (_, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident) => $body:tt) => {
         match $vdaf_instance {
-            ::janus_core::task::VdafInstance::Prio3Aes128Count
-            | ::janus_core::task::VdafInstance::Prio3Aes128CountVec { .. }
-            | ::janus_core::task::VdafInstance::Prio3Aes128Sum { .. }
-            | ::janus_core::task::VdafInstance::Prio3Aes128Histogram { .. } => {
+            ::janus_core::task::VdafInstance::Prio3Count
+            | ::janus_core::task::VdafInstance::Prio3CountVec { .. }
+            | ::janus_core::task::VdafInstance::Prio3Sum { .. }
+            | ::janus_core::task::VdafInstance::Prio3Histogram { .. } => {
                 ::janus_core::vdaf_dispatch_impl_base!(impl match base $vdaf_instance, (_, $Vdaf, $VERIFY_KEY_LENGTH) => $body)
             }
 
-            ::janus_core::task::VdafInstance::Prio3Aes128FixedPoint16BitBoundedL2VecSum { .. }
-            | ::janus_core::task::VdafInstance::Prio3Aes128FixedPoint32BitBoundedL2VecSum { .. }
-            | ::janus_core::task::VdafInstance::Prio3Aes128FixedPoint64BitBoundedL2VecSum { .. } => {
+            ::janus_core::task::VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { .. }
+            | ::janus_core::task::VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { .. }
+            | ::janus_core::task::VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { .. } => {
                 ::janus_core::vdaf_dispatch_impl_fpvec_bounded_l2!(impl match fpvec_bounded_l2 $vdaf_instance, (_, $Vdaf, $VERIFY_KEY_LENGTH) => $body)
             }
 
@@ -335,16 +322,16 @@ macro_rules! vdaf_dispatch_impl {
     // Construct a VDAF instance, and provide that to the block as well.
     (impl match all $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident) => $body:tt) => {
         match $vdaf_instance {
-            ::janus_core::task::VdafInstance::Prio3Aes128Count
-            | ::janus_core::task::VdafInstance::Prio3Aes128CountVec { .. }
-            | ::janus_core::task::VdafInstance::Prio3Aes128Sum { .. }
-            | ::janus_core::task::VdafInstance::Prio3Aes128Histogram { .. } => {
+            ::janus_core::task::VdafInstance::Prio3Count
+            | ::janus_core::task::VdafInstance::Prio3CountVec { .. }
+            | ::janus_core::task::VdafInstance::Prio3Sum { .. }
+            | ::janus_core::task::VdafInstance::Prio3Histogram { .. } => {
                 ::janus_core::vdaf_dispatch_impl_base!(impl match base $vdaf_instance, ($vdaf, $Vdaf, $VERIFY_KEY_LENGTH) => $body)
             }
 
-            ::janus_core::task::VdafInstance::Prio3Aes128FixedPoint16BitBoundedL2VecSum { .. }
-            | ::janus_core::task::VdafInstance::Prio3Aes128FixedPoint32BitBoundedL2VecSum { .. }
-            | ::janus_core::task::VdafInstance::Prio3Aes128FixedPoint64BitBoundedL2VecSum { .. } => {
+            ::janus_core::task::VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { .. }
+            | ::janus_core::task::VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { .. }
+            | ::janus_core::task::VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { .. } => {
                 ::janus_core::vdaf_dispatch_impl_fpvec_bounded_l2!(impl match fpvec_bounded_l2 $vdaf_instance, ($vdaf, $Vdaf, $VERIFY_KEY_LENGTH) => $body)
             }
 
@@ -366,16 +353,16 @@ macro_rules! vdaf_dispatch_impl {
     // Provide the dispatched type only, don't construct a VDAF instance.
     (impl match all $vdaf_instance:expr, (_, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident) => $body:tt) => {
         match $vdaf_instance {
-            ::janus_core::task::VdafInstance::Prio3Aes128Count
-            | ::janus_core::task::VdafInstance::Prio3Aes128CountVec { .. }
-            | ::janus_core::task::VdafInstance::Prio3Aes128Sum { .. }
-            | ::janus_core::task::VdafInstance::Prio3Aes128Histogram { .. } => {
+            ::janus_core::task::VdafInstance::Prio3Count
+            | ::janus_core::task::VdafInstance::Prio3CountVec { .. }
+            | ::janus_core::task::VdafInstance::Prio3Sum { .. }
+            | ::janus_core::task::VdafInstance::Prio3Histogram { .. } => {
                 ::janus_core::vdaf_dispatch_impl_base!(impl match base $vdaf_instance, (_, $Vdaf, $VERIFY_KEY_LENGTH) => $body)
             }
 
-            ::janus_core::task::VdafInstance::Prio3Aes128FixedPoint16BitBoundedL2VecSum { .. }
-            | ::janus_core::task::VdafInstance::Prio3Aes128FixedPoint32BitBoundedL2VecSum { .. }
-            | ::janus_core::task::VdafInstance::Prio3Aes128FixedPoint64BitBoundedL2VecSum { .. } => {
+            ::janus_core::task::VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { .. }
+            | ::janus_core::task::VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { .. }
+            | ::janus_core::task::VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { .. } => {
                 ::janus_core::vdaf_dispatch_impl_fpvec_bounded_l2!(impl match fpvec_bounded_l2 $vdaf_instance, (_, $Vdaf, $VERIFY_KEY_LENGTH) => $body)
             }
 
@@ -386,16 +373,16 @@ macro_rules! vdaf_dispatch_impl {
     // Construct a VDAF instance, and provide that to the block as well.
     (impl match all $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident) => $body:tt) => {
         match $vdaf_instance {
-            ::janus_core::task::VdafInstance::Prio3Aes128Count
-            | ::janus_core::task::VdafInstance::Prio3Aes128CountVec { .. }
-            | ::janus_core::task::VdafInstance::Prio3Aes128Sum { .. }
-            | ::janus_core::task::VdafInstance::Prio3Aes128Histogram { .. } => {
+            ::janus_core::task::VdafInstance::Prio3Count
+            | ::janus_core::task::VdafInstance::Prio3CountVec { .. }
+            | ::janus_core::task::VdafInstance::Prio3Sum { .. }
+            | ::janus_core::task::VdafInstance::Prio3Histogram { .. } => {
                 ::janus_core::vdaf_dispatch_impl_base!(impl match base $vdaf_instance, ($vdaf, $Vdaf, $VERIFY_KEY_LENGTH) => $body)
             }
 
-            ::janus_core::task::VdafInstance::Prio3Aes128FixedPoint16BitBoundedL2VecSum { .. }
-            | ::janus_core::task::VdafInstance::Prio3Aes128FixedPoint32BitBoundedL2VecSum { .. }
-            | ::janus_core::task::VdafInstance::Prio3Aes128FixedPoint64BitBoundedL2VecSum { .. } => {
+            ::janus_core::task::VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { .. }
+            | ::janus_core::task::VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { .. }
+            | ::janus_core::task::VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { .. } => {
                 ::janus_core::vdaf_dispatch_impl_fpvec_bounded_l2!(impl match fpvec_bounded_l2 $vdaf_instance, ($vdaf, $Vdaf, $VERIFY_KEY_LENGTH) => $body)
             }
 
@@ -411,10 +398,10 @@ macro_rules! vdaf_dispatch_impl {
     // Provide the dispatched type only, don't construct a VDAF instance.
     (impl match all $vdaf_instance:expr, (_, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident) => $body:tt) => {
         match $vdaf_instance {
-            ::janus_core::task::VdafInstance::Prio3Aes128Count
-            | ::janus_core::task::VdafInstance::Prio3Aes128CountVec { .. }
-            | ::janus_core::task::VdafInstance::Prio3Aes128Sum { .. }
-            | ::janus_core::task::VdafInstance::Prio3Aes128Histogram { .. } => {
+            ::janus_core::task::VdafInstance::Prio3Count
+            | ::janus_core::task::VdafInstance::Prio3CountVec { .. }
+            | ::janus_core::task::VdafInstance::Prio3Sum { .. }
+            | ::janus_core::task::VdafInstance::Prio3Histogram { .. } => {
                 ::janus_core::vdaf_dispatch_impl_base!(impl match base $vdaf_instance, (_, $Vdaf, $VERIFY_KEY_LENGTH) => $body)
             }
 
@@ -431,10 +418,10 @@ macro_rules! vdaf_dispatch_impl {
     // Construct a VDAF instance, and provide that to the block as well.
     (impl match all $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident) => $body:tt) => {
         match $vdaf_instance {
-            ::janus_core::task::VdafInstance::Prio3Aes128Count
-            | ::janus_core::task::VdafInstance::Prio3Aes128CountVec { .. }
-            | ::janus_core::task::VdafInstance::Prio3Aes128Sum { .. }
-            | ::janus_core::task::VdafInstance::Prio3Aes128Histogram { .. } => {
+            ::janus_core::task::VdafInstance::Prio3Count
+            | ::janus_core::task::VdafInstance::Prio3CountVec { .. }
+            | ::janus_core::task::VdafInstance::Prio3Sum { .. }
+            | ::janus_core::task::VdafInstance::Prio3Histogram { .. } => {
                 ::janus_core::vdaf_dispatch_impl_base!(impl match base $vdaf_instance, ($vdaf, $Vdaf, $VERIFY_KEY_LENGTH) => $body)
             }
 
@@ -456,10 +443,10 @@ macro_rules! vdaf_dispatch_impl {
     // Provide the dispatched type only, don't construct a VDAF instance.
     (impl match all $vdaf_instance:expr, (_, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident) => $body:tt) => {
         match $vdaf_instance {
-            ::janus_core::task::VdafInstance::Prio3Aes128Count
-            | ::janus_core::task::VdafInstance::Prio3Aes128CountVec { .. }
-            | ::janus_core::task::VdafInstance::Prio3Aes128Sum { .. }
-            | ::janus_core::task::VdafInstance::Prio3Aes128Histogram { .. } => {
+            ::janus_core::task::VdafInstance::Prio3Count
+            | ::janus_core::task::VdafInstance::Prio3CountVec { .. }
+            | ::janus_core::task::VdafInstance::Prio3Sum { .. }
+            | ::janus_core::task::VdafInstance::Prio3Histogram { .. } => {
                 ::janus_core::vdaf_dispatch_impl_base!(impl match base $vdaf_instance, (_, $Vdaf, $VERIFY_KEY_LENGTH) => $body)
             }
 
@@ -470,10 +457,10 @@ macro_rules! vdaf_dispatch_impl {
     // Construct a VDAF instance, and provide that to the block as well.
     (impl match all $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident) => $body:tt) => {
         match $vdaf_instance {
-            ::janus_core::task::VdafInstance::Prio3Aes128Count
-            | ::janus_core::task::VdafInstance::Prio3Aes128CountVec { .. }
-            | ::janus_core::task::VdafInstance::Prio3Aes128Sum { .. }
-            | ::janus_core::task::VdafInstance::Prio3Aes128Histogram { .. } => {
+            ::janus_core::task::VdafInstance::Prio3Count
+            | ::janus_core::task::VdafInstance::Prio3CountVec { .. }
+            | ::janus_core::task::VdafInstance::Prio3Sum { .. }
+            | ::janus_core::task::VdafInstance::Prio3Histogram { .. } => {
                 ::janus_core::vdaf_dispatch_impl_base!(impl match base $vdaf_instance, ($vdaf, $Vdaf, $VERIFY_KEY_LENGTH) => $body)
             }
 
@@ -495,13 +482,12 @@ macro_rules! vdaf_dispatch_impl {
 /// # use janus_core::vdaf_dispatch;
 /// # fn handle_request_generic<A, const L: usize>(_vdaf: &A) -> Result<(), prio::vdaf::VdafError>
 /// # where
-/// #     A: prio::vdaf::Aggregator<L>,
-/// #     Vec<u8>: for<'a> From<&'a A::AggregateShare>,
+/// #     A: prio::vdaf::Aggregator<L, 16>,
 /// # {
 /// #     Ok(())
 /// # }
 /// # fn test() -> Result<(), prio::vdaf::VdafError> {
-/// #     let vdaf = janus_core::task::VdafInstance::Prio3Aes128Count;
+/// #     let vdaf = janus_core::task::VdafInstance::Prio3Count;
 /// vdaf_dispatch!(&vdaf, (vdaf, VdafType, VERIFY_KEY_LENGTH) => {
 ///     handle_request_generic::<VdafType, VERIFY_KEY_LENGTH>(&vdaf)
 /// })
@@ -578,18 +564,18 @@ mod tests {
         // The `Vdaf` type must have a stable serialization, as it gets stored in a JSON database
         // column.
         assert_tokens(
-            &VdafInstance::Prio3Aes128Count,
+            &VdafInstance::Prio3Count,
             &[Token::UnitVariant {
                 name: "VdafInstance",
-                variant: "Prio3Aes128Count",
+                variant: "Prio3Count",
             }],
         );
         assert_tokens(
-            &VdafInstance::Prio3Aes128CountVec { length: 8 },
+            &VdafInstance::Prio3CountVec { length: 8 },
             &[
                 Token::StructVariant {
                     name: "VdafInstance",
-                    variant: "Prio3Aes128CountVec",
+                    variant: "Prio3CountVec",
                     len: 1,
                 },
                 Token::Str("length"),
@@ -598,11 +584,11 @@ mod tests {
             ],
         );
         assert_tokens(
-            &VdafInstance::Prio3Aes128Sum { bits: 64 },
+            &VdafInstance::Prio3Sum { bits: 64 },
             &[
                 Token::StructVariant {
                     name: "VdafInstance",
-                    variant: "Prio3Aes128Sum",
+                    variant: "Prio3Sum",
                     len: 1,
                 },
                 Token::Str("bits"),
@@ -611,13 +597,13 @@ mod tests {
             ],
         );
         assert_tokens(
-            &VdafInstance::Prio3Aes128Histogram {
+            &VdafInstance::Prio3Histogram {
                 buckets: Vec::from([0, 100, 200, 400]),
             },
             &[
                 Token::StructVariant {
                     name: "VdafInstance",
-                    variant: "Prio3Aes128Histogram",
+                    variant: "Prio3Histogram",
                     len: 1,
                 },
                 Token::Str("buckets"),

--- a/docs/samples/tasks.yaml
+++ b/docs/samples/tasks.yaml
@@ -15,7 +15,7 @@
   query_type: TimeInterval
 
   # The task's VDAF. Each VDAF requires its own set of parameters.
-  vdaf: !Prio3Aes128Sum
+  vdaf: !Prio3Sum
     bits: 16
 
   # The DAP role of this Janus instance in this task. Either "Leader" or
@@ -101,7 +101,7 @@
   # parameter must be provided.
   query_type: !FixedSize
     max_batch_size: 100
-  vdaf: Prio3Aes128Count
+  vdaf: Prio3Count
   role: Helper
   vdaf_verify_keys:
   - "ZXtE4kLqtsCOr8h_pNUeoQ"

--- a/integration_tests/src/daphne.rs
+++ b/integration_tests/src/daphne.rs
@@ -311,15 +311,15 @@ impl<'a> Drop for Daphne<'a> {
 
 fn daphne_vdaf_config_from_janus_vdaf(vdaf: &VdafInstance) -> daphne::VdafConfig {
     match vdaf {
-        VdafInstance::Prio3Aes128Count => daphne::VdafConfig::Prio3(daphne::Prio3Config::Count),
+        VdafInstance::Prio3Count => daphne::VdafConfig::Prio3(daphne::Prio3Config::Count),
 
-        VdafInstance::Prio3Aes128Histogram { buckets } => {
+        VdafInstance::Prio3Histogram { buckets } => {
             daphne::VdafConfig::Prio3(daphne::Prio3Config::Histogram {
                 buckets: buckets.clone(),
             })
         }
 
-        VdafInstance::Prio3Aes128Sum { bits } => {
+        VdafInstance::Prio3Sum { bits } => {
             daphne::VdafConfig::Prio3(daphne::Prio3Config::Sum { bits: *bits })
         }
 

--- a/integration_tests/tests/daphne.rs
+++ b/integration_tests/tests/daphne.rs
@@ -23,7 +23,7 @@ async fn daphne_janus() {
     // Start servers.
     let network = generate_network_name();
     let (collector_private_key, leader_task, helper_task) =
-        test_task_builders(VdafInstance::Prio3Aes128Count);
+        test_task_builders(VdafInstance::Prio3Count);
 
     // Daphne is hardcoded to serve from a path starting with /v01/.
     let [leader_task, helper_task]: [Task; 2] = [leader_task, helper_task]
@@ -59,7 +59,7 @@ async fn janus_daphne() {
     // Start servers.
     let network = generate_network_name();
     let (collector_private_key, leader_task, helper_task) =
-        test_task_builders(VdafInstance::Prio3Aes128Count);
+        test_task_builders(VdafInstance::Prio3Count);
 
     // Daphne is hardcoded to serve from a path starting with /v01/.
     let [leader_task, helper_task]: [Task; 2] = [leader_task, helper_task]

--- a/integration_tests/tests/divviup_ts.rs
+++ b/integration_tests/tests/divviup_ts.rs
@@ -38,30 +38,29 @@ async fn run_divviup_ts_integration_test(container_client: &Cli, vdaf: VdafInsta
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "divviup-ts is not yet compatible with DAP-04"]
 async fn janus_divviup_ts_count() {
     install_test_trace_subscriber();
 
-    run_divviup_ts_integration_test(&container_client(), VdafInstance::Prio3Aes128Count).await;
+    run_divviup_ts_integration_test(&container_client(), VdafInstance::Prio3Count).await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "divviup-ts is not yet compatible with DAP-04"]
 async fn janus_divviup_ts_sum() {
     install_test_trace_subscriber();
 
-    run_divviup_ts_integration_test(
-        &container_client(),
-        VdafInstance::Prio3Aes128Sum { bits: 8 },
-    )
-    .await;
+    run_divviup_ts_integration_test(&container_client(), VdafInstance::Prio3Sum { bits: 8 }).await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "divviup-ts is not yet compatible with DAP-04"]
 async fn janus_divviup_ts_histogram() {
     install_test_trace_subscriber();
 
     run_divviup_ts_integration_test(
         &container_client(),
-        VdafInstance::Prio3Aes128Histogram {
+        VdafInstance::Prio3Histogram {
             buckets: Vec::from([1, 10, 100, 1000]),
         },
     )

--- a/integration_tests/tests/janus.rs
+++ b/integration_tests/tests/janus.rs
@@ -142,7 +142,7 @@ impl<'a> JanusPair<'a> {
     }
 }
 
-/// This test exercises Prio3Aes128Count with Janus as both the leader and the helper.
+/// This test exercises Prio3Count with Janus as both the leader and the helper.
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_janus_count() {
     install_test_trace_subscriber();
@@ -151,7 +151,7 @@ async fn janus_janus_count() {
     let container_client = container_client();
     let janus_pair = JanusPair::new(
         &container_client,
-        VdafInstance::Prio3Aes128Count,
+        VdafInstance::Prio3Count,
         QueryType::TimeInterval,
     )
     .await;
@@ -166,7 +166,7 @@ async fn janus_janus_count() {
     .await;
 }
 
-/// This test exercises Prio3Aes128Sum with Janus as both the leader and the helper.
+/// This test exercises Prio3Sum with Janus as both the leader and the helper.
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_janus_sum_16() {
     install_test_trace_subscriber();
@@ -175,7 +175,7 @@ async fn janus_janus_sum_16() {
     let container_client = container_client();
     let janus_pair = JanusPair::new(
         &container_client,
-        VdafInstance::Prio3Aes128Sum { bits: 16 },
+        VdafInstance::Prio3Sum { bits: 16 },
         QueryType::TimeInterval,
     )
     .await;
@@ -190,7 +190,7 @@ async fn janus_janus_sum_16() {
     .await;
 }
 
-/// This test exercises Prio3Aes128Histogram with Janus as both the leader and the helper.
+/// This test exercises Prio3Histogram with Janus as both the leader and the helper.
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_janus_histogram_4_buckets() {
     install_test_trace_subscriber();
@@ -201,7 +201,7 @@ async fn janus_janus_histogram_4_buckets() {
     let container_client = container_client();
     let janus_pair = JanusPair::new(
         &container_client,
-        VdafInstance::Prio3Aes128Histogram { buckets },
+        VdafInstance::Prio3Histogram { buckets },
         QueryType::TimeInterval,
     )
     .await;
@@ -216,7 +216,7 @@ async fn janus_janus_histogram_4_buckets() {
     .await;
 }
 
-/// This test exercises Prio3Aes128CountVec with Janus as both the leader and the helper.
+/// This test exercises Prio3CountVec with Janus as both the leader and the helper.
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_janus_count_vec_15() {
     install_test_trace_subscriber();
@@ -225,7 +225,7 @@ async fn janus_janus_count_vec_15() {
     let container_client = container_client();
     let janus_pair = JanusPair::new(
         &container_client,
-        VdafInstance::Prio3Aes128CountVec { length: 15 },
+        VdafInstance::Prio3CountVec { length: 15 },
         QueryType::TimeInterval,
     )
     .await;
@@ -249,7 +249,7 @@ async fn janus_janus_fixed_size() {
     let container_client = container_client();
     let janus_pair = JanusPair::new(
         &container_client,
-        VdafInstance::Prio3Aes128Count,
+        VdafInstance::Prio3Count,
         QueryType::FixedSize { max_batch_size: 50 },
     )
     .await;

--- a/interop_binaries/Cargo.toml
+++ b/interop_binaries/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [features]
-fpvec_bounded_l2 = ["dep:fixed", "dep:fixed-macro", "janus_core/fpvec_bounded_l2", "janus_aggregator/fpvec_bounded_l2"]
+fpvec_bounded_l2 = ["dep:fixed", "dep:fixed-macro", "janus_core/fpvec_bounded_l2", "janus_aggregator/fpvec_bounded_l2", "prio/experimental"]
 test-util = [
     "dep:hex",
     "dep:futures",

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -101,26 +101,26 @@ where
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum VdafObject {
-    Prio3Aes128Count,
-    Prio3Aes128CountVec {
+    Prio3Count,
+    Prio3CountVec {
         length: NumberAsString<usize>,
     },
-    Prio3Aes128Sum {
+    Prio3Sum {
         bits: NumberAsString<u32>,
     },
-    Prio3Aes128Histogram {
+    Prio3Histogram {
         buckets: Vec<NumberAsString<u64>>,
     },
     #[cfg(feature = "fpvec_bounded_l2")]
-    Prio3Aes128FixedPoint16BitBoundedL2VecSum {
+    Prio3FixedPoint16BitBoundedL2VecSum {
         length: NumberAsString<usize>,
     },
     #[cfg(feature = "fpvec_bounded_l2")]
-    Prio3Aes128FixedPoint32BitBoundedL2VecSum {
+    Prio3FixedPoint32BitBoundedL2VecSum {
         length: NumberAsString<usize>,
     },
     #[cfg(feature = "fpvec_bounded_l2")]
-    Prio3Aes128FixedPoint64BitBoundedL2VecSum {
+    Prio3FixedPoint64BitBoundedL2VecSum {
         length: NumberAsString<usize>,
     },
 }
@@ -128,37 +128,37 @@ pub enum VdafObject {
 impl From<VdafInstance> for VdafObject {
     fn from(vdaf: VdafInstance) -> Self {
         match vdaf {
-            VdafInstance::Prio3Aes128Count => VdafObject::Prio3Aes128Count,
+            VdafInstance::Prio3Count => VdafObject::Prio3Count,
 
-            VdafInstance::Prio3Aes128CountVec { length } => VdafObject::Prio3Aes128CountVec {
+            VdafInstance::Prio3CountVec { length } => VdafObject::Prio3CountVec {
                 length: NumberAsString(length),
             },
 
-            VdafInstance::Prio3Aes128Sum { bits } => VdafObject::Prio3Aes128Sum {
+            VdafInstance::Prio3Sum { bits } => VdafObject::Prio3Sum {
                 bits: NumberAsString(bits),
             },
 
-            VdafInstance::Prio3Aes128Histogram { buckets } => VdafObject::Prio3Aes128Histogram {
+            VdafInstance::Prio3Histogram { buckets } => VdafObject::Prio3Histogram {
                 buckets: buckets.iter().copied().map(NumberAsString).collect(),
             },
 
             #[cfg(feature = "fpvec_bounded_l2")]
-            VdafInstance::Prio3Aes128FixedPoint16BitBoundedL2VecSum { length } => {
-                VdafObject::Prio3Aes128FixedPoint16BitBoundedL2VecSum {
+            VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { length } => {
+                VdafObject::Prio3FixedPoint16BitBoundedL2VecSum {
                     length: NumberAsString(length),
                 }
             }
 
             #[cfg(feature = "fpvec_bounded_l2")]
-            VdafInstance::Prio3Aes128FixedPoint32BitBoundedL2VecSum { length } => {
-                VdafObject::Prio3Aes128FixedPoint32BitBoundedL2VecSum {
+            VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { length } => {
+                VdafObject::Prio3FixedPoint32BitBoundedL2VecSum {
                     length: NumberAsString(length),
                 }
             }
 
             #[cfg(feature = "fpvec_bounded_l2")]
-            VdafInstance::Prio3Aes128FixedPoint64BitBoundedL2VecSum { length } => {
-                VdafObject::Prio3Aes128FixedPoint64BitBoundedL2VecSum {
+            VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { length } => {
+                VdafObject::Prio3FixedPoint64BitBoundedL2VecSum {
                     length: NumberAsString(length),
                 }
             }
@@ -170,31 +170,31 @@ impl From<VdafInstance> for VdafObject {
 impl From<VdafObject> for VdafInstance {
     fn from(vdaf: VdafObject) -> Self {
         match vdaf {
-            VdafObject::Prio3Aes128Count => VdafInstance::Prio3Aes128Count,
+            VdafObject::Prio3Count => VdafInstance::Prio3Count,
 
-            VdafObject::Prio3Aes128CountVec { length } => {
-                VdafInstance::Prio3Aes128CountVec { length: length.0 }
+            VdafObject::Prio3CountVec { length } => {
+                VdafInstance::Prio3CountVec { length: length.0 }
             }
 
-            VdafObject::Prio3Aes128Sum { bits } => VdafInstance::Prio3Aes128Sum { bits: bits.0 },
+            VdafObject::Prio3Sum { bits } => VdafInstance::Prio3Sum { bits: bits.0 },
 
-            VdafObject::Prio3Aes128Histogram { buckets } => VdafInstance::Prio3Aes128Histogram {
+            VdafObject::Prio3Histogram { buckets } => VdafInstance::Prio3Histogram {
                 buckets: buckets.iter().map(|value| value.0).collect(),
             },
 
             #[cfg(feature = "fpvec_bounded_l2")]
-            VdafObject::Prio3Aes128FixedPoint16BitBoundedL2VecSum { length } => {
-                VdafInstance::Prio3Aes128FixedPoint16BitBoundedL2VecSum { length: length.0 }
+            VdafObject::Prio3FixedPoint16BitBoundedL2VecSum { length } => {
+                VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { length: length.0 }
             }
 
             #[cfg(feature = "fpvec_bounded_l2")]
-            VdafObject::Prio3Aes128FixedPoint32BitBoundedL2VecSum { length } => {
-                VdafInstance::Prio3Aes128FixedPoint32BitBoundedL2VecSum { length: length.0 }
+            VdafObject::Prio3FixedPoint32BitBoundedL2VecSum { length } => {
+                VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { length: length.0 }
             }
 
             #[cfg(feature = "fpvec_bounded_l2")]
-            VdafObject::Prio3Aes128FixedPoint64BitBoundedL2VecSum { length } => {
-                VdafInstance::Prio3Aes128FixedPoint64BitBoundedL2VecSum { length: length.0 }
+            VdafObject::Prio3FixedPoint64BitBoundedL2VecSum { length } => {
+                VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { length: length.0 }
             }
         }
     }

--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -554,7 +554,7 @@ async fn run(
 async fn e2e_prio3_count() {
     let result = run(
         QueryKind::TimeInterval,
-        json!({"type": "Prio3Aes128Count"}),
+        json!({"type": "Prio3Count"}),
         &[
             json!("0"),
             json!("1"),
@@ -585,7 +585,7 @@ async fn e2e_prio3_count() {
 async fn e2e_prio3_sum() {
     let result = run(
         QueryKind::TimeInterval,
-        json!({"type": "Prio3Aes128Sum", "bits": "64"}),
+        json!({"type": "Prio3Sum", "bits": "64"}),
         &[
             json!("0"),
             json!("10"),
@@ -606,7 +606,7 @@ async fn e2e_prio3_histogram() {
     let result = run(
         QueryKind::TimeInterval,
         json!({
-            "type": "Prio3Aes128Histogram",
+            "type": "Prio3Histogram",
             "buckets": ["0", "1", "10", "100", "1000", "10000", "100000"],
         }),
         &[
@@ -636,7 +636,7 @@ async fn e2e_prio3_histogram() {
 async fn e2e_prio3_count_vec() {
     let result = run(
         QueryKind::TimeInterval,
-        json!({"type": "Prio3Aes128CountVec", "length": "4"}),
+        json!({"type": "Prio3CountVec", "length": "4"}),
         &[
             json!(["0", "0", "0", "1"]),
             json!(["0", "0", "1", "0"]),
@@ -661,7 +661,7 @@ async fn e2e_prio3_fixed16vec() {
     let fp16_16_inv = fixed!(0.0625: I1F15);
     let result = run(
         QueryKind::TimeInterval,
-        json!({"type": "Prio3Aes128FixedPoint16BitBoundedL2VecSum", "length": "3"}),
+        json!({"type": "Prio3FixedPoint16BitBoundedL2VecSum", "length": "3"}),
         &[
             json!([
                 fp16_4_inv.to_string(),
@@ -697,7 +697,7 @@ async fn e2e_prio3_fixed32vec() {
     let fp32_16_inv = fixed!(0.0625: I1F31);
     let result = run(
         QueryKind::TimeInterval,
-        json!({"type": "Prio3Aes128FixedPoint32BitBoundedL2VecSum", "length": "3"}),
+        json!({"type": "Prio3FixedPoint32BitBoundedL2VecSum", "length": "3"}),
         &[
             json!([
                 fp32_4_inv.to_string(),
@@ -733,7 +733,7 @@ async fn e2e_prio3_fixed64vec() {
     let fp64_16_inv = fixed!(0.0625: I1F63);
     let result = run(
         QueryKind::TimeInterval,
-        json!({"type": "Prio3Aes128FixedPoint64BitBoundedL2VecSum", "length": "3"}),
+        json!({"type": "Prio3FixedPoint64BitBoundedL2VecSum", "length": "3"}),
         &[
             json!([
                 fp64_4_inv.to_string(),
@@ -769,7 +769,7 @@ async fn e2e_prio3_fixed16vec_fixed_size() {
     let fp16_16_inv = fixed!(0.0625: I1F15);
     let result = run(
         QueryKind::FixedSize,
-        json!({"type": "Prio3Aes128FixedPoint16BitBoundedL2VecSum", "length": "3"}),
+        json!({"type": "Prio3FixedPoint16BitBoundedL2VecSum", "length": "3"}),
         &[
             json!([
                 fp16_4_inv.to_string(),
@@ -805,7 +805,7 @@ async fn e2e_prio3_fixed32vec_fixed_size() {
     let fp32_16_inv = fixed!(0.0625: I1F31);
     let result = run(
         QueryKind::FixedSize,
-        json!({"type": "Prio3Aes128FixedPoint32BitBoundedL2VecSum", "length": "3"}),
+        json!({"type": "Prio3FixedPoint32BitBoundedL2VecSum", "length": "3"}),
         &[
             json!([
                 fp32_4_inv.to_string(),
@@ -841,7 +841,7 @@ async fn e2e_prio3_fixed64vec_fixed_size() {
     let fp64_16_inv = fixed!(0.0625: I1F63);
     let result = run(
         QueryKind::FixedSize,
-        json!({"type": "Prio3Aes128FixedPoint64BitBoundedL2VecSum", "length": "3"}),
+        json!({"type": "Prio3FixedPoint64BitBoundedL2VecSum", "length": "3"}),
         &[
             json!([
                 fp64_4_inv.to_string(),
@@ -874,7 +874,7 @@ async fn e2e_prio3_fixed64vec_fixed_size() {
 async fn e2e_prio3_count_fixed_size() {
     let result = run(
         QueryKind::FixedSize,
-        json!({"type": "Prio3Aes128Count"}),
+        json!({"type": "Prio3Count"}),
         &[
             json!("0"),
             json!("1"),

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -20,7 +20,7 @@ hex = "0.4"
 num_enum = "0.5.11"
 # We can't pull prio in from the workspace because that would enable default features, and we do not
 # want prio/crypto-dependencies
-prio = { version = "0.10.0", default-features = false }
+prio = { version = "0.11.0", default-features = false }
 rand = "0.8"
 serde = { version = "1.0.152", features = ["derive"] }
 thiserror = "1.0"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [features]
-fpvec_bounded_l2 = ["dep:fixed", "janus_collector/fpvec_bounded_l2"]
+fpvec_bounded_l2 = ["dep:fixed", "janus_collector/fpvec_bounded_l2", "prio/experimental"]
 
 [dependencies]
 anyhow = "1"

--- a/tools/tests/cmd/collect.trycmd
+++ b/tools/tests/cmd/collect.trycmd
@@ -36,10 +36,10 @@ VDAF Algorithm and Parameters:
           VDAF algorithm
 
           Possible values:
-          - count:     Prio3Aes128Count
-          - countvec:  Prio3Aes128CountVec
-          - sum:       Prio3Aes128Sum
-          - histogram: Prio3Aes128Histogram
+          - count:     Prio3Count
+          - countvec:  Prio3CountVec
+          - sum:       Prio3Sum
+          - histogram: Prio3Histogram
 
       --length <LENGTH>
           Number of vector elements, for use with --vdaf=countvec

--- a/tools/tests/cmd/collect_fpvec_bounded_l2.trycmd
+++ b/tools/tests/cmd/collect_fpvec_bounded_l2.trycmd
@@ -36,10 +36,10 @@ VDAF Algorithm and Parameters:
           VDAF algorithm
 
           Possible values:
-          - count:                          Prio3Aes128Count
-          - countvec:                       Prio3Aes128CountVec
-          - sum:                            Prio3Aes128Sum
-          - histogram:                      Prio3Aes128Histogram
+          - count:                          Prio3Count
+          - countvec:                       Prio3CountVec
+          - sum:                            Prio3Sum
+          - histogram:                      Prio3Histogram
           - fixedpoint16bitboundedl2vecsum: Prio3FixedPoint16BitBoundedL2VecSum
           - fixedpoint32bitboundedl2vecsum: Prio3FixedPoint32BitBoundedL2VecSum
           - fixedpoint64bitboundedl2vecsum: Prio3FixedPoint64BitBoundedL2VecSum


### PR DESCRIPTION
This upgrades to prio 0.11.0, and thus VDAF-04. This required ancillary changes to thread VDAF objects through more code, to make them available for decoding messages. Serialization used for the database and task parameters changed, because of the new VDAF names. Some traits and structs have an additional const generic now, for the nonce size, which we can fix at 16 as DAP does. I was able to get rid of infectious trait bounds on `Vec<u8>` and the like. Closes #932.