### PR TITLE
Improve aggregation job creator graceful shutdown

### DIFF
--- a/aggregator/src/bin/aggregation_job_creator.rs
+++ b/aggregator/src/bin/aggregation_job_creator.rs
@@ -27,7 +27,7 @@ async fn main() -> anyhow::Result<()> {
             ctx.config.min_aggregation_job_size,
             ctx.config.max_aggregation_job_size,
         ));
-        stopper.stop_future(aggregation_job_creator.run()).await;
+        aggregation_job_creator.run(stopper).await;
 
         Ok(())
     })


### PR DESCRIPTION
This PR replaces oneshot channels and `select!` with `Stopper` in per-DAP task job creation tasks, checks for shutdown signals during each loop's sleep, and waits for all tasks to complete before exiting instead of cancelling the main task and letting per-DAP task tasks run detached.

Using `Stopper` should be more lightweight than `select!`, as the combinator future is better optimized for this simple case, and random number generators don't need to get involved. Avoiding cancellation of futures that interact with the database means we get a chance to finish work-in-progress in open transactions, and we will cause fewer transaction rollbacks and connection errors during normal operation.