### PR TITLE
Docker improvements

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -65,6 +65,8 @@ jobs:
         workdir: .
         targets: interop_binaries_small
         load: true
+    - name: Expose GitHub Runtime
+      uses: crazy-max/ghaction-github-runtime@v2
     - name: Build minimal janus_messages
       run: cargo build --package janus_messages --no-default-features
     - name: Build janus_core

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -49,10 +49,22 @@ jobs:
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust-toolchain }}
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+      with:
+        driver: docker-container
+        use: true
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
       with:
         key: ${{ steps.os-version.outputs.release }}
+    - name: Pre-build embedded container images
+      uses: docker/bake-action@v3.0.1
+      with:
+        files: docker-bake.hcl
+        workdir: .
+        targets: interop_binaries_small
+        load: true
     - name: Build minimal janus_messages
       run: cargo build --package janus_messages --no-default-features
     - name: Build janus_core
@@ -120,11 +132,18 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: echo "GIT_REVISION=$(git describe --always --dirty=-modified)" >> $GITHUB_ENV
-    - run: docker build --tag janus_aggregator --build-arg GIT_REVISION=${GIT_REVISION} .
-    - run: docker build --tag janus_aggregation_job_creator --build-arg BINARY=aggregation_job_creator --build-arg GIT_REVISION=${GIT_REVISION} .
-    - run: docker build --tag janus_aggregation_job_driver --build-arg BINARY=aggregation_job_driver --build-arg GIT_REVISION=${GIT_REVISION} .
-    - run: docker build --tag janus_collection_job_driver --build-arg BINARY=collection_job_driver --build-arg GIT_REVISION=${GIT_REVISION} .
-    - run: docker build --tag janus_cli --build-arg BINARY=janus_cli --build-arg GIT_REVISION=${GIT_REVISION} .
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+      with:
+        driver: docker-container
+        use: true
+    - name: Build
+      uses: docker/bake-action@v3.0.1
+      with:
+        files: docker-bake.hcl
+        workdir: .
+        targets: janus
+        load: true
     - run: docker run --rm janus_aggregator --help
     - run: docker run --rm janus_aggregation_job_creator --help
     - run: docker run --rm janus_aggregation_job_driver --help
@@ -137,6 +156,14 @@ jobs:
       DOCKER_BUILDKIT: 1
     steps:
     - uses: actions/checkout@v3
-    - run: docker build --tag janus_interop_client --build-arg BINARY=janus_interop_client -f Dockerfile.interop .
-    - run: docker build --tag janus_interop_aggregator -f Dockerfile.interop_aggregator .
-    - run: docker build --tag janus_interop_collector --build-arg BINARY=janus_interop_collector -f Dockerfile.interop .
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+      with:
+        driver: docker-container
+        use: true
+    - name: Build
+      uses: docker/bake-action@v3.0.1
+      with:
+        files: docker-bake.hcl
+        workdir: .
+        targets: interop_binaries

--- a/.github/workflows/push-docker-images-release.yml
+++ b/.github/workflows/push-docker-images-release.yml
@@ -19,6 +19,11 @@ jobs:
     - uses: actions/checkout@v3
     - run: echo "GIT_REVISION=$(git describe --always --dirty=-modified)" >> $GITHUB_ENV
     # See https://github.com/google-github-actions/auth#authenticating-to-container-registry-and-artifact-registry
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+      with:
+        driver: docker-container
+        use: true
     - id: "gcp-auth-private"
       name: "Authenticate to GCP (private repositories)"
       uses: "google-github-actions/auth@v1"
@@ -44,66 +49,26 @@ jobs:
         password: ${{ steps.gcp-auth-private.outputs.access_token }}
     - name: Get the version
       id: get_version
