### PR TITLE
Wire up `Prio3SumVec`

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -29,7 +29,7 @@ use prio::{
     codec::Encode,
     vdaf::{
         self,
-        prio3::{Prio3Count, Prio3Histogram, Prio3Sum, Prio3SumVecMultithreaded},
+        prio3::{Prio3Count, Prio3Histogram, Prio3Sum, Prio3SumVec, Prio3SumVecMultithreaded},
     },
 };
 use rand::{random, thread_rng, Rng};
@@ -248,6 +248,11 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                     .await
             }
 
+            (task::QueryType::TimeInterval, VdafInstance::Prio3SumVec { .. }) => {
+                self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3SumVec>(task)
+                    .await
+            }
+
             (task::QueryType::TimeInterval, VdafInstance::Prio3Histogram { .. }) => {
                 self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Histogram>(task)
                     .await
@@ -289,6 +294,14 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                 let max_batch_size = *max_batch_size;
                 self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Sum>(task, max_batch_size)
                     .await
+            }
+
+            (task::QueryType::FixedSize { max_batch_size }, VdafInstance::Prio3SumVec { .. }) => {
+                let max_batch_size = *max_batch_size;
+                self.create_aggregation_jobs_for_fixed_size_task_no_param::<
+                    PRIO3_VERIFY_KEY_LENGTH,
+                    Prio3SumVec,
+                >(task, max_batch_size).await
             }
 
             (task::QueryType::FixedSize{max_batch_size}, VdafInstance::Prio3Histogram { .. }) => {

--- a/integration_tests/src/client.rs
+++ b/integration_tests/src/client.rs
@@ -9,7 +9,7 @@ use prio::{
     codec::Encode,
     vdaf::{
         self,
-        prio3::{Prio3Count, Prio3Histogram, Prio3Sum, Prio3SumVec},
+        prio3::{Prio3Count, Prio3Histogram, Prio3Sum, Prio3SumVecMultithreaded},
     },
 };
 use rand::random;
@@ -42,7 +42,7 @@ impl InteropClientEncoding for Prio3Histogram {
     }
 }
 
