### PR TITLE
Move `client_timestamp_interval` from batch_aggregations to batches.

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1935,6 +1935,7 @@ impl VdafOps {
                                         aggregation_param.as_ref().clone(),
                                         batch_state,
                                         0,
+                                        Interval::EMPTY,
                                     ),
                                 )),
 
@@ -2069,11 +2070,10 @@ impl VdafOps {
                             )
                         })?;
 
-                    let (batch_aggregations, _) = try_join!(
-                        Q::get_batch_aggregations_for_collection_identifier(
+                    let (batches, _) = try_join!(
+                        Q::get_batches_for_collection_identifier(
                             tx,
                             &task,
-                            vdaf.as_ref(),
                             collection_job.batch_identifier(),
                             collection_job.aggregation_parameter()
                         ),
@@ -2083,9 +2083,9 @@ impl VdafOps {
                     // Merge the intervals spanned by the constituent batch aggregations into the
                     // interval spanned by the collection.
                     let mut spanned_interval: Option<Interval> = None;
-                    for interval in batch_aggregations
+                    for interval in batches
                         .iter()
-                        .map(BatchAggregation::<SEED_SIZE, Q, A>::client_timestamp_interval)
+                        .map(Batch::<SEED_SIZE, Q, A>::client_timestamp_interval)
                     {
                         match spanned_interval {
                             Some(m) => spanned_interval = Some(m.merge(interval)?),
@@ -2519,7 +2519,6 @@ fn empty_batch_aggregations<
                 BatchAggregationState::Collected,
                 None,
                 0,
-                Interval::EMPTY,
                 ReportIdChecksum::default(),
             ))
         } else {

--- a/aggregator/src/aggregator/accumulator.rs
+++ b/aggregator/src/aggregator/accumulator.rs
@@ -11,11 +11,8 @@ use janus_aggregator_core::{
     query_type::AccumulableQueryType,
     task::Task,
 };
-use janus_core::{
-    report_id::ReportIdChecksumExt,
-    time::{Clock, IntervalExt},
-};
-use janus_messages::{Interval, ReportId, ReportIdChecksum, Time};
+use janus_core::{report_id::ReportIdChecksumExt, time::Clock};
+use janus_messages::{ReportId, ReportIdChecksum, Time};
 use prio::vdaf;
 use rand::{thread_rng, Rng};
 use std::{
@@ -82,8 +79,6 @@ impl<const SEED_SIZE: usize, Q: AccumulableQueryType, A: vdaf::Aggregator<SEED_S
     ) -> Result<(), datastore::Error> {
         let batch_identifier =
             Q::to_batch_identifier(&self.task, partial_batch_identifier, client_timestamp)?;
-        let client_timestamp_interval =
-            Interval::from_time(client_timestamp).map_err(|e| datastore::Error::User(e.into()))?;
         let batch_aggregation_fn = || {
             BatchAggregation::new(
                 *self.task.id(),
@@ -93,7 +88,6 @@ impl<const SEED_SIZE: usize, Q: AccumulableQueryType, A: vdaf::Aggregator<SEED_S
                 BatchAggregationState::Aggregating,
                 Some(A::AggregateShare::from(output_share.clone())),
                 1,
-                client_timestamp_interval,
                 ReportIdChecksum::for_report_id(report_id),
             )
         };

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -728,11 +728,11 @@ mod tests {
             dummy_vdaf::{self},
             install_test_trace_subscriber,
         },
-        time::{Clock, MockClock},
+        time::{Clock, IntervalExt, MockClock},
     };
     use janus_messages::{
         query_type::{FixedSize, TimeInterval},
-        AggregationJobRound, ReportId, Role, TaskId, Time,
+        AggregationJobRound, Interval, ReportId, Role, TaskId, Time,
     };
     use prio::vdaf::{self, prio3::Prio3Count};
     use std::{collections::HashSet, iter, sync::Arc, time::Duration};
@@ -858,7 +858,8 @@ mod tests {
                 batch_identifier,
                 (),
                 BatchState::Open,
-                1
+                1,
+                Interval::from_time(&report_time).unwrap(),
             )])
         );
 
@@ -972,6 +973,7 @@ mod tests {
                 (),
                 BatchState::Open,
                 agg_jobs.len().try_into().unwrap(),
+                Interval::from_time(&report_time).unwrap(),
             )])
         );
     }
@@ -1093,7 +1095,8 @@ mod tests {
                 batch_identifier,
                 (),
                 BatchState::Open,
-                1
+                1,
+                Interval::from_time(&report_time).unwrap(),
             )])
         );
     }
@@ -1144,6 +1147,7 @@ mod tests {
                         (),
                         BatchState::Closed,
                         0,
+                        Interval::from_time(&report_time).unwrap(),
                     ),
                 )
                 .await?;
@@ -1216,6 +1220,7 @@ mod tests {
                 (),
                 BatchState::Closed,
                 0,
+                Interval::from_time(&report_time).unwrap(),
             )])
         );
     }
