### PR TITLE
Enable memory in OTel metrics processor

### DIFF
--- a/aggregator/src/metrics.rs
+++ b/aggregator/src/metrics.rs
@@ -147,10 +147,13 @@ pub async fn install_metrics_exporter(
         }) => {
             let exporter = Arc::new(
                 opentelemetry_prometheus::exporter(
-                    controllers::basic(processors::factory(
-                        CustomAggregatorSelector,
-                        stateless_temporality_selector(),
-                    ))
+                    controllers::basic(
+                        processors::factory(
+                            CustomAggregatorSelector,
+                            stateless_temporality_selector(),
+                        )
+                        .with_memory(true),
+                    )
                     .build(),
                 )
                 .try_init()?,


### PR DESCRIPTION
This fixes #1016 by applying the change needed with opentelemetry 0.18. It seems it could still be a while before we can use opentelemetry 0.19, so we may as well do this for now. With this change applied, I always see `janus_build_info` in metrics scrape responses, across multiple attempts and several minutes of time.

The builder method `with_memory()` is private, but here's its rustdoc comment.

> Memory controls whether the processor remembers metric instruments and attribute sets that were previously reported.
>
> When Memory is `true`, `Reader::try_for_each` will visit metrics that were not updated in the most recent interval.
