### PR TITLE
Track authentication mode per-auth-token

### DIFF
--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -56,8 +56,9 @@ impl CollectionJobTestCase {
             .collection_job_uri(collection_job_id)
             .unwrap()
             .path());
-        if let Some(token) = auth_token {
-            test_conn = test_conn.with_request_header("DAP-Auth-Token", token.as_ref().to_owned())
+        if let Some(auth) = auth_token {
+            let (header, value) = auth.request_authentication();
+            test_conn = test_conn.with_request_header(header, value);
         }
 
         test_conn
@@ -94,8 +95,9 @@ impl CollectionJobTestCase {
                 .unwrap()
                 .path(),
         );
-        if let Some(token) = auth_token {
-            test_conn = test_conn.with_request_header("DAP-Auth-Token", token.as_ref().to_owned())
+        if let Some(auth) = auth_token {
+            let (header, value) = auth.request_authentication();
+            test_conn = test_conn.with_request_header(header, value);
         }
         test_conn.run_async(&self.handler).await
     }

--- a/aggregator/src/aggregator/problem_details.rs
+++ b/aggregator/src/aggregator/problem_details.rs
@@ -66,10 +66,7 @@ mod tests {
     use assert_matches::assert_matches;
     use futures::future::join_all;
     use http::Method;
-    use janus_core::{
-        task::AuthenticationToken,
-        time::{Clock, RealClock},
-    };
+    use janus_core::time::{Clock, RealClock};
     use janus_messages::{
         problem_type::{DapProblemType, DapProblemTypeParseError},
         Duration, HpkeConfigId, Interval, ReportIdChecksum,
@@ -242,7 +239,7 @@ mod tests {
                         "test",
                         "text/plain",
                         (),
-                        &AuthenticationToken::try_from("auth".as_bytes().to_vec()).unwrap(),
+                        &random(),
                         &request_histogram,
                     )
                     .await

--- a/db/00000000000009_auth_token_kind.down.sql
+++ b/db/00000000000009_auth_token_kind.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE task_collector_auth_tokens DROP COLUMN type AUTH_TOKEN_TYPE;
+ALTER TABLE task_aggregator_auth_tokens DROP COLUMN type AUTH_TOKEN_TYPE;
+
+DROP TYPE AUTH_TOKEN_TYPE;

--- a/db/00000000000009_auth_token_kind.up.sql
+++ b/db/00000000000009_auth_token_kind.up.sql
@@ -1,0 +1,7 @@
+CREATE TYPE AUTH_TOKEN_TYPE AS ENUM(
+    'DAP_AUTH', -- DAP-01 style DAP-Auth-Token header
+    'BEARER' -- RFC 6750 bearer token
+);
+
+ALTER TABLE task_aggregator_auth_tokens ADD COLUMN type AUTH_TOKEN_TYPE NOT NULL DEFAULT 'DAP_AUTH';
+ALTER TABLE task_collector_auth_tokens ADD COLUMN type AUTH_TOKEN_TYPE NOT NULL DEFAULT 'DAP_AUTH';

--- a/docs/samples/tasks.yaml
+++ b/docs/samples/tasks.yaml
@@ -65,20 +65,28 @@
   # authenticate leader-to-helper requests. In the case of a leader-role task,
   # the leader will include the first token in a header when making requests to
   # the helper. In the case of a helper-role task, the helper will accept
-  # requests with any of the listed authentication tokens. Each token is encoded
-  # in base64url, and the decoded value is sent as an HTTP header value. For
-  # example, this value decodes to
-  # "aggregator-235242f99406c4fd28b820c32eab0f68".
+  # requests with any of the listed authentication tokens.
+  #
+  # Each token's `type` governs how it is inserted into HTTP requests if used by
+  # the leader to authenticate a request to the helper.
   aggregator_auth_tokens:
-  - "YWdncmVnYXRvci0yMzUyNDJmOTk0MDZjNGZkMjhiODIwYzMyZWFiMGY2OA"
+    # DAP-Auth-Token values are encoded in unpadded base64url, and the decoded
+    # value is sent in an HTTP header. For example, this token's value decodes
+    # to "aggregator-235242f99406c4fd28b820c32eab0f68".
+  - type: "DapAuth"
+    token: "YWdncmVnYXRvci0yMzUyNDJmOTk0MDZjNGZkMjhiODIwYzMyZWFiMGY2OA"
+    # Bearer token values are encoded in base64 with padding.
+  - type: "Bearer"
+    token: "YWdncmVnYXRvci04NDc1NjkwZjJmYzQzMDBmYjE0NmJiMjk1NDIzNDk1NA=="
 
   # Authentication tokens shared between the leader and the collector, and used
   # to authenticate collector-to-leader requests. For leader tasks, this has the
   # same format as `aggregator_auth_tokens` above. For helper tasks, this will
-  # be an empty list instead. This example decodes to
-  # "collector-abf5408e2b1601831625af3959106458".
+  # be an empty list instead.
+  # This example decodes to "collector-abf5408e2b1601831625af3959106458".
   collector_auth_tokens:
-  - "Y29sbGVjdG9yLWFiZjU0MDhlMmIxNjAxODMxNjI1YWYzOTU5MTA2NDU4"
+  - type: "Bearer"
+    token: "Y29sbGVjdG9yLWFiZjU0MDhlMmIxNjAxODMxNjI1YWYzOTU5MTA2NDU4"
 
   # This aggregator's HPKE keypairs. The first keypair's HPKE configuration will
   # be served via the `hpke_config` DAP endpoint. All keypairs will be tried
@@ -118,7 +126,8 @@
     aead_id: Aes128Gcm
     public_key: KHRLcWgfWxli8cdOLPsgsZPttHXh0ho3vLVLrW-63lE
   aggregator_auth_tokens:
-  - "YWdncmVnYXRvci1jZmE4NDMyZjdkMzllMjZiYjU3OGUzMzY5Mzk1MWQzNQ"
+  - type: "Bearer"
+    token: "YWdncmVnYXRvci1jZmE4NDMyZjdkMzllMjZiYjU3OGUzMzY5Mzk1MWQzNQ=="
   # Note that this task does not have any collector authentication tokens, since
   # it is a helper role task.
   collector_auth_tokens: []

--- a/integration_tests/tests/common/mod.rs
+++ b/integration_tests/tests/common/mod.rs
@@ -2,8 +2,7 @@ use backoff::{future::retry, ExponentialBackoffBuilder};
 use itertools::Itertools;
 use janus_aggregator_core::task::{test_util::TaskBuilder, QueryType, Task};
 use janus_collector::{
-    test_util::collect_with_rewritten_url, Authentication, Collection, Collector,
-    CollectorParameters,
+    test_util::collect_with_rewritten_url, Collection, Collector, CollectorParameters,
 };
 use janus_core::{
     hpke::{test_util::generate_test_hpke_config_and_private_key, HpkePrivateKey},
@@ -126,7 +125,7 @@ pub async fn submit_measurements_and_verify_aggregate_generic<'a, V>(
     let collector_params = CollectorParameters::new_with_authentication(
         *leader_task.id(),
         aggregator_endpoints[Role::Leader.index().unwrap()].clone(),
-        Authentication::DapAuthToken(leader_task.primary_collector_auth_token().clone()),
+        leader_task.primary_collector_auth_token().clone(),
         leader_task.collector_hpke_config().clone(),
         collector_private_key.clone(),
     )


### PR DESCRIPTION
Previously, we taught Janus to accept authentication tokens presented in HTTP requests as either `DAP-Auth-Token: <token>` or `Authorization: Bearer <token>`. However, we also want a Janus leader to be able to work with a DAP helper that expects only one or the other authentication mode.

The `task_aggregator_auth_tokens` and `task_collector_auth_tokens` tables now have columns that track the type of auth token, which is either `DAP_AUTH` or `BEARER`. `send_request_to_helper` will now consult this value to decide how it should authenticate requests.

We didn't strictly need this column in `task_collector_auth_tokens` as the leader's collection job handlers will still accept either kind of token, but it's nice to have consistent handling of these types across the two tables.

The distinction between DAP-Auth-Token and bearer tokens is plumbed up from `janus_core` through `janus_aggregator` by combining `janus_core::task::AuthenticationToken` with `janus_collector::Authentication` into an enum that distinguishes between the two authentication modes and can produce suitable HTTP header names and values.

Note that we track authentication mode per-token and not per-task. This means that it's possible for a task to use two different kinds of tokens.

A task defined in YAML and provisioned via `janus_cli` may use Bearer tokens, but this isn't yet possible via `janus_aggregator_api`, which still assumes it is receiving or generating `DAP-Auth-Token`-form tokens. The aggregator API for creating tasks will have to change to accommodate the distinction between token types, and that will arrive in a later change so that it can be coordinated with `divviup-api`.

Part of #472