@@ -1369,6 +1374,7 @@ mod tests {
                     (),
                     BatchState::Open,
                     5,
+                    Interval::from_time(&report_time).unwrap(),
                 ),
                 Batch::new(
                     *task.id(),
@@ -1376,6 +1382,7 @@ mod tests {
                     (),
                     BatchState::Open,
                     4,
+                    Interval::from_time(&report_time).unwrap(),
                 ),
             ])
         );

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -1045,6 +1045,7 @@ mod tests {
                             (),
                             BatchState::Closing,
                             1,
+                            Interval::from_time(&time).unwrap(),
                         ),
                     )
                     .await?;
@@ -1175,6 +1176,7 @@ mod tests {
             (),
             BatchState::Closed,
             0,
+            Interval::from_time(&time).unwrap(),
         );
         let want_collection_job = collection_job.with_state(CollectionJobState::Collectable);
 
@@ -1361,6 +1363,7 @@ mod tests {
                             (),
                             BatchState::Closing,
                             1,
+                            Interval::from_time(&time).unwrap(),
                         ),
                     )
                     .await?;
@@ -1500,6 +1503,7 @@ mod tests {
             (),
             BatchState::Closing,
             1,
+            Interval::from_time(&time).unwrap(),
         );
 
         let (
@@ -1678,6 +1682,7 @@ mod tests {
                             (),
                             BatchState::Open,
                             1,
+                            Interval::from_time(report.metadata().time()).unwrap(),
                         ),
                     )
                     .await?;
@@ -1798,6 +1803,7 @@ mod tests {
             (),
             BatchState::Open,
             1,
+            Interval::from_time(report.metadata().time()).unwrap(),
         );
 
         let (got_aggregation_job, got_report_aggregation, got_batch) = ds
@@ -1954,6 +1960,7 @@ mod tests {
                             (),
                             BatchState::Closing,
                             1,
+                            Interval::from_time(report.metadata().time()).unwrap(),
                         ),
                     )
                     .await?;
@@ -1964,6 +1971,7 @@ mod tests {
                             (),
                             BatchState::Closing,
                             1,
+                            Interval::EMPTY,
                         ),
                     )
                     .await?;
@@ -2098,7 +2106,6 @@ mod tests {
             BatchAggregationState::Aggregating,
             Some(leader_aggregate_share),
             1,
-            Interval::from_time(report.metadata().time()).unwrap(),
             ReportIdChecksum::for_report_id(report.metadata().id()),
         )]);
         let want_active_batch = Batch::<PRIO3_VERIFY_KEY_LENGTH, TimeInterval, Prio3Count>::new(
@@ -2107,6 +2114,7 @@ mod tests {
             (),
             BatchState::Closed,
             0,
+            Interval::from_time(report.metadata().time()).unwrap(),
         );
         let want_other_batch = Batch::<PRIO3_VERIFY_KEY_LENGTH, TimeInterval, Prio3Count>::new(
             *task.id(),
@@ -2114,6 +2122,7 @@ mod tests {
             (),
             BatchState::Closing,
             1,
+            Interval::EMPTY,
         );
 
         let (
@@ -2207,7 +2216,6 @@ mod tests {
                     *agg.state(),
                     agg.aggregate_share().cloned(),
                     agg.report_count(),
-                    *agg.client_timestamp_interval(),
                     *agg.checksum(),
                 )
             })
@@ -2327,6 +2335,7 @@ mod tests {
                             (),
                             BatchState::Closing,
                             1,
+                            Interval::from_time(report.metadata().time()).unwrap(),
                         ),
                     )
                     .await?;
@@ -2456,7 +2465,6 @@ mod tests {
             BatchAggregationState::Aggregating,
             Some(leader_aggregate_share),
             1,
-            Interval::from_time(report.metadata().time()).unwrap(),
             ReportIdChecksum::for_report_id(report.metadata().id()),
         )]);
         let want_batch = Batch::<PRIO3_VERIFY_KEY_LENGTH, FixedSize, Prio3Count>::new(
@@ -2465,6 +2473,7 @@ mod tests {
             (),
             BatchState::Closed,
             0,
+            Interval::from_time(report.metadata().time()).unwrap(),
         );
         let want_collection_job = collection_job.with_state(CollectionJobState::Collectable);
 
@@ -2535,7 +2544,6 @@ mod tests {
                     *agg.state(),
                     agg.aggregate_share().cloned(),
                     agg.report_count(),
-                    *agg.client_timestamp_interval(),
                     *agg.checksum(),
                 )
             })
@@ -2634,6 +2642,7 @@ mod tests {
                             (),
                             BatchState::Open,
                             1,
+                            Interval::from_time(report.metadata().time()).unwrap(),
                         ),
                     )
                     .await?;
@@ -2669,6 +2678,7 @@ mod tests {
             (),
             BatchState::Open,
             0,
+            Interval::from_time(report.metadata().time()).unwrap(),
         );
 
         let (got_aggregation_job, got_report_aggregation, got_batch, got_leases) = ds
