### PR TITLE
Change container back to postgres:14-alpine

### DIFF
--- a/Dockerfile.interop_aggregator
+++ b/Dockerfile.interop_aggregator
@@ -33,8 +33,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cp /src/target/$PROFILE/aggregation_job_driver /aggregation_job_driver && \
     cp /src/target/$PROFILE/collection_job_driver /collection_job_driver
 
-# TODO(#1359): switch back to postgres:14-alpine once possible
-FROM postgres:14.7-alpine
+FROM postgres:14-alpine
 RUN mkdir /logs && mkdir /etc/janus
 RUN apk add --update supervisor && rm -rf /tmp/* /var/cache/apk/*
 COPY db /etc/janus/migrations

--- a/aggregator_core/src/datastore/test_util.rs
+++ b/aggregator_core/src/datastore/test_util.rs
@@ -48,9 +48,8 @@ impl EphemeralDatabase {
             move || {
                 // Start an instance of Postgres running in a container.
                 let container_client = testcontainers::clients::Cli::default();
-                // TODO(#1359): switch back to postgres:14-alpine once possible
                 let db_container = container_client
-                    .run(RunnableImage::from(Postgres::default()).with_tag("14.7-alpine"));
+                    .run(RunnableImage::from(Postgres::default()).with_tag("14-alpine"));
                 const POSTGRES_DEFAULT_PORT: u16 = 5432;
                 let port_number = db_container.get_host_port_ipv4(POSTGRES_DEFAULT_PORT);
                 trace!("Postgres container is up with port {port_number}");


### PR DESCRIPTION
This switches the image tag back to `postgres:14-alpine` now that the upstream container has been fixed by downgrading LLVM. Closes #1359.