### PR TITLE
Update aggregator API URL in in_cluster test

### DIFF
--- a/integration_tests/tests/in_cluster.rs
+++ b/integration_tests/tests/in_cluster.rs
@@ -199,7 +199,7 @@ impl InClusterJanusPair {
 
     fn in_cluster_aggregator_api_url(namespace: &str) -> Url {
         Url::parse(&format!(
-            "http://aggregator-api.{namespace}.svc.cluster.local:8081"
+            "http://aggregator.{namespace}.svc.cluster.local:80/aggregator-api/"
         ))
         .unwrap()
     }


### PR DESCRIPTION
This updates the `in_cluster` test to work with divviup/janus-ops#888.