### PR TITLE
Update tracing-stackdriver to 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4377,9 +4377,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
  "itoa",
  "serde",
@@ -4395,9 +4395,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
 dependencies = [
  "time-core",
 ]
@@ -4760,15 +4760,15 @@ dependencies = [
 
 [[package]]
 name = "tracing-stackdriver"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff9dd91761e07727176a3dd3a1d64bbb577ea656b7b82fa4be4021832674c49"
+checksum = "da79dbf8b5b472e2d53b9a02c50771a05077a592c5f49d7fed86d59da53ca544"
 dependencies = [
  "Inflector",
  "serde",
  "serde_json",
  "thiserror",
- "time 0.3.17",
+ "time 0.3.20",
  "tracing-core",
  "tracing-subscriber",
 ]

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -90,7 +90,7 @@ tonic = { version = "0.8", optional = true, features = ["tls", "tls-webpki-roots
 tracing = "0.1.37"
 tracing-log = "0.1.3"
 tracing-opentelemetry = { version = "0.18", optional = true }
-tracing-stackdriver = "0.6.2"
+tracing-stackdriver = "0.7.1"
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt", "json"] }
 trillium.workspace = true
 trillium-api.workspace = true


### PR DESCRIPTION
This upgrades tracing-stackdriver to the just-released 0.7.1, which includes a fix for #1330.