### PR TITLE
Fix a warning related to conditional compilation

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -55,12 +55,14 @@ use opentelemetry::{
 };
 #[cfg(feature = "fpvec_bounded_l2")]
 use prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded;
+#[cfg(feature = "test-util")]
+use prio::vdaf::PrepareTransition;
 use prio::{
     codec::{Decode, Encode, ParameterizedDecode},
     vdaf::{
         self,
         prio3::{Prio3, Prio3Count, Prio3Histogram, Prio3Sum, Prio3SumVecMultithreaded},
-        PrepareTransition, VdafError,
+        VdafError,
     },
 };
 use regex::Regex;


### PR DESCRIPTION
This fixes an unused import warning when `test-util` is not set inside `janus_aggregator`.