### PR TITLE
Generate auth tokens as hex strings rather than base64 strings.

### DIFF
--- a/core/src/task.rs
+++ b/core/src/task.rs
@@ -1,4 +1,3 @@
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use rand::{distributions::Standard, prelude::Distribution};
 use reqwest::Url;
 use ring::constant_time;
@@ -562,8 +561,7 @@ impl Eq for AuthenticationToken {}
 
 impl Distribution<AuthenticationToken> for Standard {
     fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> AuthenticationToken {
-        let buf: [u8; 16] = rng.gen();
-        URL_SAFE_NO_PAD.encode(buf).into_bytes().into()
+        AuthenticationToken(Vec::from(hex::encode(rng.gen::<[u8; 16]>())))
     }
 }
 


### PR DESCRIPTION
Authentication tokens are actually arbitrary byte strings; however, DAP-Auth-Token semantics require that these byte strings also happen to be valid ASCII sequences. We made the decision to encode random bytes into base64 to produce an ASCII string with the desired amount of entropy when generating random authentication tokens.

However, now that we're working on implementing Authorization: Bearer, which requires base64-encoding of bearer tokens, the fact that our authorization tokens look like/are base64-encoded strings will cause confusion. Switch to hex encoding instead: this is somewhat wasteful of space, but is less likely to create practical confusion when handling these values.