### PR TITLE
Add support for tracing-chrome

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2011,6 +2011,7 @@ dependencies = [
  "tokio-postgres",
  "tonic 0.8.3",
  "tracing",
+ "tracing-chrome",
  "tracing-log",
  "tracing-opentelemetry",
  "tracing-stackdriver",
@@ -4593,6 +4594,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "tracing-chrome"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "496b3cd5447f7ff527bbbf19b071ad542a000adf297d4127078b4dfdb931f41a"
+dependencies = [
+ "serde_json",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -86,6 +86,7 @@ tokio = { version = "1.28", features = ["full", "tracing"] }
 tokio-postgres = { version = "0.7.8", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1", "array-impls"] }
 tonic = { version = "0.8", optional = true, features = ["tls", "tls-webpki-roots"] }                                      # keep this version in sync with what opentelemetry-otlp uses
 tracing = "0.1.37"
+tracing-chrome = "0.7.1"
 tracing-log = "0.1.3"
 tracing-opentelemetry = { version = "0.19", optional = true }
 tracing-stackdriver = "0.7.2"

--- a/aggregator/src/config.rs
+++ b/aggregator/src/config.rs
@@ -167,6 +167,7 @@ pub mod test_util {
                     ]),
                 },
             )),
+            chrome: false,
         }
     }
 

--- a/aggregator/src/trace.rs
+++ b/aggregator/src/trace.rs
@@ -64,7 +64,8 @@ pub struct TraceConfiguration {
     /// Configuration for OpenTelemetry traces, with a choice of exporters.
     #[serde(default, with = "serde_yaml::with::singleton_map")]
     pub open_telemetry_config: Option<OpenTelemetryTraceConfiguration>,
-    /// If true, outputs traces to a JSON file compatible with Chrome's trace viewer format.
+    /// Flag to write tracing spans and events to JSON files. This is compatible with Chrome's
+    /// trace viewer, available at `chrome://tracing`, and [Perfetto](https://ui.perfetto.dev).
     #[serde(default)]
     pub chrome: bool,
 }

--- a/docs/samples/advanced_config/aggregation_job_creator.yaml
+++ b/docs/samples/advanced_config/aggregation_job_creator.yaml
@@ -39,6 +39,11 @@ logging_config:
       metadata:
         key: "value"
 
+  # Flag to write tracing spans and events to JSON files. This is compatible
+  # with Chrome's trace viewer, available at `chrome://tracing`, and
+  # Perfetto, at https://ui.perfetto.dev/. (optional)
+  chrome: false
+
 # Metrics configuration. (optional)
 metrics_config:
   # Metrics exporter configuration. This contains a map with single key, either

--- a/docs/samples/advanced_config/aggregation_job_driver.yaml
+++ b/docs/samples/advanced_config/aggregation_job_driver.yaml
@@ -85,5 +85,5 @@ worker_lease_clock_skew_allowance_secs: 60
 maximum_attempts_before_failure: 10
 
 # Number of sharded database records per batch aggregation. Must not be greater
-# than the equivalent setting in the collection job driver.
+# than the equivalent setting in the collection job driver. (required)
 batch_aggregation_shard_count: 32

--- a/docs/samples/advanced_config/aggregation_job_driver.yaml
+++ b/docs/samples/advanced_config/aggregation_job_driver.yaml
@@ -39,6 +39,11 @@ logging_config:
       metadata:
         key: "value"
 
+  # Flag to write tracing spans and events to JSON files. This is compatible
+  # with Chrome's trace viewer, available at `chrome://tracing`, and
+  # Perfetto, at https://ui.perfetto.dev/. (optional)
+  chrome: false
+
 # Metrics configuration. (optional)
 metrics_config:
   # Metrics exporter configuration. This contains a map with single key, either

--- a/docs/samples/advanced_config/aggregator.yaml
+++ b/docs/samples/advanced_config/aggregator.yaml
@@ -39,6 +39,11 @@ logging_config:
       metadata:
         key: "value"
 
+  # Flag to write tracing spans and events to JSON files. This is compatible
+  # with Chrome's trace viewer, available at `chrome://tracing`, and
+  # Perfetto, at https://ui.perfetto.dev/. (optional)
+  chrome: false
+
 # Metrics configuration. (optional)
 metrics_config:
   # Metrics exporter configuration. This contains a map with single key, either

--- a/docs/samples/advanced_config/aggregator.yaml
+++ b/docs/samples/advanced_config/aggregator.yaml
@@ -78,5 +78,5 @@ max_upload_batch_size: 100
 max_upload_batch_write_delay_ms: 250
 
 # Number of sharded database records per batch aggregation. Must not be greater
-# than the equivalent setting in the collection job driver.
+# than the equivalent setting in the collection job driver. (required)
 batch_aggregation_shard_count: 32

--- a/docs/samples/advanced_config/collection_job_driver.yaml
+++ b/docs/samples/advanced_config/collection_job_driver.yaml
@@ -39,6 +39,11 @@ logging_config:
       metadata:
         key: "value"
 
+  # Flag to write tracing spans and events to JSON files. This is compatible
+  # with Chrome's trace viewer, available at `chrome://tracing`, and
+  # Perfetto, at https://ui.perfetto.dev/. (optional)
+  chrome: false
+
 # Metrics configuration. (optional)
 metrics_config:
   # Metrics exporter configuration. This contains a map with single key, either

--- a/docs/samples/advanced_config/collection_job_driver.yaml
+++ b/docs/samples/advanced_config/collection_job_driver.yaml
@@ -86,4 +86,5 @@ maximum_attempts_before_failure: 10
 
 # Number of sharded database records per batch aggregation. Must not be less
 # than the equivalent setting in the aggregator and aggregation job driver.
+# (required)
 batch_aggregation_shard_count: 32

--- a/docs/samples/advanced_config/garbage_collector.yaml
+++ b/docs/samples/advanced_config/garbage_collector.yaml
@@ -39,6 +39,11 @@ logging_config:
       metadata:
         key: "value"
 
+  # Flag to write tracing spans and events to JSON files. This is compatible
+  # with Chrome's trace viewer, available at `chrome://tracing`, and
+  # Perfetto, at https://ui.perfetto.dev/. (optional)
+  chrome: false
+
 # Metrics configuration. (optional)
 metrics_config:
   # Metrics exporter configuration. This contains a map with single key, either

--- a/docs/samples/advanced_config/janus_cli.yaml
+++ b/docs/samples/advanced_config/janus_cli.yaml
@@ -39,6 +39,11 @@ logging_config:
       metadata:
         key: "value"
 
+  # Flag to write tracing spans and events to JSON files. This is compatible
+  # with Chrome's trace viewer, available at `chrome://tracing`, and
+  # Perfetto, at https://ui.perfetto.dev/. (optional)
+  chrome: false
+
 # Metrics configuration. (optional)
 metrics_config:
   # Metrics exporter configuration. This contains a map with single key, either


### PR DESCRIPTION
This adds a configuration option to enable a `tracing-chrome` subscriber. This saves spans and events into a JSON file that's compatible with Chrome's dev tools, and [Perfetto](https://ui.perfetto.dev/).

Closes #1471