### PR TITLE
Make extract_bearer_token() just return a Vec<u8>

### DIFF
--- a/core/src/http.rs
+++ b/core/src/http.rs
@@ -1,4 +1,3 @@
-use crate::task::AuthenticationToken;
 use anyhow::{anyhow, Context};
 use base64::{engine::general_purpose::STANDARD, Engine};
 use http_api_problem::{HttpApiProblem, PROBLEM_JSON_MEDIA_TYPE};
@@ -28,13 +27,13 @@ pub async fn response_to_problem_details(response: Response) -> HttpApiProblem {
 /// If the request in `conn` has an `authorization` header, returns the bearer token in the header
 /// value. Returns `None` if there is no `authorization` header, and an error if there is an
 /// `authorization` header whose value is not a bearer token.
-pub fn extract_bearer_token(conn: &Conn) -> Result<Option<AuthenticationToken>, anyhow::Error> {
+pub fn extract_bearer_token(conn: &Conn) -> Result<Option<Vec<u8>>, anyhow::Error> {
     if let Some(authorization_value) = conn.headers().get("authorization") {
         if let Some(received_token) = authorization_value.as_ref().strip_prefix(b"Bearer ") {
             let decoded = STANDARD
                 .decode(received_token)
                 .context("bearer token cannot be decoded from Base64")?;
-            return Ok(Some(AuthenticationToken::try_from(decoded)?));
+            return Ok(Some(decoded));
         } else {
             return Err(anyhow!("authorization header value is not a bearer token"));
         }


### PR DESCRIPTION
This fixes an issue introduced with the `AuthenticationToken` refactor in #1352. Returning an `AuthenticationToken` from this function requires enforcing unnecessary validity conditions on the base64-decoded value. In this context, the returned value was decoded from base64 in a header value, so the DAP-Auth-Token related conditions do not apply, and any byte values should be allowed. For the DAP endpoint, the `AuthenticationToken` conversion and checks are pushed out to `parse_auth_token()` instead, while for the aggregator API endpoint, `AuthenticationToken` is no longer involved.