### PR TITLE
aggregator API: idempotent task creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1917,6 +1917,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_test",
+ "thiserror",
  "tokio",
  "tracing",
  "trillium",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,9 @@ kube = { version = "0.82.2", default-features = false, features = ["client", "ru
 opentelemetry = { version = "0.19", features = ["metrics"] }
 prio = { version = "0.12.2", features = ["multithreaded"] }
 serde = { version = "1.0.180", features = ["derive"] }
+serde_json = "1.0.103"
+serde_test = "1.0.175"
+serde_yaml = "0.9.25"
 rstest = "0.17.0"
 thiserror = "1.0"
 tokio = { version = "1.29", features = ["full", "tracing"] }

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -75,13 +75,13 @@ reqwest = { version = "0.11.18", default-features = false, features = ["rustls-t
 ring = "0.16.20"
 routefinder = "0.5.3"
 serde.workspace = true
-serde_json = "1.0.103"
+serde_json.workspace = true
 serde_urlencoded = "0.7.1"
-serde_yaml = "0.9.25"
+serde_yaml.workspace = true
 signal-hook = "0.3.17"
 signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
 testcontainers = { version = "0.14.0", optional = true }
-thiserror = "1.0"
+thiserror.workspace = true
 tokio.workspace = true
 tokio-postgres = { version = "0.7.8", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1", "array-impls"] }
 tonic = { version = "0.8", optional = true, features = ["tls", "tls-webpki-roots"] }                                      # keep this version in sync with what opentelemetry-otlp uses

--- a/aggregator_api/Cargo.toml
+++ b/aggregator_api/Cargo.toml
@@ -20,8 +20,9 @@ querystring = "1.1.0"
 rand = { version = "0.8", features = ["min_const_gen"] }
 ring = "0.16.20"
 serde.workspace = true
-serde_json = "1.0.103"
-serde_test = "1.0.175"
+serde_json.workspace = true
+serde_test.workspace = true
+thiserror.workspace = true
 tracing = "0.1.37"
 trillium.workspace = true
 trillium-api.workspace = true
@@ -32,5 +33,5 @@ url = { version = "2.4.0", features = ["serde"] }
 [dev-dependencies]
 futures = "0.3.28"
 janus_aggregator_core = { workspace = true, features = ["test-util"] }
-tokio = "1.29"
+tokio.workspace = true
 trillium-testing = { workspace = true, features = ["tokio"] }

--- a/aggregator_core/Cargo.toml
+++ b/aggregator_core/Cargo.toml
@@ -48,11 +48,11 @@ regex = "1"
 reqwest = { version = "0.11.18", default-features = false, features = ["rustls-tls", "json"] }
 ring = "0.16.20"
 serde.workspace = true
-serde_json = "1.0.103"
-serde_yaml = "0.9.25"
+serde_json.workspace = true
+serde_yaml.workspace = true
 sqlx = { version = "0.7.1", optional = true, features = ["runtime-tokio-rustls", "migrate", "postgres"] }
 testcontainers = { version = "0.14.0", optional = true }
-thiserror = "1.0"
+thiserror.workspace = true
 tokio.workspace = true
 tokio-postgres = { version = "0.7.8", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1", "array-impls"] }
 tracing = "0.1.37"
@@ -70,7 +70,7 @@ janus_aggregator_core = { path = ".", features = ["test-util"] }
 janus_core = { workspace = true, features = ["test-util"] }
 rstest.workspace = true
 rstest_reuse = "0.6.0"
-serde_test = "1.0.175"
+serde_test.workspace = true
 tempfile = "3.7.0"
 tokio = { version = "1", features = ["test-util"] }  # ensure this remains compatible with the non-dev dependency
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -52,13 +52,13 @@ rand = "0.8"
 reqwest = { version = "0.11.18", default-features = false, features = ["rustls-tls", "json"] }
 ring = "0.16.20"
 serde.workspace = true
-serde_json = { version = "1.0.103", optional = true }
-serde_yaml = "0.9.25"
+serde_json = { workspace = true, optional = true }
+serde_yaml.workspace = true
 stopper = { version = "0.2.0", optional = true }
 tempfile = { version = "3", optional = true }
 testcontainers = { version = "0.14", optional = true }
 thiserror.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["macros", "net", "rt"] }
 tokio-stream = { version = "0.1.14", features = ["net"], optional = true }
 tracing = "0.1.37"
 tracing-log = { version = "0.1.3", optional = true }
@@ -72,5 +72,5 @@ janus_core = { path = ".", features = ["test-util"] }
 kube.workspace = true
 mockito = "1.1.0"
 rstest.workspace = true
-serde_test = "1.0.175"
+serde_test.workspace = true
 url = "2.4.0"

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -23,9 +23,9 @@ num_enum = "0.6.1"
 prio = { version = "0.12.2", default-features = false }
 rand = "0.8"
 serde.workspace = true
-thiserror = "1.0"
+thiserror.workspace = true
 url = "2.4.0"
 
 [dev-dependencies]
 assert_matches = "1"
-serde_test = "1.0.175"
+serde_test.workspace = true


### PR DESCRIPTION
Makes the task creation endpoint in the aggregator API idempotent, by checking whether a task corresponding to the incoming `PostTaskReq` already exists. If it does, and all the other task's parameters match the `PostTaskReq`, then we return 201 Created. If the task exists but some other parameter (e.g., min batch size) differs, we return 409 Conflict.

Deletion was already correctly handled so no new changes or test were needed.

Resolves #1507