### PR TITLE
Enable differential privacy for the fixedvec type.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2652,6 +2652,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3113,9 +3134,8 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prio"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9028a8aba9ba6b647c6d6931c20473d1119079a68d9898c07a488c5180dccb58"
+version = "0.12.1"
+source = "git+https://github.com/dpsa-project/libprio-rs.git?branch=feature-fixedvec-dp#0fbd24ca05f38cf035e2b47a2646d8efccce6c97"
 dependencies = [
  "aes",
  "base64 0.21.2",
@@ -3126,6 +3146,8 @@ dependencies = [
  "fiat-crypto",
  "fixed",
  "getrandom",
+ "num-bigint",
+ "num-traits",
  "rayon",
  "serde",
  "sha3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,8 @@ janus_messages = { version = "0.5", path = "messages" }
 k8s-openapi = { version = "0.18.0", features = ["v1_24"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
 kube = { version = "0.82.2", default-features = false, features = ["client", "rustls-tls"] }
 opentelemetry = { version = "0.19", features = ["metrics"] }
-prio = { version = "0.12.2", features = ["multithreaded"] }
+# prio = { version = "0.12.2", features = ["multithreaded"] }
+prio = {git = "https://github.com/dpsa-project/libprio-rs.git", branch ="feature-fixedvec-dp", features = ["multithreaded"]}
 serde = { version = "1.0.163", features = ["derive"] }
 rstest = "0.17.0"
 trillium = "0.2.9"

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,9 @@ COPY tools /src/tools
 RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
+ARG FEATURES=
 COPY --from=planner /src/recipe.json /src/recipe.json
-RUN cargo chef cook --release -p janus_aggregator --features=prometheus
+RUN cargo chef cook --release -p janus_aggregator --features=prometheus,$FEATURES
 COPY Cargo.toml Cargo.lock /src/
 COPY aggregator /src/aggregator
 COPY aggregator_api /src/aggregator_api
@@ -39,7 +40,7 @@ COPY tools /src/tools
 ARG BINARY=aggregator
 ARG GIT_REVISION=unknown
 ENV GIT_REVISION ${GIT_REVISION}
-RUN cargo build --release -p janus_aggregator --bin $BINARY --features=prometheus
+RUN cargo build --release -p janus_aggregator --bin $BINARY --features=prometheus,$FEATURES
 
 FROM alpine:3.18.0 AS final
 ARG BINARY=aggregator

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -14,6 +14,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = []
+experimental = ["janus_aggregator_core/experimental"]
 fpvec_bounded_l2 = ["dep:fixed", "janus_core/fpvec_bounded_l2"]
 tokio-console = ["dep:console-subscriber"]
 jaeger = ["dep:tracing-opentelemetry", "dep:opentelemetry-jaeger"]

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -502,25 +502,46 @@ impl<C: Clock> TaskAggregator<C> {
             }
 
             #[cfg(feature = "fpvec_bounded_l2")]
-            VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { length } => {
+            VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum {
+                length,
+                noise_param,
+            } => {
                 let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>> =
-                    Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, *length)?;
+                    Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
+                        2,
+                        *length,
+                        *noise_param,
+                    )?;
                 let verify_key = task.primary_vdaf_verify_key()?;
                 VdafOps::Prio3FixedPoint16BitBoundedL2VecSum(Arc::new(vdaf), verify_key)
             }
 
             #[cfg(feature = "fpvec_bounded_l2")]
-            VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { length } => {
+            VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum {
+                length,
+                noise_param,
+            } => {
                 let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>> =
-                    Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, *length)?;
+                    Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
+                        2,
+                        *length,
+                        *noise_param,
+                    )?;
                 let verify_key = task.primary_vdaf_verify_key()?;
                 VdafOps::Prio3FixedPoint32BitBoundedL2VecSum(Arc::new(vdaf), verify_key)
             }
 
             #[cfg(feature = "fpvec_bounded_l2")]
-            VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { length } => {
+            VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum {
+                length,
+                noise_param,
+            } => {
                 let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>> =
-                    Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, *length)?;
+                    Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
+                        2,
+                        *length,
+                        *noise_param,
+                    )?;
                 let verify_key = task.primary_vdaf_verify_key()?;
                 VdafOps::Prio3FixedPoint64BitBoundedL2VecSum(Arc::new(vdaf), verify_key)
             }

--- a/aggregator/src/aggregator/accumulator.rs
+++ b/aggregator/src/aggregator/accumulator.rs
@@ -213,4 +213,16 @@ impl<const SEED_SIZE: usize, Q: AccumulableQueryType, A: vdaf::Aggregator<SEED_S
             .into_inner()
             .unwrap())
     }
