### PR TITLE
Reformat long string literals

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -224,14 +224,40 @@ impl AggregationJobDriver {
         }
         match (saw_start, saw_waiting, saw_finished) {
             // Only saw report aggregations in state "start" (or failed or invalid).
-            (true, false, false) => self.step_aggregation_job_aggregate_init(
-                &datastore, vdaf, lease, task, aggregation_job, report_aggregations, client_reports, verify_key).await,
+            (true, false, false) => {
+                self.step_aggregation_job_aggregate_init(
+                    &datastore,
+                    vdaf,
+                    lease,
+                    task,
+                    aggregation_job,
+                    report_aggregations,
+                    client_reports,
+                    verify_key,
+                )
+                .await
+            }
 
             // Only saw report aggregations in state "waiting" (or failed or invalid).
-            (false, true, false) => self.step_aggregation_job_aggregate_continue(
-                &datastore, vdaf, lease, task, aggregation_job, report_aggregations).await,
+            (false, true, false) => {
+                self.step_aggregation_job_aggregate_continue(
+                    &datastore,
+                    vdaf,
+                    lease,
+                    task,
+                    aggregation_job,
+                    report_aggregations,
+                )
+                .await
+            }
 
-            _ => Err(anyhow!("unexpected combination of report aggregation states (saw_start = {}, saw_waiting = {}, saw_finished = {})", saw_start, saw_waiting, saw_finished)),
+            _ => Err(anyhow!(
+                "unexpected combination of report aggregation states (saw_start = {}, saw_waiting \
+                 = {}, saw_finished = {})",
+                saw_start,
+                saw_waiting,
+                saw_finished
+            )),
         }
     }
 
