### PR TITLE
collect tool: Add support for Prio3SumVec

### DIFF
--- a/tools/tests/cmd/collect.trycmd
+++ b/tools/tests/cmd/collect.trycmd
@@ -43,10 +43,10 @@ VDAF Algorithm and Parameters:
           - histogram: Prio3Histogram
 
       --length <LENGTH>
-          Number of vector elements, for use with --vdaf=countvec
+          Number of vector elements, for use with --vdaf=countvec and --vdaf=sumvec
 
       --bits <BITS>
-          Bit length of measurements, for use with --vdaf=sum
+          Bit length of measurements, for use with --vdaf=sum and --vdaf=sumvec
 
       --buckets <BUCKETS>
           Comma-separated list of bucket boundaries, for use with --vdaf=histogram


### PR DESCRIPTION
This finishes up adding support for Prio3SumVec to the `collect` tool, by plumbing between the `clap` arguments and the generic method.