### PR TITLE
Bump crate versions to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,7 +1969,7 @@ checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "janus_aggregator"
-version = "0.4.10"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2052,7 +2052,7 @@ dependencies = [
 
 [[package]]
 name = "janus_aggregator_api"
-version = "0.4.10"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2081,7 +2081,7 @@ dependencies = [
 
 [[package]]
 name = "janus_aggregator_core"
-version = "0.4.10"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2134,14 +2134,14 @@ dependencies = [
 
 [[package]]
 name = "janus_build_script_utils"
-version = "0.4.10"
+version = "0.5.0"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "janus_client"
-version = "0.4.10"
+version = "0.5.0"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -2164,7 +2164,7 @@ dependencies = [
 
 [[package]]
 name = "janus_collector"
-version = "0.4.10"
+version = "0.5.0"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -2189,7 +2189,7 @@ dependencies = [
 
 [[package]]
 name = "janus_core"
-version = "0.4.10"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2232,7 +2232,7 @@ dependencies = [
 
 [[package]]
 name = "janus_integration_tests"
-version = "0.4.10"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "backoff",
@@ -2263,7 +2263,7 @@ dependencies = [
 
 [[package]]
 name = "janus_interop_binaries"
-version = "0.4.10"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "backoff",
@@ -2306,7 +2306,7 @@ dependencies = [
 
 [[package]]
 name = "janus_messages"
-version = "0.4.10"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2323,7 +2323,7 @@ dependencies = [
 
 [[package]]
 name = "janus_tools"
-version = "0.4.10"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://divviup.org"
 license = "MPL-2.0"
 repository = "https://github.com/divviup/janus"
 rust-version = "1.65.0"
-version = "0.4.10"
+version = "0.5.0"
 
 [workspace.dependencies]
 anyhow = "1"
@@ -29,16 +29,16 @@ anyhow = "1"
 # https://docs.rs/chrono/latest/chrono/#duration
 chrono = { version = "0.4", default-features = false }
 itertools = "0.10"
-janus_aggregator = { version = "0.4", path = "aggregator" }
-janus_aggregator_api = { version = "0.4", path = "aggregator_api" }
-janus_aggregator_core = { version = "0.4", path = "aggregator_core" }
-janus_build_script_utils = { version = "0.4", path = "build_script_utils" }
-janus_client = { version = "0.4", path = "client" }
-janus_collector = { version = "0.4", path = "collector" }
-janus_core = { version = "0.4", path = "core" }
-janus_integration_tests = { version = "0.4", path = "integration_tests" }
-janus_interop_binaries = { version = "0.4", path = "interop_binaries" }
-janus_messages = { version = "0.4", path = "messages" }
+janus_aggregator = { version = "0.5", path = "aggregator" }
+janus_aggregator_api = { version = "0.5", path = "aggregator_api" }
+janus_aggregator_core = { version = "0.5", path = "aggregator_core" }
+janus_build_script_utils = { version = "0.5", path = "build_script_utils" }
+janus_client = { version = "0.5", path = "client" }
+janus_collector = { version = "0.5", path = "collector" }
+janus_core = { version = "0.5", path = "core" }
+janus_integration_tests = { version = "0.5", path = "integration_tests" }
+janus_interop_binaries = { version = "0.5", path = "interop_binaries" }
+janus_messages = { version = "0.5", path = "messages" }
 k8s-openapi = { version = "0.18.0", features = ["v1_24"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
 kube = { version = "0.82.2", default-features = false, features = ["client", "rustls-tls"] }
 prio = { version = "0.12.1", features = ["multithreaded"] }


### PR DESCRIPTION
While we still implement `draft-ietf-ppm-dap-04`, breaking API changes have landed in `janus_collector`, so we bump the minor version for SemVer compatibility.