### PR TITLE
janus_cli: Lazily construct Kubernetes client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1642,6 +1642,7 @@ dependencies = [
  "kube",
  "lazy_static",
  "mockito",
+ "once_cell",
  "opentelemetry",
  "opentelemetry-jaeger",
  "opentelemetry-otlp",
@@ -2328,9 +2329,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "opaque-debug"

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -60,6 +60,7 @@ janus_messages.workspace = true
 k8s-openapi.workspace = true
 kube.workspace = true
 lazy_static = { version = "1", optional = true }
+once_cell = "1.17.1"
 opentelemetry = { version = "0.18", features = ["metrics", "rt-tokio"] }
 opentelemetry-jaeger = { version = "0.17", optional = true, features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.11", optional = true, features = ["metrics"] }  # ensure that the version of tonic below matches what this uses


### PR DESCRIPTION
This lazily constructs `kube::Client` inside janus_cli. The provision-tasks subcommand only needs Kubernetes access in one of its modes, so this fixes #946, resolving an error when the datastore key is provided directly and no Kubernetes configuration is available. I created a new struct to handle this lazy initialization with an async method, because `kube::Client::try_default()` is async. (Though, as of the version we're using, none of the await points inside it actually need to wait)