### PR TITLE
Explicitly pass OpenTelemetry Meters

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -2641,6 +2641,7 @@ mod tests {
             Datastore,
         },
         task::{test_util::TaskBuilder, QueryType, Task},
+        test_util::noop_meter,
     };
     use janus_core::{
         hpke::{self, HpkeApplicationInfo, Label},
@@ -2653,7 +2654,6 @@ mod tests {
         InputShareAad, Interval, PlaintextInputShare, Report, ReportId, ReportMetadata,
         ReportShare, Role, TaskId, Time,
     };
-    use opentelemetry::global::meter;
     use prio::{
         codec::Encode,
         vdaf::{self, prio3::Prio3Count, Client as _},
@@ -2740,16 +2740,12 @@ mod tests {
         .build();
 
         let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
+        let meter = noop_meter();
+        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
 
         datastore.put_task(&task).await.unwrap();
 
-        let aggregator = Aggregator::new(
-            Arc::clone(&datastore),
-            clock.clone(),
-            &meter("janus_aggregator"),
-            cfg,
-        );
+        let aggregator = Aggregator::new(Arc::clone(&datastore), clock.clone(), &meter, cfg);
 
         (
             vdaf,

--- a/aggregator/src/aggregator/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/aggregation_job_continue.rs
@@ -398,6 +398,7 @@ mod tests {
             Datastore,
         },
         task::{test_util::TaskBuilder, QueryType, Task},
+        test_util::noop_meter,
     };
     use janus_core::{
         task::VdafInstance,
@@ -435,7 +436,8 @@ mod tests {
             TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Helper).build();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
+        let meter = noop_meter();
+        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
 
         let report_generator = ReportShareGenerator::new(
             clock.clone(),
@@ -495,8 +497,13 @@ mod tests {
         );
 
         // Create aggregator handler.
-        let handler =
-            aggregator_handler(Arc::clone(&datastore), clock, default_aggregator_config()).unwrap();
+        let handler = aggregator_handler(
+            Arc::clone(&datastore),
+            clock,
+            &meter,
+            default_aggregator_config(),
+        )
+        .unwrap();
 
         AggregationJobContinueTestCase {
             task,

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -93,7 +93,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
         // TODO(#224): add support for handling only a subset of tasks in a single job (i.e. sharding).
 
         // Create metric instruments.
-        let meter = opentelemetry::global::meter("aggregation_job_creator");
+        let meter = opentelemetry::global::meter("janus_aggregator");
         let task_update_time_histogram = meter
             .f64_histogram("janus_task_update_time")
             .with_description("Time spent updating tasks.")

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -912,6 +912,7 @@ mod tests {
         },
         query_type::{AccumulableQueryType, CollectableQueryType},
         task::{test_util::TaskBuilder, QueryType, VerifyKey},
+        test_util::noop_meter,
     };
     use janus_core::{
         hpke::{
@@ -930,7 +931,6 @@ mod tests {
         Interval, PartialBatchSelector, PlaintextInputShare, PrepareStep, PrepareStepResult,
         ReportIdChecksum, ReportMetadata, ReportShare, ReportShareError, Role, TaskId, Time,
     };
-    use opentelemetry::global::meter;
     use prio::{
         codec::Encode,
         vdaf::{
@@ -958,7 +958,8 @@ mod tests {
         let clock = MockClock::default();
         let mut runtime_manager = TestRuntimeManager::new();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
+        let meter = noop_meter();
+        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
         let task = TaskBuilder::new(
             QueryType::TimeInterval,
@@ -1112,7 +1113,6 @@ mod tests {
             },
         ))
         .await;
-        let meter = meter("aggregation_job_driver");
         let aggregation_job_driver = Arc::new(AggregationJobDriver::new(
             reqwest::Client::new(),
             &meter,
@@ -1239,7 +1239,8 @@ mod tests {
         let mut server = mockito::Server::new_async().await;
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
+        let meter = noop_meter();
+        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
 
         let task = TaskBuilder::new(
@@ -1439,7 +1440,6 @@ mod tests {
             .await;
 
         // Run: create an aggregation job driver & try to step the aggregation we've created twice.
-        let meter = meter("aggregation_job_driver");
         let aggregation_job_driver =
             AggregationJobDriver::new(reqwest::Client::builder().build().unwrap(), &meter, 32);
         let error = aggregation_job_driver
@@ -1601,7 +1601,8 @@ mod tests {
         let mut server = mockito::Server::new_async().await;
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
+        let meter = noop_meter();
+        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
 
         let task = TaskBuilder::new(
@@ -1758,7 +1759,6 @@ mod tests {
             .await;
 
         // Run: create an aggregation job driver & try to step the aggregation we've created twice.
-        let meter = meter("aggregation_job_driver");
         let aggregation_job_driver =
             AggregationJobDriver::new(reqwest::Client::builder().build().unwrap(), &meter, 32);
         let error = aggregation_job_driver
@@ -1855,7 +1855,8 @@ mod tests {
         let mut server = mockito::Server::new_async().await;
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
+        let meter = noop_meter();
+        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
 
         let task = TaskBuilder::new(
@@ -2053,7 +2054,6 @@ mod tests {
             .await;
 
         // Run: create an aggregation job driver & try to step the aggregation we've created twice.
-        let meter = meter("aggregation_job_driver");
         let aggregation_job_driver =
             AggregationJobDriver::new(reqwest::Client::builder().build().unwrap(), &meter, 32);
         let error = aggregation_job_driver
@@ -2244,7 +2244,8 @@ mod tests {
         let mut server = mockito::Server::new_async().await;
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
+        let meter = noop_meter();
+        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
 
         let task = TaskBuilder::new(
@@ -2417,7 +2418,6 @@ mod tests {
             .await;
 
         // Run: create an aggregation job driver & try to step the aggregation we've created twice.
-        let meter = meter("aggregation_job_driver");
         let aggregation_job_driver =
             AggregationJobDriver::new(reqwest::Client::builder().build().unwrap(), &meter, 32);
         let error = aggregation_job_driver
@@ -2569,7 +2569,8 @@ mod tests {
         install_test_trace_subscriber();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
+        let meter = noop_meter();
+        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
 
         let task = TaskBuilder::new(
@@ -2666,7 +2667,6 @@ mod tests {
         assert_eq!(lease.leased().aggregation_job_id(), &aggregation_job_id);
 
         // Run: create an aggregation job driver & cancel the aggregation job.
-        let meter = meter("aggregation_job_driver");
         let aggregation_job_driver =
             AggregationJobDriver::new(reqwest::Client::builder().build().unwrap(), &meter, 32);
         aggregation_job_driver
@@ -2781,7 +2781,8 @@ mod tests {
         let clock = MockClock::default();
         let mut runtime_manager = TestRuntimeManager::new();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
+        let meter = noop_meter();
+        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
         let stopper = Stopper::new();
 
         let task = TaskBuilder::new(
@@ -2878,7 +2879,6 @@ mod tests {
         .unwrap();
 
         // Set up the aggregation job driver.
-        let meter = meter("aggregation_job_driver");
         let aggregation_job_driver = Arc::new(AggregationJobDriver::new(
             reqwest::Client::new(),
             &meter,

--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -11,6 +11,7 @@ use janus_aggregator_core::{
         Datastore,
     },
     task::{test_util::TaskBuilder, QueryType, Task},
+    test_util::noop_meter,
 };
 use janus_core::{
     hpke::{
@@ -127,13 +128,15 @@ pub(crate) async fn setup_collection_job_test_case(
         .build();
     let clock = MockClock::default();
     let ephemeral_datastore = ephemeral_datastore().await;
-    let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
+    let meter = noop_meter();
+    let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
 
     datastore.put_task(&task).await.unwrap();
 
     let handler = aggregator_handler(
         Arc::clone(&datastore),
         clock.clone(),
+        &meter,
         Config {
             batch_aggregation_shard_count: 32,
             ..Default::default()

--- a/aggregator/src/aggregator/garbage_collector.rs
+++ b/aggregator/src/aggregator/garbage_collector.rs
@@ -84,6 +84,7 @@ mod tests {
             test_util::ephemeral_datastore,
         },
         task::{self, test_util::TaskBuilder},
+        test_util::noop_meter,
     };
     use janus_core::{
         task::VdafInstance,
@@ -109,7 +110,11 @@ mod tests {
 
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
+        let ds = Arc::new(
+            ephemeral_datastore
+                .datastore(clock.clone(), &noop_meter())
+                .await,
+        );
         let vdaf = dummy_vdaf::Vdaf::new();
 
         // Setup.
@@ -211,7 +216,11 @@ mod tests {
 
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
+        let ds = Arc::new(
+            ephemeral_datastore
+                .datastore(clock.clone(), &noop_meter())
+                .await,
+        );
         let vdaf = dummy_vdaf::Vdaf::new();
 
         // Setup.
@@ -322,7 +331,11 @@ mod tests {
 
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
+        let ds = Arc::new(
+            ephemeral_datastore
+                .datastore(clock.clone(), &noop_meter())
+                .await,
+        );
         let vdaf = dummy_vdaf::Vdaf::new();
 
         // Setup.
@@ -422,7 +435,11 @@ mod tests {
 
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
+        let ds = Arc::new(
+            ephemeral_datastore
+                .datastore(clock.clone(), &noop_meter())
+                .await,
+        );
         let vdaf = dummy_vdaf::Vdaf::new();
 
         // Setup.

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -204,10 +204,10 @@ pub(crate) static AGGREGATE_SHARES_ROUTE: &str = "tasks/:task_id/aggregate_share
 pub fn aggregator_handler<C: Clock>(
     datastore: Arc<Datastore<C>>,
     clock: C,
+    meter: &Meter,
     cfg: Config,
 ) -> Result<impl Handler, Error> {
-    let meter = opentelemetry::global::meter("janus_aggregator");
-    let aggregator = Arc::new(Aggregator::new(datastore, clock, &meter, cfg));
+    let aggregator = Arc::new(Aggregator::new(datastore, clock, meter, cfg));
 
     Ok((
         State(aggregator),
@@ -250,7 +250,7 @@ pub fn aggregator_handler<C: Clock>(
                 AGGREGATE_SHARES_ROUTE,
                 instrumented(api(aggregate_shares::<C>)),
             ),
-        StatusCounter::new(&meter),
+        StatusCounter::new(meter),
     ))
 }
 
@@ -574,6 +574,7 @@ mod tests {
         },
         query_type::{AccumulableQueryType, CollectableQueryType},
         task::{test_util::TaskBuilder, QueryType, VerifyKey},
+        test_util::noop_meter,
     };
     use janus_core::{
         hpke::{
@@ -624,14 +625,20 @@ mod tests {
         let unknown_task_id: TaskId = random();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = ephemeral_datastore.datastore(clock.clone()).await;
+        let meter = noop_meter();
+        let datastore = ephemeral_datastore.datastore(clock.clone(), &meter).await;
 
         datastore.put_task(&task).await.unwrap();
 
         let want_hpke_key = task.current_hpke_key().clone();
 
-        let handler =
-            aggregator_handler(Arc::new(datastore), clock, default_aggregator_config()).unwrap();
+        let handler = aggregator_handler(
+            Arc::new(datastore),
+            clock,
+            &meter,
+            default_aggregator_config(),
+        )
+        .unwrap();
 
         // No task ID provided
         let mut test_conn = get("/hpke_config").run_async(&handler).await;
@@ -739,12 +746,18 @@ mod tests {
         .build();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = ephemeral_datastore.datastore(clock.clone()).await;
+        let meter = noop_meter();
+        let datastore = ephemeral_datastore.datastore(clock.clone(), &meter).await;
 
         datastore.put_task(&task).await.unwrap();
 
-        let handler =
-            aggregator_handler(Arc::new(datastore), clock, default_aggregator_config()).unwrap();
+        let handler = aggregator_handler(
+            Arc::new(datastore),
+            clock,
+            &meter,
+            default_aggregator_config(),
+        )
+        .unwrap();
 
         // Check for appropriate CORS headers in response to a preflight request.
         let test_conn = TestConn::build(
@@ -818,13 +831,15 @@ mod tests {
         .build();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
+        let meter = noop_meter();
+        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
 
         datastore.put_task(&task).await.unwrap();
         let report = create_report(&task, clock.now());
         let handler = aggregator_handler(
             Arc::clone(&datastore),
             clock.clone(),
+            &meter,
             default_aggregator_config(),
         )
         .unwrap();
@@ -1047,7 +1062,8 @@ mod tests {
 
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = ephemeral_datastore.datastore(clock.clone()).await;
+        let meter = noop_meter();
+        let datastore = ephemeral_datastore.datastore(clock.clone(), &meter).await;
 
         let task = TaskBuilder::new(
             QueryType::TimeInterval,
@@ -1058,8 +1074,13 @@ mod tests {
         datastore.put_task(&task).await.unwrap();
         let report = create_report(&task, clock.now());
 
-        let handler =
-            aggregator_handler(Arc::new(datastore), clock, default_aggregator_config()).unwrap();
+        let handler = aggregator_handler(
+            Arc::new(datastore),
+            clock,
+            &meter,
+            default_aggregator_config(),
+        )
+        .unwrap();
 
         let mut test_conn = put(task.report_upload_uri().unwrap().path())
             .with_request_header(KnownHeaderName::ContentType, Report::MEDIA_TYPE)
@@ -1108,7 +1129,8 @@ mod tests {
         .build();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = ephemeral_datastore.datastore(clock.clone()).await;
+        let meter = noop_meter();
+        let datastore = ephemeral_datastore.datastore(clock.clone(), &meter).await;
 
         datastore.put_task(&task).await.unwrap();
 
@@ -1118,8 +1140,13 @@ mod tests {
             Vec::new(),
         );
 
-        let handler =
-            aggregator_handler(Arc::new(datastore), clock, default_aggregator_config()).unwrap();
+        let handler = aggregator_handler(
+            Arc::new(datastore),
+            clock,
+            &meter,
+            default_aggregator_config(),
+        )
+        .unwrap();
         let aggregation_job_id: AggregationJobId = random();
 
         let mut test_conn =
@@ -1196,7 +1223,8 @@ mod tests {
         .build();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = ephemeral_datastore.datastore(clock.clone()).await;
+        let meter = noop_meter();
+        let datastore = ephemeral_datastore.datastore(clock.clone(), &meter).await;
 
         datastore.put_task(&task).await.unwrap();
 
@@ -1206,8 +1234,13 @@ mod tests {
             Vec::new(),
         );
 
-        let handler =
-            aggregator_handler(Arc::new(datastore), clock, default_aggregator_config()).unwrap();
+        let handler = aggregator_handler(
+            Arc::new(datastore),
+            clock,
+            &meter,
+            default_aggregator_config(),
+        )
+        .unwrap();
         let aggregation_job_id: AggregationJobId = random();
 
         let wrong_token_value = random();
@@ -1274,7 +1307,8 @@ mod tests {
             TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Helper).build();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
+        let meter = noop_meter();
+        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
 
         let vdaf = dummy_vdaf::Vdaf::new();
         let verify_key: VerifyKey<0> = task.primary_vdaf_verify_key().unwrap();
@@ -1641,8 +1675,13 @@ mod tests {
 
         // Create aggregator handler, send request, and parse response. Do this twice to prove that
         // the request is idempotent.
-        let handler =
-            aggregator_handler(Arc::clone(&datastore), clock, default_aggregator_config()).unwrap();
+        let handler = aggregator_handler(
+            Arc::clone(&datastore),
+            clock,
+            &meter,
+            default_aggregator_config(),
+        )
+        .unwrap();
         let aggregation_job_id: AggregationJobId = random();
 
         for _ in 0..2 {
@@ -1845,7 +1884,8 @@ mod tests {
         .build();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = ephemeral_datastore.datastore(clock.clone()).await;
+        let meter = noop_meter();
+        let datastore = ephemeral_datastore.datastore(clock.clone(), &meter).await;
         let hpke_key = task.current_hpke_key();
 
         datastore.put_task(&task).await.unwrap();
@@ -1871,8 +1911,13 @@ mod tests {
         );
 
         // Create aggregator handler, send request, and parse response.
-        let handler =
-            aggregator_handler(Arc::new(datastore), clock, default_aggregator_config()).unwrap();
+        let handler = aggregator_handler(
+            Arc::new(datastore),
+            clock,
+            &meter,
+            default_aggregator_config(),
+        )
+        .unwrap();
         let aggregation_job_id: AggregationJobId = random();
 
         let mut test_conn =
@@ -1914,7 +1959,8 @@ mod tests {
         .build();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = ephemeral_datastore.datastore(clock.clone()).await;
+        let meter = noop_meter();
+        let datastore = ephemeral_datastore.datastore(clock.clone(), &meter).await;
         let hpke_key = task.current_hpke_key();
 
         datastore.put_task(&task).await.unwrap();
@@ -1940,8 +1986,13 @@ mod tests {
         );
 
         // Create aggregator filter, send request, and parse response.
-        let handler =
-            aggregator_handler(Arc::new(datastore), clock, default_aggregator_config()).unwrap();
+        let handler = aggregator_handler(
+            Arc::new(datastore),
+            clock,
+            &meter,
+            default_aggregator_config(),
+        )
+        .unwrap();
         let aggregation_job_id: AggregationJobId = random();
 
         let mut test_conn =
@@ -1982,7 +2033,8 @@ mod tests {
         .build();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = ephemeral_datastore.datastore(clock.clone()).await;
+        let meter = noop_meter();
+        let datastore = ephemeral_datastore.datastore(clock.clone(), &meter).await;
 
         datastore.put_task(&task).await.unwrap();
 
@@ -2006,8 +2058,13 @@ mod tests {
             Vec::from([report_share.clone(), report_share]),
         );
 
-        let handler =
-            aggregator_handler(Arc::new(datastore), clock, default_aggregator_config()).unwrap();
+        let handler = aggregator_handler(
+            Arc::new(datastore),
+            clock,
+            &meter,
+            default_aggregator_config(),
+        )
+        .unwrap();
         let aggregation_job_id: AggregationJobId = random();
 
         let mut test_conn =
@@ -2049,7 +2106,8 @@ mod tests {
         .build();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
+        let meter = noop_meter();
+        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
 
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
         let verify_key: VerifyKey<PRIO3_VERIFY_KEY_LENGTH> =
@@ -2251,8 +2309,13 @@ mod tests {
         );
 
         // Create aggregator handler, send request, and parse response.
-        let handler =
-            aggregator_handler(Arc::clone(&datastore), clock, default_aggregator_config()).unwrap();
+        let handler = aggregator_handler(
+            Arc::clone(&datastore),
+            clock,
+            &meter,
+            default_aggregator_config(),
+        )
+        .unwrap();
 
         let aggregate_resp =
             post_aggregation_job_and_decode(&task, &aggregation_job_id, &request, &handler).await;
@@ -2363,7 +2426,12 @@ mod tests {
         let aggregation_job_id_0 = random();
         let aggregation_job_id_1 = random();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = Arc::new(ephemeral_datastore.datastore(MockClock::default()).await);
+        let meter = noop_meter();
+        let datastore = Arc::new(
+            ephemeral_datastore
+                .datastore(MockClock::default(), &meter)
+                .await,
+        );
         let first_batch_interval_clock = MockClock::default();
         let second_batch_interval_clock = MockClock::new(
             first_batch_interval_clock
@@ -2594,6 +2662,7 @@ mod tests {
         let handler = aggregator_handler(
             Arc::clone(&datastore),
             first_batch_interval_clock.clone(),
+            &meter,
             default_aggregator_config(),
         )
         .unwrap();
@@ -2896,6 +2965,7 @@ mod tests {
         let handler = aggregator_handler(
             Arc::clone(&datastore),
             first_batch_interval_clock,
+            &meter,
             default_aggregator_config(),
         )
         .unwrap();
@@ -3030,7 +3100,8 @@ mod tests {
         );
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
+        let meter = noop_meter();
+        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
 
         // Setup datastore.
         datastore
@@ -3094,8 +3165,13 @@ mod tests {
             )]),
         );
 
-        let handler =
-            aggregator_handler(Arc::clone(&datastore), clock, default_aggregator_config()).unwrap();
+        let handler = aggregator_handler(
+            Arc::clone(&datastore),
+            clock,
+            &meter,
+            default_aggregator_config(),
+        )
+        .unwrap();
 
         post_aggregation_job_expecting_error(
             &task,
@@ -3128,7 +3204,8 @@ mod tests {
         );
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
+        let meter = noop_meter();
+        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
 
         // Setup datastore.
         datastore
@@ -3192,8 +3269,13 @@ mod tests {
             )]),
         );
 
-        let handler =
-            aggregator_handler(Arc::clone(&datastore), clock, default_aggregator_config()).unwrap();
+        let handler = aggregator_handler(
+            Arc::clone(&datastore),
+            clock,
+            &meter,
+            default_aggregator_config(),
+        )
+        .unwrap();
 
         let aggregate_resp =
             post_aggregation_job_and_decode(&task, &aggregation_job_id, &request, &handler).await;
@@ -3277,7 +3359,8 @@ mod tests {
         );
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = ephemeral_datastore.datastore(clock.clone()).await;
+        let meter = noop_meter();
+        let datastore = ephemeral_datastore.datastore(clock.clone(), &meter).await;
 
         // Setup datastore.
         datastore
@@ -3343,8 +3426,13 @@ mod tests {
             )]),
         );
 
-        let handler =
-            aggregator_handler(Arc::new(datastore), clock, default_aggregator_config()).unwrap();
+        let handler = aggregator_handler(
+            Arc::new(datastore),
+            clock,
+            &meter,
+            default_aggregator_config(),
+        )
+        .unwrap();
 
         post_aggregation_job_expecting_error(
             &task,
@@ -3378,7 +3466,8 @@ mod tests {
 
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = ephemeral_datastore.datastore(clock.clone()).await;
+        let meter = noop_meter();
+        let datastore = ephemeral_datastore.datastore(clock.clone(), &meter).await;
 
         // Setup datastore.
         datastore
@@ -3482,8 +3571,13 @@ mod tests {
             ]),
         );
 
-        let handler =
-            aggregator_handler(Arc::new(datastore), clock, default_aggregator_config()).unwrap();
+        let handler = aggregator_handler(
+            Arc::new(datastore),
+            clock,
+            &meter,
+            default_aggregator_config(),
+        )
+        .unwrap();
 
         post_aggregation_job_expecting_error(
             &task,
@@ -3513,7 +3607,8 @@ mod tests {
 
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = ephemeral_datastore.datastore(clock.clone()).await;
+        let meter = noop_meter();
+        let datastore = ephemeral_datastore.datastore(clock.clone(), &meter).await;
 
         // Setup datastore.
         datastore
@@ -3576,8 +3671,13 @@ mod tests {
             )]),
         );
 
-        let handler =
-            aggregator_handler(Arc::new(datastore), clock, default_aggregator_config()).unwrap();
+        let handler = aggregator_handler(
+            Arc::new(datastore),
+            clock,
+            &meter,
+            default_aggregator_config(),
+        )
+        .unwrap();
 
         post_aggregation_job_expecting_error(
             &task,
@@ -3727,12 +3827,18 @@ mod tests {
             .build();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = ephemeral_datastore.datastore(clock.clone()).await;
+        let meter = noop_meter();
+        let datastore = ephemeral_datastore.datastore(clock.clone(), &meter).await;
 
         datastore.put_task(&task).await.unwrap();
 
-        let handler =
-            aggregator_handler(Arc::new(datastore), clock, default_aggregator_config()).unwrap();
+        let handler = aggregator_handler(
+            Arc::new(datastore),
+            clock,
+            &meter,
+            default_aggregator_config(),
+        )
+        .unwrap();
 
         let collection_job_id: CollectionJobId = random();
         let request = CollectionReq::new(
@@ -4430,12 +4536,18 @@ mod tests {
             TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Leader).build();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = ephemeral_datastore.datastore(clock.clone()).await;
+        let meter = noop_meter();
+        let datastore = ephemeral_datastore.datastore(clock.clone(), &meter).await;
 
         datastore.put_task(&task).await.unwrap();
 
-        let handler =
-            aggregator_handler(Arc::new(datastore), clock, default_aggregator_config()).unwrap();
+        let handler = aggregator_handler(
+            Arc::new(datastore),
+            clock,
+            &meter,
+            default_aggregator_config(),
+        )
+        .unwrap();
 
         let request = AggregateShareReq::new(
             BatchSelector::new_time_interval(
@@ -4491,13 +4603,15 @@ mod tests {
             .build();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = ephemeral_datastore.datastore(clock.clone()).await;
+        let meter = noop_meter();
+        let datastore = ephemeral_datastore.datastore(clock.clone(), &meter).await;
 
         datastore.put_task(&task).await.unwrap();
 
         let handler = aggregator_handler(
             Arc::new(datastore),
             clock.clone(),
+            &meter,
             default_aggregator_config(),
         )
         .unwrap();
@@ -4593,12 +4707,18 @@ mod tests {
 
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
+        let meter = noop_meter();
+        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
 
         datastore.put_task(&task).await.unwrap();
 
-        let handler =
-            aggregator_handler(Arc::clone(&datastore), clock, default_aggregator_config()).unwrap();
+        let handler = aggregator_handler(
+            Arc::clone(&datastore),
+            clock,
+            &meter,
+            default_aggregator_config(),
+        )
+        .unwrap();
 
         // There are no batch aggregations in the datastore yet
         let request = AggregateShareReq::new(

--- a/aggregator/src/aggregator/problem_details.rs
+++ b/aggregator/src/aggregator/problem_details.rs
@@ -66,6 +66,7 @@ mod tests {
     use assert_matches::assert_matches;
     use futures::future::join_all;
     use http::Method;
+    use janus_aggregator_core::test_util::noop_meter;
     use janus_core::time::{Clock, RealClock};
     use janus_messages::{
         problem_type::{DapProblemType, DapProblemTypeParseError},
@@ -101,8 +102,7 @@ mod tests {
 
     #[tokio::test]
     async fn problem_details_round_trip() {
-        let meter = opentelemetry::global::meter("tests");
-        let request_histogram = meter
+        let request_histogram = noop_meter()
             .f64_histogram("janus_http_request_duration_seconds")
             .init();
 

--- a/aggregator/src/aggregator/problem_details.rs
+++ b/aggregator/src/aggregator/problem_details.rs
@@ -101,7 +101,7 @@ mod tests {
 
     #[tokio::test]
     async fn problem_details_round_trip() {
-        let meter = opentelemetry::global::meter("");
+        let meter = opentelemetry::global::meter("tests");
         let request_histogram = meter
             .f64_histogram("janus_http_request_duration_seconds")
             .init();

--- a/aggregator/src/bin/aggregation_job_creator.rs
+++ b/aggregator/src/bin/aggregation_job_creator.rs
@@ -21,6 +21,7 @@ async fn main() -> anyhow::Result<()> {
         // Start creating aggregation jobs.
         let aggregation_job_creator = Arc::new(AggregationJobCreator::new(
             ctx.datastore,
+            ctx.meter,
             Duration::from_secs(ctx.config.tasks_update_frequency_secs),
             Duration::from_secs(ctx.config.aggregation_job_creation_interval_secs),
             ctx.config.min_aggregation_job_size,

--- a/aggregator/src/bin/aggregation_job_driver.rs
+++ b/aggregator/src/bin/aggregation_job_driver.rs
@@ -22,7 +22,7 @@ async fn main() -> anyhow::Result<()> {
     );
 
     janus_main::<_, Options, Config, _, _>(RealClock::default(), |ctx| async move {
-        let meter = opentelemetry::global::meter("aggregation_job_driver");
+        let meter = opentelemetry::global::meter("janus_aggregator");
         let datastore = Arc::new(ctx.datastore);
         let aggregation_job_driver = Arc::new(AggregationJobDriver::new(
             reqwest::Client::builder()

--- a/aggregator/src/bin/aggregation_job_driver.rs
+++ b/aggregator/src/bin/aggregation_job_driver.rs
@@ -22,14 +22,13 @@ async fn main() -> anyhow::Result<()> {
     );
 
     janus_main::<_, Options, Config, _, _>(RealClock::default(), |ctx| async move {
-        let meter = opentelemetry::global::meter("janus_aggregator");
         let datastore = Arc::new(ctx.datastore);
         let aggregation_job_driver = Arc::new(AggregationJobDriver::new(
             reqwest::Client::builder()
                 .user_agent(CLIENT_USER_AGENT)
                 .build()
                 .context("couldn't create HTTP client")?,
-            &meter,
+            &ctx.meter,
             ctx.config.batch_aggregation_shard_count,
         ));
         let lease_duration =
@@ -42,7 +41,7 @@ async fn main() -> anyhow::Result<()> {
         let job_driver = Arc::new(JobDriver::new(
             ctx.clock,
             TokioRuntime,
-            meter,
+            ctx.meter,
             stopper,
             Duration::from_secs(ctx.config.job_driver_config.min_job_discovery_delay_secs),
             Duration::from_secs(ctx.config.job_driver_config.max_job_discovery_delay_secs),

--- a/aggregator/src/bin/aggregator.rs
+++ b/aggregator/src/bin/aggregator.rs
@@ -36,6 +36,7 @@ async fn main() -> Result<()> {
             aggregator_handler(
                 Arc::clone(&datastore),
                 ctx.clock,
+                &ctx.meter,
                 ctx.config.aggregator_config(),
             )?,
             None,

--- a/aggregator/src/bin/collection_job_driver.rs
+++ b/aggregator/src/bin/collection_job_driver.rs
@@ -22,7 +22,7 @@ async fn main() -> anyhow::Result<()> {
     );
 
     janus_main::<_, Options, Config, _, _>(RealClock::default(), |ctx| async move {
-        let meter = opentelemetry::global::meter("collection_job_driver");
+        let meter = opentelemetry::global::meter("janus_aggregator");
         let datastore = Arc::new(ctx.datastore);
         let collection_job_driver = Arc::new(CollectionJobDriver::new(
             reqwest::Client::builder()

--- a/aggregator/src/bin/collection_job_driver.rs
+++ b/aggregator/src/bin/collection_job_driver.rs
@@ -22,14 +22,13 @@ async fn main() -> anyhow::Result<()> {
     );
 
     janus_main::<_, Options, Config, _, _>(RealClock::default(), |ctx| async move {
-        let meter = opentelemetry::global::meter("janus_aggregator");
         let datastore = Arc::new(ctx.datastore);
         let collection_job_driver = Arc::new(CollectionJobDriver::new(
             reqwest::Client::builder()
                 .user_agent(CLIENT_USER_AGENT)
                 .build()
                 .context("couldn't create HTTP client")?,
-            &meter,
+            &ctx.meter,
             ctx.config.batch_aggregation_shard_count,
         ));
         let lease_duration =
@@ -42,7 +41,7 @@ async fn main() -> anyhow::Result<()> {
         let job_driver = Arc::new(JobDriver::new(
             ctx.clock,
             TokioRuntime,
-            meter,
+            ctx.meter,
             stopper,
             Duration::from_secs(ctx.config.job_driver_config.min_job_discovery_delay_secs),
             Duration::from_secs(ctx.config.job_driver_config.max_job_discovery_delay_secs),

--- a/aggregator/src/binary_utils/job_driver.rs
+++ b/aggregator/src/binary_utils/job_driver.rs
@@ -298,7 +298,10 @@ where
 mod tests {
     use super::JobDriver;
     use chrono::NaiveDateTime;
-    use janus_aggregator_core::datastore::{self, models::Lease};
+    use janus_aggregator_core::{
+        datastore::{self, models::Lease},
+        test_util::noop_meter,
+    };
     use janus_core::{
         task::VdafInstance,
         test_util::{install_test_trace_subscriber, runtime::TestRuntimeManager},
@@ -306,7 +309,6 @@ mod tests {
         Runtime,
     };
     use janus_messages::{AggregationJobId, TaskId};
-    use opentelemetry::global::meter;
     use rand::random;
     use std::{sync::Arc, time::Duration};
     use tokio::sync::Mutex;
@@ -392,7 +394,7 @@ mod tests {
             JobDriver::new(
                 clock,
                 runtime_manager.with_label("stepper"),
-                meter("job_driver_test"),
+                noop_meter(),
                 stopper.clone(),
                 Duration::from_secs(1),
                 Duration::from_secs(1),

--- a/aggregator/tests/graceful_shutdown.rs
+++ b/aggregator/tests/graceful_shutdown.rs
@@ -7,6 +7,7 @@ use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine};
 use janus_aggregator_core::{
     datastore::test_util::ephemeral_datastore,
     task::{test_util::TaskBuilder, QueryType},
+    test_util::noop_meter,
 };
 use janus_core::{task::VdafInstance, test_util::install_test_trace_subscriber, time::RealClock};
 use janus_messages::Role;
@@ -110,7 +111,9 @@ async fn graceful_shutdown(binary: &Path, mut config: Mapping) {
     // This datastore will be used indirectly by the child process, which
     // will connect to its backing database separately.
     let ephemeral_datastore = ephemeral_datastore().await;
-    let datastore = ephemeral_datastore.datastore(RealClock::default()).await;
+    let datastore = ephemeral_datastore
+        .datastore(RealClock::default(), &noop_meter())
+        .await;
 
     let health_check_port = select_open_port().await.unwrap();
     let health_check_listen_address = SocketAddr::from((Ipv4Addr::LOCALHOST, health_check_port));

--- a/aggregator_api/src/lib.rs
+++ b/aggregator_api/src/lib.rs
@@ -83,7 +83,7 @@ pub fn aggregator_api_handler<C: Clock>(ds: Arc<Datastore<C>>, cfg: Config) -> i
         State(ds),
         State(Arc::new(cfg)),
         // Metrics.
-        metrics("janus_aggregator_api").with_route(|conn| conn.route().map(ToString::to_string)),
+        metrics("janus_aggregator").with_route(|conn| conn.route().map(ToString::to_string)),
         // Authorization check.
         api(auth_check),
         // Check content type and accept headers

--- a/aggregator_api/src/lib.rs
+++ b/aggregator_api/src/lib.rs
@@ -606,8 +606,10 @@ mod tests {
                 ReportAggregationState,
             },
             test_util::{ephemeral_datastore, EphemeralDatastore},
+            Datastore,
         },
         task::{test_util::TaskBuilder, QueryType, Task},
+        test_util::noop_meter,
         SecretBytes,
     };
     use janus_core::{
@@ -634,24 +636,28 @@ mod tests {
 
     const AUTH_TOKEN: &str = "auth_token";
 
-    async fn setup_api_test() -> (impl Handler, EphemeralDatastore) {
+    async fn setup_api_test() -> (impl Handler, EphemeralDatastore, Arc<Datastore<MockClock>>) {
         install_test_trace_subscriber();
         let ephemeral_datastore = ephemeral_datastore().await;
+        let datastore = Arc::new(
+            ephemeral_datastore
+                .datastore(MockClock::default(), &noop_meter())
+                .await,
+        );
         let handler = aggregator_api_handler(
-            Arc::new(ephemeral_datastore.datastore(MockClock::default()).await),
+            Arc::clone(&datastore),
             Config {
                 auth_tokens: Vec::from([SecretBytes::new(AUTH_TOKEN.as_bytes().to_vec())]),
             },
         );
 
-        (handler, ephemeral_datastore)
+        (handler, ephemeral_datastore, datastore)
     }
 
     #[tokio::test]
     async fn get_task_ids() {
         // Setup: write a few tasks to the datastore.
-        let (handler, ephemeral_datastore) = setup_api_test().await;
-        let ds = ephemeral_datastore.datastore(MockClock::default()).await;
+        let (handler, _ephemeral_datastore, ds) = setup_api_test().await;
 
         let mut task_ids: Vec<_> = ds
             .run_tx(|tx| {
@@ -756,7 +762,7 @@ mod tests {
     #[tokio::test]
     async fn post_task_bad_role() {
         // Setup: create a datastore & handler.
-        let (handler, _ephemeral_datastore) = setup_api_test().await;
+        let (handler, _ephemeral_datastore, _) = setup_api_test().await;
 
         let vdaf_verify_key =
             SecretBytes::new(thread_rng().sample_iter(Standard).take(16).collect());
@@ -800,7 +806,7 @@ mod tests {
     #[tokio::test]
     async fn post_task_unauthorized() {
         // Setup: create a datastore & handler.
-        let (handler, _ephemeral_datastore) = setup_api_test().await;
+        let (handler, _ephemeral_datastore, _) = setup_api_test().await;
 
         let vdaf_verify_key =
             SecretBytes::new(thread_rng().sample_iter(Standard).take(16).collect());
@@ -842,8 +848,7 @@ mod tests {
     #[tokio::test]
     async fn post_task_helper_no_optional_fields() {
         // Setup: create a datastore & handler.
-        let (handler, ephemeral_datastore) = setup_api_test().await;
-        let ds = ephemeral_datastore.datastore(MockClock::default()).await;
+        let (handler, _ephemeral_datastore, ds) = setup_api_test().await;
 
         let vdaf_verify_key =
             SecretBytes::new(thread_rng().sample_iter(Standard).take(16).collect());
@@ -922,7 +927,7 @@ mod tests {
     #[tokio::test]
     async fn post_task_helper_with_aggregator_auth_token() {
         // Setup: create a datastore & handler.
-        let (handler, _ephemeral_datastore) = setup_api_test().await;
+        let (handler, _ephemeral_datastore, _) = setup_api_test().await;
 
         let vdaf_verify_key =
             SecretBytes::new(thread_rng().sample_iter(Standard).take(16).collect());
@@ -968,8 +973,7 @@ mod tests {
     #[tokio::test]
     async fn post_task_leader_all_optional_fields() {
         // Setup: create a datastore & handler.
-        let (handler, ephemeral_datastore) = setup_api_test().await;
-        let ds = ephemeral_datastore.datastore(MockClock::default()).await;
+        let (handler, _ephemeral_datastore, ds) = setup_api_test().await;
 
         let vdaf_verify_key =
             SecretBytes::new(thread_rng().sample_iter(Standard).take(16).collect());
@@ -1060,7 +1064,7 @@ mod tests {
     #[tokio::test]
     async fn post_task_leader_no_aggregator_auth_token() {
         // Setup: create a datastore & handler.
-        let (handler, _ephemeral_datastore) = setup_api_test().await;
+        let (handler, _ephemeral_datastore, _) = setup_api_test().await;
 
         let vdaf_verify_key =
             SecretBytes::new(thread_rng().sample_iter(Standard).take(16).collect());
@@ -1105,8 +1109,7 @@ mod tests {
     #[tokio::test]
     async fn get_task() {
         // Setup: write a task to the datastore.
-        let (handler, ephemeral_datastore) = setup_api_test().await;
-        let ds = ephemeral_datastore.datastore(MockClock::default()).await;
+        let (handler, _ephemeral_datastore, ds) = setup_api_test().await;
 
         let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Leader)
             .with_aggregator_auth_tokens(Vec::from([random()]))
@@ -1173,8 +1176,7 @@ mod tests {
     #[tokio::test]
     async fn delete_task() {
         // Setup: write a task to the datastore.
-        let (handler, ephemeral_datastore) = setup_api_test().await;
-        let ds = ephemeral_datastore.datastore(MockClock::default()).await;
+        let (handler, _ephemeral_datastore, ds) = setup_api_test().await;
 
         let task_id = ds
             .run_tx(|tx| {
@@ -1259,8 +1261,7 @@ mod tests {
         const REPORT_COUNT: usize = 10;
         const REPORT_AGGREGATION_COUNT: usize = 4;
 
-        let (handler, ephemeral_datastore) = setup_api_test().await;
-        let ds = ephemeral_datastore.datastore(MockClock::default()).await;
+        let (handler, _ephemeral_datastore, ds) = setup_api_test().await;
         let task_id = ds
             .run_tx(|tx| {
                 Box::pin(async move {

--- a/aggregator_core/src/datastore/test_util.rs
+++ b/aggregator_core/src/datastore/test_util.rs
@@ -2,6 +2,7 @@ use crate::datastore::{Crypter, Datastore};
 use deadpool_postgres::{Manager, Pool};
 use janus_core::time::Clock;
 use lazy_static::lazy_static;
+use opentelemetry::metrics::Meter;
 use rand::{distributions::Standard, random, thread_rng, Rng};
 use ring::aead::{LessSafeKey, UnboundKey, AES_128_GCM};
 use sqlx::{
@@ -108,8 +109,8 @@ pub struct EphemeralDatastore {
 impl EphemeralDatastore {
     /// Creates a Datastore instance based on this EphemeralDatastore. All returned Datastore
     /// instances will refer to the same underlying durable state.
-    pub async fn datastore<C: Clock>(&self, clock: C) -> Datastore<C> {
-        Datastore::new(self.pool(), self.crypter(), clock)
+    pub async fn datastore<C: Clock>(&self, clock: C, meter: &Meter) -> Datastore<C> {
+        Datastore::new(self.pool(), self.crypter(), clock, meter)
             .await
             .unwrap()
     }

--- a/aggregator_core/src/lib.rs
+++ b/aggregator_core/src/lib.rs
@@ -81,3 +81,12 @@ impl<H: Handler> InstrumentedHandler<H> {
         conn
     }
 }
+
+#[cfg(feature = "test-util")]
+pub mod test_util {
+    use opentelemetry::metrics::{noop::NoopMeterProvider, Meter, MeterProvider};
+
+    pub fn noop_meter() -> Meter {
+        NoopMeterProvider::new().meter("janus_aggregator")
+    }
+}


### PR DESCRIPTION
This refactors our OpenTelemetry metrics handling by passing a `Meter` instance around explicitly when setting up components. We now only emit metrics under a single library name, and most tests use a `Meter` from `NoopMeterProvider`. By explicitly passing this dependency, we can now replace it by using a non-global `BasicController` in tests, in order to either test metrics themselves, or use metrics as an introspection hook to test some other behavior.

Closes #1531.