### PR TITLE
aggregator API: default to bearer tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2037,6 +2037,7 @@ dependencies = [
  "rand",
  "reqwest",
  "ring",
+ "rstest",
  "serde",
  "serde_json",
  "serde_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ opentelemetry = { version = "0.19", features = ["metrics"] }
 prio = { version = "0.12.2", features = ["multithreaded"] }
 serde = { version = "1.0.175", features = ["derive"] }
 rstest = "0.17.0"
+thiserror = "1.0"
+tokio = { version = "1.29", features = ["full", "tracing"] }
 trillium = "0.2.9"
 trillium-api = { version = "0.2.0-rc.3", default-features = false }
 trillium-caching-headers = "0.2.1"

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -82,7 +82,7 @@ signal-hook = "0.3.17"
 signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
 testcontainers = { version = "0.14.0", optional = true }
 thiserror = "1.0"
-tokio = { version = "1.29", features = ["full", "tracing"] }
+tokio.workspace = true
 tokio-postgres = { version = "0.7.8", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1", "array-impls"] }
 tonic = { version = "0.8", optional = true, features = ["tls", "tls-webpki-roots"] }                                      # keep this version in sync with what opentelemetry-otlp uses
 tracing = "0.1.37"

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use janus_aggregator_core::{datastore::Datastore, instrumented};
 use janus_core::{
     http::extract_bearer_token,
-    task::{AuthenticationToken, DapAuthToken, DAP_AUTH_HEADER},
+    task::{AuthenticationToken, DAP_AUTH_HEADER},
     time::Clock,
 };
 use janus_messages::{
@@ -538,14 +538,13 @@ fn parse_auth_token(task_id: &TaskId, conn: &Conn) -> Result<Option<Authenticati
     if let Some(bearer_token) =
         extract_bearer_token(conn).map_err(|_| Error::UnauthorizedRequest(*task_id))?
     {
-        return Ok(Some(AuthenticationToken::Bearer(bearer_token)));
+        return Ok(Some(bearer_token));
     }
 
     conn.request_headers()
         .get(DAP_AUTH_HEADER)
         .map(|value| {
-            DapAuthToken::try_from(value.as_ref().to_vec())
-                .map(AuthenticationToken::DapAuth)
+            AuthenticationToken::new_dap_auth_token_from_bytes(value.as_ref())
                 .map_err(|e| Error::BadRequest(format!("bad DAP-Auth-Token header: {e}")))
         })
         .transpose()
@@ -1376,7 +1375,7 @@ mod tests {
             .aggregator_auth_tokens()
             .iter()
             .find(|token| matches!(token, AuthenticationToken::DapAuth(_)))
-            .map(|token| AuthenticationToken::Bearer(token.as_ref().to_vec()))
+            .map(|token| AuthenticationToken::new_bearer_token_from_bytes(token.as_ref()).unwrap())
             .unwrap();
 
         for auth_token in [Some(wrong_token_value), Some(wrong_token_format), None] {

--- a/aggregator_core/Cargo.toml
+++ b/aggregator_core/Cargo.toml
@@ -53,7 +53,7 @@ serde_yaml = "0.9.25"
 sqlx = { version = "0.6.3", optional = true, features = ["runtime-tokio-rustls", "migrate", "postgres"] }
 testcontainers = { version = "0.14.0", optional = true }
 thiserror = "1.0"
-tokio = { version = "1.29", features = ["full", "tracing"] }
+tokio.workspace = true
 tokio-postgres = { version = "0.7.8", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1", "array-impls"] }
 tracing = "0.1.37"
 tracing-log = "0.1.3"

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -7,7 +7,7 @@ use derivative::Derivative;
 use janus_core::{
     hpke::HpkeKeypair,
     report_id::ReportIdChecksumExt,
-    task::{AuthenticationToken, DapAuthToken, VdafInstance},
+    task::{AuthenticationToken, VdafInstance},
     time::{DurationExt, IntervalExt, TimeExt},
 };
 use janus_messages::{
@@ -47,13 +47,14 @@ pub enum AuthenticationTokenType {
 }
 
 impl AuthenticationTokenType {
-    pub fn as_authentication(&self, token: &[u8]) -> Result<AuthenticationToken, Error> {
+    pub fn as_authentication(&self, token_bytes: &[u8]) -> Result<AuthenticationToken, Error> {
         match self {
-            Self::DapAuthToken => DapAuthToken::try_from(token.to_vec())
-                .map(AuthenticationToken::DapAuth)
-                .map_err(|e| Error::DbState(format!("invalid DAP auth token in database: {e:?}"))),
-            Self::AuthorizationBearerToken => Ok(AuthenticationToken::Bearer(token.into())),
+            Self::DapAuthToken => AuthenticationToken::new_dap_auth_token_from_bytes(token_bytes),
+            Self::AuthorizationBearerToken => {
+                AuthenticationToken::new_bearer_token_from_bytes(token_bytes)
+            }
         }
+        .map_err(|e| Error::DbState(format!("invalid DAP auth token in database: {e:?}")))
     }
 }
 

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -784,7 +784,7 @@ mod tests {
     };
     use janus_core::{
         hpke::{test_util::generate_test_hpke_config_and_private_key, HpkeKeypair, HpkePrivateKey},
-        task::{AuthenticationToken, DapAuthToken, PRIO3_VERIFY_KEY_LENGTH},
+        task::{AuthenticationToken, PRIO3_VERIFY_KEY_LENGTH},
         test_util::roundtrip_encoding,
         time::DurationExt,
     };
@@ -1017,10 +1017,14 @@ mod tests {
                     HpkeAeadId::Aes128Gcm,
                     HpkePublicKey::from(b"collector hpke public key".to_vec()),
                 ),
-                Vec::from([AuthenticationToken::DapAuth(
-                    DapAuthToken::try_from(b"aggregator token".to_vec()).unwrap(),
-                )]),
-                Vec::from([AuthenticationToken::Bearer(b"collector token".to_vec())]),
+                Vec::from([AuthenticationToken::new_dap_auth_token_from_string(
+                    "YWdncmVnYXRvciB0b2tlbg",
+                )
+                .unwrap()]),
+                Vec::from([AuthenticationToken::new_bearer_token_from_string(
+                    "Y29sbGVjdG9yIHRva2Vu",
+                )
+                .unwrap()]),
                 [HpkeKeypair::new(
                     HpkeConfig::new(
                         HpkeConfigId::from(255),
@@ -1197,7 +1201,10 @@ mod tests {
                     HpkeAeadId::Aes128Gcm,
                     HpkePublicKey::from(b"collector hpke public key".to_vec()),
                 ),
-                Vec::from([AuthenticationToken::Bearer(b"aggregator token".to_vec())]),
+                Vec::from([AuthenticationToken::new_bearer_token_from_string(
+                    "YWdncmVnYXRvciB0b2tlbg",
+                )
+                .unwrap()]),
                 Vec::new(),
                 [HpkeKeypair::new(
                     HpkeConfig::new(
@@ -1304,7 +1311,7 @@ mod tests {
                 Token::Str("type"),
                 Token::Str("Bearer"),
                 Token::Str("token"),
-                Token::Str("YWdncmVnYXRvciB0b2tlbg=="),
+                Token::Str("YWdncmVnYXRvciB0b2tlbg"),
                 Token::StructEnd,
                 Token::SeqEnd,
                 Token::Str("collector_auth_tokens"),

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -19,8 +19,8 @@ janus_messages.workspace = true
 prio.workspace = true
 rand = "0.8"
 reqwest = { version = "0.11.18", default-features = false, features = ["rustls-tls", "json"] }
-thiserror = "1.0"
-tokio = { version = "1.29", features = ["full"] }
+thiserror.workspace = true
+tokio.workspace = true
 tracing = "0.1.37"
 url = "2.4.0"
 

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -30,8 +30,8 @@ prio.workspace = true
 rand = { version = "0.8", features = ["min_const_gen"] }
 reqwest = { version = "0.11.18", default-features = false, features = ["rustls-tls", "json"] }
 retry-after = "0.3.1"
-thiserror = "1.0"
-tokio = { version = "1.29", features = ["full"] }
+thiserror.workspace = true
+tokio.workspace = true
 tracing = "0.1.37"
 url = "2.4.0"
 

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -29,7 +29,7 @@
 //! let parameters = CollectorParameters::new(
 //!     task_id,
 //!     "https://example.com/dap/".parse().unwrap(),
-//!     AuthenticationToken::Bearer(b"my-authentication-token".to_vec()),
+//!     AuthenticationToken::new_bearer_token_from_string("Y29sbGVjdG9yIHRva2Vu").unwrap(),
 //!     hpke_keypair.config().clone(),
 //!     hpke_keypair.private_key().clone(),
 //! );
@@ -704,7 +704,7 @@ mod tests {
         let parameters = CollectorParameters::new(
             random(),
             server_url,
-            AuthenticationToken::Bearer(b"token".to_vec()),
+            AuthenticationToken::new_bearer_token_from_string("Y29sbGVjdG9yIHRva2Vu").unwrap(),
             hpke_keypair.config().clone(),
             hpke_keypair.private_key().clone(),
         )
@@ -805,7 +805,7 @@ mod tests {
         let collector_parameters = CollectorParameters::new(
             random(),
             "http://example.com/dap".parse().unwrap(),
-            AuthenticationToken::Bearer(b"token".to_vec()),
+            AuthenticationToken::new_bearer_token_from_string("Y29sbGVjdG9yIHRva2Vu").unwrap(),
             hpke_keypair.config().clone(),
             hpke_keypair.private_key().clone(),
         );
@@ -818,7 +818,7 @@ mod tests {
         let collector_parameters = CollectorParameters::new(
             random(),
             "http://example.com".parse().unwrap(),
-            AuthenticationToken::Bearer(b"token".to_vec()),
+            AuthenticationToken::new_bearer_token_from_string("Y29sbGVjdG9yIHRva2Vu").unwrap(),
             hpke_keypair.config().clone(),
             hpke_keypair.private_key().clone(),
         );
@@ -838,7 +838,6 @@ mod tests {
         let collector = setup_collector(&mut server, vdaf);
         let (auth_header, auth_value) =
             collector.parameters.authentication.request_authentication();
-        let auth_value = String::from_utf8(auth_value).unwrap();
 
         let batch_interval = Interval::new(
             Time::from_seconds_since_epoch(1_000_000),
@@ -1224,7 +1223,7 @@ mod tests {
         let parameters = CollectorParameters::new(
             random(),
             server_url,
-            AuthenticationToken::Bearer(Vec::from([0x41u8; 16])),
+            AuthenticationToken::new_bearer_token_from_bytes(Vec::from([0x41u8; 16])).unwrap(),
             hpke_keypair.config().clone(),
             hpke_keypair.private_key().clone(),
         )
@@ -1247,7 +1246,7 @@ mod tests {
                 CONTENT_TYPE.as_str(),
                 CollectionReq::<TimeInterval>::MEDIA_TYPE,
             )
-            .match_header(AUTHORIZATION.as_str(), "Bearer QUFBQUFBQUFBQUFBQUFBQQ==")
+            .match_header(AUTHORIZATION.as_str(), "Bearer AAAAAAAAAAAAAAAA")
             .with_status(201)
             .expect(1)
             .create_async()
@@ -1255,15 +1254,15 @@ mod tests {
 
         let job = collector
             .start_collection(Query::new_time_interval(batch_interval), &())
-            .await
-            .unwrap();
-        assert_eq!(job.query.batch_interval(), &batch_interval);
+            .await;
 
         mocked_collect_start_success.assert_async().await;
+        let job = job.unwrap();
+        assert_eq!(job.query.batch_interval(), &batch_interval);
 
         let mocked_collect_complete = server
             .mock("POST", job.collection_job_url.path())
-            .match_header(AUTHORIZATION.as_str(), "Bearer QUFBQUFBQUFBQUFBQUFBQQ==")
+            .match_header(AUTHORIZATION.as_str(), "Bearer AAAAAAAAAAAAAAAA")
             .with_status(200)
             .with_header(
                 CONTENT_TYPE.as_str(),

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -57,8 +57,8 @@ serde_yaml = "0.9.25"
 stopper = { version = "0.2.0", optional = true }
 tempfile = { version = "3", optional = true }
 testcontainers = { version = "0.14", optional = true }
-thiserror = "1.0"
-tokio = { version = "1.29", features = ["macros", "net", "rt"] }
+thiserror.workspace = true
+tokio.workspace = true
 tokio-stream = { version = "0.1.14", features = ["net"], optional = true }
 tracing = "0.1.37"
 tracing-log = { version = "0.1.3", optional = true }
@@ -71,5 +71,6 @@ hex = { version = "0.4", features = ["serde"] }  # ensure this remains compatibl
 janus_core = { path = ".", features = ["test-util"] }
 kube.workspace = true
 mockito = "1.1.0"
+rstest.workspace = true
 serde_test = "1.0.175"
 url = "2.4.0"

--- a/docs/samples/tasks.yaml
+++ b/docs/samples/tasks.yaml
@@ -75,9 +75,9 @@
     # to "aggregator-235242f99406c4fd28b820c32eab0f68".
   - type: "DapAuth"
     token: "YWdncmVnYXRvci0yMzUyNDJmOTk0MDZjNGZkMjhiODIwYzMyZWFiMGY2OA"
-    # Bearer token values are encoded in base64 with padding.
+    # Bearer token values are encoded in unpadded base64url.
   - type: "Bearer"
-    token: "YWdncmVnYXRvci04NDc1NjkwZjJmYzQzMDBmYjE0NmJiMjk1NDIzNDk1NA=="
+    token: "YWdncmVnYXRvci04NDc1NjkwZjJmYzQzMDBmYjE0NmJiMjk1NDIzNDk1NA"
 
   # Authentication tokens shared between the leader and the collector, and used
   # to authenticate collector-to-leader requests. For leader tasks, this has the
@@ -127,7 +127,7 @@
     public_key: KHRLcWgfWxli8cdOLPsgsZPttHXh0ho3vLVLrW-63lE
   aggregator_auth_tokens:
   - type: "Bearer"
-    token: "YWdncmVnYXRvci1jZmE4NDMyZjdkMzllMjZiYjU3OGUzMzY5Mzk1MWQzNQ=="
+    token: "YWdncmVnYXRvci1jZmE4NDMyZjdkMzllMjZiYjU3OGUzMzY5Mzk1MWQzNQ"
   # Note that this task does not have any collector authentication tokens, since
   # it is a helper role task.
   collector_auth_tokens: []

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -33,7 +33,7 @@ reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"
 serde.workspace = true
 serde_json = "1.0.103"
 testcontainers = "0.14.0"
-tokio = { version = "1", features = ["full", "tracing"] }
+tokio.workspace = true
 url = { version = "2.4.0", features = ["serde"] }
 
 [dev-dependencies]

--- a/integration_tests/src/divviup_api_client.rs
+++ b/integration_tests/src/divviup_api_client.rs
@@ -81,6 +81,15 @@ pub struct DivviUpAggregator {
     pub dap_url: Url,
 }
 
+/// Representation of a collector auth token in divviup-api.
+#[derive(Deserialize)]
+pub struct CollectorAuthToken {
+    /// Type of the authentication token. Always "Bearer" in divviup-api.
+    pub r#type: String,
+    /// Encoded value of the token. The encoding is opaque to divviup-api.
+    pub token: String,
+}
+
 const DIVVIUP_CONTENT_TYPE: &str = "application/vnd.divviup+json;version=0.1";
 
 pub struct DivviupApiClient {
@@ -176,7 +185,10 @@ impl DivviupApiClient {
         .await
     }
 
-    pub async fn list_collector_auth_tokens(&self, task: &DivviUpApiTask) -> Vec<String> {
+    pub async fn list_collector_auth_tokens(
+        &self,
+        task: &DivviUpApiTask,
+    ) -> Vec<CollectorAuthToken> {
         // Hack: we must choose some specialization for the B type despite the request having no
         // Body
         self.make_request::<String, _>(

--- a/interop_binaries/Cargo.toml
+++ b/interop_binaries/Cargo.toml
@@ -48,7 +48,7 @@ serde.workspace = true
 serde_json = "1.0.103"
 sqlx = { version = "0.6.3", features = ["runtime-tokio-rustls", "migrate", "postgres"] }
 testcontainers = { version = "0.14" }
-tokio = { version = "1.29", features = ["full", "tracing"] }
+tokio.workspace = true
 tracing = "0.1.37"
 tracing-log = "0.1.3"
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt"] }

--- a/interop_binaries/src/bin/janus_interop_aggregator.rs
+++ b/interop_binaries/src/bin/janus_interop_aggregator.rs
@@ -11,10 +11,7 @@ use janus_aggregator_core::{
     task::{self, Task},
     SecretBytes,
 };
-use janus_core::{
-    task::{AuthenticationToken, DapAuthToken},
-    time::RealClock,
-};
+use janus_core::{task::AuthenticationToken, time::RealClock};
 use janus_interop_binaries::{
     status::{ERROR, SUCCESS},
     AddTaskResponse, AggregatorAddTaskRequest, AggregatorRole, HpkeConfigRegistry, Keyring,
@@ -42,10 +39,9 @@ async fn handle_add_task(
     request: AggregatorAddTaskRequest,
 ) -> anyhow::Result<()> {
     let vdaf = request.vdaf.into();
-    let leader_authentication_token = AuthenticationToken::DapAuth(
-        DapAuthToken::try_from(request.leader_authentication_token.into_bytes())
-            .context("invalid header value in \"leader_authentication_token\"")?,
-    );
+    let leader_authentication_token =
+        AuthenticationToken::new_dap_auth_token_from_string(request.leader_authentication_token)
+            .context("invalid header value in \"leader_authentication_token\"")?;
     let vdaf_verify_key = SecretBytes::new(
         URL_SAFE_NO_PAD
             .decode(request.vdaf_verify_key)
@@ -64,10 +60,10 @@ async fn handle_add_task(
                 return Err(anyhow::anyhow!("collector authentication token is missing"))
             }
             (AggregatorRole::Leader, Some(collector_authentication_token)) => {
-                Vec::from([AuthenticationToken::DapAuth(
-                    DapAuthToken::try_from(collector_authentication_token.into_bytes())
-                        .context("invalid header value in \"collector_authentication_token\"")?,
-                )])
+                Vec::from([AuthenticationToken::new_dap_auth_token_from_string(
+                    collector_authentication_token,
+                )
+                .context("invalid header value in \"collector_authentication_token\"")?])
             }
             (AggregatorRole::Helper, _) => Vec::new(),
         };

--- a/interop_binaries/src/bin/janus_interop_collector.rs
+++ b/interop_binaries/src/bin/janus_interop_collector.rs
@@ -7,7 +7,6 @@ use fixed::types::extra::{U15, U31, U63};
 #[cfg(feature = "fpvec_bounded_l2")]
 use fixed::{FixedI16, FixedI32, FixedI64};
 use janus_collector::{Collector, CollectorParameters};
-use janus_core::task::DapAuthToken;
 use janus_core::{
     hpke::HpkeKeypair,
     task::{AuthenticationToken, VdafInstance},
@@ -167,10 +166,9 @@ async fn handle_add_task(
     let keypair = keyring.lock().await.get_random_keypair();
     let hpke_config = keypair.config().clone();
 
-    let auth_token = AuthenticationToken::DapAuth(
-        DapAuthToken::try_from(request.collector_authentication_token.into_bytes())
-            .context("invalid header value in \"collector_authentication_token\"")?,
-    );
+    let auth_token =
+        AuthenticationToken::new_dap_auth_token_from_string(request.collector_authentication_token)
+            .context("invalid header value in \"collector_authentication_token\"")?;
 
     entry.or_insert(TaskState {
         keypair,

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -23,7 +23,7 @@ janus_messages.workspace = true
 prio.workspace = true
 reqwest = { version = "0.11.18", default-features = false, features = ["rustls-tls", "json"] }
 serde_yaml = "0.9.25"
-tokio = { version = "1.29", features = ["full"] }
+tokio.workspace = true
 tracing = "0.1.37"
 tracing-log = "0.1.3"
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt"] }

--- a/tools/tests/cmd/collect.trycmd
+++ b/tools/tests/cmd/collect.trycmd
@@ -33,7 +33,7 @@ Authorization:
           [env: DAP_AUTH_TOKEN=]
 
       --authorization-bearer-token <AUTHORIZATION_BEARER_TOKEN>
-          Authentication token for the "Authorization: Bearer ..." HTTP header, in base64
+          Authentication token for the "Authorization: Bearer ..." HTTP header
           
           [env: AUTHORIZATION_BEARER_TOKEN=]
 


### PR DESCRIPTION
Previously, the aggregator API assumed that any aggregator or collector auth tokens it was handling were `AuthenticationToken::DapAuth`. Janus must support those for the interop testing API and to work with Daphne, but generally, we prefer to use more boring `Authorization: Bearer` tokens. Certainly any tasks provisioned via the aggregator API and `divviup-api` should use bearer tokens.

With this PR, we augment the `PostTaskReq` and `PostTaskResp` messages so that they use `AuthenticationToken` to represent aggregator and collector tokens, meaning that on the wire, a token now looks like:

```
{
  "type": "Bearer",
  "token": "AAAAAAAAA<etc.>"
}
```

Also, when the aggregator API generates either kind of token, it now generates a bearer token. I'm not aware of any scenarios where we need to generate `DapAuth` tokens in the aggregator API so there is no affordance for requesting that kind of token.

See #472