+
+    /// Applies the vdaf-postprocessing function to all aggregate shares.
+    /// This functionality can be used, e.g., to add noise in the sense of
+    /// differential privacy. But note that this interface is purely experimental
+    /// and may change at any time.
+    #[cfg(feature = "experimental")]
+    pub fn postprocess(&mut self, vdaf: &A) -> Result<(), anyhow::Error> {
+        for (_, accumulation) in &mut self.aggregations {
+            accumulation.batch_aggregation.postprocess(vdaf)?;
+        }
+        Ok(())
+    }
 }

--- a/aggregator/src/aggregator/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/aggregation_job_continue.rs
@@ -199,6 +199,11 @@ impl VdafOps {
             }
         }
 
+        // Postprocess the aggregated shares. This allows, e.g., for central differential privacy,
+        // but the implementation is experimental.
+        #[cfg(feature = "experimental")]
+        accumulator.postprocess(&vdaf).unwrap();
+
         // Write accumulated aggregation values back to the datastore; mark any reports that can't
         // be aggregated because the batch is collected with error BatchCollected.
         let unwritable_reports = accumulator.flush_to_datastore(tx, &vdaf).await?;

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -267,11 +267,16 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
             #[cfg(feature = "fpvec_bounded_l2")]
             (
                 task::QueryType::TimeInterval,
-                VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { length },
+                VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum {
+                    length,
+                    noise_param,
+                },
             ) => {
                 let vdaf: Arc<Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>>> =
                     Arc::new(Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
-                        2, *length,
+                        2,
+                        *length,
+                        *noise_param,
                     )?);
                 self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>>>(task, vdaf)
                     .await
@@ -280,11 +285,16 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
             #[cfg(feature = "fpvec_bounded_l2")]
             (
                 task::QueryType::TimeInterval,
-                VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { length },
+                VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum {
+                    length,
+                    noise_param,
+                },
             ) => {
                 let vdaf: Arc<Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>>> =
                     Arc::new(Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
-                        2, *length,
+                        2,
+                        *length,
+                        *noise_param,
                     )?);
                 self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>>>(task, vdaf)
                     .await
@@ -293,11 +303,16 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
             #[cfg(feature = "fpvec_bounded_l2")]
             (
                 task::QueryType::TimeInterval,
-                VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { length },
+                VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum {
+                    length,
+                    noise_param,
+                },
             ) => {
                 let vdaf: Arc<Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>>> =
                     Arc::new(Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
-                        2, *length,
+                        2,
+                        *length,
+                        *noise_param,
                     )?);
                 self.create_aggregation_jobs_for_time_interval_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>>>(task, vdaf)
                     .await
@@ -354,11 +369,16 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
             #[cfg(feature = "fpvec_bounded_l2")]
             (
                 task::QueryType::FixedSize { max_batch_size },
-                VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { length },
+                VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum {
+                    length,
+                    noise_param,
+                },
             ) => {
                 let vdaf: Arc<Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>>> =
                     Arc::new(Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
-                        2, *length,
+                        2,
+                        *length,
+                        *noise_param,
                     )?);
                 let max_batch_size = *max_batch_size;
                 self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>>>(task, vdaf, max_batch_size)
@@ -368,11 +388,16 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
             #[cfg(feature = "fpvec_bounded_l2")]
             (
                 task::QueryType::FixedSize { max_batch_size },
-                VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { length },
+                VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum {
+                    length,
+                    noise_param,
+                },
             ) => {
                 let vdaf: Arc<Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>>> =
                     Arc::new(Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
-                        2, *length,
+                        2,
+                        *length,
+                        *noise_param,
                     )?);
                 let max_batch_size = *max_batch_size;
                 self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>>>(task, vdaf, max_batch_size)
@@ -382,11 +407,16 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
             #[cfg(feature = "fpvec_bounded_l2")]
             (
                 task::QueryType::FixedSize { max_batch_size },
-                VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { length },
+                VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum {
+                    length,
+                    noise_param,
+                },
             ) => {
                 let vdaf: Arc<Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>>> =
                     Arc::new(Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
-                        2, *length,
+                        2,
+                        *length,
+                        *noise_param,
                     )?);
                 let max_batch_size = *max_batch_size;
                 self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>>>(task, vdaf, max_batch_size)

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -663,6 +663,11 @@ impl AggregationJobDriver {
             report_aggregations_to_write.push(report_aggregation.with_state(new_state));
         }
 
