### PR TITLE
Split out CI Cargo profile, re-enable debug on dev

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -68,18 +68,18 @@ jobs:
     - name: Expose GitHub Runtime
       uses: crazy-max/ghaction-github-runtime@v2
     - name: Build minimal janus_messages
-      run: cargo build --package janus_messages --no-default-features
+      run: cargo build --profile ci --package janus_messages --no-default-features
     - name: Build janus_core
-      run: cargo build --package janus_core
+      run: cargo build --profile ci --package janus_core
     # Note: keep Build & Test steps consecutive, and match flags other than `--no-run`.
     - name: Build
-      run: cargo test --no-run --locked --all-targets
+      run: cargo test --profile ci --no-run --locked --all-targets
     - name: Test
       id: test
       env:
         JANUS_E2E_LOGS_PATH: ${{ github.workspace }}/test-logs
         DIVVIUP_TS_INTEROP_CONTAINER: ${{ steps.default-input-values.outputs.divviup_ts_interop_container }}
-      run: cargo test --locked --all-targets
+      run: cargo test --profile ci --locked --all-targets
       # Continue on error so we can upload logs
       continue-on-error: true
     - name: Upload container logs
@@ -121,11 +121,11 @@ jobs:
     - name: Format
       run: cargo fmt --message-format human -- --check
     - name: Clippy
-      run: cargo clippy --workspace --all-targets
+      run: cargo clippy --profile ci --workspace --all-targets
     - name: Clippy (all features)
-      run: cargo clippy --workspace --all-targets --all-features
+      run: cargo clippy --profile ci --workspace --all-targets --all-features
     - name: Document
-      run: cargo doc --workspace
+      run: cargo doc --profile ci --workspace
 
   janus_docker:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,9 @@ trillium-router = "0.3.5"
 trillium-testing = "0.5.0"
 trillium-tokio = "0.3.1"
 
-[profile.dev]
+[profile.ci]
 # Disabling debug info improves build speeds & reduces build artifact sizes, which helps CI caching.
+inherits = "dev"
 debug = 0
 
 [profile.small]


### PR DESCRIPTION
Previously, we set `debug = 0` on the `dev` profile in order to minimize the amount of data we need to cache between CI runs. This has side-effects on local development, as `debug = 0` breaks stepping in `lldb` and removes line numbers from backtraces. Thus, this PR creates a new `ci` Cargo profile, moves the `debug = 0` setting to it, and uses it in the `ci-build` workflow action. (only in jobs/commands run on the host -- note that Cargo commands run during Docker builds are already using `release` or `small` profiles) The `dev` profile is returned to its default settings.