### PR TITLE
Test that auth token format must match

### DIFF
--- a/core/src/task.rs
+++ b/core/src/task.rs
@@ -556,9 +556,13 @@ pub enum AuthenticationToken {
     ),
 
     /// Token presented as the value of the "DAP-Auth-Token" HTTP header. Conforms to
-    /// [draft-ietf-dap-ppm-01 section 3.2][1].
+    /// [draft-dcook-ppm-dap-interop-test-design-03][1], sections [4.3.3][2] and [4.4.2][3], and
+    /// [draft-ietf-dap-ppm-01 section 3.2][4].
     ///
-    /// [1]: https://datatracker.ietf.org/doc/html/draft-ietf-ppm-dap-01#name-https-sender-authentication
+    /// [1]: https://datatracker.ietf.org/doc/html/draft-dcook-ppm-dap-interop-test-design-03
+    /// [2]: https://datatracker.ietf.org/doc/html/draft-dcook-ppm-dap-interop-test-design-03#section-4.3.3
+    /// [3]: https://datatracker.ietf.org/doc/html/draft-dcook-ppm-dap-interop-test-design-03#section-4.4.2
+    /// [4]: https://datatracker.ietf.org/doc/html/draft-ietf-ppm-dap-01#name-https-sender-authentication
     DapAuth(DapAuthToken),
 }
 


### PR DESCRIPTION
If some task accepts an `AuthenticationToken::DapAuth`, it should not be possible to present its value as an `AuthenticationToken::Bearer` and have it be accepted (or vice versa, should a Bearer token happen to also be a legal `DAP-Auth-Token` value). This was already the case because we evaluate tokens using `AuthenticationToken::eq`, but this commit adds a test to explicitly verify this.

While we're in here, improve a doccomment to explain that `AuthenticationToken::DapAuth` complies with the interop testing framework as well as the now-obsolete `draft-ietf-ppm-dap-01`, and add a constant for the collection job route to match the ones for aggregation jobs and aggregate shares.

Closes #1300