+        // Postprocess the aggregated shares. This allows, e.g., for central differential privacy,
+        // but the implementation is experimental.
+        #[cfg(feature = "experimental")]
+        accumulator.postprocess(&vdaf)?;
+
         // Write everything back to storage.
         let mut aggregation_job_writer = AggregationJobWriter::new(Arc::clone(&task));
         let new_round = aggregation_job.round().increment();

--- a/aggregator_core/Cargo.toml
+++ b/aggregator_core/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 
 [features]
 default = []
+experimental = ["prio/experimental"]
 test-util = [
     "dep:hex",
     "dep:lazy_static",

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -5150,6 +5150,14 @@ pub mod models {
                 ..self
             })
         }
+
+        #[cfg(feature = "experimental")]
+        pub fn postprocess(&mut self, vdaf: &A) -> Result<(), anyhow::Error> {
+            if let Some(aggregate_share) = &mut self.aggregate_share {
+                vdaf.postprocess(&self.aggregation_parameter, aggregate_share)?
+            }
+            Ok(())
+        }
     }
 
     impl<const SEED_SIZE: usize, A: vdaf::Aggregator<SEED_SIZE, 16>>

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -1070,7 +1070,7 @@ mod tests {
     async fn successful_collect_prio3_fixedpoint_boundedl2_vec_sum() {
         install_test_trace_subscriber();
         let mut server = mockito::Server::new_async().await;
-        let vdaf = Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, 3).unwrap();
+        let vdaf = Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, 3, (1, 0)).unwrap();
         let fp32_4_inv = fixed!(0.25: I1F31);
         let fp32_8_inv = fixed!(0.125: I1F31);
         let fp32_16_inv = fixed!(0.0625: I1F31);

--- a/interop_binaries/src/bin/janus_interop_client.rs
+++ b/interop_binaries/src/bin/janus_interop_client.rs
@@ -176,31 +176,40 @@ async fn handle_upload(
         }
 
         #[cfg(feature = "fpvec_bounded_l2")]
-        VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { length } => {
+        VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum {
+            length,
+            noise_param,
+        } => {
             let measurement =
                 parse_vector_measurement::<FixedI16<U15>>(request.measurement.clone())?;
             let vdaf_client: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>> =
-                Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length)
+                Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length, noise_param)
                     .context("failed to construct Prio3FixedPoint16BitBoundedL2VecSum VDAF")?;
             handle_upload_generic(http_client, vdaf_client, request, measurement).await?;
         }
 
         #[cfg(feature = "fpvec_bounded_l2")]
-        VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { length } => {
+        VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum {
+            length,
+            noise_param,
+        } => {
             let measurement =
                 parse_vector_measurement::<FixedI32<U31>>(request.measurement.clone())?;
             let vdaf_client: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>> =
-                Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length)
+                Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length, noise_param)
                     .context("failed to construct Prio3FixedPoint32BitBoundedL2VecSum VDAF")?;
             handle_upload_generic(http_client, vdaf_client, request, measurement).await?;
         }
 
         #[cfg(feature = "fpvec_bounded_l2")]
-        VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { length } => {
+        VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum {
+            length,
+            noise_param,
+        } => {
             let measurement =
                 parse_vector_measurement::<FixedI64<U63>>(request.measurement.clone())?;
             let vdaf_client: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>> =
-                Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length)
+                Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length, noise_param)
                     .context("failed to construct Prio3FixedPoint64BitBoundedL2VecSum VDAF")?;
             handle_upload_generic(http_client, vdaf_client, request, measurement).await?;
         }

