### PR TITLE
Use no secrets in `ci-build`

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -27,7 +27,6 @@ jobs:
     env:
       CARGO_INCREMENTAL: 0
       CARGO_TERM_COLOR: always
-      DAPHNE_INTEROP_CONTAINER: prebuilt=${{ secrets.DAPHNE_PREBUILT_IMAGE_NAME_AND_TAG }}
       RUSTFLAGS: "-D warnings"
     steps:
     - name: Set default input values
@@ -39,22 +38,6 @@ jobs:
       id: os-version
       run: echo "release=$(lsb_release --release --short)" >> $GITHUB_OUTPUT
     - uses: actions/checkout@v3
-    # See https://github.com/google-github-actions/auth#authenticating-to-container-registry-and-artifact-registry
-    - id: "gcp-auth"
-      name: "Authenticate to GCP"
-      uses: "google-github-actions/auth@v1"
-      with:
-        workload_identity_provider: ${{ secrets.GCP_ARTIFACT_READER_WORKFLOW_IDENTITY_PROVIDER }}
-        service_account: ${{ secrets.GCP_ARTIFACT_READER_SERVICE_ACCOUNT }}
-        token_format: "access_token"
-        access_token_lifetime: "3600s"
-        access_token_scopes: "https://www.googleapis.com/auth/cloud-platform"
-        export_environment_variables: true
-    - uses: "docker/login-action@v2"
-      with:
-        registry: "us-west2-docker.pkg.dev"
-        username: "oauth2accesstoken"
-        password: ${{ steps.gcp-auth.outputs.access_token }}
     - name: Setup Go toolchain
       uses: actions/setup-go@v4
     - name: Install Kind


### PR DESCRIPTION
The `ci-build` workflow is not runnable from forks. This is because it wants to authenticate to our private Google Artifact Repository in order to fetch Daphne container images. However, those tests are disabled, and going forward we'll test Daphne using the generic interop test interface and using containers that team publishes to DockerHub. So we should have no need to authenticate to private repositories and thus use secrets. This commit removes mention of `DAPHNE_INTEROP_CONTAINER` from `ci-build.yml` and deletes the steps that authenticate to GCP and the Docker repository it hosts. This should make it possible for PRs on forks to run CI.