### PR TITLE
Add HPKE key generation tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,6 +1927,7 @@ dependencies = [
  "prio",
  "rand",
  "reqwest",
+ "serde_yaml 0.9.19",
  "tokio",
  "tracing",
  "tracing-log",

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -22,6 +22,7 @@ janus_core.workspace = true
 janus_messages.workspace = true
 prio.workspace = true
 reqwest = { version = "0.11.14", default-features = false, features = ["rustls-tls", "json"] }
+serde_yaml = "0.9.19"
 tokio = { version = "1.26", features = ["full"] }
 tracing = "0.1.37"
 tracing-log = "0.1.3"

--- a/tools/src/bin/dap_decode.rs
+++ b/tools/src/bin/dap_decode.rs
@@ -133,7 +133,7 @@ enum MediaType {
 
 #[derive(Debug, Parser)]
 #[command(
-    name = "dap-decode",
+    name = "dap_decode",
     about = "Distributed Aggregation Protocol message decoder",
     version,
     rename_all = "kebab-case"
@@ -145,4 +145,15 @@ struct Options {
     /// Media type of the message to decode.
     #[arg(long, short = 't', required = true)]
     media_type: MediaType,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Options;
+    use clap::CommandFactory;
+
+    #[test]
+    fn verify_clap_app() {
+        Options::command().debug_assert();
+    }
 }

--- a/tools/src/bin/hpke_keygen.rs
+++ b/tools/src/bin/hpke_keygen.rs
@@ -1,0 +1,180 @@
+use anyhow::Result;
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use clap::{Parser, ValueEnum};
+use janus_core::hpke::generate_hpke_config_and_private_key;
+use janus_messages::{HpkeAeadId, HpkeConfigId, HpkeKdfId, HpkeKemId};
+use prio::codec::Encode;
+use serde_yaml::to_writer;
+use std::{
+    fmt::Display,
+    io::{stdout, Write},
+};
+
+fn main() -> Result<()> {
+    let options = Options::parse();
+
+    let id = HpkeConfigId::from(options.id);
+    let keypair = generate_hpke_config_and_private_key(
+        id,
+        options.kem.into(),
+        options.kdf.into(),
+        options.aead.into(),
+    );
+
+    let mut writer = stdout().lock();
+
+    writeln!(writer, "# HPKE configuration, Janus format")?;
+    to_writer(&mut writer, keypair.config())?;
+
+    writeln!(writer, "---")?;
+
+    writeln!(writer, "# HPKE private key, in base64url")?;
+    writeln!(
+        writer,
+        "{}",
+        URL_SAFE_NO_PAD.encode(keypair.private_key().as_ref())
+    )?;
+
+    writeln!(writer, "---")?;
+
+    writeln!(writer, "# HPKE keypair, Janus format")?;
+    to_writer(&mut writer, &keypair)?;
+
+    writeln!(writer, "---")?;
+
+    writeln!(writer, "# HPKE configuration, DAP encoded, in base64url")?;
+    writeln!(
+        writer,
+        "{}",
+        URL_SAFE_NO_PAD.encode(keypair.config().get_encoded())
+    )?;
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, ValueEnum)]
+#[value()]
+enum KemAlgorithm {
+    /// DHKEM(P-256, HKDF-SHA256)
+    #[value(name = "p-256")]
+    P256HkdfSha256,
+
+    /// DHKEM(X25519, HKDF-SHA256)
+    #[value(name = "x25519")]
+    X25519HkdfSha256,
+}
+
+impl From<KemAlgorithm> for HpkeKemId {
+    fn from(value: KemAlgorithm) -> Self {
+        match value {
+            KemAlgorithm::P256HkdfSha256 => HpkeKemId::P256HkdfSha256,
+            KemAlgorithm::X25519HkdfSha256 => HpkeKemId::X25519HkdfSha256,
+        }
+    }
+}
+
+impl Display for KemAlgorithm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // This is safe to unwrap because we don't skip any enum variants.
+        let possible_value = self.to_possible_value().unwrap();
+        f.write_str(possible_value.get_name())
+    }
+}
+
+#[derive(Debug, Clone, ValueEnum)]
+#[value()]
+enum KdfAlgorithm {
+    /// HKDF-SHA256
+    #[value(name = "hkdf-sha256")]
+    HkdfSha256,
+
+    /// HKDF-SHA384
+    #[value(name = "hkdf-sha384")]
+    HkdfSha384,
+
+    /// HKDF-SHA512
+    #[value(name = "hkdf-sha512")]
+    HkdfSha512,
+}
+
+impl From<KdfAlgorithm> for HpkeKdfId {
+    fn from(value: KdfAlgorithm) -> Self {
+        match value {
+            KdfAlgorithm::HkdfSha256 => HpkeKdfId::HkdfSha256,
+            KdfAlgorithm::HkdfSha384 => HpkeKdfId::HkdfSha384,
+            KdfAlgorithm::HkdfSha512 => HpkeKdfId::HkdfSha512,
+        }
+    }
+}
+
+impl Display for KdfAlgorithm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // This is safe to unwrap because we don't skip any enum variants.
+        let possible_value = self.to_possible_value().unwrap();
+        f.write_str(possible_value.get_name())
+    }
+}
+
+#[derive(Debug, Clone, ValueEnum)]
+#[value()]
+enum AeadAlgorithm {
+    /// AES-128-GCM
+    #[value(name = "aes-128-gcm")]
+    Aes128Gcm,
+
+    /// AES-256-GCM
+    #[value(name = "aes-256-gcm")]
+    Aes256Gcm,
+
+    /// ChaCha20Poly1305
+    #[value(name = "chacha20poly1305")]
+    ChaCha20Poly1305,
+}
+
+impl From<AeadAlgorithm> for HpkeAeadId {
+    fn from(value: AeadAlgorithm) -> Self {
+        match value {
+            AeadAlgorithm::Aes128Gcm => HpkeAeadId::Aes128Gcm,
+            AeadAlgorithm::Aes256Gcm => HpkeAeadId::Aes256Gcm,
+            AeadAlgorithm::ChaCha20Poly1305 => HpkeAeadId::ChaCha20Poly1305,
+        }
+    }
+}
+
+impl Display for AeadAlgorithm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // This is safe to unwrap because we don't skip any enum variants.
+        let possible_value = self.to_possible_value().unwrap();
+        f.write_str(possible_value.get_name())
+    }
+}
+
+#[derive(Debug, Parser)]
+#[command(name = "hpke_keygen", about = "DAP-compatible HPKE keypair generator")]
+struct Options {
+    /// Numeric identifier of the HPKE configuration.
+    id: u8,
+
+    /// HPKE Key Encapsulation Mechanism algorithm.
+    #[arg(long, default_value_t = KemAlgorithm::X25519HkdfSha256)]
+    kem: KemAlgorithm,
+
+    /// HPKE Key Derivation Function algorithm.
+    #[arg(long, default_value_t = KdfAlgorithm::HkdfSha256)]
+    kdf: KdfAlgorithm,
+
+    /// HPKE Authenticated Encryption with Associated Data algorithm.
+    #[arg(long, default_value_t = AeadAlgorithm::Aes128Gcm)]
+    aead: AeadAlgorithm,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Options;
+    use clap::CommandFactory;
+
+    #[test]
+    fn verify_clap_app() {
+        Options::command().debug_assert();
+    }
+}

