### PR TITLE
Fix high cardinality, HTTP client histogram metric

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -2341,17 +2341,13 @@ async fn send_request_to_helper<T: Encode>(
     http_client: &Client,
     method: Method,
     url: Url,
+    route_label: &'static str,
     content_type: &str,
     request: T,
     auth_token: &AuthenticationToken,
     http_request_duration_histogram: &Histogram<f64>,
 ) -> Result<Bytes, Error> {
     let domain = url.domain().unwrap_or_default().to_string();
-    let endpoint = url
-        .path_segments()
-        .and_then(|mut split| split.next_back())
-        .unwrap_or_default()
-        .to_string();
     let request_body = request.get_encoded();
 
     let start = Instant::now();
@@ -2375,7 +2371,7 @@ async fn send_request_to_helper<T: Encode>(
                 &[
                     KeyValue::new("status", "error"),
                     KeyValue::new("domain", domain),
-                    KeyValue::new("endpoint", endpoint),
+                    KeyValue::new("endpoint", route_label),
                 ],
             );
             return Err(error.into());
@@ -2390,7 +2386,7 @@ async fn send_request_to_helper<T: Encode>(
             &[
                 KeyValue::new("status", "error"),
                 KeyValue::new("domain", domain),
-                KeyValue::new("endpoint", endpoint),
+                KeyValue::new("endpoint", route_label),
             ],
         );
         let problem_details = response_to_problem_details(response).await;
@@ -2412,7 +2408,7 @@ async fn send_request_to_helper<T: Encode>(
                 &[
                     KeyValue::new("status", "success"),
                     KeyValue::new("domain", domain),
-                    KeyValue::new("endpoint", endpoint),
+                    KeyValue::new("endpoint", route_label),
                 ],
             );
             Ok(response_body)
@@ -2424,7 +2420,7 @@ async fn send_request_to_helper<T: Encode>(
                 &[
                     KeyValue::new("status", "error"),
                     KeyValue::new("domain", domain),
-                    KeyValue::new("endpoint", endpoint),
+                    KeyValue::new("endpoint", route_label),
                 ],
             );
             Err(error.into())

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -1,5 +1,6 @@
 use crate::aggregator::{
-    accumulator::Accumulator, aggregate_step_failure_counter, send_request_to_helper,
+    accumulator::Accumulator, aggregate_step_failure_counter, http_handlers::AGGREGATION_JOB_ROUTE,
+    send_request_to_helper,
 };
 use anyhow::{anyhow, Context as _, Result};
 use derivative::Derivative;
@@ -384,6 +385,7 @@ impl AggregationJobDriver {
             &self.http_client,
             Method::PUT,
             task.aggregation_job_uri(aggregation_job.id())?,
+            AGGREGATION_JOB_ROUTE,
             AggregationJobInitializeReq::<Q>::MEDIA_TYPE,
             req,
             task.primary_aggregator_auth_token(),
@@ -496,6 +498,7 @@ impl AggregationJobDriver {
             &self.http_client,
             Method::POST,
             task.aggregation_job_uri(aggregation_job.id())?,
+            AGGREGATION_JOB_ROUTE,
             AggregationJobContinueReq::MEDIA_TYPE,
             req,
             task.primary_aggregator_auth_token(),

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -2,7 +2,8 @@
 
 use crate::aggregator::{
     aggregate_share::compute_aggregate_share, empty_batch_aggregations,
-    query_type::CollectableQueryType, send_request_to_helper, Error,
+    http_handlers::AGGREGATE_SHARES_ROUTE, query_type::CollectableQueryType,
+    send_request_to_helper, Error,
 };
 use derivative::Derivative;
 use futures::future::{try_join_all, BoxFuture};
@@ -225,6 +226,7 @@ impl CollectionJobDriver {
             &self.http_client,
             Method::POST,
             task.aggregate_shares_uri()?,
+            AGGREGATE_SHARES_ROUTE,
             AggregateShareReq::<TimeInterval>::MEDIA_TYPE,
             req,
             task.primary_aggregator_auth_token(),

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -196,6 +196,10 @@ impl Handler for StatusCounter {
     }
 }
 
+pub(crate) static AGGREGATION_JOB_ROUTE: &str =
+    "tasks/:task_id/aggregation_jobs/:aggregation_job_id";
+pub(crate) static AGGREGATE_SHARES_ROUTE: &str = "tasks/:task_id/aggregate_shares";
+
 /// Constructs a Trillium handler for the aggregator.
 pub fn aggregator_handler<C: Clock>(
     datastore: Arc<Datastore<C>>,
@@ -223,11 +227,11 @@ pub fn aggregator_handler<C: Clock>(
                 upload_cors_preflight,
             )
             .put(
-                "tasks/:task_id/aggregation_jobs/:aggregation_job_id",
+                AGGREGATION_JOB_ROUTE,
                 instrumented(api(aggregation_jobs_put::<C>)),
             )
             .post(
-                "tasks/:task_id/aggregation_jobs/:aggregation_job_id",
+                AGGREGATION_JOB_ROUTE,
                 instrumented(api(aggregation_jobs_post::<C>)),
             )
             .put(
@@ -243,7 +247,7 @@ pub fn aggregator_handler<C: Clock>(
                 instrumented(api(collection_jobs_delete::<C>)),
             )
             .post(
-                "tasks/:task_id/aggregate_shares",
+                AGGREGATE_SHARES_ROUTE,
                 instrumented(api(aggregate_shares::<C>)),
             ),
         StatusCounter::new(&meter),

--- a/aggregator/src/aggregator/problem_details.rs
+++ b/aggregator/src/aggregator/problem_details.rs
@@ -239,6 +239,7 @@ mod tests {
                         &Client::new(),
                         Method::POST,
                         server.url().parse().unwrap(),
+                        "test",
                         "text/plain",
                         (),
                         &AuthenticationToken::from("auth".as_bytes().to_vec()),


### PR DESCRIPTION
This limits the cardinality of `janus_http_request_duration_seconds_count` by introducing a separate argument for the `endpoint` label, taking a description of the route, rather than extracting the last component of the URL. Fixes #1275.