### PR TITLE
fix a test failure on macos

### DIFF
--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -616,7 +616,11 @@ impl<V: vdaf::Collector> Collector<V> {
                 // Check if sleeping for as long as the Retry-After header recommends would result
                 // in exceeding the maximum elapsed time, and return a timeout error if so.
                 if let Some(deadline) = deadline {
-                    if Instant::now() + retry_after_duration > deadline {
+                    let recommendation_is_past_deadline = Instant::now()
+                        .checked_add(retry_after_duration)
+                        .map_or(true, |recommendation| recommendation > deadline);
+
+                    if recommendation_is_past_deadline {
                         return Err(Error::CollectPollTimeout);
                     }
                 }


### PR DESCRIPTION
Previous to this commit, janus tests failed on macos with

```
---- tests::poll_timing stdout ----
thread 'tests::poll_timing' panicked at 'overflow when adding duration to instant', library/std/src/time.rs:408:33
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This possibly has to do with [OS-specific behaviors of std::time::Instant](https://doc.rust-lang.org/std/time/struct.Instant.html#os-specific-behaviors).

As a fix, this commit does a checked_add before the compare, which is likely safer anyway on all operating systems, but at the very least resolves the macos test failure.

Would it make sense to add a github action to run tests on macos to avoid future regressions?