### PR TITLE
Use sharded report counts in get_filled_outstanding_batch()

### DIFF
--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -3608,17 +3608,14 @@ impl<C: Clock> Transaction<'_, C> {
                 "WITH batches AS (
                     SELECT
                         outstanding_batches.batch_id AS batch_id,
-                        COUNT(DISTINCT report_aggregations.client_report_id) AS count
+                        SUM(batch_aggregations.report_count) AS count
                     FROM outstanding_batches
-                    JOIN aggregation_jobs
-                      ON aggregation_jobs.task_id = (SELECT id FROM tasks WHERE task_id = $1)
-                     AND aggregation_jobs.batch_id = outstanding_batches.batch_id
-                    JOIN report_aggregations
-                      ON report_aggregations.aggregation_job_id = aggregation_jobs.id
-                     AND report_aggregations.state = 'FINISHED'
-                    GROUP BY outstanding_batches.batch_id
+                    JOIN batch_aggregations
+                      ON batch_aggregations.batch_identifier = outstanding_batches.batch_id
+                    WHERE outstanding_batches.task_id = (SELECT id FROM tasks WHERE task_id = $1)
+                    GROUP BY outstanding_batches.batch_id, batch_aggregations.aggregation_param
                 )
-                SELECT batch_id FROM batches WHERE count >= $2 LIMIT 1",
+                SELECT DISTINCT batch_id FROM batches WHERE count >= $2::bigint LIMIT 1",
             )
             .await?;
         self.query_opt(
@@ -10251,6 +10248,33 @@ mod tests {
                         .await?;
                         tx.put_report_aggregation(report_aggregation).await?;
                     }
+
+                    tx.put_batch_aggregation(
+                        &BatchAggregation::<0, FixedSize, dummy_vdaf::Vdaf>::new(
+                            *task.id(),
+                            batch_id,
+                            AggregationParam(0),
+                            0,
+                            BatchAggregationState::Aggregating,
+                            Some(AggregateShare(0)),
+                            1,
+                            ReportIdChecksum::default(),
+                        ),
+                    )
+                    .await?;
+                    tx.put_batch_aggregation(
+                        &BatchAggregation::<0, FixedSize, dummy_vdaf::Vdaf>::new(
+                            *task.id(),
+                            batch_id,
+                            AggregationParam(0),
+                            1,
+                            BatchAggregationState::Aggregating,
+                            Some(AggregateShare(0)),
+                            1,
+                            ReportIdChecksum::default(),
+                        ),
+                    )
+                    .await?;
 
                     Ok((*task.id(), batch_id))
                 })


### PR DESCRIPTION
This PR simplifies the `get_filled_outstanding_batch()` query, so that it only joins against `batch_aggregations`, not `aggregation_jobs` and `report_aggregations`. Instead of counting finished report aggregations directly, we add up `report_count` columns from sharded batch aggregations, and perform the same filtering.

While looking at #1574, I was concerned that this query would fare poorly with many never-to-be-filled outstanding batches. This doesn't address the underlying asymptotic issue, but it does knock down the cardinality by using a much cheaper join and aggregate function. This rewrite may also be of use to #1467, since the query no longer touches report_aggregations.