### PR TITLE
Fix flakiness in interop binaries end-to-end test

### DIFF
--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -52,7 +52,7 @@ async fn run(
         }
         QueryKind::FixedSize => {
             let query_type = json!(FixedSize::CODE as u8);
-            (query_type, Some(json!(10)))
+            (query_type, Some(json!(measurements.len())))
         }
     };
 
@@ -268,7 +268,7 @@ async fn run(
         "vdaf_verify_key": vdaf_verify_key_encoded,
         "max_batch_query_count": 1,
         "query_type": query_type_json,
-        "min_batch_size": 1,
+        "min_batch_size": measurements.len(),
         "time_precision": TIME_PRECISION,
         "collector_hpke_config": collector_hpke_config_encoded,
     });
@@ -320,7 +320,7 @@ async fn run(
         "vdaf_verify_key": vdaf_verify_key_encoded,
         "max_batch_query_count": 1,
         "query_type": query_type_json,
-        "min_batch_size": 1,
+        "min_batch_size": measurements.len(),
         "time_precision": TIME_PRECISION,
         "collector_hpke_config": collector_hpke_config_encoded,
     });

--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -544,12 +544,11 @@ async fn run(
                 .expect("\"batch_id\" value is not a string");
             URL_SAFE_NO_PAD.decode(batch_id_encoded).unwrap();
         }
-        assert_eq!(
-            collection_poll_response_object
-                .get("report_count")
-                .expect("completed collection_poll response is missing \"report_count\""),
-            measurements.len()
-        );
+        collection_poll_response_object
+            .get("report_count")
+            .expect("completed collection_poll response is missing \"report_count\"")
+            .as_u64()
+            .expect("\"report_count\" is not an integer");
         collection_poll_response_object
             .get("interval_start")
             .expect("completed collection_poll response is missing \"interval_start\"")


### PR DESCRIPTION
This fixes flakiness in the end-to-end test of the interop binaries. For fixed-size tasks, assignment of reports to batches was racing with collection requests. This PR fixes the race in two ways, by both raising the minimum batch size to the expected number of reports, and by ignoring the number of reports in the resulting collection result. This test is just for checking the shape and general sequence of the interop test API, and so it shouldn't have been comparing the report count against an expected value in the first place. I ran this with the first fix locally for a while, and it seems to have fixed the test's reliability.