### PR TITLE
Move InstrumentedHandler to janus_aggregator_core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2059,7 +2059,6 @@ dependencies = [
  "tracing",
  "trillium",
  "trillium-api",
- "trillium-macros",
  "trillium-opentelemetry",
  "trillium-router",
  "trillium-testing",
@@ -2115,6 +2114,9 @@ dependencies = [
  "tokio-postgres",
  "tracing",
  "tracing-log",
+ "trillium",
+ "trillium-macros",
+ "trillium-router",
  "url",
  "uuid",
 ]

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -1,8 +1,7 @@
 use super::{Aggregator, Config, Error};
 use crate::aggregator::problem_details::ProblemDetailsConnExt;
 use async_trait::async_trait;
-use janus_aggregator_api::instrumented;
-use janus_aggregator_core::datastore::Datastore;
+use janus_aggregator_core::{datastore::Datastore, instrumented};
 use janus_core::{
     http::extract_bearer_token,
     task::{AuthenticationToken, DapAuthToken, DAP_AUTH_HEADER},

--- a/aggregator_api/Cargo.toml
+++ b/aggregator_api/Cargo.toml
@@ -25,7 +25,6 @@ serde_test = "1.0.163"
 tracing = "0.1.37"
 trillium.workspace = true
 trillium-api.workspace = true
-trillium-macros = "0.0.4"
 trillium-opentelemetry.workspace = true
 trillium-router.workspace = true
 url = { version = "2.3.1", features = ["serde"] }

--- a/aggregator_core/Cargo.toml
+++ b/aggregator_core/Cargo.toml
@@ -57,12 +57,15 @@ tokio = { version = "1.28", features = ["full", "tracing"] }
 tokio-postgres = { version = "0.7.8", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1", "array-impls"] }
 tracing = "0.1.37"
 tracing-log = "0.1.3"
+trillium.workspace = true
+trillium-macros = "0.0.4"
+trillium-router.workspace = true
 url = { version = "2.3.1", features = ["serde"] }
 uuid = { version = "1.3.3", features = ["v4"] }
 
 [dev-dependencies]
 assert_matches = "1"
-async-std = { version = "1.12.0",  features = ["attributes"] }
+async-std = { version = "1.12.0", features = ["attributes"] }
 hyper = "0.14.26"
 janus_aggregator_core = { path = ".", features = ["test-util"] }
 janus_core = { workspace = true, features = ["test-util"] }


### PR DESCRIPTION
This moves `InstrumentedHandler` from `janus_aggregator_api` to `janus_aggregator_core`. This seems like a natural home for it, as it's a common utility for both parts of the aggregator. Having `janus_aggregator_api` appear as the target name in the "endpoint" span may be confusing when it's used by the DAP HTTP server.