### PR TITLE
Use `gcloud` installed on GitHub Actions runners

### DIFF
--- a/.github/workflows/publish-sql-schema.yml
+++ b/.github/workflows/publish-sql-schema.yml
@@ -19,12 +19,6 @@ jobs:
       with:
         workload_identity_provider: ${{ secrets.GCP_ARTIFACT_PUBLISHER_WORKLOAD_IDENTITY_PROVIDER }}
         service_account: ${{ secrets.GCP_ARTIFACT_PUBLISHER_DEPLOY_SERVICE_ACCOUNT }}
-    - name: "Set up Google Cloud SDK"
-      uses: "google-github-actions/setup-gcloud@v1"
-      with:
-        # We opt into the alpha components so we can use the storage subcommand of gcloud, which
-        # uses Workload Identity Federation more reliably than gsutil.
-        install_components: "alpha"
     - name: Get the version
       id: get_version
       run: echo VERSION=${GITHUB_REF/refs\/tags\//} >> $GITHUB_OUTPUT


### PR DESCRIPTION
While testing https://github.com/divviup/janus-ops/pull/617, I observed that the Google Cloud SDK pre-installed into the GitHub Actions Ubuntu 22.04 image ([1]) already comes with the `alpha` components we need to use the `gcloud storage` subcommand, so we don't need to install it ourselves. Installing the SDK takes about a minute, far and away the most expensive part of running the `publish-sql-schema` action ([2]).

[1]: https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md
[2]: https://github.com/divviup/janus/actions/runs/4619878571/jobs/8169222366