### PR TITLE
Deal with DAP-04 aggregation job round

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1846,7 +1846,7 @@ impl VdafOps {
 
                     // The leader is advancing us to the next round. Step the aggregation job to
                     // compute the next round of prepare messages and state.
-                    return Self::step_aggregation_job(
+                    Self::step_aggregation_job(
                         tx,
                         &task,
                         &vdaf,
@@ -1856,7 +1856,7 @@ impl VdafOps {
                         &leader_aggregation_job,
                         &aggregate_step_failure_counter,
                     )
-                    .await;
+                    .await
                 })
             })
             .await?)

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -43,11 +43,11 @@ use janus_messages::{
     problem_type::DapProblemType,
     query_type::{FixedSize, TimeInterval},
     AggregateShare, AggregateShareAad, AggregateShareReq, AggregationJobContinueReq,
-    AggregationJobId, AggregationJobInitializeReq, AggregationJobResp, BatchSelector, Collection,
-    CollectionJobId, CollectionReq, Duration, HpkeCiphertext, HpkeConfigId, HpkeConfigList,
-    InputShareAad, Interval, PartialBatchSelector, PlaintextInputShare, PrepareStep,
-    PrepareStepResult, Report, ReportId, ReportIdChecksum, ReportShare, ReportShareError, Role,
-    TaskId, Time,
+    AggregationJobId, AggregationJobInitializeReq, AggregationJobResp, AggregationJobRound,
+    BatchSelector, Collection, CollectionJobId, CollectionReq, Duration, HpkeCiphertext,
+    HpkeConfigId, HpkeConfigList, InputShareAad, Interval, PartialBatchSelector,
+    PlaintextInputShare, PrepareStep, PrepareStepResult, Report, ReportId, ReportIdChecksum,
+    ReportShare, ReportShareError, Role, TaskId, Time,
 };
 use opentelemetry::{
     metrics::{Counter, Histogram, Meter, Unit},
@@ -71,7 +71,6 @@ use std::{
     convert::Infallible,
     fmt::{self, Debug, Display, Formatter},
     future::Future,
-    io::Cursor,
     net::SocketAddr,
     num::TryFromIntError,
     sync::Arc,
@@ -118,6 +117,14 @@ pub enum Error {
     /// Corresponds to `unrecognizedMessage`, §3.2
     #[error("task {0:?}: unrecognized message: {1}")]
     UnrecognizedMessage(Option<TaskId>, &'static str),
+    /// Corresponds to `roundMismatch`
+    #[error("task {task_id}: unexpected round in aggregation job {aggregation_job_id} (expected {expected_round}, got {got_round})")]
+    RoundMismatch {
+        task_id: TaskId,
+        aggregation_job_id: AggregationJobId,
+        expected_round: AggregationJobRound,
+        got_round: AggregationJobRound,
+    },
     /// Corresponds to `unrecognizedTask`, §3.2
     #[error("task {0}: unrecognized task")]
     UnrecognizedTask(TaskId),
@@ -209,6 +216,7 @@ impl Error {
             Error::ReportRejected(_, _, _) => "report_rejected",
             Error::ReportTooEarly(_, _, _) => "report_too_early",
             Error::UnrecognizedMessage(_, _) => "unrecognized_message",
+            Error::RoundMismatch { .. } => "round_mismatch",
             Error::UnrecognizedTask(_) => "unrecognized_task",
             Error::MissingTaskId => "missing_task_id",
             Error::UnrecognizedAggregationJob(_, _) => "unrecognized_aggregation_job",
@@ -1611,6 +1619,7 @@ impl VdafOps {
             } else {
                 AggregationJobState::Finished
             },
+            AggregationJobRound::from(0),
         ));
 
         let prep_steps = datastore
@@ -1763,7 +1772,7 @@ impl VdafOps {
         task: Arc<Task>,
         batch_aggregation_shard_count: u64,
         aggregation_job_id: &AggregationJobId,
-        req: Arc<AggregationJobContinueReq>,
+        leader_aggregation_job: Arc<AggregationJobContinueReq>,
     ) -> Result<AggregationJobResp, Error>
     where
         A: 'static + Send + Sync,
@@ -1778,12 +1787,23 @@ impl VdafOps {
         // TODO(#224): don't do O(n) network round-trips (where n is the number of prepare steps)
         Ok(datastore
             .run_tx_with_name("aggregate_continue", |tx| {
-                let (vdaf, aggregate_step_failure_counter, task, aggregation_job_id, req) =
-                    (Arc::clone(&vdaf), aggregate_step_failure_counter.clone(), Arc::clone(&task), *aggregation_job_id, Arc::clone(&req));
+                let (
+                    vdaf,
+                    aggregate_step_failure_counter,
+                    task,
+                    aggregation_job_id,
+                    leader_aggregation_job,
+                ) = (
+                    Arc::clone(&vdaf),
+                    aggregate_step_failure_counter.clone(),
+                    Arc::clone(&task),
+                    *aggregation_job_id,
+                    Arc::clone(&leader_aggregation_job),
+                );
 
                 Box::pin(async move {
                     // Read existing state.
-                    let (aggregation_job, report_aggregations) = try_join!(
+                    let (helper_aggregation_job, report_aggregations) = try_join!(
                         tx.get_aggregation_job::<L, Q, A>(task.id(), &aggregation_job_id),
                         tx.get_report_aggregations_for_aggregation_job(
                             vdaf.as_ref(),
@@ -1792,144 +1812,51 @@ impl VdafOps {
                             &aggregation_job_id,
                         ),
                     )?;
-                    let aggregation_job = aggregation_job.ok_or_else(|| datastore::Error::User(Error::UnrecognizedAggregationJob(*task.id(), aggregation_job_id).into()))?;
 
-                    // Handle each transition in the request.
-                    let mut report_aggregations = report_aggregations.into_iter();
-                    let (mut saw_continue, mut saw_finish) = (false, false);
-                    let mut response_prep_steps = Vec::new();
-                    let mut accumulator = Accumulator::<L, Q, A>::new(Arc::clone(&task), batch_aggregation_shard_count, aggregation_job.aggregation_parameter().clone());
+                    let helper_aggregation_job = helper_aggregation_job.ok_or_else(|| {
+                        datastore::Error::User(
+                            Error::UnrecognizedAggregationJob(*task.id(), aggregation_job_id)
+                                .into(),
+                        )
+                    })?;
 
-                    for prep_step in req.prepare_steps().iter() {
-                        // Match preparation step received from leader to stored report aggregation,
-                        // and extract the stored preparation step.
-                        let report_aggregation = loop {
-                            let report_agg = report_aggregations.next().ok_or_else(|| {
-                                datastore::Error::User(Error::UnrecognizedMessage(
-                                    Some(*task.id()),
-                                    "leader sent unexpected, duplicate, or out-of-order prepare steps",
-                                ).into())
-                            })?;
-                            if report_agg.report_id() != prep_step.report_id() {
-                                // This report was omitted by the leader because of a prior failure.
-                                // Note that the report was dropped (if it's not already in an error
-                                // state) and continue.
-                                if matches!(report_agg.state(), ReportAggregationState::Waiting(_, _)) {
-                                    tx.update_report_aggregation(&report_agg.with_state(ReportAggregationState::Failed(ReportShareError::ReportDropped))).await?;
-                                }
-                                continue;
+                    // If the leader's request is on the same round as our stored aggregation job,
+                    // then we probably have already received this message and computed this round,
+                    // but the leader never got our response and so retried stepping the job.
+                    // TODO(issue #1087): measure how often this happens with a Prometheus metric
+                    if helper_aggregation_job.round() == leader_aggregation_job.round() {
+                        return Self::replay_aggregation_job_round::<C, L, Q, A>(
+                            report_aggregations,
+                        );
+                    } else if helper_aggregation_job.round().increment()
+                        != leader_aggregation_job.round()
+                    {
+                        // If this is not a replay, the leader should be advancing our state to the next
+                        // round and no further.
+                        return Err(datastore::Error::User(
+                            Error::RoundMismatch {
+                                task_id: *task.id(),
+                                aggregation_job_id,
+                                expected_round: helper_aggregation_job.round().increment(),
+                                got_round: leader_aggregation_job.round(),
                             }
-                            break report_agg;
-                        };
-
-                        // Make sure this report isn't in an interval that has already started
-                        // collection.
-                        let conflicting_aggregate_share_jobs = tx.get_aggregate_share_jobs_including_time::<L, A>(&vdaf, task.id(), report_aggregation.time()).await?;
-                        if !conflicting_aggregate_share_jobs.is_empty() {
-                            response_prep_steps.push(PrepareStep::new(
-                                *prep_step.report_id(),
-                                PrepareStepResult::Failed(ReportShareError::BatchCollected),
-                            ));
-                            tx.update_report_aggregation(&report_aggregation.with_state(ReportAggregationState::Failed(ReportShareError::BatchCollected))).await?;
-                            continue;
-                        }
-
-                        let prep_state =
-                            match report_aggregation.state() {
-                                ReportAggregationState::Waiting(prep_state, _) => prep_state,
-                                _ => {
-                                    return Err(datastore::Error::User(
-                                        Error::UnrecognizedMessage(
-                                            Some(*task.id()),
-                                            "leader sent prepare step for non-WAITING report aggregation",
-                                        ).into()
-                                    ));
-                                },
-                            };
-
-                        // Parse preparation message out of prepare step received from leader.
-                        let prep_msg = match prep_step.result() {
-                            PrepareStepResult::Continued(payload) => {
-                                A::PrepareMessage::decode_with_param(
-                                    prep_state,
-                                    &mut Cursor::new(payload.as_ref()),
-                                )?
-                            }
-                            _ => {
-                                return Err(datastore::Error::User(
-                                    Error::UnrecognizedMessage(
-                                        Some(*task.id()),
-                                        "leader sent non-Continued prepare step",
-                                    ).into()
-                                ));
-                            }
-                        };
-
-                        // Compute the next transition, prepare to respond & update DB.
-                        let next_state = match vdaf.prepare_step(prep_state.clone(), prep_msg) {
-                            Ok(PrepareTransition::Continue(prep_state, prep_share))=> {
-                                saw_continue = true;
-                                response_prep_steps.push(PrepareStep::new(
-                                    *prep_step.report_id(),
-                                    PrepareStepResult::Continued(prep_share.get_encoded()),
-                                ));
-                                ReportAggregationState::Waiting(prep_state, PrepareMessageOrShare::Helper(prep_share))
-                            }
-
-                            Ok(PrepareTransition::Finish(output_share)) => {
-                                saw_finish = true;
-                                accumulator.update(
-                                    aggregation_job.partial_batch_identifier(),
-                                    prep_step.report_id(),
-                                    report_aggregation.time(),
-                                    &output_share,
-                                )?;
-                                response_prep_steps.push(PrepareStep::new(
-                                    *prep_step.report_id(),
-                                    PrepareStepResult::Finished,
-                                ));
-                                ReportAggregationState::Finished(output_share)
-                            }
-
-                            Err(error) => {
-                                info!(task_id = %task.id(), job_id = %aggregation_job_id, report_id = %prep_step.report_id(), ?error, "Prepare step failed");
-                                aggregate_step_failure_counter.add(&Context::current(), 1, &[KeyValue::new("type", "prepare_step_failure")]);
-                                response_prep_steps.push(PrepareStep::new(
-                                    *prep_step.report_id(),
-                                    PrepareStepResult::Failed(ReportShareError::VdafPrepError),
-                                ));
-                                ReportAggregationState::Failed(ReportShareError::VdafPrepError)
-                            }
-                        };
-
-                        tx.update_report_aggregation(&report_aggregation.with_state(next_state)).await?;
+                            .into(),
+                        ));
                     }
 
-                    for report_agg in report_aggregations {
-                        // This report was omitted by the leader because of a prior failure.
-                        // Note that the report was dropped (if it's not already in an error state)
-                        // and continue.
-                        if matches!(report_agg.state(), ReportAggregationState::Waiting(_, _)) {
-                            tx.update_report_aggregation(&report_agg.with_state(ReportAggregationState::Failed(ReportShareError::ReportDropped))).await?;
-                        }
-                    }
-
-                    let aggregation_job = aggregation_job.with_state(match (saw_continue, saw_finish) {
-                        (false, false) => AggregationJobState::Finished, // everything failed, or there were no reports
-                        (true, false) => AggregationJobState::InProgress,
-                        (false, true) => AggregationJobState::Finished,
-                        (true, true) => {
-                            return Err(datastore::Error::User(Error::Internal(
-                                "VDAF took an inconsistent number of rounds to reach Finish state"
-                                    .to_string(),
-                            ).into()))
-                        }
-                    });
-                    tx.update_aggregation_job(&aggregation_job).await?;
-
-                    accumulator.flush_to_datastore(tx, &vdaf).await?;
-
-                    Ok(AggregationJobResp::new(response_prep_steps))
+                    // The leader is advancing us to the next round. Step the aggregation job to
+                    // compute the next round of prepare messages and state.
+                    return Self::step_aggregation_job(
+                        tx,
+                        &task,
+                        &vdaf,
+                        batch_aggregation_shard_count,
+                        helper_aggregation_job,
+                        report_aggregations,
+                        &leader_aggregation_job,
+                        &aggregate_step_failure_counter,
+                    )
+                    .await;
                 })
             })
             .await?)
@@ -2638,6 +2565,10 @@ where
                             DapProblemType::UnrecognizedMessage,
                             *task_id,
                         ),
+                        Error::RoundMismatch { task_id, .. } => build_problem_details_response(
+                            DapProblemType::RoundMismatch,
+                            Some(*task_id),
+                        ),
                         Error::UnrecognizedTask(task_id) => {
                             // TODO(#237): ensure that a helper returns HTTP 404 or 403 when this happens.
                             build_problem_details_response(
@@ -3272,11 +3203,11 @@ mod tests {
         query_type::TimeInterval,
         AggregateShare as AggregateShareMessage, AggregateShareAad, AggregateShareReq,
         AggregationJobContinueReq, AggregationJobId, AggregationJobInitializeReq,
-        AggregationJobResp, BatchSelector, Collection, CollectionJobId, CollectionReq, Duration,
-        Extension, ExtensionType, HpkeCiphertext, HpkeConfig, HpkeConfigId, HpkeConfigList,
-        InputShareAad, Interval, PartialBatchSelector, PlaintextInputShare, PrepareStep,
-        PrepareStepResult, Query, Report, ReportId, ReportIdChecksum, ReportMetadata, ReportShare,
-        ReportShareError, Role, TaskId, Time,
+        AggregationJobResp, AggregationJobRound, BatchSelector, Collection, CollectionJobId,
+        CollectionReq, Duration, Extension, ExtensionType, HpkeCiphertext, HpkeConfig,
+        HpkeConfigId, HpkeConfigList, InputShareAad, Interval, PartialBatchSelector,
+        PlaintextInputShare, PrepareStep, PrepareStepResult, Query, Report, ReportId,
+        ReportIdChecksum, ReportMetadata, ReportShare, ReportShareError, Role, TaskId, Time,
     };
     use opentelemetry::global::meter;
     use prio::{
@@ -3301,7 +3232,7 @@ mod tests {
 
     const DUMMY_VERIFY_KEY_LENGTH: usize = dummy_vdaf::Vdaf::VERIFY_KEY_LENGTH;
 
-    fn default_aggregator_config() -> Config {
+    pub(crate) fn default_aggregator_config() -> Config {
         // Enable upload write batching & batch aggregation sharding by default, in hopes that we
         // can shake out any bugs.
         Config {
@@ -4633,6 +4564,7 @@ mod tests {
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,
+                        AggregationJobRound::from(0),
                     );
                     tx.put_aggregation_job::<0, TimeInterval, dummy_vdaf::Vdaf>(
                         &conflicting_aggregation_job,
@@ -4662,6 +4594,7 @@ mod tests {
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,
+                        AggregationJobRound::from(0),
                     );
                     tx.put_aggregation_job::<0, TimeInterval, dummy_vdaf::Vdaf>(
                         &non_conflicting_aggregation_job,
@@ -5232,6 +5165,7 @@ mod tests {
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,
+                        AggregationJobRound::from(0),
                     ))
                     .await?;
 
@@ -5298,16 +5232,19 @@ mod tests {
             .await
             .unwrap();
 
-        let request = AggregationJobContinueReq::new(Vec::from([
-            PrepareStep::new(
-                *report_metadata_0.id(),
-                PrepareStepResult::Continued(prep_msg_0.get_encoded()),
-            ),
-            PrepareStep::new(
-                *report_metadata_2.id(),
-                PrepareStepResult::Continued(prep_msg_2.get_encoded()),
-            ),
-        ]));
+        let request = AggregationJobContinueReq::new(
+            AggregationJobRound::from(1),
+            Vec::from([
+                PrepareStep::new(
+                    *report_metadata_0.id(),
+                    PrepareStepResult::Continued(prep_msg_0.get_encoded()),
+                ),
+                PrepareStep::new(
+                    *report_metadata_2.id(),
+                    PrepareStepResult::Continued(prep_msg_2.get_encoded()),
+                ),
+            ]),
+        );
 
         // Create aggregator filter, send request, and parse response.
         let filter =
@@ -5363,6 +5300,7 @@ mod tests {
                 Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                     .unwrap(),
                 AggregationJobState::Finished,
+                AggregationJobRound::from(1),
             ))
         );
         assert_eq!(
@@ -5550,6 +5488,7 @@ mod tests {
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,
+                        AggregationJobRound::from(0),
                     ))
                     .await?;
 
@@ -5605,20 +5544,23 @@ mod tests {
             .await
             .unwrap();
 
-        let request = AggregationJobContinueReq::new(Vec::from([
-            PrepareStep::new(
-                *report_metadata_0.id(),
-                PrepareStepResult::Continued(prep_msg_0.get_encoded()),
-            ),
-            PrepareStep::new(
-                *report_metadata_1.id(),
-                PrepareStepResult::Continued(prep_msg_1.get_encoded()),
-            ),
-            PrepareStep::new(
-                *report_metadata_2.id(),
-                PrepareStepResult::Continued(prep_msg_2.get_encoded()),
-            ),
-        ]));
+        let request = AggregationJobContinueReq::new(
+            AggregationJobRound::from(1),
+            Vec::from([
+                PrepareStep::new(
+                    *report_metadata_0.id(),
+                    PrepareStepResult::Continued(prep_msg_0.get_encoded()),
+                ),
+                PrepareStep::new(
+                    *report_metadata_1.id(),
+                    PrepareStepResult::Continued(prep_msg_1.get_encoded()),
+                ),
+                PrepareStep::new(
+                    *report_metadata_2.id(),
+                    PrepareStepResult::Continued(prep_msg_2.get_encoded()),
+                ),
+            ]),
+        );
 
         // Create aggregator filter, send request, and parse response.
         let filter = aggregator_filter(
@@ -5846,6 +5788,7 @@ mod tests {
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,
+                        AggregationJobRound::from(0),
                     ))
                     .await?;
 
@@ -5901,20 +5844,23 @@ mod tests {
             .await
             .unwrap();
 
-        let request = AggregationJobContinueReq::new(Vec::from([
-            PrepareStep::new(
-                *report_metadata_3.id(),
-                PrepareStepResult::Continued(prep_msg_3.get_encoded()),
-            ),
-            PrepareStep::new(
-                *report_metadata_4.id(),
-                PrepareStepResult::Continued(prep_msg_4.get_encoded()),
-            ),
-            PrepareStep::new(
-                *report_metadata_5.id(),
-                PrepareStepResult::Continued(prep_msg_5.get_encoded()),
-            ),
-        ]));
+        let request = AggregationJobContinueReq::new(
+            AggregationJobRound::from(1),
+            Vec::from([
+                PrepareStep::new(
+                    *report_metadata_3.id(),
+                    PrepareStepResult::Continued(prep_msg_3.get_encoded()),
+                ),
+                PrepareStep::new(
+                    *report_metadata_4.id(),
+                    PrepareStepResult::Continued(prep_msg_4.get_encoded()),
+                ),
+                PrepareStep::new(
+                    *report_metadata_5.id(),
+                    PrepareStepResult::Continued(prep_msg_5.get_encoded()),
+                ),
+            ]),
+        );
 
         // Create aggregator filter, send request, and parse response.
         let filter = aggregator_filter(
@@ -6088,6 +6034,7 @@ mod tests {
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,
+                        AggregationJobRound::from(0),
                     ))
                     .await?;
                     tx.put_report_aggregation(&ReportAggregation::<
@@ -6111,10 +6058,13 @@ mod tests {
             .unwrap();
 
         // Make request.
-        let request = AggregationJobContinueReq::new(Vec::from([PrepareStep::new(
-            *report_metadata.id(),
-            PrepareStepResult::Finished,
-        )]));
+        let request = AggregationJobContinueReq::new(
+            AggregationJobRound::from(1),
+            Vec::from([PrepareStep::new(
+                *report_metadata.id(),
+                PrepareStepResult::Finished,
+            )]),
+        );
 
         let filter =
             aggregator_filter(datastore.clone(), clock, default_aggregator_config()).unwrap();
@@ -6184,6 +6134,7 @@ mod tests {
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,
+                        AggregationJobRound::from(0),
                     ))
                     .await?;
                     tx.put_report_aggregation(&ReportAggregation::<
@@ -6207,10 +6158,13 @@ mod tests {
             .unwrap();
 
         // Make request.
-        let request = AggregationJobContinueReq::new(Vec::from([PrepareStep::new(
-            *report_metadata.id(),
-            PrepareStepResult::Continued(Vec::new()),
-        )]));
+        let request = AggregationJobContinueReq::new(
+            AggregationJobRound::from(1),
+            Vec::from([PrepareStep::new(
+                *report_metadata.id(),
+                PrepareStepResult::Continued(Vec::new()),
+            )]),
+        );
 
         let filter =
             aggregator_filter(datastore.clone(), clock, default_aggregator_config()).unwrap();
@@ -6261,6 +6215,7 @@ mod tests {
                 Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                     .unwrap(),
                 AggregationJobState::Finished,
+                AggregationJobRound::from(1),
             ))
         );
         assert_eq!(
@@ -6325,6 +6280,7 @@ mod tests {
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,
+                        AggregationJobRound::from(0),
                     ))
                     .await?;
                     tx.put_report_aggregation(&ReportAggregation::<
@@ -6348,12 +6304,15 @@ mod tests {
             .unwrap();
 
         // Make request.
-        let request = AggregationJobContinueReq::new(Vec::from([PrepareStep::new(
-            ReportId::from(
-                [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1], // not the same as above
-            ),
-            PrepareStepResult::Continued(Vec::new()),
-        )]));
+        let request = AggregationJobContinueReq::new(
+            AggregationJobRound::from(1),
+            Vec::from([PrepareStep::new(
+                ReportId::from(
+                    [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1], // not the same as above
+                ),
+                PrepareStepResult::Continued(Vec::new()),
+            )]),
+        );
 
         let filter =
             aggregator_filter(Arc::new(datastore), clock, default_aggregator_config()).unwrap();
@@ -6443,6 +6402,7 @@ mod tests {
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,
+                        AggregationJobRound::from(0),
                     ))
                     .await?;
 
@@ -6482,17 +6442,20 @@ mod tests {
             .unwrap();
 
         // Make request.
-        let request = AggregationJobContinueReq::new(Vec::from([
-            // Report IDs are in opposite order to what was stored in the datastore.
-            PrepareStep::new(
-                *report_metadata_1.id(),
-                PrepareStepResult::Continued(Vec::new()),
-            ),
-            PrepareStep::new(
-                *report_metadata_0.id(),
-                PrepareStepResult::Continued(Vec::new()),
-            ),
-        ]));
+        let request = AggregationJobContinueReq::new(
+            AggregationJobRound::from(1),
+            Vec::from([
+                // Report IDs are in opposite order to what was stored in the datastore.
+                PrepareStep::new(
+                    *report_metadata_1.id(),
+                    PrepareStepResult::Continued(Vec::new()),
+                ),
+                PrepareStep::new(
+                    *report_metadata_0.id(),
+                    PrepareStepResult::Continued(Vec::new()),
+                ),
+            ]),
+        );
 
         let filter =
             aggregator_filter(Arc::new(datastore), clock, default_aggregator_config()).unwrap();
@@ -6558,6 +6521,7 @@ mod tests {
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,
+                        AggregationJobRound::from(0),
                     ))
                     .await?;
                     tx.put_report_aggregation(&ReportAggregation::<
@@ -6578,10 +6542,13 @@ mod tests {
             .unwrap();
 
         // Make request.
-        let request = AggregationJobContinueReq::new(Vec::from([PrepareStep::new(
-            ReportId::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
-            PrepareStepResult::Continued(Vec::new()),
-        )]));
+        let request = AggregationJobContinueReq::new(
+            AggregationJobRound::from(1),
+            Vec::from([PrepareStep::new(
+                ReportId::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+                PrepareStepResult::Continued(Vec::new()),
+            )]),
+        );
 
         let filter =
             aggregator_filter(Arc::new(datastore), clock, default_aggregator_config()).unwrap();
@@ -6989,6 +6956,7 @@ mod tests {
                                 (),
                                 spanned_interval,
                                 AggregationJobState::Finished,
+                                AggregationJobRound::from(1),
                             ),
                         )
                         .await

--- a/aggregator/src/aggregator/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/aggregation_job_continue.rs
@@ -1,5 +1,275 @@
 //! Implements portions of aggregation job continuation for the helper.
 
+use crate::aggregator::{accumulator::Accumulator, Error, VdafOps};
+use janus_aggregator_core::{
+    datastore::{
+        self,
+        models::{
+            AggregationJob, AggregationJobState, PrepareMessageOrShare, ReportAggregation,
+            ReportAggregationState,
+        },
+        Transaction,
+    },
+    query_type::AccumulableQueryType,
+    task::Task,
+};
+use janus_core::time::Clock;
+use janus_messages::{
+    AggregationJobContinueReq, AggregationJobResp, PrepareStep, PrepareStepResult, ReportShareError,
+};
+use opentelemetry::{metrics::Counter, Context, KeyValue};
+use prio::{
+    codec::{Encode, ParameterizedDecode},
+    vdaf::{self, PrepareTransition},
+};
+use std::{io::Cursor, sync::Arc};
+use tracing::info;
+
+impl VdafOps {
+    /// Step the helper's aggregation job to the next round of VDAF preparation using the round `n`
+    /// prepare state in `report_aggregations` with the round `n+1` broadcast prepare messages in
+    /// `leader_aggregation_job`.
+    pub(super) async fn step_aggregation_job<const L: usize, C, Q, A>(
+        tx: &Transaction<'_, C>,
+        task: &Arc<Task>,
+        vdaf: &Arc<A>,
+        batch_aggregation_shard_count: u64,
+        helper_aggregation_job: AggregationJob<L, Q, A>,
+        report_aggregations: Vec<ReportAggregation<L, A>>,
+        leader_aggregation_job: &Arc<AggregationJobContinueReq>,
+        aggregate_step_failure_counter: &Counter<u64>,
+    ) -> Result<AggregationJobResp, datastore::Error>
+    where
+        C: Clock,
+        Q: AccumulableQueryType,
+        A: vdaf::Aggregator<L, 16> + 'static + Send + Sync,
+        for<'a> A::PrepareState: Send + Sync + Encode + ParameterizedDecode<(&'a A, usize)>,
+    {
+        // Handle each transition in the request.
+        let mut report_aggregations = report_aggregations.into_iter();
+        let (mut saw_continue, mut saw_finish) = (false, false);
+        let mut response_prep_steps = Vec::new();
+        let mut accumulator = Accumulator::<L, Q, A>::new(
+            Arc::clone(task),
+            batch_aggregation_shard_count,
+            helper_aggregation_job.aggregation_parameter().clone(),
+        );
+
+        for prep_step in leader_aggregation_job.prepare_steps() {
+            // Match preparation step received from leader to stored report aggregation, and extract
+            // the stored preparation step.
+            let report_aggregation = loop {
+                let report_agg = report_aggregations.next().ok_or_else(|| {
+                    datastore::Error::User(
+                        Error::UnrecognizedMessage(
+                            Some(*task.id()),
+                            "leader sent unexpected, duplicate, or out-of-order prepare steps",
+                        )
+                        .into(),
+                    )
+                })?;
+                if report_agg.report_id() != prep_step.report_id() {
+                    // This report was omitted by the leader because of a prior failure. Note that
+                    // the report was dropped (if it's not already in an error state) and continue.
+                    if matches!(report_agg.state(), ReportAggregationState::Waiting(_, _)) {
+                        tx.update_report_aggregation(&report_agg.with_state(
+                            ReportAggregationState::Failed(ReportShareError::ReportDropped),
+                        ))
+                        .await?;
+                    }
+                    continue;
+                }
+                break report_agg;
+            };
+
+            // Make sure this report isn't in an interval that has already started collection.
+            let conflicting_aggregate_share_jobs = tx
+                .get_aggregate_share_jobs_including_time::<L, A>(
+                    vdaf,
+                    task.id(),
+                    report_aggregation.time(),
+                )
+                .await?;
+            if !conflicting_aggregate_share_jobs.is_empty() {
+                response_prep_steps.push(PrepareStep::new(
+                    *prep_step.report_id(),
+                    PrepareStepResult::Failed(ReportShareError::BatchCollected),
+                ));
+                tx.update_report_aggregation(&report_aggregation.with_state(
+                    ReportAggregationState::Failed(ReportShareError::BatchCollected),
+                ))
+                .await?;
+                continue;
+            }
+
+            let prep_state = match report_aggregation.state() {
+                ReportAggregationState::Waiting(prep_state, _) => prep_state,
+                _ => {
+                    return Err(datastore::Error::User(
+                        Error::UnrecognizedMessage(
+                            Some(*task.id()),
+                            "leader sent prepare step for non-WAITING report aggregation",
+                        )
+                        .into(),
+                    ));
+                }
+            };
+
+            // Parse preparation message out of prepare step received from leader.
+            let prep_msg = match prep_step.result() {
+                PrepareStepResult::Continued(payload) => A::PrepareMessage::decode_with_param(
+                    prep_state,
+                    &mut Cursor::new(payload.as_ref()),
+                )?,
+                _ => {
+                    return Err(datastore::Error::User(
+                        Error::UnrecognizedMessage(
+                            Some(*task.id()),
+                            "leader sent non-Continued prepare step",
+                        )
+                        .into(),
+                    ));
+                }
+            };
+
+            // Compute the next transition, prepare to respond & update DB.
+            let next_state = match vdaf.prepare_step(prep_state.clone(), prep_msg) {
+                Ok(PrepareTransition::Continue(prep_state, prep_share)) => {
+                    saw_continue = true;
+                    response_prep_steps.push(PrepareStep::new(
+                        *prep_step.report_id(),
+                        PrepareStepResult::Continued(prep_share.get_encoded()),
+                    ));
+                    ReportAggregationState::Waiting(
+                        prep_state,
+                        PrepareMessageOrShare::Helper(prep_share),
+                    )
+                }
+
+                Ok(PrepareTransition::Finish(output_share)) => {
+                    saw_finish = true;
+                    accumulator.update(
+                        helper_aggregation_job.partial_batch_identifier(),
+                        prep_step.report_id(),
+                        report_aggregation.time(),
+                        &output_share,
+                    )?;
+                    response_prep_steps.push(PrepareStep::new(
+                        *prep_step.report_id(),
+                        PrepareStepResult::Finished,
+                    ));
+                    ReportAggregationState::Finished(output_share)
+                }
+
+                Err(error) => {
+                    info!(
+                        task_id = %task.id(),
+                        job_id = %helper_aggregation_job.id(),
+                        report_id = %prep_step.report_id(),
+                        ?error, "Prepare step failed",
+                    );
+                    aggregate_step_failure_counter.add(
+                        &Context::current(),
+                        1,
+                        &[KeyValue::new("type", "prepare_step_failure")],
+                    );
+                    response_prep_steps.push(PrepareStep::new(
+                        *prep_step.report_id(),
+                        PrepareStepResult::Failed(ReportShareError::VdafPrepError),
+                    ));
+                    ReportAggregationState::Failed(ReportShareError::VdafPrepError)
+                }
+            };
+
+            tx.update_report_aggregation(&report_aggregation.with_state(next_state))
+                .await?;
+        }
+
+        for report_agg in report_aggregations {
+            // This report was omitted by the leader because of a prior failure. Note that the
+            // report was dropped (if it's not already in an error state) and continue.
+            if matches!(report_agg.state(), ReportAggregationState::Waiting(_, _)) {
+                tx.update_report_aggregation(&report_agg.with_state(
+                    ReportAggregationState::Failed(ReportShareError::ReportDropped),
+                ))
+                .await?;
+            }
+        }
+
+        let helper_aggregation_job = helper_aggregation_job
+            // Advance the job to the leader's round
+            .with_round(leader_aggregation_job.round())
+            .with_state(match (saw_continue, saw_finish) {
+                (false, false) => AggregationJobState::Finished, // everything failed, or there were no reports
+                (true, false) => AggregationJobState::InProgress,
+                (false, true) => AggregationJobState::Finished,
+                (true, true) => {
+                    return Err(datastore::Error::User(
+                        Error::Internal(
+                            "VDAF took an inconsistent number of rounds to reach Finish state"
+                                .to_string(),
+                        )
+                        .into(),
+                    ))
+                }
+            });
+        tx.update_aggregation_job(&helper_aggregation_job).await?;
+
+        accumulator.flush_to_datastore(tx, vdaf).await?;
+
+        Ok(AggregationJobResp::new(response_prep_steps))
+    }
+
+    /// Fetch previously-computed prepare message shares and replay them back to the leader.
+    pub(super) fn replay_aggregation_job_round<C, const L: usize, Q, A>(
+        report_aggregations: Vec<ReportAggregation<L, A>>,
+    ) -> Result<AggregationJobResp, datastore::Error>
+    where
+        C: Clock,
+        Q: AccumulableQueryType,
+        A: vdaf::Aggregator<L, 16> + 'static + Send + Sync,
+        for<'a> A::PrepareState: Send + Sync + Encode + ParameterizedDecode<(&'a A, usize)>,
+    {
+        // DAP suggests that when detecting a replayed aggregation job continuation request, helper
+        // implementations should verify that the current leader request matches whatever request we
+        // previously serviced (i.e., that they contain the same report IDs and the same prepare
+        // messages). The idea is to stop the leader from rewinding VDAF preparation and re-running
+        // it with different parameters. However, we have already committed to the previous request
+        // by updating the relevant report_aggregations rows. If the leader did vary the request
+        // contents, the response we generate here will still be based on the previous request.
+        let response_prep_steps = report_aggregations
+            .iter()
+            .map(|report_aggregation| {
+                let prepare_step_state = match report_aggregation.state() {
+                    ReportAggregationState::Waiting(_, prep_msg) => PrepareStepResult::Continued(
+                        prep_msg.get_helper_prepare_share()?.get_encoded(),
+                    ),
+                    ReportAggregationState::Finished(_) => PrepareStepResult::Finished,
+                    ReportAggregationState::Failed(report_share_error) => {
+                        PrepareStepResult::Failed(*report_share_error)
+                    }
+                    state => {
+                        return Err(datastore::Error::User(
+                            Error::Internal(format!(
+                                "report aggregation {} unexpectedly in state {state:?}",
+                                report_aggregation.report_id()
+                            ))
+                            .into(),
+                        ));
+                    }
+                };
+
+                Ok(PrepareStep::new(
+                    *report_aggregation.report_id(),
+                    prepare_step_state,
+                ))
+            })
+            .collect::<Result<_, _>>()?;
+
+        Ok(AggregationJobResp::new(response_prep_steps))
+    }
+}
+
 #[cfg(feature = "test-util")]
 #[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
 pub mod test_util {
@@ -74,5 +344,320 @@ pub mod test_util {
                 "taskid": format!("{}", task.id()),
             })
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::aggregator::{
+        aggregate_init_tests::ReportShareGenerator,
+        aggregation_job_continue::test_util::{
+            post_aggregation_job_and_decode, post_aggregation_job_expecting_error,
+        },
+        aggregator_filter,
+        tests::default_aggregator_config,
+    };
+    use http::StatusCode;
+    use janus_aggregator_core::{
+        datastore::{
+            models::{
+                AggregationJob, AggregationJobState, PrepareMessageOrShare, ReportAggregation,
+                ReportAggregationState,
+            },
+            test_util::{ephemeral_datastore, EphemeralDatastore},
+            Datastore,
+        },
+        task::{test_util::TaskBuilder, QueryType, Task},
+    };
+    use janus_core::{
+        task::VdafInstance,
+        test_util::{dummy_vdaf, install_test_trace_subscriber},
+        time::{IntervalExt, MockClock},
+    };
+    use janus_messages::{
+        query_type::TimeInterval, AggregationJobContinueReq, AggregationJobId, AggregationJobResp,
+        AggregationJobRound, Interval, PrepareStep, PrepareStepResult, Role,
+    };
+    use prio::codec::Encode;
+    use rand::random;
+    use std::sync::Arc;
+    use warp::{filters::BoxedFilter, Reply};
+
+    struct AggregationJobContinueTestCase<R> {
+        task: Task,
+        datastore: Arc<Datastore<MockClock>>,
+        report_generator: ReportShareGenerator,
+        aggregation_job_id: AggregationJobId,
+        first_continue_request: AggregationJobContinueReq,
+        first_continue_response: AggregationJobResp,
+        filter: BoxedFilter<(R,)>,
+        _ephemeral_datastore: EphemeralDatastore,
+    }
+
+    /// Set up a helper with an aggregation job in round 1
+    #[allow(clippy::unit_arg)]
+    async fn setup_aggregation_job_continue_round_recovery_test(
+    ) -> AggregationJobContinueTestCase<impl Reply + 'static> {
+        // Prepare datastore & request.
+        install_test_trace_subscriber();
+
+        let aggregation_job_id = random();
+        let task =
+            TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Helper).build();
+        let clock = MockClock::default();
+        let ephemeral_datastore = ephemeral_datastore().await;
+        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()));
+
+        let report_generator = ReportShareGenerator::new(
+            clock.clone(),
+            task.clone(),
+            dummy_vdaf::AggregationParam::default(),
+        );
+
+        let report = report_generator.next();
+
+        datastore
+            .run_tx(|tx| {
+                let (task, report) = (task.clone(), report.clone());
+
+                Box::pin(async move {
+                    tx.put_task(&task).await.unwrap();
+                    tx.put_report_share(task.id(), &report.0).await.unwrap();
+
+                    tx.put_aggregation_job(
+                        &AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
+                            *task.id(),
+                            aggregation_job_id,
+                            dummy_vdaf::AggregationParam::default(),
+                            (),
+                            Interval::from_time(report.0.metadata().time()).unwrap(),
+                            AggregationJobState::InProgress,
+                            AggregationJobRound::from(0),
+                        ),
+                    )
+                    .await
+                    .unwrap();
+
+                    let (prep_state, prep_share) = report.1.helper_prep_state(0);
+                    tx.put_report_aggregation::<0, dummy_vdaf::Vdaf>(&ReportAggregation::new(
+                        *task.id(),
+                        aggregation_job_id,
+                        *report.0.metadata().id(),
+                        *report.0.metadata().time(),
+                        0,
+                        ReportAggregationState::Waiting(
+                            *prep_state,
+                            PrepareMessageOrShare::Helper(*prep_share),
+                        ),
+                    ))
+                    .await
+                    .unwrap();
+
+                    Ok(())
+                })
+            })
+            .await
+            .unwrap();
+
+        let first_continue_request = AggregationJobContinueReq::new(
+            AggregationJobRound::from(1),
+            Vec::from([PrepareStep::new(
+                *report.0.metadata().id(),
+                PrepareStepResult::Continued(report.1.prepare_messages[0].get_encoded()),
+            )]),
+        );
+
+        // Create aggregator filter, send request, and parse response.
+        let filter =
+            aggregator_filter(datastore.clone(), clock, default_aggregator_config()).unwrap();
+
+        let first_continue_response = post_aggregation_job_and_decode(
+            &task,
+            &aggregation_job_id,
+            &first_continue_request,
+            &filter,
+        )
+        .await;
+
+        // Validate response.
+        assert_eq!(
+            first_continue_response,
+            AggregationJobResp::new(Vec::from([PrepareStep::new(
+                *report.0.metadata().id(),
+                PrepareStepResult::Finished,
+            ),]))
+        );
+
+        AggregationJobContinueTestCase {
+            task,
+            datastore,
+            report_generator,
+            aggregation_job_id,
+            first_continue_request,
+            first_continue_response,
+            filter,
+            _ephemeral_datastore: ephemeral_datastore,
+        }
+    }
+
+    #[tokio::test]
+    async fn aggregation_job_continue_round_recovery_replay_request() {
+        let test_case = setup_aggregation_job_continue_round_recovery_test().await;
+
+        // Re-send the request, simulating the leader crashing and losing the helper's response. The
+        // helper should send back the exact same response.
+        let second_continue_resp = post_aggregation_job_and_decode(
+            &test_case.task,
+            &test_case.aggregation_job_id,
+            &test_case.first_continue_request,
+            &test_case.filter,
+        )
+        .await;
+        assert_eq!(test_case.first_continue_response, second_continue_resp);
+    }
+
+    #[tokio::test]
+    #[allow(clippy::unit_arg)]
+    async fn aggregation_job_continue_round_recovery_mutate_continue_request() {
+        let test_case = setup_aggregation_job_continue_round_recovery_test().await;
+
+        let unrelated_report = test_case.report_generator.next();
+
+        let (before_aggregation_job, before_report_aggregations) = test_case
+            .datastore
+            .run_tx(|tx| {
+                let (task_id, unrelated_report, aggregation_job_id) = (
+                    *test_case.task.id(),
+                    unrelated_report.clone(),
+                    test_case.aggregation_job_id,
+                );
+                Box::pin(async move {
+                    tx.put_report_share(&task_id, &unrelated_report.0)
+                        .await
+                        .unwrap();
+
+                    let aggregation_job = tx
+                        .get_aggregation_job::<0, TimeInterval, dummy_vdaf::Vdaf>(
+                            &task_id,
+                            &aggregation_job_id,
+                        )
+                        .await
+                        .unwrap();
+
+                    let report_aggregations = tx
+                        .get_report_aggregations_for_aggregation_job::<0, dummy_vdaf::Vdaf>(
+                            &dummy_vdaf::Vdaf::new(),
+                            &Role::Helper,
+                            &task_id,
+                            &aggregation_job_id,
+                        )
+                        .await
+                        .unwrap();
+
+                    Ok((aggregation_job, report_aggregations))
+                })
+            })
+            .await
+            .unwrap();
+
+        // Send another continue request for the same aggregation job, but with a different report
+        // ID.
+        let modified_request = AggregationJobContinueReq::new(
+            test_case.first_continue_request.round(),
+            Vec::from([PrepareStep::new(
+                *unrelated_report.0.metadata().id(),
+                PrepareStepResult::Continued(unrelated_report.1.prepare_messages[0].get_encoded()),
+            )]),
+        );
+
+        let second_response = post_aggregation_job_and_decode(
+            &test_case.task,
+            &test_case.aggregation_job_id,
+            &modified_request,
+            &test_case.filter,
+        )
+        .await;
+
+        // Despite mutating the request, we should get the same response as the first time.
+        assert_eq!(test_case.first_continue_response, second_response);
+
+        // Make sure the state of the aggregation job and report aggregations has not changed
+        let (after_aggregation_job, after_report_aggregations) = test_case
+            .datastore
+            .run_tx(|tx| {
+                let (task_id, aggregation_job_id) =
+                    (*test_case.task.id(), test_case.aggregation_job_id);
+                Box::pin(async move {
+                    let aggregation_job = tx
+                        .get_aggregation_job::<0, TimeInterval, dummy_vdaf::Vdaf>(
+                            &task_id,
+                            &aggregation_job_id,
+                        )
+                        .await
+                        .unwrap();
+
+                    let report_aggregations = tx
+                        .get_report_aggregations_for_aggregation_job::<0, dummy_vdaf::Vdaf>(
+                            &dummy_vdaf::Vdaf::new(),
+                            &Role::Helper,
+                            &task_id,
+                            &aggregation_job_id,
+                        )
+                        .await
+                        .unwrap();
+
+                    Ok((aggregation_job, report_aggregations))
+                })
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(before_aggregation_job, after_aggregation_job);
+        assert_eq!(before_report_aggregations, after_report_aggregations);
+    }
+
+    #[tokio::test]
+    async fn aggregation_job_continue_round_recovery_past_round() {
+        let test_case = setup_aggregation_job_continue_round_recovery_test().await;
+
+        // Send another request for a round that the helper is past. Should fail.
+        let past_round_request = AggregationJobContinueReq::new(
+            AggregationJobRound::from(0),
+            test_case.first_continue_request.prepare_steps().to_vec(),
+        );
+
+        post_aggregation_job_expecting_error(
+            &test_case.task,
+            &test_case.aggregation_job_id,
+            &past_round_request,
+            &test_case.filter,
+            StatusCode::BAD_REQUEST,
+            "urn:ietf:params:ppm:dap:error:roundMismatch",
+            "The leader and helper are not on the same round of VDAF preparation.",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn aggregation_job_continue_round_recovery_future_round() {
+        let test_case = setup_aggregation_job_continue_round_recovery_test().await;
+
+        // Send another request for a round too far past the helper's round. Should fail because the
+        // helper isn't on that round.
+        let future_round_request = AggregationJobContinueReq::new(
+            AggregationJobRound::from(17),
+            test_case.first_continue_request.prepare_steps().to_vec(),
+        );
+
+        post_aggregation_job_expecting_error(
+            &test_case.task,
+            &test_case.aggregation_job_id,
+            &future_round_request,
+            &test_case.filter,
+            StatusCode::BAD_REQUEST,
+            "urn:ietf:params:ppm:dap:error:roundMismatch",
+            "The leader and helper are not on the same round of VDAF preparation.",
+        )
+        .await;
     }
 }

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -27,7 +27,7 @@ use opentelemetry::{
 };
 use prio::{
     codec::{Decode, Encode},
-    vdaf::{self},
+    vdaf,
 };
 use reqwest::Method;
 use std::{sync::Arc, time::Duration};
@@ -483,8 +483,8 @@ mod tests {
         Runtime,
     };
     use janus_messages::{
-        query_type::TimeInterval, AggregateShare, AggregateShareReq, BatchSelector, Duration,
-        HpkeCiphertext, HpkeConfigId, Interval, ReportIdChecksum, Role,
+        query_type::TimeInterval, AggregateShare, AggregateShareReq, AggregationJobRound,
+        BatchSelector, Duration, HpkeCiphertext, HpkeConfigId, Interval, ReportIdChecksum, Role,
     };
     use opentelemetry::global::meter;
     use prio::codec::{Decode, Encode};
@@ -545,6 +545,7 @@ mod tests {
                             (),
                             Interval::from_time(&report_timestamp).unwrap(),
                             AggregationJobState::Finished,
+                            AggregationJobRound::from(1),
                         ),
                     )
                     .await?;
@@ -672,6 +673,7 @@ mod tests {
                             (),
                             Interval::from_time(&report_timestamp).unwrap(),
                             AggregationJobState::Finished,
+                            AggregationJobRound::from(1),
                         ),
                     )
                     .await?;

--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -23,8 +23,8 @@ use janus_core::{
 };
 use janus_messages::{
     query_type::{FixedSize, QueryType as QueryTypeTrait, TimeInterval},
-    AggregateShareAad, BatchId, BatchSelector, Collection, CollectionJobId, CollectionReq,
-    Duration, FixedSizeQuery, Interval, Query, ReportIdChecksum, Role, Time,
+    AggregateShareAad, AggregationJobRound, BatchId, BatchSelector, Collection, CollectionJobId,
+    CollectionReq, Duration, FixedSizeQuery, Interval, Query, ReportIdChecksum, Role, Time,
 };
 use prio::codec::{Decode, Encode};
 use rand::random;
@@ -183,6 +183,7 @@ async fn setup_fixed_size_current_batch_collection_job_test_case() -> (
                         batch_id,
                         interval,
                         AggregationJobState::Finished,
+                        AggregationJobRound::from(1),
                     ))
                     .await
                     .unwrap();

--- a/aggregator/src/aggregator/garbage_collector.rs
+++ b/aggregator/src/aggregator/garbage_collector.rs
@@ -101,7 +101,8 @@ mod tests {
     };
     use janus_messages::{
         query_type::{FixedSize, TimeInterval},
-        Duration, HpkeCiphertext, HpkeConfigId, Interval, ReportMetadata, ReportShare, Role,
+        AggregationJobRound, Duration, HpkeCiphertext, HpkeConfigId, Interval, ReportMetadata,
+        ReportShare, Role,
     };
     use rand::random;
     use std::sync::Arc;
@@ -148,6 +149,7 @@ mod tests {
                         (),
                         batch_identifier,
                         AggregationJobState::InProgress,
+                        AggregationJobRound::from(0),
                     );
                     tx.put_aggregation_job(&aggregation_job).await.unwrap();
 
@@ -308,6 +310,7 @@ mod tests {
                         (),
                         batch_identifier,
                         AggregationJobState::InProgress,
+                        AggregationJobRound::from(0),
                     );
                     tx.put_aggregation_job(&aggregation_job).await.unwrap();
 
@@ -464,6 +467,7 @@ mod tests {
                         batch_identifier,
                         Interval::new(client_timestamp, Duration::from_seconds(1)).unwrap(),
                         AggregationJobState::InProgress,
+                        AggregationJobRound::from(0),
                     );
                     tx.put_aggregation_job(&aggregation_job).await.unwrap();
 
@@ -628,6 +632,7 @@ mod tests {
                         batch_identifier,
                         Interval::new(client_timestamp, Duration::from_seconds(1)).unwrap(),
                         AggregationJobState::InProgress,
+                        AggregationJobRound::from(0),
                     );
                     tx.put_aggregation_job(&aggregation_job).await.unwrap();
 

--- a/core/src/test_util/mod.rs
+++ b/core/src/test_util/mod.rs
@@ -31,10 +31,7 @@ pub struct VdafTranscript<const L: usize, V: vdaf::Aggregator<L, 16>> {
     pub aggregate_shares: Vec<V::AggregateShare>,
 }
 
-impl<const L: usize, V> VdafTranscript<L, V>
-where
-    V: vdaf::Aggregator<L, 16>,
-{
+impl<const L: usize, V: vdaf::Aggregator<L, 16>> VdafTranscript<L, V> {
     /// Get the leader's preparation state at the requested round.
     pub fn leader_prep_state(&self, round: usize) -> &V::PrepareState {
         assert_matches!(

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -105,6 +105,7 @@ CREATE TABLE aggregation_jobs(
     batch_id                  BYTEA NOT NULL,                  -- batch ID (fixed-size only; corresponds to identifier in BatchSelector)
     client_timestamp_interval TSRANGE NOT NULL,                -- the minimal interval containing all of client timestamps included in this aggregation job
     state                     AGGREGATION_JOB_STATE NOT NULL,  -- current state of the aggregation job
+    round                     INTEGER NOT NULL,                -- current round of the VDAF preparation protocol
 
     lease_expiry             TIMESTAMP NOT NULL DEFAULT TIMESTAMP '-infinity',  -- when lease on this aggregation job expires; -infinity implies no current lease
     lease_token              BYTEA,                                             -- a value identifying the current leaseholder; NULL implies no current lease

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -2078,7 +2078,7 @@ impl<Q: QueryType> Decode for AggregationJobInitializeReq<Q> {
     }
 }
 
-/// DAP protocol message representing the round of an aggregation job.
+/// Type representing the round of an aggregation job.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct AggregationJobRound(u16);
 

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -20,6 +20,7 @@ use serde::{
 use std::{
     fmt::{self, Debug, Display, Formatter},
     io::{Cursor, Read},
+    num::TryFromIntError,
     str::FromStr,
 };
 
@@ -2077,9 +2078,63 @@ impl<Q: QueryType> Decode for AggregationJobInitializeReq<Q> {
     }
 }
 
+/// DAP protocol message representing the round of an aggregation job.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct AggregationJobRound(u16);
+
+impl AggregationJobRound {
+    /// Construct a new [`AggregationJobRound`] representing the round after this one.
+    pub fn increment(&self) -> Self {
+        Self(self.0 + 1)
+    }
+}
+
+impl Display for AggregationJobRound {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Encode for AggregationJobRound {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        self.0.encode(bytes)
+    }
+}
+
+impl Decode for AggregationJobRound {
+    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        Ok(Self(u16::decode(bytes)?))
+    }
+}
+
+impl From<u16> for AggregationJobRound {
+    fn from(value: u16) -> Self {
+        Self(value)
+    }
+}
+
+impl From<AggregationJobRound> for u16 {
+    fn from(value: AggregationJobRound) -> Self {
+        value.0
+    }
+}
+
+impl TryFrom<i32> for AggregationJobRound {
+    // This implementation is convenient for converting from the representation of a round in
+    // PostgreSQL, where the smallest type that can store a u16 is `integer`, which is represented
+    // as i32 in Rust.
+
+    type Error = TryFromIntError;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        Ok(AggregationJobRound(u16::try_from(value)?))
+    }
+}
+
 /// DAP protocol message representing a request to continue an aggregation job.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AggregationJobContinueReq {
+    round: AggregationJobRound,
     prepare_steps: Vec<PrepareStep>,
 }
 
@@ -2088,8 +2143,16 @@ impl AggregationJobContinueReq {
     pub const MEDIA_TYPE: &'static str = "application/dap-aggregation-job-continue-req";
 
     /// Constructs a new aggregate continuation response from its components.
-    pub fn new(prepare_steps: Vec<PrepareStep>) -> Self {
-        Self { prepare_steps }
+    pub fn new(round: AggregationJobRound, prepare_steps: Vec<PrepareStep>) -> Self {
+        Self {
+            round,
+            prepare_steps,
+        }
+    }
+
+    /// Gets the round of VDAF preparation this aggregation job is on.
+    pub fn round(&self) -> AggregationJobRound {
+        self.round
     }
 
     /// Gets the prepare steps associated with this aggregate continuation response.
@@ -2100,14 +2163,16 @@ impl AggregationJobContinueReq {
 
 impl Encode for AggregationJobContinueReq {
     fn encode(&self, bytes: &mut Vec<u8>) {
+        self.round.encode(bytes);
         encode_u32_items(bytes, &(), &self.prepare_steps);
     }
 }
 
 impl Decode for AggregationJobContinueReq {
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        let round = AggregationJobRound::decode(bytes)?;
         let prepare_steps = decode_u32_items(&(), bytes)?;
-        Ok(Self { prepare_steps })
+        Ok(Self::new(round, prepare_steps))
     }
 }
 
@@ -2333,12 +2398,13 @@ impl Decode for AggregateShare {
 mod tests {
     use crate::{
         query_type, AggregateShare, AggregateShareAad, AggregateShareReq,
-        AggregationJobInitializeReq, AggregationJobResp, BatchId, BatchSelector, Collection,
-        CollectionReq, Duration, Extension, ExtensionType, FixedSize, FixedSizeQuery, HpkeAeadId,
-        HpkeCiphertext, HpkeConfig, HpkeConfigId, HpkeKdfId, HpkeKemId, HpkePublicKey,
-        InputShareAad, Interval, PartialBatchSelector, PlaintextInputShare, PrepareStep,
-        PrepareStepResult, Query, Report, ReportId, ReportIdChecksum, ReportMetadata, ReportShare,
-        ReportShareError, Role, TaskId, Time, TimeInterval,
+        AggregationJobContinueReq, AggregationJobInitializeReq, AggregationJobResp,
+        AggregationJobRound, BatchId, BatchSelector, Collection, CollectionReq, Duration,
+        Extension, ExtensionType, FixedSize, FixedSizeQuery, HpkeAeadId, HpkeCiphertext,
+        HpkeConfig, HpkeConfigId, HpkeKdfId, HpkeKemId, HpkePublicKey, InputShareAad, Interval,
+        PartialBatchSelector, PlaintextInputShare, PrepareStep, PrepareStepResult, Query, Report,
+        ReportId, ReportIdChecksum, ReportMetadata, ReportShare, ReportShareError, Role, TaskId,
+        Time, TimeInterval,
     };
     use assert_matches::assert_matches;
     use prio::codec::{CodecError, Decode, Encode};
@@ -3609,6 +3675,49 @@ mod tests {
                             ),
                         ),
                     ),
+                ),
+            ),
+        )])
+    }
+
+    #[test]
+    fn roundtrip_aggregation_job_continue_req() {
+        roundtrip_encoding(&[(
+            AggregationJobContinueReq {
+                round: AggregationJobRound(42405),
+                prepare_steps: Vec::from([
+                    PrepareStep {
+                        report_id: ReportId::from([
+                            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+                        ]),
+                        result: PrepareStepResult::Continued(Vec::from("012345")),
+                    },
+                    PrepareStep {
+                        report_id: ReportId::from([
+                            16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1,
+                        ]),
+                        result: PrepareStepResult::Finished,
+                    },
+                ]),
+            },
+            concat!(
+                "A5A5", // round
+                concat!(
+                    // prepare_steps
+                    "0000002C", // length
+                    concat!(
+                        "0102030405060708090A0B0C0D0E0F10", // report_id
+                        "00",                               // prepare_step_result
+                        concat!(
+                            // payload
+                            "00000006",     // length
+                            "303132333435", // opaque data
+                        ),
+                    ),
+                    concat!(
+                        "100F0E0D0C0B0A090807060504030201", // report_id
+                        "01",                               // prepare_step_result
+                    )
                 ),
             ),
         )])

--- a/messages/src/problem_type.rs
+++ b/messages/src/problem_type.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 pub enum DapProblemType {
     UnrecognizedMessage,
     UnrecognizedTask,
+    RoundMismatch,
     MissingTaskId,
     UnrecognizedAggregationJob,
     OutdatedConfig,
@@ -26,6 +27,7 @@ impl DapProblemType {
                 "urn:ietf:params:ppm:dap:error:unrecognizedMessage"
             }
             DapProblemType::UnrecognizedTask => "urn:ietf:params:ppm:dap:error:unrecognizedTask",
+            DapProblemType::RoundMismatch => "urn:ietf:params:ppm:dap:error:roundMismatch",
             DapProblemType::MissingTaskId => "urn:ietf:params:ppm:dap:error:missingTaskID",
             DapProblemType::UnrecognizedAggregationJob => {
                 "urn:ietf:params:ppm:dap:error:unrecognizedAggregationJob"
@@ -54,6 +56,9 @@ impl DapProblemType {
             }
             DapProblemType::UnrecognizedTask => {
                 "An endpoint received a message with an unknown task ID."
+            }
+            DapProblemType::RoundMismatch => {
+                "The leader and helper are not on the same round of VDAF preparation."
             }
             DapProblemType::MissingTaskId => {
                 "HPKE configuration was requested without specifying a task ID."
@@ -101,6 +106,7 @@ impl FromStr for DapProblemType {
             "urn:ietf:params:ppm:dap:error:unrecognizedTask" => {
                 Ok(DapProblemType::UnrecognizedTask)
             }
+            "urn:ietf:params:ppm:dap:error:roundMismatch" => Ok(DapProblemType::RoundMismatch),
             "urn:ietf:params:ppm:dap:error:missingTaskID" => Ok(DapProblemType::MissingTaskId),
             "urn:ietf:params:ppm:dap:error:unrecognizedAggregationJob" => {
                 Ok(DapProblemType::UnrecognizedAggregationJob)


### PR DESCRIPTION
`VdafOps::handle_aggregate_continue_generic` now checks whether the incoming `AggregationJobContinueReq` is a replay of a previously seen message. If it is, then we fetch previously-computed prepare shares and serve them back to the leader (`VdafOps::replay_aggregation_job_round`). If not, then we advance to the next round based on the leader's prepare messages (`VdafOps::step_aggregation_job`).

These new methods (and tests for this behavior) are defined in `mod aggregation_job_continue` to avoid growing the already too large `aggregator/src/aggregator.rs`.

Resolves #994
