### PR TITLE
Add comments to interop binary config files

### DIFF
--- a/interop_binaries/config/aggregation_job_creator.yaml
+++ b/interop_binaries/config/aggregation_job_creator.yaml
@@ -1,3 +1,6 @@
+# This configuration file is used in the janus_interop_aggregator container
+# image. It is tuned for very low aggregation latency, to speed up integration
+# tests, and is not intended for production use.
 database:
   url: postgres://postgres@127.0.0.1:5432/postgres
 health_check_listen_address: 0.0.0.0:8001

--- a/interop_binaries/config/aggregation_job_driver.yaml
+++ b/interop_binaries/config/aggregation_job_driver.yaml
@@ -1,3 +1,6 @@
+# This configuration file is used in the janus_interop_aggregator container
+# image. It is tuned for very low aggregation latency, to speed up integration
+# tests, and is not intended for production use.
 database:
   url: postgres://postgres@127.0.0.1:5432/postgres
 health_check_listen_address: 0.0.0.0:8002

--- a/interop_binaries/config/collection_job_driver.yaml
+++ b/interop_binaries/config/collection_job_driver.yaml
@@ -1,3 +1,6 @@
+# This configuration file is used in the janus_interop_aggregator container
+# image. It is tuned for very low aggregation latency, to speed up integration
+# tests, and is not intended for production use.
 database:
   url: postgres://postgres@127.0.0.1:5432/postgres
 health_check_listen_address: 0.0.0.0:8003

--- a/interop_binaries/config/janus_cli.yaml
+++ b/interop_binaries/config/janus_cli.yaml
@@ -1,3 +1,5 @@
+# This configuration file is used in the janus_interop_aggregator container
+# image.
 database:
   url: postgres://postgres@127.0.0.1:5432/postgres
 logging_config:

--- a/interop_binaries/config/janus_interop_aggregator.yaml
+++ b/interop_binaries/config/janus_interop_aggregator.yaml
@@ -1,3 +1,5 @@
+# This configuration file is used in the janus_interop_aggregator container
+# image.
 database:
   url: postgres://postgres@127.0.0.1:5432/postgres
 health_check_listen_address: 0.0.0.0:8000


### PR DESCRIPTION
This adds some comments to the interop binary config files, explaining their purposes.

cc @simon-friedberger