### PR TITLE
Bump Janus crate versions to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1661,7 +1661,7 @@ checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "janus_aggregator"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1781,14 +1781,14 @@ dependencies = [
 
 [[package]]
 name = "janus_build_script_utils"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "janus_client"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -1811,7 +1811,7 @@ dependencies = [
 
 [[package]]
 name = "janus_collector"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -1836,7 +1836,7 @@ dependencies = [
 
 [[package]]
 name = "janus_core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -1874,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "janus_integration_tests"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "backoff",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "janus_interop_binaries"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "backoff",
@@ -1945,7 +1945,7 @@ dependencies = [
 
 [[package]]
 name = "janus_messages"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ homepage = "https://divviup.org"
 license = "MPL-2.0"
 repository = "https://github.com/divviup/janus"
 rust-version = "1.65.0"
-version = "0.3.0"
+version = "0.3.1"
 
 [workspace.dependencies]
 # Disable default features to disable compatibility with the old `time` crate, and we also don't

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,22 +19,22 @@ homepage = "https://divviup.org"
 license = "MPL-2.0"
 repository = "https://github.com/divviup/janus"
 rust-version = "1.65.0"
-version = "0.3.1"
+version = "0.4.0"
 
 [workspace.dependencies]
 # Disable default features to disable compatibility with the old `time` crate, and we also don't
 # (yet) need other default features.
 # https://docs.rs/chrono/latest/chrono/#duration
 chrono = { version = "0.4", default-features = false }
-janus_aggregator = { version = "0.3", path = "aggregator" }
-janus_aggregator_core = { version = "0.3", path = "aggregator_core" }
-janus_build_script_utils = { version = "0.3", path = "build_script_utils" }
-janus_client = { version = "0.3", path = "client" }
-janus_collector = { version = "0.3", path = "collector" }
-janus_core = { version = "0.3", path = "core" }
-janus_integration_tests = { version = "0.3", path = "integration_tests" }
-janus_interop_binaries = { version = "0.3", path = "interop_binaries" }
-janus_messages = { version = "0.3", path = "messages" }
+janus_aggregator = { version = "0.4", path = "aggregator" }
+janus_aggregator_core = { version = "0.4", path = "aggregator_core" }
+janus_build_script_utils = { version = "0.4", path = "build_script_utils" }
+janus_client = { version = "0.4", path = "client" }
+janus_collector = { version = "0.4", path = "collector" }
+janus_core = { version = "0.4", path = "core" }
+janus_integration_tests = { version = "0.4", path = "integration_tests" }
+janus_interop_binaries = { version = "0.4", path = "interop_binaries" }
+janus_messages = { version = "0.4", path = "messages" }
 k8s-openapi = { version = "0.16.0", features = ["v1_24"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
 kube = { version = "0.75.0", default-features = false, features = ["client"] }
 prio = { version = "0.11.1", features = ["multithreaded"] }

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -102,7 +102,7 @@ itertools = "0.10.5"
 # lack of support for connecting to servers by IP addresses, which affects many
 # Kubernetes clusters. Enable the `test-util` feature for various utilities
 # used in unit tests.
-janus_aggregator = { workspace = true, features = ["fpvec_bounded_l2", "kube-openssl", "test-util"] }
+janus_aggregator = { path = ".", features = ["fpvec_bounded_l2", "kube-openssl", "test-util"] }
 janus_aggregator_core = { workspace = true, features = ["test-util"] }
 mockito = "1.0.0"
 tempfile = "3.4.0"

--- a/aggregator_core/Cargo.toml
+++ b/aggregator_core/Cargo.toml
@@ -61,7 +61,7 @@ uuid = { version = "1.3.0", features = ["v4"] }
 [dev-dependencies]
 assert_matches = "1"
 hyper = "0.14.25"
-janus_aggregator_core = { workspace = true, features = ["test-util"] }
+janus_aggregator_core = { path = ".", features = ["test-util"] }
 janus_core = { workspace = true, features = ["test-util"] }
 serde_test = "1.0.158"
 tempfile = "3.4.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -61,7 +61,7 @@ tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt"],
 [dev-dependencies]
 fixed = "1.23"
 hex = { version = "0.4", features = ["serde"] }  # ensure this remains compatible with the non-dev dependency
-janus_core = { workspace = true, features = ["test-util"] }
+janus_core = { path = ".", features = ["test-util"] }
 # Enable `kube`'s `openssl-tls` feature (which takes precedence over the
 # `rustls-tls` feature when creating a default client) to work around rustls's
 # lack of support for connecting to servers by IP addresses, which affects many


### PR DESCRIPTION
Since we want to deploy a DAP-04 environment imminently, we might as well release 0.4.0, even though our DAP-04 implementation technically isn't totally complete.