### PR TITLE
Abandon release/0.2 branch.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,21 +18,3 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "main"
-
-  # Manage dependencies on the release/0.2 branch
-  - package-ecosystem: "cargo"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    target-branch: "release/0.2"
-    open-pull-requests-limit: 20
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    target-branch: "release/0.2"
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    target-branch: "release/0.2"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ branch.
 | Git branch | Draft version | Conforms to protocol? | Status |
 | ---------- | ------------- | --------------------- | ------ |
 | `release/0.1` | [`draft-ietf-ppm-dap-01`](https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/01/) | Yes | Unmaintained as of December 7, 2022 |
-| `release/0.2` | [`draft-ietf-ppm-dap-02`](https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/02/) | Yes | Supported |
+| `release/0.2` | [`draft-ietf-ppm-dap-02`](https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/02/) | Yes | Unmaintained as of July 13, 2023 |
 | `release/0.3` | [`draft-ietf-ppm-dap-03`](https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/03/) | Yes | Unmaintained as of February 6, 2023 |
 | `main` | [`draft-ietf-ppm-dap-04`](https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/04/) | Yes | Supported |
 


### PR DESCRIPTION
(We'll soon be forking `main` back to a DAP-02 release to pick up all of the work that has gone in since release/0.2 was under active development.)