### PR TITLE
Bump `prio` to 0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2757,9 +2757,9 @@ dependencies = [
 
 [[package]]
 name = "prio"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4223a3572e19886b36122fe471b99a06684776cc8e827adefc6bb3890b29e9bf"
+checksum = "942b15465147a8f027aba46630d1f5fe2decb15ec6263a396eb763b269cac60a"
 dependencies = [
  "aes",
  "base64 0.21.0",
@@ -2963,9 +2963,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
 dependencies = [
  "either",
  "rayon-core",
@@ -2973,9 +2973,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.2"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ janus_interop_binaries = { version = "0.3", path = "interop_binaries" }
 janus_messages = { version = "0.3", path = "messages" }
 k8s-openapi = { version = "0.16.0", features = ["v1_24"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
 kube = { version = "0.75.0", default-features = false, features = ["client"] }
-prio = { version = "0.11.0", features = ["multithreaded"] }
+prio = { version = "0.11.1", features = ["multithreaded"] }
 
 [profile.dev]
 # Disabling debug info improves build speeds & reduces build artifact sizes, which helps CI caching.

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -20,7 +20,7 @@ hex = "0.4"
 num_enum = "0.5.11"
 # We can't pull prio in from the workspace because that would enable default features, and we do not
 # want prio/crypto-dependencies
-prio = { version = "0.11.0", default-features = false }
+prio = { version = "0.11.1", default-features = false }
 rand = "0.8"
 serde = { version = "1.0.153", features = ["derive"] }
 thiserror = "1.0"


### PR DESCRIPTION
Having `Clone` on `vdaf::PrepareTransition` will be useful for #994.