### PR TITLE
Use new crate for extracted metrics handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1816,6 +1816,7 @@ dependencies = [
  "tracing-subscriber",
  "trillium",
  "trillium-head",
+ "trillium-prometheus",
  "trillium-router",
  "trillium-tokio",
  "trycmd",
@@ -4488,6 +4489,18 @@ checksum = "058ce68d79872eb606079571cf0212633ae1095541a9c6afa0a363de3de4301b"
 dependencies = [
  "opentelemetry",
  "trillium",
+]
+
+[[package]]
+name = "trillium-prometheus"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a50568433817ef994081242d1c62e672fec0c32165f431f47dc8bb58d2665c1a"
+dependencies = [
+ "prometheus",
+ "tracing",
+ "trillium",
+ "trillium-router",
 ]
 
 [[package]]

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -91,6 +91,7 @@ tracing-stackdriver = "0.6.2"
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt", "json"] }
 trillium.workspace = true
 trillium-head.workspace = true
+trillium-prometheus = "0.1.0"
 trillium-router.workspace = true
 trillium-tokio.workspace = true
 url = { version = "2.3.1", features = ["serde"] }


### PR DESCRIPTION
This moves the HTTP part of our Prometheus code out to a dependency for reuse with divviup-api.