### PR TITLE
Test down migrations against all existing tests

### DIFF
--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -5863,7 +5863,7 @@ mod tests {
             },
             schema_versions_template,
             test_util::{
-                ephemeral_datastore_max_schema_version, generate_aead_key, EphemeralDatastore,
+                ephemeral_datastore_schema_version, generate_aead_key, EphemeralDatastore,
             },
             Crypter, Datastore, Error, Transaction,
         },

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -5877,7 +5877,7 @@ mod tests {
             test_util::{
                 ephemeral_datastore_schema_version, generate_aead_key, EphemeralDatastore,
             },
-            Crypter, Datastore, Error, Transaction,
+            Crypter, Datastore, Error, Transaction, SUPPORTED_SCHEMA_VERSIONS,
         },
         query_type::CollectableQueryType,
         task::{self, test_util::TaskBuilder, Task},
@@ -5916,6 +5916,13 @@ mod tests {
         time::Duration as StdDuration,
     };
     use tokio::time::timeout;
+
+    #[test]
+    fn check_supported_versions() {
+        if SUPPORTED_SCHEMA_VERSIONS[0] != *SUPPORTED_SCHEMA_VERSIONS.iter().max().unwrap() {
+            panic!("the latest supported schema version must be first in the list");
+        }
+    }
 
     #[rstest_reuse::apply(schema_versions_template)]
     #[tokio::test]

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -5861,6 +5861,10 @@ pub mod models {
 
 #[cfg(test)]
 mod tests {
+    // This function is only used when there are multiple supported versions.
+    #[allow(unused_imports)]
+    use crate::datastore::test_util::ephemeral_datastore_schema_version_by_downgrade;
+
     use crate::{
         datastore::{
             models::{
@@ -5871,15 +5875,14 @@ mod tests {
             },
             schema_versions_template,
             test_util::{
-                ephemeral_datastore_schema_version,
-                ephemeral_datastore_schema_version_by_downgrade, generate_aead_key,
-                EphemeralDatastore,
+                ephemeral_datastore_schema_version, generate_aead_key, EphemeralDatastore,
             },
             Crypter, Datastore, Error, Transaction,
         },
         query_type::CollectableQueryType,
         task::{self, test_util::TaskBuilder, Task},
     };
+
     use assert_matches::assert_matches;
     use async_trait::async_trait;
     use chrono::NaiveDate;
@@ -5931,7 +5934,7 @@ mod tests {
     }
 
     #[rstest::rstest]
-    #[case(ephemeral_datastore_max_schema_version(i64::MAX))]
+    #[case(ephemeral_datastore_schema_version(i64::MAX))]
     #[tokio::test]
     async fn down_migrations(
         #[future(awt)]

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -71,7 +71,7 @@ pub mod test_util;
 ///
 /// [1]: https://docs.rs/rstest_reuse/latest/rstest_reuse/
 macro_rules! supported_schema_versions {
-    ( $i_latest:literal, $( $i:literal ),* ) => {
+    ( $i_latest:literal $(,)? $( $i:literal ),* ) => {
         const SUPPORTED_SCHEMA_VERSIONS: &[i64] = &[$i_latest, $($i),*];
 
         #[cfg(test)]
@@ -98,7 +98,7 @@ macro_rules! supported_schema_versions {
 // version is seen, [`Datastore::new`] fails.
 //
 // Note that the latest supported version must be first in the list.
-supported_schema_versions!(11, 10, 9);
+supported_schema_versions!(9);
 
 /// Datastore represents a datastore for Janus, with support for transactional reads and writes.
 /// In practice, Datastore instances are currently backed by a PostgreSQL database.

--- a/aggregator_core/src/datastore/test_util.rs
+++ b/aggregator_core/src/datastore/test_util.rs
@@ -168,7 +168,7 @@ impl EphemeralDatastore {
 
 /// Create a new, empty EphemeralDatastore with all schema migrations up to the specified version
 /// applied to it.
-pub async fn ephemeral_datastore_max_schema_version(max_schema_version: i64) -> EphemeralDatastore {
+pub async fn ephemeral_datastore_schema_version(schema_version: i64) -> EphemeralDatastore {
     let db = EphemeralDatabase::shared().await;
     let db_name = format!("janus_test_{}", hex::encode(random::<[u8; 16]>()));
     trace!("Creating ephemeral postgres datastore {db_name}");
@@ -197,7 +197,7 @@ pub async fn ephemeral_datastore_max_schema_version(max_schema_version: i64) -> 
     migrator.migrations = migrator
         .migrations
         .iter()
-        .filter(|migration| migration.version <= max_schema_version)
+        .filter(|migration| migration.version <= schema_version)
         .cloned()
         .collect();
 
@@ -219,7 +219,7 @@ pub async fn ephemeral_datastore_max_schema_version(max_schema_version: i64) -> 
 
 /// Creates a new, empty EphemeralDatastore with all schema migrations applied to it.
 pub async fn ephemeral_datastore() -> EphemeralDatastore {
-    ephemeral_datastore_max_schema_version(i64::MAX).await
+    ephemeral_datastore_schema_version(i64::MAX).await
 }
 
 pub fn generate_aead_key_bytes() -> Vec<u8> {

--- a/aggregator_core/src/datastore/test_util.rs
+++ b/aggregator_core/src/datastore/test_util.rs
@@ -222,6 +222,16 @@ pub async fn ephemeral_datastore() -> EphemeralDatastore {
     ephemeral_datastore_schema_version(i64::MAX).await
 }
 
+/// Creates a new, empty EphemeralDatabase by applying all available schema migrations,
+/// then downgrading to the target schema version.
+pub async fn ephemeral_datastore_schema_version_by_downgrade(
+    schema_version: i64,
+) -> EphemeralDatastore {
+    let datastore = ephemeral_datastore().await;
+    datastore.downgrade(schema_version).await;
+    datastore
+}
+
 pub fn generate_aead_key_bytes() -> Vec<u8> {
     thread_rng()
         .sample_iter(Standard)


### PR DESCRIPTION

This uses the technique suggested by @divergentdave in https://github.com/divviup/janus/issues/1279#issuecomment-1569374474 to test down migrations when there are multiple supported versions of the schema.

We can test the validity of this approach by creating a set of benign migrations and adding a new version.

```rust
// in datastore.rs
supported_schema_versions!(10, 9);
```
```sql
-- db/00000000000010_inahga_test.up.sql
CREATE TABLE inahga_test(id BIGINT GENERATED);
```
```sql
-- db/00000000000010_inahga_test.down.sql
DROP TABLE inahga_test;
```

This should result in a passing set of tests, each test should have 3 cases (1 latest, 1 old via normal upgrade, 1 old via downgrade).

We can simulate a regression caused by a downgraded migration by editing the down script to break a feature of Janus.
```sql
-- db/00000000000010_inahga_test.down.sql
DROP TABLE inahga_test;
ALTER TABLE task_collector_auth_tokens DROP COLUMN type;
```

We then see several tests fail on test case 3, because the downgrade script has broken auth token support.

For maximum paranoia, we can add a quick test that exercises the example table, to ensure that the migrations are actually being applied when they should.
```rust
// in datastore.rs
    #[rstest_reuse::apply(schema_versions_template)]
    #[tokio::test]
    async fn inahga_test(ephemeral_datastore: EphemeralDatastore) {
        let datastore = ephemeral_datastore.datastore(MockClock::default()).await;

        datastore
            .run_tx(|tx| {
                Box::pin(async move {
                    tx.query("SELECT * FROM inahga_test", &[]).await.unwrap();
                    Ok(())
                })
            })
            .await
            .unwrap();
    }
```

We then see this test fails on cases 2 and 3, because it exercises functionality that's only present in the newest schema, as expected.

(I'm sure given enough time this manual test of the tests can be automated, but I think that crosses the line of diminishing returns).
