### PR TITLE
Refactor integration tests to decouple from janus_aggregator_core::task

### DIFF
--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -21,6 +21,7 @@ http = "0.2"
 janus_aggregator = { workspace = true, features = ["test-util"] }
 janus_aggregator_core = { workspace = true, features = ["test-util"] }
 janus_client.workspace = true
+janus_collector.workspace = true
 janus_core = { workspace = true, features = ["test-util"] }
 janus_interop_binaries = { workspace = true, features = ["testcontainer"] }
 janus_messages.workspace = true

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -1,7 +1,72 @@
 //! This crate contains functionality useful for Janus integration tests.
 
+use janus_aggregator_core::task::QueryType;
+use janus_collector::AuthenticationToken;
+use janus_core::{hpke::HpkePrivateKey, task::VdafInstance};
+use janus_messages::{Duration, HpkeConfig, TaskId};
+use url::Url;
+
 pub mod client;
 pub mod daphne;
 pub mod divviup_api_client;
 pub mod interop_api;
 pub mod janus;
+
+/// Task parameters needed for an integration test. This encompasses the parameters used by either
+/// the client or collector.
+pub struct TaskParameters {
+    pub task_id: TaskId,
+    pub endpoint_fragments: EndpointFragments,
+    pub query_type: QueryType,
+    pub vdaf: VdafInstance,
+    pub min_batch_size: u64,
+    pub time_precision: Duration,
+    pub collector_hpke_config: HpkeConfig,
+    pub collector_private_key: HpkePrivateKey,
+    pub collector_auth_token: AuthenticationToken,
+}
+
+/// Components of DAP endpoints for a leader and helper aggregator. By default, the scheme is
+/// assumed to be `http:`, and the port number is assumed to be 8080.
+pub struct EndpointFragments {
+    pub leader_endpoint_host: String,
+    pub leader_endpoint_path: String,
+    pub helper_endpoint_host: String,
+    pub helper_endpoint_path: String,
+}
+
+impl EndpointFragments {
+    pub fn port_forwarded_leader_endpoint(&self, leader_port: u16) -> Url {
+        Url::parse(&format!(
+            "http://127.0.0.1:{leader_port}{}",
+            self.leader_endpoint_path
+        ))
+        .unwrap()
+    }
+
+    pub fn port_forwarded_endpoints(&self, leader_port: u16, helper_port: u16) -> Vec<Url> {
+        Vec::from([
+            self.port_forwarded_leader_endpoint(leader_port),
+            Url::parse(&format!(
+                "http://127.0.0.1:{helper_port}{}",
+                self.helper_endpoint_path
+            ))
+            .unwrap(),
+        ])
+    }
+
+    pub fn container_network_endpoints(&self) -> Vec<Url> {
+        Vec::from([
+            Url::parse(&format!(
+                "http://{}:8080{}",
+                self.leader_endpoint_host, self.leader_endpoint_path
+            ))
+            .unwrap(),
+            Url::parse(&format!(
+                "http://{}:8080{}",
+                self.helper_endpoint_host, self.helper_endpoint_path
+            ))
+            .unwrap(),
+        ])
+    }
+}

