### PR TITLE
Pin Postgres container to 14.7-alpine.

### DIFF
--- a/Dockerfile.interop_aggregator
+++ b/Dockerfile.interop_aggregator
@@ -30,7 +30,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cp /src/target/$PROFILE/aggregation_job_driver /aggregation_job_driver && \
     cp /src/target/$PROFILE/collect_job_driver /collect_job_driver
 
-FROM postgres:14-alpine
+# TODO(#1359): switch back to postgres:14-alpine once possible
+FROM postgres:14.7-alpine
 RUN mkdir /logs && mkdir /etc/janus
 RUN apk add --update supervisor && rm -rf /tmp/* /var/cache/apk/*
 COPY db /etc/janus/migrations

--- a/aggregator/src/datastore.rs
+++ b/aggregator/src/datastore.rs
@@ -5043,8 +5043,9 @@ pub mod test_util {
     /// schema and creates a datastore.
     pub fn ephemeral_db_handle() -> DbHandle {
         // Start an instance of Postgres running in a container.
+        // TODO(#1359): switch back to postgres:14-alpine once possible
         let db_container =
-            CONTAINER_CLIENT.run(RunnableImage::from(Postgres::default()).with_tag("14-alpine"));
+            CONTAINER_CLIENT.run(RunnableImage::from(Postgres::default()).with_tag("14.7-alpine"));
 
         // Compute the Postgres connection string.
         const POSTGRES_DEFAULT_PORT: u16 = 5432;


### PR DESCRIPTION
This is a temporary workaround to an issue in the latest version of the Postgres containers, and will be reverted once a fix is available.

Part of #1359.