### PR TITLE
janus_cli observability fixes

### DIFF
--- a/aggregator/src/bin/janus_cli.rs
+++ b/aggregator/src/bin/janus_cli.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use janus_aggregator::{
     binary_utils::{database_pool, datastore, read_config, CommonBinaryOptions},
     config::{BinaryConfig, CommonConfig},
-    metrics::install_metrics_exporter,
+    metrics::{install_metrics_exporter, MetricsExporterHandle},
     trace::install_trace_subscriber,
 };
 use janus_aggregator_core::{
@@ -32,7 +32,8 @@ async fn main() -> Result<()> {
     let command_line_options = CommandLineOptions::parse();
     let config_file: ConfigFile = read_config(&command_line_options.common_options)?;
 
-    install_tracing_and_metrics_handlers(config_file.common_config()).await?;
+    let _metrics_handler =
+        install_tracing_and_metrics_handlers(config_file.common_config()).await?;
 
     debug!(?command_line_options, ?config_file, "Starting up");
 
@@ -135,14 +136,14 @@ impl Command {
     }
 }
 
-async fn install_tracing_and_metrics_handlers(config: &CommonConfig) -> Result<()> {
+async fn install_tracing_and_metrics_handlers(
+    config: &CommonConfig,
+) -> Result<MetricsExporterHandle> {
     install_trace_subscriber(&config.logging_config)
         .context("couldn't install tracing subscriber")?;
-    let _metrics_exporter = install_metrics_exporter(&config.metrics_config)
+    install_metrics_exporter(&config.metrics_config)
         .await
-        .context("failed to install metrics exporter")?;
-
-    Ok(())
+        .context("failed to install metrics exporter")
 }
 
 async fn provision_tasks<C: Clock>(

--- a/aggregator/src/bin/janus_cli.rs
+++ b/aggregator/src/bin/janus_cli.rs
@@ -39,7 +39,11 @@ async fn main() -> Result<()> {
 
     record_build_info_gauge();
 
-    debug!(?command_line_options, ?config_file, "Starting up");
+    info!(
+        common_options = ?&command_line_options.common_options,
+        config = ?config_file,
+        "Starting up"
+    );
 
     if command_line_options.dry_run {
         info!("DRY RUN: no persistent changes will be made")

--- a/aggregator/src/bin/janus_cli.rs
+++ b/aggregator/src/bin/janus_cli.rs
@@ -2,7 +2,9 @@ use anyhow::{anyhow, Context, Result};
 use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine};
 use clap::Parser;
 use janus_aggregator::{
-    binary_utils::{database_pool, datastore, read_config, CommonBinaryOptions},
+    binary_utils::{
+        database_pool, datastore, read_config, record_build_info_gauge, CommonBinaryOptions,
+    },
     config::{BinaryConfig, CommonConfig},
     metrics::{install_metrics_exporter, MetricsExporterHandle},
     trace::install_trace_subscriber,
@@ -34,6 +36,8 @@ async fn main() -> Result<()> {
 
     let _metrics_handler =
         install_tracing_and_metrics_handlers(config_file.common_config()).await?;
+
+    record_build_info_gauge();
 
     debug!(?command_line_options, ?config_file, "Starting up");
 

--- a/aggregator/src/bin/janus_cli.rs
+++ b/aggregator/src/bin/janus_cli.rs
@@ -7,7 +7,7 @@ use janus_aggregator::{
     },
     config::{BinaryConfig, CommonConfig},
     metrics::{install_metrics_exporter, MetricsExporterHandle},
-    trace::install_trace_subscriber,
+    trace::{cleanup_trace_subscriber, install_trace_subscriber},
 };
 use janus_aggregator_core::{
     datastore::{self, Datastore},
@@ -49,10 +49,16 @@ async fn main() -> Result<()> {
         info!("DRY RUN: no persistent changes will be made")
     }
 
-    command_line_options
+    let logging_config = config_file.common_config.logging_config.clone();
+
+    let result = command_line_options
         .cmd
         .execute(&command_line_options, &config_file)
-        .await
+        .await;
+
+    cleanup_trace_subscriber(&logging_config);
+
+    result
 }
 
 #[derive(Debug, Parser)]

--- a/aggregator/src/trace.rs
+++ b/aggregator/src/trace.rs
@@ -227,7 +227,7 @@ pub fn install_trace_subscriber(config: &TraceConfiguration) -> Result<(), Error
     Ok(())
 }
 
-pub(crate) fn cleanup_trace_subscriber(_config: &TraceConfiguration) {
+pub fn cleanup_trace_subscriber(_config: &TraceConfiguration) {
     #[cfg(feature = "otlp")]
     if _config.open_telemetry_config.is_some() {
         // Flush buffered traces in the OpenTelemetry pipeline.


### PR DESCRIPTION
This trues up `main()` in janus_cli with `janus_main()`, fixing a few observability-related issues.

- Hang on to the metrics exporter handle. Dropping this early would stop the exporter if pushing metrics over OTLP.
- Add the `janus_build_info` gauge metric.
- Make the "Starting up" log line more consistent with that in other binaries.
- Flush the trace exporter before exiting by shutting down the current tracer provider. This avoids losing traces when using OTLP for them.