### PR TITLE
Publish SQL migrations to minor version directory

### DIFF
--- a/.github/workflows/publish-sql-schema.yml
+++ b/.github/workflows/publish-sql-schema.yml
@@ -21,9 +21,15 @@ jobs:
         service_account: ${{ secrets.GCP_ARTIFACT_PUBLISHER_DEPLOY_SERVICE_ACCOUNT }}
     - name: Get the version
       id: get_version
-      run: echo VERSION=${GITHUB_REF/refs\/tags\//} >> $GITHUB_OUTPUT
+      run: |
+        VERSION=${GITHUB_REF/refs\/tags\//}
+        echo VERSION=${VERSION} >> $GITHUB_OUTPUT
+        echo "MINOR_VERSION=$(echo ${VERSION} | awk -F'.' '{if (NF != 3) {exit 1}; printf "%s.%s", $1, $2}')" >> $GITHUB_OUTPUT
     - name: "Upload schema file(s)"
       run: |-
         gcloud alpha storage cp --recursive \
           db \
           gs://janus-artifacts-sql-schemas/${{ steps.get_version.outputs.VERSION }}/
+        gcloud alpha storage cp --recursive \
+          db \
+          gs://janus-artifacts-sql-schemas/${{ steps.get_version.outputs.MINOR_VERSION }}/


### PR DESCRIPTION
Publish SQL migration scripts to a directory in the bucket named for the minor version (e.g., "0.2") as well as the patch version (e.g., "0.2.17"). Going forward, downstream projects will consume migrations from the minor version directory, but we publish to both places for now, to ease the transition.

Part of #1240