### PR TITLE
Add route to HTTP metrics on DAP endpoints

### DIFF
--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -211,7 +211,7 @@ pub fn aggregator_handler<C: Clock>(
 
     Ok((
         State(aggregator),
-        metrics("janus_aggregator"),
+        metrics("janus_aggregator").with_route(|conn| conn.route().map(ToString::to_string)),
         Router::new()
             .without_options_handling()
             .get("hpke_config", instrumented(api(hpke_config::<C>)))


### PR DESCRIPTION
Our usage of `trillium-opentelemetry` in `janus_aggregator` is missing a callback to get the route for a connection. We already do this in `janus_aggregator_api`.