### PR TITLE
Remove opentelemetry-jaeger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1906,12 +1906,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-encoding"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
-
-[[package]]
 name = "io-lifetimes"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1990,7 +1984,6 @@ dependencies = [
  "mockito",
  "once_cell",
  "opentelemetry",
- "opentelemetry-jaeger",
  "opentelemetry-otlp",
  "opentelemetry-prometheus",
  "opentelemetry-semantic-conventions",
@@ -2738,23 +2731,6 @@ checksum = "5f4b8347cc26099d3aeee044065ecc3ae11469796b4d65d065a23a584ed92a6f"
 dependencies = [
  "opentelemetry_api",
  "opentelemetry_sdk",
-]
-
-[[package]]
-name = "opentelemetry-jaeger"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08e028dc9f4f304e9320ce38c80e7cf74067415b1ad5a8750a38bae54a4d450d"
-dependencies = [
- "async-trait",
- "futures",
- "futures-executor",
- "once_cell",
- "opentelemetry",
- "opentelemetry-semantic-conventions",
- "thiserror",
- "thrift",
- "tokio",
 ]
 
 [[package]]
@@ -4270,28 +4246,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
-]
-
-[[package]]
-name = "thrift"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
-dependencies = [
- "byteorder",
- "integer-encoding",
- "log",
- "ordered-float",
- "threadpool",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -81,8 +81,6 @@ its configuration and operation.
 
 `janus_aggregator` has the following features available.
 
-* `jaeger`: Enables tracing support and a Jaeger exporter; see the
-  [documentation](docs/CONFIGURING_TRACING.md) for configuration instructions.
 * `otlp`: Enables OTLP exporter support for both metrics and tracing. See the
   [metrics](docs/CONFIGURING_METRICS.md) and
   [tracing](docs/CONFIGURING_TRACING.md) documentation for configuration

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -16,7 +16,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = []
 fpvec_bounded_l2 = ["dep:fixed", "janus_core/fpvec_bounded_l2"]
 tokio-console = ["dep:console-subscriber"]
-jaeger = ["dep:tracing-opentelemetry", "dep:opentelemetry-jaeger"]
 otlp = [
     "dep:tracing-opentelemetry",
     "dep:opentelemetry-otlp",
@@ -63,7 +62,6 @@ kube.workspace = true
 lazy_static = { version = "1", optional = true }
 once_cell = "1.18.0"
 opentelemetry = { workspace = true, features = ["rt-tokio"] }
-opentelemetry-jaeger = { version = "0.18", optional = true, features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.12", optional = true, features = ["metrics"] } # ensure that the version of tonic below matches what this uses
 opentelemetry-prometheus = { version = "0.12", optional = true }
 opentelemetry-semantic-conventions = { version = "0.11", optional = true }

--- a/aggregator/src/bin/aggregator.rs
+++ b/aggregator/src/bin/aggregator.rs
@@ -334,7 +334,9 @@ mod tests {
         url: "postgres://postgres:postgres@localhost:5432/postgres"
         connection_pool_timeouts_secs: 60
     logging_config:
-        open_telemetry_config: jaeger
+        open_telemetry_config:
+            otlp:
+                endpoint: "http://localhost:4317"
     max_upload_batch_size: 100
     max_upload_batch_write_delay_ms: 250
     batch_aggregation_shard_count: 32
@@ -344,7 +346,12 @@ mod tests {
             .common_config()
             .logging_config
             .open_telemetry_config,
-            Some(OpenTelemetryTraceConfiguration::Jaeger),
+            Some(OpenTelemetryTraceConfiguration::Otlp(
+                OtlpTraceConfiguration {
+                    endpoint: "http://localhost:4317".to_string(),
+                    metadata: HashMap::new()
+                }
+            )),
         );
 
         assert_eq!(

--- a/docs/CONFIGURING_TRACING.md
+++ b/docs/CONFIGURING_TRACING.md
@@ -6,20 +6,20 @@ systems through the OpenTelemetry SDK, and various exporters.
 ## Jaeger
 
 [Jaeger](https://www.jaegertracing.io/) is a software stack that stores,
-indexes, and displays distributed traces. While Jaeger supports the
-OpenTelemetry object model, it uses its own wire protocols, and thus requires
-Jaeger-specific exporters.
+indexes, and displays distributed traces.
 
-For local testing, start Jaeger by running `docker run -d -p6831:6831/udp
--p6832:6832/udp -p16686:16686 -p14268:14268 jaegertracing/all-in-one:latest`,
-and open its web interface at http://localhost:16686/. Enable experimental
-support for Jaeger by compiling with the `jaeger` feature. Add the following
-configuration file stanza. Trace data will be pushed to the local Jaeger agent
-via UDP.
+For local testing, start Jaeger by running
+`docker run -d -e COLLECTOR_OTLP_ENABLED=true -p4317:4317 -p16686:16686 jaegertracing/all-in-one:latest`,
+and open its web interface at http://localhost:16686/. Compile
+`janus_aggregator` with the `otlp` feature enabled, to pull in the OTLP
+exporter. Add the following configuration file stanza. Trace data will be pushed
+to the local Jaeger agent via OTLP/gRPC.
 
 ```yaml
 logging_config:
-  open_telemetry_config: jaeger
+  open_telemetry_config:
+    otlp:
+      endpoint: "http://localhost:4317"
 ```
 
 ## Honeycomb

--- a/docs/samples/advanced_config/aggregation_job_creator.yaml
+++ b/docs/samples/advanced_config/aggregation_job_creator.yaml
@@ -29,16 +29,15 @@ logging_config:
     # Socket address to listen on. (optional)
     listen_address: "127.0.0.1:6669"
 
-  # OpenTelemetry tracing configuration. This can either contain the string
-  # "jaeger" or a map with an "otlp" key. (optional)
-  open_telemetry_config: "jaeger"
-
-  ##otlp:
-  ##  # OTLP gRPC endpoint.
-  ##  endpoint: "https://example.com/"
-  ##  # gRPC metadata to send with OTLP requests. (optional)
-  ##  metadata:
-  ##    key: "value"
+  # OpenTelemetry tracing configuration. This can contain an "otlp" key with a
+  # map containing exporter configuration. (optional)
+  open_telemetry_config:
+    otlp:
+      # OTLP gRPC endpoint.
+      endpoint: "https://example.com"
+      # gRPC metadata to send with OTLP requests. (optional)
+      metadata:
+        key: "value"
 
 # Metrics configuration. (optional)
 metrics_config:

--- a/docs/samples/advanced_config/aggregation_job_driver.yaml
+++ b/docs/samples/advanced_config/aggregation_job_driver.yaml
@@ -29,16 +29,15 @@ logging_config:
     # Socket address to listen on. (optional)
     listen_address: "127.0.0.1:6669"
 
-  # OpenTelemetry tracing configuration. This can either contain the string
-  # "jaeger" or a map with an "otlp" key. (optional)
-  open_telemetry_config: "jaeger"
-
-  ##otlp:
-  ##  # OTLP gRPC endpoint.
-  ##  endpoint: "https://example.com/"
-  ##  # gRPC metadata to send with OTLP requests. (optional)
-  ##  metadata:
-  ##    key: "value"
+  # OpenTelemetry tracing configuration. This can contain an "otlp" key with a
+  # map containing exporter configuration. (optional)
+  open_telemetry_config:
+    otlp:
+      # OTLP gRPC endpoint.
+      endpoint: "https://example.com"
+      # gRPC metadata to send with OTLP requests. (optional)
+      metadata:
+        key: "value"
 
 # Metrics configuration. (optional)
 metrics_config:

--- a/docs/samples/advanced_config/aggregator.yaml
+++ b/docs/samples/advanced_config/aggregator.yaml
@@ -29,16 +29,15 @@ logging_config:
     # Socket address to listen on. (optional)
     listen_address: "127.0.0.1:6669"
 
-  # OpenTelemetry tracing configuration. This can either contain the string
-  # "jaeger" or a map with an "otlp" key. (optional)
-  open_telemetry_config: "jaeger"
-
-  ##otlp:
-  ##  # OTLP gRPC endpoint.
-  ##  endpoint: "https://example.com/"
-  ##  # gRPC metadata to send with OTLP requests. (optional)
-  ##  metadata:
-  ##    key: "value"
+  # OpenTelemetry tracing configuration. This can contain an "otlp" key with a
+  # map containing exporter configuration. (optional)
+  open_telemetry_config:
+    otlp:
+      # OTLP gRPC endpoint.
+      endpoint: "https://example.com"
+      # gRPC metadata to send with OTLP requests. (optional)
+      metadata:
+        key: "value"
 
 # Metrics configuration. (optional)
 metrics_config:

--- a/docs/samples/advanced_config/collection_job_driver.yaml
+++ b/docs/samples/advanced_config/collection_job_driver.yaml
@@ -29,16 +29,15 @@ logging_config:
     # Socket address to listen on. (optional)
     listen_address: "127.0.0.1:6669"
 
-  # OpenTelemetry tracing configuration. This can either contain the string
-  # "jaeger" or a map with an "otlp" key. (optional)
-  open_telemetry_config: "jaeger"
-
-  ##otlp:
-  ##  # OTLP gRPC endpoint.
-  ##  endpoint: "https://example.com/"
-  ##  # gRPC metadata to send with OTLP requests. (optional)
-  ##  metadata:
-  ##    key: "value"
+  # OpenTelemetry tracing configuration. This can contain an "otlp" key with a
+  # map containing exporter configuration. (optional)
+  open_telemetry_config:
+    otlp:
+      # OTLP gRPC endpoint.
+      endpoint: "https://example.com"
+      # gRPC metadata to send with OTLP requests. (optional)
+      metadata:
+        key: "value"
 
 # Metrics configuration. (optional)
 metrics_config:

--- a/docs/samples/advanced_config/garbage_collector.yaml
+++ b/docs/samples/advanced_config/garbage_collector.yaml
@@ -29,16 +29,15 @@ logging_config:
     # Socket address to listen on. (optional)
     listen_address: "127.0.0.1:6669"
 
-  # OpenTelemetry tracing configuration. This can either contain the string
-  # "jaeger" or a map with an "otlp" key. (optional)
-  open_telemetry_config: "jaeger"
-
-  ##otlp:
-  ##  # OTLP gRPC endpoint.
-  ##  endpoint: "https://example.com/"
-  ##  # gRPC metadata to send with OTLP requests. (optional)
-  ##  metadata:
-  ##    key: "value"
+  # OpenTelemetry tracing configuration. This can contain an "otlp" key with a
+  # map containing exporter configuration. (optional)
+  open_telemetry_config:
+    otlp:
+      # OTLP gRPC endpoint.
+      endpoint: "https://example.com"
+      # gRPC metadata to send with OTLP requests. (optional)
+      metadata:
+        key: "value"
 
 # Metrics configuration. (optional)
 metrics_config:

--- a/docs/samples/advanced_config/janus_cli.yaml
+++ b/docs/samples/advanced_config/janus_cli.yaml
@@ -29,16 +29,15 @@ logging_config:
     # Socket address to listen on. (optional)
     listen_address: "127.0.0.1:6669"
 
-  # OpenTelemetry tracing configuration. This can either contain the string
-  # "jaeger" or a map with an "otlp" key. (optional)
-  open_telemetry_config: "jaeger"
-
-  ##otlp:
-  ##  # OTLP gRPC endpoint.
-  ##  endpoint: "https://example.com/"
-  ##  # gRPC metadata to send with OTLP requests. (optional)
-  ##  metadata:
-  ##    key: "value"
+  # OpenTelemetry tracing configuration. This can contain an "otlp" key with a
+  # map containing exporter configuration. (optional)
+  open_telemetry_config:
+    otlp:
+      # OTLP gRPC endpoint.
+      endpoint: "https://example.com"
+      # gRPC metadata to send with OTLP requests. (optional)
+      metadata:
+        key: "value"
 
 # Metrics configuration. (optional)
 metrics_config:


### PR DESCRIPTION
This removes the `opentelemetry-jaeger` exporter, and documents how to use the OTLP exporter with Jaeger instead.