### PR TITLE
Rewrite port forwarding, use kube-rs, in-process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2217,10 +2217,12 @@ dependencies = [
  "serde_json",
  "serde_test",
  "serde_yaml",
+ "stopper",
  "tempfile",
  "testcontainers",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-log",
  "tracing-subscriber",
@@ -2248,7 +2250,6 @@ dependencies = [
  "janus_messages",
  "k8s-openapi",
  "kube",
- "portpicker",
  "prio",
  "rand",
  "reqwest",
@@ -2434,6 +2435,7 @@ dependencies = [
  "kube-core",
  "pem",
  "pin-project",
+ "rand",
  "rustls 0.21.0",
  "rustls-pemfile",
  "secrecy",
@@ -2442,6 +2444,7 @@ dependencies = [
  "serde_yaml",
  "thiserror",
  "tokio",
+ "tokio-tungstenite",
  "tokio-util",
  "tower",
  "tower-http 0.4.0",
@@ -4511,13 +4514,25 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cd2598a37719e3cd4c28af93f978506a97a2920ef4d96e4b12e38b8cbc8940"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -4990,6 +5005,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
+dependencies = [
+ "base64 0.13.1",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5073,6 +5107,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8parse"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,15 +18,17 @@ fpvec_bounded_l2 = ["prio/experimental"]
 test-util = [
     "dep:assert_matches",
     "dep:lazy_static",
-    "dep:kube",
     "dep:k8s-openapi",
     "dep:serde_json",
+    "dep:stopper",
     "dep:tempfile",
     "dep:testcontainers",
+    "dep:tokio-stream",
     "dep:tracing-log",
     "dep:tracing-subscriber",
+    "kube/ws",
     "tokio/macros",
-    "tokio/sync"
+    "tokio/sync",
 ]
 
 [dependencies]
@@ -51,10 +53,12 @@ ring = "0.16.20"
 serde = { version = "1.0.162", features = ["derive"] }
 serde_json = { version = "1.0.96", optional = true }
 serde_yaml = "0.9.21"
+stopper = { version = "0.2.0", optional = true }
 tempfile = { version = "3", optional = true }
 testcontainers = { version = "0.14", optional = true }
 thiserror = "1.0"
 tokio = { version = "1.28", features = ["macros", "net", "rt"] }
+tokio-stream = { version = "0.1.14", optional = true }
 tracing = "0.1.37"
 tracing-log = { version = "0.1.3", optional = true }
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt"], optional = true }

--- a/core/src/test_util/kubernetes.rs
+++ b/core/src/test_util/kubernetes.rs
@@ -74,18 +74,10 @@ impl Cluster {
 
         // List pods that match the label key-value pairs in the service's selector. Pick the first
         // one.
-        let mut label_selector_param = String::with_capacity(
-            selector
-                .iter()
-                .map(|(name, value)| name.len() + value.len() + 2)
-                .sum(),
-        );
-        for (name, value) in selector.iter() {
-            label_selector_param.push_str(name);
-            label_selector_param.push('=');
-            label_selector_param.push_str(value);
-            label_selector_param.push(',');
-        }
+        let mut label_selector_param = selector
+            .iter()
+            .flat_map(|(name, value)| [name, "=", value, ","])
+            .collect::<String>();
         label_selector_param.pop();
         let lp = ListParams::default().labels(&label_selector_param);
         let client = self.client().await;

--- a/core/src/test_util/kubernetes.rs
+++ b/core/src/test_util/kubernetes.rs
@@ -1,18 +1,27 @@
 //! Testing framework for functionality that interacts with Kubernetes.
 
-use kube::config::{KubeConfigOptions, Kubeconfig};
+use anyhow::Context;
+use futures::TryStreamExt;
+use k8s_openapi::api::core::v1::{Pod, Service};
+use kube::{
+    api::ListParams,
+    config::{KubeConfigOptions, Kubeconfig},
+    Api, ResourceExt,
+};
 use rand::random;
 use std::{
-    io::{self, ErrorKind},
+    net::{Ipv4Addr, SocketAddrV4},
     path::{Path, PathBuf},
-    process::{Child, Command, Stdio},
+    process::{Command, Stdio},
 };
+use stopper::Stopper;
 use tempfile::NamedTempFile;
 use tokio::{
-    net::TcpStream,
-    time::{sleep, timeout},
+    net::{TcpListener, TcpStream},
+    task::{self},
 };
-use tracing::debug;
+use tokio_stream::wrappers::TcpListenerStream;
+use tracing::{debug, error, trace};
 
 /// Cluster represents a running Kubernetes cluster.
 pub struct Cluster {
@@ -49,63 +58,114 @@ impl Cluster {
         .unwrap()
     }
 
-    /// Set up port forwarding from `local_port` to `service_port` on the service in the namespace.
-    /// Returns a [`PortForward`] which will kill the child `kubectl` process on drop.
+    /// Set up port forwarding from a dynamically chosen local port to `service_port` on the service
+    /// in the namespace. Returns a [`PortForward`] handle.
     pub async fn forward_port(
         &self,
         namespace: &str,
-        service: &str,
-        local_port: u16,
+        service_name: &str,
         service_port: u16,
     ) -> PortForward {
-        let args = [
-            "--kubeconfig",
-            &self.kubeconfig_path.to_string_lossy(),
-            "--context",
-            &self.context_name,
-            "--namespace",
-            namespace,
-            "port-forward",
-            &format!("service/{service}"),
-            &format!("{local_port}:{service_port}"),
-        ];
-        debug!(?args, "Invoking kubectl");
-        let mut child = Command::new("kubectl")
-            .args(args)
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
+        // Fetch the service.
+        let client = self.client().await;
+        let services: Api<Service> = Api::namespaced(client, namespace);
+        let service = services.get(service_name).await.unwrap();
+        let selector = service.spec.as_ref().unwrap().selector.as_ref().unwrap();
+
+        // List pods that match the label key-value pairs in the service's selector. Pick the first
+        // one.
+        let mut label_selector_param = String::with_capacity(
+            selector
+                .iter()
+                .map(|(name, value)| name.len() + value.len() + 2)
+                .sum(),
+        );
+        for (name, value) in selector.iter() {
+            label_selector_param.push_str(name);
+            label_selector_param.push('=');
+            label_selector_param.push_str(value);
+            label_selector_param.push(',');
+        }
+        label_selector_param.pop();
+        let lp = ListParams::default().labels(&label_selector_param);
+        let client = self.client().await;
+        let pods: Api<Pod> = Api::namespaced(client, namespace);
+        let matching_pods = pods.list(&lp).await.unwrap();
+        let pod = matching_pods
+            .items
+            .get(0)
+            .unwrap_or_else(|| panic!("could not find any pods for the service {service_name}"));
+        let pod_name = pod.name_unchecked();
+
+        // Set up a port forwarding connection with the pod. (based on the pod_portforward_bind
+        // example from the kube crate)
+        let tcp_listener = TcpListener::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+            .await
             .unwrap();
-
-        // Wait for up to five seconds for the forwarded port to be available.
-        timeout(tokio::time::Duration::from_secs(5), async {
-            loop {
-                let stream = match TcpStream::connect(&format!("127.0.0.1:{local_port}")).await {
-                    Err(e) if e.kind() == ErrorKind::ConnectionRefused => {
-                        if let Ok(Some(status)) = child.try_wait() {
-                            Err(io::Error::new(
-                                ErrorKind::Other,
-                                format!("child kubectl process exited with status {status})"),
-                            ))
-                        } else {
-                            sleep(tokio::time::Duration::from_millis(100)).await;
-                            continue;
-                        }
-                    }
-                    r => r,
+        let local_port = tcp_listener.local_addr().unwrap().port();
+        debug!(
+            namespace,
+            service_name, service_port, local_port, "Forwarding port"
+        );
+        let stopper = Stopper::new();
+        let stream = stopper.stop_stream(TcpListenerStream::new(tcp_listener));
+        task::spawn({
+            let stopper = stopper.clone();
+            async move {
+                let res = stream
+                    .try_for_each(|stream| async {
+                        let (pods, pod_name, stopper) =
+                            (pods.clone(), pod_name.clone(), stopper.clone());
+                        trace!(local_port, "new connection");
+                        task::spawn(async move {
+                            if let Err(e) =
+                                forward_connection(&pods, &pod_name, service_port, stream, &stopper)
+                                    .await
+                            {
+                                error!(local_port, error = %e, "Port forward error");
+                            }
+                        });
+                        Ok(())
+                    })
+                    .await;
+                if let Err(e) = res {
+                    error!(local_port, error = %e, "Port forward TCP server error");
                 }
-                .unwrap();
-                stream.writable().await.unwrap();
-                debug!(local_port, service_port, "forwarded port became writable");
-                break;
             }
-        })
-        .await
-        .expect("timeout waiting for forwarded port to become writable");
+        });
 
-        PortForward { local_port, child }
+        // Listen on a local TCP port, and forward incoming connections over the port forwarding
+        // connection.
+
+        PortForward {
+            local_port,
+            stopper,
+        }
     }
+}
+
+async fn forward_connection(
+    pods_api: &Api<Pod>,
+    pod_name: &str,
+    port: u16,
+    mut tcp_stream: TcpStream,
+    stopper: &Stopper,
+) -> anyhow::Result<()> {
+    let mut forwarder = pods_api.portforward(pod_name, &[port]).await?;
+    let mut pod_stream = forwarder
+        .take_stream(port)
+        .context("stream for forwarded port was missing")?;
+    stopper
+        .stop_future(tokio::io::copy_bidirectional(
+            &mut tcp_stream,
+            &mut pod_stream,
+        ))
+        .await
+        .transpose()?;
+    drop(pod_stream);
+    forwarder.join().await?;
+    trace!("connection closed");
+    Ok(())
 }
 
 /// EphemeralCluster represents a running ephemeral Kubernetes cluster for testing. Dropping an
@@ -185,7 +245,7 @@ impl Drop for EphemeralCluster {
 /// value is dropped.
 pub struct PortForward {
     local_port: u16,
-    child: Child,
+    stopper: Stopper,
 }
 
 impl PortForward {
@@ -197,12 +257,8 @@ impl PortForward {
 
 impl Drop for PortForward {
     fn drop(&mut self) {
-        debug!(?self.child, "dropping port forward");
-        // We kill and reap child `kubectl` processes here to ensure that we don't orphan children
-        // on test failures. This is normally a questionable practice, but acceptable since this is
-        // only used in test code.
-        self.child.kill().unwrap();
-        self.child.wait().unwrap();
+        debug!(?self.local_port, "dropping port forward");
+        self.stopper.stop();
     }
 }
 

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -28,7 +28,6 @@ janus_interop_binaries = { workspace = true, features = ["testcontainer"] }
 janus_messages.workspace = true
 k8s-openapi.workspace = true
 kube.workspace = true
-portpicker = "0.1"
 prio.workspace = true
 rand = "0.8"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }


### PR DESCRIPTION
This rewrites the port forwarding part of the Kind integration tests to use `kube-rs` instead of shelling out to `kubectl`. This allows us to remove a use of `portpicker`, plus I've had reliability issues with the `kubectl port-forward` processes quitting while running `kind-integration-test` locally in the past, so I wanted to swap this out before further big changes. I've tested this locally a few times, and it works well.