### PR TITLE
Pin Postgres container to 14.7-alpine.

### DIFF
--- a/Dockerfile.interop_aggregator
+++ b/Dockerfile.interop_aggregator
@@ -33,7 +33,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cp /src/target/$PROFILE/aggregation_job_driver /aggregation_job_driver && \
     cp /src/target/$PROFILE/collection_job_driver /collection_job_driver
 
-FROM postgres:14-alpine
+# TODO(#1359): switch back to postgres:14-alpine once possible
+FROM postgres:14.7-alpine
 RUN mkdir /logs && mkdir /etc/janus
 RUN apk add --update supervisor && rm -rf /tmp/* /var/cache/apk/*
 COPY db /etc/janus/migrations


### PR DESCRIPTION
This is a temporary workaround to an issue in the latest version of the Postgres containers, and will be reverted once a fix is available.