### PR TITLE
Migrate health check to Trillium

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1813,6 +1813,10 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-stackdriver",
  "tracing-subscriber",
+ "trillium",
+ "trillium-head",
+ "trillium-router",
+ "trillium-tokio",
  "trycmd",
  "url",
  "uuid",
@@ -1822,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "janus_aggregator_api"
-version = "0.3.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4409,9 +4413,9 @@ dependencies = [
 
 [[package]]
 name = "trillium"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5598bb9ee521a4c76df72b4c54123eca7add1dc260b5d57d120c1992a25437e"
+checksum = "79b4d1605a08d6bda5d3023035007fad7f220aa4aeefb24caac3856c0dfdede8"
 dependencies = [
  "async-trait",
  "futures-lite",
@@ -4433,6 +4437,15 @@ dependencies = [
  "thiserror",
  "trillium",
  "trillium-http",
+]
+
+[[package]]
+name = "trillium-head"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc99042d2de11f55a2447d860ba272bb7edf11cccdb046645b172f46449c52a"
+dependencies = [
+ "trillium",
 ]
 
 [[package]]

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -89,6 +89,10 @@ tracing-log = "0.1.3"
 tracing-opentelemetry = { version = "0.18", optional = true }
 tracing-stackdriver = "0.6.2"
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt", "json"] }
+trillium = "0.2.8"
+trillium-head = "0.2.0"
+trillium-router = "0.3.5"
+trillium-tokio = "0.2.1"
 url = { version = "2.3.1", features = ["serde"] }
 uuid = { version = "1.3.0", features = ["v4"] }
 warp = { version = "0.3", features = ["tls"] }

--- a/aggregator/src/binary_utils.rs
+++ b/aggregator/src/binary_utils.rs
@@ -15,7 +15,6 @@ use deadpool::managed::TimeoutType;
 use deadpool_postgres::{Manager, Pool, PoolError, Runtime, Timeouts};
 use futures::StreamExt;
 use git_version::git_version;
-use http::StatusCode;
 use janus_aggregator_core::datastore::{Crypter, Datastore};
 use janus_core::time::Clock;
 use opentelemetry::{Context, KeyValue};
@@ -31,7 +30,8 @@ use std::{
 };
 use tokio_postgres::NoTls;
 use tracing::{debug, info};
-use warp::Filter;
+use trillium_head::Head;
+use trillium_router::Router;
 
 /// Reads, parses, and returns the config referenced by the given options, or None if no config file
 /// path was set.
@@ -332,11 +332,17 @@ where
 /// body and status code 200. Each Janus component exposes this HTTP server to enable health
 /// checks, and to indicate when it has successfully started up.
 async fn health_endpoint_server(address: SocketAddr) {
-    let filter = warp::path("healthz")
-        .and(warp::get().or(warp::head()).unify())
-        .map(|| warp::reply::with_status(warp::reply::reply(), StatusCode::OK));
-    let server = warp::serve(filter);
-    server.bind(address).await;
+    let router = Router::new().get(
+        "/healthz",
+        |conn: trillium::Conn| async move { conn.ok("") },
+    );
+    let handler = (Head::new(), router);
+    trillium_tokio::config()
+        .with_port(address.port())
+        .with_host(&address.ip().to_string())
+        .without_signals()
+        .run_async(handler)
+        .await;
 }
 
 /// Register a signal handler for SIGTERM, and return a future that will become ready when a


### PR DESCRIPTION
This rewrites the simple health check HTTP server using Trillium.

cc @jbr