### PR TITLE
Update to prio 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,9 +964,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b2f3c51e4dd999930845da5d10a48775b8fe4ca9f4f9ec1f9161f334da5dfe"
+checksum = "93ace6ec7cc19c8ed33a32eaa9ea692d7faea05006b5356b9e2b668ec4bc3955"
 
 [[package]]
 name = "filetime"
@@ -2807,9 +2807,9 @@ dependencies = [
 
 [[package]]
 name = "prio"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942b15465147a8f027aba46630d1f5fe2decb15ec6263a396eb763b269cac60a"
+checksum = "9c2aa1f9faa3fab6f02b54025f411d6f4fcd31765765600db339280e3678ae20"
 dependencies = [
  "aes",
  "base64 0.21.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ janus_interop_binaries = { version = "0.3", path = "interop_binaries" }
 janus_messages = { version = "0.3", path = "messages" }
 k8s-openapi = { version = "0.16.0", features = ["v1_24"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
 kube = { version = "0.75.0", default-features = false, features = ["client"] }
-prio = { version = "0.11.1", features = ["multithreaded"] }
+prio = { version = "0.12.0", features = ["multithreaded"] }
 
 [profile.dev]
 # Disabling debug info improves build speeds & reduces build artifact sizes, which helps CI caching.

--- a/core/src/task.rs
+++ b/core/src/task.rs
@@ -22,7 +22,7 @@ pub enum VdafInstance {
     /// A vector of `Prio3` counters.
     Prio3CountVec { length: usize },
     /// A `Prio3` sum.
-    Prio3Sum { bits: u32 },
+    Prio3Sum { bits: usize },
     /// A vector of `Prio3` sums.
     Prio3SumVec { bits: usize, length: usize },
     /// A `Prio3` histogram.
@@ -617,7 +617,7 @@ mod tests {
                     len: 1,
                 },
                 Token::Str("bits"),
-                Token::U32(64),
+                Token::U64(64),
                 Token::StructVariantEnd,
             ],
         );

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -106,7 +106,7 @@ pub enum VdafObject {
         length: NumberAsString<usize>,
     },
     Prio3Sum {
-        bits: NumberAsString<u32>,
+        bits: NumberAsString<usize>,
     },
     Prio3SumVec {
         bits: NumberAsString<usize>,

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -20,7 +20,7 @@ hex = "0.4"
 num_enum = "0.5.11"
 # We can't pull prio in from the workspace because that would enable default features, and we do not
 # want prio/crypto-dependencies
-prio = { version = "0.11.1", default-features = false }
+prio = { version = "0.12.0", default-features = false }
 rand = "0.8"
 serde = { version = "1.0.158", features = ["derive"] }
 thiserror = "1.0"

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -304,7 +304,7 @@ struct Options {
     length: Option<usize>,
     /// Bit length of measurements, for use with --vdaf=sum
     #[clap(long, help_heading = "VDAF Algorithm and Parameters")]
-    bits: Option<u32>,
+    bits: Option<usize>,
     /// Comma-separated list of bucket boundaries, for use with --vdaf=histogram
     #[clap(
         long,


### PR DESCRIPTION
This upgrades libprio-rs to 0.12.0, supporting VDAF-05. The only relevant breaking change was swapping a u32 for a usize in Prio3Sum.

Closes #1094.