### PR TITLE
Remove &Meter parameter from EphemeralDatastore::datastore().

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -2740,12 +2740,11 @@ mod tests {
         .build();
 
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
+        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
 
         datastore.put_task(&task).await.unwrap();
 
-        let aggregator = Aggregator::new(Arc::clone(&datastore), clock.clone(), &meter, cfg);
+        let aggregator = Aggregator::new(Arc::clone(&datastore), clock.clone(), &noop_meter(), cfg);
 
         (
             vdaf,

--- a/aggregator/src/aggregator/aggregate_init_tests.rs
+++ b/aggregator/src/aggregator/aggregate_init_tests.rs
@@ -118,15 +118,14 @@ async fn setup_aggregate_init_test_without_sending_request() -> AggregationJobIn
     let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Helper).build();
     let clock = MockClock::default();
     let ephemeral_datastore = ephemeral_datastore().await;
-    let meter = noop_meter();
-    let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
+    let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
 
     datastore.put_task(&task).await.unwrap();
 
     let handler = aggregator_handler(
         Arc::clone(&datastore),
         clock.clone(),
-        &meter,
+        &noop_meter(),
         Config::default(),
     )
     .unwrap();

--- a/aggregator/src/aggregator/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/aggregation_job_continue.rs
@@ -437,7 +437,7 @@ mod tests {
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
         let meter = noop_meter();
-        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
+        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
 
         let report_generator = ReportShareGenerator::new(
             clock.clone(),

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -776,8 +776,7 @@ mod tests {
         install_test_trace_subscriber();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let ds = ephemeral_datastore.datastore(clock.clone(), &meter).await;
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         // TODO(#234): consider using tokio::time::pause() to make time deterministic, and allow
         // this test to run without the need for a (racy, wallclock-consuming) real sleep.
@@ -824,7 +823,7 @@ mod tests {
         const AGGREGATION_JOB_CREATION_INTERVAL: Duration = Duration::from_secs(1);
         let job_creator = Arc::new(AggregationJobCreator::new(
             ds,
-            meter,
+            noop_meter(),
             Duration::from_secs(3600),
             AGGREGATION_JOB_CREATION_INTERVAL,
             0,
@@ -902,8 +901,7 @@ mod tests {
         install_test_trace_subscriber();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let ds = ephemeral_datastore.datastore(clock.clone(), &meter).await;
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
         const MIN_AGGREGATION_JOB_SIZE: usize = 50;
         const MAX_AGGREGATION_JOB_SIZE: usize = 60;
 
@@ -946,7 +944,7 @@ mod tests {
         // Run.
         let job_creator = Arc::new(AggregationJobCreator::new(
             ds,
-            meter,
+            noop_meter(),
             Duration::from_secs(3600),
             Duration::from_secs(1),
             MIN_AGGREGATION_JOB_SIZE,
@@ -1015,8 +1013,7 @@ mod tests {
         install_test_trace_subscriber();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let ds = ephemeral_datastore.datastore(clock.clone(), &meter).await;
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
         let task = Arc::new(
             TaskBuilder::new(
                 TaskQueryType::TimeInterval,
@@ -1044,7 +1041,7 @@ mod tests {
         // Run.
         let job_creator = Arc::new(AggregationJobCreator::new(
             ds,
-            meter,
+            noop_meter(),
             Duration::from_secs(3600),
             Duration::from_secs(1),
             2,
@@ -1140,8 +1137,7 @@ mod tests {
         install_test_trace_subscriber();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let ds = ephemeral_datastore.datastore(clock.clone(), &meter).await;
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
         const MIN_AGGREGATION_JOB_SIZE: usize = 50;
         const MAX_AGGREGATION_JOB_SIZE: usize = 60;
 
@@ -1194,7 +1190,7 @@ mod tests {
         // Run.
         let job_creator = Arc::new(AggregationJobCreator::new(
             ds,
-            meter,
+            noop_meter(),
             Duration::from_secs(3600),
             Duration::from_secs(1),
             MIN_AGGREGATION_JOB_SIZE,
@@ -1266,8 +1262,7 @@ mod tests {
         install_test_trace_subscriber();
         let clock: MockClock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let ds = ephemeral_datastore.datastore(clock.clone(), &meter).await;
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         const MIN_AGGREGATION_JOB_SIZE: usize = 50;
         const MAX_AGGREGATION_JOB_SIZE: usize = 60;
@@ -1316,7 +1311,7 @@ mod tests {
         // Run.
         let job_creator = Arc::new(AggregationJobCreator::new(
             ds,
-            meter,
+            noop_meter(),
             Duration::from_secs(3600),
             Duration::from_secs(1),
             MIN_AGGREGATION_JOB_SIZE,

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -958,8 +958,7 @@ mod tests {
         let clock = MockClock::default();
         let mut runtime_manager = TestRuntimeManager::new();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
+        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
         let task = TaskBuilder::new(
             QueryType::TimeInterval,
@@ -1115,7 +1114,7 @@ mod tests {
         .await;
         let aggregation_job_driver = Arc::new(AggregationJobDriver::new(
             reqwest::Client::new(),
-            &meter,
+            &noop_meter(),
             32,
         ));
         let stopper = Stopper::new();
@@ -1125,7 +1124,7 @@ mod tests {
             JobDriver::new(
                 clock,
                 runtime_manager.with_label("stepper"),
-                meter,
+                noop_meter(),
                 stopper.clone(),
                 StdDuration::from_secs(1),
                 StdDuration::from_secs(1),
@@ -1239,8 +1238,7 @@ mod tests {
         let mut server = mockito::Server::new_async().await;
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
+        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
 
         let task = TaskBuilder::new(
@@ -1440,8 +1438,11 @@ mod tests {
             .await;
 
         // Run: create an aggregation job driver & try to step the aggregation we've created twice.
-        let aggregation_job_driver =
-            AggregationJobDriver::new(reqwest::Client::builder().build().unwrap(), &meter, 32);
+        let aggregation_job_driver = AggregationJobDriver::new(
+            reqwest::Client::builder().build().unwrap(),
+            &noop_meter(),
+            32,
+        );
         let error = aggregation_job_driver
             .step_aggregation_job(ds.clone(), Arc::new(lease.clone()))
             .await
@@ -1601,8 +1602,7 @@ mod tests {
         let mut server = mockito::Server::new_async().await;
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
+        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
 
         let task = TaskBuilder::new(
@@ -1759,8 +1759,11 @@ mod tests {
             .await;
 
         // Run: create an aggregation job driver & try to step the aggregation we've created twice.
-        let aggregation_job_driver =
-            AggregationJobDriver::new(reqwest::Client::builder().build().unwrap(), &meter, 32);
+        let aggregation_job_driver = AggregationJobDriver::new(
+            reqwest::Client::builder().build().unwrap(),
+            &noop_meter(),
+            32,
+        );
         let error = aggregation_job_driver
             .step_aggregation_job(ds.clone(), Arc::new(lease.clone()))
             .await
@@ -1855,8 +1858,7 @@ mod tests {
         let mut server = mockito::Server::new_async().await;
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
+        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
 
         let task = TaskBuilder::new(
@@ -2054,8 +2056,11 @@ mod tests {
             .await;
 
         // Run: create an aggregation job driver & try to step the aggregation we've created twice.
-        let aggregation_job_driver =
-            AggregationJobDriver::new(reqwest::Client::builder().build().unwrap(), &meter, 32);
+        let aggregation_job_driver = AggregationJobDriver::new(
+            reqwest::Client::builder().build().unwrap(),
+            &noop_meter(),
+            32,
+        );
         let error = aggregation_job_driver
             .step_aggregation_job(ds.clone(), Arc::new(lease.clone()))
             .await
@@ -2244,8 +2249,7 @@ mod tests {
         let mut server = mockito::Server::new_async().await;
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
+        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
 
         let task = TaskBuilder::new(
@@ -2418,8 +2422,11 @@ mod tests {
             .await;
 
         // Run: create an aggregation job driver & try to step the aggregation we've created twice.
-        let aggregation_job_driver =
-            AggregationJobDriver::new(reqwest::Client::builder().build().unwrap(), &meter, 32);
+        let aggregation_job_driver = AggregationJobDriver::new(
+            reqwest::Client::builder().build().unwrap(),
+            &noop_meter(),
+            32,
+        );
         let error = aggregation_job_driver
             .step_aggregation_job(ds.clone(), Arc::new(lease.clone()))
             .await
@@ -2569,8 +2576,7 @@ mod tests {
         install_test_trace_subscriber();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
+        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
 
         let task = TaskBuilder::new(
@@ -2667,8 +2673,11 @@ mod tests {
         assert_eq!(lease.leased().aggregation_job_id(), &aggregation_job_id);
 
         // Run: create an aggregation job driver & cancel the aggregation job.
-        let aggregation_job_driver =
-            AggregationJobDriver::new(reqwest::Client::builder().build().unwrap(), &meter, 32);
+        let aggregation_job_driver = AggregationJobDriver::new(
+            reqwest::Client::builder().build().unwrap(),
+            &noop_meter(),
+            32,
+        );
         aggregation_job_driver
             .cancel_aggregation_job(Arc::clone(&ds), lease)
             .await
@@ -2781,8 +2790,7 @@ mod tests {
         let clock = MockClock::default();
         let mut runtime_manager = TestRuntimeManager::new();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
+        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
         let stopper = Stopper::new();
 
         let task = TaskBuilder::new(
@@ -2881,14 +2889,14 @@ mod tests {
         // Set up the aggregation job driver.
         let aggregation_job_driver = Arc::new(AggregationJobDriver::new(
             reqwest::Client::new(),
-            &meter,
+            &noop_meter(),
             32,
         ));
         let job_driver = Arc::new(
             JobDriver::new(
                 clock.clone(),
                 runtime_manager.with_label("stepper"),
-                meter,
+                noop_meter(),
                 stopper.clone(),
                 StdDuration::from_secs(1),
                 StdDuration::from_secs(1),

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -689,8 +689,7 @@ mod tests {
         let mut server = mockito::Server::new_async().await;
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
+        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
 
         let time_precision = Duration::from_seconds(500);
         let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Leader)
@@ -771,8 +770,11 @@ mod tests {
             .await
             .unwrap();
 
-        let collection_job_driver =
-            CollectionJobDriver::new(reqwest::Client::builder().build().unwrap(), &meter, 1);
+        let collection_job_driver = CollectionJobDriver::new(
+            reqwest::Client::builder().build().unwrap(),
+            &noop_meter(),
+            1,
+        );
 
         // No batch aggregations inserted yet.
         let error = collection_job_driver
@@ -952,14 +954,16 @@ mod tests {
         let mut server = mockito::Server::new_async().await;
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
+        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
 
         let (_, lease, collection_job) =
             setup_collection_job_test_case(&mut server, clock, Arc::clone(&ds), true).await;
 
-        let collection_job_driver =
-            CollectionJobDriver::new(reqwest::Client::builder().build().unwrap(), &meter, 1);
+        let collection_job_driver = CollectionJobDriver::new(
+            reqwest::Client::builder().build().unwrap(),
+            &noop_meter(),
+            1,
+        );
 
         // Run: abandon the collection job.
         collection_job_driver
@@ -1003,8 +1007,7 @@ mod tests {
         let clock = MockClock::default();
         let mut runtime_manager = TestRuntimeManager::new();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
+        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
         let stopper = Stopper::new();
 
         let (task, _, collection_job) =
@@ -1012,13 +1015,16 @@ mod tests {
                 .await;
 
         // Set up the collection job driver
-        let collection_job_driver =
-            Arc::new(CollectionJobDriver::new(reqwest::Client::new(), &meter, 1));
+        let collection_job_driver = Arc::new(CollectionJobDriver::new(
+            reqwest::Client::new(),
+            &noop_meter(),
+            1,
+        ));
         let job_driver = Arc::new(
             JobDriver::new(
                 clock.clone(),
                 runtime_manager.with_label("stepper"),
-                meter,
+                noop_meter(),
                 stopper.clone(),
                 StdDuration::from_secs(1),
                 StdDuration::from_secs(1),
@@ -1100,8 +1106,7 @@ mod tests {
         let mut server = mockito::Server::new_async().await;
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
+        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
 
         let (task, lease, collection_job) =
             setup_collection_job_test_case(&mut server, clock, Arc::clone(&ds), true).await;
@@ -1134,7 +1139,8 @@ mod tests {
             .create_async()
             .await;
 
-        let collection_job_driver = CollectionJobDriver::new(reqwest::Client::new(), &meter, 1);
+        let collection_job_driver =
+            CollectionJobDriver::new(reqwest::Client::new(), &noop_meter(), 1);
 
         // Step the collection job. The driver should successfully run the job, but then discard the
         // results when it notices the job has been deleted.

--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -128,15 +128,14 @@ pub(crate) async fn setup_collection_job_test_case(
         .build();
     let clock = MockClock::default();
     let ephemeral_datastore = ephemeral_datastore().await;
-    let meter = noop_meter();
-    let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
+    let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
 
     datastore.put_task(&task).await.unwrap();
 
     let handler = aggregator_handler(
         Arc::clone(&datastore),
         clock.clone(),
-        &meter,
+        &noop_meter(),
         Config {
             batch_aggregation_shard_count: 32,
             ..Default::default()

--- a/aggregator/src/aggregator/garbage_collector.rs
+++ b/aggregator/src/aggregator/garbage_collector.rs
@@ -84,7 +84,6 @@ mod tests {
             test_util::ephemeral_datastore,
         },
         task::{self, test_util::TaskBuilder},
-        test_util::noop_meter,
     };
     use janus_core::{
         task::VdafInstance,
@@ -110,11 +109,7 @@ mod tests {
 
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let ds = Arc::new(
-            ephemeral_datastore
-                .datastore(clock.clone(), &noop_meter())
-                .await,
-        );
+        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
         let vdaf = dummy_vdaf::Vdaf::new();
 
         // Setup.
@@ -216,11 +211,7 @@ mod tests {
 
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let ds = Arc::new(
-            ephemeral_datastore
-                .datastore(clock.clone(), &noop_meter())
-                .await,
-        );
+        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
         let vdaf = dummy_vdaf::Vdaf::new();
 
         // Setup.
@@ -331,11 +322,7 @@ mod tests {
 
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let ds = Arc::new(
-            ephemeral_datastore
-                .datastore(clock.clone(), &noop_meter())
-                .await,
-        );
+        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
         let vdaf = dummy_vdaf::Vdaf::new();
 
         // Setup.
@@ -435,11 +422,7 @@ mod tests {
 
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let ds = Arc::new(
-            ephemeral_datastore
-                .datastore(clock.clone(), &noop_meter())
-                .await,
-        );
+        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
         let vdaf = dummy_vdaf::Vdaf::new();
 
         // Setup.

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -625,8 +625,7 @@ mod tests {
         let unknown_task_id: TaskId = random();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let datastore = ephemeral_datastore.datastore(clock.clone(), &meter).await;
+        let datastore = ephemeral_datastore.datastore(clock.clone()).await;
 
         datastore.put_task(&task).await.unwrap();
 
@@ -635,7 +634,7 @@ mod tests {
         let handler = aggregator_handler(
             Arc::new(datastore),
             clock,
-            &meter,
+            &noop_meter(),
             default_aggregator_config(),
         )
         .unwrap();
@@ -746,15 +745,14 @@ mod tests {
         .build();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let datastore = ephemeral_datastore.datastore(clock.clone(), &meter).await;
+        let datastore = ephemeral_datastore.datastore(clock.clone()).await;
 
         datastore.put_task(&task).await.unwrap();
 
         let handler = aggregator_handler(
             Arc::new(datastore),
             clock,
-            &meter,
+            &noop_meter(),
             default_aggregator_config(),
         )
         .unwrap();
@@ -831,15 +829,14 @@ mod tests {
         .build();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
+        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
 
         datastore.put_task(&task).await.unwrap();
         let report = create_report(&task, clock.now());
         let handler = aggregator_handler(
             Arc::clone(&datastore),
             clock.clone(),
-            &meter,
+            &noop_meter(),
             default_aggregator_config(),
         )
         .unwrap();
@@ -1062,8 +1059,7 @@ mod tests {
 
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let datastore = ephemeral_datastore.datastore(clock.clone(), &meter).await;
+        let datastore = ephemeral_datastore.datastore(clock.clone()).await;
 
         let task = TaskBuilder::new(
             QueryType::TimeInterval,
@@ -1077,7 +1073,7 @@ mod tests {
         let handler = aggregator_handler(
             Arc::new(datastore),
             clock,
-            &meter,
+            &noop_meter(),
             default_aggregator_config(),
         )
         .unwrap();
@@ -1129,8 +1125,7 @@ mod tests {
         .build();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let datastore = ephemeral_datastore.datastore(clock.clone(), &meter).await;
+        let datastore = ephemeral_datastore.datastore(clock.clone()).await;
 
         datastore.put_task(&task).await.unwrap();
 
@@ -1143,7 +1138,7 @@ mod tests {
         let handler = aggregator_handler(
             Arc::new(datastore),
             clock,
-            &meter,
+            &noop_meter(),
             default_aggregator_config(),
         )
         .unwrap();
@@ -1223,8 +1218,7 @@ mod tests {
         .build();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let datastore = ephemeral_datastore.datastore(clock.clone(), &meter).await;
+        let datastore = ephemeral_datastore.datastore(clock.clone()).await;
 
         datastore.put_task(&task).await.unwrap();
 
@@ -1237,7 +1231,7 @@ mod tests {
         let handler = aggregator_handler(
             Arc::new(datastore),
             clock,
-            &meter,
+            &noop_meter(),
             default_aggregator_config(),
         )
         .unwrap();
@@ -1307,8 +1301,7 @@ mod tests {
             TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Helper).build();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
+        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
 
         let vdaf = dummy_vdaf::Vdaf::new();
         let verify_key: VerifyKey<0> = task.primary_vdaf_verify_key().unwrap();
@@ -1678,7 +1671,7 @@ mod tests {
         let handler = aggregator_handler(
             Arc::clone(&datastore),
             clock,
-            &meter,
+            &noop_meter(),
             default_aggregator_config(),
         )
         .unwrap();
@@ -1884,8 +1877,7 @@ mod tests {
         .build();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let datastore = ephemeral_datastore.datastore(clock.clone(), &meter).await;
+        let datastore = ephemeral_datastore.datastore(clock.clone()).await;
         let hpke_key = task.current_hpke_key();
 
         datastore.put_task(&task).await.unwrap();
@@ -1914,7 +1906,7 @@ mod tests {
         let handler = aggregator_handler(
             Arc::new(datastore),
             clock,
-            &meter,
+            &noop_meter(),
             default_aggregator_config(),
         )
         .unwrap();
@@ -1959,8 +1951,7 @@ mod tests {
         .build();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let datastore = ephemeral_datastore.datastore(clock.clone(), &meter).await;
+        let datastore = ephemeral_datastore.datastore(clock.clone()).await;
         let hpke_key = task.current_hpke_key();
 
         datastore.put_task(&task).await.unwrap();
@@ -1989,7 +1980,7 @@ mod tests {
         let handler = aggregator_handler(
             Arc::new(datastore),
             clock,
-            &meter,
+            &noop_meter(),
             default_aggregator_config(),
         )
         .unwrap();
@@ -2033,8 +2024,7 @@ mod tests {
         .build();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let datastore = ephemeral_datastore.datastore(clock.clone(), &meter).await;
+        let datastore = ephemeral_datastore.datastore(clock.clone()).await;
 
         datastore.put_task(&task).await.unwrap();
 
@@ -2061,7 +2051,7 @@ mod tests {
         let handler = aggregator_handler(
             Arc::new(datastore),
             clock,
-            &meter,
+            &noop_meter(),
             default_aggregator_config(),
         )
         .unwrap();
@@ -2106,8 +2096,7 @@ mod tests {
         .build();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
+        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
 
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
         let verify_key: VerifyKey<PRIO3_VERIFY_KEY_LENGTH> =
@@ -2312,7 +2301,7 @@ mod tests {
         let handler = aggregator_handler(
             Arc::clone(&datastore),
             clock,
-            &meter,
+            &noop_meter(),
             default_aggregator_config(),
         )
         .unwrap();
@@ -2426,12 +2415,7 @@ mod tests {
         let aggregation_job_id_0 = random();
         let aggregation_job_id_1 = random();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let datastore = Arc::new(
-            ephemeral_datastore
-                .datastore(MockClock::default(), &meter)
-                .await,
-        );
+        let datastore = Arc::new(ephemeral_datastore.datastore(MockClock::default()).await);
         let first_batch_interval_clock = MockClock::default();
         let second_batch_interval_clock = MockClock::new(
             first_batch_interval_clock
@@ -2662,7 +2646,7 @@ mod tests {
         let handler = aggregator_handler(
             Arc::clone(&datastore),
             first_batch_interval_clock.clone(),
-            &meter,
+            &noop_meter(),
             default_aggregator_config(),
         )
         .unwrap();
@@ -2965,7 +2949,7 @@ mod tests {
         let handler = aggregator_handler(
             Arc::clone(&datastore),
             first_batch_interval_clock,
-            &meter,
+            &noop_meter(),
             default_aggregator_config(),
         )
         .unwrap();
@@ -3100,8 +3084,7 @@ mod tests {
         );
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
+        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
 
         // Setup datastore.
         datastore
@@ -3168,7 +3151,7 @@ mod tests {
         let handler = aggregator_handler(
             Arc::clone(&datastore),
             clock,
-            &meter,
+            &noop_meter(),
             default_aggregator_config(),
         )
         .unwrap();
@@ -3204,8 +3187,7 @@ mod tests {
         );
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
+        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
 
         // Setup datastore.
         datastore
@@ -3272,7 +3254,7 @@ mod tests {
         let handler = aggregator_handler(
             Arc::clone(&datastore),
             clock,
-            &meter,
+            &noop_meter(),
             default_aggregator_config(),
         )
         .unwrap();
@@ -3359,8 +3341,7 @@ mod tests {
         );
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let datastore = ephemeral_datastore.datastore(clock.clone(), &meter).await;
+        let datastore = ephemeral_datastore.datastore(clock.clone()).await;
 
         // Setup datastore.
         datastore
@@ -3429,7 +3410,7 @@ mod tests {
         let handler = aggregator_handler(
             Arc::new(datastore),
             clock,
-            &meter,
+            &noop_meter(),
             default_aggregator_config(),
         )
         .unwrap();
@@ -3466,8 +3447,7 @@ mod tests {
 
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let datastore = ephemeral_datastore.datastore(clock.clone(), &meter).await;
+        let datastore = ephemeral_datastore.datastore(clock.clone()).await;
 
         // Setup datastore.
         datastore
@@ -3574,7 +3554,7 @@ mod tests {
         let handler = aggregator_handler(
             Arc::new(datastore),
             clock,
-            &meter,
+            &noop_meter(),
             default_aggregator_config(),
         )
         .unwrap();
@@ -3607,8 +3587,7 @@ mod tests {
 
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let datastore = ephemeral_datastore.datastore(clock.clone(), &meter).await;
+        let datastore = ephemeral_datastore.datastore(clock.clone()).await;
 
         // Setup datastore.
         datastore
@@ -3674,7 +3653,7 @@ mod tests {
         let handler = aggregator_handler(
             Arc::new(datastore),
             clock,
-            &meter,
+            &noop_meter(),
             default_aggregator_config(),
         )
         .unwrap();
@@ -3827,15 +3806,14 @@ mod tests {
             .build();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let datastore = ephemeral_datastore.datastore(clock.clone(), &meter).await;
+        let datastore = ephemeral_datastore.datastore(clock.clone()).await;
 
         datastore.put_task(&task).await.unwrap();
 
         let handler = aggregator_handler(
             Arc::new(datastore),
             clock,
-            &meter,
+            &noop_meter(),
             default_aggregator_config(),
         )
         .unwrap();
@@ -4536,15 +4514,14 @@ mod tests {
             TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Leader).build();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let datastore = ephemeral_datastore.datastore(clock.clone(), &meter).await;
+        let datastore = ephemeral_datastore.datastore(clock.clone()).await;
 
         datastore.put_task(&task).await.unwrap();
 
         let handler = aggregator_handler(
             Arc::new(datastore),
             clock,
-            &meter,
+            &noop_meter(),
             default_aggregator_config(),
         )
         .unwrap();
@@ -4603,15 +4580,14 @@ mod tests {
             .build();
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let datastore = ephemeral_datastore.datastore(clock.clone(), &meter).await;
+        let datastore = ephemeral_datastore.datastore(clock.clone()).await;
 
         datastore.put_task(&task).await.unwrap();
 
         let handler = aggregator_handler(
             Arc::new(datastore),
             clock.clone(),
-            &meter,
+            &noop_meter(),
             default_aggregator_config(),
         )
         .unwrap();
@@ -4707,15 +4683,14 @@ mod tests {
 
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let meter = noop_meter();
-        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone(), &meter).await);
+        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
 
         datastore.put_task(&task).await.unwrap();
 
         let handler = aggregator_handler(
             Arc::clone(&datastore),
             clock,
-            &meter,
+            &noop_meter(),
             default_aggregator_config(),
         )
         .unwrap();

--- a/aggregator/src/bin/janus_cli.rs
+++ b/aggregator/src/bin/janus_cli.rs
@@ -470,7 +470,6 @@ mod tests {
     use janus_aggregator_core::{
         datastore::{test_util::ephemeral_datastore, Datastore},
         task::{test_util::TaskBuilder, QueryType, Task},
-        test_util::noop_meter,
     };
     use janus_core::{
         task::VdafInstance,
@@ -586,9 +585,7 @@ mod tests {
     #[tokio::test]
     async fn provision_tasks() {
         let ephemeral_datastore = ephemeral_datastore().await;
-        let ds = ephemeral_datastore
-            .datastore(RealClock::default(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(RealClock::default()).await;
 
         let tasks = Vec::from([
             TaskBuilder::new(
@@ -622,9 +619,7 @@ mod tests {
     #[tokio::test]
     async fn provision_task_dry_run() {
         let ephemeral_datastore = ephemeral_datastore().await;
-        let ds = ephemeral_datastore
-            .datastore(RealClock::default(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(RealClock::default()).await;
 
         let tasks = Vec::from([TaskBuilder::new(
             QueryType::TimeInterval,
@@ -664,9 +659,7 @@ mod tests {
         ]);
 
         let ephemeral_datastore = ephemeral_datastore().await;
-        let ds = ephemeral_datastore
-            .datastore(RealClock::default(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(RealClock::default()).await;
 
         let mut tasks_file = NamedTempFile::new().unwrap();
         tasks_file
@@ -772,9 +765,7 @@ mod tests {
 "#;
 
         let ephemeral_datastore = ephemeral_datastore().await;
-        let ds = ephemeral_datastore
-            .datastore(RealClock::default(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(RealClock::default()).await;
 
         let mut tasks_file = NamedTempFile::new().unwrap();
         tasks_file

--- a/aggregator/tests/graceful_shutdown.rs
+++ b/aggregator/tests/graceful_shutdown.rs
@@ -7,7 +7,6 @@ use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine};
 use janus_aggregator_core::{
     datastore::test_util::ephemeral_datastore,
     task::{test_util::TaskBuilder, QueryType},
-    test_util::noop_meter,
 };
 use janus_core::{task::VdafInstance, test_util::install_test_trace_subscriber, time::RealClock};
 use janus_messages::Role;
@@ -111,9 +110,7 @@ async fn graceful_shutdown(binary: &Path, mut config: Mapping) {
     // This datastore will be used indirectly by the child process, which
     // will connect to its backing database separately.
     let ephemeral_datastore = ephemeral_datastore().await;
-    let datastore = ephemeral_datastore
-        .datastore(RealClock::default(), &noop_meter())
-        .await;
+    let datastore = ephemeral_datastore.datastore(RealClock::default()).await;
 
     let health_check_port = select_open_port().await.unwrap();
     let health_check_listen_address = SocketAddr::from((Ipv4Addr::LOCALHOST, health_check_port));

--- a/aggregator_api/src/lib.rs
+++ b/aggregator_api/src/lib.rs
@@ -609,7 +609,6 @@ mod tests {
             Datastore,
         },
         task::{test_util::TaskBuilder, QueryType, Task},
-        test_util::noop_meter,
         SecretBytes,
     };
     use janus_core::{
@@ -639,11 +638,7 @@ mod tests {
     async fn setup_api_test() -> (impl Handler, EphemeralDatastore, Arc<Datastore<MockClock>>) {
         install_test_trace_subscriber();
         let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = Arc::new(
-            ephemeral_datastore
-                .datastore(MockClock::default(), &noop_meter())
-                .await,
-        );
+        let datastore = Arc::new(ephemeral_datastore.datastore(MockClock::default()).await);
         let handler = aggregator_api_handler(
             Arc::clone(&datastore),
             Config {

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -6005,9 +6005,7 @@ mod tests {
     #[tokio::test]
     async fn roundtrip_task(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
-        let ds = ephemeral_datastore
-            .datastore(MockClock::default(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         // Insert tasks, check that they can be retrieved by ID.
         let mut want_tasks = HashMap::new();
@@ -6127,9 +6125,7 @@ mod tests {
         const REPORT_EXPIRY_AGE: Duration = Duration::from_seconds(1000);
 
         let clock = MockClock::new(OLDEST_ALLOWED_REPORT_TIMESTAMP);
-        let ds = ephemeral_datastore
-            .datastore(clock.clone(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         let task_id = ds
             .run_tx(|tx| {
@@ -6329,9 +6325,7 @@ mod tests {
     #[tokio::test]
     async fn get_task_ids(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
-        let ds = ephemeral_datastore
-            .datastore(MockClock::default(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         ds.run_tx(|tx| {
             Box::pin(async move {
@@ -6372,9 +6366,7 @@ mod tests {
     async fn roundtrip_report(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
         let clock = MockClock::default();
-        let ds = ephemeral_datastore
-            .datastore(clock.clone(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
         const OLDEST_ALLOWED_REPORT_TIMESTAMP: Time = Time::from_seconds_since_epoch(1000);
         let report_expiry_age = clock
             .now()
@@ -6498,9 +6490,7 @@ mod tests {
     #[tokio::test]
     async fn report_not_found(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
-        let ds = ephemeral_datastore
-            .datastore(MockClock::default(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         let rslt = ds
             .run_tx(|tx| {
@@ -6523,9 +6513,7 @@ mod tests {
         const OLDEST_ALLOWED_REPORT_TIMESTAMP: Time = Time::from_seconds_since_epoch(1000);
         const REPORT_EXPIRY_AGE: Duration = Duration::from_seconds(1000);
         let clock = MockClock::new(OLDEST_ALLOWED_REPORT_TIMESTAMP);
-        let ds = ephemeral_datastore
-            .datastore(clock.clone(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
         let report_interval = Interval::new(
             OLDEST_ALLOWED_REPORT_TIMESTAMP
                 .sub(&Duration::from_seconds(1))
@@ -6705,9 +6693,7 @@ mod tests {
         const OLDEST_ALLOWED_REPORT_TIMESTAMP: Time = Time::from_seconds_since_epoch(1000);
         const REPORT_EXPIRY_AGE: Duration = Duration::from_seconds(1000);
         let clock = MockClock::new(OLDEST_ALLOWED_REPORT_TIMESTAMP);
-        let ds = ephemeral_datastore
-            .datastore(clock.clone(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         let task = TaskBuilder::new(
             task::QueryType::TimeInterval,
@@ -6835,9 +6821,7 @@ mod tests {
         const OLDEST_ALLOWED_REPORT_TIMESTAMP: Time = Time::from_seconds_since_epoch(1000);
         const REPORT_EXPIRY_AGE: Duration = Duration::from_seconds(1000);
         let clock = MockClock::new(OLDEST_ALLOWED_REPORT_TIMESTAMP);
-        let ds = ephemeral_datastore
-            .datastore(clock.clone(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         let task = TaskBuilder::new(
             task::QueryType::FixedSize { max_batch_size: 10 },
@@ -7017,9 +7001,7 @@ mod tests {
     #[tokio::test]
     async fn roundtrip_report_share(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
-        let ds = ephemeral_datastore
-            .datastore(MockClock::default(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         let task = TaskBuilder::new(
             task::QueryType::TimeInterval,
@@ -7119,9 +7101,7 @@ mod tests {
         const OLDEST_ALLOWED_REPORT_TIMESTAMP: Time = Time::from_seconds_since_epoch(1000);
         const REPORT_EXPIRY_AGE: Duration = Duration::from_seconds(1000);
         let clock = MockClock::new(OLDEST_ALLOWED_REPORT_TIMESTAMP);
-        let ds = ephemeral_datastore
-            .datastore(clock.clone(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         // We use a dummy VDAF & fixed-size task for this test, to better exercise the
         // serialization/deserialization roundtrip of the batch_identifier & aggregation_param.
@@ -7339,11 +7319,7 @@ mod tests {
         const REPORT_EXPIRY_AGE: Duration = Duration::from_seconds(1000);
         const LEASE_DURATION: StdDuration = StdDuration::from_secs(300);
         let clock = MockClock::new(OLDEST_ALLOWED_REPORT_TIMESTAMP);
-        let ds = Arc::new(
-            ephemeral_datastore
-                .datastore(clock.clone(), &noop_meter())
-                .await,
-        );
+        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
 
         const AGGREGATION_JOB_COUNT: usize = 10;
         let task = TaskBuilder::new(
@@ -7684,9 +7660,7 @@ mod tests {
     #[tokio::test]
     async fn aggregation_job_not_found(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
-        let ds = ephemeral_datastore
-            .datastore(MockClock::default(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         let rslt = ds
             .run_tx(|tx| {
@@ -7732,9 +7706,7 @@ mod tests {
     async fn get_aggregation_jobs_for_task(ephemeral_datastore: EphemeralDatastore) {
         // Setup.
         install_test_trace_subscriber();
-        let ds = ephemeral_datastore
-            .datastore(MockClock::default(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         // We use a dummy VDAF & fixed-size task for this test, to better exercise the
         // serialization/deserialization roundtrip of the batch_identifier & aggregation_param.
@@ -7834,7 +7806,6 @@ mod tests {
     #[tokio::test]
     async fn roundtrip_report_aggregation(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
-        let meter = noop_meter();
 
         const OLDEST_ALLOWED_REPORT_TIMESTAMP: Time = Time::from_seconds_since_epoch(1000);
         const REPORT_EXPIRY_AGE: Duration = Duration::from_seconds(1000);
@@ -7859,7 +7830,7 @@ mod tests {
         .enumerate()
         {
             let clock = MockClock::new(OLDEST_ALLOWED_REPORT_TIMESTAMP);
-            let ds = ephemeral_datastore.datastore(clock.clone(), &meter).await;
+            let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
             let task = TaskBuilder::new(
                 task::QueryType::TimeInterval,
@@ -8021,9 +7992,7 @@ mod tests {
         const OLDEST_ALLOWED_REPORT_TIMESTAMP: Time = Time::from_seconds_since_epoch(1000);
         const REPORT_EXPIRY_AGE: Duration = Duration::from_seconds(1000);
         let clock = MockClock::new(OLDEST_ALLOWED_REPORT_TIMESTAMP);
-        let ds = ephemeral_datastore
-            .datastore(clock.clone(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         let task = TaskBuilder::new(
             task::QueryType::TimeInterval,
@@ -8175,9 +8144,7 @@ mod tests {
     #[tokio::test]
     async fn report_aggregation_not_found(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
-        let ds = ephemeral_datastore
-            .datastore(MockClock::default(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         let vdaf = Arc::new(dummy_vdaf::Vdaf::default());
 
@@ -8226,9 +8193,7 @@ mod tests {
         const OLDEST_ALLOWED_REPORT_TIMESTAMP: Time = Time::from_seconds_since_epoch(1000);
         const REPORT_EXPIRY_AGE: Duration = Duration::from_seconds(1000);
         let clock = MockClock::new(OLDEST_ALLOWED_REPORT_TIMESTAMP);
-        let ds = ephemeral_datastore
-            .datastore(clock.clone(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         let report_id = random();
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
@@ -8416,9 +8381,7 @@ mod tests {
         .unwrap();
         let aggregation_param = AggregationParam(13);
 
-        let ds = ephemeral_datastore
-            .datastore(MockClock::default(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         ds.run_tx(|tx| {
             let task = task.clone();
@@ -8516,9 +8479,7 @@ mod tests {
         // Setup: write collection jobs to the datastore.
         install_test_trace_subscriber();
 
-        let ds = ephemeral_datastore
-            .datastore(MockClock::default(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         let task = TaskBuilder::new(
             task::QueryType::TimeInterval,
@@ -8776,9 +8737,7 @@ mod tests {
     ) {
         install_test_trace_subscriber();
         let clock = MockClock::default();
-        let ds = ephemeral_datastore
-            .datastore(clock.clone(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         let task_id = random();
         let reports = Vec::from([LeaderStoredReport::new_dummy(
@@ -8908,9 +8867,7 @@ mod tests {
     ) {
         install_test_trace_subscriber();
         let clock = MockClock::default();
-        let ds = ephemeral_datastore
-            .datastore(clock.clone(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         let task_id = random();
         let reports = Vec::from([LeaderStoredReport::new_dummy(
@@ -9032,9 +8989,7 @@ mod tests {
     ) {
         install_test_trace_subscriber();
         let clock = MockClock::default();
-        let ds = ephemeral_datastore
-            .datastore(clock.clone(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         let task_id = random();
         let other_task_id = random();
@@ -9087,9 +9042,7 @@ mod tests {
     ) {
         install_test_trace_subscriber();
         let clock = MockClock::default();
-        let ds = ephemeral_datastore
-            .datastore(clock.clone(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         let task_id = random();
         let reports = Vec::from([LeaderStoredReport::new_dummy(
@@ -9145,9 +9098,7 @@ mod tests {
     ) {
         install_test_trace_subscriber();
         let clock = MockClock::default();
-        let ds = ephemeral_datastore
-            .datastore(clock.clone(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         let task_id = random();
         let reports = Vec::from([LeaderStoredReport::new_dummy(
@@ -9211,9 +9162,7 @@ mod tests {
     async fn collection_job_acquire_release_job_finished(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
         let clock = MockClock::default();
-        let ds = ephemeral_datastore
-            .datastore(clock.clone(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         let task_id = random();
         let reports = Vec::from([LeaderStoredReport::new_dummy(
@@ -9279,9 +9228,7 @@ mod tests {
     ) {
         install_test_trace_subscriber();
         let clock = MockClock::default();
-        let ds = ephemeral_datastore
-            .datastore(clock.clone(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         let task_id = random();
         let reports = Vec::from([
@@ -9368,9 +9315,7 @@ mod tests {
     async fn collection_job_acquire_job_max(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
         let clock = MockClock::default();
-        let ds = ephemeral_datastore
-            .datastore(clock.clone(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         let task_id = random();
         let reports = Vec::from([LeaderStoredReport::new_dummy(
@@ -9519,9 +9464,7 @@ mod tests {
     async fn collection_job_acquire_state_filtering(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
         let clock = MockClock::default();
-        let ds = ephemeral_datastore
-            .datastore(clock.clone(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         let task_id = random();
         let reports = Vec::from([LeaderStoredReport::new_dummy(
@@ -9656,9 +9599,7 @@ mod tests {
     async fn roundtrip_batch_aggregation_time_interval(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
 
-        let ds = ephemeral_datastore
-            .datastore(MockClock::default(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         ds.run_tx(|tx| {
             Box::pin(async move {
@@ -9875,9 +9816,7 @@ mod tests {
     async fn roundtrip_batch_aggregation_fixed_size(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
 
-        let ds = ephemeral_datastore
-            .datastore(MockClock::default(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         ds.run_tx(|tx| {
             Box::pin(async move {
@@ -10004,9 +9943,7 @@ mod tests {
     async fn roundtrip_aggregate_share_job(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
 
-        let ds = ephemeral_datastore
-            .datastore(MockClock::default(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
         ds.run_tx(|tx| {
             Box::pin(async move {
@@ -10116,9 +10053,7 @@ mod tests {
         install_test_trace_subscriber();
 
         let clock = MockClock::default();
-        let ds = ephemeral_datastore
-            .datastore(clock.clone(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         let (task_id, batch_id) = ds
             .run_tx(|tx| {
@@ -10333,9 +10268,7 @@ mod tests {
         install_test_trace_subscriber();
 
         let clock = MockClock::default();
-        let ds = ephemeral_datastore
-            .datastore(clock.clone(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         ds.run_tx(|tx| {
             Box::pin(async move {
@@ -10514,9 +10447,7 @@ mod tests {
         install_test_trace_subscriber();
 
         let clock = MockClock::default();
-        let ds = ephemeral_datastore
-            .datastore(clock.clone(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
         let vdaf = dummy_vdaf::Vdaf::new();
 
         // Setup.
@@ -10613,9 +10544,7 @@ mod tests {
         const OLDEST_ALLOWED_REPORT_TIMESTAMP: Time = Time::from_seconds_since_epoch(1000);
         const REPORT_EXPIRY_AGE: Duration = Duration::from_seconds(1000);
         let clock = MockClock::new(OLDEST_ALLOWED_REPORT_TIMESTAMP);
-        let ds = ephemeral_datastore
-            .datastore(clock.clone(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
         let vdaf = dummy_vdaf::Vdaf::new();
 
         // Setup.
@@ -11069,9 +10998,7 @@ mod tests {
         install_test_trace_subscriber();
 
         let clock = MockClock::default();
-        let ds = ephemeral_datastore
-            .datastore(clock.clone(), &noop_meter())
-            .await;
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
         // Setup.
         async fn write_collect_artifacts<Q: ExpirationQueryTypeExt>(
@@ -11620,9 +11547,7 @@ mod tests {
     #[tokio::test]
     async fn roundtrip_interval_sql(ephemeral_datastore: EphemeralDatastore) {
         install_test_trace_subscriber();
-        let datastore = ephemeral_datastore
-            .datastore(MockClock::default(), &noop_meter())
-            .await;
+        let datastore = ephemeral_datastore.datastore(MockClock::default()).await;
 
         datastore
             .run_tx(|tx| {

--- a/aggregator_core/src/datastore/test_util.rs
+++ b/aggregator_core/src/datastore/test_util.rs
@@ -1,8 +1,10 @@
-use crate::datastore::{Crypter, Datastore};
+use crate::{
+    datastore::{Crypter, Datastore},
+    test_util::noop_meter,
+};
 use deadpool_postgres::{Manager, Pool};
 use janus_core::time::Clock;
 use lazy_static::lazy_static;
-use opentelemetry::metrics::Meter;
 use rand::{distributions::Standard, random, thread_rng, Rng};
 use ring::aead::{LessSafeKey, UnboundKey, AES_128_GCM};
 use sqlx::{
@@ -109,8 +111,8 @@ pub struct EphemeralDatastore {
 impl EphemeralDatastore {
     /// Creates a Datastore instance based on this EphemeralDatastore. All returned Datastore
     /// instances will refer to the same underlying durable state.
-    pub async fn datastore<C: Clock>(&self, clock: C, meter: &Meter) -> Datastore<C> {
-        Datastore::new(self.pool(), self.crypter(), clock, meter)
+    pub async fn datastore<C: Clock>(&self, clock: C) -> Datastore<C> {
+        Datastore::new(self.pool(), self.crypter(), clock, &noop_meter())
             .await
             .unwrap()
     }


### PR DESCRIPTION
This was categorically set to &noop_meter(), so that value is now hard-wired. If we want to introduce tests for the meter behavior later, we can introduce a separate constructor for datastores, perhaps named something like `datastore_with_meter()`.