### PR TITLE
Instrument more methods with tracing spans

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -400,7 +400,6 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
         }
     }
 
-    #[tracing::instrument(skip(self, task), fields(task_id = ?task.id()), err)]
     async fn create_aggregation_jobs_for_time_interval_task_no_param<
         const SEED_SIZE: usize,
         A: vdaf::Aggregator<SEED_SIZE, 16, AggregationParam = ()>,
@@ -502,7 +501,6 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
             .await?)
     }
 
-    #[tracing::instrument(skip(self, task), fields(task_id = ?task.id()), err)]
     async fn create_aggregation_jobs_for_fixed_size_task_no_param<
         const SEED_SIZE: usize,
         A: vdaf::Aggregator<SEED_SIZE, 16, AggregationParam = ()>,
@@ -703,7 +701,6 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
     /// be used with VDAFs that have non-unit type aggregation parameters.
     // This is only used in tests thus far.
     #[cfg(test)]
-    #[tracing::instrument(skip(self, task), fields(task_id = ?task.id()), err)]
     async fn create_aggregation_jobs_for_task_with_param<const SEED_SIZE: usize, A>(
         self: Arc<Self>,
         task: Arc<Task>,

--- a/aggregator/src/aggregator/aggregation_job_writer.rs
+++ b/aggregator/src/aggregator/aggregation_job_writer.rs
@@ -153,6 +153,7 @@ impl<const SEED_SIZE: usize, Q: CollectableQueryType, A: vdaf::Aggregator<SEED_S
     ///
     /// A call to write, successful or not, does not change the internal state of the aggregation
     /// job writer; calling write again will cause the same set of aggregation jobs to be written.
+    #[tracing::instrument(skip(self, tx), err)]
     pub async fn write<C>(
         &self,
         tx: &Transaction<'_, C>,

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -73,6 +73,7 @@ impl CollectionJobDriver {
     /// will not yield a result. The collection job lease will eventually expire, allowing a later run
     /// of the collection job driver to try again. Both aggregate shares will be recomputed at that
     /// time.
+    #[tracing::instrument(skip(self, datastore), err)]
     pub async fn step_collection_job<C: Clock>(
         &self,
         datastore: Arc<Datastore<C>>,
@@ -104,7 +105,6 @@ impl CollectionJobDriver {
         }
     }
 
-    #[tracing::instrument(skip(self, datastore), err)]
     async fn step_collection_job_generic<
         const SEED_SIZE: usize,
         C: Clock,

--- a/aggregator/src/aggregator/report_writer.rs
+++ b/aggregator/src/aggregator/report_writer.rs
@@ -57,6 +57,7 @@ impl<C: Clock> ReportWriteBatcher<C> {
         rslt_rx.await.unwrap()
     }
 
+    #[tracing::instrument(skip(ds, report_rx))]
     async fn run_upload_batcher(
         ds: Arc<Datastore<C>>,
         mut report_rx: ReportWriteBatcherReceiver<C>,
@@ -110,6 +111,7 @@ impl<C: Clock> ReportWriteBatcher<C> {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     async fn write_batch(
         ds: Arc<Datastore<C>>,
         report_writers: Vec<Box<dyn ReportWriter<C>>>,

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -1487,6 +1487,7 @@ impl<C: Clock> Transaction<'_, C> {
 
     /// Return the number of reports in the provided task & batch, regardless of whether the reports
     /// have been aggregated or collected. Applies only to fixed-size queries.
+    #[tracing::instrument(skip(self), err)]
     pub async fn count_client_reports_for_batch_id(
         &self,
         task_id: &TaskId,
@@ -1765,6 +1766,7 @@ impl<C: Clock> Transaction<'_, C> {
     /// aggregation jobs. At most `maximum_acquire_count` jobs are acquired. The job is acquired
     /// with a "lease" that will time out; the desired duration of the lease is a parameter, and the
     /// returned lease provides the absolute timestamp at which the lease is no longer live.
+    #[tracing::instrument(skip(self), err)]
     pub async fn acquire_incomplete_aggregation_jobs(
         &self,
         lease_duration: &StdDuration,
@@ -1831,6 +1833,7 @@ impl<C: Clock> Transaction<'_, C> {
 
     /// release_aggregation_job releases an acquired (via e.g. acquire_incomplete_aggregation_jobs)
     /// aggregation job. It returns an error if the aggregation job has no current lease.
+    #[tracing::instrument(skip(self), err)]
     pub async fn release_aggregation_job(
         &self,
         lease: &Lease<AcquiredAggregationJob>,
@@ -2363,6 +2366,7 @@ impl<C: Clock> Transaction<'_, C> {
 
     /// Returns all collection jobs for the given task which include the given timestamp. Applies only
     /// to time-interval tasks.
+    #[tracing::instrument(skip(self), err)]
     pub async fn get_collection_jobs_including_time<
         const SEED_SIZE: usize,
         A: vdaf::Aggregator<SEED_SIZE, 16>,
@@ -2407,6 +2411,7 @@ impl<C: Clock> Transaction<'_, C> {
 
     /// Returns all collection jobs for the given task whose collect intervals intersect with the given
     /// interval. Applies only to time-interval tasks.
+    #[tracing::instrument(skip(self), err)]
     pub async fn get_collection_jobs_intersecting_interval<
         const SEED_SIZE: usize,
         A: vdaf::Aggregator<SEED_SIZE, 16>,
@@ -2457,6 +2462,7 @@ impl<C: Clock> Transaction<'_, C> {
 
     /// Retrieves all collection jobs for the given batch identifier. Multiple collection jobs may be
     /// returned with distinct aggregation parameters.
+    #[tracing::instrument(skip(self), err)]
     pub async fn get_collection_jobs_by_batch_identifier<
         const SEED_SIZE: usize,
         Q: QueryType,
@@ -2659,6 +2665,7 @@ impl<C: Clock> Transaction<'_, C> {
     /// collection jobs. At most `maximum_acquire_count` jobs are acquired. The job is acquired with
     /// a "lease" that will time out; the desired duration of the lease is a parameter, and the
     /// lease expiration time is returned.
+    #[tracing::instrument(skip(self), err)]
     pub async fn acquire_incomplete_collection_jobs(
         &self,
         lease_duration: &StdDuration,
@@ -2719,6 +2726,7 @@ impl<C: Clock> Transaction<'_, C> {
 
     /// release_collection_job releases an acquired (via e.g. acquire_incomplete_collection_jobs)
     /// collect job. It returns an error if the collection job has no current lease.
+    #[tracing::instrument(skip(self), err)]
     pub async fn release_collection_job(
         &self,
         lease: &Lease<AcquiredCollectionJob>,
@@ -2813,6 +2821,7 @@ impl<C: Clock> Transaction<'_, C> {
     }
 
     /// Retrieves an existing batch aggregation.
+    #[tracing::instrument(skip(self, aggregation_parameter), err)]
     pub async fn get_batch_aggregation<
         const SEED_SIZE: usize,
         Q: QueryType,
@@ -2863,6 +2872,7 @@ impl<C: Clock> Transaction<'_, C> {
 
     /// Retrieves all batch aggregations stored for a given batch, identified by task ID, batch
     /// identifier, and aggregation parameter.
+    #[tracing::instrument(skip(self, aggregation_parameter), err)]
     pub async fn get_batch_aggregations_for_batch<
         const SEED_SIZE: usize,
         Q: QueryType,
@@ -3147,6 +3157,7 @@ impl<C: Clock> Transaction<'_, C> {
 
     /// Returns all aggregate share jobs for the given task which include the given timestamp.
     /// Applies only to time-interval tasks.
+    #[tracing::instrument(skip(self), err)]
     pub async fn get_aggregate_share_jobs_including_time<
         const SEED_SIZE: usize,
         A: vdaf::Aggregator<SEED_SIZE, 16>,
@@ -3194,6 +3205,7 @@ impl<C: Clock> Transaction<'_, C> {
 
     /// Returns all aggregate share jobs for the given task whose collect intervals intersect with
     /// the given interval. Applies only to time-interval tasks.
+    #[tracing::instrument(skip(self), err)]
     pub async fn get_aggregate_share_jobs_intersecting_interval<
         const SEED_SIZE: usize,
         A: vdaf::Aggregator<SEED_SIZE, 16>,
@@ -3241,6 +3253,7 @@ impl<C: Clock> Transaction<'_, C> {
 
     /// Returns all aggregate share jobs for the given task with the given batch identifier.
     /// Multiple aggregate share jobs may be returned with distinct aggregation parameters.
+    #[tracing::instrument(skip(self), err)]
     pub async fn get_aggregate_share_jobs_by_batch_identifier<
         const SEED_SIZE: usize,
         Q: QueryType,
@@ -3389,6 +3402,7 @@ impl<C: Clock> Transaction<'_, C> {
 
     /// Writes an outstanding batch. (This method does not take an [`OutstandingBatch`] as several
     /// of the included values are read implicitly.)
+    #[tracing::instrument(skip(self), err)]
     pub async fn put_outstanding_batch(
         &self,
         task_id: &TaskId,
@@ -3414,6 +3428,7 @@ impl<C: Clock> Transaction<'_, C> {
     }
 
     /// Retrieves all [`OutstandingBatch`]es for a given task.
+    #[tracing::instrument(skip(self), err)]
     pub async fn get_outstanding_batches_for_task(
         &self,
         task_id: &TaskId,
@@ -3486,6 +3501,7 @@ impl<C: Clock> Transaction<'_, C> {
     }
 
     /// Deletes an outstanding batch.
+    #[tracing::instrument(skip(self), err)]
     pub async fn delete_outstanding_batch(
         &self,
         task_id: &TaskId,
@@ -3550,6 +3566,7 @@ impl<C: Clock> Transaction<'_, C> {
 
     /// Puts a `batch` into the datastore. Returns `MutationTargetAlreadyExists` if the batch is
     /// already stored.
+    #[tracing::instrument(skip(self), err)]
     pub async fn put_batch<
         const SEED_SIZE: usize,
         Q: QueryType,
@@ -3585,6 +3602,7 @@ impl<C: Clock> Transaction<'_, C> {
 
     /// Updates a given `batch` in the datastore. Returns `MutationTargetNotFound` if no such batch
     /// is currently stored.
+    #[tracing::instrument(skip(self), err)]
     pub async fn update_batch<
         const SEED_SIZE: usize,
         Q: QueryType,
@@ -3619,6 +3637,7 @@ impl<C: Clock> Transaction<'_, C> {
 
     /// Gets a given `batch` from the datastore, based on the primary key. Returns `None` if no such
     /// batch is stored in the datastore.
+    #[tracing::instrument(skip(self), err)]
     pub async fn get_batch<
         const SEED_SIZE: usize,
         Q: QueryType,
@@ -5623,10 +5642,12 @@ pub mod models {
 
     /// Represents the state of a given batch (and aggregation parameter).
 
-    #[derive(Clone, Debug)]
+    #[derive(Clone, Derivative)]
+    #[derivative(Debug)]
     pub struct Batch<const SEED_SIZE: usize, Q: QueryType, A: vdaf::Aggregator<SEED_SIZE, 16>> {
         task_id: TaskId,
         batch_identifier: Q::BatchIdentifier,
+        #[derivative(Debug = "ignore")]
         aggregation_parameter: A::AggregationParam,
         state: BatchState,
         outstanding_aggregation_jobs: u64,

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -204,6 +204,7 @@ impl<C: Clock> Datastore<C> {
 
     /// See [`Datastore::run_tx`]. This method additionally allows specifying a name for the
     /// transaction, for use in database-related metrics.
+    #[tracing::instrument(level = "trace", skip(self, f))]
     pub async fn run_tx_with_name<F, T>(&self, name: &'static str, f: F) -> Result<T, Error>
     where
         for<'a> F:
@@ -236,6 +237,7 @@ impl<C: Clock> Datastore<C> {
         }
     }
 
+    #[tracing::instrument(level = "trace", skip_all)]
     async fn run_tx_once<F, T>(&self, f: &F) -> (Result<T, Error>, bool)
     where
         for<'a> F:


### PR DESCRIPTION
This adds tracing instrumentation to methods throughout the aggregator and datastore modules. Part of #1473.