### PR TITLE
Honor `DAP-Auth-Token` or `Authorization: Bearer`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2011,6 +2011,7 @@ dependencies = [
  "reqwest",
  "ring",
  "routefinder",
+ "rstest",
  "rustc_version",
  "serde",
  "serde_json",
@@ -2185,6 +2186,7 @@ dependencies = [
 name = "janus_core"
 version = "0.4.6"
 dependencies = [
+ "anyhow",
  "assert_matches",
  "backoff",
  "base64 0.21.0",
@@ -2216,6 +2218,7 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber",
+ "trillium",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ rust-version = "1.65.0"
 version = "0.4.6"
 
 [workspace.dependencies]
+anyhow = "1"
 # Disable default features to disable compatibility with the old `time` crate, and we also don't
 # (yet) need other default features.
 # https://docs.rs/chrono/latest/chrono/#duration
@@ -41,6 +42,7 @@ janus_messages = { version = "0.4", path = "messages" }
 k8s-openapi = { version = "0.18.0", features = ["v1_24"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
 kube = { version = "0.82.2", default-features = false, features = ["client", "rustls-tls"] }
 prio = { version = "0.12.1", features = ["multithreaded"] }
+rstest = "0.17.0"
 trillium = "0.2.9"
 trillium-api = { version = "0.2.0-rc.3", default-features = false }
 trillium-caching-headers = "0.2.1"

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -35,7 +35,7 @@ test-util = [
 
 [dependencies]
 async-trait = "0.1"
-anyhow = "1"
+anyhow.workspace = true
 atty = "0.2"
 backoff = { version = "0.4.0", features = ["tokio"] }
 base64 = "0.21.0"
@@ -110,6 +110,7 @@ hyper = "0.14.26"
 janus_aggregator = { path = ".", features = ["fpvec_bounded_l2", "test-util"] }
 janus_aggregator_core = { workspace = true, features = ["test-util"] }
 mockito = "1.0.2"
+rstest.workspace = true
 tempfile = "3.5.0"
 tokio = { version = "1", features = ["test-util"] } # ensure this remains compatible with the non-dev dependency
 trillium-testing.workspace = true

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -2358,6 +2358,10 @@ async fn send_request_to_helper<T: Encode>(
     let response_result = http_client
         .request(method, url)
         .header(CONTENT_TYPE, content_type)
+        // TODO(#472): We want to be able to communicate with new Janus (prefers bearer token but
+        // supports `DAP-Auth-Token`) as well as older Janus and Daphne (which require
+        // `DAP-Auth-Token`) so for the moment, we send `DAP-Auth-Token`. But eventually we should
+        // determine the appropriate token header to send for a given task.
         .header(DAP_AUTH_HEADER, auth_token.as_ref())
         .body(request_body)
         .send()

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -15,8 +15,7 @@ use janus_aggregator_core::{
     },
     task,
 };
-use janus_core::time::Clock;
-use janus_core::vdaf_dispatch;
+use janus_core::{time::Clock, vdaf_dispatch};
 use janus_messages::{
     query_type::{FixedSize, QueryType, TimeInterval},
     AggregateShare, AggregateShareReq, BatchSelector,

--- a/aggregator_api/Cargo.toml
+++ b/aggregator_api/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-anyhow = "1"
+anyhow.workspace = true
 async-trait = "0.1"
 base64 = "0.21.0"
 janus_aggregator_core.workspace = true

--- a/aggregator_core/Cargo.toml
+++ b/aggregator_core/Cargo.toml
@@ -20,8 +20,8 @@ test-util = [
 ]
 
 [dependencies]
+anyhow.workspace = true
 async-trait = "0.1"
-anyhow = "1"
 backoff = { version = "0.4.0", features = ["tokio"] }
 base64 = "0.21.0"
 bytes = "1.4.0"
@@ -66,7 +66,7 @@ async-std = { version = "1.12.0",  features = ["attributes"] }
 hyper = "0.14.26"
 janus_aggregator_core = { path = ".", features = ["test-util"] }
 janus_core = { workspace = true, features = ["test-util"] }
-rstest = "0.17.0"
+rstest.workspace = true
 rstest_reuse = "0.5.0"
 serde_test = "1.0.160"
 tempfile = "3.5.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -30,6 +30,7 @@ test-util = [
 ]
 
 [dependencies]
+anyhow.workspace = true
 assert_matches = { version = "1", optional = true }
 backoff = { version = "0.4.0", features = ["tokio"] }
 base64 = "0.21.0"
@@ -57,6 +58,7 @@ tokio = { version = "1.27", features = ["macros", "net", "rt"] }
 tracing = "0.1.37"
 tracing-log = { version = "0.1.3", optional = true }
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt"], optional = true }
+trillium.workspace = true
 
 [dev-dependencies]
 fixed = "1.23"

--- a/core/src/http.rs
+++ b/core/src/http.rs
@@ -1,6 +1,10 @@
+use crate::task::AuthenticationToken;
+use anyhow::{anyhow, Context};
+use base64::{engine::general_purpose::STANDARD, Engine};
 use http_api_problem::{HttpApiProblem, PROBLEM_JSON_MEDIA_TYPE};
 use reqwest::{header::CONTENT_TYPE, Response};
 use tracing::warn;
+use trillium::Conn;
 
 /// Turn a [`reqwest::Response`] into a [`HttpApiProblem`]. If applicable, a JSON problem details
 /// document is parsed from the request's body, otherwise it is solely constructed from the
@@ -19,4 +23,22 @@ pub async fn response_to_problem_details(response: Response) -> HttpApiProblem {
         }
     }
     HttpApiProblem::new(status)
+}
+
+/// If the request in `conn` has an `authorization` header, returns the bearer token in the header
+/// value. Returns `None` if there is no `authorization` header, and an error if there is an
+/// `authorization` header whose value is not a bearer token.
+pub fn extract_bearer_token(conn: &Conn) -> Result<Option<AuthenticationToken>, anyhow::Error> {
+    if let Some(authorization_value) = conn.headers().get("authorization") {
+        if let Some(received_token) = authorization_value.as_ref().strip_prefix(b"Bearer ") {
+            let decoded = STANDARD
+                .decode(received_token)
+                .context("bearer token cannot be decoded from Base64")?;
+            return Ok(Some(AuthenticationToken::from(decoded)));
+        } else {
+            return Err(anyhow!("authorization header value is not a bearer token"));
+        }
+    }
+
+    Ok(None)
 }

--- a/core/src/task.rs
+++ b/core/src/task.rs
@@ -1,7 +1,9 @@
+use base64::{engine::general_purpose::STANDARD, Engine};
 use rand::{distributions::Standard, prelude::Distribution};
 use reqwest::Url;
 use ring::constant_time;
 use serde::{Deserialize, Serialize};
+use std::str;
 
 /// HTTP header where auth tokens are provided in messages between participants.
 pub const DAP_AUTH_HEADER: &str = "DAP-Auth-Token";
@@ -535,6 +537,13 @@ macro_rules! vdaf_dispatch {
 #[derive(Clone)]
 pub struct AuthenticationToken(Vec<u8>);
 
+impl AuthenticationToken {
+    /// Constructs a bearer token string suitable for use as the value in an HTTP `Authorization`
+    /// header.
+    pub fn bearer_token(&self) -> String {
+        format!("Bearer {}", STANDARD.encode(self.as_ref()))
+    }
+}
 impl AsRef<[u8]> for AuthenticationToken {
     fn as_ref(&self) -> &[u8] {
         &self.0

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -15,7 +15,7 @@ version.workspace = true
 kube-openssl = []
 
 [dependencies]
-anyhow = "1"
+anyhow.workspace = true
 backoff = { version = "0.4", features = ["tokio"] }
 base64 = "0.21.0"
 futures = "0.3.28"

--- a/interop_binaries/Cargo.toml
+++ b/interop_binaries/Cargo.toml
@@ -23,7 +23,7 @@ testcontainer = [
 ]
 
 [dependencies]
-anyhow = "1"
+anyhow.workspace = true
 backoff = { version = "0.4", features = ["tokio"] }
 base64 = "0.21.0"
 clap = "4.2.4"

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -13,7 +13,7 @@ version.workspace = true
 test-util = []
 
 [dependencies]
-anyhow = "1"
+anyhow.workspace = true
 base64 = "0.21.0"
 derivative = "2.2.0"
 hex = "0.4"


### PR DESCRIPTION
When acting as an HTTP server (i.e., helpers handling aggregation job or aggregate share messages, or leaders handling collection requests), Janus will now check for the authentication token in the more standard `Authorization: Bearer <token>` format defined in RFC 6750, as it already does in the aggregator API. If that header is absent, it falls back to checking `DAP-Auth-Token` for compatibility with existing peers. Nothing changes about the format or handling of the authentication token itself, which remains an opaque blob o' bytes.

Part of #472