### PR TITLE
Rename type parameters to SEED_SIZE

### DIFF
--- a/aggregator/src/aggregator/aggregate_share.rs
+++ b/aggregator/src/aggregator/aggregate_share.rs
@@ -12,12 +12,12 @@ use prio::vdaf::{self, Aggregatable};
 /// included batches.
 #[tracing::instrument(skip(task), fields(task_id = ?task.id()), err)]
 pub(crate) async fn compute_aggregate_share<
-    const L: usize,
+    const SEED_SIZE: usize,
     Q: QueryType,
-    A: vdaf::Aggregator<L, 16>,
+    A: vdaf::Aggregator<SEED_SIZE, 16>,
 >(
     task: &Task,
-    batch_aggregations: &[BatchAggregation<L, Q, A>],
+    batch_aggregations: &[BatchAggregation<SEED_SIZE, Q, A>],
 ) -> Result<(A::AggregateShare, u64, ReportIdChecksum), Error> {
     // At the moment we construct an aggregate share (either handling AggregateShareReq in the
     // helper or driving a collection job in the leader), there could be some incomplete aggregation

--- a/aggregator_core/src/lib.rs
+++ b/aggregator_core/src/lib.rs
@@ -27,7 +27,10 @@ impl AsRef<[u8]> for SecretBytes {
 /// A marker trait for VDAFs that have an aggregation parameter other than the unit type.
 pub trait VdafHasAggregationParameter {}
 
-impl<P, const L: usize> VdafHasAggregationParameter for prio::vdaf::poplar1::Poplar1<P, L> {}
+impl<P, const SEED_SIZE: usize> VdafHasAggregationParameter
+    for prio::vdaf::poplar1::Poplar1<P, SEED_SIZE>
+{
+}
 
 #[cfg(feature = "test-util")]
 impl VdafHasAggregationParameter for dummy_vdaf::Vdaf {}

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -50,23 +50,23 @@ pub enum QueryType {
 
 /// A verification key for a VDAF, with a fixed length. It must be kept secret from clients to
 /// maintain robustness, and it must be shared between aggregators.
-pub struct VerifyKey<const L: usize>([u8; L]);
+pub struct VerifyKey<const SEED_SIZE: usize>([u8; SEED_SIZE]);
 
-impl<const L: usize> VerifyKey<L> {
-    pub fn new(array: [u8; L]) -> VerifyKey<L> {
+impl<const SEED_SIZE: usize> VerifyKey<SEED_SIZE> {
+    pub fn new(array: [u8; SEED_SIZE]) -> VerifyKey<SEED_SIZE> {
         VerifyKey(array)
     }
 
-    pub fn as_bytes(&self) -> &[u8; L] {
+    pub fn as_bytes(&self) -> &[u8; SEED_SIZE] {
         &self.0
     }
 }
 
-impl<const L: usize> TryFrom<&SecretBytes> for VerifyKey<L> {
+impl<const SEED_SIZE: usize> TryFrom<&SecretBytes> for VerifyKey<SEED_SIZE> {
     type Error = TryFromSliceError;
 
-    fn try_from(value: &SecretBytes) -> Result<VerifyKey<L>, TryFromSliceError> {
-        let array = <[u8; L] as TryFrom<&[u8]>>::try_from(&value.0)?;
+    fn try_from(value: &SecretBytes) -> Result<VerifyKey<SEED_SIZE>, TryFromSliceError> {
+        let array = <[u8; SEED_SIZE] as TryFrom<&[u8]>>::try_from(&value.0)?;
         Ok(VerifyKey::new(array))
     }
 }
@@ -346,7 +346,9 @@ impl Task {
     ///
     /// If the verify key is not the correct length as required by the VDAF, an error will be
     /// returned.
-    pub fn primary_vdaf_verify_key<const L: usize>(&self) -> Result<VerifyKey<L>, Error> {
+    pub fn primary_vdaf_verify_key<const SEED_SIZE: usize>(
+        &self,
+    ) -> Result<VerifyKey<SEED_SIZE>, Error> {
         // We can safely unwrap this because we maintain an invariant that this vector is
         // non-empty.
         let secret_bytes = self.vdaf_verify_keys.first().unwrap();

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -719,8 +719,8 @@ mod tests {
         ))
     }
 
-    fn build_collect_response_time<const L: usize, V: vdaf::Aggregator<L, 16>>(
-        transcript: &VdafTranscript<L, V>,
+    fn build_collect_response_time<const SEED_SIZE: usize, V: vdaf::Aggregator<SEED_SIZE, 16>>(
+        transcript: &VdafTranscript<SEED_SIZE, V>,
         parameters: &CollectorParameters,
         batch_interval: Interval,
     ) -> CollectionMessage<TimeInterval> {
@@ -759,8 +759,8 @@ mod tests {
         )
     }
 
-    fn build_collect_response_fixed<const L: usize, V: vdaf::Aggregator<L, 16>>(
-        transcript: &VdafTranscript<L, V>,
+    fn build_collect_response_fixed<const SEED_SIZE: usize, V: vdaf::Aggregator<SEED_SIZE, 16>>(
+        transcript: &VdafTranscript<SEED_SIZE, V>,
         parameters: &CollectorParameters,
         batch_id: BatchId,
     ) -> CollectionMessage<FixedSize> {

--- a/core/src/task.rs
+++ b/core/src/task.rs
@@ -480,9 +480,9 @@ macro_rules! vdaf_dispatch_impl {
 ///
 /// ```
 /// # use janus_core::vdaf_dispatch;
-/// # fn handle_request_generic<A, const L: usize>(_vdaf: &A) -> Result<(), prio::vdaf::VdafError>
+/// # fn handle_request_generic<A, const SEED_SIZE: usize>(_vdaf: &A) -> Result<(), prio::vdaf::VdafError>
 /// # where
-/// #     A: prio::vdaf::Aggregator<L, 16>,
+/// #     A: prio::vdaf::Aggregator<SEED_SIZE, 16>,
 /// # {
 /// #     Ok(())
 /// # }

--- a/core/src/test_util/mod.rs
+++ b/core/src/test_util/mod.rs
@@ -14,14 +14,14 @@ pub mod testcontainers;
 /// A transcript of a VDAF run. All fields are indexed by natural role index (i.e., index 0 =
 /// leader, index 1 = helper).
 #[derive(Clone, Debug)]
-pub struct VdafTranscript<const L: usize, V: vdaf::Aggregator<L, 16>> {
+pub struct VdafTranscript<const SEED_SIZE: usize, V: vdaf::Aggregator<SEED_SIZE, 16>> {
     /// The public share, from the sharding algorithm.
     pub public_share: V::PublicShare,
     /// The measurement's input shares, from the sharding algorithm.
     pub input_shares: Vec<V::InputShare>,
     /// Prepare transitions sent throughout the protocol run. The outer `Vec` is indexed by
     /// aggregator, and the inner `Vec`s are indexed by VDAF round.
-    prepare_transitions: Vec<Vec<PrepareTransition<V, L, 16>>>,
+    prepare_transitions: Vec<Vec<PrepareTransition<V, SEED_SIZE, 16>>>,
     /// The prepare messages broadcast to all aggregators prior to each continuation round of the
     /// VDAF.
     pub prepare_messages: Vec<V::PrepareMessage>,
@@ -31,12 +31,12 @@ pub struct VdafTranscript<const L: usize, V: vdaf::Aggregator<L, 16>> {
     pub aggregate_shares: Vec<V::AggregateShare>,
 }
 
-impl<const L: usize, V: vdaf::Aggregator<L, 16>> VdafTranscript<L, V> {
+impl<const SEED_SIZE: usize, V: vdaf::Aggregator<SEED_SIZE, 16>> VdafTranscript<SEED_SIZE, V> {
     /// Get the leader's preparation state at the requested round.
     pub fn leader_prep_state(&self, round: usize) -> &V::PrepareState {
         assert_matches!(
             &self.prepare_transitions[Role::Leader.index().unwrap()][round],
-            PrepareTransition::<V, L, 16>::Continue(prep_state, _) => prep_state
+            PrepareTransition::<V, SEED_SIZE, 16>::Continue(prep_state, _) => prep_state
         )
     }
 
@@ -44,7 +44,7 @@ impl<const L: usize, V: vdaf::Aggregator<L, 16>> VdafTranscript<L, V> {
     pub fn helper_prep_state(&self, round: usize) -> (&V::PrepareState, &V::PrepareShare) {
         assert_matches!(
             &self.prepare_transitions[Role::Helper.index().unwrap()][round],
-            PrepareTransition::<V, L, 16>::Continue(prep_state, prep_share) => (prep_state, prep_share)
+            PrepareTransition::<V, SEED_SIZE, 16>::Continue(prep_state, prep_share) => (prep_state, prep_share)
         )
     }
 
@@ -56,16 +56,16 @@ impl<const L: usize, V: vdaf::Aggregator<L, 16>> VdafTranscript<L, V> {
 
 /// run_vdaf runs a VDAF state machine from sharding through to generating an output share,
 /// returning a "transcript" of all states & messages.
-pub fn run_vdaf<const L: usize, V: vdaf::Aggregator<L, 16> + vdaf::Client<16>>(
+pub fn run_vdaf<const SEED_SIZE: usize, V: vdaf::Aggregator<SEED_SIZE, 16> + vdaf::Client<16>>(
     vdaf: &V,
-    verify_key: &[u8; L],
+    verify_key: &[u8; SEED_SIZE],
     aggregation_param: &V::AggregationParam,
     report_id: &ReportId,
     measurement: &V::Measurement,
-) -> VdafTranscript<L, V> {
+) -> VdafTranscript<SEED_SIZE, V> {
     // Shard inputs into input shares, and initialize the initial PrepareTransitions.
     let (public_share, input_shares) = vdaf.shard(measurement, report_id.as_ref()).unwrap();
-    let mut prep_trans: Vec<Vec<PrepareTransition<V, L, 16>>> = input_shares
+    let mut prep_trans: Vec<Vec<PrepareTransition<V, SEED_SIZE, 16>>> = input_shares
         .iter()
         .enumerate()
         .map(|(agg_id, input_share)| {
@@ -81,7 +81,7 @@ pub fn run_vdaf<const L: usize, V: vdaf::Aggregator<L, 16> + vdaf::Client<16>>(
                 prep_state, prep_share,
             )]))
         })
-        .collect::<Result<Vec<Vec<PrepareTransition<V, L, 16>>>, VdafError>>()
+        .collect::<Result<Vec<Vec<PrepareTransition<V, SEED_SIZE, 16>>>, VdafError>>()
         .unwrap();
     let mut prep_msgs = Vec::new();
 
@@ -94,7 +94,7 @@ pub fn run_vdaf<const L: usize, V: vdaf::Aggregator<L, 16> + vdaf::Client<16>>(
         let mut output_shares = Vec::new();
         for pts in &prep_trans {
             match pts.last().unwrap() {
-                PrepareTransition::<V, L, 16>::Continue(_, prep_share) => {
+                PrepareTransition::<V, SEED_SIZE, 16>::Continue(_, prep_share) => {
                     prep_shares.push(prep_share.clone())
                 }
                 PrepareTransition::Finish(output_share) => {
@@ -123,7 +123,7 @@ pub fn run_vdaf<const L: usize, V: vdaf::Aggregator<L, 16> + vdaf::Client<16>>(
         for pts in &mut prep_trans {
             let prep_state = assert_matches!(
                 pts.last().unwrap(),
-                PrepareTransition::<V, L, 16>::Continue(prep_state, _) => prep_state
+                PrepareTransition::<V, SEED_SIZE, 16>::Continue(prep_state, _) => prep_state
             )
             .clone();
             pts.push(vdaf.prepare_step(prep_state, prep_msg.clone()).unwrap());


### PR DESCRIPTION
This renames several type parameters from `L` to `SEED_SIZE` for readability.