### PR TITLE
Log statement cleanup

### DIFF
--- a/aggregator/src/bin/aggregator.rs
+++ b/aggregator/src/bin/aggregator.rs
@@ -88,7 +88,7 @@ async fn main() -> Result<()> {
                 // DAP API handler in the setup_server call below
                 info!(
                     aggregator_bound_address = ?ctx.config.listen_address,
-                    ?path_prefix,
+                    path_prefix,
                     "Serving aggregator API relative to DAP API"
                 );
                 // Append wildcard so that this handler will match anything under the prefix


### PR DESCRIPTION
This changes a log statement that is currently using the Debug implementation of String, resulting in extra quote marks.

```json
{
  "timestamp": "2023-07-05T19:07:50.771116Z",
  "level": "INFO",
  "fields": {
    "message": "Serving aggregator API relative to DAP API",
    "aggregator_bound_address": "0.0.0.0:80",
    "path_prefix": "\"aggregator-api\""
  },
  "target": "aggregator",
  "filename": "aggregator/src/bin/aggregator.rs",
  "line_number": 89,
  "threadId": "ThreadId(1)"
}
```