### PR TITLE
Nits from #1219

### DIFF
--- a/aggregator_core/src/datastore/test_util.rs
+++ b/aggregator_core/src/datastore/test_util.rs
@@ -169,8 +169,7 @@ pub async fn ephemeral_datastore() -> EphemeralDatastore {
     // changes to the migration scripts will be picked up by every run of the tests.
     let migrations_path = PathBuf::from_str(env!("CARGO_MANIFEST_DIR"))
         .unwrap()
-        .join("..")
-        .join("db");
+        .join("../db");
     let migrator = Migrator::new(migrations_path).await.unwrap();
     migrator.run(&mut connection).await.unwrap();
 

--- a/interop_binaries/config/janus_interop_aggregator.yaml
+++ b/interop_binaries/config/janus_interop_aggregator.yaml
@@ -6,4 +6,3 @@ health_check_listen_address: 0.0.0.0:8000
 logging_config:
   force_json_output: true
 listen_address: 0.0.0.0:8080
-sql_migrations_source: /etc/janus/migrations


### PR DESCRIPTION
 - use a single `join` call to construct path to migrations
 - remove `sql_migrations_path` config option from interop aggregator

See #1240