### PR TITLE
Nits from #1219 (backport #1243)

### DIFF
--- a/aggregator/src/datastore.rs
+++ b/aggregator/src/datastore.rs
@@ -5079,8 +5079,7 @@ pub mod test_util {
         // changes to the migration scripts will be picked up by every run of the tests.
         let migrations_path = PathBuf::from_str(env!("CARGO_MANIFEST_DIR"))
             .unwrap()
-            .join("..")
-            .join("db");
+            .join("../db");
         let migrator = Migrator::new(migrations_path).await.unwrap();
         migrator.run(&mut connection).await.unwrap();
 

--- a/interop_binaries/config/janus_interop_aggregator.yaml
+++ b/interop_binaries/config/janus_interop_aggregator.yaml
@@ -4,4 +4,3 @@ health_check_listen_address: 0.0.0.0:8000
 logging_config:
   force_json_output: true
 listen_address: 0.0.0.0:8080
-sql_migrations_source: /etc/janus/migrations

--- a/interop_binaries/src/bin/janus_interop_aggregator.rs
+++ b/interop_binaries/src/bin/janus_interop_aggregator.rs
@@ -21,7 +21,7 @@ use sqlx::{migrate::Migrator, Connection, PgConnection};
 use std::{
     collections::{HashMap, HashSet},
     net::SocketAddr,
-    path::PathBuf,
+    path::Path,
     sync::Arc,
 };
 use tokio::sync::Mutex;
@@ -318,9 +318,6 @@ struct Config {
     /// Path prefix, e.g. `/dap/`, to serve DAP from.
     #[serde(default = "default_dap_serving_prefix")]
     dap_serving_prefix: String,
-
-    /// Path at which `sqlx` migration files can be found. Migrations will be applied at startup.
-    sql_migrations_source: PathBuf,
 }
 
 impl BinaryConfig for Config {
@@ -341,7 +338,9 @@ async fn main() -> anyhow::Result<()> {
         // Apply SQL migrations to database
         let mut connection =
             PgConnection::connect(ctx.config.common_config.database.url.as_str()).await?;
-        let migrator = Migrator::new(ctx.config.sql_migrations_source).await?;
+        // Migration scripts are mounted into the container at this path by
+        // Dockerfile.interop_aggregator
+        let migrator = Migrator::new(Path::new("/etc/janus/migrations")).await?;
         migrator.run(&mut connection).await?;
 
         // Run an HTTP server with both the DAP aggregator endpoints and the interoperation test


### PR DESCRIPTION
 - use a single `join` call to construct path to migrations
 - remove `sql_migrations_path` config option from interop aggregator

See #1240