--- a/integration_tests/tests/daphne.rs
+++ b/integration_tests/tests/daphne.rs
@@ -18,10 +18,11 @@ async fn daphne_janus() {
 
     // Start servers.
     let network = generate_network_name();
-    let (collector_private_key, leader_task, helper_task) =
+    let (mut task_parameters, leader_task, helper_task) =
         test_task_builders(VdafInstance::Prio3Count, QueryType::TimeInterval);
 
     // Daphne is hardcoded to serve from a path starting with /v04/.
+    task_parameters.endpoint_fragments.leader_endpoint_path = "/v04/".to_string();
     let [leader_task, helper_task]: [Task; 2] = [leader_task, helper_task]
         .into_iter()
         .map(|task| {
@@ -39,9 +40,8 @@ async fn daphne_janus() {
 
     // Run the behavioral test.
     submit_measurements_and_verify_aggregate(
+        &task_parameters,
         (leader.port(), helper.port()),
-        &leader_task,
-        &collector_private_key,
         &ClientBackend::InProcess,
     )
     .await;
@@ -54,10 +54,11 @@ async fn janus_daphne() {
 
     // Start servers.
     let network = generate_network_name();
-    let (collector_private_key, leader_task, helper_task) =
+    let (mut task_parameters, leader_task, helper_task) =
         test_task_builders(VdafInstance::Prio3Count, QueryType::TimeInterval);
 
     // Daphne is hardcoded to serve from a path starting with /v04/.
+    task_parameters.endpoint_fragments.helper_endpoint_path = "/v04/".to_string();
     let [leader_task, helper_task]: [Task; 2] = [leader_task, helper_task]
         .into_iter()
         .map(|task| {
@@ -75,9 +76,8 @@ async fn janus_daphne() {
 
     // Run the behavioral test.
     submit_measurements_and_verify_aggregate(
+        &task_parameters,
         (leader.port(), helper.port()),
-        &leader_task,
-        &collector_private_key,
         &ClientBackend::InProcess,
     )
     .await;

--- a/integration_tests/tests/divviup_ts.rs
+++ b/integration_tests/tests/divviup_ts.rs
@@ -16,11 +16,10 @@ use testcontainers::clients::Cli;
 mod common;
 
 async fn run_divviup_ts_integration_test(container_client: &Cli, vdaf: VdafInstance) {
-    let (collector_private_key, leader_task, helper_task) =
+    let (task_parameters, leader_task, helper_task) =
         test_task_builders(vdaf, QueryType::TimeInterval);
-    let leader_task = leader_task.build();
     let network = generate_network_name();
-    let leader = Janus::new(container_client, &network, &leader_task).await;
+    let leader = Janus::new(container_client, &network, &leader_task.build()).await;
     let helper = Janus::new(container_client, &network, &helper_task.build()).await;
 
     let client_backend = ClientBackend::Container {
@@ -29,9 +28,8 @@ async fn run_divviup_ts_integration_test(container_client: &Cli, vdaf: VdafInsta
         network: &network,
     };
     submit_measurements_and_verify_aggregate(
+        &task_parameters,
         (leader.port(), helper.port()),
-        &leader_task,
-        &collector_private_key,
         &client_backend,
     )
     .await;

--- a/integration_tests/tests/in_cluster.rs
+++ b/integration_tests/tests/in_cluster.rs
@@ -5,10 +5,9 @@ use base64::engine::{
     Engine,
 };
 use common::{submit_measurements_and_verify_aggregate, test_task_builders};
-use janus_aggregator_core::task::{test_util::TaskBuilder, QueryType, Task};
+use janus_aggregator_core::task::QueryType;
 use janus_collector::AuthenticationToken;
 use janus_core::{
-    hpke::HpkePrivateKey,
     task::{DapAuthToken, VdafInstance},
     test_util::{
         install_test_trace_subscriber,
@@ -18,6 +17,7 @@ use janus_core::{
 use janus_integration_tests::{
     client::ClientBackend,
     divviup_api_client::{DivviupApiClient, NewAggregatorRequest, NewTaskRequest},
+    TaskParameters,
 };
 use janus_messages::TaskId;
 use prio::codec::Encode;
@@ -27,11 +27,9 @@ use url::Url;
 mod common;
 
 struct InClusterJanusPair {
-    /// The leader's view of the task configured in both Janus aggregators.
-    leader_task: Task,
-    /// The private key corresponding to the collector HPKE configuration in the task configured in
-    /// both Janus aggregators.
-    collector_private_key: HpkePrivateKey,
+    /// Task parameters needed by the client and collector, for the task configured in both Janus
+    /// aggregators.
+    task_parameters: TaskParameters,
 
     /// Handle to the leader's resources, which are released on drop.
     leader: InClusterJanus,
@@ -95,8 +93,9 @@ impl InClusterJanusPair {
 
         let cluster = Cluster::new(&kubeconfig_path, &kubectl_context_name);
 
-        let (collector_private_key, task_builder, _) = test_task_builders(vdaf, query_type);
+        let (mut task_parameters, task_builder, _) = test_task_builders(vdaf, query_type);
         let task = task_builder.with_min_batch_size(100).build();
+        task_parameters.min_batch_size = 100;
 
         // From outside the cluster, the aggregators are reached at a dynamically allocated port on
         // localhost. When the aggregators talk to each other, they do so in the cluster's network,
@@ -169,22 +168,19 @@ impl InClusterJanusPair {
             .list_collector_auth_tokens(&provisioned_task)
             .await;
 
-        // Update the task with the ID and collector auth token from divviup-api.
-        let task = TaskBuilder::from(task)
-            .with_id(TaskId::from_str(provisioned_task.id.as_ref()).unwrap())
-            .with_collector_auth_tokens(Vec::from([AuthenticationToken::DapAuth(
-                DapAuthToken::try_from(
-                    URL_SAFE_NO_PAD
-                        .decode(collector_auth_tokens[0].clone())
-                        .unwrap(),
-                )
-                .unwrap(),
-            )]))
-            .build();
+        // Update the task parameters with the ID and collector auth token from divviup-api.
+        task_parameters.task_id = TaskId::from_str(provisioned_task.id.as_ref()).unwrap();
+        task_parameters.collector_auth_token = AuthenticationToken::DapAuth(
+            DapAuthToken::try_from(
+                URL_SAFE_NO_PAD
+                    .decode(collector_auth_tokens[0].clone())
+                    .unwrap(),
+            )
+            .unwrap(),
+        );
 
         Self {
-            leader_task: task,
-            collector_private_key,
+            task_parameters,
             leader: InClusterJanus::new(&cluster, &leader_namespace).await,
             helper: InClusterJanus::new(&cluster, &helper_namespace).await,
         }
@@ -236,9 +232,8 @@ async fn in_cluster_count() {
 
     // Run the behavioral test.
     submit_measurements_and_verify_aggregate(
+        &janus_pair.task_parameters,
         (janus_pair.leader.port(), janus_pair.helper.port()),
-        &janus_pair.leader_task,
-        &janus_pair.collector_private_key,
         &ClientBackend::InProcess,
     )
     .await;
@@ -254,9 +249,8 @@ async fn in_cluster_sum() {
 
     // Run the behavioral test.
     submit_measurements_and_verify_aggregate(
+        &janus_pair.task_parameters,
         (janus_pair.leader.port(), janus_pair.helper.port()),
-        &janus_pair.leader_task,
-        &janus_pair.collector_private_key,
         &ClientBackend::InProcess,
     )
     .await;
@@ -276,9 +270,8 @@ async fn in_cluster_histogram() {
 
     // Run the behavioral test.
     submit_measurements_and_verify_aggregate(
+        &janus_pair.task_parameters,
         (janus_pair.leader.port(), janus_pair.helper.port()),
-        &janus_pair.leader_task,
-        &janus_pair.collector_private_key,
         &ClientBackend::InProcess,
     )
     .await;
@@ -299,9 +292,8 @@ async fn in_cluster_fixed_size() {
 
     // Run the behavioral test.
     submit_measurements_and_verify_aggregate(
+        &janus_pair.task_parameters,
         (janus_pair.leader.port(), janus_pair.helper.port()),
-        &janus_pair.leader_task,
-        &janus_pair.collector_private_key,
         &ClientBackend::InProcess,
     )
     .await;


### PR DESCRIPTION
This PR refactors the common integration test support code to rely less on the leader's `Task`, by introducing a new `TaskParameters` struct containing the parameters relevant to the client or collector. This supports #1524. `TaskParameters` contains the hostnames and path components of aggregator endpoints, and construction of endpoint URLs is deferred until we set up the client and collector. This means we no longer rely on modifying and reading the leader's endpoint in the leader `Task`.