### PR TITLE
Make filter for tracing-opentelemetry and tracing-chrome configurable

### DIFF
--- a/aggregator/src/trace.rs
+++ b/aggregator/src/trace.rs
@@ -121,7 +121,7 @@ fn make_trace_filter() -> Result<EnvFilter, FromEnvError> {
     EnvFilter::builder()
         .with_default_directive(Level::INFO.into())
         .with_env_var("RUST_TRACE")
-        .try_from_env()
+        .from_env()
 }
 
 /// Configures and installs a tracing subscriber, to capture events logged with
@@ -134,7 +134,7 @@ pub fn install_trace_subscriber(config: &TraceConfiguration) -> Result<TraceGuar
 
     // Configure filters with RUST_LOG env var. Format discussed at
     // https://docs.rs/tracing-subscriber/latest/tracing_subscriber/struct.EnvFilter.html
-    let stdout_filter = EnvFilter::try_from_default_env()?;
+    let stdout_filter = EnvFilter::builder().from_env()?;
 
     let mut layers = Vec::new();
     match (

--- a/core/src/test_util/mod.rs
+++ b/core/src/test_util/mod.rs
@@ -144,7 +144,7 @@ pub fn roundtrip_encoding<T: Serialize + DeserializeOwned + Debug + Eq>(value: T
 pub fn install_test_trace_subscriber() {
     static INSTALL_TRACE_SUBSCRIBER: Once = Once::new();
     INSTALL_TRACE_SUBSCRIBER.call_once(|| {
-        let stdout_filter = EnvFilter::try_from_default_env().unwrap();
+        let stdout_filter = EnvFilter::builder().from_env().unwrap();
         let layer = tracing_subscriber::fmt::layer()
             .with_thread_ids(true)
             .with_level(true)

--- a/core/src/test_util/mod.rs
+++ b/core/src/test_util/mod.rs
@@ -144,7 +144,7 @@ pub fn roundtrip_encoding<T: Serialize + DeserializeOwned + Debug + Eq>(value: T
 pub fn install_test_trace_subscriber() {
     static INSTALL_TRACE_SUBSCRIBER: Once = Once::new();
     INSTALL_TRACE_SUBSCRIBER.call_once(|| {
-        let stdout_filter = EnvFilter::from_default_env();
+        let stdout_filter = EnvFilter::try_from_default_env().unwrap();
         let layer = tracing_subscriber::fmt::layer()
             .with_thread_ids(true)
             .with_level(true)

--- a/docs/CONFIGURING_TRACING.md
+++ b/docs/CONFIGURING_TRACING.md
@@ -3,6 +3,12 @@
 Tracing spans from Janus components can be exported to distributed tracing
 systems through the OpenTelemetry SDK, and various exporters.
 
+Verbosity of traces can be controlled by setting the `RUST_TRACE` environment
+variable to a [filter][EnvFilter], just as with `RUST_LOG` for log output. By
+default, all spans and events of severity `INFO` or higher will be exported.
+
+[EnvFilter]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/struct.EnvFilter.html
+
 ## Jaeger
 
 [Jaeger](https://www.jaegertracing.io/) is a software stack that stores,

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -318,7 +318,7 @@ impl From<Task> for AggregatorAddTaskRequest {
 }
 
 pub fn install_tracing_subscriber() -> anyhow::Result<()> {
-    let stdout_filter = EnvFilter::from_default_env();
+    let stdout_filter = EnvFilter::try_from_default_env()?;
     let layer = tracing_subscriber::fmt::layer()
         .with_thread_ids(true)
         .with_level(true)

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -318,7 +318,7 @@ impl From<Task> for AggregatorAddTaskRequest {
 }
 
 pub fn install_tracing_subscriber() -> anyhow::Result<()> {
-    let stdout_filter = EnvFilter::try_from_default_env()?;
+    let stdout_filter = EnvFilter::builder().from_env()?;
     let layer = tracing_subscriber::fmt::layer()
         .with_thread_ids(true)
         .with_level(true)

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -564,7 +564,7 @@ where
 }
 
 fn install_tracing_subscriber() -> anyhow::Result<()> {
-    let stdout_filter = EnvFilter::from_default_env();
+    let stdout_filter = EnvFilter::try_from_default_env()?;
     let layer = tracing_subscriber::fmt::layer()
         .with_level(true)
         .with_target(true)

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -564,7 +564,7 @@ where
 }
 
 fn install_tracing_subscriber() -> anyhow::Result<()> {
-    let stdout_filter = EnvFilter::try_from_default_env()?;
+    let stdout_filter = EnvFilter::builder().from_env()?;
     let layer = tracing_subscriber::fmt::layer()
         .with_level(true)
         .with_target(true)


### PR DESCRIPTION
This makes the filter for our two trace-specific subscribers configurable, through a new environment variable, `RUST_TRACE`. This works the same as `RUST_LOG`, and allows us to change verbosity for each independently.

I also changed the existing uses of `EnvFilter::from_default_env()` to ~~`EnvFilter::try_from_default_env()`~~ `EnvFilter::builder.from_env()`, so that we get errors on startup if filter syntax is incorrect.