### PR TITLE
Skip batch_aggregations argument in tracing span

### DIFF
--- a/aggregator/src/aggregator/aggregate_share.rs
+++ b/aggregator/src/aggregator/aggregate_share.rs
@@ -10,7 +10,7 @@ use prio::vdaf::{self, Aggregatable};
 /// The assumption is that all aggregation jobs contributing to those batch aggregations have
 /// been driven to completion, and that the query count requirements have been validated for the
 /// included batches.
-#[tracing::instrument(skip(task), fields(task_id = ?task.id()), err)]
+#[tracing::instrument(skip(task, batch_aggregations), fields(task_id = ?task.id()), err)]
 pub(crate) async fn compute_aggregate_share<
     const SEED_SIZE: usize,
     Q: QueryType,


### PR DESCRIPTION
Now that we pre-create batch aggregation objects, logging them all is burdensome. With typical configurations, there will be at least 32 batch aggregations in this slice. One output line from an integration test got broken up into two log lines due to its length, and the "batch_aggregations" string itself was 18513 characters long. This PR skips including the `batch_aggregations` slice in tracing spans.