### PR TITLE
Aggregation job writer improvements.

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -693,6 +693,7 @@ impl AggregationJobDriver {
                     // aggregations; this should be guaranteed by the system as we do not make batch
                     // aggregations unwritable until after we make report aggregations unwritable.
                     // But we should certainly check that this is true!
+                    // TODO(#1392): remove this check by fusing report aggregation/batch aggregation writes.
                     assert!(unwritable_ba_report_ids.is_subset(&unwritable_ra_report_ids));
                     Ok(())
                 })

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -984,6 +984,8 @@ mod tests {
                 Box::pin(async move {
                     tx.put_task(&task).await?;
                     tx.put_client_report(vdaf.borrow(), &report).await?;
+                    tx.mark_report_aggregated(task.id(), report.metadata().id())
+                        .await?;
 
                     tx.put_aggregation_job(&AggregationJob::<
                         PRIO3_VERIFY_KEY_LENGTH,
@@ -1851,6 +1853,8 @@ mod tests {
                 Box::pin(async move {
                     tx.put_task(&task).await?;
                     tx.put_client_report(vdaf.borrow(), &report).await?;
+                    tx.mark_report_aggregated(task.id(), report.metadata().id())
+                        .await?;
 
                     tx.put_aggregation_job(&AggregationJob::<
                         PRIO3_VERIFY_KEY_LENGTH,

--- a/integration_tests/tests/common/mod.rs
+++ b/integration_tests/tests/common/mod.rs
@@ -150,10 +150,6 @@ pub async fn submit_measurements_and_verify_aggregate_generic<'a, V>(
     // Send a collect request and verify that we got the correct result.
     match leader_task.query_type() {
         QueryType::TimeInterval => {
-            // Give the aggregators a few seconds to settle.
-            // TODO(#1380): remove the need for this wait.
-            sleep(StdDuration::from_secs(5)).await;
-
             let batch_interval = Interval::new(
                 before_timestamp
                     .to_batch_interval_start(leader_task.time_precision())

--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -421,9 +421,6 @@ async fn run(
         }
     };
 
-    // Wait a few seconds to allow the aggregation process to start for all uploaded reports.
-    sleep(StdDuration::from_secs(5)).await;
-
     // Try collecting one or more times. For fixed size tasks, a "current batch" query will fail
     // with an invalid batch until enough reports are ready.
     let mut collect_attempt_backoff = ExponentialBackoffBuilder::new()


### PR DESCRIPTION
Two changes:
* Semantics change: for time-interval tasks, we now require all reports included in the batch to be associated with some aggregation job before the batch can be closed. Effectively, this means that any reports which are received before the collection request arrives are now guaranteed to go through the aggregation process before the collection request is complete, which should remove flakiness from integration test scenarios without requiring arbitrary pauses. It is also useful in a "production" scenario: a collector can now issue a collection request after the end of an interval and be guaranteed that all reports received in the interval will be included in the collection result, even if the aggregation process is running behind.
* Bugfix: initial batch writes, if contended (e.g. if the first two aggregation jobs for a given batch complete concurrently), would fail the DB transaction rather than triggering a retry. This would lead to a retry at the aggregation job level, but if the peer aggregator did not implement idempotent aggregation job initialization, these retries would fail since the DB transaction failure occurred after the peer aggregator received & processed the initial request.

See commit messages for more detail. Closes #1380.