### PR TITLE
Miscellaneous fixes following load test

### DIFF
--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -4544,7 +4544,7 @@ pub mod models {
         }
 
         /// Returns a new [`ReportAggregation`] corresponding to this report aggregation updated to
-        /// have the given state.
+        /// have the given last preparation step.
         pub fn with_last_prep_step(self, last_prep_step: Option<PrepareStep>) -> Self {
             Self {
                 last_prep_step,

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -193,7 +193,7 @@ impl Task {
             return Err(Error::InvalidParameter("vdaf_verify_keys"));
         }
         if self.hpke_keys.is_empty() {
-            return Err(Error::InvalidParameter("hpke_configs"));
+            return Err(Error::InvalidParameter("hpke_keys"));
         }
         Ok(())
     }

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -470,7 +470,7 @@ impl SerializedTask {
                 random(),
                 HpkeKemId::X25519HkdfSha256,
                 HpkeKdfId::HkdfSha256,
-                HpkeAeadId::ChaCha20Poly1305,
+                HpkeAeadId::Aes128Gcm,
             );
 
             self.hpke_keys = Vec::from([hpke_keypair]);


### PR DESCRIPTION
This rolls up three one-line changes for small issues I noticed recently.

- janus_cli provision-tasks --generate-missing-parameters` should use AES-128-GCM instead of ChaCha20Poly1305 when generating HPKE keypairs, because it is on the list of algorithms that must be supported, and thus it'll have broader compatibility.
- Fixed a copy-paste error in a builder-style method.
- Fixed an error message that wasn't updated after `Task.hpke_configs` was renamed to `Task.hpke_keys`.