### PR TITLE
Upgrade to opentelemetry 0.19

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -49,10 +49,6 @@ jobs:
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust-toolchain }}
-    - name: Install Protoc
-      uses: arduino/setup-protoc@v1
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
       with:
@@ -108,10 +104,6 @@ jobs:
       with:
         toolchain: ${{ matrix.rust-toolchain }}
         components: clippy, rustfmt
-    - name: Install Protoc
-      uses: arduino/setup-protoc@v1
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Format
       run: cargo fmt --message-format human -- --check
     - name: Clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,12 +1313,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
 name = "flate2"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2628,12 +2622,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multimap"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2759,9 +2747,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "opentelemetry"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d6c3d7288a106c0a363e4b0e8d308058d56902adefb16f4936f417ffef086e"
+checksum = "5f4b8347cc26099d3aeee044065ecc3ae11469796b4d65d065a23a584ed92a6f"
 dependencies = [
  "opentelemetry_api",
  "opentelemetry_sdk",
@@ -2769,9 +2757,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-jaeger"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e785d273968748578931e4dc3b4f5ec86b26e09d9e0d66b55adda7fce742f7a"
+checksum = "08e028dc9f4f304e9320ce38c80e7cf74067415b1ad5a8750a38bae54a4d450d"
 dependencies = [
  "async-trait",
  "futures",
@@ -2786,9 +2774,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c928609d087790fc936a1067bdc310ae702bdf3b090c3f281b713622c8bbde"
+checksum = "8af72d59a4484654ea8eb183fea5ae4eb6a41d7ac3e3bae5f4d2a282a3a7d3ca"
 dependencies = [
  "async-trait",
  "futures",
@@ -2804,9 +2792,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-prometheus"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c3d833835a53cf91331d2cfb27e9121f5a95261f31f08a1f79ab31688b8da8"
+checksum = "9a9f186f6293ebb693caddd0595e66b74a6068fa51048e26e0bf9c95478c639c"
 dependencies = [
  "opentelemetry",
  "prometheus",
@@ -2815,48 +2803,47 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61a2f56df5574508dd86aaca016c917489e589ece4141df1b5e349af8d66c28"
+checksum = "045f8eea8c0fa19f7d48e7bc3128a39c2e5c533d5c61298c548dfefc1064474c"
 dependencies = [
  "futures",
  "futures-util",
  "opentelemetry",
  "prost",
  "tonic 0.8.3",
- "tonic-build",
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b02e0230abb0ab6636d18e2ba8fa02903ea63772281340ccac18e0af3ec9eeb"
+checksum = "24e33428e6bf08c6f7fcea4ddb8e358fab0fe48ab877a87c70c6ebe20f673ce5"
 dependencies = [
  "opentelemetry",
 ]
 
 [[package]]
 name = "opentelemetry_api"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c24f96e21e7acc813c7a8394ee94978929db2bcc46cf6b5014fc612bf7760c22"
+checksum = "ed41783a5bf567688eb38372f2b7a8530f5a607a4b49d38dd7573236c23ca7e2"
 dependencies = [
  "fnv",
  "futures-channel",
  "futures-util",
  "indexmap",
- "js-sys",
  "once_cell",
  "pin-project-lite",
  "thiserror",
+ "urlencoding",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca41c4933371b61c2a2f214bf16931499af4ec90543604ec828f7a625c09113"
+checksum = "8b3a2a91fdbfdd4d212c0dcc2ab540de2c2bcbbd90be17de7a7daf8822d010c1"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -2872,15 +2859,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
-]
-
-[[package]]
-name = "ordered-float"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -2991,16 +2969,6 @@ name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
-
-[[package]]
-name = "petgraph"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
-dependencies = [
- "fixedbitset",
- "indexmap",
-]
 
 [[package]]
 name = "phf"
@@ -3159,16 +3127,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "prettyplease"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97e3215779627f01ee256d2fad52f3d95e8e1c11e9fc6fd08f7cd455d5d5c78"
-dependencies = [
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "prio"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3264,28 +3222,6 @@ checksum = "21dc42e00223fc37204bd4aa177e69420c604ca4a183209a8f9de30c6d934698"
 dependencies = [
  "bytes",
  "prost-derive",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f8ad728fb08fe212df3c05169e940fbb6d9d16a877ddde14644a983ba2012e"
-dependencies = [
- "bytes",
- "heck",
- "itertools",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
- "regex",
- "syn 1.0.109",
- "tempfile",
- "which",
 ]
 
 [[package]]
@@ -3796,7 +3732,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
- "ordered-float 2.10.0",
+ "ordered-float",
  "serde",
 ]
 
@@ -4362,14 +4298,14 @@ dependencies = [
 
 [[package]]
 name = "thrift"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09678c4cdbb4eed72e18b7c2af1329c69825ed16fcbac62d083fc3e2b0590ff0"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
 dependencies = [
  "byteorder",
  "integer-encoding",
  "log",
- "ordered-float 1.1.1",
+ "ordered-float",
  "threadpool",
 ]
 
@@ -4644,19 +4580,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic-build"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
-dependencies = [
- "prettyplease",
- "proc-macro2",
- "prost-build",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4766,9 +4689,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ebb87a95ea13271332df069020513ab70bdb5637ca42d6e492dc3bbbad48de"
+checksum = "00a39dcf9bfc1742fa4d6215253b33a6e474be78275884c216fc2a06267b3600"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -4906,9 +4829,9 @@ dependencies = [
 
 [[package]]
 name = "trillium-opentelemetry"
-version = "0.0.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "058ce68d79872eb606079571cf0212633ae1095541a9c6afa0a363de3de4301b"
+checksum = "9cf4382553673f7ccce1f2bbc43b2f344cc68ab681dce8a79f7941857e4208f1"
 dependencies = [
  "opentelemetry",
  "trillium",
@@ -5118,6 +5041,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5311,17 +5240,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
-]
-
-[[package]]
-name = "which"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
-dependencies = [
- "either",
- "libc",
- "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ janus_interop_binaries = { version = "0.4", path = "interop_binaries" }
 janus_messages = { version = "0.4", path = "messages" }
 k8s-openapi = { version = "0.18.0", features = ["v1_24"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
 kube = { version = "0.82.2", default-features = false, features = ["client", "rustls-tls"] }
+opentelemetry = { version = "0.19", features = ["metrics"] }
 prio = { version = "0.12.1", features = ["multithreaded"] }
 serde = { version = "1.0.163", features = ["derive"] }
 rstest = "0.17.0"
@@ -48,7 +49,7 @@ trillium = "0.2.9"
 trillium-api = { version = "0.2.0-rc.3", default-features = false }
 trillium-caching-headers = "0.2.1"
 trillium-head = "0.2.0"
-trillium-opentelemetry = "0.0.1"
+trillium-opentelemetry = "0.1.0"
 trillium-router = "0.3.5"
 trillium-testing = "0.5.0"
 trillium-tokio = "0.3.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM rust:1.69.0-alpine as builder
 ARG BINARY=aggregator
 ARG GIT_REVISION=unknown
-RUN apk add libc-dev protobuf-dev protoc
+RUN apk add libc-dev
 WORKDIR /src
 COPY Cargo.toml /src/Cargo.toml
 COPY Cargo.lock /src/Cargo.lock

--- a/Dockerfile.interop
+++ b/Dockerfile.interop
@@ -4,7 +4,7 @@ ARG PROFILE=release
 FROM rust:1.69.0-alpine as builder
 ARG BINARY
 ARG PROFILE
-RUN apk add libc-dev protobuf-dev protoc
+RUN apk add libc-dev
 WORKDIR /src
 COPY Cargo.toml /src/Cargo.toml
 COPY Cargo.lock /src/Cargo.lock

--- a/Dockerfile.interop_aggregator
+++ b/Dockerfile.interop_aggregator
@@ -2,7 +2,7 @@ ARG PROFILE=release
 
 FROM rust:1.69.0-alpine as builder
 ARG PROFILE
-RUN apk add libc-dev protobuf-dev protoc
+RUN apk add libc-dev
 WORKDIR /src
 COPY Cargo.toml /src/Cargo.toml
 COPY Cargo.lock /src/Cargo.lock

--- a/README.md
+++ b/README.md
@@ -32,10 +32,6 @@ branch.
 Note that `podman` is not an acceptable substitute for `docker`. There are
 subtle incompatibilities between the two that will cause tests to fail.
 
-Building Janus with `janus_aggregator`'s `otlp` feature enabled currently
-requires the Protocol Buffers compiler, `protoc`, be installed on the machine
-performing the build.
-
 ### Container image
 
 To build container images, run the following commands.

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -62,11 +62,11 @@ k8s-openapi.workspace = true
 kube.workspace = true
 lazy_static = { version = "1", optional = true }
 once_cell = "1.17.1"
-opentelemetry = { version = "0.18", features = ["metrics", "rt-tokio"] }
-opentelemetry-jaeger = { version = "0.17", optional = true, features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.11", optional = true, features = ["metrics"] } # ensure that the version of tonic below matches what this uses
-opentelemetry-prometheus = { version = "0.11", optional = true }
-opentelemetry-semantic-conventions = { version = "0.10", optional = true }
+opentelemetry = { workspace = true, features = ["rt-tokio"] }
+opentelemetry-jaeger = { version = "0.18", optional = true, features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.12", optional = true, features = ["metrics"] } # ensure that the version of tonic below matches what this uses
+opentelemetry-prometheus = { version = "0.12", optional = true }
+opentelemetry-semantic-conventions = { version = "0.11", optional = true }
 postgres-protocol = "0.6.5"
 postgres-types = { version = "0.2.5", features = ["derive", "array-impls"] }
 prio.workspace = true
@@ -89,7 +89,7 @@ tokio-postgres = { version = "0.7.8", features = ["with-chrono-0_4", "with-serde
 tonic = { version = "0.8", optional = true, features = ["tls", "tls-webpki-roots"] }                                      # keep this version in sync with what opentelemetry-otlp uses
 tracing = "0.1.37"
 tracing-log = "0.1.3"
-tracing-opentelemetry = { version = "0.18", optional = true }
+tracing-opentelemetry = { version = "0.19", optional = true }
 tracing-stackdriver = "0.7.1"
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt", "json"] }
 trillium.workspace = true

--- a/aggregator/src/metrics.rs
+++ b/aggregator/src/metrics.rs
@@ -147,13 +147,10 @@ pub async fn install_metrics_exporter(
         }) => {
             let exporter = Arc::new(
                 opentelemetry_prometheus::exporter(
-                    controllers::basic(
-                        processors::factory(
-                            CustomAggregatorSelector,
-                            stateless_temporality_selector(),
-                        )
-                        .with_memory(true),
-                    )
+                    controllers::basic(processors::factory(
+                        CustomAggregatorSelector,
+                        stateless_temporality_selector(),
+                    ))
                     .build(),
                 )
                 .try_init()?,

--- a/aggregator_api/Cargo.toml
+++ b/aggregator_api/Cargo.toml
@@ -15,7 +15,7 @@ base64 = "0.21.0"
 janus_aggregator_core.workspace = true
 janus_core.workspace = true
 janus_messages.workspace = true
-opentelemetry = "0.18"
+opentelemetry.workspace = true
 querystring = "1.1.0"
 rand = { version = "0.8", features = ["min_const_gen"] }
 ring = "0.16.20"

--- a/aggregator_core/Cargo.toml
+++ b/aggregator_core/Cargo.toml
@@ -39,7 +39,7 @@ janus_messages.workspace = true
 k8s-openapi.workspace = true
 kube.workspace = true
 lazy_static = { version = "1", optional = true }
-opentelemetry = { version = "0.18", features = ["metrics", "rt-tokio"] }
+opentelemetry = { workspace = true, features = ["rt-tokio"] }
 postgres-protocol = "0.6.5"
 postgres-types = { version = "0.2.5", features = ["derive", "array-impls"] }
 prio = { workspace = true, features = ["experimental"] }

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -148,11 +148,11 @@ impl<C: Clock> Datastore<C> {
     ) -> Datastore<C> {
         let meter = opentelemetry::global::meter("janus_aggregator");
         let transaction_status_counter = meter
-            .u64_counter("janus_database_transactions_total")
+            .u64_counter("janus_database_transactions")
             .with_description("Count of database transactions run, with their status.")
             .init();
         let rollback_error_counter = meter
-            .u64_counter("janus_database_rollback_errors_total")
+            .u64_counter("janus_database_rollback_errors")
             .with_description(concat!(
                 "Count of errors received when rolling back a database transaction, ",
                 "with their PostgreSQL error code.",

--- a/interop_binaries/Cargo.toml
+++ b/interop_binaries/Cargo.toml
@@ -38,7 +38,7 @@ janus_client.workspace = true
 janus_collector.workspace = true
 janus_core.workspace = true
 janus_messages.workspace = true
-opentelemetry = { version = "0.18", features = ["metrics"] }
+opentelemetry.workspace = true
 prio.workspace = true
 rand = "0.8"
 regex = { version = "1", optional = true }


### PR DESCRIPTION
This is a refresh of #1149, now that tracing-opentelemetry has a new compatible release.