--- a/tools/tests/cli.rs
+++ b/tools/tests/cli.rs
@@ -6,6 +6,7 @@ fn cli_tests() {
     let test_cases = TestCases::new();
 
     test_cases.case("tests/cmd/dap_decode.trycmd");
+    test_cases.case("tests/cmd/hpke_keygen.trycmd");
 
     cfg_if! {
         if #[cfg(feature = "fpvec_bounded_l2")] {

--- a/tools/tests/cmd/hpke_keygen.trycmd
+++ b/tools/tests/cmd/hpke_keygen.trycmd
@@ -1,0 +1,69 @@
+```
+$ hpke_keygen --help
+DAP-compatible HPKE keypair generator
+
+Usage: hpke_keygen [OPTIONS] <ID>
+
+Arguments:
+  <ID>
+          Numeric identifier of the HPKE configuration
+
+Options:
+      --kem <KEM>
+          HPKE Key Encapsulation Mechanism algorithm
+          
+          [default: x25519]
+
+          Possible values:
+          - p-256:  DHKEM(P-256, HKDF-SHA256)
+          - x25519: DHKEM(X25519, HKDF-SHA256)
+
+      --kdf <KDF>
+          HPKE Key Derivation Function algorithm
+          
+          [default: hkdf-sha256]
+
+          Possible values:
+          - hkdf-sha256: HKDF-SHA256
+          - hkdf-sha384: HKDF-SHA384
+          - hkdf-sha512: HKDF-SHA512
+
+      --aead <AEAD>
+          HPKE Authenticated Encryption with Associated Data algorithm
+          
+          [default: aes-128-gcm]
+
+          Possible values:
+          - aes-128-gcm:      AES-128-GCM
+          - aes-256-gcm:      AES-256-GCM
+          - chacha20poly1305: ChaCha20Poly1305
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+```
+
+```
+$ hpke_keygen 5
+# HPKE configuration, Janus format
+id: 5
+kem_id: X25519HkdfSha256
+kdf_id: HkdfSha256
+aead_id: Aes128Gcm
+public_key: [..]
+---
+# HPKE private key, in base64url
+[..]
+---
+# HPKE keypair, Janus format
+config:
+  id: 5
+  kem_id: X25519HkdfSha256
+  kdf_id: HkdfSha256
+  aead_id: Aes128Gcm
+  public_key: [..]
+private_key: [..]
+---
+# HPKE configuration, DAP encoded, in base64url
+BQAgAAEAAQAg[..]
+```


### PR DESCRIPTION
This adds a command-line tool to generate HPKE keypairs, closing #801. Sample output:

```
# HPKE configuration, Janus format
id: 255
kem_id: X25519HkdfSha256
kdf_id: HkdfSha256
aead_id: Aes128Gcm
public_key: vaiPHYKo6c_HZvqjMgfcFLgWmvo45nbJ_5G4ShFBQnc
---
# HPKE private key, in base64url
EC9SQqZky66zQ5dl1aWu-5xZ34MVfB2RdoSCFGkHlGo
---
# HPKE keypair, Janus format
config:
  id: 255
  kem_id: X25519HkdfSha256
  kdf_id: HkdfSha256
  aead_id: Aes128Gcm
  public_key: vaiPHYKo6c_HZvqjMgfcFLgWmvo45nbJ_5G4ShFBQnc
private_key: EC9SQqZky66zQ5dl1aWu-5xZ34MVfB2RdoSCFGkHlGo
---
# HPKE configuration, DAP encoded, in base64url
_wAgAAEAAQAgvaiPHYKo6c_HZvqjMgfcFLgWmvo45nbJ_5G4ShFBQnc
```

Fun fact: since the various ID fields and the public key's length prefix are nine bytes all together, a multiple of three, the base64url-encoded public key appears verbatim in the base64url-encoded HpkeConfig message.