### PR TITLE
Convert Prometheus scrape endpoint to use Trillium

### DIFF
--- a/aggregator/src/bin/janus_cli.rs
+++ b/aggregator/src/bin/janus_cli.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<()> {
     let command_line_options = CommandLineOptions::parse();
     let config_file: ConfigFile = read_config(&command_line_options.common_options)?;
 
-    install_tracing_and_metrics_handlers(config_file.common_config())?;
+    install_tracing_and_metrics_handlers(config_file.common_config()).await?;
 
     debug!(?command_line_options, ?config_file, "Starting up");
 
@@ -153,10 +153,11 @@ impl Command {
     }
 }
 
-fn install_tracing_and_metrics_handlers(config: &CommonConfig) -> Result<()> {
+async fn install_tracing_and_metrics_handlers(config: &CommonConfig) -> Result<()> {
     install_trace_subscriber(&config.logging_config)
         .context("couldn't install tracing subscriber")?;
     let _metrics_exporter = install_metrics_exporter(&config.metrics_config)
+        .await
         .context("failed to install metrics exporter")?;
 
     Ok(())

--- a/aggregator/src/binary_utils.rs
+++ b/aggregator/src/binary_utils.rs
@@ -263,6 +263,7 @@ where
     install_trace_subscriber(&config.common_config().logging_config)
         .context("couldn't install tracing subscriber")?;
     let _metrics_exporter = install_metrics_exporter(&config.common_config().metrics_config)
+        .await
         .context("failed to install metrics exporter")?;
 
     // Create build info metrics gauge.

--- a/aggregator/src/metrics.rs
+++ b/aggregator/src/metrics.rs
@@ -285,7 +285,7 @@ mod tests {
 
         match handle {
             MetricsExporterHandle::Prometheus(handle) => handle.abort(),
-            MetricsExporterHandle::Noop => {}
+            _ => unreachable!(),
         }
     }
 }

--- a/aggregator/src/metrics.rs
+++ b/aggregator/src/metrics.rs
@@ -169,7 +169,7 @@ pub fn install_metrics_exporter(
                                 KnownHeaderName::ContentType,
                                 encoder.format_type().to_owned(),
                             )
-                            .with_body(buffer),
+                            .ok(buffer),
                         Err(error) => {
                             tracing::error!(?error, "Failed to encode Prometheus metrics");
                             conn.with_status(Status::InternalServerError)


### PR DESCRIPTION
This converts the HTTP server for Prometheus scrapes from Warp to Trillium.