### PR TITLE
Breaking changes to Collector constructors

### DIFF
--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -26,7 +26,7 @@
 //!     HpkeKdfId::HkdfSha256,
 //!     HpkeAeadId::Aes128Gcm,
 //! );
-//! let parameters = CollectorParameters::new_with_authentication(
+//! let parameters = CollectorParameters::new(
 //!     task_id,
 //!     "https://example.com/dap/".parse().unwrap(),
 //!     AuthenticationToken::Bearer(b"my-authentication-token".to_vec()),
@@ -178,29 +178,7 @@ pub struct CollectorParameters {
 
 impl CollectorParameters {
     /// Creates a new set of collector task parameters.
-    ///
-    /// This constructor is deprecated, because it always uses the `DAP-Auth-Token` header for
-    /// authentication. See [CollectorParameters::new_with_authentication] for a more flexible
-    /// constructor.
-    #[deprecated]
     pub fn new(
-        task_id: TaskId,
-        leader_endpoint: Url,
-        authentication: AuthenticationToken,
-        hpke_config: HpkeConfig,
-        hpke_private_key: HpkePrivateKey,
-    ) -> CollectorParameters {
-        Self::new_with_authentication(
-            task_id,
-            leader_endpoint,
-            authentication,
-            hpke_config,
-            hpke_private_key,
-        )
-    }
-
-    /// Creates a new set of collector task parameters.
-    pub fn new_with_authentication(
         task_id: TaskId,
         mut leader_endpoint: Url,
         authentication: AuthenticationToken,
@@ -723,7 +701,7 @@ mod tests {
     ) -> Collector<V> {
         let server_url = Url::parse(&server.url()).unwrap();
         let hpke_keypair = generate_test_hpke_config_and_private_key();
-        let parameters = CollectorParameters::new_with_authentication(
+        let parameters = CollectorParameters::new(
             random(),
             server_url,
             AuthenticationToken::Bearer(b"token".to_vec()),
@@ -824,7 +802,7 @@ mod tests {
     #[test]
     fn leader_endpoint_end_in_slash() {
         let hpke_keypair = generate_test_hpke_config_and_private_key();
-        let collector_parameters = CollectorParameters::new_with_authentication(
+        let collector_parameters = CollectorParameters::new(
             random(),
             "http://example.com/dap".parse().unwrap(),
             AuthenticationToken::Bearer(b"token".to_vec()),
@@ -837,7 +815,7 @@ mod tests {
             "http://example.com/dap/",
         );
 
-        let collector_parameters = CollectorParameters::new_with_authentication(
+        let collector_parameters = CollectorParameters::new(
             random(),
             "http://example.com".parse().unwrap(),
             AuthenticationToken::Bearer(b"token".to_vec()),
@@ -1243,7 +1221,7 @@ mod tests {
         let transcript = run_vdaf(&vdaf, &random(), &(), &random(), &1);
         let server_url = Url::parse(&server.url()).unwrap();
         let hpke_keypair = generate_test_hpke_config_and_private_key();
-        let parameters = CollectorParameters::new_with_authentication(
+        let parameters = CollectorParameters::new(
             random(),
             server_url,
             AuthenticationToken::Bearer(Vec::from([0x41u8; 16])),

--- a/integration_tests/tests/common/mod.rs
+++ b/integration_tests/tests/common/mod.rs
@@ -122,7 +122,7 @@ pub async fn submit_measurements_and_verify_aggregate_generic<'a, V>(
         client_implementation.upload(measurement).await.unwrap();
     }
 
-    let collector_params = CollectorParameters::new_with_authentication(
+    let collector_params = CollectorParameters::new(
         *leader_task.id(),
         aggregator_endpoints[Role::Leader.index().unwrap()].clone(),
         leader_task.primary_collector_auth_token().clone(),

--- a/interop_binaries/src/bin/janus_interop_collector.rs
+++ b/interop_binaries/src/bin/janus_interop_collector.rs
@@ -236,7 +236,7 @@ async fn handle_collection_start(
         .get(&task_id)
         .context("task was not added before being used in a collect request")?;
 
-    let collector_params = CollectorParameters::new_with_authentication(
+    let collector_params = CollectorParameters::new(
         task_id,
         task_state.leader_url.clone(),
         task_state.auth_token.clone(),

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -451,7 +451,7 @@ where
         (Some(token), None) => token,
         (None, None) | (Some(_), Some(_)) => unreachable!(),
     };
-    let parameters = CollectorParameters::new_with_authentication(
+    let parameters = CollectorParameters::new(
         options.task_id,
         options.leader,
         authentication,


### PR DESCRIPTION
This removes the deprecated `CollectorParameters::new()` constructor, and renames `CollectorParameters::new_with_authentication()` to `CollectorParameters::new()`. Since we're already going to be releasing 0.5.0, I'd like to batch up this breaking change as well, to clean out some cruft.