### PR TITLE
Validate max_batch_size parameter, when present

### DIFF
--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -192,6 +192,11 @@ impl Task {
         if self.hpke_keys.is_empty() {
             return Err(Error::InvalidParameter("hpke_keys"));
         }
+        if let QueryType::FixedSize { max_batch_size } = self.query_type() {
+            if *max_batch_size < self.min_batch_size() {
+                return Err(Error::InvalidParameter("max_batch_size"));
+            }
+        }
         Ok(())
     }
 


### PR DESCRIPTION
This adds a check to `Task::validate()` that `max_batch_size` is not less than `min_batch_size`. If these limits were flipped relative to each other, no batch would be collectable.