### PR TITLE
Update trillium-opentelemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4814,9 +4814,9 @@ dependencies = [
 
 [[package]]
 name = "trillium-opentelemetry"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf4382553673f7ccce1f2bbc43b2f344cc68ab681dce8a79f7941857e4208f1"
+checksum = "b4a2a2411d01474be6b26f9ee2b5e9b3e02f4a4143462eb04d9bc905517de91b"
 dependencies = [
  "opentelemetry",
  "trillium",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ trillium = "0.2.9"
 trillium-api = { version = "0.2.0-rc.3", default-features = false }
 trillium-caching-headers = "0.2.1"
 trillium-head = "0.2.0"
-trillium-opentelemetry = "0.1.0"
+trillium-opentelemetry = "0.2.0"
 trillium-router = "0.3.5"
 trillium-testing = "0.5.0"
 trillium-tokio = "0.3.1"


### PR DESCRIPTION
This updates trillium-opentelemetry to pick up a change in units of `http.server.duration`. The semantic conventions document that defines this metric changed it from milliseconds to seconds a couple months ago, to be more in line with Prometheus's conventions for units. See https://github.com/trillium-rs/trillium-opentelemetry/pull/11.