### PR TITLE
docs: don't use podman, use docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ branch.
 [`docker`](https://www.docker.com) must be installed at build time, and the
 `docker` daemon must be running. To build Janus, execute `cargo build`.
 
+Note that `podman` is not an acceptable substitute for `docker`. There are
+subtle incompatibilities between the two that will cause tests to fail.
+
 Building Janus with `janus_aggregator`'s `otlp` feature enabled currently
 requires the Protocol Buffers compiler, `protoc`, be installed on the machine
 performing the build.


### PR DESCRIPTION
The exact reasoning is that there are differences between the output of `docker inspect` and `podman inspect` that [cause serialization panics](https://github.com/testcontainers/testcontainers-rs/blob/b22713aae20f6da1c1a15b007410054014c1ba6b/testcontainers/src/clients/cli.rs#L339) in `testcontainers`. In fact, it's their [intent to discourage podman usage](https://github.com/testcontainers/testcontainers-rs/issues/422).

RHEL derivatives come default with podman, so hopefully this blurb will save the next person a bit of troubleshooting.