@@ -2848,6 +2858,7 @@ mod tests {
                         (),
                         BatchState::Open,
                         1,
+                        Interval::from_time(report.metadata().time()).unwrap(),
                     ),
                 )
                 .await?;
@@ -2984,6 +2995,7 @@ mod tests {
                 (),
                 BatchState::Open,
                 0,
+                Interval::from_time(report.metadata().time()).unwrap(),
             ),
         );
     }

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -641,7 +641,6 @@ mod tests {
                             BatchAggregationState::Aggregating,
                             Some(dummy_vdaf::AggregateShare(0)),
                             5,
-                            Interval::from_time(&report_timestamp).unwrap(),
                             ReportIdChecksum::get_decoded(&[3; 32]).unwrap(),
                         ),
                     )
@@ -659,7 +658,6 @@ mod tests {
                             BatchAggregationState::Aggregating,
                             Some(dummy_vdaf::AggregateShare(0)),
                             5,
-                            Interval::from_time(&report_timestamp).unwrap(),
                             ReportIdChecksum::get_decoded(&[2; 32]).unwrap(),
                         ),
                     )
@@ -799,7 +797,6 @@ mod tests {
                         BatchAggregationState::Aggregating,
                         Some(dummy_vdaf::AggregateShare(0)),
                         5,
-                        Interval::from_time(&report_timestamp).unwrap(),
                         ReportIdChecksum::get_decoded(&[3; 32]).unwrap(),
                     ),
                 )
@@ -818,7 +815,6 @@ mod tests {
                         BatchAggregationState::Aggregating,
                         Some(dummy_vdaf::AggregateShare(0)),
                         5,
-                        Interval::from_time(&report_timestamp).unwrap(),
                         ReportIdChecksum::get_decoded(&[2; 32]).unwrap(),
                     ),
                 )

--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -3,8 +3,9 @@ use http::StatusCode;
 use janus_aggregator_core::{
     datastore::{
         models::{
-            AggregationJob, AggregationJobState, BatchAggregation, BatchAggregationState,
-            CollectionJobState, LeaderStoredReport, ReportAggregation, ReportAggregationState,
+            AggregationJob, AggregationJobState, Batch, BatchAggregation, BatchAggregationState,
+            BatchState, CollectionJobState, LeaderStoredReport, ReportAggregation,
+            ReportAggregationState,
         },
         test_util::{ephemeral_datastore, EphemeralDatastore},
         Datastore,
@@ -214,10 +215,20 @@ async fn setup_fixed_size_current_batch_collection_job_test_case(
                             BatchAggregationState::Aggregating,
                             Some(dummy_vdaf::AggregateShare(0)),
                             task.min_batch_size() + 1,
-                            interval,
                             ReportIdChecksum::default(),
                         ),
                     )
+                    .await
+                    .unwrap();
+
+                    tx.put_batch::<0, FixedSize, dummy_vdaf::Vdaf>(&Batch::new(
+                        *task.id(),
+                        batch_id,
+                        dummy_vdaf::AggregationParam::default(),
+                        BatchState::Closed,
+                        0,
+                        interval,
+                    ))
                     .await
                     .unwrap();
 

--- a/core/src/time.rs
+++ b/core/src/time.rs
@@ -264,6 +264,9 @@ pub trait IntervalExt: Sized {
     /// Returns a new minimal [`Interval`] that contains both this interval and `other`.
     fn merge(&self, other: &Self) -> Result<Self, Error>;
 
+    // Returns a new minimal [`Interval`] that contains both this interval and the given time.
+    fn merged_with(&self, time: &Time) -> Result<Self, Error>;
+
     /// Returns a 0-length `[Interval]` that contains exactly the provided [`Time`].
     fn from_time(time: &Time) -> Result<Self, Error>;
 
@@ -291,6 +294,10 @@ impl IntervalExt for Interval {
 
         // This can't actually fail for any valid Intervals
         Self::new(*min_time, max_time.difference(min_time)?)
+    }
+
+    fn merged_with(&self, time: &Time) -> Result<Self, Error> {
+        self.merge(&Self::from_time(time)?)
     }
 
     fn from_time(time: &Time) -> Result<Self, Error> {

--- a/db/00000000000011_batches_client_timestamp_interval.down.sql
+++ b/db/00000000000011_batches_client_timestamp_interval.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE batches DROP COLUMN client_timestamp_interval;
+ALTER TABLE batch_aggregations ADD COLUMN client_timestamp_interval TSRANGE NOT NULL;

--- a/db/00000000000011_batches_client_timestamp_interval.up.sql
+++ b/db/00000000000011_batches_client_timestamp_interval.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE batch_aggregations DROP COLUMN client_timestamp_interval;
+ALTER TABLE batches ADD COLUMN client_timestamp_interval TSRANGE NOT NULL;


### PR DESCRIPTION
The incremental GC design expected batches to have a `client_timestamp_interval` field; I tried writing the queries to read from the sharded batch_aggregations table, but this was painful, so I move it to batches instead and implement the design as written. Eventually I want to merge `batches`, `batch_aggregations`, and `outstanding_batches`; this is one step along that path.

Part of #1467.