@@ -540,7 +566,10 @@ impl AggregationJobDriver {
                                 .context("couldn't decode helper's prepare message");
                         let prep_msg = helper_prep_share.and_then(|helper_prep_share| {
                             vdaf.prepare_preprocess([leader_prep_share.clone(), helper_prep_share])
-                                .context("couldn't preprocess leader & helper prepare shares into prepare message")
+                                .context(
+                                    "couldn't preprocess leader & helper prepare shares into \
+                                     prepare message",
+                                )
                         });
                         match prep_msg {
                             Ok(prep_msg) => ReportAggregationState::Waiting(

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -426,7 +426,8 @@ impl CollectionJobDriverMetrics {
         let jobs_already_finished_counter = meter
             .u64_counter("janus_collection_jobs_already_finished")
             .with_description(
-                "Count of collection jobs for which a lease was acquired but were already finished.",
+                "Count of collection jobs for which a lease was acquired but were already \
+                 finished.",
             )
             .init();
         jobs_already_finished_counter.add(&Context::current(), 0, &[]);
@@ -434,14 +435,19 @@ impl CollectionJobDriverMetrics {
         let deleted_jobs_encountered_counter = meter
             .u64_counter("janus_collect_deleted_jobs_encountered")
             .with_description(
-                "Count of collection jobs that were run to completion but found to have been deleted.",
+                "Count of collection jobs that were run to completion but found to have been \
+                 deleted.",
             )
             .init();
         deleted_jobs_encountered_counter.add(&Context::current(), 0, &[]);
 
         let unexpected_job_state_counter = meter
             .u64_counter("janus_collect_unexpected_job_state")
-            .with_description("Count of collection jobs that were run to completion but found in an unexpected state.").init();
+            .with_description(
+                "Count of collection jobs that were run to completion but found in an unexpected \
+                 state.",
+            )
+            .init();
         unexpected_job_state_counter.add(&Context::current(), 0, &[]);
 
         Self {

--- a/aggregator/src/bin/janus_cli.rs
+++ b/aggregator/src/bin/janus_cli.rs
@@ -371,7 +371,7 @@ struct KubernetesSecretOptions {
         env = "SECRETS_K8S_NAMESPACE",
         num_args = 1,
         long_help = "Kubernetes namespace where the datastore key is stored. Required if \
-        --datastore-keys is not set or if command is create-datastore-key."
+                     --datastore-keys is not set or if command is create-datastore-key."
     )]
     secrets_k8s_namespace: Option<String>,
 

--- a/aggregator/src/binary_utils.rs
+++ b/aggregator/src/binary_utils.rs
@@ -233,7 +233,8 @@ fn parse_metadata_entry(input: &str) -> Result<(String, String)> {
         Ok((key.to_string(), value.to_string()))
     } else {
         Err(anyhow!(
-            "`--otlp-tracing-metadata` and `--otlp-metrics-metadata` must be provided a key and value, joined with an `=`"
+            "`--otlp-tracing-metadata` and `--otlp-metrics-metadata` must be provided a key and \
+             value, joined with an `=`"
         ))
     }
 }

--- a/aggregator/src/metrics.rs
+++ b/aggregator/src/metrics.rs
@@ -184,9 +184,8 @@ pub fn install_metrics_exporter(
         }
         #[cfg(not(feature = "prometheus"))]
         Some(MetricsExporterConfiguration::Prometheus { .. }) => Err(Error::Other(
-            "The OpenTelemetry Prometheus metrics exporter was enabled in the \
-            configuration file, but support was not enabled at compile time. \
-            Rebuild with `--features prometheus`.",
+            "The OpenTelemetry Prometheus metrics exporter was enabled in the configuration file, \
+             but support was not enabled at compile time. Rebuild with `--features prometheus`.",
         )),
 
         #[cfg(feature = "otlp")]
@@ -218,9 +217,8 @@ pub fn install_metrics_exporter(
         }
         #[cfg(not(feature = "otlp"))]
         Some(MetricsExporterConfiguration::Otlp(_)) => Err(Error::Other(
-            "The OpenTelemetry OTLP metrics exporter was enabled in the \
-            configuration file, but support was not enabled at compile time. \
-            Rebuild with `--features otlp`.",
+            "The OpenTelemetry OTLP metrics exporter was enabled in the configuration file, but \
+             support was not enabled at compile time. Rebuild with `--features otlp`.",
         )),
 
         // If neither exporter is configured, leave the default NoopMeterProvider in place.

--- a/aggregator/src/trace.rs
+++ b/aggregator/src/trace.rs
@@ -168,10 +168,9 @@ pub fn install_trace_subscriber(config: &TraceConfiguration) -> Result<(), Error
     #[cfg(not(feature = "tokio-console"))]
     if config.tokio_console_config.enabled {
         return Err(Error::Other(
-            "The tokio-console subscriber was enabled in the \
-            configuration file, but support was not enabled at compile \
-            time. Rebuild with `RUSTFLAGS=\"--cfg tokio_unstable\"` and \
-            `--features tokio-console`.",
+            "The tokio-console subscriber was enabled in the configuration file, but support was \
+             not enabled at compile time. Rebuild with `RUSTFLAGS=\"--cfg tokio_unstable\"` and \
+             `--features tokio-console`.",
         ));
     }
 
@@ -189,9 +188,8 @@ pub fn install_trace_subscriber(config: &TraceConfiguration) -> Result<(), Error
     #[cfg(not(feature = "jaeger"))]
     if let Some(OpenTelemetryTraceConfiguration::Jaeger) = &config.open_telemetry_config {
         return Err(Error::Other(
-            "The OpenTelemetry Jaeger subscriber was enabled in the \
-            configuration file, but support was not enabled at compile time. \
-            Rebuild with `--features jaeger`.",
+            "The OpenTelemetry Jaeger subscriber was enabled in the configuration file, but \
+             support was not enabled at compile time. Rebuild with `--features jaeger`.",
         ));
     }
 
@@ -234,9 +232,8 @@ pub fn install_trace_subscriber(config: &TraceConfiguration) -> Result<(), Error
     #[cfg(not(feature = "otlp"))]
     if let Some(OpenTelemetryTraceConfiguration::Otlp(_)) = &config.open_telemetry_config {
         return Err(Error::Other(
-            "The OpenTelemetry OTLP subscriber was enabled in the \
-            configuration file, but support was not enabled at compile time. \
-            Rebuild with `--features otlp`.",
+            "The OpenTelemetry OTLP subscriber was enabled in the configuration file, but support \
+             was not enabled at compile time. Rebuild with `--features otlp`.",
         ));
     }
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -416,18 +416,22 @@ mod tests {
         let mut server = mockito::Server::new_async().await;
         let client = setup_client(&mut server, Prio3::new_count(2).unwrap());
 
-        let mocked_upload = server.mock("PUT", format!("/tasks/{}/reports", client.parameters.task_id).as_str())
+        let mocked_upload = server
+            .mock(
+                "PUT",
+                format!("/tasks/{}/reports", client.parameters.task_id).as_str(),
+            )
             .match_header(CONTENT_TYPE.as_str(), Report::MEDIA_TYPE)
             .with_status(400)
             .with_header("Content-Type", "application/problem+json")
-            .with_body(
-                concat!(
-                    "{\"type\": \"urn:ietf:params:ppm:dap:error:unrecognizedMessage\", ",
-                    "\"detail\": \"The message type for a response was incorrect or the payload was malformed.\"}",
-                )
-            )
+            .with_body(concat!(
+                "{\"type\": \"urn:ietf:params:ppm:dap:error:unrecognizedMessage\", ",
+                "\"detail\": \"The message type for a response was incorrect or the payload was \
+                 malformed.\"}",
+            ))
             .expect(1)
-            .create_async().await;
+            .create_async()
+            .await;
 
         assert_matches!(
             client.upload(&1).await,

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -1265,19 +1265,19 @@ mod tests {
 
         mock_server_error_details.assert_async().await;
 
-        let mock_bad_request = server.mock("PUT", matcher)
+        let mock_bad_request = server
+            .mock("PUT", matcher)
             .match_header(
                 CONTENT_TYPE.as_str(),
                 CollectionReq::<TimeInterval>::MEDIA_TYPE,
             )
             .with_status(400)
             .with_header("Content-Type", "application/problem+json")
-            .with_body(
-                concat!(
-                    "{\"type\": \"urn:ietf:params:ppm:dap:error:unrecognizedMessage\", ",
-                    "\"detail\": \"The message type for a response was incorrect or the payload was malformed.\"}"
-                )
-            )
+            .with_body(concat!(
+                "{\"type\": \"urn:ietf:params:ppm:dap:error:unrecognizedMessage\", ",
+                "\"detail\": \"The message type for a response was incorrect or the payload was \
+                 malformed.\"}"
+            ))
             .expect_at_least(1)
             .create_async()
             .await;
@@ -1359,12 +1359,14 @@ mod tests {
             .assert_async()
             .await;
 
-        let mock_collection_job_bad_request = server.mock("POST", job.collection_job_url.path())
+        let mock_collection_job_bad_request = server
+            .mock("POST", job.collection_job_url.path())
             .with_status(400)
             .with_header("Content-Type", "application/problem+json")
             .with_body(concat!(
                 "{\"type\": \"urn:ietf:params:ppm:dap:error:unrecognizedMessage\", ",
-                "\"detail\": \"The message type for a response was incorrect or the payload was malformed.\"}"
+                "\"detail\": \"The message type for a response was incorrect or the payload was \
+                 malformed.\"}"
             ))
             .expect_at_least(1)
             .create_async()

--- a/core/src/test_util/kubernetes.rs
+++ b/core/src/test_util/kubernetes.rs
@@ -138,7 +138,8 @@ impl EphemeralCluster {
                 "--name",
                 &kind_cluster_name,
                 "--image",
-                "kindest/node:v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315",
+                "kindest/node:v1.24.7@sha256:\
+                 577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315",
             ])
             .stdin(Stdio::null())
             .stdout(Stdio::null())

--- a/core/src/test_util/runtime.rs
+++ b/core/src/test_util/runtime.rs
@@ -49,8 +49,8 @@ where
         let mut receiver = labeled_runtime.inner.sender.subscribe();
         while *receiver.borrow_and_update() < target_count {
             receiver.changed().await.expect(
-                "The channel sender should not be dropped before waits have \
-                finished, this likely indicates an issue with a test.",
+                "The channel sender should not be dropped before waits have finished, this likely \
+                 indicates an issue with a test.",
             );
         }
     }

--- a/integration_tests/build.rs
+++ b/integration_tests/build.rs
@@ -171,7 +171,10 @@ fn main() {
                 .expect("Couldn't write metadata file");
             drop(metadata_file);
         } else {
-            panic!("Unexpected DAPHNE_INTEROP_CONTAINER value {container_strategy:?} (valid values are \"build\", \"prebuilt=image_name:image_tag\", & \"skip\")")
+            panic!(
+                "Unexpected DAPHNE_INTEROP_CONTAINER value {container_strategy:?} (valid values \
+                 are \"build\", \"prebuilt=image_name:image_tag\", & \"skip\")"
+            )
         }
     }
 }

--- a/integration_tests/src/client.rs
+++ b/integration_tests/src/client.rs
@@ -115,8 +115,12 @@ impl InteropClient {
             }
         } else {
             InteropClient {
-                name: "us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-ts/divviup_ts_interop_client".to_string(),
-                tag: "dap-draft-04@sha256:ad6fa3f6fa6f732ccf8291692e250ffa0cc50acd31bb393d98ebaec0f1d2f48c".to_string(),
+                name: "us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-ts/\
+                       divviup_ts_interop_client"
+                    .to_string(),
+                tag: "dap-draft-04@sha256:\
+                      ad6fa3f6fa6f732ccf8291692e250ffa0cc50acd31bb393d98ebaec0f1d2f48c"
+                    .to_string(),
             }
         }
     }

--- a/integration_tests/src/daphne.rs
+++ b/integration_tests/src/daphne.rs
@@ -135,7 +135,8 @@ impl<'a> Daphne<'a> {
                             .as_str()
                             .unwrap_or_else(|| {
                                 panic!(
-                                    "Daphne test image metadata image_name field was not a string: {}",
+                                    "Daphne test image metadata image_name field was not a \
+                                     string: {}",
                                     metadata["image_name"]
                                 )
                             })
@@ -144,14 +145,18 @@ impl<'a> Daphne<'a> {
                             .as_str()
                             .unwrap_or_else(|| {
                                 panic!(
-                                    "Daphne test image metadata image_tag field was not a string: {}",
+                                    "Daphne test image metadata image_tag field was not a string: \
+                                     {}",
                                     metadata["image_tag"]
                                 )
                             })
                             .to_string(),
                     ),
 
-                    "skip" => panic!("No Daphne test image available (compiled with DAPHNE_INTEROP_CONTAINER=skip)"),
+                    "skip" => panic!(
+                        "No Daphne test image available (compiled with \
+                         DAPHNE_INTEROP_CONTAINER=skip)"
+                    ),
 
                     _ => panic!("Unknown Daphne test image build strategy: {strategy:?}"),
                 });

--- a/integration_tests/tests/common/mod.rs
+++ b/integration_tests/tests/common/mod.rs
@@ -192,7 +192,8 @@ pub async fn submit_measurements_and_verify_aggregate_generic<'a, V>(
                     Err(e) => {
                         if requests >= 15 {
                             panic!(
-                                "timed out waiting for a current batch query to succeed, error: {e}"
+                                "timed out waiting for a current batch query to succeed, error: \
+                                 {e}"
                             );
                         }
                         sleep(StdDuration::from_secs(1)).await;

--- a/interop_binaries/build.rs
+++ b/interop_binaries/build.rs
@@ -65,7 +65,10 @@ fn main() {
                         "Docker build of interop client failed:\n{}",
                         String::from_utf8_lossy(&client_build_output.stderr)
                     );
-                    String::from_utf8(client_build_output.stdout).unwrap().trim().to_string()
+                    String::from_utf8(client_build_output.stdout)
+                        .unwrap()
+                        .trim()
+                        .to_string()
                 };
 
                 let aggregator_image_id = {
@@ -86,7 +89,10 @@ fn main() {
                         "Docker build of interop aggregator failed:\n{}",
                         String::from_utf8_lossy(&aggregator_build_output.stderr)
                     );
-                    String::from_utf8(aggregator_build_output.stdout).unwrap().trim().to_string()
+                    String::from_utf8(aggregator_build_output.stdout)
+                        .unwrap()
+                        .trim()
+                        .to_string()
                 };
 
                 let collector_image_id = {
@@ -97,7 +103,7 @@ fn main() {
                             "--file=Dockerfile.interop",
                             "--build-arg=PROFILE=small",
                             "--build-arg=BINARY=janus_interop_collector",
-                            "."
+                            ".",
                         ])
                         .current_dir("..")
                         .env("DOCKER_BUILDKIT", "1")
@@ -108,7 +114,10 @@ fn main() {
                         "Docker build of interop collector failed:\n{}",
                         String::from_utf8_lossy(&collector_build_output.stderr)
                     );
-                    String::from_utf8(collector_build_output.stdout).unwrap().trim().to_string()
+                    String::from_utf8(collector_build_output.stdout)
+                        .unwrap()
+                        .trim()
+                        .to_string()
                 };
 
                 // Save off containers to disk.
