### PR TITLE
Test infra for aggregation job continuation

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/aggregation_job_continue.rs
@@ -1,0 +1,78 @@
+//! Implements portions of aggregation job continuation for the helper.
+
+#[cfg(feature = "test-util")]
+#[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
+pub mod test_util {
+    use http::{header::CONTENT_TYPE, StatusCode};
+    use hyper::body;
+    use janus_aggregator_core::task::Task;
+    use janus_messages::{AggregationJobContinueReq, AggregationJobId, AggregationJobResp};
+    use prio::codec::{Decode, Encode};
+    use serde_json::json;
+    use warp::{filters::BoxedFilter, reply::Response, Reply};
+
+    async fn post_aggregation_job(
+        task: &Task,
+        aggregation_job_id: &AggregationJobId,
+        request: &AggregationJobContinueReq,
+        filter: &BoxedFilter<(impl Reply + 'static,)>,
+    ) -> Response {
+        warp::test::request()
+            .method("POST")
+            .path(task.aggregation_job_uri(aggregation_job_id).unwrap().path())
+            .header(
+                "DAP-Auth-Token",
+                task.primary_aggregator_auth_token().as_bytes(),
+            )
+            .header(CONTENT_TYPE, AggregationJobContinueReq::MEDIA_TYPE)
+            .body(request.get_encoded())
+            .filter(filter)
+            .await
+            .unwrap()
+            .into_response()
+    }
+
+    pub async fn post_aggregation_job_and_decode(
+        task: &Task,
+        aggregation_job_id: &AggregationJobId,
+        request: &AggregationJobContinueReq,
+        filter: &BoxedFilter<(impl Reply + 'static,)>,
+    ) -> AggregationJobResp {
+        let mut response = post_aggregation_job(task, aggregation_job_id, request, filter).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(CONTENT_TYPE).unwrap(),
+            AggregationJobResp::MEDIA_TYPE
+        );
+        let body_bytes = body::to_bytes(response.body_mut()).await.unwrap();
+        AggregationJobResp::get_decoded(&body_bytes).unwrap()
+    }
+
+    pub async fn post_aggregation_job_expecting_error(
+        task: &Task,
+        aggregation_job_id: &AggregationJobId,
+        request: &AggregationJobContinueReq,
+        filter: &BoxedFilter<(impl Reply + 'static,)>,
+        want_status: StatusCode,
+        want_error_type: &str,
+        want_error_title: &str,
+    ) {
+        let (parts, body) = post_aggregation_job(task, aggregation_job_id, request, filter)
+            .await
+            .into_parts();
+
+        assert_eq!(want_status, parts.status);
+        let problem_details: serde_json::Value =
+            serde_json::from_slice(&body::to_bytes(body).await.unwrap()).unwrap();
+        assert_eq!(
+            problem_details,
+            json!({
+                "status": want_status.as_u16(),
+                "type": want_error_type,
+                "title": want_error_title,
+                "taskid": format!("{}", task.id()),
+            })
+        );
+    }
+}

--- a/core/src/test_util/mod.rs
+++ b/core/src/test_util/mod.rs
@@ -13,6 +13,7 @@ pub mod testcontainers;
 
 /// A transcript of a VDAF run. All fields are indexed by natural role index (i.e., index 0 =
 /// leader, index 1 = helper).
+#[derive(Clone, Debug)]
 pub struct VdafTranscript<const L: usize, V: vdaf::Aggregator<L, 16>> {
     /// The public share, from the sharding algorithm.
     pub public_share: V::PublicShare,


### PR DESCRIPTION
Adds a new module
`janus_aggregator::aggregator::aggregation_job_continue`. Currently, this module contains nothing but a further `test_util` module which defines some utility functions for testing aggregation job continuation. We refactor some tests in `aggregator/src/aggregator.rs` to use some items, shrinking that file by a couple hundred lines.

In the near future, `mod aggregation_job_continue` will define items needed for round skew recovery. The idea here is to avoid growing `aggregator/src/aggregator.rs`, which even after this change is over 8,000 lines. See #1086 for a glimpse of where this is going.

Part of #994