-      run: echo VERSION=${GITHUB_REF/refs\/tags\//} >> $GITHUB_OUTPUT
-    - run: |-
-        docker build \
-          --tag us-west2-docker.pkg.dev/janus-artifacts/janus/janus_aggregator:${{ steps.get_version.outputs.VERSION }} \
-          --tag us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_aggregator:${{ steps.get_version.outputs.VERSION }} \
-          --build-arg GIT_REVISION=${GIT_REVISION} \
-          .
-    - run: docker push us-west2-docker.pkg.dev/janus-artifacts/janus/janus_aggregator:${{ steps.get_version.outputs.VERSION }}
-    - run: |-
-        docker build \
-          --tag us-west2-docker.pkg.dev/janus-artifacts/janus/janus_aggregation_job_creator:${{ steps.get_version.outputs.VERSION }} \
-          --tag us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_aggregation_job_creator:${{ steps.get_version.outputs.VERSION }} \
-          --build-arg BINARY=aggregation_job_creator \
-          --build-arg GIT_REVISION=${GIT_REVISION} \
-          .
-    - run: docker push us-west2-docker.pkg.dev/janus-artifacts/janus/janus_aggregation_job_creator:${{ steps.get_version.outputs.VERSION }}
-    - run: |-
-        docker build \
-          --tag us-west2-docker.pkg.dev/janus-artifacts/janus/janus_aggregation_job_driver:${{ steps.get_version.outputs.VERSION }} \
-          --tag us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_aggregation_job_driver:${{ steps.get_version.outputs.VERSION }} \
-          --build-arg BINARY=aggregation_job_driver \
-          --build-arg GIT_REVISION=${GIT_REVISION} \
-          .
-    - run: docker push us-west2-docker.pkg.dev/janus-artifacts/janus/janus_aggregation_job_driver:${{ steps.get_version.outputs.VERSION }}
-    - run: |-
-        docker build \
-          --tag us-west2-docker.pkg.dev/janus-artifacts/janus/janus_collection_job_driver:${{ steps.get_version.outputs.VERSION }} \
-          --tag us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_collection_job_driver:${{ steps.get_version.outputs.VERSION }} \
-          --build-arg BINARY=collection_job_driver \
-          --build-arg GIT_REVISION=${GIT_REVISION} \
-          .
-    - run: docker push us-west2-docker.pkg.dev/janus-artifacts/janus/janus_collection_job_driver:${{ steps.get_version.outputs.VERSION }}
-    - run: |-
-        docker build \
-          --tag us-west2-docker.pkg.dev/janus-artifacts/janus/janus_cli:${{ steps.get_version.outputs.VERSION }} \
-          --tag us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_cli:${{ steps.get_version.outputs.VERSION }} \
-          --build-arg BINARY=janus_cli \
-          --build-arg GIT_REVISION=${GIT_REVISION} \
-          .
-    - run: docker push us-west2-docker.pkg.dev/janus-artifacts/janus/janus_cli:${{ steps.get_version.outputs.VERSION }}
+      run: echo VERSION=${GITHUB_REF/refs\/tags\//} | tee -a $GITHUB_OUTPUT | tee -a $GITHUB_ENV
+    - name: Build
+      uses: docker/bake-action@v3.0.1
+      with:
+        files: docker-bake.hcl
+        workdir: .
+        targets: release
+        load: true
+        # Note that we can't push all tags simultaneously, since we use two
+        # different sets of credentials on us-west2-docker.pkg.dev. Instead, we
+        # save all images locally first, and then push to one repository at a
+        # time.
 
-    - run: |-
-        docker build \
-          --tag us-west2-docker.pkg.dev/janus-artifacts/janus/janus_interop_client:${{ steps.get_version.outputs.VERSION }} \
-          --tag us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_interop_client:${{ steps.get_version.outputs.VERSION }} \
-          --build-arg BINARY=janus_interop_client \
-          -f Dockerfile.interop .
+    - run: docker push us-west2-docker.pkg.dev/janus-artifacts/janus/janus_aggregator:${{ steps.get_version.outputs.VERSION }}
+    - run: docker push us-west2-docker.pkg.dev/janus-artifacts/janus/janus_aggregation_job_creator:${{ steps.get_version.outputs.VERSION }}
+    - run: docker push us-west2-docker.pkg.dev/janus-artifacts/janus/janus_aggregation_job_driver:${{ steps.get_version.outputs.VERSION }}
+    - run: docker push us-west2-docker.pkg.dev/janus-artifacts/janus/janus_collection_job_driver:${{ steps.get_version.outputs.VERSION }}
+    - run: docker push us-west2-docker.pkg.dev/janus-artifacts/janus/janus_cli:${{ steps.get_version.outputs.VERSION }}
     - run: docker push us-west2-docker.pkg.dev/janus-artifacts/janus/janus_interop_client:${{ steps.get_version.outputs.VERSION }}
-    - run: |-
-        docker build \
-          --tag us-west2-docker.pkg.dev/janus-artifacts/janus/janus_interop_aggregator:${{ steps.get_version.outputs.VERSION }} \
-          --tag us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_interop_aggregator:${{ steps.get_version.outputs.VERSION }} \
-          -f Dockerfile.interop_aggregator .
     - run: docker push us-west2-docker.pkg.dev/janus-artifacts/janus/janus_interop_aggregator:${{ steps.get_version.outputs.VERSION }}
-    - run: |-
-        docker build \
-          --tag us-west2-docker.pkg.dev/janus-artifacts/janus/janus_interop_collector:${{ steps.get_version.outputs.VERSION }} \
-          --tag us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_interop_collector:${{ steps.get_version.outputs.VERSION }} \
-          --build-arg BINARY=janus_interop_collector \
-          -f Dockerfile.interop .
     - run: docker push us-west2-docker.pkg.dev/janus-artifacts/janus/janus_interop_collector:${{ steps.get_version.outputs.VERSION }}
 
     - uses: "docker/login-action@v2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
 FROM rust:1.69.0-alpine as builder
-ARG BINARY=aggregator
-ARG GIT_REVISION=unknown
 RUN apk add libc-dev
 WORKDIR /src
 COPY Cargo.toml /src/Cargo.toml
@@ -17,6 +15,8 @@ COPY integration_tests /src/integration_tests
 COPY interop_binaries /src/interop_binaries
 COPY messages /src/messages
 COPY tools /src/tools
+ARG BINARY=aggregator
+ARG GIT_REVISION=unknown
 ENV GIT_REVISION ${GIT_REVISION}
 RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,target=/src/target cargo build --release -p janus_aggregator --bin $BINARY --features=prometheus && cp /src/target/release/$BINARY /$BINARY
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM rust:1.69.0-alpine as builder
 RUN apk add libc-dev
 WORKDIR /src
-COPY Cargo.toml /src/Cargo.toml
-COPY Cargo.lock /src/Cargo.lock
+COPY Cargo.toml Cargo.lock /src/
 COPY aggregator /src/aggregator
 COPY aggregator_api /src/aggregator_api
 COPY aggregator_core /src/aggregator_core

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,27 @@
-FROM rust:1.69.0-alpine as builder
+FROM rust:1.69.0-alpine AS chef
 RUN apk add libc-dev
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+RUN cargo install cargo-chef --version 0.1.60
 WORKDIR /src
+
+FROM chef AS planner
+COPY Cargo.toml Cargo.lock /src/
+COPY aggregator /src/aggregator
+COPY aggregator_api /src/aggregator_api
+COPY aggregator_core /src/aggregator_core
+COPY build_script_utils /src/build_script_utils
+COPY client /src/client
+COPY collector /src/collector
+COPY core /src/core
+COPY integration_tests /src/integration_tests
+COPY interop_binaries /src/interop_binaries
+COPY messages /src/messages
+COPY tools /src/tools
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /src/recipe.json /src/recipe.json
+RUN cargo chef cook --release -p janus_aggregator --features=prometheus
 COPY Cargo.toml Cargo.lock /src/
 COPY aggregator /src/aggregator
 COPY aggregator_api /src/aggregator_api
@@ -17,13 +38,13 @@ COPY tools /src/tools
 ARG BINARY=aggregator
 ARG GIT_REVISION=unknown
 ENV GIT_REVISION ${GIT_REVISION}
-RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,target=/src/target cargo build --release -p janus_aggregator --bin $BINARY --features=prometheus && cp /src/target/release/$BINARY /$BINARY
+RUN cargo build --release -p janus_aggregator --bin $BINARY --features=prometheus
 
-FROM alpine:3.18.0
+FROM alpine:3.18.0 AS final
 ARG BINARY=aggregator
 ARG GIT_REVISION=unknown
 LABEL revision ${GIT_REVISION}
-COPY --from=builder /$BINARY /$BINARY
+COPY --from=builder /src/target/release/$BINARY /$BINARY
 # Store the build argument in an environment variable so we can reference it
 # from the ENTRYPOINT at runtime.
 ENV BINARY=$BINARY

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM rust:1.69.0-alpine AS chef
 RUN apk add libc-dev
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
-RUN cargo install cargo-chef --version 0.1.60
+RUN cargo install cargo-chef --version 0.1.60 && \
+    rm -r $CARGO_HOME/registry
 WORKDIR /src
 
 FROM chef AS planner

--- a/Dockerfile.interop
+++ b/Dockerfile.interop
@@ -1,9 +1,31 @@
 ARG BINARY
 ARG PROFILE=release
 
-FROM rust:1.69.0-alpine as builder
+FROM rust:1.69.0-alpine AS chef
 RUN apk add libc-dev
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+RUN cargo install cargo-chef --version 0.1.60
 WORKDIR /src
+
+FROM chef AS planner
+COPY Cargo.toml Cargo.lock /src/
+COPY aggregator /src/aggregator
+COPY aggregator_api /src/aggregator_api
+COPY aggregator_core /src/aggregator_core
+COPY build_script_utils /src/build_script_utils
+COPY client /src/client
+COPY collector /src/collector
+COPY core /src/core
+COPY integration_tests /src/integration_tests
+COPY interop_binaries /src/interop_binaries
+COPY messages /src/messages
+COPY tools /src/tools
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /src/recipe.json /src/recipe.json
+ARG PROFILE
+RUN cargo chef cook --features fpvec_bounded_l2 --profile $PROFILE -p janus_interop_binaries
 COPY Cargo.toml Cargo.lock /src/
 COPY aggregator /src/aggregator
 COPY aggregator_api /src/aggregator_api
@@ -18,13 +40,14 @@ COPY interop_binaries /src/interop_binaries
 COPY messages /src/messages
 COPY tools /src/tools
 ARG BINARY
-ARG PROFILE
-RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,target=/src/target cargo build --features fpvec_bounded_l2 --profile $PROFILE -p janus_interop_binaries --bin $BINARY && cp /src/target/$PROFILE/$BINARY /$BINARY
+RUN cargo build --features fpvec_bounded_l2 --profile $PROFILE -p janus_interop_binaries \
+    --bin $BINARY
 
-FROM alpine:3.18.0
+FROM alpine:3.18.0 AS final
 ARG BINARY
+ARG PROFILE
 RUN mkdir /logs
-COPY --from=builder /$BINARY /$BINARY
+COPY --from=builder /src/target/$PROFILE/$BINARY /$BINARY
 EXPOSE 8080
 # Store the build argument in an environment variable so we can reference it
 # from the ENTRYPOINT at runtime.

--- a/Dockerfile.interop
+++ b/Dockerfile.interop
@@ -2,8 +2,6 @@ ARG BINARY
 ARG PROFILE=release
 
 FROM rust:1.69.0-alpine as builder
-ARG BINARY
-ARG PROFILE
 RUN apk add libc-dev
 WORKDIR /src
 COPY Cargo.toml /src/Cargo.toml
@@ -20,6 +18,8 @@ COPY integration_tests /src/integration_tests
 COPY interop_binaries /src/interop_binaries
 COPY messages /src/messages
 COPY tools /src/tools
+ARG BINARY
+ARG PROFILE
 RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,target=/src/target cargo build --features fpvec_bounded_l2 --profile $PROFILE -p janus_interop_binaries --bin $BINARY && cp /src/target/$PROFILE/$BINARY /$BINARY
 
 FROM alpine:3.18.0

--- a/Dockerfile.interop
+++ b/Dockerfile.interop
@@ -4,7 +4,8 @@ ARG PROFILE=release
 FROM rust:1.69.0-alpine AS chef
 RUN apk add libc-dev
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
-RUN cargo install cargo-chef --version 0.1.60
+RUN cargo install cargo-chef --version 0.1.60 && \
+    rm -r $CARGO_HOME/registry
 WORKDIR /src
 
 FROM chef AS planner

--- a/Dockerfile.interop
+++ b/Dockerfile.interop
@@ -4,8 +4,7 @@ ARG PROFILE=release
 FROM rust:1.69.0-alpine as builder
 RUN apk add libc-dev
 WORKDIR /src
-COPY Cargo.toml /src/Cargo.toml
-COPY Cargo.lock /src/Cargo.lock
+COPY Cargo.toml Cargo.lock /src/
 COPY aggregator /src/aggregator
 COPY aggregator_api /src/aggregator_api
 COPY aggregator_core /src/aggregator_core

--- a/Dockerfile.interop_aggregator
+++ b/Dockerfile.interop_aggregator
@@ -3,8 +3,7 @@ ARG PROFILE=release
 FROM rust:1.69.0-alpine as builder
 RUN apk add libc-dev
 WORKDIR /src
-COPY Cargo.toml /src/Cargo.toml
-COPY Cargo.lock /src/Cargo.lock
+COPY Cargo.toml Cargo.lock /src/
 COPY aggregator /src/aggregator
 COPY aggregator_api /src/aggregator_api
 COPY aggregator_core /src/aggregator_core
@@ -38,14 +37,17 @@ RUN mkdir /logs && mkdir /etc/janus
 RUN apk add --update supervisor && rm -rf /tmp/* /var/cache/apk/*
 COPY db /etc/janus/migrations
 COPY interop_binaries/setup.sh /usr/local/bin/setup.sh
-COPY interop_binaries/config/supervisord.conf /etc/janus/supervisord.conf
-COPY interop_binaries/config/janus_interop_aggregator.yaml /etc/janus/janus_interop_aggregator.yaml
-COPY interop_binaries/config/aggregation_job_creator.yaml /etc/janus/aggregation_job_creator.yaml
-COPY interop_binaries/config/aggregation_job_driver.yaml /etc/janus/aggregation_job_driver.yaml
-COPY interop_binaries/config/collection_job_driver.yaml /etc/janus/collection_job_driver.yaml
-COPY --from=builder /janus_interop_aggregator /usr/local/bin/janus_interop_aggregator
-COPY --from=builder /aggregation_job_creator /usr/local/bin/aggregation_job_creator
-COPY --from=builder /aggregation_job_driver /usr/local/bin/aggregation_job_driver
-COPY --from=builder /collection_job_driver /usr/local/bin/collection_job_driver
+COPY interop_binaries/config/supervisord.conf \
+    interop_binaries/config/janus_interop_aggregator.yaml \
+    interop_binaries/config/aggregation_job_creator.yaml \
+    interop_binaries/config/aggregation_job_driver.yaml \
+    interop_binaries/config/collection_job_driver.yaml \
+    /etc/janus/
+COPY --from=builder \
+    /src/target/$PROFILE/janus_interop_aggregator \
+    /src/target/$PROFILE/aggregation_job_creator \
+    /src/target/$PROFILE/aggregation_job_driver \
+    /src/target/$PROFILE/collection_job_driver \
+    /usr/local/bin/
 EXPOSE 8080
 ENTRYPOINT ["/usr/bin/supervisord", "-c", "/etc/janus/supervisord.conf"]

--- a/Dockerfile.interop_aggregator
+++ b/Dockerfile.interop_aggregator
@@ -3,7 +3,8 @@ ARG PROFILE=release
 FROM rust:1.69.0-alpine AS chef
 RUN apk add libc-dev
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
-RUN cargo install cargo-chef --version 0.1.60
+RUN cargo install cargo-chef --version 0.1.60 && \
+    rm -r $CARGO_HOME/registry
 WORKDIR /src
 
 FROM chef AS planner

--- a/Dockerfile.interop_aggregator
+++ b/Dockerfile.interop_aggregator
@@ -1,7 +1,6 @@
 ARG PROFILE=release
 
 FROM rust:1.69.0-alpine as builder
-ARG PROFILE
 RUN apk add libc-dev
 WORKDIR /src
 COPY Cargo.toml /src/Cargo.toml
@@ -18,6 +17,7 @@ COPY integration_tests /src/integration_tests
 COPY interop_binaries /src/interop_binaries
 COPY messages /src/messages
 COPY tools /src/tools
+ARG PROFILE
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/src/target \
     cargo build --features fpvec_bounded_l2 --profile $PROFILE -p janus_interop_binaries \

--- a/Dockerfile.interop_aggregator
+++ b/Dockerfile.interop_aggregator
@@ -1,8 +1,30 @@
 ARG PROFILE=release
 
-FROM rust:1.69.0-alpine as builder
+FROM rust:1.69.0-alpine AS chef
 RUN apk add libc-dev
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+RUN cargo install cargo-chef --version 0.1.60
 WORKDIR /src
+
+FROM chef AS planner
+COPY Cargo.toml Cargo.lock /src/
+COPY aggregator /src/aggregator
+COPY aggregator_api /src/aggregator_api
+COPY aggregator_core /src/aggregator_core
+COPY build_script_utils /src/build_script_utils
+COPY client /src/client
+COPY collector /src/collector
+COPY core /src/core
+COPY integration_tests /src/integration_tests
+COPY interop_binaries /src/interop_binaries
+COPY messages /src/messages
+COPY tools /src/tools
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder-aggregator
+COPY --from=planner /src/recipe.json /src/recipe.json
+ARG PROFILE
+RUN cargo chef cook --features fpvec_bounded_l2 --profile $PROFILE -p janus_aggregator
 COPY Cargo.toml Cargo.lock /src/
 COPY aggregator /src/aggregator
 COPY aggregator_api /src/aggregator_api
@@ -16,23 +38,32 @@ COPY integration_tests /src/integration_tests
 COPY interop_binaries /src/interop_binaries
 COPY messages /src/messages
 COPY tools /src/tools
-ARG PROFILE
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/src/target \
-    cargo build --features fpvec_bounded_l2 --profile $PROFILE -p janus_interop_binaries \
-    --bin janus_interop_aggregator && \
-    cp /src/target/$PROFILE/janus_interop_aggregator /janus_interop_aggregator
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/src/target \
-    cargo build --features fpvec_bounded_l2 --profile $PROFILE -p janus_aggregator \
+RUN cargo build --features fpvec_bounded_l2 --profile $PROFILE -p janus_aggregator \
     --bin aggregation_job_creator \
     --bin aggregation_job_driver \
-    --bin collection_job_driver && \
-    cp /src/target/$PROFILE/aggregation_job_creator /aggregation_job_creator && \
-    cp /src/target/$PROFILE/aggregation_job_driver /aggregation_job_driver && \
-    cp /src/target/$PROFILE/collection_job_driver /collection_job_driver
+    --bin collection_job_driver
 
-FROM postgres:14-alpine
+FROM chef AS builder-interop
+COPY --from=planner /src/recipe.json /src/recipe.json
+ARG PROFILE
+RUN cargo chef cook --features fpvec_bounded_l2 --profile $PROFILE -p janus_interop_binaries
+COPY Cargo.toml Cargo.lock /src/
+COPY aggregator /src/aggregator
+COPY aggregator_api /src/aggregator_api
+COPY aggregator_core /src/aggregator_core
+COPY build_script_utils /src/build_script_utils
+COPY client /src/client
+COPY collector /src/collector
+COPY core /src/core
+COPY db /src/db
+COPY integration_tests /src/integration_tests
+COPY interop_binaries /src/interop_binaries
+COPY messages /src/messages
+COPY tools /src/tools
+RUN cargo build --features fpvec_bounded_l2 --profile $PROFILE -p janus_interop_binaries \
+    --bin janus_interop_aggregator
+
+FROM postgres:14-alpine AS final
 RUN mkdir /logs && mkdir /etc/janus
 RUN apk add --update supervisor && rm -rf /tmp/* /var/cache/apk/*
 COPY db /etc/janus/migrations
@@ -43,8 +74,9 @@ COPY interop_binaries/config/supervisord.conf \
     interop_binaries/config/aggregation_job_driver.yaml \
     interop_binaries/config/collection_job_driver.yaml \
     /etc/janus/
-COPY --from=builder \
-    /src/target/$PROFILE/janus_interop_aggregator \
+ARG PROFILE
+COPY --from=builder-interop /src/target/$PROFILE/janus_interop_aggregator /usr/local/bin/
+COPY --from=builder-aggregator \
     /src/target/$PROFILE/aggregation_job_creator \
     /src/target/$PROFILE/aggregation_job_driver \
     /src/target/$PROFILE/collection_job_driver \

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ DOCKER_BUILDKIT=1 docker build --tag=janus_aggregation_job_driver --build-arg BI
 DOCKER_BUILDKIT=1 docker build --tag=janus_collection_job_driver --build-arg BINARY=collection_job_driver .
 ```
 
+Alternately, run `docker buildx bake` to build images in parallel.
+
 ## Running tests
 
 Tests require that [`docker`](https://www.docker.com) and

--- a/README.md
+++ b/README.md
@@ -34,16 +34,11 @@ subtle incompatibilities between the two that will cause tests to fail.
 
 ### Container image
 
-To build container images, run the following commands.
-
-```bash
-DOCKER_BUILDKIT=1 docker build --tag=janus_aggregator .
-DOCKER_BUILDKIT=1 docker build --tag=janus_aggregation_job_creator --build-arg BINARY=aggregation_job_creator .
-DOCKER_BUILDKIT=1 docker build --tag=janus_aggregation_job_driver --build-arg BINARY=aggregation_job_driver .
-DOCKER_BUILDKIT=1 docker build --tag=janus_collection_job_driver --build-arg BINARY=collection_job_driver .
-```
-
-Alternately, run `docker buildx bake` to build images in parallel.
+To build container images, run `docker buildx bake --load`. This will produce images
+tagged `janus_aggregator`, `janus_aggregation_job_creator`,
+`janus_aggregation_job_driver`, `janus_collection_job_driver`, `janus_cli`,
+`janus_interop_client`, `janus_interop_aggregator`, and
+`janus_interop_collector` by default.
 
 ## Running tests
 

--- a/build_script_utils/src/lib.rs
+++ b/build_script_utils/src/lib.rs
@@ -8,7 +8,7 @@ pub fn save_zstd_compressed_docker_image<W: Write>(image_id: &str, writer: W) {
         .args(["save", image_id])
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
+        .stderr(Stdio::inherit())
         .spawn()
         .expect("Failed to execute `docker save`");
     let save_stdout = save_child.stdout.take().unwrap();

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,272 @@
+variable "GIT_REVISION" {
+  default = "unknown"
+}
+
+variable "VERSION" {
+  default = "latest"
+}
+
+variable "GITHUB_REF_NAME" {}
+
+variable "GITHUB_BASE_REF" {}
+
+group "default" {
+  targets = ["janus", "interop_binaries"]
+}
+
+group "janus" {
+  targets = [
+    "janus_aggregator",
+    "janus_aggregation_job_creator",
+    "janus_aggregation_job_driver",
+    "janus_collection_job_driver",
+    "janus_cli",
+  ]
+}
+
+group "interop_binaries" {
+  targets = [
+    "janus_interop_client",
+    "janus_interop_aggregator",
+    "janus_interop_collector",
+  ]
+}
+
+group "release" {
+  targets = ["janus_release", "interop_binaries_release"]
+}
+
+group "janus_release" {
+  targets = [
+    "janus_aggregator_release",
+    "janus_aggregation_job_creator_release",
+    "janus_aggregation_job_driver_release",
+    "janus_collection_job_driver_release",
+    "janus_cli_release",
+  ]
+}
+
+group "interop_binaries_release" {
+  targets = [
+    "janus_interop_client_release",
+    "janus_interop_aggregator_release",
+    "janus_interop_collector_release",
+  ]
+}
+
+group "interop_binaries_small" {
+  targets = [
+    "janus_interop_client_small",
+    "janus_interop_aggregator_small",
+    "janus_interop_collector_small",
+  ]
+}
+
+target "janus_aggregator" {
+  args = {
+    GIT_REVISION = "${GIT_REVISION}"
+  }
+  cache-from = [
+    "type=gha,scope=main-janus",
+    "type=gha,scope=${GITHUB_BASE_REF}-janus",
+    "type=gha,scope=${GITHUB_REF_NAME}-janus",
+  ]
+  cache-to = ["type=gha,scope=${GITHUB_REF_NAME}-janus,mode=max"]
+  tags = ["janus_aggregator"]
+}
+
+target "janus_aggregator_release" {
+  inherits = ["janus_aggregator"]
+  tags = [
+    "us-west2-docker.pkg.dev/janus-artifacts/janus/janus_aggregator:${VERSION}",
+    "us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_aggregator:${VERSION}",
+  ]
+}
+
+target "janus_aggregation_job_creator" {
+  args = {
+    BINARY = "aggregation_job_creator"
+    GIT_REVISION = "${GIT_REVISION}"
+  }
+  cache-from = [
+    "type=gha,scope=main-janus",
+    "type=gha,scope=${GITHUB_BASE_REF}-janus",
+    "type=gha,scope=${GITHUB_REF_NAME}-janus",
+  ]
+  tags = ["janus_aggregation_job_creator"]
+}
+
+target "janus_aggregation_job_creator_release" {
+  inherits = ["janus_aggregation_job_creator"]
+  tags = [
+    "us-west2-docker.pkg.dev/janus-artifacts/janus/janus_aggregation_job_creator:${VERSION}",
+    "us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_aggregation_job_creator:${VERSION}",
+  ]
+}
+
+target "janus_aggregation_job_driver" {
+  args = {
+    BINARY = "aggregation_job_driver"
+    GIT_REVISION = "${GIT_REVISION}"
+  }
+  cache-from = [
+    "type=gha,scope=main-janus",
+    "type=gha,scope=${GITHUB_BASE_REF}-janus",
+    "type=gha,scope=${GITHUB_REF_NAME}-janus",
+  ]
+  tags = ["janus_aggregation_job_driver"]
+}
+
+target "janus_aggregation_job_driver_release" {
+  inherits = ["janus_aggregation_job_driver"]
+  tags = [
+    "us-west2-docker.pkg.dev/janus-artifacts/janus/janus_aggregation_job_driver:${VERSION}",
+    "us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_aggregation_job_driver:${VERSION}",
+  ]
+}
+
+target "janus_collection_job_driver" {
+  args = {
+    BINARY = "collection_job_driver"
+    GIT_REVISION = "${GIT_REVISION}"
+  }
+  cache-from = [
+    "type=gha,scope=main-janus",
+    "type=gha,scope=${GITHUB_BASE_REF}-janus",
+    "type=gha,scope=${GITHUB_REF_NAME}-janus",
+  ]
+  tags = ["janus_collection_job_driver"]
+}
+
+target "janus_collection_job_driver_release" {
+  inherits = ["janus_collection_job_driver"]
+  tags = [
+    "us-west2-docker.pkg.dev/janus-artifacts/janus/janus_collection_job_driver:${VERSION}",
+    "us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_collection_job_driver:${VERSION}",
+  ]
+}
+
+target "janus_cli" {
+  args = {
+    BINARY = "janus_cli"
+    GIT_REVISION = "${GIT_REVISION}"
+  }
+  cache-from = [
+    "type=gha,scope=main-janus",
+    "type=gha,scope=${GITHUB_BASE_REF}-janus",
+    "type=gha,scope=${GITHUB_REF_NAME}-janus",
+  ]
+  tags = ["janus_cli"]
+}
+
+target "janus_cli_release" {
+  inherits = ["janus_cli"]
+  tags = [
+    "us-west2-docker.pkg.dev/janus-artifacts/janus/janus_cli:${VERSION}",
+    "us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_cli:${VERSION}",
+  ]
+}
+
+target "janus_interop_client" {
+  args = {
+    BINARY = "janus_interop_client"
+  }
+  dockerfile = "Dockerfile.interop"
+  cache-from = [
+    "type=gha,scope=main-interop",
+    "type=gha,scope=${GITHUB_BASE_REF}-interop",
+    "type=gha,scope=${GITHUB_REF_NAME}-interop",
+  ]
+  tags = ["janus_interop_client"]
+}
+
+target "janus_interop_client_release" {
+  inherits = ["janus_interop_client"]
+  tags = [
+    "us-west2-docker.pkg.dev/janus-artifacts/janus/janus_interop_client:${VERSION}",
+    "us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_interop_client:${VERSION}",
+  ]
+}
+
+target "janus_interop_aggregator" {
+  dockerfile = "Dockerfile.interop_aggregator"
+  cache-from = [
+    "type=gha,scope=main-interop",
+    "type=gha,scope=${GITHUB_BASE_REF}-interop",
+    "type=gha,scope=${GITHUB_REF_NAME}-interop",
+  ]
+  cache-to = ["type=gha,scope=${GITHUB_REF_NAME}-interop,mode=max"]
+  tags = ["janus_interop_aggregator"]
+}
+
+target "janus_interop_aggregator_release" {
+  inherits = ["janus_interop_aggregator"]
+  tags = [
+    "us-west2-docker.pkg.dev/janus-artifacts/janus/janus_interop_aggregator:${VERSION}",
+    "us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_interop_aggregator:${VERSION}",
+  ]
+}
+
+target "janus_interop_collector" {
+  args = {
+    BINARY = "janus_interop_collector"
+  }
+  dockerfile = "Dockerfile.interop"
+  cache-from = [
+    "type=gha,scope=main-interop",
+    "type=gha,scope=${GITHUB_BASE_REF}-interop",
+    "type=gha,scope=${GITHUB_REF_NAME}-interop",
+  ]
+  tags = ["janus_interop_collector"]
+}
+
+target "janus_interop_collector_release" {
+  inherits = ["janus_interop_collector"]
+  tags = [
+    "us-west2-docker.pkg.dev/janus-artifacts/janus/janus_interop_collector:${VERSION}",
+    "us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_interop_collector:${VERSION}",
+  ]
+}
+
+# These targets should match the `docker build` commands run in the
+# janus_interop_binaries build script. They are run separately in CI for
+# caching purposes.
+
+target "janus_interop_client_small" {
+  args = {
+    PROFILE = "small"
+    BINARY = "janus_interop_client"
+  }
+  cache-from = [
+    "type=gha,scope=main-interop-small",
+    "type=gha,scope=${GITHUB_BASE_REF}-interop-small",
+    "type=gha,scope=${GITHUB_REF_NAME}-interop-small",
+  ]
+  dockerfile = "Dockerfile.interop"
+}
+
+target "janus_interop_aggregator_small" {
+  args = {
+    PROFILE = "small"
+  }
+  cache-from = [
+    "type=gha,scope=main-interop-small",
+    "type=gha,scope=${GITHUB_BASE_REF}-interop-small",
+    "type=gha,scope=${GITHUB_REF_NAME}-interop-small",
+  ]
+  cache-to = ["type=gha,scope=${GITHUB_REF_NAME}-interop-small,mode=max"]
+  dockerfile = "Dockerfile.interop_aggregator"
+}
+
+target "janus_interop_collector_small" {
+  args = {
+    PROFILE = "small"
+    BINARY = "janus_interop_collector"
+  }
+  cache-from = [
+    "type=gha,scope=main-interop-small",
+    "type=gha,scope=${GITHUB_BASE_REF}-interop-small",
+    "type=gha,scope=${GITHUB_REF_NAME}-interop-small",
+  ]
+  dockerfile = "Dockerfile.interop"
+}

--- a/interop_binaries/build.rs
+++ b/interop_binaries/build.rs
@@ -58,13 +58,13 @@ fn main() {
                             "--build-arg=PROFILE=small",
                             "--build-arg=BINARY=janus_interop_client",
                             "--load",
+                            &format!("--iidfile={image_id_file_name}"),
+                            &format!(
+                                "--cache-from=type=gha,scope={}-interop-small",
+                                env::var("GITHUB_REF_NAME").unwrap_or_else(|_| "main".to_string())
+                            ),
+                            ".",
                         ])
-                        .arg(format!("--iidfile={image_id_file_name}"))
-                        .arg(format!(
-                            "--cache-from=type=gha,scope={}-interop-small",
-                            env::var("GITHUB_REF_NAME").unwrap_or_else(|_| "main".to_string())
-                        ))
-                        .arg(".")
                         .current_dir("..")
                         .output()
                         .expect("Failed to execute `docker build` for interop client");
@@ -92,13 +92,13 @@ fn main() {
                             "--file=Dockerfile.interop_aggregator",
                             "--build-arg=PROFILE=small",
                             "--load",
+                            &format!("--iidfile={image_id_file_name}"),
+                            &format!(
+                                "--cache-from=type=gha,scope={}-interop-small",
+                                env::var("GITHUB_REF_NAME").unwrap_or_else(|_| "main".to_string())
+                            ),
+                            ".",
                         ])
-                        .arg(format!("--iidfile={image_id_file_name}"))
-                        .arg(format!(
-                            "--cache-from=type=gha,scope={}-interop-small",
-                            env::var("GITHUB_REF_NAME").unwrap_or_else(|_| "main".to_string())
-                        ))
-                        .arg(".")
                         .current_dir("..")
                         .output()
                         .expect("Failed to execute `docker build` for interop aggregator");
@@ -127,13 +127,13 @@ fn main() {
                             "--build-arg=PROFILE=small",
                             "--build-arg=BINARY=janus_interop_collector",
                             "--load",
+                            &format!("--iidfile={image_id_file_name}"),
+                            &format!(
+                                "--cache-from=type=gha,scope={}-interop-small",
+                                env::var("GITHUB_REF_NAME").unwrap_or_else(|_| "main".to_string())
+                            ),
+                            ".",
                         ])
-                        .arg(format!("--iidfile={image_id_file_name}"))
-                        .arg(format!(
-                            "--cache-from=type=gha,scope={}-interop-small",
-                            env::var("GITHUB_REF_NAME").unwrap_or_else(|_| "main".to_string())
-                        ))
-                        .arg(".")
                         .current_dir("..")
                         .output()
                         .expect("Failed to execute `docker build` for interop collector");

--- a/interop_binaries/build.rs
+++ b/interop_binaries/build.rs
@@ -15,12 +15,13 @@ fn main() {
     #[cfg(feature = "testcontainer")]
     {
         use janus_build_script_utils::save_zstd_compressed_docker_image;
-        use std::{fs::File, process::Command};
+        use std::{fs::File, io::Read, process::Command};
 
         println!("cargo:rerun-if-env-changed=JANUS_INTEROP_CONTAINER");
         let container_strategy = env::var("JANUS_INTEROP_CONTAINER")
             .ok()
             .unwrap_or_else(|| "build".to_string());
+        let out_dir = env::var("OUT_DIR").unwrap();
 
         match container_strategy.as_str() {
             "build" => {
@@ -47,17 +48,24 @@ fn main() {
                 // any other image metadata (such as exposed ports, the entrypoint, etc), so we can't easily
                 // use it.
                 let client_image_id = {
+                    let image_id_file_name = format!("{out_dir}/janus_interop_client_image_id.txt");
+
                     let client_build_output = Command::new("docker")
                         .args([
+                            "buildx",
                             "build",
-                            "--quiet",
                             "--file=Dockerfile.interop",
                             "--build-arg=PROFILE=small",
                             "--build-arg=BINARY=janus_interop_client",
-                            ".",
+                            "--load",
                         ])
+                        .arg(format!("--iidfile={image_id_file_name}"))
+                        .arg(format!(
+                            "--cache-from=type=gha,scope={}-interop-small",
+                            env::var("GITHUB_REF_NAME").unwrap_or_else(|_| "main".to_string())
+                        ))
+                        .arg(".")
                         .current_dir("..")
-                        .env("DOCKER_BUILDKIT", "1")
                         .output()
                         .expect("Failed to execute `docker build` for interop client");
                     assert!(
@@ -65,23 +73,33 @@ fn main() {
                         "Docker build of interop client failed:\n{}",
                         String::from_utf8_lossy(&client_build_output.stderr)
                     );
-                    String::from_utf8(client_build_output.stdout)
-                        .unwrap()
-                        .trim()
-                        .to_string()
+                    let mut image_id = String::new();
+                    File::open(image_id_file_name)
+                        .expect("Failed to open image ID file")
+                        .read_to_string(&mut image_id)
+                        .expect("Failed to read image ID file");
+                    image_id.trim().to_string()
                 };
 
                 let aggregator_image_id = {
+                    let image_id_file_name =
+                        format!("{out_dir}/janus_interop_aggregator_image_id.txt");
+
                     let aggregator_build_output = Command::new("docker")
                         .args([
+                            "buildx",
                             "build",
-                            "--quiet",
                             "--file=Dockerfile.interop_aggregator",
                             "--build-arg=PROFILE=small",
-                            ".",
+                            "--load",
                         ])
+                        .arg(format!("--iidfile={image_id_file_name}"))
+                        .arg(format!(
+                            "--cache-from=type=gha,scope={}-interop-small",
+                            env::var("GITHUB_REF_NAME").unwrap_or_else(|_| "main".to_string())
+                        ))
+                        .arg(".")
                         .current_dir("..")
-                        .env("DOCKER_BUILDKIT", "1")
                         .output()
                         .expect("Failed to execute `docker build` for interop aggregator");
                     assert!(
@@ -89,24 +107,34 @@ fn main() {
                         "Docker build of interop aggregator failed:\n{}",
                         String::from_utf8_lossy(&aggregator_build_output.stderr)
                     );
-                    String::from_utf8(aggregator_build_output.stdout)
-                        .unwrap()
-                        .trim()
-                        .to_string()
+                    let mut image_id = String::new();
+                    File::open(image_id_file_name)
+                        .expect("Failed to open image ID file")
+                        .read_to_string(&mut image_id)
+                        .expect("Failed to read image ID file");
+                    image_id.trim().to_string()
                 };
 
                 let collector_image_id = {
+                    let image_id_file_name =
+                        format!("{out_dir}/janus_interop_collector_image_id.txt");
+
                     let collector_build_output = Command::new("docker")
                         .args([
+                            "buildx",
                             "build",
-                            "--quiet",
                             "--file=Dockerfile.interop",
                             "--build-arg=PROFILE=small",
                             "--build-arg=BINARY=janus_interop_collector",
-                            ".",
+                            "--load",
                         ])
+                        .arg(format!("--iidfile={image_id_file_name}"))
+                        .arg(format!(
+                            "--cache-from=type=gha,scope={}-interop-small",
+                            env::var("GITHUB_REF_NAME").unwrap_or_else(|_| "main".to_string())
+                        ))
+                        .arg(".")
                         .current_dir("..")
-                        .env("DOCKER_BUILDKIT", "1")
                         .output()
                         .expect("Failed to execute `docker build` for interop collector");
                     assert!(
@@ -114,40 +142,35 @@ fn main() {
                         "Docker build of interop collector failed:\n{}",
                         String::from_utf8_lossy(&collector_build_output.stderr)
                     );
-                    String::from_utf8(collector_build_output.stdout)
-                        .unwrap()
-                        .trim()
-                        .to_string()
+                    let mut image_id = String::new();
+                    File::open(image_id_file_name)
+                        .expect("Failed to open image ID file")
+                        .read_to_string(&mut image_id)
+                        .expect("Failed to read image ID file");
+                    image_id.trim().to_string()
                 };
 
                 // Save off containers to disk.
-                let client_image_file = File::create(format!(
-                    "{}/interop_client.tar.zst",
-                    env::var("OUT_DIR").unwrap()
-                ))
-                .expect("Couldn't create interop client image file");
+                let client_image_file = File::create(format!("{out_dir}/interop_client.tar.zst"))
+                    .expect("Couldn't create interop client image file");
                 save_zstd_compressed_docker_image(&client_image_id, &client_image_file);
                 client_image_file
                     .sync_all()
                     .expect("Couldn't write compressed image file");
                 drop(client_image_file);
 
-                let aggregator_image_file = File::create(format!(
-                    "{}/interop_aggregator.tar.zst",
-                    env::var("OUT_DIR").unwrap()
-                ))
-                .expect("Couldn't create interop aggregator image file");
+                let aggregator_image_file =
+                    File::create(format!("{out_dir}/interop_aggregator.tar.zst"))
+                        .expect("Couldn't create interop aggregator image file");
                 save_zstd_compressed_docker_image(&aggregator_image_id, &aggregator_image_file);
                 aggregator_image_file
                     .sync_all()
                     .expect("Couldn't write compressed image file");
                 drop(aggregator_image_file);
 
-                let collector_image_file = File::create(format!(
-                    "{}/interop_collector.tar.zst",
-                    env::var("OUT_DIR").unwrap()
-                ))
-                .expect("Couldn't create interop collector image file");
+                let collector_image_file =
+                    File::create(format!("{out_dir}/interop_collector.tar.zst"))
+                        .expect("Couldn't create interop collector image file");
                 save_zstd_compressed_docker_image(&collector_image_id, &collector_image_file);
                 collector_image_file
                     .sync_all()
@@ -175,11 +198,8 @@ fn main() {
                 // succeed; the consumer (testcontainer.rs) will panic if someone attempts to
                 // instantiate a container in this case.
                 for filename in ["interop_client", "interop_aggregator", "interop_collector"] {
-                    let image_file = File::create(format!(
-                        "{}/{filename}.tar.zst",
-                        env::var("OUT_DIR").unwrap()
-                    ))
-                    .expect("Couldn't create empty image file");
+                    let image_file = File::create(format!("{out_dir}/{filename}.tar.zst"))
+                        .expect("Couldn't create empty image file");
                     image_file
                         .sync_all()
                         .expect("Couldn't write empty image file");


### PR DESCRIPTION
This makes some changes to speed up Docker builds, particularly in CI. Cache mounts are abandoned in favor of using `cargo-chef` to split dependency compilation artifacts and first-party compilation artifacts into separate layers. `ARG` directives are pushed down as far as possible to allow layers to be reused between different image builds. Repetitive `docker build` command lines are replaced with `docker buildx bake` and a new `docker-bake.hcl` file which represents each existing `docker build` invocation declaratively. Using `bake` also allows for better pipelined scheduling of multiple container image builds, which is relevant for our CI jobs. The GitHub Actions cache backend is enabled, with three unique builds writing to the cache, and all builds reading from whichever cache scope is the best fit. The janus_interop_binaries container images are built with the "small" profile in our build-and-test CI job before `cargo build`, so that layer caching can be used.