### PR TITLE
Release CI: defer login steps until after build

### DIFF
--- a/.github/workflows/push-docker-images-release.yml
+++ b/.github/workflows/push-docker-images-release.yml
@@ -24,29 +24,6 @@ jobs:
       with:
         driver: docker-container
         use: true
-    - id: "gcp-auth-private"
-      name: "Authenticate to GCP (private repositories)"
-      uses: "google-github-actions/auth@v1"
-      with:
-        workload_identity_provider: ${{ vars.GCP_ARTIFACT_PUBLISHER_WORKLOAD_IDENTITY_PROVIDER }}
-        service_account: ${{ vars.GCP_ARTIFACT_PUBLISHER_DEPLOY_SERVICE_ACCOUNT }}
-        token_format: "access_token"
-        access_token_lifetime: "3600s"
-        access_token_scopes: "https://www.googleapis.com/auth/cloud-platform"
-    - id: "gcp-auth-public"
-      name: "Authenticate to GCP (public repositories)"
-      uses: "google-github-actions/auth@v1"
-      with:
-        workload_identity_provider: ${{ vars.GCP_PUBLIC_ARTIFACT_PUBLISHER_WORKLOAD_IDENTITY_PROVIDER }}
-        service_account: ${{ vars.GCP_PUBLIC_ARTIFACT_PUBLISHER_DEPLOY_SERVICE_ACCOUNT }}
-        token_format: "access_token"
-        access_token_lifetime: "3600s"
-        access_token_scopes: "https://www.googleapis.com/auth/cloud-platform"
-    - uses: "docker/login-action@v2"
-      with:
-        registry: "us-west2-docker.pkg.dev"
-        username: "oauth2accesstoken"
-        password: ${{ steps.gcp-auth-private.outputs.access_token }}
     - name: Get the version
       id: get_version
       run: echo VERSION=${GITHUB_REF/refs\/tags\//} | tee -a $GITHUB_OUTPUT | tee -a $GITHUB_ENV
@@ -62,6 +39,21 @@ jobs:
         # save all images locally first, and then push to one repository at a
         # time.
 
+    - id: "gcp-auth-private"
+      name: "Authenticate to GCP (private repositories)"
+      uses: "google-github-actions/auth@v1"
+      with:
+        workload_identity_provider: ${{ vars.GCP_ARTIFACT_PUBLISHER_WORKLOAD_IDENTITY_PROVIDER }}
+        service_account: ${{ vars.GCP_ARTIFACT_PUBLISHER_DEPLOY_SERVICE_ACCOUNT }}
+        token_format: "access_token"
+        access_token_lifetime: "3600s"
+        access_token_scopes: "https://www.googleapis.com/auth/cloud-platform"
+    - uses: "docker/login-action@v2"
+      with:
+        registry: "us-west2-docker.pkg.dev"
+        username: "oauth2accesstoken"
+        password: ${{ steps.gcp-auth-private.outputs.access_token }}
+
     - run: docker push us-west2-docker.pkg.dev/janus-artifacts/janus/janus_aggregator:${{ steps.get_version.outputs.VERSION }}
     - run: docker push us-west2-docker.pkg.dev/janus-artifacts/janus/janus_aggregation_job_creator:${{ steps.get_version.outputs.VERSION }}
     - run: docker push us-west2-docker.pkg.dev/janus-artifacts/janus/janus_aggregation_job_driver:${{ steps.get_version.outputs.VERSION }}
@@ -71,11 +63,21 @@ jobs:
     - run: docker push us-west2-docker.pkg.dev/janus-artifacts/janus/janus_interop_aggregator:${{ steps.get_version.outputs.VERSION }}
     - run: docker push us-west2-docker.pkg.dev/janus-artifacts/janus/janus_interop_collector:${{ steps.get_version.outputs.VERSION }}
 
+    - id: "gcp-auth-public"
+      name: "Authenticate to GCP (public repositories)"
+      uses: "google-github-actions/auth@v1"
+      with:
+        workload_identity_provider: ${{ vars.GCP_PUBLIC_ARTIFACT_PUBLISHER_WORKLOAD_IDENTITY_PROVIDER }}
+        service_account: ${{ vars.GCP_PUBLIC_ARTIFACT_PUBLISHER_DEPLOY_SERVICE_ACCOUNT }}
+        token_format: "access_token"
+        access_token_lifetime: "3600s"
+        access_token_scopes: "https://www.googleapis.com/auth/cloud-platform"
     - uses: "docker/login-action@v2"
       with:
         registry: "us-west2-docker.pkg.dev"
         username: "oauth2accesstoken"
         password: ${{ steps.gcp-auth-public.outputs.access_token }}
+
     - run: docker push us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_aggregator:${{ steps.get_version.outputs.VERSION }}
     - run: docker push us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_aggregation_job_creator:${{ steps.get_version.outputs.VERSION }}
     - run: docker push us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_aggregation_job_driver:${{ steps.get_version.outputs.VERSION }}


### PR DESCRIPTION
I recently ran the release action with a cold cache, and the build step ended up taking long enough that the GCP token used to push to the repository had expired. (re-running the action worked, because the cache was now warm) This reorders the steps, so that we log in immediately before pushing.