### PR TITLE
Janus Aggregator API implementation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,6 +1774,8 @@ dependencies = [
 name = "janus_aggregator_api"
 version = "0.3.0"
 dependencies = [
+ "anyhow",
+ "async-trait",
  "base64 0.21.0",
  "futures",
  "janus_aggregator_core",
@@ -1790,6 +1792,7 @@ dependencies = [
  "trillium",
  "trillium-api",
  "trillium-http",
+ "trillium-opentelemetry",
  "trillium-router",
  "trillium-testing",
  "url",
@@ -3475,6 +3478,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7f05c1d5476066defcdfacce1f52fc3cae3af1d3089727100c02ae92e5abbe0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4344,21 +4356,25 @@ dependencies = [
 
 [[package]]
 name = "trillium-api"
-version = "0.1.0"
+version = "0.2.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b43854c11d5cb8de23e7ca11d738d1a7d76a1ab29a569852204f3963429221"
+checksum = "ca25de1243325a6ca367d4fa1736fe6589c5a11c8414271c1ce0dafaa7eec6e8"
 dependencies = [
+ "log",
  "mime",
  "serde",
  "serde_json",
+ "serde_path_to_error",
+ "thiserror",
  "trillium",
+ "trillium-http",
 ]
 
 [[package]]
 name = "trillium-http"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17a0d2c2ac37537f8029ec79eb0ec346e83789e90d9a3f4d34764c710f1a24f5"
+checksum = "66cdadc7099cb2ab839310c3dd9292c4907acf2dbeebd9a1e3aff3956de93651"
 dependencies = [
  "encoding_rs",
  "futures-lite",
@@ -4376,10 +4392,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "trillium-router"
-version = "0.3.4"
+name = "trillium-opentelemetry"
+version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c99c71c690a3cb8b54fda9f784d89c773e60b853190a7672e73fa590beabe7"
+checksum = "058ce68d79872eb606079571cf0212633ae1095541a9c6afa0a363de3de4301b"
+dependencies = [
+ "opentelemetry",
+ "trillium",
+]
+
+[[package]]
+name = "trillium-router"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93cacd817bbd4e8308e5ca8223009e6de60198580d66a7fede1c022ceb16cd7"
 dependencies = [
  "log",
  "routefinder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,6 +111,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
+name = "async-channel"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-compat"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b48b4ff0c2026db683dea961cd8ea874737f56cffca86fa84415eaddc51c00d"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "once_cell",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "async-dup"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7427a12b8dc09291528cfb1da2447059adb4a257388c2acd6497a79d55cf6f7c"
+dependencies = [
+ "futures-io",
+ "simple-mutex",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +175,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "debc29dde2e69f9e47506b525f639ed42300fc014a3e007832592448fa8e4599"
 
 [[package]]
 name = "atty"
@@ -457,6 +508,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a90734b3d5dcf656e7624cca6bce9c3a90ee11f900e80141a7427ccfb3d317"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c278839b831783b70278b14df4d45e1beb1aad306c07bb796637de9a0e323e8e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console-api"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,7 +781,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -865,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.31"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
 ]
@@ -892,6 +952,12 @@ dependencies = [
  "cc",
  "libc",
 ]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "fallible-iterator"
@@ -1084,6 +1150,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
 
 [[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,6 +1310,15 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hdrhistogram"
@@ -1539,7 +1629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1678,6 +1768,31 @@ dependencies = [
  "uuid",
  "wait-timeout",
  "warp",
+]
+
+[[package]]
+name = "janus_aggregator_api"
+version = "0.3.0"
+dependencies = [
+ "base64 0.21.0",
+ "futures",
+ "janus_aggregator_core",
+ "janus_core",
+ "janus_messages",
+ "opentelemetry",
+ "querystring",
+ "rand",
+ "ring",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "trillium",
+ "trillium-api",
+ "trillium-http",
+ "trillium-router",
+ "trillium-testing",
+ "url",
 ]
 
 [[package]]
@@ -2147,6 +2262,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
 name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2551,6 +2672,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2904,6 +3031,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
+name = "querystring"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9318ead08c799aad12a55a3e78b82e0b6167271ffd1f627b758891282f739187"
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3097,6 +3230,25 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rlimit"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc0bf25554376fd362f54332b8410a625c71f15445bca32ffdfdf4ec9ac91726"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "routefinder"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f8f99b10dedd317514253dda1fa7c14e344aac96e1f78149a64879ce282aca"
+dependencies = [
+ "smartcow",
+ "smartstring",
 ]
 
 [[package]]
@@ -3495,6 +3647,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
 
 [[package]]
+name = "simple-mutex"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38aabbeafa6f6dead8cebf246fe9fae1f9215c8d29b3a69f93bd62a9e4a3dcd6"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3514,6 +3675,26 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "smartcow"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656fcb1c1fca8c4655372134ce87d8afdf5ec5949ebabe8d314be0141d8b5da2"
+dependencies = [
+ "smartstring",
+]
+
+[[package]]
+name = "smartstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+dependencies = [
+ "autocfg",
+ "static_assertions",
+ "version_check",
+]
 
 [[package]]
 name = "snapbox"
@@ -3564,6 +3745,17 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stopper"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4573bf2456e356934de15c7151d1c9fc8873e8866a7c2b5e0bb20f8244bd0073"
+dependencies = [
+ "futures-lite",
+ "pin-project",
+ "waker-set",
+]
 
 [[package]]
 name = "stringprep"
@@ -4139,6 +4331,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "trillium"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5598bb9ee521a4c76df72b4c54123eca7add1dc260b5d57d120c1992a25437e"
+dependencies = [
+ "async-trait",
+ "futures-lite",
+ "log",
+ "trillium-http",
+]
+
+[[package]]
+name = "trillium-api"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b43854c11d5cb8de23e7ca11d738d1a7d76a1ab29a569852204f3963429221"
+dependencies = [
+ "mime",
+ "serde",
+ "serde_json",
+ "trillium",
+]
+
+[[package]]
+name = "trillium-http"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17a0d2c2ac37537f8029ec79eb0ec346e83789e90d9a3f4d34764c710f1a24f5"
+dependencies = [
+ "encoding_rs",
+ "futures-lite",
+ "hashbrown 0.13.2",
+ "httparse",
+ "httpdate",
+ "log",
+ "memmem",
+ "mime",
+ "smallvec",
+ "smartcow",
+ "smartstring",
+ "stopper",
+ "thiserror",
+]
+
+[[package]]
+name = "trillium-router"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83c99c71c690a3cb8b54fda9f784d89c773e60b853190a7672e73fa590beabe7"
+dependencies = [
+ "log",
+ "routefinder",
+ "trillium",
+]
+
+[[package]]
+name = "trillium-server-common"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02f8a8649680599d1142d454668be5f864f81809d77543ec5ac615b73241b8aa"
+dependencies = [
+ "atomic-waker",
+ "futures-lite",
+ "log",
+ "pin-project-lite",
+ "rlimit",
+ "trillium",
+ "trillium-http",
+ "trillium-tls-common",
+]
+
+[[package]]
+name = "trillium-testing"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b813287bb4edb1653b0a8eeebccfc1f1bb0aff122a7b1db6357a2ba2c784b60"
+dependencies = [
+ "async-channel",
+ "async-dup",
+ "cfg-if",
+ "futures-lite",
+ "portpicker",
+ "trillium",
+ "trillium-http",
+ "trillium-server-common",
+ "trillium-tokio",
+ "url",
+]
+
+[[package]]
+name = "trillium-tls-common"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25c024962f8fdad586fb329e91b64ef0f4034652779ef5d3720102ca0f88d714"
+dependencies = [
+ "async-trait",
+ "futures-lite",
+ "url",
+]
+
+[[package]]
+name = "trillium-tokio"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cc915392c17586f51a945ac6c11a7840582ff1efa2063ef81bb30fe20fc061"
+dependencies = [
+ "async-compat",
+ "log",
+ "signal-hook",
+ "signal-hook-tokio",
+ "tokio",
+ "tokio-stream",
+ "trillium",
+ "trillium-http",
+ "trillium-server-common",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4310,6 +4620,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
+name = "waker-set"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e958152c46345e1af5c61812030ac85200573a0b384c137e83ce2c01ac4bc07"
+dependencies = [
+ "crossbeam-utils",
+ "slab",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "aggregator",
+    "aggregator_api",
     "aggregator_core",
     "build_script_utils",
     "client",

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /src
 COPY Cargo.toml /src/Cargo.toml
 COPY Cargo.lock /src/Cargo.lock
 COPY aggregator /src/aggregator
+COPY aggregator_api /src/aggregator_api
 COPY aggregator_core /src/aggregator_core
 COPY build_script_utils /src/build_script_utils
 COPY client /src/client

--- a/Dockerfile.interop
+++ b/Dockerfile.interop
@@ -9,6 +9,7 @@ WORKDIR /src
 COPY Cargo.toml /src/Cargo.toml
 COPY Cargo.lock /src/Cargo.lock
 COPY aggregator /src/aggregator
+COPY aggregator_api /src/aggregator_api
 COPY aggregator_core /src/aggregator_core
 COPY build_script_utils /src/build_script_utils
 COPY client /src/client

--- a/Dockerfile.interop_aggregator
+++ b/Dockerfile.interop_aggregator
@@ -7,6 +7,7 @@ WORKDIR /src
 COPY Cargo.toml /src/Cargo.toml
 COPY Cargo.lock /src/Cargo.lock
 COPY aggregator /src/aggregator
+COPY aggregator_api /src/aggregator_api
 COPY aggregator_core /src/aggregator_core
 COPY build_script_utils /src/build_script_utils
 COPY client /src/client

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -3140,7 +3140,7 @@ async fn send_request_to_helper<T: Encode>(
     let response_result = http_client
         .request(method, url)
         .header(CONTENT_TYPE, content_type)
-        .header(DAP_AUTH_HEADER, auth_token.as_bytes())
+        .header(DAP_AUTH_HEADER, auth_token.as_ref())
         .body(request_body)
         .send()
         .await;
@@ -4271,7 +4271,7 @@ mod tests {
                     .unwrap()
                     .path(),
             )
-            .header("DAP-Auth-Token", random::<AuthenticationToken>().as_bytes())
+            .header("DAP-Auth-Token", random::<AuthenticationToken>().as_ref())
             .header(
                 CONTENT_TYPE,
                 AggregationJobInitializeReq::<TimeInterval>::MEDIA_TYPE,
@@ -6764,7 +6764,7 @@ mod tests {
             .path(task.collection_job_uri(&collection_job_id).unwrap().path())
             .header(
                 "DAP-Auth-Token",
-                task.primary_collector_auth_token().as_bytes(),
+                task.primary_collector_auth_token().as_ref(),
             )
             .header(CONTENT_TYPE, CollectionReq::<TimeInterval>::MEDIA_TYPE)
             .body(request.get_encoded())
@@ -7149,7 +7149,7 @@ mod tests {
             ))
             .header(
                 "DAP-Auth-Token",
-                test_case.task.primary_collector_auth_token().as_bytes(),
+                test_case.task.primary_collector_auth_token().as_ref(),
             )
             .filter(&test_case.filter)
             .await
@@ -7326,7 +7326,7 @@ mod tests {
             )
             .header(
                 "DAP-Auth-Token",
-                test_case.task.primary_collector_auth_token().as_bytes(),
+                test_case.task.primary_collector_auth_token().as_ref(),
             )
             .filter(&test_case.filter)
             .await
@@ -7358,7 +7358,7 @@ mod tests {
             )
             .header(
                 "DAP-Auth-Token",
-                test_case.task.primary_collector_auth_token().as_bytes(),
+                test_case.task.primary_collector_auth_token().as_ref(),
             )
             .filter(&test_case.filter)
             .await
@@ -7401,7 +7401,7 @@ mod tests {
             .path(task.aggregate_shares_uri().unwrap().path())
             .header(
                 "DAP-Auth-Token",
-                task.primary_aggregator_auth_token().as_bytes(),
+                task.primary_aggregator_auth_token().as_ref(),
             )
             .header(CONTENT_TYPE, AggregateShareReq::<TimeInterval>::MEDIA_TYPE)
             .body(request.get_encoded())
@@ -7467,7 +7467,7 @@ mod tests {
             .method("POST")
             .header(
                 "DAP-Auth-Token",
-                task.primary_aggregator_auth_token().as_bytes(),
+                task.primary_aggregator_auth_token().as_ref(),
             )
             .header(CONTENT_TYPE, AggregateShareReq::<TimeInterval>::MEDIA_TYPE)
             .path(task.aggregate_shares_uri().unwrap().path())
@@ -7496,7 +7496,7 @@ mod tests {
             .method("POST")
             .header(
                 "DAP-Auth-Token",
-                task.primary_aggregator_auth_token().as_bytes(),
+                task.primary_aggregator_auth_token().as_ref(),
             )
             .header(CONTENT_TYPE, AggregateShareReq::<TimeInterval>::MEDIA_TYPE)
             .path(task.aggregate_shares_uri().unwrap().path())
@@ -7557,7 +7557,7 @@ mod tests {
             .path(task.aggregate_shares_uri().unwrap().path())
             .header(
                 "DAP-Auth-Token",
-                task.primary_aggregator_auth_token().as_bytes(),
+                task.primary_aggregator_auth_token().as_ref(),
             )
             .header(CONTENT_TYPE, AggregateShareReq::<TimeInterval>::MEDIA_TYPE)
             .body(request.get_encoded())
@@ -7698,7 +7698,7 @@ mod tests {
             .path(task.aggregate_shares_uri().unwrap().path())
             .header(
                 "DAP-Auth-Token",
-                task.primary_aggregator_auth_token().as_bytes(),
+                task.primary_aggregator_auth_token().as_ref(),
             )
             .header(CONTENT_TYPE, AggregateShareReq::<TimeInterval>::MEDIA_TYPE)
             .body(request.get_encoded())
@@ -7755,7 +7755,7 @@ mod tests {
                 .path(task.aggregate_shares_uri().unwrap().path())
                 .header(
                     "DAP-Auth-Token",
-                    task.primary_aggregator_auth_token().as_bytes(),
+                    task.primary_aggregator_auth_token().as_ref(),
                 )
                 .header(CONTENT_TYPE, AggregateShareReq::<TimeInterval>::MEDIA_TYPE)
                 .body(misaligned_request.get_encoded())
@@ -7824,7 +7824,7 @@ mod tests {
                     .path(task.aggregate_shares_uri().unwrap().path())
                     .header(
                         "DAP-Auth-Token",
-                        task.primary_aggregator_auth_token().as_bytes(),
+                        task.primary_aggregator_auth_token().as_ref(),
                     )
                     .header(CONTENT_TYPE, AggregateShareReq::<TimeInterval>::MEDIA_TYPE)
                     .body(request.get_encoded())
@@ -7890,7 +7890,7 @@ mod tests {
             .path(task.aggregate_shares_uri().unwrap().path())
             .header(
                 "DAP-Auth-Token",
-                task.primary_aggregator_auth_token().as_bytes(),
+                task.primary_aggregator_auth_token().as_ref(),
             )
             .header(CONTENT_TYPE, AggregateShareReq::<TimeInterval>::MEDIA_TYPE)
             .body(all_batch_request.get_encoded())
@@ -7944,7 +7944,7 @@ mod tests {
                 .path(task.aggregate_shares_uri().unwrap().path())
                 .header(
                     "DAP-Auth-Token",
-                    task.primary_aggregator_auth_token().as_bytes(),
+                    task.primary_aggregator_auth_token().as_ref(),
                 )
                 .header(CONTENT_TYPE, AggregateShareReq::<TimeInterval>::MEDIA_TYPE)
                 .body(query_count_violation_request.get_encoded())

--- a/aggregator/src/aggregator/aggregate_init_tests.rs
+++ b/aggregator/src/aggregator/aggregate_init_tests.rs
@@ -157,7 +157,7 @@ pub(crate) async fn put_aggregation_job(
         .path(task.aggregation_job_uri(aggregation_job_id).unwrap().path())
         .header(
             "DAP-Auth-Token",
-            task.primary_aggregator_auth_token().as_bytes(),
+            task.primary_aggregator_auth_token().as_ref(),
         )
         .header(
             CONTENT_TYPE,

--- a/aggregator/src/aggregator/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/aggregation_job_continue.rs
@@ -287,7 +287,7 @@ pub mod test_util {
             .path(task.aggregation_job_uri(aggregation_job_id).unwrap().path())
             .header(
                 "DAP-Auth-Token",
-                task.primary_aggregator_auth_token().as_bytes(),
+                task.primary_aggregator_auth_token().as_ref(),
             )
             .header(CONTENT_TYPE, AggregationJobContinueReq::MEDIA_TYPE)
             .body(request.get_encoded())

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -995,7 +995,7 @@ mod tests {
                     )
                     .match_header(
                         "DAP-Auth-Token",
-                        str::from_utf8(agg_auth_token.as_bytes()).unwrap(),
+                        str::from_utf8(agg_auth_token.as_ref()).unwrap(),
                     )
                     .match_header(CONTENT_TYPE.as_str(), req_content_type)
                     .with_status(200)
@@ -1260,7 +1260,7 @@ mod tests {
             )
             .match_header(
                 "DAP-Auth-Token",
-                str::from_utf8(agg_auth_token.as_bytes()).unwrap(),
+                str::from_utf8(agg_auth_token.as_ref()).unwrap(),
             )
             .match_header(
                 CONTENT_TYPE.as_str(),
@@ -1526,7 +1526,7 @@ mod tests {
             )
             .match_header(
                 "DAP-Auth-Token",
-                str::from_utf8(agg_auth_token.as_bytes()).unwrap(),
+                str::from_utf8(agg_auth_token.as_ref()).unwrap(),
             )
             .match_header(
                 CONTENT_TYPE.as_str(),
@@ -1764,7 +1764,7 @@ mod tests {
             )
             .match_header(
                 "DAP-Auth-Token",
-                str::from_utf8(agg_auth_token.as_bytes()).unwrap(),
+                str::from_utf8(agg_auth_token.as_ref()).unwrap(),
             )
             .match_header(CONTENT_TYPE.as_str(), AggregationJobContinueReq::MEDIA_TYPE)
             .match_body(leader_request.get_encoded())
@@ -2056,7 +2056,7 @@ mod tests {
             )
             .match_header(
                 "DAP-Auth-Token",
-                str::from_utf8(agg_auth_token.as_bytes()).unwrap(),
+                str::from_utf8(agg_auth_token.as_ref()).unwrap(),
             )
             .match_header(CONTENT_TYPE.as_str(), AggregationJobContinueReq::MEDIA_TYPE)
             .match_body(leader_request.get_encoded())
@@ -2487,7 +2487,7 @@ mod tests {
             )
             .match_header(
                 "DAP-Auth-Token",
-                str::from_utf8(agg_auth_token.as_bytes()).unwrap(),
+                str::from_utf8(agg_auth_token.as_ref()).unwrap(),
             )
             .match_header(
                 CONTENT_TYPE.as_str(),
@@ -2509,7 +2509,7 @@ mod tests {
             )
             .match_header(
                 "DAP-Auth-Token",
-                str::from_utf8(agg_auth_token.as_bytes()).unwrap(),
+                str::from_utf8(agg_auth_token.as_ref()).unwrap(),
             )
             .match_header(
                 CONTENT_TYPE.as_str(),

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -781,7 +781,7 @@ mod tests {
             .mock("POST", task.aggregate_shares_uri().unwrap().path())
             .match_header(
                 "DAP-Auth-Token",
-                str::from_utf8(agg_auth_token.as_bytes()).unwrap(),
+                str::from_utf8(agg_auth_token.as_ref()).unwrap(),
             )
             .match_header(
                 CONTENT_TYPE.as_str(),
@@ -839,7 +839,7 @@ mod tests {
             .mock("POST", task.aggregate_shares_uri().unwrap().path())
             .match_header(
                 "DAP-Auth-Token",
-                str::from_utf8(agg_auth_token.as_bytes()).unwrap(),
+                str::from_utf8(agg_auth_token.as_ref()).unwrap(),
             )
             .match_header(
                 CONTENT_TYPE.as_str(),

--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -58,7 +58,7 @@ impl<R: Reply + 'static> CollectionJobTestCase<R> {
                 .path(),
         );
         if let Some(token) = auth_token {
-            builder = builder.header("DAP-Auth-Token", token.as_bytes())
+            builder = builder.header("DAP-Auth-Token", token.as_ref())
         }
 
         builder
@@ -95,7 +95,7 @@ impl<R: Reply + 'static> CollectionJobTestCase<R> {
                 .path(),
         );
         if let Some(token) = auth_token {
-            builder = builder.header("DAP-Auth-Token", token.as_bytes())
+            builder = builder.header("DAP-Auth-Token", token.as_ref())
         }
         builder.filter(&self.filter).await.unwrap().into_response()
     }

--- a/aggregator_api/Cargo.toml
+++ b/aggregator_api/Cargo.toml
@@ -9,6 +9,8 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
+anyhow = "1"
+async-trait = "0.1"
 base64 = "0.21.0"
 janus_aggregator_core.workspace = true
 janus_core.workspace = true
@@ -21,9 +23,10 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
 tracing = "0.1.37"
 trillium = "0.2.6"
-trillium-api = { version = "0.1.0", default-features = false }
-trillium-http = "0.2.11"
-trillium-router = "0.3.4"
+trillium-api = { version = "0.2.0-rc.2", default-features = false }
+trillium-http = "0.2.13"
+trillium-opentelemetry = "0.0.1"
+trillium-router = "0.3.5"
 url = { version = "2.3.1", features = ["serde"] }
 
 [dev-dependencies]

--- a/aggregator_api/Cargo.toml
+++ b/aggregator_api/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "janus_aggregator_api"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+publish = false
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+base64 = "0.21.0"
+janus_aggregator_core.workspace = true
+janus_core.workspace = true
+janus_messages.workspace = true
+opentelemetry = "0.18"
+querystring = "1.1.0"
+rand = { version = "0.8", features = ["min_const_gen"] }
+ring = "0.16.20"
+serde = { version = "1.0.152", features = ["derive"] }
+serde_json = "1.0.93"
+tracing = "0.1.37"
+trillium = "0.2.6"
+trillium-api = { version = "0.1.0", default-features = false }
+trillium-http = "0.2.11"
+trillium-router = "0.3.4"
+url = { version = "2.3.1", features = ["serde"] }
+
+[dev-dependencies]
+futures = "0.3.26"
+janus_aggregator_core = { workspace = true, features = ["test-util"] }
+tokio = "1.25"
+trillium-testing = { version = "0.4.1", features = ["tokio"] }

--- a/aggregator_api/src/lib.rs
+++ b/aggregator_api/src/lib.rs
@@ -1,0 +1,897 @@
+//! This crate implements the Janus aggregator API.
+
+use crate::models::{GetTaskIdsResp, PostTaskReq};
+use janus_aggregator_core::{
+    datastore::{Datastore, Error},
+    task::Task,
+    SecretBytes,
+};
+use janus_core::{hpke::generate_hpke_config_and_private_key, time::Clock};
+use janus_messages::{Duration, HpkeAeadId, HpkeKdfId, HpkeKemId, TaskId, Time};
+use models::{GetTaskMetricsResp, TaskResp};
+use opentelemetry::{
+    global::meter,
+    metrics::{Histogram, Unit},
+    Context, KeyValue,
+};
+use querystring::querify;
+use rand::{distributions::Standard, random, thread_rng, Rng};
+use ring::constant_time;
+use std::{future::Future, str::FromStr, sync::Arc, time::Instant};
+use tracing::{info_span, warn, Instrument};
+use trillium::{conn_try, conn_unwrap, Body, Conn, Handler, State, Status};
+use trillium_api::ApiConnExt;
+use trillium_router::{Router, RouterConnExt};
+
+/// Represents the configuration for an instance of the Aggregator API.
+#[derive(Clone)]
+pub struct Config {
+    pub auth_tokens: Vec<SecretBytes>,
+}
+
+/// Returns a new handler for an instance of the aggregator API, backed by the given datastore,
+/// according to the given configuration.
+pub fn aggregator_api_handler<C: Clock>(ds: Datastore<C>, cfg: Config) -> impl Handler {
+    let response_time_histogram = meter("janus_aggregator_api")
+        .f64_histogram("janus_aggregator_api_response_time")
+        .with_description("Elapsed time handling incoming requests, by endpoint & status.")
+        .with_unit(Unit::new("seconds"))
+        .init();
+
+    (
+        // State (used by endpoint_handler).
+        State::new(Arc::new(AggregatorApi {
+            ds,
+            cfg,
+            response_time_histogram,
+        })),
+        // Main functionality router.
+        Router::new()
+            .get("/task_ids", {
+                const ENDPOINT_NAME: &str = "get_task_ids";
+                |conn: Conn| {
+                    async move {
+                        endpoint_handler::<C, _>(
+                            conn,
+                            ENDPOINT_NAME,
+                            |aggregator_api, conn| async move {
+                                aggregator_api.handle_get_task_ids(conn).await
+                            },
+                        )
+                        .await
+                    }
+                    .instrument(info_span!(ENDPOINT_NAME))
+                }
+            })
+            .post("/tasks", {
+                const ENDPOINT_NAME: &str = "post_task";
+                |conn: Conn| {
+                    async move {
+                        endpoint_handler::<C, _>(
+                            conn,
+                            ENDPOINT_NAME,
+                            |aggregator_api, conn| async move {
+                                aggregator_api.handle_post_task(conn).await
+                            },
+                        )
+                        .await
+                    }
+                    .instrument(info_span!(ENDPOINT_NAME))
+                }
+            })
+            .get("/tasks/:task_id", {
+                const ENDPOINT_NAME: &str = "get_task";
+                |conn: Conn| {
+                    async move {
+                        endpoint_handler::<C, _>(
+                            conn,
+                            ENDPOINT_NAME,
+                            |aggregator_api, conn| async move {
+                                aggregator_api.handle_get_task(conn).await
+                            },
+                        )
+                        .await
+                    }
+                    .instrument(info_span!(ENDPOINT_NAME))
+                }
+            })
+            .delete("/tasks/:task_id", {
+                const ENDPOINT_NAME: &str = "delete_task";
+                |conn: Conn| {
+                    async move {
+                        endpoint_handler::<C, _>(
+                            conn,
+                            ENDPOINT_NAME,
+                            |aggregator_api, conn| async move {
+                                aggregator_api.handle_delete_task(conn).await
+                            },
+                        )
+                        .await
+                    }
+                    .instrument(info_span!(ENDPOINT_NAME))
+                }
+            })
+            .get("/tasks/:task_id/metrics", {
+                const ENDPOINT_NAME: &str = "get_task_metrics";
+                |conn: Conn| {
+                    async move {
+                        endpoint_handler::<C, _>(
+                            conn,
+                            ENDPOINT_NAME,
+                            |aggregator_api, conn| async move {
+                                aggregator_api.handle_get_task_metrics(conn).await
+                            },
+                        )
+                        .await
+                    }
+                    .instrument(info_span!(ENDPOINT_NAME))
+                }
+            }),
+    )
+}
+
+async fn endpoint_handler<C: Clock, Fut>(
+    mut conn: Conn,
+    endpoint_name: impl Into<String>,
+    handler: impl Fn(Arc<AggregatorApi<C>>, Conn) -> Fut,
+) -> Conn
+where
+    Fut: Future<Output = Conn>,
+{
+    let start_instant = Instant::now();
+    let aggregator_api: Arc<AggregatorApi<C>> =
+        Arc::clone(conn.state().expect("No AggregatorApi in connection state"));
+
+    conn = aggregator_api.check_auth(conn);
+    if !conn.is_halted() {
+        conn = handler(Arc::clone(&aggregator_api), conn).await;
+    }
+
+    let status: u16 = match conn.status() {
+        Some(status) => status.into(),
+        None => {
+            warn!(path = conn.path(), "No status set on connection");
+            return conn;
+        }
+    };
+
+    aggregator_api.response_time_histogram.record(
+        &Context::current(),
+        start_instant.elapsed().as_secs_f64(),
+        &[
+            KeyValue::new("endpoint", endpoint_name.into()),
+            KeyValue::new("status", status.to_string()),
+        ],
+    );
+    conn
+}
+
+struct AggregatorApi<C: Clock> {
+    ds: Datastore<C>,
+    cfg: Config,
+    response_time_histogram: Histogram<f64>,
+}
+
+impl<C: Clock> AggregatorApi<C> {
+    fn check_auth(&self, conn: Conn) -> Conn {
+        if let Some(authorization_value) = conn.headers().get("authorization") {
+            if let Some(received_token) = authorization_value.as_ref().strip_prefix(b"Basic ") {
+                if self.cfg.auth_tokens.iter().any(|key| {
+                    constant_time::verify_slices_are_equal(received_token, key.as_ref()).is_ok()
+                }) {
+                    // Authorization succeeds.
+                    return conn;
+                }
+            }
+        }
+
+        // Authorization fails.
+        conn.with_status(Status::Unauthorized).halt()
+    }
+
+    async fn handle_get_task_ids(&self, conn: Conn) -> Conn {
+        const PAGINATION_TOKEN_KEY: &str = "pagination_token";
+        let lower_bound = querify(conn.querystring())
+            .into_iter()
+            .find(|&(k, _)| k == PAGINATION_TOKEN_KEY)
+            .map(|(_, v)| TaskId::from_str(v))
+            .transpose();
+        let lower_bound = match lower_bound {
+            Ok(task_id_param) => task_id_param,
+            Err(_) => return conn.with_status(Status::BadRequest).halt(),
+        };
+
+        let task_ids = conn_try!(
+            self.ds
+                .run_tx_with_name("get_task_ids", |tx| Box::pin(async move {
+                    tx.get_task_ids(lower_bound).await
+                }))
+                .await,
+            conn
+        );
+        let pagination_token = task_ids.last().cloned();
+
+        conn.with_json(&GetTaskIdsResp {
+            task_ids,
+            pagination_token,
+        })
+    }
+
+    async fn handle_post_task(&self, mut conn: Conn) -> Conn {
+        let req: PostTaskReq = match conn.deserialize().await {
+            Ok(req) => req,
+            Err(_) => return conn.with_status(Status::BadRequest).halt(),
+        };
+
+        let vdaf_verify_keys = Vec::from([SecretBytes::new(
+            thread_rng()
+                .sample_iter(Standard)
+                .take(req.vdaf.verify_key_length())
+                .collect(),
+        )]);
+        let task_expiration = Time::from_seconds_since_epoch(req.task_expiration);
+        let time_precision = Duration::from_seconds(req.time_precision);
+        let hpke_keys = Vec::from([generate_hpke_config_and_private_key(
+            random(),
+            HpkeKemId::X25519HkdfSha256,
+            HpkeKdfId::HkdfSha256,
+            HpkeAeadId::Aes128Gcm,
+        )]);
+
+        let task = Task::new(
+            /* task_id */ random(),
+            /* aggregator_endpoints */ req.aggregator_endpoints,
+            /* query_type */ req.query_type,
+            /* vdaf */ req.vdaf,
+            /* role */ req.role,
+            /* vdaf_verify_keys */ vdaf_verify_keys,
+            /* max_batch_query_count */ req.max_batch_query_count,
+            /* task_expiration */ task_expiration,
+            /* report_expiry_age */
+            Some(Duration::from_seconds(3600 * 24 * 7 * 2)), // 2 weeks
+            /* min_batch_size */ req.min_batch_size,
+            /* time_precision */ time_precision,
+            /* tolerable_clock_skew */
+            Duration::from_seconds(60), // 1 minute,
+            /* collector_hpke_config */ req.collector_hpke_config,
+            /* aggregator_auth_tokens */ Vec::from([random()]),
+            /* collector_auth_tokens */ Vec::from([random()]),
+            /* hpke_keys */ hpke_keys,
+        );
+        let task = match task {
+            Ok(task) => Arc::new(task),
+            Err(_) => return conn.with_status(Status::BadRequest).halt(),
+        };
+
+        conn_try!(
+            self.ds
+                .run_tx_with_name("post_task", |tx| {
+                    let task = Arc::clone(&task);
+                    Box::pin(async move { tx.put_task(&task).await })
+                })
+                .await,
+            conn
+        );
+
+        conn.with_json(&TaskResp::from(task.as_ref()))
+    }
+
+    async fn handle_get_task(&self, conn: Conn) -> Conn {
+        let task_id = TaskId::from_str(conn_unwrap!(conn.param("task_id"), conn));
+        let task_id = match task_id {
+            Ok(task_id) => task_id,
+            Err(_) => return conn.with_status(Status::BadRequest).halt(),
+        };
+
+        let task = conn_try!(
+            self.ds
+                .run_tx_with_name("get_task", |tx| {
+                    Box::pin(async move { tx.get_task(&task_id).await })
+                })
+                .await,
+            conn
+        );
+        let task = match task {
+            Some(task) => task,
+            None => return conn.with_status(Status::NotFound).halt(),
+        };
+
+        conn.with_json(&TaskResp::from(&task))
+    }
+
+    async fn handle_delete_task(&self, conn: Conn) -> Conn {
+        let task_id = TaskId::from_str(conn_unwrap!(conn.param("task_id"), conn));
+        let task_id = match task_id {
+            Ok(task_id) => task_id,
+            Err(_) => return conn.with_status(Status::BadRequest).halt(),
+        };
+
+        let rslt = self
+            .ds
+            .run_tx_with_name("delete_task", |tx| {
+                Box::pin(async move { tx.delete_task(&task_id).await })
+            })
+            .await;
+        match rslt {
+            Ok(()) => conn.ok(Body::default()),
+            Err(Error::MutationTargetNotFound) => conn.with_status(Status::NotFound).halt(),
+            Err(_) => conn.with_status(Status::InternalServerError).halt(),
+        }
+    }
+
+    async fn handle_get_task_metrics(&self, conn: Conn) -> Conn {
+        let task_id = TaskId::from_str(conn_unwrap!(conn.param("task_id"), conn));
+        let task_id = match task_id {
+            Ok(task_id) => task_id,
+            Err(_) => return conn.with_status(Status::BadRequest).halt(),
+        };
+
+        let metrics = conn_try!(
+            self.ds
+                .run_tx_with_name("get_task_metrics", |tx| {
+                    Box::pin(async move { tx.get_task_metrics(task_id).await })
+                })
+                .await,
+            conn
+        );
+        match metrics {
+            Some((reports, report_aggregations)) => conn.with_json(&GetTaskMetricsResp {
+                reports,
+                report_aggregations,
+            }),
+            None => conn.with_status(Status::NotFound).halt(),
+        }
+    }
+}
+
+mod models {
+    use std::collections::HashMap;
+
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+    use janus_aggregator_core::task::{QueryType, Task};
+    use janus_core::task::VdafInstance;
+    use janus_messages::{Duration, HpkeConfig, HpkeConfigId, Role, TaskId, Time};
+    use serde::{Deserialize, Serialize};
+    use url::Url;
+
+    #[derive(Serialize)]
+    pub(crate) struct GetTaskIdsResp {
+        pub(crate) task_ids: Vec<TaskId>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub(crate) pagination_token: Option<TaskId>,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    pub(crate) struct PostTaskReq {
+        pub(crate) aggregator_endpoints: Vec<Url>,
+        pub(crate) query_type: QueryType,
+        pub(crate) vdaf: VdafInstance,
+        pub(crate) role: Role,
+        pub(crate) max_batch_query_count: u64,
+        pub(crate) task_expiration: u64, // seconds since UNIX epoch
+        pub(crate) min_batch_size: u64,
+        pub(crate) time_precision: u64, // seconds
+        pub(crate) collector_hpke_config: HpkeConfig,
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+    pub(crate) struct TaskResp {
+        pub(crate) task_id: TaskId,
+        pub(crate) aggregator_endpoints: Vec<Url>,
+        pub(crate) query_type: QueryType,
+        pub(crate) vdaf: VdafInstance,
+        pub(crate) role: Role,
+        pub(crate) vdaf_verify_keys: Vec<String>,
+        pub(crate) max_batch_query_count: u64,
+        pub(crate) task_expiration: Time,
+        pub(crate) report_expiry_age: Option<Duration>,
+        pub(crate) min_batch_size: u64,
+        pub(crate) time_precision: Duration,
+        pub(crate) tolerable_clock_skew: Duration,
+        pub(crate) collector_hpke_config: HpkeConfig,
+        pub(crate) aggregator_auth_tokens: Vec<String>,
+        pub(crate) collector_auth_tokens: Vec<String>,
+        pub(crate) aggregator_hpke_configs: HashMap<HpkeConfigId, HpkeConfig>,
+    }
+
+    impl From<&Task> for TaskResp {
+        fn from(task: &Task) -> Self {
+            let encoded_verify_keys: Vec<_> = task
+                .vdaf_verify_keys()
+                .iter()
+                .map(|key| URL_SAFE_NO_PAD.encode(key))
+                .collect();
+            let encoded_aggregator_auth_tokens: Vec<_> = task
+                .aggregator_auth_tokens()
+                .iter()
+                .map(|token| URL_SAFE_NO_PAD.encode(token))
+                .collect();
+            let encoded_collector_auth_tokens: Vec<_> = task
+                .collector_auth_tokens()
+                .iter()
+                .map(|token| URL_SAFE_NO_PAD.encode(token))
+                .collect();
+            let aggregator_hpke_configs: HashMap<_, _> = task
+                .hpke_keys()
+                .iter()
+                .map(|(&config_id, keypair)| (config_id, keypair.config().clone()))
+                .collect();
+
+            Self {
+                task_id: *task.id(),
+                aggregator_endpoints: task.aggregator_endpoints().to_vec(),
+                query_type: *task.query_type(),
+                vdaf: task.vdaf().clone(),
+                role: *task.role(),
+                vdaf_verify_keys: encoded_verify_keys,
+                max_batch_query_count: task.max_batch_query_count(),
+                task_expiration: *task.task_expiration(),
+                report_expiry_age: task.report_expiry_age().cloned(),
+                min_batch_size: task.min_batch_size(),
+                time_precision: *task.time_precision(),
+                tolerable_clock_skew: *task.tolerable_clock_skew(),
+                collector_hpke_config: task.collector_hpke_config().clone(),
+                aggregator_auth_tokens: encoded_aggregator_auth_tokens,
+                collector_auth_tokens: encoded_collector_auth_tokens,
+                aggregator_hpke_configs,
+            }
+        }
+    }
+
+    #[derive(Serialize)]
+    pub(crate) struct GetTaskMetricsResp {
+        pub(crate) reports: u64,
+        pub(crate) report_aggregations: u64,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        aggregator_api_handler,
+        models::{GetTaskIdsResp, GetTaskMetricsResp, PostTaskReq, TaskResp},
+        Config,
+    };
+    use futures::future::try_join_all;
+    use janus_aggregator_core::{
+        datastore::{
+            models::{
+                AggregationJob, AggregationJobState, LeaderStoredReport, ReportAggregation,
+                ReportAggregationState,
+            },
+            test_util::{ephemeral_datastore, EphemeralDatastore},
+        },
+        task::{test_util::TaskBuilder, QueryType},
+        SecretBytes,
+    };
+    use janus_core::{
+        hpke::generate_hpke_config_and_private_key,
+        task::VdafInstance,
+        test_util::{
+            dummy_vdaf::{self, AggregationParam},
+            install_test_trace_subscriber,
+        },
+        time::MockClock,
+    };
+    use janus_messages::{
+        query_type::TimeInterval, AggregationJobRound, Duration, HpkeAeadId, HpkeKdfId, HpkeKemId,
+        Interval, Role, TaskId, Time,
+    };
+    use rand::random;
+    use std::iter;
+    use trillium::{Handler, Status};
+    use trillium_testing::{
+        assert_response, assert_status,
+        prelude::{delete, get, post},
+    };
+
+    const AUTH_TOKEN: &str = "auth_token";
+
+    async fn setup_api_test() -> (impl Handler, EphemeralDatastore) {
+        install_test_trace_subscriber();
+        let ephemeral_datastore = ephemeral_datastore().await;
+        let handler = aggregator_api_handler(
+            ephemeral_datastore.datastore(MockClock::default()),
+            Config {
+                auth_tokens: Vec::from([SecretBytes::new(AUTH_TOKEN.as_bytes().to_vec())]),
+            },
+        );
+
+        (handler, ephemeral_datastore)
+    }
+
+    #[tokio::test]
+    async fn get_task_ids() {
+        // Setup: write a few tasks to the datastore.
+        let (handler, ephemeral_datastore) = setup_api_test().await;
+        let ds = ephemeral_datastore.datastore(MockClock::default());
+
+        let mut task_ids: Vec<_> = ds
+            .run_tx(|tx| {
+                Box::pin(async move {
+                    let tasks: Vec<_> = iter::repeat_with(|| {
+                        TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Leader)
+                            .build()
+                    })
+                    .take(10)
+                    .collect();
+
+                    try_join_all(tasks.iter().map(|task| tx.put_task(task))).await?;
+
+                    Ok(tasks.into_iter().map(|task| *task.id()).collect())
+                })
+            })
+            .await
+            .unwrap();
+        task_ids.sort();
+
+        fn response_for(task_ids: &[TaskId]) -> String {
+            serde_json::to_string(&GetTaskIdsResp {
+                task_ids: task_ids.to_vec(),
+                pagination_token: task_ids.last().cloned(),
+            })
+            .unwrap()
+        }
+
+        // Verify: we can get the task IDs we wrote back from the API.
+        assert_response!(
+            get("/task_ids")
+                .with_request_header("Authorization", format!("Basic {}", AUTH_TOKEN))
+                .run_async(&handler)
+                .await,
+            Status::Ok,
+            response_for(&task_ids),
+        );
+
+        // Verify: the lower_bound is respected, if specified.
+        assert_response!(
+            get(&format!(
+                "/task_ids?pagination_token={}",
+                task_ids.first().unwrap()
+            ))
+            .with_request_header("Authorization", format!("Basic {}", AUTH_TOKEN))
+            .run_async(&handler)
+            .await,
+            Status::Ok,
+            response_for(&task_ids[1..]),
+        );
+
+        // Verify: if the lower bound is large enough, nothing is returned.
+        // (also verifies the "last" response will not include a pagination token)
+        assert_response!(
+            get(&format!(
+                "/task_ids?pagination_token={}",
+                task_ids.last().unwrap()
+            ))
+            .with_request_header("Authorization", format!("Basic {}", AUTH_TOKEN))
+            .run_async(&handler)
+            .await,
+            Status::Ok,
+            response_for(&[]),
+        );
+
+        // Verify: unauthorized requests are denied appropriately.
+        assert_response!(
+            get("/task_ids").run_async(&handler).await,
+            Status::Unauthorized,
+            "",
+        );
+    }
+
+    #[tokio::test]
+    async fn post_task() {
+        // Setup: create a datastore & handler.
+        let (handler, ephemeral_datastore) = setup_api_test().await;
+        let ds = ephemeral_datastore.datastore(MockClock::default());
+
+        // Verify: posting a task creates a new task which matches the request.
+        let req = PostTaskReq {
+            aggregator_endpoints: Vec::from([
+                "http://leader.endpoint".try_into().unwrap(),
+                "http://helper.endpoint".try_into().unwrap(),
+            ]),
+            query_type: QueryType::TimeInterval,
+            vdaf: VdafInstance::Prio3Count,
+            role: Role::Leader,
+            max_batch_query_count: 12,
+            task_expiration: 12345,
+            min_batch_size: 223,
+            time_precision: 62,
+            collector_hpke_config: generate_hpke_config_and_private_key(
+                random(),
+                HpkeKemId::X25519HkdfSha256,
+                HpkeKdfId::HkdfSha256,
+                HpkeAeadId::Aes128Gcm,
+            )
+            .config()
+            .clone(),
+        };
+        let mut conn = post("/tasks")
+            .with_request_body(serde_json::to_vec(&req).unwrap())
+            .with_request_header("Authorization", format!("Basic {}", AUTH_TOKEN))
+            .run_async(&handler)
+            .await;
+        assert_status!(conn, Status::Ok);
+        let got_task_resp: TaskResp = serde_json::from_slice(
+            &conn
+                .take_response_body()
+                .unwrap()
+                .into_bytes()
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+
+        let got_task = ds
+            .run_tx(|tx| {
+                let got_task_resp = got_task_resp.clone();
+                Box::pin(async move { tx.get_task(&got_task_resp.task_id).await })
+            })
+            .await
+            .unwrap()
+            .expect("task was not created");
+
+        // Verify that the task written to the datastore matches the request...
+        assert_eq!(&req.aggregator_endpoints, got_task.aggregator_endpoints());
+        assert_eq!(&req.query_type, got_task.query_type());
+        assert_eq!(&req.vdaf, got_task.vdaf());
+        assert_eq!(&req.role, got_task.role());
+        assert_eq!(req.max_batch_query_count, got_task.max_batch_query_count());
+        assert_eq!(
+            &Time::from_seconds_since_epoch(req.task_expiration),
+            got_task.task_expiration()
+        );
+        assert_eq!(req.min_batch_size, got_task.min_batch_size());
+        assert_eq!(
+            &Duration::from_seconds(req.time_precision),
+            got_task.time_precision()
+        );
+        assert_eq!(&req.collector_hpke_config, got_task.collector_hpke_config());
+
+        // ...and the response.
+        assert_eq!(got_task_resp, TaskResp::from(&got_task));
+
+        // Verify: unauthorized requests are denied appropriately.
+        assert_response!(
+            post("/tasks")
+                .with_request_body(serde_json::to_vec(&req).unwrap())
+                .run_async(&handler)
+                .await,
+            Status::Unauthorized,
+            "",
+        );
+    }
+
+    #[tokio::test]
+    async fn get_task() {
+        // Setup: write a task to the datastore.
+        let (handler, ephemeral_datastore) = setup_api_test().await;
+        let ds = ephemeral_datastore.datastore(MockClock::default());
+
+        let task =
+            TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Leader).build();
+
+        ds.run_tx(|tx| {
+            let task = task.clone();
+            Box::pin(async move {
+                tx.put_task(&task).await?;
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
+
+        // Verify: getting the task returns the expected result.
+        let want_task_resp = TaskResp::from(&task);
+        let mut conn = get(&format!("/tasks/{}", task.id()))
+            .with_request_header("Authorization", format!("Basic {}", AUTH_TOKEN))
+            .run_async(&handler)
+            .await;
+        assert_status!(conn, Status::Ok);
+        let got_task_resp = serde_json::from_slice(
+            &conn
+                .take_response_body()
+                .unwrap()
+                .into_bytes()
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(want_task_resp, got_task_resp);
+
+        // Verify: getting a nonexistent task returns NotFound.
+        assert_response!(
+            get(&format!("/tasks/{}", random::<TaskId>()))
+                .with_request_header("Authorization", format!("Basic {}", AUTH_TOKEN))
+                .run_async(&handler)
+                .await,
+            Status::NotFound,
+            "",
+        );
+
+        // Verify: unauthorized requests are denied appropriately.
+        assert_response!(
+            get(&format!("/tasks/{}", task.id()))
+                .run_async(&handler)
+                .await,
+            Status::Unauthorized,
+            "",
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_task() {
+        // Setup: write a task to the datastore.
+        let (handler, ephemeral_datastore) = setup_api_test().await;
+        let ds = ephemeral_datastore.datastore(MockClock::default());
+
+        let task_id = ds
+            .run_tx(|tx| {
+                Box::pin(async move {
+                    let task =
+                        TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Leader)
+                            .build();
+
+                    tx.put_task(&task).await?;
+
+                    Ok(*task.id())
+                })
+            })
+            .await
+            .unwrap();
+
+        // Verify: deleting a task succeeds (and actually deletes the task).
+        assert_response!(
+            delete(&format!("/tasks/{}", &task_id))
+                .with_request_header("Authorization", format!("Basic {}", AUTH_TOKEN))
+                .run_async(&handler)
+                .await,
+            Status::Ok,
+            "",
+        );
+
+        ds.run_tx(|tx| {
+            Box::pin(async move {
+                assert_eq!(tx.get_task(&task_id).await.unwrap(), None);
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
+
+        // Verify: deleting a task twice returns NotFound.
+        assert_response!(
+            delete(&format!("/tasks/{}", &task_id))
+                .with_request_header("Authorization", format!("Basic {}", AUTH_TOKEN))
+                .run_async(&handler)
+                .await,
+            Status::NotFound,
+            "",
+        );
+
+        // Verify: deleting an arbitrary nonexistent task ID returns NotFound.
+        assert_response!(
+            delete(&format!("/tasks/{}", &random::<TaskId>()))
+                .with_request_header("Authorization", format!("Basic {}", AUTH_TOKEN))
+                .run_async(&handler)
+                .await,
+            Status::NotFound,
+            "",
+        );
+
+        // Verify: unauthorized requests are denied appropriately.
+        assert_response!(
+            delete(&format!("/tasks/{}", &task_id))
+                .run_async(&handler)
+                .await,
+            Status::Unauthorized,
+            ""
+        );
+    }
+
+    #[tokio::test]
+    async fn get_task_metrics() {
+        // Setup: write a task, some reports, and some report aggregations to the datastore.
+        const REPORT_COUNT: usize = 10;
+        const REPORT_AGGREGATION_COUNT: usize = 4;
+
+        let (handler, ephemeral_datastore) = setup_api_test().await;
+        let ds = ephemeral_datastore.datastore(MockClock::default());
+        let task_id = ds
+            .run_tx(|tx| {
+                Box::pin(async move {
+                    let task =
+                        TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Leader)
+                            .build();
+                    let task_id = *task.id();
+                    tx.put_task(&task).await?;
+
+                    let reports: Vec<_> = iter::repeat_with(|| {
+                        LeaderStoredReport::new_dummy(task_id, Time::from_seconds_since_epoch(0))
+                    })
+                    .take(REPORT_COUNT)
+                    .collect();
+                    try_join_all(reports.iter().map(|report| async move {
+                        tx.put_client_report(&dummy_vdaf::Vdaf::new(), report).await
+                    }))
+                    .await?;
+
+                    let aggregation_job_id = random();
+                    tx.put_aggregation_job(
+                        &AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
+                            task_id,
+                            aggregation_job_id,
+                            AggregationParam(0),
+                            (),
+                            Interval::new(
+                                Time::from_seconds_since_epoch(0),
+                                Duration::from_seconds(1),
+                            )
+                            .unwrap(),
+                            AggregationJobState::InProgress,
+                            AggregationJobRound::from(0),
+                        ),
+                    )
+                    .await?;
+
+                    try_join_all(
+                        reports
+                            .iter()
+                            .take(REPORT_AGGREGATION_COUNT)
+                            .enumerate()
+                            .map(|(ord, report)| async move {
+                                tx.put_report_aggregation(
+                                    &ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
+                                        task_id,
+                                        aggregation_job_id,
+                                        *report.metadata().id(),
+                                        *report.metadata().time(),
+                                        ord.try_into().unwrap(),
+                                        ReportAggregationState::Start,
+                                    ),
+                                )
+                                .await
+                            }),
+                    )
+                    .await?;
+
+                    Ok(task_id)
+                })
+            })
+            .await
+            .unwrap();
+
+        // Verify: requesting metrics on a task returns the correct result.
+        assert_response!(
+            get(&format!("/tasks/{}/metrics", &task_id))
+                .with_request_header("Authorization", format!("Basic {}", AUTH_TOKEN))
+                .run_async(&handler)
+                .await,
+            Status::Ok,
+            serde_json::to_string(&GetTaskMetricsResp {
+                reports: REPORT_COUNT.try_into().unwrap(),
+                report_aggregations: REPORT_AGGREGATION_COUNT.try_into().unwrap(),
+            })
+            .unwrap(),
+        );
+
+        // Verify: requesting metrics on a nonexistent task returns NotFound.
+        assert_response!(
+            delete(&format!("/tasks/{}", &random::<TaskId>()))
+                .with_request_header("Authorization", format!("Basic {}", AUTH_TOKEN))
+                .run_async(&handler)
+                .await,
+            Status::NotFound,
+            "",
+        );
+
+        // Verify: unauthorized requests are denied appropriately.
+        assert_response!(
+            get(&format!("/tasks/{}/metrics", &task_id))
+                .run_async(&handler)
+                .await,
+            Status::Unauthorized,
+            "",
+        );
+    }
+}

--- a/aggregator_api/src/lib.rs
+++ b/aggregator_api/src/lib.rs
@@ -77,7 +77,7 @@ async fn get_task_ids<C: Clock>(
         .map(|(_, v)| TaskId::from_str(v))
         .transpose()
         .map_err(|err| {
-            warn!(err = %err, "Couldn't parse pagination_token");
+            warn!(err = ?err, "Couldn't parse pagination_token");
             Status::BadRequest
         })?;
 
@@ -336,7 +336,7 @@ impl ConnExt for Conn {
             Status::InternalServerError
         })?)
         .map_err(|err| {
-            warn!(err = %err, "Couldn't parse task_id parameter");
+            warn!(err = ?err, "Couldn't parse task_id parameter");
             Status::BadRequest
         })
     }

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -492,6 +492,7 @@ impl<C: Clock> Transaction<'_, C> {
     /// aggregations, etc).
     #[tracing::instrument(skip(self))]
     pub async fn delete_task(&self, task_id: &TaskId) -> Result<(), Error> {
+        // Deletion of other data implemented via ON DELETE CASCADE.
         let stmt = self
             .prepare_cached("DELETE FROM tasks WHERE task_id = $1")
             .await?;

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -457,12 +457,12 @@ impl SerializedTask {
 
         if self.aggregator_auth_tokens.is_empty() {
             self.aggregator_auth_tokens =
-                Vec::from([URL_SAFE_NO_PAD.encode(random::<AuthenticationToken>().as_bytes())]);
+                Vec::from([URL_SAFE_NO_PAD.encode(random::<AuthenticationToken>())]);
         }
 
         if self.collector_auth_tokens.is_empty() && self.role == Role::Leader {
             self.collector_auth_tokens =
-                Vec::from([URL_SAFE_NO_PAD.encode(random::<AuthenticationToken>().as_bytes())]);
+                Vec::from([URL_SAFE_NO_PAD.encode(random::<AuthenticationToken>())]);
         }
 
         if self.hpke_keys.is_empty() {
@@ -488,12 +488,12 @@ impl Serialize for Task {
         let aggregator_auth_tokens = self
             .aggregator_auth_tokens
             .iter()
-            .map(|token| URL_SAFE_NO_PAD.encode(token.as_bytes()))
+            .map(|token| URL_SAFE_NO_PAD.encode(token))
             .collect();
         let collector_auth_tokens = self
             .collector_auth_tokens
             .iter()
-            .map(|token| URL_SAFE_NO_PAD.encode(token.as_bytes()))
+            .map(|token| URL_SAFE_NO_PAD.encode(token))
             .collect();
         let hpke_keys = self.hpke_keys.values().cloned().collect();
 
@@ -542,7 +542,7 @@ impl TryFrom<SerializedTask> for Task {
             .map(|token| Ok(AuthenticationToken::from(URL_SAFE_NO_PAD.decode(token)?)))
             .collect::<Result<Vec<AuthenticationToken>, Self::Error>>()?;
         for token in aggregator_auth_tokens.iter() {
-            HeaderValue::try_from(token.as_bytes()).map_err(|_| {
+            HeaderValue::try_from(token.as_ref()).map_err(|_| {
                 Error::InvalidParameter(concat!(
                     "value in aggregator_auth_tokens does not base64url-decode to a valid ",
                     "HTTP header value"
@@ -557,7 +557,7 @@ impl TryFrom<SerializedTask> for Task {
             .map(|token| Ok(AuthenticationToken::from(URL_SAFE_NO_PAD.decode(token)?)))
             .collect::<Result<Vec<AuthenticationToken>, Self::Error>>()?;
         for token in collector_auth_tokens.iter() {
-            HeaderValue::try_from(token.as_bytes()).map_err(|_| {
+            HeaderValue::try_from(token.as_ref()).map_err(|_| {
                 Error::InvalidParameter(concat!(
                     "value in collector_auth_tokens does not base64url-decode to a valid ",
                     "HTTP header value"
@@ -1412,7 +1412,7 @@ mod tests {
             tolerable_clock_skew: Duration::from_seconds(15),
             collector_hpke_config: collector_keypair.config().clone(),
             aggregator_auth_tokens: Vec::from([
-                URL_SAFE_NO_PAD.encode(random::<AuthenticationToken>().as_bytes())
+                URL_SAFE_NO_PAD.encode(random::<AuthenticationToken>())
             ]),
             collector_auth_tokens: Vec::from(["AAAAAAAAAAAAAA".to_string()]),
             hpke_keys: Vec::from([aggregator_keypair]),

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -410,7 +410,7 @@ impl<V: vdaf::Collector> Collector<V> {
                     .body(collect_request.get_encoded());
                 match &self.parameters.authentication {
                     Authentication::DapAuthToken(token) => {
-                        request = request.header(DAP_AUTH_HEADER, token.as_bytes())
+                        request = request.header(DAP_AUTH_HEADER, token.as_ref())
                     }
                 }
                 request.send().await
@@ -458,7 +458,7 @@ impl<V: vdaf::Collector> Collector<V> {
                 let mut request = self.http_client.post(job.collection_job_url.clone());
                 match &self.parameters.authentication {
                     Authentication::DapAuthToken(token) => {
-                        request = request.header(DAP_AUTH_HEADER, token.as_bytes())
+                        request = request.header(DAP_AUTH_HEADER, token.as_ref())
                     }
                 }
                 request.send().await

--- a/core/src/task.rs
+++ b/core/src/task.rs
@@ -536,16 +536,15 @@ macro_rules! vdaf_dispatch {
 #[derive(Clone)]
 pub struct AuthenticationToken(Vec<u8>);
 
-impl From<Vec<u8>> for AuthenticationToken {
-    fn from(token: Vec<u8>) -> Self {
-        Self(token)
+impl AsRef<[u8]> for AuthenticationToken {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
     }
 }
 
-impl AuthenticationToken {
-    /// Returns a view of the aggregator authentication token as a byte slice.
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.0
+impl From<Vec<u8>> for AuthenticationToken {
+    fn from(token: Vec<u8>) -> Self {
+        Self(token)
     }
 }
 

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -287,12 +287,12 @@ impl From<Task> for AggregatorAddTaskRequest {
             helper: task.aggregator_url(&Role::Helper).unwrap().clone(),
             vdaf: task.vdaf().clone().into(),
             leader_authentication_token: String::from_utf8(
-                task.primary_aggregator_auth_token().as_bytes().to_vec(),
+                task.primary_aggregator_auth_token().as_ref().to_vec(),
             )
             .unwrap(),
             collector_authentication_token: if task.role() == &Role::Leader {
                 Some(
-                    String::from_utf8(task.primary_collector_auth_token().as_bytes().to_vec())
+                    String::from_utf8(task.primary_collector_auth_token().as_ref().to_vec())
                         .unwrap(),
                 )
             } else {

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -258,11 +258,11 @@ impl From<[u8; Self::LEN]> for ReportId {
 }
 
 impl<'a> TryFrom<&'a [u8]> for ReportId {
-    type Error = &'static str;
+    type Error = anyhow::Error;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self(value.try_into().map_err(|_| {
-            "byte slice has incorrect length for ReportId"
+            anyhow!("byte slice has incorrect length for ReportId")
         })?))
     }
 }
@@ -304,13 +304,11 @@ impl Decode for ReportId {
 }
 
 impl FromStr for ReportId {
-    type Err = Box<dyn Debug>;
+    type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let bytes = URL_SAFE_NO_PAD
-            .decode(s)
-            .map_err(|e| Box::new(e) as Box<dyn Debug>)?;
-        Self::try_from(bytes.as_ref()).map_err(|e| Box::new(e) as Box<dyn Debug>)
+        let bytes = URL_SAFE_NO_PAD.decode(s)?;
+        Self::try_from(bytes.as_ref())
     }
 }
 
@@ -546,11 +544,11 @@ impl From<[u8; Self::LEN]> for TaskId {
 }
 
 impl<'a> TryFrom<&'a [u8]> for TaskId {
-    type Error = &'static str;
+    type Error = anyhow::Error;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self(value.try_into().map_err(|_| {
-            "byte slice has incorrect length for TaskId"
+            anyhow!("byte slice has incorrect length for TaskId")
         })?))
     }
 }
@@ -562,13 +560,11 @@ impl AsRef<[u8; Self::LEN]> for TaskId {
 }
 
 impl FromStr for TaskId {
-    type Err = Box<dyn Debug>;
+    type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let bytes = URL_SAFE_NO_PAD
-            .decode(s)
-            .map_err(|e| Box::new(e) as Box<dyn Debug>)?;
-        Self::try_from(bytes.as_ref()).map_err(|e| Box::new(e) as Box<dyn Debug>)
+        let bytes = URL_SAFE_NO_PAD.decode(s)?;
+        Self::try_from(bytes.as_ref())
     }
 }
 
@@ -1407,23 +1403,21 @@ impl AsRef<[u8; Self::LEN]> for CollectionJobId {
 }
 
 impl TryFrom<&[u8]> for CollectionJobId {
-    type Error = &'static str;
+    type Error = anyhow::Error;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self(value.try_into().map_err(|_| {
-            "byte slice has incorrect length for CollectionId"
+            anyhow!("byte slice has incorrect length for CollectionId")
         })?))
     }
 }
 
 impl FromStr for CollectionJobId {
-    type Err = Box<dyn Debug>;
+    type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let bytes = URL_SAFE_NO_PAD
-            .decode(s)
-            .map_err(|e| Box::new(e) as Box<dyn Debug>)?;
-        Self::try_from(bytes.as_ref()).map_err(|e| Box::new(e) as Box<dyn Debug>)
+        let bytes = URL_SAFE_NO_PAD.decode(s)?;
+        Self::try_from(bytes.as_ref())
     }
 }
 
@@ -1963,13 +1957,12 @@ impl From<[u8; Self::LEN]> for AggregationJobId {
 }
 
 impl<'a> TryFrom<&'a [u8]> for AggregationJobId {
-    type Error = Error;
+    type Error = anyhow::Error;
 
-    fn try_from(aggregation_job_id: &[u8]) -> Result<Self, Self::Error> {
-        let aggregation_job_id: [u8; Self::LEN] = aggregation_job_id
-            .try_into()
-            .map_err(|_| Error::InvalidParameter("AggregationJobId length incorrect"))?;
-        Ok(Self::from(aggregation_job_id))
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        Ok(Self(value.try_into().map_err(|_| {
+            anyhow!("byte slice has incorrect length for AggregationJobId")
+        })?))
     }
 }
 
@@ -1980,13 +1973,11 @@ impl AsRef<[u8; Self::LEN]> for AggregationJobId {
 }
 
 impl FromStr for AggregationJobId {
-    type Err = Box<dyn Debug>;
+    type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let bytes = URL_SAFE_NO_PAD
-            .decode(s)
-            .map_err(|e| Box::new(e) as Box<dyn Debug>)?;
-        Self::try_from(bytes.as_ref()).map_err(|e| Box::new(e) as Box<dyn Debug>)
+        let bytes = URL_SAFE_NO_PAD.decode(s)?;
+        Self::try_from(bytes.as_ref())
     }
 }
 

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -258,11 +258,11 @@ impl From<[u8; Self::LEN]> for ReportId {
 }
 
 impl<'a> TryFrom<&'a [u8]> for ReportId {
-    type Error = anyhow::Error;
+    type Error = &'static str;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self(value.try_into().map_err(|_| {
-            anyhow!("byte slice has incorrect length for ReportId")
+            "byte slice has incorrect length for ReportId"
         })?))
     }
 }
@@ -304,11 +304,13 @@ impl Decode for ReportId {
 }
 
 impl FromStr for ReportId {
-    type Err = anyhow::Error;
+    type Err = Box<dyn Debug>;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let bytes = URL_SAFE_NO_PAD.decode(s)?;
-        Self::try_from(bytes.as_ref())
+        let bytes = URL_SAFE_NO_PAD
+            .decode(s)
+            .map_err(|err| Box::new(err) as Box<dyn Debug>)?;
+        Self::try_from(bytes.as_ref()).map_err(|err| Box::new(err) as Box<dyn Debug>)
     }
 }
 
@@ -544,11 +546,11 @@ impl From<[u8; Self::LEN]> for TaskId {
 }
 
 impl<'a> TryFrom<&'a [u8]> for TaskId {
-    type Error = anyhow::Error;
+    type Error = &'static str;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self(value.try_into().map_err(|_| {
-            anyhow!("byte slice has incorrect length for TaskId")
+            "byte slice has incorrect length for TaskId"
         })?))
     }
 }
@@ -560,11 +562,13 @@ impl AsRef<[u8; Self::LEN]> for TaskId {
 }
 
 impl FromStr for TaskId {
-    type Err = anyhow::Error;
+    type Err = Box<dyn Debug>;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let bytes = URL_SAFE_NO_PAD.decode(s)?;
-        Self::try_from(bytes.as_ref())
+        let bytes = URL_SAFE_NO_PAD
+            .decode(s)
+            .map_err(|err| Box::new(err) as Box<dyn Debug>)?;
+        Self::try_from(bytes.as_ref()).map_err(|err| Box::new(err) as Box<dyn Debug>)
     }
 }
 
@@ -1403,21 +1407,23 @@ impl AsRef<[u8; Self::LEN]> for CollectionJobId {
 }
 
 impl TryFrom<&[u8]> for CollectionJobId {
-    type Error = anyhow::Error;
+    type Error = &'static str;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self(value.try_into().map_err(|_| {
-            anyhow!("byte slice has incorrect length for CollectionId")
+            "byte slice has incorrect length for CollectionId"
         })?))
     }
 }
 
 impl FromStr for CollectionJobId {
-    type Err = anyhow::Error;
+    type Err = Box<dyn Debug>;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let bytes = URL_SAFE_NO_PAD.decode(s)?;
-        Self::try_from(bytes.as_ref())
+        let bytes = URL_SAFE_NO_PAD
+            .decode(s)
+            .map_err(|err| Box::new(err) as Box<dyn Debug>)?;
+        Self::try_from(bytes.as_ref()).map_err(|err| Box::new(err) as Box<dyn Debug>)
     }
 }
 
@@ -1957,11 +1963,11 @@ impl From<[u8; Self::LEN]> for AggregationJobId {
 }
 
 impl<'a> TryFrom<&'a [u8]> for AggregationJobId {
-    type Error = anyhow::Error;
+    type Error = Error;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self(value.try_into().map_err(|_| {
-            anyhow!("byte slice has incorrect length for AggregationJobId")
+            Error::InvalidParameter("byte slice has incorrect length for AggregationJobId")
         })?))
     }
 }
@@ -1973,11 +1979,13 @@ impl AsRef<[u8; Self::LEN]> for AggregationJobId {
 }
 
 impl FromStr for AggregationJobId {
-    type Err = anyhow::Error;
+    type Err = Box<dyn Debug>;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let bytes = URL_SAFE_NO_PAD.decode(s)?;
-        Self::try_from(bytes.as_ref())
+        let bytes = URL_SAFE_NO_PAD
+            .decode(s)
+            .map_err(|err| Box::new(err) as Box<dyn Debug>)?;
+        Self::try_from(bytes.as_ref()).map_err(|err| Box::new(err) as Box<dyn Debug>)
     }
 }
 


### PR DESCRIPTION
Based on Trillium; I was pretty happy with how the library worked out.

Note that I currently return the entire task -- including secrets --
wherever a task is returned (e.g. post task, get task). We had
previously discussed that the secrets would be returned by a different
endpoint. I think this can be changed later, and more than that, I think
the most common case will be adding a new task -- where the control
plane will need the secrets in order to relay them to the co-aggregator.