### PR TITLE
Run `datastore` tests against multiple schemas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,6 +215,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-executor"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fa3dc5f2a8564f07759c008b9109dc0d39de92a88d5588b8a5036d286383afb"
+dependencies = [
+ "async-lock",
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1b6f5d7df27bd294849f8eec66ecfc63d11814df7a4f5d74168a2394467b776"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
+dependencies = [
+ "async-lock",
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-lite",
+ "log",
+ "parking",
+ "polling",
+ "rustix 0.37.3",
+ "slab",
+ "socket2 0.4.9",
+ "waker-fn",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-std"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
+dependencies = [
+ "async-attributes",
+ "async-channel",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,6 +319,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
 
 [[package]]
 name = "async-trait"
@@ -383,6 +484,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77231a1c8f801696fc0123ec6150ce92cffb8e164a02afb9c8ddee0e9b65ad65"
+dependencies = [
+ "async-channel",
+ "async-lock",
+ "async-task",
+ "atomic-waker",
+ "fastrand",
+ "futures-lite",
+ "log",
 ]
 
 [[package]]
@@ -756,6 +872,16 @@ dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "ctor"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1316,6 +1442,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,6 +1525,18 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "group"
@@ -1935,6 +2079,7 @@ version = "0.4.6"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "async-std",
  "async-trait",
  "backoff",
  "base64 0.21.0",
@@ -1962,6 +2107,8 @@ dependencies = [
  "regex",
  "reqwest",
  "ring",
+ "rstest",
+ "rstest_reuse",
  "rustc_version",
  "serde",
  "serde_json",
@@ -2309,6 +2456,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2358,6 +2514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
+ "value-bag",
 ]
 
 [[package]]
@@ -2890,6 +3047,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
+name = "polling"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be1c66a6add46bff50935c313dae30a5030cf8385c5206e8a95e9e9def974aa"
+dependencies = [
+ "autocfg",
+ "bitflags",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3354,6 +3527,44 @@ checksum = "94f8f99b10dedd317514253dda1fa7c14e344aac96e1f78149a64879ce282aca"
 dependencies = [
  "smartcow",
  "smartstring",
+]
+
+[[package]]
+name = "rstest"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de1bb486a691878cd320c2f0d319ba91eeaa2e894066d8b5f8f117c000e9d962"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290ca1a1c8ca7edb7c3283bd44dc35dd54fdec6253a3912e201ba1072018fca8"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 1.0.109",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rstest_reuse"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45f80dcc84beab3a327bbe161f77db25f336a1452428176787c8c79ac79d7073"
+dependencies = [
+ "quote",
+ "rand",
+ "rustc_version",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4876,6 +5087,16 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "value-bag"
+version = "1.0.0-alpha.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
+dependencies = [
+ "ctor",
+ "version_check",
+]
 
 [[package]]
 name = "version_check"

--- a/aggregator_core/Cargo.toml
+++ b/aggregator_core/Cargo.toml
@@ -62,9 +62,12 @@ uuid = { version = "1.3.1", features = ["v4"] }
 
 [dev-dependencies]
 assert_matches = "1"
+async-std = { version = "1.12.0",  features = ["attributes"] }
 hyper = "0.14.26"
 janus_aggregator_core = { path = ".", features = ["test-util"] }
 janus_core = { workspace = true, features = ["test-util"] }
+rstest = "0.17.0"
+rstest_reuse = "0.5.0"
 serde_test = "1.0.160"
 tempfile = "3.5.0"
 tokio = { version = "1", features = ["test-util"] }  # ensure this remains compatible with the non-dev dependency

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -61,9 +61,32 @@ pub mod test_util;
 
 // TODO(#196): retry network-related & other transient failures once we know what they look like
 
-/// List of schema versions that this version of Janus can safely run on. If any other schema
-/// version is seen, [`Datastore::new`] fails.
-const SUPPORTED_SCHEMA_VERSIONS: &[i64] = &[20230405185602, 20230417204528];
+/// This macro stamps out an array of schema versions supported by this version of Janus and an
+/// [`rstest_reuse`][1] template that can be applied to tests to have them run against all supported
+/// schema versions.
+///
+/// [1]: https://docs.rs/rstest_reuse/latest/rstest_reuse/
+macro_rules! supported_schema_versions {
+    ($( $i:literal ),*) => {
+        const SUPPORTED_SCHEMA_VERSIONS: &[i64] = &[$($i),*];
+
+        #[cfg(test)]
+        #[rstest_reuse::template]
+        #[rstest::rstest]
+        $(#[case(ephemeral_datastore_max_schema_version($i))])*
+        async fn schema_versions_template(
+            #[future(awt)]
+            #[case]
+            ephemeral_datastore: EphemeralDatastore,
+        ) {
+            // This is an rstest template and never gets run.
+        }
+    }
+}
+
+// List of schema versions that this version of Janus can safely run on. If any other schema
+// version is seen, [`Datastore::new`] fails.
+supported_schema_versions!(20230417204528);
 
 /// Datastore represents a datastore for Janus, with support for transactional reads and writes.
 /// In practice, Datastore instances are currently backed by a PostgreSQL database.
@@ -5408,7 +5431,10 @@ mod tests {
                 LeaderStoredReport, Lease, OutstandingBatch, ReportAggregation,
                 ReportAggregationState, SqlInterval,
             },
-            test_util::{ephemeral_datastore, generate_aead_key},
+            schema_versions_template,
+            test_util::{
+                ephemeral_datastore_max_schema_version, generate_aead_key, EphemeralDatastore,
+            },
             Crypter, Datastore, Error, Transaction,
         },
         query_type::CollectableQueryType,
@@ -5447,10 +5473,10 @@ mod tests {
         time::Duration as StdDuration,
     };
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn reject_unsupported_schema_version() {
+    async fn reject_unsupported_schema_version(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let error = Datastore::new_with_supported_versions(
             ephemeral_datastore.pool(),
             ephemeral_datastore.crypter(),
@@ -5463,10 +5489,10 @@ mod tests {
         assert_matches!(error, Error::DbState(_));
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn roundtrip_task() {
+    async fn roundtrip_task(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         // Insert tasks, check that they can be retrieved by ID.
@@ -5576,10 +5602,10 @@ mod tests {
         assert_eq!(want_tasks, got_tasks);
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn get_task_metrics() {
+    async fn get_task_metrics(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         ds.run_tx(|tx| {
@@ -5711,10 +5737,10 @@ mod tests {
         .unwrap();
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn get_task_ids() {
+    async fn get_task_ids(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         ds.run_tx(|tx| {
@@ -5751,10 +5777,10 @@ mod tests {
         .unwrap();
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn roundtrip_report() {
+    async fn roundtrip_report(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         let task = TaskBuilder::new(
@@ -5852,10 +5878,10 @@ mod tests {
         assert_matches!(result, Err(Error::MutationTargetAlreadyExists));
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn report_not_found() {
+    async fn report_not_found(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         let rslt = ds
@@ -5875,10 +5901,10 @@ mod tests {
         assert_eq!(rslt, None);
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn get_unaggregated_client_report_ids_for_task() {
+    async fn get_unaggregated_client_report_ids_for_task(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         let time_precision = Duration::from_seconds(1000);
@@ -6033,10 +6059,12 @@ mod tests {
         );
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn get_unaggregated_client_report_ids_with_agg_param_for_task() {
+    async fn get_unaggregated_client_report_ids_with_agg_param_for_task(
+        ephemeral_datastore: EphemeralDatastore,
+    ) {
         install_test_trace_subscriber();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         let task = TaskBuilder::new(
@@ -6295,10 +6323,10 @@ mod tests {
         assert_eq!(got_reports, expected_reports);
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn count_client_reports_for_interval() {
+    async fn count_client_reports_for_interval(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         let task = TaskBuilder::new(
@@ -6406,10 +6434,10 @@ mod tests {
         assert_eq!(no_reports_task_report_count, 0);
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn count_client_reports_for_batch_id() {
+    async fn count_client_reports_for_batch_id(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         let task = TaskBuilder::new(
@@ -6544,10 +6572,10 @@ mod tests {
         assert_eq!(report_count, 2);
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn roundtrip_report_share() {
+    async fn roundtrip_report_share(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         let task = TaskBuilder::new(
@@ -6640,10 +6668,10 @@ mod tests {
         .unwrap();
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn roundtrip_aggregation_job() {
+    async fn roundtrip_aggregation_job(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         // We use a dummy VDAF & fixed-size task for this test, to better exercise the
@@ -6819,12 +6847,12 @@ mod tests {
         .unwrap();
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn aggregation_job_acquire_release() {
+    async fn aggregation_job_acquire_release(ephemeral_datastore: EphemeralDatastore) {
         // Setup: insert a few aggregation jobs.
         install_test_trace_subscriber();
         let clock = MockClock::default();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         const AGGREGATION_JOB_COUNT: usize = 10;
@@ -7107,10 +7135,10 @@ mod tests {
         .unwrap();
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn aggregation_job_not_found() {
+    async fn aggregation_job_not_found(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         let rslt = ds
@@ -7152,11 +7180,11 @@ mod tests {
         assert_matches!(rslt, Err(Error::MutationTargetNotFound));
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn get_aggregation_jobs_for_task() {
+    async fn get_aggregation_jobs_for_task(ephemeral_datastore: EphemeralDatastore) {
         // Setup.
         install_test_trace_subscriber();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         // We use a dummy VDAF & fixed-size task for this test, to better exercise the
@@ -7253,10 +7281,10 @@ mod tests {
         assert_eq!(want_agg_jobs, got_agg_jobs);
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn roundtrip_report_aggregation() {
+    async fn roundtrip_report_aggregation(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         let report_id = ReportId::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
@@ -7404,10 +7432,10 @@ mod tests {
         }
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn check_report_aggregation_exists() {
+    async fn check_report_aggregation_exists(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(MockClock::default()).await;
         let task = TaskBuilder::new(
             task::QueryType::TimeInterval,
@@ -7529,10 +7557,10 @@ mod tests {
         .unwrap();
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn report_aggregation_not_found() {
+    async fn report_aggregation_not_found(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         let vdaf = Arc::new(dummy_vdaf::Vdaf::default());
@@ -7574,10 +7602,10 @@ mod tests {
         assert_matches!(rslt, Err(Error::MutationTargetNotFound));
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn get_report_aggregations_for_aggregation_job() {
+    async fn get_report_aggregations_for_aggregation_job(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         let report_id = ReportId::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
@@ -7722,8 +7750,9 @@ mod tests {
             .is_err());
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn get_collection_job() {
+    async fn get_collection_job(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
 
         let task = TaskBuilder::new(
@@ -7744,7 +7773,6 @@ mod tests {
         .unwrap();
         let aggregation_param = AggregationParam(13);
 
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         ds.run_tx(|tx| {
@@ -7837,12 +7865,12 @@ mod tests {
         .unwrap();
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn update_collection_jobs() {
+    async fn update_collection_jobs(ephemeral_datastore: EphemeralDatastore) {
         // Setup: write collection jobs to the datastore.
         install_test_trace_subscriber();
 
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         let task = TaskBuilder::new(
@@ -8100,11 +8128,13 @@ mod tests {
         .unwrap()
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn time_interval_collection_job_acquire_release_happy_path() {
+    async fn time_interval_collection_job_acquire_release_happy_path(
+        ephemeral_datastore: EphemeralDatastore,
+    ) {
         install_test_trace_subscriber();
         let clock = MockClock::default();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         let task_id = random();
@@ -8237,11 +8267,13 @@ mod tests {
         .unwrap();
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn fixed_size_collection_job_acquire_release_happy_path() {
+    async fn fixed_size_collection_job_acquire_release_happy_path(
+        ephemeral_datastore: EphemeralDatastore,
+    ) {
         install_test_trace_subscriber();
         let clock = MockClock::default();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         let task_id = random();
@@ -8363,11 +8395,13 @@ mod tests {
         .unwrap();
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn collection_job_acquire_no_aggregation_job_with_task_id() {
+    async fn collection_job_acquire_no_aggregation_job_with_task_id(
+        ephemeral_datastore: EphemeralDatastore,
+    ) {
         install_test_trace_subscriber();
         let clock = MockClock::default();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         let task_id = random();
@@ -8414,11 +8448,13 @@ mod tests {
         .await;
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn collection_job_acquire_no_aggregation_job_with_agg_param() {
+    async fn collection_job_acquire_no_aggregation_job_with_agg_param(
+        ephemeral_datastore: EphemeralDatastore,
+    ) {
         install_test_trace_subscriber();
         let clock = MockClock::default();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         let task_id = random();
@@ -8468,11 +8504,13 @@ mod tests {
         .await;
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn collection_job_acquire_report_shares_outside_interval() {
+    async fn collection_job_acquire_report_shares_outside_interval(
+        ephemeral_datastore: EphemeralDatastore,
+    ) {
         install_test_trace_subscriber();
         let clock = MockClock::default();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         let task_id = random();
@@ -8532,11 +8570,11 @@ mod tests {
         .await;
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn collection_job_acquire_release_job_finished() {
+    async fn collection_job_acquire_release_job_finished(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
         let clock = MockClock::default();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         let task_id = random();
@@ -8596,11 +8634,13 @@ mod tests {
         .await;
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn collection_job_acquire_release_aggregation_job_in_progress() {
+    async fn collection_job_acquire_release_aggregation_job_in_progress(
+        ephemeral_datastore: EphemeralDatastore,
+    ) {
         install_test_trace_subscriber();
         let clock = MockClock::default();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         let task_id = random();
@@ -8683,11 +8723,11 @@ mod tests {
         .await;
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn collection_job_acquire_job_max() {
+    async fn collection_job_acquire_job_max(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
         let clock = MockClock::default();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         let task_id = random();
@@ -8838,11 +8878,11 @@ mod tests {
         .unwrap();
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn collection_job_acquire_state_filtering() {
+    async fn collection_job_acquire_state_filtering(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
         let clock = MockClock::default();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         let task_id = random();
@@ -8976,11 +9016,11 @@ mod tests {
         .unwrap();
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn roundtrip_batch_aggregation_time_interval() {
+    async fn roundtrip_batch_aggregation_time_interval(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
 
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         ds.run_tx(|tx| {
@@ -9193,11 +9233,11 @@ mod tests {
         .unwrap();
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn roundtrip_batch_aggregation_fixed_size() {
+    async fn roundtrip_batch_aggregation_fixed_size(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
 
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         ds.run_tx(|tx| {
@@ -9323,11 +9363,11 @@ mod tests {
         .unwrap();
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn roundtrip_aggregate_share_job() {
+    async fn roundtrip_aggregate_share_job(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
 
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         ds.run_tx(|tx| {
@@ -9432,12 +9472,12 @@ mod tests {
         .unwrap();
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn roundtrip_outstanding_batch() {
+    async fn roundtrip_outstanding_batch(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
 
         let clock = MockClock::default();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         let (task_id, batch_id) = ds
@@ -9720,12 +9760,12 @@ mod tests {
         }
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn delete_expired_client_reports() {
+    async fn delete_expired_client_reports(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
 
         let clock = MockClock::default();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(clock.clone()).await;
         let vdaf = dummy_vdaf::Vdaf::new();
 
@@ -9851,12 +9891,12 @@ mod tests {
         assert_eq!(want_report_ids, got_report_ids);
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn delete_expired_aggregation_artifacts() {
+    async fn delete_expired_aggregation_artifacts(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
 
         let clock = MockClock::default();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(clock.clone()).await;
         let vdaf = dummy_vdaf::Vdaf::new();
 
@@ -10595,12 +10635,12 @@ mod tests {
         assert_eq!(want_report_ids, got_report_ids);
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn delete_expired_collection_artifacts() {
+    async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
 
         let clock = MockClock::default();
-        let ephemeral_datastore = ephemeral_datastore().await;
         let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         // Setup.
@@ -11150,9 +11190,10 @@ mod tests {
         assert_eq!(want_outstanding_batch_ids, got_outstanding_batch_ids);
     }
 
+    #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]
-    async fn roundtrip_interval_sql() {
-        let ephemeral_datastore = ephemeral_datastore().await;
+    async fn roundtrip_interval_sql(ephemeral_datastore: EphemeralDatastore) {
+        install_test_trace_subscriber();
         let datastore = ephemeral_datastore.datastore(MockClock::default()).await;
 
         datastore

--- a/aggregator_core/src/lib.rs
+++ b/aggregator_core/src/lib.rs
@@ -1,5 +1,15 @@
 //! This crate contains core functionality for Janus aggregator crates.
 
+// Workaround lint suppression but in older clippy by allowing this lint at module-level.
+// https://github.com/rust-lang/rust-clippy/issues/8768
+// https://github.com/rust-lang/rust-clippy/pull/9879
+#![allow(clippy::single_component_path_imports)]
+
+// We must import `rstest_reuse` at the top of the crate
+// https://docs.rs/rstest_reuse/0.5.0/rstest_reuse/#use-rstest_reuse-at-the-top-of-your-crate
+#[cfg(test)]
+use rstest_reuse;
+
 #[cfg(feature = "test-util")]
 use janus_core::test_util::dummy_vdaf;
 

--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -114,6 +114,10 @@ This will generate two new migration scripts. Fill the `*.up.sql` file with the
 migration you want to run and the `*.down.sql` file with a script that reverses
 the first script.
 
+After adding a migration, you must add its version number to
+`datastore::SUPPORTED_SCHEMA_VERSIONS` as Janus will refuse to run if it does
+not recognize the database schema version.
+
 [sqlx-cli]: https://crates.io/crates/sqlx-cli
 
 ## `janus_cli provision-tasks`


### PR DESCRIPTION
We want to prove in tests that some Janus version can run safely on multiple schema versions to make database schema migrations safer. In this commit:

 - `aggregator_core::test_util::EphemeralDatastore` can now be constructed with a `max_schema_version` argument to control which migration scripts are applied during tests
 - We adopt [`rstest`][1] to inject an `EphemeralDatastore` instance into tests in `aggregator_core::datastore::Datatore::tests`. Using [`rstest_reuse`][2], we can automatically stamp out versions of existing tests that run using multiple schema versions.

We only use this dependency injection technique in the `datastore` module, because that should be the only module that's tightly coupled to the database schema. We could run all tests that use a datastore this way, at the cost of increasing overall test runtime.

[1]: https://docs.rs/rstest
[2]: https://docs.rs/rstest_reuse