@@ -147,7 +156,13 @@ fn main() {
 
                 // Make a best-effort attempt to clean up Docker's post-build state.
                 Command::new("docker")
-                    .args(["image", "rm", &client_image_id, &aggregator_image_id, &collector_image_id])
+                    .args([
+                        "image",
+                        "rm",
+                        &client_image_id,
+                        &aggregator_image_id,
+                        &collector_image_id,
+                    ])
                     .status()
                     .expect("Failed to execute `docker image remove`");
             }
@@ -165,11 +180,16 @@ fn main() {
                         env::var("OUT_DIR").unwrap()
                     ))
                     .expect("Couldn't create empty image file");
-                    image_file.sync_all().expect("Couldn't write empty image file");
+                    image_file
+                        .sync_all()
+                        .expect("Couldn't write empty image file");
                 }
             }
 
-            _ => panic!("Unexpected JANUS_INTEROP_CONTAINER value {container_strategy:?} (valid values are \"build\" & \"skip\")")
+            _ => panic!(
+                "Unexpected JANUS_INTEROP_CONTAINER value {container_strategy:?} (valid values \
+                 are \"build\" & \"skip\")"
+            ),
         }
     }
 }

--- a/interop_binaries/src/testcontainer.rs
+++ b/interop_binaries/src/testcontainer.rs
@@ -84,7 +84,10 @@ impl Default for Aggregator {
         // One-time initialization step: load compiled image into docker, recording its image tag,
         // so that we can launch it later.
         if INTEROP_AGGREGATOR_IMAGE_BYTES.is_empty() {
-            panic!("Cannot create interop aggregator image. (Compiled with JANUS_INTEROP_CONTAINER=skip?)");
+            panic!(
+                "Cannot create interop aggregator image. (Compiled with \
+                 JANUS_INTEROP_CONTAINER=skip?)"
+            );
         }
         let mut image_hash = INTEROP_AGGREGATOR_IMAGE_HASH.lock().unwrap();
         if image_hash.is_none() {
@@ -136,7 +139,8 @@ impl Default for Collector {
         // so that we can launch it later.
         if INTEROP_COLLECTOR_IMAGE_BYTES.is_empty() {
             panic!(
-                "Cannot create interop collector image. (Compiled with JANUS_INTEROP_CONTAINER=skip?)"
+                "Cannot create interop collector image. (Compiled with \
+                 JANUS_INTEROP_CONTAINER=skip?)"
             );
         }
         let mut image_hash = INTEROP_COLLECTOR_IMAGE_HASH.lock().unwrap();


### PR DESCRIPTION
This PR was produced with the following commands.

```bash
echo "format_strings = true" > rustfmt.toml
cargo +nightly fmt
```

This breaks up various long string literals with escaped newlines, and thus gets some un-format-able blocks unstuck.