--- a/interop_binaries/src/bin/janus_interop_collector.rs
+++ b/interop_binaries/src/bin/janus_interop_collector.rs
@@ -384,10 +384,13 @@ async fn handle_collection_start(
         #[cfg(feature = "fpvec_bounded_l2")]
         (
             ParsedQuery::TimeInterval(batch_interval),
-            janus_core::task::VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { length },
+            janus_core::task::VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum {
+                length,
+                noise_param,
+            },
         ) => {
             let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>> =
-                Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length)
+                Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length, noise_param)
                     .context("failed to construct Prio3FixedPoint16BitBoundedL2VecSum VDAF")?;
             handle_collect_generic(
                 http_client,
@@ -407,10 +410,13 @@ async fn handle_collection_start(
         #[cfg(feature = "fpvec_bounded_l2")]
         (
             ParsedQuery::TimeInterval(batch_interval),
-            janus_core::task::VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { length },
+            janus_core::task::VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum {
+                length,
+                noise_param,
+            },
         ) => {
             let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>> =
-                Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length)
+                Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length, noise_param)
                     .context("failed to construct Prio3FixedPoint32BitBoundedL2VecSum VDAF")?;
             handle_collect_generic(
                 http_client,
@@ -430,10 +436,13 @@ async fn handle_collection_start(
         #[cfg(feature = "fpvec_bounded_l2")]
         (
             ParsedQuery::TimeInterval(batch_interval),
-            janus_core::task::VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { length },
+            janus_core::task::VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum {
+                length,
+                noise_param,
+            },
         ) => {
             let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>> =
-                Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length)
+                Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length, noise_param)
                     .context("failed to construct Prio3FixedPoint64BitBoundedL2VecSum VDAF")?;
             handle_collect_generic(
                 http_client,
@@ -485,10 +494,13 @@ async fn handle_collection_start(
         #[cfg(feature = "fpvec_bounded_l2")]
         (
             ParsedQuery::FixedSize(fixed_size_query),
-            janus_core::task::VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { length },
+            janus_core::task::VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum {
+                length,
+                noise_param,
+            },
         ) => {
             let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>> =
-                Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length)
+                Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length, noise_param)
                     .context("failed to construct Prio3FixedPoint16BitBoundedL2VecSum VDAF")?;
             handle_collect_generic(
                 http_client,
@@ -508,10 +520,13 @@ async fn handle_collection_start(
         #[cfg(feature = "fpvec_bounded_l2")]
         (
             ParsedQuery::FixedSize(fixed_size_query),
-            janus_core::task::VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { length },
+            janus_core::task::VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum {
+                length,
+                noise_param,
+            },
         ) => {
             let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>> =
-                Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length)
+                Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length, noise_param)
                     .context("failed to construct Prio3FixedPoint32BitBoundedL2VecSum VDAF")?;
             handle_collect_generic(
                 http_client,
@@ -531,10 +546,13 @@ async fn handle_collection_start(
         #[cfg(feature = "fpvec_bounded_l2")]
         (
             ParsedQuery::FixedSize(fixed_size_query),
-            janus_core::task::VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { length },
+            janus_core::task::VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum {
+                length,
+                noise_param,
+            },
         ) => {
             let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>> =
-                Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length)
+                Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length, noise_param)
                     .context("failed to construct Prio3FixedPoint64BitBoundedL2VecSum VDAF")?;
             handle_collect_generic(
                 http_client,

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -122,14 +122,17 @@ pub enum VdafObject {
     #[cfg(feature = "fpvec_bounded_l2")]
     Prio3FixedPoint16BitBoundedL2VecSum {
         length: NumberAsString<usize>,
+        noise_param: (NumberAsString<u128>, NumberAsString<u128>),
     },
     #[cfg(feature = "fpvec_bounded_l2")]
     Prio3FixedPoint32BitBoundedL2VecSum {
         length: NumberAsString<usize>,
+        noise_param: (NumberAsString<u128>, NumberAsString<u128>),
     },
     #[cfg(feature = "fpvec_bounded_l2")]
     Prio3FixedPoint64BitBoundedL2VecSum {
         length: NumberAsString<usize>,
+        noise_param: (NumberAsString<u128>, NumberAsString<u128>),
     },
 }
 
@@ -156,25 +159,31 @@ impl From<VdafInstance> for VdafObject {
             },
 
             #[cfg(feature = "fpvec_bounded_l2")]
-            VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { length } => {
-                VdafObject::Prio3FixedPoint16BitBoundedL2VecSum {
-                    length: NumberAsString(length),
-                }
-            }
+            VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum {
+                length,
+                noise_param,
+            } => VdafObject::Prio3FixedPoint16BitBoundedL2VecSum {
+                length: NumberAsString(length),
+                noise_param: (NumberAsString(noise_param.0), NumberAsString(noise_param.1)),
+            },
 
             #[cfg(feature = "fpvec_bounded_l2")]
-            VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { length } => {
-                VdafObject::Prio3FixedPoint32BitBoundedL2VecSum {
-                    length: NumberAsString(length),
-                }
-            }
+            VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum {
+                length,
+                noise_param,
+            } => VdafObject::Prio3FixedPoint32BitBoundedL2VecSum {
+                length: NumberAsString(length),
+                noise_param: (NumberAsString(noise_param.0), NumberAsString(noise_param.1)),
+            },
 
             #[cfg(feature = "fpvec_bounded_l2")]
-            VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { length } => {
-                VdafObject::Prio3FixedPoint64BitBoundedL2VecSum {
-                    length: NumberAsString(length),
-                }
-            }
+            VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum {
+                length,
+                noise_param,
+            } => VdafObject::Prio3FixedPoint64BitBoundedL2VecSum {
+                length: NumberAsString(length),
+                noise_param: (NumberAsString(noise_param.0), NumberAsString(noise_param.1)),
+            },
             _ => panic!("Unsupported VDAF: {vdaf:?}"),
         }
     }
@@ -201,19 +210,31 @@ impl From<VdafObject> for VdafInstance {
             },
 
             #[cfg(feature = "fpvec_bounded_l2")]
-            VdafObject::Prio3FixedPoint16BitBoundedL2VecSum { length } => {
-                VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { length: length.0 }
-            }
+            VdafObject::Prio3FixedPoint16BitBoundedL2VecSum {
+                length,
+                noise_param,
+            } => VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum {
+                length: length.0,
+                noise_param: (noise_param.0 .0, noise_param.1 .0),
+            },
 
             #[cfg(feature = "fpvec_bounded_l2")]
-            VdafObject::Prio3FixedPoint32BitBoundedL2VecSum { length } => {
-                VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { length: length.0 }
-            }
+            VdafObject::Prio3FixedPoint32BitBoundedL2VecSum {
+                length,
+                noise_param,
+            } => VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum {
+                length: length.0,
+                noise_param: (noise_param.0 .0, noise_param.1 .0),
+            },
 
             #[cfg(feature = "fpvec_bounded_l2")]
-            VdafObject::Prio3FixedPoint64BitBoundedL2VecSum { length } => {
-                VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { length: length.0 }
-            }
+            VdafObject::Prio3FixedPoint64BitBoundedL2VecSum {
+                length,
+                noise_param,
+            } => VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum {
+                length: length.0,
+                noise_param: (noise_param.0 .0, noise_param.1 .0),
+            },
         }
     }
 }

--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -697,7 +697,7 @@ async fn e2e_prio3_fixed16vec() {
     let fp16_16_inv = fixed!(0.0625: I1F15);
     let result = run(
         QueryKind::TimeInterval,
-        json!({"type": "Prio3FixedPoint16BitBoundedL2VecSum", "length": "3"}),
+        json!({"type": "Prio3FixedPoint16BitBoundedL2VecSum", "length": "3", "noise_param": ["1", "0"]}),
         &[
             json!([
                 fp16_4_inv.to_string(),
@@ -733,7 +733,7 @@ async fn e2e_prio3_fixed32vec() {
     let fp32_16_inv = fixed!(0.0625: I1F31);
     let result = run(
         QueryKind::TimeInterval,
-        json!({"type": "Prio3FixedPoint32BitBoundedL2VecSum", "length": "3"}),
+        json!({"type": "Prio3FixedPoint32BitBoundedL2VecSum", "length": "3", "noise_param": ["1", "0"]}),
         &[
             json!([
                 fp32_4_inv.to_string(),
@@ -769,7 +769,7 @@ async fn e2e_prio3_fixed64vec() {
     let fp64_16_inv = fixed!(0.0625: I1F63);
     let result = run(
         QueryKind::TimeInterval,
-        json!({"type": "Prio3FixedPoint64BitBoundedL2VecSum", "length": "3"}),
+        json!({"type": "Prio3FixedPoint64BitBoundedL2VecSum", "length": "3", "noise_param": ["1", "0"]}),
         &[
             json!([
                 fp64_4_inv.to_string(),
@@ -805,7 +805,7 @@ async fn e2e_prio3_fixed16vec_fixed_size() {
     let fp16_16_inv = fixed!(0.0625: I1F15);
     let result = run(
         QueryKind::FixedSize,
-        json!({"type": "Prio3FixedPoint16BitBoundedL2VecSum", "length": "3"}),
+        json!({"type": "Prio3FixedPoint16BitBoundedL2VecSum", "length": "3", "noise_param": ["1", "0"]}),
         &[
             json!([
                 fp16_4_inv.to_string(),
@@ -841,7 +841,7 @@ async fn e2e_prio3_fixed32vec_fixed_size() {
     let fp32_16_inv = fixed!(0.0625: I1F31);
     let result = run(
         QueryKind::FixedSize,
-        json!({"type": "Prio3FixedPoint32BitBoundedL2VecSum", "length": "3"}),
+        json!({"type": "Prio3FixedPoint32BitBoundedL2VecSum", "length": "3", "noise_param": ["1", "0"]}),
         &[
             json!([
                 fp32_4_inv.to_string(),
@@ -877,7 +877,7 @@ async fn e2e_prio3_fixed64vec_fixed_size() {
     let fp64_16_inv = fixed!(0.0625: I1F63);
     let result = run(
         QueryKind::FixedSize,
-        json!({"type": "Prio3FixedPoint64BitBoundedL2VecSum", "length": "3"}),
+        json!({"type": "Prio3FixedPoint64BitBoundedL2VecSum", "length": "3", "noise_param": ["1", "0"]}),
         &[
             json!([
                 fp64_4_inv.to_string(),

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -20,7 +20,8 @@ hex = "0.4"
 num_enum = "0.6.1"
 # We can't pull prio in from the workspace because that would enable default features, and we do not
 # want prio/crypto-dependencies
-prio = { version = "0.12.2", default-features = false }
+# prio = { version = "0.12.2", default-features = false }
+prio = {git = "https://github.com/dpsa-project/libprio-rs.git", branch ="feature-fixedvec-dp", default-features = false}
 rand = "0.8"
 serde.workspace = true
 thiserror = "1.0"

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -495,8 +495,12 @@ where
         #[cfg(feature = "fpvec_bounded_l2")]
         (VdafType::FixedPoint16BitBoundedL2VecSum, Some(length), None, None) => {
             let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>> =
-                Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length)
-                    .map_err(|err| Error::Anyhow(err.into()))?;
+                Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
+                    2,
+                    length,
+                    prio::flp::types::fixedpoint_l2::zero_privacy_parameter(),
+                )
+                .map_err(|err| Error::Anyhow(err.into()))?;
             run_collection_generic(parameters, vdaf, http_client, query, &())
                 .await
                 .map_err(|err| Error::Anyhow(err.into()))
@@ -504,8 +508,12 @@ where
         #[cfg(feature = "fpvec_bounded_l2")]
         (VdafType::FixedPoint32BitBoundedL2VecSum, Some(length), None, None) => {
             let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>> =
-                Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length)
-                    .map_err(|err| Error::Anyhow(err.into()))?;
+                Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
+                    2,
+                    length,
+                    prio::flp::types::fixedpoint_l2::zero_privacy_parameter(),
+                )
+                .map_err(|err| Error::Anyhow(err.into()))?;
             run_collection_generic(parameters, vdaf, http_client, query, &())
                 .await
                 .map_err(|err| Error::Anyhow(err.into()))
@@ -513,8 +521,12 @@ where
         #[cfg(feature = "fpvec_bounded_l2")]
         (VdafType::FixedPoint64BitBoundedL2VecSum, Some(length), None, None) => {
             let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>> =
-                Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length)
-                    .map_err(|err| Error::Anyhow(err.into()))?;
+                Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
+                    2,
+                    length,
+                    prio::flp::types::fixedpoint_l2::zero_privacy_parameter(),
+                )
+                .map_err(|err| Error::Anyhow(err.into()))?;
             run_collection_generic(parameters, vdaf, http_client, query, &())
                 .await
                 .map_err(|err| Error::Anyhow(err.into()))


### PR DESCRIPTION
This comprises the following changes:
 - Add a `noise_param` parameter to the fixedvec type(s) in the various vdaf enums.
   This describes the amount of noise to be added.
 - Wire up the new `postprocess()` function of prio to be called in both leader
   and helper. The noising itself happens in the implementation of the fixedvec
   type in prio, see the relevant pr (https://github.com/divviup/libprio-rs/pull/578).

**Notes**:
 1. We currently call the `postprocess()` function of prio in two seperate locations for the leader and for the helper, as it seems that their respective aggregation mechanism utilizes different codepaths. I can imagine that there could be a better way to hook up our noising function. Is there?
 2. We have a new `noise_param` argument for our vdaf. Should we add such an argument to `tools/collect`? Currently, a default value (no noise) is used when instantiating our vdaf.
 3. We added an `experimental` feature for `janus/aggregator` and `janus/aggregator_core` which depends on the `experimental` feature for prio.

**Tasks**:
 - [ ] Switch prio dependency back to crates.io, after our other pr is merged.
