### PR TITLE
Break dependency of report_aggregations on client_reports.

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -126,6 +126,7 @@ pub(crate) fn aggregate_step_failure_counter(meter: &Meter) -> Counter<u64> {
         "helper_step_failure",
         "plaintext_input_share_decode_failure",
         "duplicate_extension",
+        "missing_client_report",
     ] {
         aggregate_step_failure_counter.add(
             &Context::current(),

--- a/aggregator/src/aggregator/aggregation_job_writer.rs
+++ b/aggregator/src/aggregator/aggregation_job_writer.rs
@@ -125,7 +125,7 @@ impl<const SEED_SIZE: usize, Q: CollectableQueryType, A: vdaf::Aggregator<SEED_S
                 Q::to_batch_identifier(
                     &self.task,
                     info.aggregation_job.partial_batch_identifier(),
-                    ra.report_metadata().time(),
+                    ra.time(),
                 )
             })
             .collect::<Result<Vec<_>, _>>()?;

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -3713,7 +3713,7 @@ impl<C: Clock> Transaction<'_, C> {
                 WHERE task_id = (SELECT id FROM tasks WHERE task_id = $1) AND client_timestamp < $2
                 AND NOT EXISTS(
                     SELECT FROM report_aggregations
-                    WHERE report_aggregations.client_report_id = client_reports.report_id)  -- this join is very slow, fix before deploying",
+                    WHERE report_aggregations.client_report_id = client_reports.report_id)  -- TODO(#1467): this join is very slow, fix before deploying",
             )
             .await?;
         self.execute(

--- a/aggregator_core/src/datastore/test_util.rs
+++ b/aggregator_core/src/datastore/test_util.rs
@@ -19,6 +19,8 @@ use tokio::sync::{oneshot, Mutex};
 use tokio_postgres::{connect, Config, NoTls};
 use tracing::trace;
 
+use super::SUPPORTED_SCHEMA_VERSIONS;
+
 struct EphemeralDatabase {
     port_number: u16,
     shutdown_barrier: Arc<Barrier>,
@@ -219,7 +221,13 @@ pub async fn ephemeral_datastore_schema_version(schema_version: i64) -> Ephemera
 
 /// Creates a new, empty EphemeralDatastore with all schema migrations applied to it.
 pub async fn ephemeral_datastore() -> EphemeralDatastore {
-    ephemeral_datastore_schema_version(i64::MAX).await
+    ephemeral_datastore_schema_version(
+        *SUPPORTED_SCHEMA_VERSIONS
+            .iter()
+            .max()
+            .expect("SUPPORTED_SCHEMA_VERSIONS is empty"),
+    )
+    .await
 }
 
 /// Creates a new, empty EphemeralDatabase by applying all available schema migrations,

--- a/db/00000000000010_rm_client_report_fk.down.sql
+++ b/db/00000000000010_rm_client_report_fk.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE report_aggregations DROP COLUMN client_timestamp;
+ALTER TABLE report_aggregations DROP COLUMN client_report_id;
+ALTER TABLE report_aggregations ADD COLUMN client_report_id BIGINT NOT NULL;
+ALTER TABLE report_aggregations ADD CONSTRAINT fk_client_report_id FOREIGN KEY(client_report_id) REFERENCES client_reports(id) ON DELETE CASCADE;
+CREATE INDEX report_aggregations_client_report_id_index ON report_aggregations(client_report_id);

--- a/db/00000000000010_rm_client_report_fk.up.sql
+++ b/db/00000000000010_rm_client_report_fk.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE report_aggregations DROP CONSTRAINT fk_client_report_id;
+ALTER TABLE report_aggregations DROP COLUMN client_report_id;
+ALTER TABLE report_aggregations ADD COLUMN client_report_id BYTEA NOT NULL;
+ALTER TABLE report_aggregations ADD COLUMN client_timestamp TIMESTAMP NOT NULL; -- the client timestamp this report aggregation is associated with
+CREATE INDEX report_aggregations_client_report_id_index ON report_aggregations(client_report_id);


### PR DESCRIPTION
This is required to allow client reports to be GC'ed independently of aggregation jobs; notably, this is the only foreign-key relationship crossing the reports/aggregations/collections boundary.

The changes are, roughly:
  * The report_aggregations table now stores the client report ID, rather than a reference to a client_reports row, as well as the client_timestamp of the report.
  * At the start of the aggregation process, if a client report can't be found, it fails aggregation of that report (with a ReportDropped error) rather than failing the entire aggregtion.

Rather than copying input share information at time of the first aggregation step, we could instead copy it at time of aggregation job creation. The upside is that this would remove the possibility of the client report being GC'ed between aggregation job creation & the first step. However, I think aggregating reports that are actively being GC'ed is a marginal enough case that it does not warrant the extra storage complexity to make this happen.

Part of #1467.