### PR TITLE
Upgrade mockito, remove workaround

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2251,9 +2251,9 @@ dependencies = [
 
 [[package]]
 name = "mockito"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1eecc3baf782e3c8d6803cc8780268da1f32df6eb88c016c1d80b0df7944cf"
+checksum = "a383b2462062a0ef6f378d44b8057ef2bdcb94429b8e30bd4078842cd38ee453"
 dependencies = [
  "assert-json-diff",
  "colored",

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -104,7 +104,7 @@ itertools = "0.10.5"
 # used in unit tests.
 janus_aggregator = { path = ".", features = ["fpvec_bounded_l2", "kube-openssl", "test-util"] }
 janus_aggregator_core = { workspace = true, features = ["test-util"] }
-mockito = "1.0.0"
+mockito = "1.0.1"
 tempfile = "3.4.0"
 tokio = { version = "1", features = ["test-util"] }  # ensure this remains compatible with the non-dev dependency
 trycmd = "0.14.15"

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -8175,9 +8175,7 @@ mod tests {
                         .await;
 
                     // Serve the response via mockito, and run it through post_to_helper's error handling.
-                    // Workaround: use `new_with_port_async` to skip Mockito's server pool, which
-                    // has a bug in 1.0.0.
-                    let mut server = mockito::Server::new_with_port_async(0).await;
+                    let mut server = mockito::Server::new_async().await;
                     let error_mock = server
                         .mock("POST", "/")
                         .with_status(response.status().as_u16().into())

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -27,6 +27,6 @@ url = "2.3.1"
 [dev-dependencies]
 assert_matches = "1"
 janus_core = { workspace = true, features = ["test-util"]}
-mockito = "1.0.0"
+mockito = "1.0.1"
 tracing-log = "0.1.3"
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt"] }

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -39,5 +39,5 @@ url = "2.3.1"
 assert_matches = "1"
 janus_collector = { path = ".", features = ["fpvec_bounded_l2", "test-util"] }
 janus_core = { workspace = true, features = ["fpvec_bounded_l2", "test-util"] }
-mockito = "1.0.0"
+mockito = "1.0.1"
 rand = "0.8"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -67,6 +67,6 @@ janus_core = { path = ".", features = ["test-util"] }
 # lack of support for connecting to servers by IP addresses, which affects many
 # Kubernetes clusters.
 kube = { workspace = true, features = ["openssl-tls"] }
-mockito = "1.0.0"
+mockito = "1.0.1"
 serde_test = "1.0.158"
 url = "2.3.1"


### PR DESCRIPTION
This upgrades mockito to 1.0.1, and removes a workaround we had to use for 1.0.0.