-impl InteropClientEncoding for Prio3SumVec {
+impl InteropClientEncoding for Prio3SumVecMultithreaded {
     fn json_encode_measurement(&self, measurement: &Self::Measurement) -> Value {
         Value::Array(
             measurement
@@ -65,6 +65,11 @@ fn json_encode_vdaf(vdaf: &VdafInstance) -> Value {
         VdafInstance::Prio3Sum { bits } => json!({
             "type": "Prio3Sum",
             "bits": format!("{bits}"),
+        }),
+        VdafInstance::Prio3SumVec { bits, length } => json!({
+            "type": "Prio3SumVec",
+            "bits": format!("{bits}"),
+            "length": format!("{length}"),
         }),
         VdafInstance::Prio3Histogram { buckets } => {
             let buckets = Value::Array(

--- a/integration_tests/tests/janus.rs
+++ b/integration_tests/tests/janus.rs
@@ -263,3 +263,28 @@ async fn janus_janus_fixed_size() {
     )
     .await;
 }
+
+// This test exercises Prio3SumVec with Janus as both the leader and the helper.
+#[tokio::test(flavor = "multi_thread")]
+async fn janus_janus_sum_vec() {
+    install_test_trace_subscriber();
+
+    let container_client = container_client();
+    let janus_pair = JanusPair::new(
+        &container_client,
+        VdafInstance::Prio3SumVec {
+            bits: 16,
+            length: 15,
+        },
+        QueryType::TimeInterval,
+    )
+    .await;
+
+    submit_measurements_and_verify_aggregate(
+        (janus_pair.leader.port(), janus_pair.helper.port()),
+        &janus_pair.leader_task,
+        &janus_pair.collector_private_key,
+        &ClientBackend::InProcess,
+    )
+    .await;
+}

--- a/interop_binaries/src/bin/janus_interop_client.rs
+++ b/interop_binaries/src/bin/janus_interop_client.rs
@@ -163,6 +163,13 @@ async fn handle_upload(
             handle_upload_generic(http_client, vdaf_client, request, measurement).await?;
         }
 
+        VdafInstance::Prio3SumVec { bits, length } => {
+            let measurement = parse_vector_measurement::<u128>(request.measurement.clone())?;
+            let vdaf_client = Prio3::new_sum_vec_multithreaded(2, bits, length)
+                .context("failed to construct Prio3SumVec VDAF")?;
+            handle_upload_generic(http_client, vdaf_client, request, measurement).await?;
+        }
+
         VdafInstance::Prio3Histogram { ref buckets } => {
             let measurement = parse_primitive_measurement::<u128>(request.measurement.clone())?;
             let vdaf_client = Prio3::new_histogram(2, buckets)

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -108,6 +108,10 @@ pub enum VdafObject {
     Prio3Sum {
         bits: NumberAsString<u32>,
     },
+    Prio3SumVec {
+        bits: NumberAsString<usize>,
+        length: NumberAsString<usize>,
+    },
     Prio3Histogram {
         buckets: Vec<NumberAsString<u64>>,
     },
@@ -136,6 +140,11 @@ impl From<VdafInstance> for VdafObject {
 
             VdafInstance::Prio3Sum { bits } => VdafObject::Prio3Sum {
                 bits: NumberAsString(bits),
+            },
+
+            VdafInstance::Prio3SumVec { bits, length } => VdafObject::Prio3SumVec {
+                bits: NumberAsString(bits),
+                length: NumberAsString(length),
             },
 
             VdafInstance::Prio3Histogram { buckets } => VdafObject::Prio3Histogram {
@@ -177,6 +186,11 @@ impl From<VdafObject> for VdafInstance {
             }
 
             VdafObject::Prio3Sum { bits } => VdafInstance::Prio3Sum { bits: bits.0 },
+
+            VdafObject::Prio3SumVec { bits, length } => VdafInstance::Prio3SumVec {
+                bits: bits.0,
+                length: length.0,
+            },
 
             VdafObject::Prio3Histogram { buckets } => VdafInstance::Prio3Histogram {
                 buckets: buckets.iter().map(|value| value.0).collect(),

--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -602,6 +602,25 @@ async fn e2e_prio3_sum() {
 }
 
 #[tokio::test]
+async fn e2e_prio3_sum_vec() {
+    let result = run(
+        QueryKind::TimeInterval,
+        json!({"type": "Prio3SumVec", "bits": "64", "length": "4"}),
+        &[
+            json!(["0", "0", "0", "10"]),
+            json!(["0", "0", "10", "0"]),
+            json!(["0", "10", "0", "0"]),
+            json!(["10", "0", "0", "0"]),
+        ],
+        b"",
+    )
+    .await;
+    for element in result.as_array().expect("SumVec result should be an array") {
+        assert!(element.is_string());
+    }
+}
+
+#[tokio::test]
 async fn e2e_prio3_histogram() {
     let result = run(
         QueryKind::TimeInterval,

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -59,6 +59,8 @@ enum VdafType {
     CountVec,
     /// Prio3Sum
     Sum,
+    /// Prio3SumVec
+    SumVec,
     /// Prio3Histogram
     Histogram,
     #[cfg(feature = "fpvec_bounded_l2")]

--- a/tools/tests/cmd/collect.trycmd
+++ b/tools/tests/cmd/collect.trycmd
@@ -39,6 +39,7 @@ VDAF Algorithm and Parameters:
           - count:     Prio3Count
           - countvec:  Prio3CountVec
           - sum:       Prio3Sum
+          - sumvec:    Prio3SumVec
           - histogram: Prio3Histogram
 
       --length <LENGTH>

--- a/tools/tests/cmd/collect_fpvec_bounded_l2.trycmd
+++ b/tools/tests/cmd/collect_fpvec_bounded_l2.trycmd
@@ -39,6 +39,7 @@ VDAF Algorithm and Parameters:
           - count:                          Prio3Count
           - countvec:                       Prio3CountVec
           - sum:                            Prio3Sum
+          - sumvec:                         Prio3SumVec
           - histogram:                      Prio3Histogram
           - fixedpoint16bitboundedl2vecsum: Prio3FixedPoint16BitBoundedL2VecSum
           - fixedpoint32bitboundedl2vecsum: Prio3FixedPoint32BitBoundedL2VecSum


### PR DESCRIPTION
Plumb `Prio3SumVec` throughout Janus so it can be used by clients.

Resolves #1039