### PR TITLE
Add serialization tests for aggregator API bodies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,6 +1842,7 @@ dependencies = [
  "ring",
  "serde",
  "serde_json",
+ "serde_test",
  "tokio",
  "tracing",
  "trillium",

--- a/aggregator_api/Cargo.toml
+++ b/aggregator_api/Cargo.toml
@@ -21,6 +21,7 @@ rand = { version = "0.8", features = ["min_const_gen"] }
 ring = "0.16.20"
 serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.93"
+serde_test = "1.0.159"
 tracing = "0.1.37"
 trillium.workspace = true
 trillium-api.workspace = true


### PR DESCRIPTION
This adds serialization tests for the aggregator API request and response types, to catch any wire breaking changes on this interface.