### PR TITLE
Fix counter metric name

### DIFF
--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -146,7 +146,7 @@ impl StatusCounter {
     fn new(meter: &Meter) -> Self {
         Self(
             meter
-                .u64_counter("janus_aggregator_responses_total")
+                .u64_counter("janus_aggregator_responses")
                 .with_description(
                     "Count of requests handled by the aggregator, by method, route, and response status.",
                 )


### PR DESCRIPTION
This incorrectly shows up as `janus_aggregator_responses_total_total` in Prometheus currently.