### PR TITLE
Implement time bucketing for fixed size query type

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -90,6 +90,7 @@ pub mod aggregation_job_continue;
 pub mod aggregation_job_creator;
 pub mod aggregation_job_driver;
 pub mod aggregation_job_writer;
+pub mod batch_creator;
 pub mod collection_job_driver;
 #[cfg(test)]
 mod collection_job_tests;

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -4,12 +4,11 @@ use fixed::{
     types::extra::{U15, U31, U63},
     FixedI16, FixedI32, FixedI64,
 };
-use futures::future::try_join_all;
 use janus_aggregator_core::{
     datastore::models::{
         AggregationJob, AggregationJobState, ReportAggregation, ReportAggregationState,
     },
-    datastore::{self, models::OutstandingBatch, Datastore},
+    datastore::{self, Datastore},
     task::{self, Task},
 };
 use janus_core::{
@@ -34,21 +33,12 @@ use prio::{
     },
 };
 use rand::{random, thread_rng, Rng};
-use std::{
-    cmp::{max, min},
-    collections::HashMap,
-    iter,
-    num::TryFromIntError,
-    ops::RangeInclusive,
-    sync::Arc,
-    time::Duration,
-};
-use tokio::{
-    time::{self, sleep_until, Instant, MissedTickBehavior},
-    try_join,
-};
+use std::{collections::HashMap, sync::Arc, time::Duration};
+use tokio::time::{self, sleep_until, Instant, MissedTickBehavior};
 use tracing::{debug, error, info};
 use trillium_tokio::{CloneCounterObserver, Stopper};
+
+use super::batch_creator::BatchCreator;
 
 // TODO(#680): add metrics to aggregation job creator.
 pub struct AggregationJobCreator<C: Clock> {
@@ -80,6 +70,10 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
         min_aggregation_job_size: usize,
         max_aggregation_job_size: usize,
     ) -> AggregationJobCreator<C> {
+        assert!(
+            max_aggregation_job_size > 0,
+            "invalid configuration: max_aggregation_job_size cannot be zero"
+        );
         AggregationJobCreator {
             datastore,
             meter,
@@ -341,57 +335,92 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                     .await
             }
 
-            (task::QueryType::FixedSize { max_batch_size }, VdafInstance::Prio3Count) => {
+            (
+                task::QueryType::FixedSize {
+                    max_batch_size,
+                    batch_time_window_size,
+                },
+                VdafInstance::Prio3Count,
+            ) => {
                 let vdaf = Arc::new(Prio3::new_count(2)?);
                 let max_batch_size = *max_batch_size;
-                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Count>(task, vdaf, max_batch_size)
-                    .await
+                let batch_time_window_size = *batch_time_window_size;
+                self.create_aggregation_jobs_for_fixed_size_task_no_param::<
+                    PRIO3_VERIFY_KEY_LENGTH,
+                    Prio3Count,
+                >(task, vdaf, max_batch_size, batch_time_window_size).await
             }
 
             (
-                task::QueryType::FixedSize { max_batch_size },
+                task::QueryType::FixedSize {
+                    max_batch_size,
+                    batch_time_window_size,
+                },
                 VdafInstance::Prio3CountVec { length },
             ) => {
                 let vdaf = Arc::new(Prio3::new_sum_vec_multithreaded(2, 1, *length)?);
                 let max_batch_size = *max_batch_size;
+                let batch_time_window_size = *batch_time_window_size;
                 self.create_aggregation_jobs_for_fixed_size_task_no_param::<
                     PRIO3_VERIFY_KEY_LENGTH,
                     Prio3SumVecMultithreaded
-                >(task, vdaf, max_batch_size).await
-            }
-
-            (task::QueryType::FixedSize { max_batch_size }, VdafInstance::Prio3Sum { bits }) => {
-                let vdaf = Arc::new(Prio3::new_sum(2, *bits)?);
-                let max_batch_size = *max_batch_size;
-                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Sum>(task, vdaf, max_batch_size)
-                    .await
+                >(task, vdaf, max_batch_size, batch_time_window_size).await
             }
 
             (
-                task::QueryType::FixedSize { max_batch_size },
+                task::QueryType::FixedSize {
+                    max_batch_size,
+                    batch_time_window_size,
+                },
+                VdafInstance::Prio3Sum { bits },
+            ) => {
+                let vdaf = Arc::new(Prio3::new_sum(2, *bits)?);
+                let max_batch_size = *max_batch_size;
+                let batch_time_window_size = *batch_time_window_size;
+                self.create_aggregation_jobs_for_fixed_size_task_no_param::<
+                    PRIO3_VERIFY_KEY_LENGTH,
+                    Prio3Sum,
+                >(task, vdaf, max_batch_size, batch_time_window_size).await
+            }
+
+            (
+                task::QueryType::FixedSize {
+                    max_batch_size,
+                    batch_time_window_size,
+                },
                 VdafInstance::Prio3SumVec { bits, length },
             ) => {
                 let vdaf = Arc::new(Prio3::new_sum_vec_multithreaded(2, *bits, *length)?);
                 let max_batch_size = *max_batch_size;
+                let batch_time_window_size = *batch_time_window_size;
                 self.create_aggregation_jobs_for_fixed_size_task_no_param::<
                     PRIO3_VERIFY_KEY_LENGTH,
                     Prio3SumVecMultithreaded,
-                >(task, vdaf, max_batch_size).await
+                >(task, vdaf, max_batch_size, batch_time_window_size).await
             }
 
             (
-                task::QueryType::FixedSize { max_batch_size },
+                task::QueryType::FixedSize {
+                    max_batch_size,
+                    batch_time_window_size,
+                },
                 VdafInstance::Prio3Histogram { buckets },
             ) => {
                 let vdaf = Arc::new(Prio3::new_histogram(2, buckets)?);
                 let max_batch_size = *max_batch_size;
-                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3Histogram>(task, vdaf, max_batch_size)
-                    .await
+                let batch_time_window_size = *batch_time_window_size;
+                self.create_aggregation_jobs_for_fixed_size_task_no_param::<
+                    PRIO3_VERIFY_KEY_LENGTH,
+                    Prio3Histogram,
+                >(task, vdaf, max_batch_size, batch_time_window_size).await
             }
 
             #[cfg(feature = "fpvec_bounded_l2")]
             (
-                task::QueryType::FixedSize { max_batch_size },
+                task::QueryType::FixedSize {
+                    max_batch_size,
+                    batch_time_window_size,
+                },
                 VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { length },
             ) => {
                 let vdaf: Arc<Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>>> =
@@ -399,13 +428,19 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                         2, *length,
                     )?);
                 let max_batch_size = *max_batch_size;
-                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>>>(task, vdaf, max_batch_size)
-                    .await
+                let batch_time_window_size = *batch_time_window_size;
+                self.create_aggregation_jobs_for_fixed_size_task_no_param::<
+                    PRIO3_VERIFY_KEY_LENGTH,
+                    Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>>,
+                >(task, vdaf, max_batch_size, batch_time_window_size).await
             }
 
             #[cfg(feature = "fpvec_bounded_l2")]
             (
-                task::QueryType::FixedSize { max_batch_size },
+                task::QueryType::FixedSize {
+                    max_batch_size,
+                    batch_time_window_size,
+                },
                 VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { length },
             ) => {
                 let vdaf: Arc<Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>>> =
@@ -413,13 +448,19 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                         2, *length,
                     )?);
                 let max_batch_size = *max_batch_size;
-                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>>>(task, vdaf, max_batch_size)
-                    .await
+                let batch_time_window_size = *batch_time_window_size;
+                self.create_aggregation_jobs_for_fixed_size_task_no_param::<
+                    PRIO3_VERIFY_KEY_LENGTH,
+                    Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>>,
+                >(task, vdaf, max_batch_size, batch_time_window_size).await
             }
 
             #[cfg(feature = "fpvec_bounded_l2")]
             (
-                task::QueryType::FixedSize { max_batch_size },
+                task::QueryType::FixedSize {
+                    max_batch_size,
+                    batch_time_window_size,
+                },
                 VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { length },
             ) => {
                 let vdaf: Arc<Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>>> =
@@ -427,8 +468,11 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                         2, *length,
                     )?);
                 let max_batch_size = *max_batch_size;
-                self.create_aggregation_jobs_for_fixed_size_task_no_param::<PRIO3_VERIFY_KEY_LENGTH, Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>>>(task, vdaf, max_batch_size)
-                    .await
+                let batch_time_window_size = *batch_time_window_size;
+                self.create_aggregation_jobs_for_fixed_size_task_no_param::<
+                    PRIO3_VERIFY_KEY_LENGTH,
+                    Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>>,
+                >(task, vdaf, max_batch_size, batch_time_window_size).await
             }
 
             _ => {
@@ -547,6 +591,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
         task: Arc<Task>,
         vdaf: Arc<A>,
         task_max_batch_size: u64,
+        task_batch_time_window_size: Option<janus_messages::Duration>,
     ) -> anyhow::Result<bool>
     where
         A: Send + Sync + 'static,
@@ -568,166 +613,30 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                 let vdaf = Arc::clone(&vdaf);
 
                 Box::pin(async move {
-                    // Find unaggregated client reports & existing unfilled batches.
-                    let (mut unaggregated_report_ids, outstanding_batches) = try_join!(
-                        tx.get_unaggregated_client_report_ids_for_task(task.id()),
-                        tx.get_outstanding_batches_for_task(task.id())
-                    )?;
+                    // Find unaggregated client reports.
+                    let unaggregated_report_ids = tx
+                        .get_unaggregated_client_report_ids_for_task(task.id())
+                        .await?;
 
-                    // First attempt to allocate unaggregated reports to existing unfilled batches,
-                    // then generate new batches as necessary. This iterator has no end and
-                    // therefore it is safe to unwrap the result of a call to `next`.
-                    let mut batch_iter = outstanding_batches
-                        .into_iter()
-                        .map(|outstanding_batch| (false, outstanding_batch))
-                        .chain(iter::repeat_with(|| {
-                            (
-                                true,
-                                OutstandingBatch::new(
-                                    *task.id(),
-                                    random(),
-                                    RangeInclusive::new(0, 0),
-                                ),
-                            )
-                        }));
-
-                    // Main loop: repeatedly consume some of the unaggregated report IDs to generate
-                    // an aggregation job, assigning it to an existing batch which has need of
-                    // reports, or a new batch if no existing batch needs reports.
                     let mut aggregation_job_writer =
                         AggregationJobWriter::<SEED_SIZE, FixedSize, A>::new(Arc::clone(&task));
-                    let mut new_batches = Vec::new();
-                    let (mut is_batch_new, mut batch) = batch_iter.next().unwrap(); // unwrap safety: infinite iterator
-                    let mut batch_max_size = *batch.size().end();
-                    loop {
-                        // Figure out desired aggregation job size:
-                        //  * It can't be larger than the number of reports available.
-                        //  * It can't be larger than the configured maximum aggregation job size.
-                        //  * It can't be larger than the difference between the maximum batch size
-                        //    & the maximum number of reports that may end up aggregated into this
-                        //    batch based on already-existing aggregation jobs; otherwise, we risk
-                        //    aggregating more than max_batch_size reports together.
-                        // Choose the maximal size meeting all of these requirements.
-                        let aggregation_job_size = [
-                            unaggregated_report_ids.len(),
-                            this.max_aggregation_job_size,
-                            task_max_batch_size - batch_max_size,
-                        ]
-                        .into_iter()
-                        .min()
-                        .unwrap(); // unwrap safety: iterator is non-empty, so result is Some
+                    let mut batch_creator = BatchCreator::new(
+                        this.min_aggregation_job_size,
+                        this.max_aggregation_job_size,
+                        *task.id(),
+                        task_min_batch_size,
+                        task_max_batch_size,
+                        task_batch_time_window_size,
+                        &mut aggregation_job_writer,
+                    );
 
-                        if aggregation_job_size < this.min_aggregation_job_size {
-                            if batch_max_size < task_min_batch_size
-                                && batch_max_size + aggregation_job_size >= task_min_batch_size
-                            {
-                                // This batch is short of the minimum batch size, and requires an
-                                // unusually small aggregation job (smaller than the normal minimum
-                                // aggregation job size) for it to be ever completed. Go ahead and
-                                // generate one. (We also wait until the size of the aggregation job
-                                // we can generate will meet the minimum configured batch size, in
-                                // an attempt to minimize the number of "small" aggregation jobs we
-                                // create.)
-                            } else if !is_batch_new {
-                                // Move on to the next unfilled batch to see if we can allocate
-                                // reports to it.
-                                (is_batch_new, batch) = batch_iter.next().unwrap(); // unwrap safety: infinite iterator
-                                batch_max_size = *batch.size().end();
-                                continue;
-                            } else {
-                                // We have run out of preexisting batches to evaluate adding reports
-                                // to. Trying additional new batches won't help (since all of the
-                                // relevant parameters will be the same as in this iteration), so
-                                // stop generating aggregation jobs.
-                                break;
-                            }
-                        }
-
-                        // Generate an aggregation job, then update batch metadata & continue.
-                        let aggregation_job_id = random();
-                        debug!(
-                            task_id = %task.id(),
-                            batch_id = %batch.id(),
-                            %aggregation_job_id,
-                            report_count = aggregation_job_size,
-                            "Creating aggregation job"
-                        );
-
-                        let mut min_client_timestamp = None;
-                        let mut max_client_timestamp = None;
-                        let report_aggregations = unaggregated_report_ids
-                            .drain(..aggregation_job_size)
-                            .enumerate()
-                            .map(|(ord, (report_id, client_timestamp))| {
-                                min_client_timestamp = Some(
-                                    min_client_timestamp
-                                        .map_or(client_timestamp, |ts| min(ts, client_timestamp)),
-                                );
-                                max_client_timestamp = Some(
-                                    max_client_timestamp
-                                        .map_or(client_timestamp, |ts| max(ts, client_timestamp)),
-                                );
-                                Ok(ReportAggregation::new(
-                                    *task.id(),
-                                    aggregation_job_id,
-                                    report_id,
-                                    client_timestamp,
-                                    ord.try_into()?,
-                                    None,
-                                    ReportAggregationState::Start,
-                                ))
-                            })
-                            .collect::<Result<_, TryFromIntError>>()?;
-
-                        let min_client_timestamp = min_client_timestamp.unwrap(); // unwrap safety: aggregation_job_size > 0
-                        let max_client_timestamp = max_client_timestamp.unwrap(); // unwrap safety: aggregation_job_size > 0
-                        let client_timestamp_interval = Interval::new(
-                            min_client_timestamp,
-                            max_client_timestamp
-                                .difference(&min_client_timestamp)?
-                                .add(&DurationMsg::from_seconds(1))?,
-                        )?;
-                        let aggregation_job = AggregationJob::new(
-                            *task.id(),
-                            aggregation_job_id,
-                            (),
-                            *batch.id(),
-                            client_timestamp_interval,
-                            AggregationJobState::InProgress,
-                            AggregationJobRound::from(0),
-                        );
-                        aggregation_job_writer.put(aggregation_job, report_aggregations)?;
-
-                        if is_batch_new {
-                            new_batches.push(*batch.id())
-                        }
-                        is_batch_new = false;
-                        batch_max_size += aggregation_job_size;
+                    for (report_id, client_timestamp) in unaggregated_report_ids {
+                        batch_creator
+                            .add_report(tx, &report_id, &client_timestamp)
+                            .await?;
                     }
+                    batch_creator.finish(tx, vdaf).await?;
 
-                    // Write the outstanding batches, aggregation jobs, & report aggregations we
-                    // created.
-                    try_join!(
-                        aggregation_job_writer.write(tx, vdaf),
-                        try_join_all(
-                            new_batches
-                                .iter()
-                                .map(|batch_id| tx.put_outstanding_batch(task.id(), batch_id)),
-                        ),
-                        {
-                            let task_id = *task.id();
-                            async move {
-                                if !unaggregated_report_ids.is_empty() {
-                                    let report_ids: Vec<_> = unaggregated_report_ids
-                                        .iter()
-                                        .map(|(report_id, _)| *report_id)
-                                        .collect();
-                                    tx.mark_reports_unaggregated(&task_id, &report_ids).await?;
-                                }
-                                Ok(())
-                            }
-                        },
-                    )?;
                     Ok(!aggregation_job_writer.is_empty())
                 })
             })
@@ -755,7 +664,7 @@ mod tests {
             dummy_vdaf::{self},
             install_test_trace_subscriber,
         },
-        time::{Clock, IntervalExt, MockClock},
+        time::{Clock, DurationExt, IntervalExt, MockClock, TimeExt},
     };
     use janus_messages::{
         query_type::{FixedSize, TimeInterval},
@@ -983,7 +892,7 @@ mod tests {
             // The batch is at least MIN_AGGREGATION_JOB_SIZE in size.
             assert!(report_ids.len() >= MIN_AGGREGATION_JOB_SIZE);
 
-            // Report IDs are non-repeated across or inside aggregation jobs.
+            // Report IDs are not repeated across or inside aggregation jobs.
             for report_id in report_ids {
                 assert!(!seen_report_ids.contains(report_id));
                 seen_report_ids.insert(*report_id);
@@ -1232,7 +1141,7 @@ mod tests {
             // The batch is at least MIN_AGGREGATION_JOB_SIZE in size.
             assert!(report_ids.len() >= MIN_AGGREGATION_JOB_SIZE);
 
-            // Report IDs are non-repeated across or inside aggregation jobs.
+            // Report IDs are not repeated across or inside aggregation jobs.
             for report_id in report_ids {
                 assert!(!seen_report_ids.contains(report_id));
                 seen_report_ids.insert(*report_id);
@@ -1273,6 +1182,7 @@ mod tests {
             TaskBuilder::new(
                 TaskQueryType::FixedSize {
                     max_batch_size: MAX_BATCH_SIZE as u64,
+                    batch_time_window_size: None,
                 },
                 VdafInstance::Prio3Count,
                 Role::Leader,
@@ -1329,7 +1239,7 @@ mod tests {
                 let task = Arc::clone(&task);
                 Box::pin(async move {
                     Ok((
-                        tx.get_outstanding_batches_for_task(task.id()).await?,
+                        tx.get_outstanding_batches(task.id(), &None).await?,
                         read_aggregate_info_for_task::<
                             PRIO3_VERIFY_KEY_LENGTH,
                             FixedSize,
@@ -1386,7 +1296,7 @@ mod tests {
             // The aggregation job is at most MAX_AGGREGATION_JOB_SIZE in size.
             assert!(report_ids.len() <= MAX_AGGREGATION_JOB_SIZE);
 
-            // Report IDs are non-repeated across or inside aggregation jobs.
+            // Report IDs are not repeated across or inside aggregation jobs.
             for report_id in report_ids {
                 assert!(!seen_report_ids.contains(&report_id));
                 seen_report_ids.insert(report_id);
@@ -1416,6 +1326,703 @@ mod tests {
                     Interval::from_time(&report_time).unwrap(),
                 ),
             ])
+        );
+    }
+
+    #[tokio::test]
+    async fn create_aggregation_jobs_for_fixed_size_task_insufficient_reports() {
+        // Setup.
+        install_test_trace_subscriber();
+        let clock: MockClock = MockClock::default();
+        let ephemeral_datastore = ephemeral_datastore().await;
+        let meter = noop_meter();
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
+
+        const MIN_AGGREGATION_JOB_SIZE: usize = 50;
+        const MAX_AGGREGATION_JOB_SIZE: usize = 60;
+        const MIN_BATCH_SIZE: usize = 200;
+        const MAX_BATCH_SIZE: usize = 300;
+
+        let task = Arc::new(
+            TaskBuilder::new(
+                TaskQueryType::FixedSize {
+                    max_batch_size: MAX_BATCH_SIZE as u64,
+                    batch_time_window_size: None,
+                },
+                VdafInstance::Prio3Count,
+                Role::Leader,
+            )
+            .with_min_batch_size(MIN_BATCH_SIZE as u64)
+            .build(),
+        );
+
+        // Create a small number of reports. No batches or aggregation jobs should be created, and
+        // the reports should remain "unaggregated".
+        let report_time = clock.now();
+        let reports: Vec<LeaderStoredReport<0, dummy_vdaf::Vdaf>> =
+            iter::repeat_with(|| LeaderStoredReport::new_dummy(*task.id(), report_time))
+                .take(5)
+                .collect();
+
+        ds.run_tx(|tx| {
+            let (task, reports) = (task.clone(), reports.clone());
+            Box::pin(async move {
+                tx.put_task(&task).await?;
+                let vdaf = dummy_vdaf::Vdaf::new();
+                for report in &reports {
+                    tx.put_client_report(&vdaf, report).await?;
+                }
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
+
+        // Run.
+        let job_creator = Arc::new(AggregationJobCreator::new(
+            ds,
+            meter,
+            Duration::from_secs(3600),
+            Duration::from_secs(1),
+            MIN_AGGREGATION_JOB_SIZE,
+            MAX_AGGREGATION_JOB_SIZE,
+        ));
+        Arc::clone(&job_creator)
+            .create_aggregation_jobs_for_task(Arc::clone(&task))
+            .await
+            .unwrap();
+
+        // Verify.
+        let (outstanding_batches, (agg_jobs, batches)) = job_creator
+            .datastore
+            .run_tx(|tx| {
+                let task = Arc::clone(&task);
+                Box::pin(async move {
+                    Ok((
+                        tx.get_outstanding_batches(task.id(), &None).await?,
+                        read_aggregate_info_for_task::<
+                            PRIO3_VERIFY_KEY_LENGTH,
+                            FixedSize,
+                            Prio3Count,
+                            _,
+                        >(tx, task.id())
+                        .await,
+                    ))
+                })
+            })
+            .await
+            .unwrap();
+
+        // Verify outstanding batches and aggregation jobs.
+        assert_eq!(outstanding_batches.len(), 0);
+        assert_eq!(agg_jobs.len(), 0);
+        assert_eq!(batches.len(), 0);
+
+        // Confirm the reports are still available.
+        let report_count = job_creator
+            .datastore
+            .run_tx(|tx| {
+                let task = Arc::clone(&task);
+                Box::pin(async move {
+                    let report_ids = tx
+                        .get_unaggregated_client_report_ids_for_task(task.id())
+                        .await?
+                        .into_iter()
+                        .map(|(report_id, _)| report_id)
+                        .collect::<Vec<_>>();
+                    tx.mark_reports_unaggregated(task.id(), &report_ids).await?;
+                    Ok(report_ids.len())
+                })
+            })
+            .await
+            .unwrap();
+        assert_eq!(report_count, 5);
+    }
+
+    #[tokio::test]
+    async fn create_aggregation_jobs_for_fixed_size_task_finish_batch() {
+        // Setup.
+        install_test_trace_subscriber();
+        let clock: MockClock = MockClock::default();
+        let ephemeral_datastore = ephemeral_datastore().await;
+        let meter = noop_meter();
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
+
+        const MIN_AGGREGATION_JOB_SIZE: usize = 50;
+        const MAX_AGGREGATION_JOB_SIZE: usize = 60;
+        const MIN_BATCH_SIZE: usize = 200;
+        const MAX_BATCH_SIZE: usize = 300;
+
+        let task = Arc::new(
+            TaskBuilder::new(
+                TaskQueryType::FixedSize {
+                    max_batch_size: MAX_BATCH_SIZE as u64,
+                    batch_time_window_size: None,
+                },
+                VdafInstance::Prio3Count,
+                Role::Leader,
+            )
+            .with_min_batch_size(MIN_BATCH_SIZE as u64)
+            .build(),
+        );
+
+        // Create enough reports to produce two batches, but not enough to meet the minimum number
+        // of reports for the second batch.
+        let report_time = clock.now();
+        let reports: Vec<LeaderStoredReport<0, dummy_vdaf::Vdaf>> =
+            iter::repeat_with(|| LeaderStoredReport::new_dummy(*task.id(), report_time))
+                .take(MAX_BATCH_SIZE + MIN_BATCH_SIZE - 1)
+                .collect();
+
+        let mut report_ids: HashSet<_> = reports
+            .iter()
+            .map(|report| *report.metadata().id())
+            .collect();
+
+        ds.run_tx(|tx| {
+            let (task, reports) = (task.clone(), reports.clone());
+            Box::pin(async move {
+                tx.put_task(&task).await?;
+                let vdaf = dummy_vdaf::Vdaf::new();
+                for report in &reports {
+                    tx.put_client_report(&vdaf, report).await?;
+                }
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
+
+        // Run.
+        let job_creator = Arc::new(AggregationJobCreator::new(
+            ds,
+            meter,
+            Duration::from_secs(3600),
+            Duration::from_secs(1),
+            MIN_AGGREGATION_JOB_SIZE,
+            MAX_AGGREGATION_JOB_SIZE,
+        ));
+        Arc::clone(&job_creator)
+            .create_aggregation_jobs_for_task(Arc::clone(&task))
+            .await
+            .unwrap();
+
+        // Verify.
+        let (outstanding_batches, (agg_jobs, _batches)) = job_creator
+            .datastore
+            .run_tx(|tx| {
+                let task = Arc::clone(&task);
+                Box::pin(async move {
+                    Ok((
+                        tx.get_outstanding_batches(task.id(), &None).await?,
+                        read_aggregate_info_for_task::<
+                            PRIO3_VERIFY_KEY_LENGTH,
+                            FixedSize,
+                            Prio3Count,
+                            _,
+                        >(tx, task.id())
+                        .await,
+                    ))
+                })
+            })
+            .await
+            .unwrap();
+
+        // Verify sizes of batches and aggregation jobs.
+        let mut outstanding_batch_sizes = outstanding_batches
+            .iter()
+            .map(|outstanding_batch| *outstanding_batch.size().end())
+            .collect::<Vec<_>>();
+        outstanding_batch_sizes.sort();
+        assert_eq!(outstanding_batch_sizes, [180, MAX_BATCH_SIZE]);
+        let mut agg_job_sizes = agg_jobs
+            .iter()
+            .map(|(_agg_job, report_ids)| report_ids.len())
+            .collect::<Vec<_>>();
+        agg_job_sizes.sort();
+        assert_eq!(agg_job_sizes, [60, 60, 60, 60, 60, 60, 60, 60]);
+
+        // Add one more report.
+        let last_report = LeaderStoredReport::new_dummy(*task.id(), report_time);
+        report_ids.insert(*last_report.metadata().id());
+        job_creator
+            .datastore
+            .run_tx(|tx| {
+                let last_report = last_report.clone();
+                Box::pin(async move {
+                    let vdaf = dummy_vdaf::Vdaf::new();
+                    tx.put_client_report(&vdaf, &last_report).await
+                })
+            })
+            .await
+            .unwrap();
+
+        // Run again.
+        Arc::clone(&job_creator)
+            .create_aggregation_jobs_for_task(Arc::clone(&task))
+            .await
+            .unwrap();
+
+        // Verify.
+        let (outstanding_batches, (agg_jobs, _batches)) = job_creator
+            .datastore
+            .run_tx(|tx| {
+                let task = Arc::clone(&task);
+                Box::pin(async move {
+                    Ok((
+                        tx.get_outstanding_batches(task.id(), &None).await?,
+                        read_aggregate_info_for_task::<
+                            PRIO3_VERIFY_KEY_LENGTH,
+                            FixedSize,
+                            Prio3Count,
+                            _,
+                        >(tx, task.id())
+                        .await,
+                    ))
+                })
+            })
+            .await
+            .unwrap();
+        let batch_ids: HashSet<_> = outstanding_batches
+            .iter()
+            .map(|outstanding_batch| *outstanding_batch.id())
+            .collect();
+
+        // Verify sizes of batches and aggregation jobs.
+        let mut outstanding_batch_sizes = outstanding_batches
+            .iter()
+            .map(|outstanding_batch| *outstanding_batch.size().end())
+            .collect::<Vec<_>>();
+        outstanding_batch_sizes.sort();
+        assert_eq!(outstanding_batch_sizes, [MIN_BATCH_SIZE, MAX_BATCH_SIZE]);
+        let mut agg_job_sizes = agg_jobs
+            .iter()
+            .map(|(_agg_job, report_ids)| report_ids.len())
+            .collect::<Vec<_>>();
+        agg_job_sizes.sort();
+        assert_eq!(agg_job_sizes, [20, 60, 60, 60, 60, 60, 60, 60, 60]);
+
+        // Verify consistency of batches and aggregation jobs.
+        let mut seen_report_ids = HashSet::new();
+        for (agg_job, report_ids) in agg_jobs {
+            assert_eq!(agg_job.round(), AggregationJobRound::from(0));
+            assert!(batch_ids.contains(agg_job.batch_id()));
+            assert!(report_ids.len() <= MAX_AGGREGATION_JOB_SIZE);
+
+            // Report IDs are not repeated across or inside aggregation jobs.
+            for report_id in report_ids {
+                let newly_inserted = seen_report_ids.insert(report_id);
+                assert!(newly_inserted);
+            }
+        }
+        assert_eq!(report_ids, seen_report_ids);
+    }
+
+    #[tokio::test]
+    async fn create_aggregation_jobs_for_fixed_size_task_intermediate_agg_job_size() {
+        // Setup.
+        install_test_trace_subscriber();
+        let clock: MockClock = MockClock::default();
+        let ephemeral_datastore = ephemeral_datastore().await;
+        let meter = noop_meter();
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
+
+        const MIN_AGGREGATION_JOB_SIZE: usize = 50;
+        const MAX_AGGREGATION_JOB_SIZE: usize = 60;
+        const MIN_BATCH_SIZE: usize = 200;
+        const MAX_BATCH_SIZE: usize = 300;
+
+        let task = Arc::new(
+            TaskBuilder::new(
+                TaskQueryType::FixedSize {
+                    max_batch_size: MAX_BATCH_SIZE as u64,
+                    batch_time_window_size: None,
+                },
+                VdafInstance::Prio3Count,
+                Role::Leader,
+            )
+            .with_min_batch_size(MIN_BATCH_SIZE as u64)
+            .build(),
+        );
+
+        // Create enough reports to produce two batches, and produce a non-maximum size aggregation
+        // job with the remainder of the reports.
+        let report_time = clock.now();
+        let reports: Vec<LeaderStoredReport<0, dummy_vdaf::Vdaf>> =
+            iter::repeat_with(|| LeaderStoredReport::new_dummy(*task.id(), report_time))
+                .take(MAX_BATCH_SIZE + MIN_AGGREGATION_JOB_SIZE + 5)
+                .collect();
+
+        let mut report_ids: HashSet<ReportId> = reports
+            .iter()
+            .map(|report| *report.metadata().id())
+            .collect();
+
+        ds.run_tx(|tx| {
+            let (task, reports) = (task.clone(), reports.clone());
+            Box::pin(async move {
+                tx.put_task(&task).await?;
+                let vdaf = dummy_vdaf::Vdaf::new();
+                for report in &reports {
+                    tx.put_client_report(&vdaf, report).await?;
+                }
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
+
+        // Run.
+        let job_creator = Arc::new(AggregationJobCreator::new(
+            ds,
+            meter,
+            Duration::from_secs(3600),
+            Duration::from_secs(1),
+            MIN_AGGREGATION_JOB_SIZE,
+            MAX_AGGREGATION_JOB_SIZE,
+        ));
+        Arc::clone(&job_creator)
+            .create_aggregation_jobs_for_task(Arc::clone(&task))
+            .await
+            .unwrap();
+
+        // Verify.
+        let (outstanding_batches, (agg_jobs, _batches)) = job_creator
+            .datastore
+            .run_tx(|tx| {
+                let task = Arc::clone(&task);
+                Box::pin(async move {
+                    Ok((
+                        tx.get_outstanding_batches(task.id(), &None).await?,
+                        read_aggregate_info_for_task::<
+                            PRIO3_VERIFY_KEY_LENGTH,
+                            FixedSize,
+                            Prio3Count,
+                            _,
+                        >(tx, task.id())
+                        .await,
+                    ))
+                })
+            })
+            .await
+            .unwrap();
+
+        // Verify sizes of batches and aggregation jobs.
+        let mut outstanding_batch_sizes = outstanding_batches
+            .iter()
+            .map(|outstanding_batch| *outstanding_batch.size().end())
+            .collect::<Vec<_>>();
+        outstanding_batch_sizes.sort();
+        assert_eq!(outstanding_batch_sizes, [55, MAX_BATCH_SIZE]);
+        let mut agg_job_sizes = agg_jobs
+            .iter()
+            .map(|(_agg_job, report_ids)| report_ids.len())
+            .collect::<Vec<_>>();
+        agg_job_sizes.sort();
+        assert_eq!(agg_job_sizes, [55, 60, 60, 60, 60, 60]);
+
+        // Add more reports, enough to allow creating a second intermediate-sized aggregation job in
+        // the existing outstanding batch.
+        let new_reports: Vec<LeaderStoredReport<0, dummy_vdaf::Vdaf>> =
+            iter::repeat_with(|| LeaderStoredReport::new_dummy(*task.id(), report_time))
+                .take(MIN_AGGREGATION_JOB_SIZE + 5)
+                .collect();
+        report_ids.extend(new_reports.iter().map(|report| *report.metadata().id()));
+        job_creator
+            .datastore
+            .run_tx(|tx| {
+                let new_reports = new_reports.clone();
+                Box::pin(async move {
+                    let vdaf = dummy_vdaf::Vdaf::new();
+                    for report in new_reports.iter() {
+                        tx.put_client_report(&vdaf, report).await?;
+                    }
+                    Ok(())
+                })
+            })
+            .await
+            .unwrap();
+
+        // Run again.
+        Arc::clone(&job_creator)
+            .create_aggregation_jobs_for_task(Arc::clone(&task))
+            .await
+            .unwrap();
+
+        // Verify.
+        let (outstanding_batches, (agg_jobs, _batches)) = job_creator
+            .datastore
+            .run_tx(|tx| {
+                let task = Arc::clone(&task);
+                Box::pin(async move {
+                    Ok((
+                        tx.get_outstanding_batches(task.id(), &None).await?,
+                        read_aggregate_info_for_task::<
+                            PRIO3_VERIFY_KEY_LENGTH,
+                            FixedSize,
+                            Prio3Count,
+                            _,
+                        >(tx, task.id())
+                        .await,
+                    ))
+                })
+            })
+            .await
+            .unwrap();
+        let batch_ids: HashSet<_> = outstanding_batches
+            .iter()
+            .map(|outstanding_batch| *outstanding_batch.id())
+            .collect();
+
+        // Verify sizes of batches and aggregation jobs.
+        let mut outstanding_batch_sizes = outstanding_batches
+            .iter()
+            .map(|outstanding_batch| *outstanding_batch.size().end())
+            .collect::<Vec<_>>();
+        outstanding_batch_sizes.sort();
+        assert_eq!(outstanding_batch_sizes, [110, MAX_BATCH_SIZE]);
+        let mut agg_job_sizes = agg_jobs
+            .iter()
+            .map(|(_agg_job, report_ids)| report_ids.len())
+            .collect::<Vec<_>>();
+        agg_job_sizes.sort();
+        assert_eq!(agg_job_sizes, [55, 55, 60, 60, 60, 60, 60]);
+
+        // Verify consistency of batches and aggregation jobs.
+        let mut seen_report_ids = HashSet::new();
+        for (agg_job, report_ids) in agg_jobs {
+            assert_eq!(agg_job.round(), AggregationJobRound::from(0));
+            assert!(batch_ids.contains(agg_job.batch_id()));
+            assert!(report_ids.len() <= MAX_AGGREGATION_JOB_SIZE);
+
+            // Report IDs are not repeated across or inside aggregation jobs.
+            for report_id in report_ids {
+                let newly_inserted = seen_report_ids.insert(report_id);
+                assert!(newly_inserted);
+            }
+        }
+        assert_eq!(report_ids, seen_report_ids);
+    }
+
+    #[tokio::test]
+    async fn create_aggregation_jobs_for_fixed_size_time_bucketed_task() {
+        // Setup.
+        install_test_trace_subscriber();
+        let clock: MockClock = MockClock::default();
+        let ephemeral_datastore = ephemeral_datastore().await;
+        let meter = noop_meter();
+        let ds = ephemeral_datastore.datastore(clock.clone()).await;
+
+        const MIN_AGGREGATION_JOB_SIZE: usize = 50;
+        const MAX_AGGREGATION_JOB_SIZE: usize = 60;
+        const MIN_BATCH_SIZE: usize = 200;
+        const MAX_BATCH_SIZE: usize = 300;
+        let batch_time_window_size = janus_messages::Duration::from_hours(24).unwrap();
+
+        let task = Arc::new(
+            TaskBuilder::new(
+                TaskQueryType::FixedSize {
+                    max_batch_size: MAX_BATCH_SIZE as u64,
+                    batch_time_window_size: Some(batch_time_window_size),
+                },
+                VdafInstance::Prio3Count,
+                Role::Leader,
+            )
+            .with_min_batch_size(MIN_BATCH_SIZE as u64)
+            .build(),
+        );
+
+        // Create MIN_BATCH_SIZE + MAX_BATCH_SIZE reports in two different time buckets.
+        let report_time_1 = clock.now().sub(&batch_time_window_size).unwrap();
+        let report_time_2 = clock.now();
+        let mut reports = Vec::new();
+        reports.extend(
+            iter::repeat_with(|| LeaderStoredReport::new_dummy(*task.id(), report_time_1))
+                .take(MIN_BATCH_SIZE + MAX_BATCH_SIZE),
+        );
+        reports.extend(
+            iter::repeat_with(|| LeaderStoredReport::new_dummy(*task.id(), report_time_2))
+                .take(MIN_BATCH_SIZE + MAX_BATCH_SIZE),
+        );
+
+        let report_ids: HashSet<ReportId> = reports
+            .iter()
+            .map(|report| *report.metadata().id())
+            .collect();
+
+        ds.run_tx(|tx| {
+            let (task, reports) = (task.clone(), reports.clone());
+            Box::pin(async move {
+                tx.put_task(&task).await?;
+                let vdaf = dummy_vdaf::Vdaf::new();
+                for report in &reports {
+                    tx.put_client_report(&vdaf, report).await?;
+                }
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
+
+        // Run.
+        let job_creator = Arc::new(AggregationJobCreator::new(
+            ds,
+            meter,
+            Duration::from_secs(3600),
+            Duration::from_secs(1),
+            MIN_AGGREGATION_JOB_SIZE,
+            MAX_AGGREGATION_JOB_SIZE,
+        ));
+        Arc::clone(&job_creator)
+            .create_aggregation_jobs_for_task(Arc::clone(&task))
+            .await
+            .unwrap();
+
+        // Verify.
+        let time_bucket_start_1 = report_time_1
+            .to_batch_interval_start(&batch_time_window_size)
+            .unwrap();
+        let time_bucket_start_2 = report_time_2
+            .to_batch_interval_start(&batch_time_window_size)
+            .unwrap();
+        let (outstanding_batches_bucket_1, outstanding_batches_bucket_2, (agg_jobs, batches)) =
+            job_creator
+                .datastore
+                .run_tx(|tx| {
+                    let task = Arc::clone(&task);
+                    Box::pin(async move {
+                        Ok((
+                            tx.get_outstanding_batches(task.id(), &Some(time_bucket_start_1))
+                                .await?,
+                            tx.get_outstanding_batches(task.id(), &Some(time_bucket_start_2))
+                                .await?,
+                            read_aggregate_info_for_task::<
+                                PRIO3_VERIFY_KEY_LENGTH,
+                                FixedSize,
+                                Prio3Count,
+                                _,
+                            >(tx, task.id())
+                            .await,
+                        ))
+                    })
+                })
+                .await
+                .unwrap();
+
+        // Verify outstanding batches.
+        for outstanding_batches in [&outstanding_batches_bucket_1, &outstanding_batches_bucket_2] {
+            assert_eq!(outstanding_batches.len(), 2);
+            for outstanding_batch in outstanding_batches {
+                assert_eq!(outstanding_batch.size().start(), &0);
+                assert!(outstanding_batch.size().end() >= &MIN_BATCH_SIZE);
+                assert!(outstanding_batch.size().end() <= &MAX_BATCH_SIZE);
+            }
+            let total_max_size: usize = outstanding_batches
+                .iter()
+                .map(|outstanding_batch| outstanding_batch.size().end())
+                .sum();
+            assert_eq!(total_max_size, report_ids.len() / 2);
+            let smallest_batch_size = outstanding_batches
+                .iter()
+                .map(|outstanding_batch| outstanding_batch.size().end())
+                .min()
+                .unwrap();
+            assert_eq!(smallest_batch_size, &MIN_BATCH_SIZE);
+            let largest_batch_size = outstanding_batches
+                .iter()
+                .map(|outstanding_batch| outstanding_batch.size().end())
+                .max()
+                .unwrap();
+            assert_eq!(largest_batch_size, &MAX_BATCH_SIZE);
+        }
+        let batch_ids: HashSet<_> = [&outstanding_batches_bucket_1, &outstanding_batches_bucket_2]
+            .into_iter()
+            .flatten()
+            .map(|outstanding_batch| *outstanding_batch.id())
+            .collect();
+
+        // Verify aggregation jobs.
+        let mut seen_report_ids = HashSet::new();
+        let mut batches_with_small_agg_jobs = HashSet::new();
+        for (agg_job, report_ids) in agg_jobs {
+            assert_eq!(agg_job.round(), AggregationJobRound::from(0));
+            assert!(batch_ids.contains(agg_job.batch_id()));
+            assert!(report_ids.len() <= MAX_AGGREGATION_JOB_SIZE);
+
+            // At most one aggregation job per batch will be smaller than the normal minimum
+            // aggregation job size.
+            if report_ids.len() < MIN_AGGREGATION_JOB_SIZE {
+                let newly_inserted = batches_with_small_agg_jobs.insert(*agg_job.batch_id());
+                assert!(newly_inserted);
+            }
+
+            // Report IDs are not repeated across or inside aggregation jobs.
+            for report_id in report_ids {
+                let newly_inserted = seen_report_ids.insert(report_id);
+                assert!(newly_inserted);
+            }
+        }
+
+        // Every client report was added to some aggregation job.
+        assert_eq!(report_ids, seen_report_ids);
+
+        let bucket_1_small_batch_id = *outstanding_batches_bucket_1
+            .iter()
+            .find(|outstanding_batch| outstanding_batch.size().end() == &MIN_BATCH_SIZE)
+            .unwrap()
+            .id();
+        let bucket_1_large_batch_id = *outstanding_batches_bucket_1
+            .iter()
+            .find(|outstanding_batch| outstanding_batch.size().end() == &MAX_BATCH_SIZE)
+            .unwrap()
+            .id();
+        let bucket_2_small_batch_id = *outstanding_batches_bucket_2
+            .iter()
+            .find(|outstanding_batch| outstanding_batch.size().end() == &MIN_BATCH_SIZE)
+            .unwrap()
+            .id();
+        let bucket_2_large_batch_id = *outstanding_batches_bucket_2
+            .iter()
+            .find(|outstanding_batch| outstanding_batch.size().end() == &MAX_BATCH_SIZE)
+            .unwrap()
+            .id();
+
+        assert_eq!(
+            batches.into_iter().collect::<HashSet<_>>(),
+            HashSet::from([
+                Batch::new(
+                    *task.id(),
+                    bucket_1_large_batch_id,
+                    (),
+                    BatchState::Open,
+                    5,
+                    Interval::from_time(&report_time_1).unwrap(),
+                ),
+                Batch::new(
+                    *task.id(),
+                    bucket_1_small_batch_id,
+                    (),
+                    BatchState::Open,
+                    4,
+                    Interval::from_time(&report_time_1).unwrap(),
+                ),
+                Batch::new(
+                    *task.id(),
+                    bucket_2_large_batch_id,
+                    (),
+                    BatchState::Open,
+                    5,
+                    Interval::from_time(&report_time_2).unwrap(),
+                ),
+                Batch::new(
+                    *task.id(),
+                    bucket_2_small_batch_id,
+                    (),
+                    BatchState::Open,
+                    4,
+                    Interval::from_time(&report_time_2).unwrap(),
+                ),
+            ]),
         );
     }
 

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -1606,7 +1606,10 @@ mod tests {
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
 
         let task = TaskBuilder::new(
-            QueryType::FixedSize { max_batch_size: 10 },
+            QueryType::FixedSize {
+                max_batch_size: 10,
+                batch_time_window_size: None,
+            },
             VdafInstance::Prio3Count,
             Role::Leader,
         )
@@ -2255,7 +2258,10 @@ mod tests {
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
 
         let task = TaskBuilder::new(
-            QueryType::FixedSize { max_batch_size: 10 },
+            QueryType::FixedSize {
+                max_batch_size: 10,
+                batch_time_window_size: None,
+            },
             VdafInstance::Prio3Count,
             Role::Leader,
         )

--- a/aggregator/src/aggregator/batch_creator.rs
+++ b/aggregator/src/aggregator/batch_creator.rs
@@ -1,0 +1,447 @@
+//! In-memory data structure to incrementally build fixed-size batches.
+
+use futures::future::try_join_all;
+use janus_aggregator_core::datastore::{
+    models::{
+        AggregationJob, AggregationJobState, OutstandingBatch, ReportAggregation,
+        ReportAggregationState,
+    },
+    Error, Transaction,
+};
+use janus_core::time::{Clock, DurationExt, TimeExt};
+use janus_messages::{
+    query_type::FixedSize, AggregationJobRound, BatchId, Duration, Interval, ReportId, TaskId, Time,
+};
+use prio::{codec::Encode, vdaf::Aggregator};
+use rand::random;
+use std::{
+    cmp::{max, min, Ordering},
+    collections::{binary_heap::PeekMut, hash_map, BinaryHeap, HashMap, VecDeque},
+    ops::RangeInclusive,
+    sync::Arc,
+};
+use tokio::try_join;
+use tracing::debug;
+
+use super::aggregation_job_writer::AggregationJobWriter;
+
+/// This data structure loads existing outstanding batches, incrementally assigns new reports to
+/// outstanding batches and aggregation jobs, and provides unused reports at the end. If time
+/// bucketing is enabled, reports will be separated by timestamp into different sets of outstanding
+/// reports.
+pub struct BatchCreator<'a, const SEED_SIZE: usize, A>
+where
+    A: Aggregator<SEED_SIZE, 16>,
+{
+    properties: Properties,
+    aggregation_job_writer: &'a mut AggregationJobWriter<SEED_SIZE, FixedSize, A>,
+    map: HashMap<Option<Time>, Bucket>,
+    new_batches: Vec<(BatchId, Option<Time>)>,
+}
+
+/// Common properties used by [`BatchCreator`]. This is broken out into a separate structure to make
+/// them easier to pass to helper associated functions that also take mutable references to map
+/// entries.
+struct Properties {
+    min_aggregation_job_size: usize,
+    max_aggregation_job_size: usize,
+    task_id: TaskId,
+    task_min_batch_size: usize,
+    task_max_batch_size: usize,
+    task_batch_time_window_size: Option<Duration>,
+}
+
+impl<'a, const SEED_SIZE: usize, A> BatchCreator<'a, SEED_SIZE, A>
+where
+    A: Aggregator<SEED_SIZE, 16, AggregationParam = ()> + Send + Sync + 'a,
+    A::PrepareState: Encode,
+{
+    pub fn new(
+        min_aggregation_job_size: usize,
+        max_aggregation_job_size: usize,
+        task_id: TaskId,
+        task_min_batch_size: usize,
+        task_max_batch_size: usize,
+        task_batch_time_window_size: Option<Duration>,
+        aggregation_job_writer: &'a mut AggregationJobWriter<SEED_SIZE, FixedSize, A>,
+    ) -> Self {
+        Self {
+            properties: Properties {
+                min_aggregation_job_size,
+                max_aggregation_job_size,
+                task_id,
+                task_min_batch_size,
+                task_max_batch_size,
+                task_batch_time_window_size,
+            },
+            aggregation_job_writer,
+            map: HashMap::new(),
+            new_batches: Vec::new(),
+        }
+    }
+
+    pub async fn add_report<C>(
+        &mut self,
+        tx: &Transaction<'_, C>,
+        report_id: &ReportId,
+        client_timestamp: &Time,
+    ) -> Result<(), Error>
+    where
+        C: Clock,
+    {
+        let time_bucket_start_opt = self
+            .properties
+            .task_batch_time_window_size
+            .map(|batch_time_window_size| {
+                client_timestamp.to_batch_interval_start(&batch_time_window_size)
+            })
+            .transpose()?;
+        let mut map_entry = self.map.entry(time_bucket_start_opt);
+        let bucket = match &mut map_entry {
+            hash_map::Entry::Occupied(occupied) => occupied.get_mut(),
+            hash_map::Entry::Vacant(_) => {
+                // Lazily find existing unfilled batches.
+                let outstanding_batches = tx
+                    .get_outstanding_batches(&self.properties.task_id, &time_bucket_start_opt)
+                    .await?;
+                self.map
+                    .entry(time_bucket_start_opt)
+                    .or_insert_with(|| Bucket::new(outstanding_batches))
+            }
+        };
+
+        // Add to the list of unaggregated reports for this combination of task and time bucket.
+        bucket
+            .unaggregated_report_ids
+            .push_back((*report_id, *client_timestamp));
+
+        Self::process_batches(
+            &self.properties,
+            self.aggregation_job_writer,
+            &mut self.new_batches,
+            &time_bucket_start_opt,
+            bucket,
+            false,
+        )?;
+
+        Ok(())
+    }
+
+    /// Helper function to extract common batch creation and aggregate job creation logic within the
+    /// scope of one set of outstanding batches.
+    ///
+    /// If `greedy` is false, aggregation jobs will be created whenever there are enough reports to
+    /// meet the maximum aggregation job size. If `greedy` is true, aggregation jobs will be created
+    /// when there are enough reports to meet the minimum aggregation job size. In either case,
+    /// aggregation jobs may also be created when there are enough reports to make up the difference
+    /// between the task's min_batch_size parameter and the upper limit of an outstanding batch's
+    /// size range.
+    fn process_batches(
+        properties: &Properties,
+        aggregation_job_writer: &mut AggregationJobWriter<SEED_SIZE, FixedSize, A>,
+        new_batches: &mut Vec<(BatchId, Option<Time>)>,
+        time_bucket_start: &Option<Time>,
+        bucket: &mut Bucket,
+        greedy: bool,
+    ) -> Result<(), Error> {
+        loop {
+            // Consider creating aggregation jobs inside existing batches.
+            while let Some(mut largest_outstanding_batch) = bucket.outstanding_batches.peek_mut() {
+                // Short-circuit if the reports are exhausted.
+                if bucket.unaggregated_report_ids.is_empty() {
+                    return Ok(());
+                }
+                // Discard any outstanding batches that do not currently have room for more reports.
+                if largest_outstanding_batch.max_size() >= properties.task_max_batch_size {
+                    PeekMut::pop(largest_outstanding_batch);
+                    continue;
+                }
+
+                if greedy {
+                    let desired_aggregation_job_size = min(
+                        min(
+                            bucket.unaggregated_report_ids.len(),
+                            properties.max_aggregation_job_size,
+                        ),
+                        properties.task_max_batch_size - largest_outstanding_batch.max_size(),
+                    );
+                    if (desired_aggregation_job_size >= properties.min_aggregation_job_size)
+                        || (largest_outstanding_batch.max_size() < properties.task_min_batch_size
+                            && largest_outstanding_batch.max_size() + desired_aggregation_job_size
+                                >= properties.task_min_batch_size)
+                    {
+                        // First condition: Create an aggregation job with between
+                        // min_aggregation_job_size and max_aggregation_job_size reports.
+                        //
+                        // Second condition: This outstanding batch doesn't meet the minimum batch
+                        // size, and an aggregation job with the currently available reports (less
+                        // than min_aggregation_job_size) would be sufficient to meet the minimum
+                        // batch size (assuming the reports are successfully aggregated). Create
+                        // such an aggregation job.
+
+                        Self::create_aggregation_job(
+                            properties.task_id,
+                            *largest_outstanding_batch.id(),
+                            desired_aggregation_job_size,
+                            &mut bucket.unaggregated_report_ids,
+                            aggregation_job_writer,
+                        )?;
+                        largest_outstanding_batch.add_reports(desired_aggregation_job_size);
+                    } else {
+                        // There are not enough reports available to finish this outstanding batch.
+                        // Since `greedy` is true, we won't see any more reports in this run of the
+                        // aggregation job creator.
+                        //
+                        // All other outstanding batches will have lesser upper bounds on the number
+                        // of reports they contain, so they will not meet the criteria to create
+                        // less-than-min_aggregation_job_size jobs in order to finish out batches.
+                        // Exit now, to skip looping over them.
+                        return Ok(());
+                    }
+                } else {
+                    // Create an aggregation job if there are enough reports that we couldn't use
+                    // any more.
+                    let desired_aggregation_job_size = min(
+                        properties.max_aggregation_job_size,
+                        properties.task_max_batch_size - largest_outstanding_batch.max_size(),
+                    );
+                    if bucket.unaggregated_report_ids.len() >= desired_aggregation_job_size {
+                        Self::create_aggregation_job(
+                            properties.task_id,
+                            *largest_outstanding_batch.id(),
+                            desired_aggregation_job_size,
+                            &mut bucket.unaggregated_report_ids,
+                            aggregation_job_writer,
+                        )?;
+                        largest_outstanding_batch.add_reports(desired_aggregation_job_size);
+                    } else {
+                        // Cannot yet fill an aggregation job for the most-full outstanding batch.
+                        // Exit now, as we do not need to create any more batches.
+                        return Ok(());
+                    }
+                }
+            }
+
+            // If there are enough reports, create a new batch and a new full aggregation job.
+            let new_batch_threshold = if greedy {
+                properties.min_aggregation_job_size
+            } else {
+                properties.max_aggregation_job_size
+            };
+            let desired_aggregation_job_size = min(
+                min(
+                    bucket.unaggregated_report_ids.len(),
+                    properties.max_aggregation_job_size,
+                ),
+                properties.task_max_batch_size,
+            );
+            if desired_aggregation_job_size >= new_batch_threshold {
+                let batch_id = random();
+                new_batches.push((batch_id, *time_bucket_start));
+                let outstanding_batch = OutstandingBatch::new(
+                    properties.task_id,
+                    batch_id,
+                    RangeInclusive::new(0, desired_aggregation_job_size),
+                );
+                bucket
+                    .outstanding_batches
+                    .push(UpdatedOutstandingBatch::new(outstanding_batch));
+                Self::create_aggregation_job(
+                    properties.task_id,
+                    batch_id,
+                    desired_aggregation_job_size,
+                    &mut bucket.unaggregated_report_ids,
+                    aggregation_job_writer,
+                )?;
+
+                // Loop to the top of this method to create more aggregation jobs in this newly
+                // outstanding batch.
+                continue;
+            } else {
+                // Done adding reports to existing batches, and do not need to create a new batch
+                // yet. Exit.
+                return Ok(());
+            }
+        }
+    }
+
+    fn create_aggregation_job(
+        task_id: TaskId,
+        batch_id: BatchId,
+        aggregation_job_size: usize,
+        unaggregated_report_ids: &mut VecDeque<(ReportId, Time)>,
+        aggregation_job_writer: &mut AggregationJobWriter<SEED_SIZE, FixedSize, A>,
+    ) -> Result<(), Error> {
+        let aggregation_job_id = random();
+        debug!(
+            task_id = %task_id,
+            %batch_id,
+            %aggregation_job_id,
+            report_count = aggregation_job_size,
+            "Creating aggregation job"
+        );
+        let mut min_client_timestamp = None;
+        let mut max_client_timestamp = None;
+        let report_aggregations = (0u64..)
+            .zip(unaggregated_report_ids.drain(..aggregation_job_size))
+            .map(|(ord, (report_id, client_timestamp))| {
+                min_client_timestamp = Some(
+                    min_client_timestamp.map_or(client_timestamp, |ts| min(ts, client_timestamp)),
+                );
+                max_client_timestamp = Some(
+                    max_client_timestamp.map_or(client_timestamp, |ts| max(ts, client_timestamp)),
+                );
+                ReportAggregation::new(
+                    task_id,
+                    aggregation_job_id,
+                    report_id,
+                    client_timestamp,
+                    ord,
+                    None,
+                    ReportAggregationState::Start,
+                )
+            })
+            .collect();
+
+        let min_client_timestamp = min_client_timestamp.unwrap(); // unwrap safety: aggregation_job_size > 0
+        let max_client_timestamp = max_client_timestamp.unwrap(); // unwrap safety: aggregation_job_size > 0
+        let client_timestamp_interval = Interval::new(
+            min_client_timestamp,
+            max_client_timestamp
+                .difference(&min_client_timestamp)?
+                .add(&Duration::from_seconds(1))?,
+        )?;
+        let aggregation_job = AggregationJob::<SEED_SIZE, FixedSize, A>::new(
+            task_id,
+            aggregation_job_id,
+            (),
+            batch_id,
+            client_timestamp_interval,
+            AggregationJobState::InProgress,
+            AggregationJobRound::from(0),
+        );
+        aggregation_job_writer.put(aggregation_job, report_aggregations)?;
+
+        Ok(())
+    }
+
+    /// Finish creating aggregation jobs with the remaining reports where possible. Marks remaining
+    /// unused reports as unaggregated.
+    pub async fn finish<C>(mut self, tx: &Transaction<'_, C>, vdaf: Arc<A>) -> Result<(), Error>
+    where
+        C: Clock,
+    {
+        let mut unaggregated_report_ids = Vec::new();
+
+        // Create additional aggregation jobs with the remaining reports where possible. These will
+        // be smaller than max_aggregation_job_size. We will only create jobs smaller than
+        // min_aggregation_job_size if the remaining headroom in a batch requires it, otherwise
+        // remaining reports will be added to unaggregated_report_ids, to be marked as unaggregated.
+        for (time_bucket_start, mut bucket) in self.map.into_iter() {
+            Self::process_batches(
+                &self.properties,
+                self.aggregation_job_writer,
+                &mut self.new_batches,
+                &time_bucket_start,
+                &mut bucket,
+                true,
+            )?;
+            unaggregated_report_ids.extend(
+                bucket
+                    .unaggregated_report_ids
+                    .into_iter()
+                    .map(|(report_id, _)| report_id),
+            );
+        }
+
+        try_join!(
+            self.aggregation_job_writer.write(tx, vdaf),
+            try_join_all(
+                self.new_batches
+                    .iter()
+                    .map(|(batch_id, time_bucket_start)| tx.put_outstanding_batch(
+                        &self.properties.task_id,
+                        batch_id,
+                        time_bucket_start,
+                    ))
+            ),
+            async move {
+                if !unaggregated_report_ids.is_empty() {
+                    tx.mark_reports_unaggregated(
+                        &self.properties.task_id,
+                        &unaggregated_report_ids,
+                    )
+                    .await?;
+                }
+                Ok(())
+            }
+        )?;
+        Ok(())
+    }
+}
+
+/// Tracks reports and batches for one partition of a task.
+struct Bucket {
+    outstanding_batches: BinaryHeap<UpdatedOutstandingBatch>,
+    unaggregated_report_ids: VecDeque<(ReportId, Time)>,
+}
+
+impl Bucket {
+    fn new(outstanding_batches: Vec<OutstandingBatch>) -> Self {
+        Self {
+            outstanding_batches: outstanding_batches
+                .into_iter()
+                .map(UpdatedOutstandingBatch::new)
+                .collect(),
+            unaggregated_report_ids: VecDeque::new(),
+        }
+    }
+}
+
+/// This serves as both a wrapper type for sorting outstanding batches by their current maximum
+/// size, and as in-memory storage for pending changes to a batch's maximum size.
+struct UpdatedOutstandingBatch {
+    inner: OutstandingBatch,
+    new_max_size: usize,
+}
+
+impl UpdatedOutstandingBatch {
+    fn new(outstanding_batch: OutstandingBatch) -> Self {
+        Self {
+            new_max_size: *outstanding_batch.size().end(),
+            inner: outstanding_batch,
+        }
+    }
+
+    fn add_reports(&mut self, count: usize) {
+        self.new_max_size += count;
+    }
+
+    fn max_size(&self) -> usize {
+        self.new_max_size
+    }
+
+    fn id(&self) -> &BatchId {
+        self.inner.id()
+    }
+}
+
+impl PartialEq for UpdatedOutstandingBatch {
+    fn eq(&self, other: &Self) -> bool {
+        self.new_max_size == other.new_max_size
+    }
+}
+
+impl Eq for UpdatedOutstandingBatch {}
+
+impl PartialOrd for UpdatedOutstandingBatch {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.new_max_size.partial_cmp(&other.new_max_size)
+    }
+}
+
+impl Ord for UpdatedOutstandingBatch {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.new_max_size.cmp(&other.new_max_size)
+    }
+}

--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -159,9 +159,14 @@ pub(crate) async fn setup_collection_job_test_case(
 
 async fn setup_fixed_size_current_batch_collection_job_test_case(
 ) -> (CollectionJobTestCase, BatchId, BatchId, Interval) {
-    let test_case =
-        setup_collection_job_test_case(Role::Leader, QueryType::FixedSize { max_batch_size: 10 })
-            .await;
+    let test_case = setup_collection_job_test_case(
+        Role::Leader,
+        QueryType::FixedSize {
+            max_batch_size: 10,
+            batch_time_window_size: None,
+        },
+    )
+    .await;
 
     // Fill the datastore with the necessary data so that there is are two outstanding batches to be
     // collected.
@@ -239,7 +244,7 @@ async fn setup_fixed_size_current_batch_collection_job_test_case(
                     .await
                     .unwrap();
 
-                    tx.put_outstanding_batch(task.id(), &batch_id)
+                    tx.put_outstanding_batch(task.id(), &batch_id, &None)
                         .await
                         .unwrap();
                 }
@@ -640,9 +645,14 @@ async fn collection_job_put_idempotence_fixed_size_current_batch_mutate_aggregat
 
 #[tokio::test]
 async fn collection_job_put_idempotence_fixed_size_by_batch_id() {
-    let test_case =
-        setup_collection_job_test_case(Role::Leader, QueryType::FixedSize { max_batch_size: 10 })
-            .await;
+    let test_case = setup_collection_job_test_case(
+        Role::Leader,
+        QueryType::FixedSize {
+            max_batch_size: 10,
+            batch_time_window_size: None,
+        },
+    )
+    .await;
 
     let collection_job_id = random();
     let batch_id = random();
@@ -688,9 +698,14 @@ async fn collection_job_put_idempotence_fixed_size_by_batch_id() {
 
 #[tokio::test]
 async fn collection_job_put_idempotence_fixed_size_by_batch_id_mutate_batch_id() {
-    let test_case =
-        setup_collection_job_test_case(Role::Leader, QueryType::FixedSize { max_batch_size: 10 })
-            .await;
+    let test_case = setup_collection_job_test_case(
+        Role::Leader,
+        QueryType::FixedSize {
+            max_batch_size: 10,
+            batch_time_window_size: None,
+        },
+    )
+    .await;
 
     let collection_job_id = random();
     let first_batch_id = random();
@@ -752,9 +767,14 @@ async fn collection_job_put_idempotence_fixed_size_by_batch_id_mutate_batch_id()
 
 #[tokio::test]
 async fn collection_job_put_idempotence_fixed_size_by_batch_id_mutate_aggregation_param() {
-    let test_case =
-        setup_collection_job_test_case(Role::Leader, QueryType::FixedSize { max_batch_size: 10 })
-            .await;
+    let test_case = setup_collection_job_test_case(
+        Role::Leader,
+        QueryType::FixedSize {
+            max_batch_size: 10,
+            batch_time_window_size: None,
+        },
+    )
+    .await;
 
     let collection_job_id = random();
     let batch_id = random();

--- a/aggregator/src/aggregator/garbage_collector.rs
+++ b/aggregator/src/aggregator/garbage_collector.rs
@@ -493,7 +493,10 @@ mod tests {
                 let (clock, vdaf) = (clock.clone(), vdaf.clone());
                 Box::pin(async move {
                     let task = TaskBuilder::new(
-                        task::QueryType::FixedSize { max_batch_size: 10 },
+                        task::QueryType::FixedSize {
+                            max_batch_size: 10,
+                            batch_time_window_size: None,
+                        },
                         VdafInstance::Fake,
                         Role::Leader,
                     )
@@ -549,7 +552,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                    tx.put_outstanding_batch(task.id(), &batch_id)
+                    tx.put_outstanding_batch(task.id(), &batch_id, &None)
                         .await
                         .unwrap();
 
@@ -632,7 +635,7 @@ mod tests {
                     .unwrap()
                     .is_empty());
                 assert!(tx
-                    .get_outstanding_batches_for_task(task.id())
+                    .get_outstanding_batches(task.id(), &None)
                     .await
                     .unwrap()
                     .is_empty());
@@ -674,7 +677,10 @@ mod tests {
                 let clock = clock.clone();
                 Box::pin(async move {
                     let task = TaskBuilder::new(
-                        task::QueryType::FixedSize { max_batch_size: 10 },
+                        task::QueryType::FixedSize {
+                            max_batch_size: 10,
+                            batch_time_window_size: None,
+                        },
                         VdafInstance::Fake,
                         Role::Helper,
                     )
@@ -738,7 +744,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                    tx.put_outstanding_batch(task.id(), &batch_id)
+                    tx.put_outstanding_batch(task.id(), &batch_id, &None)
                         .await
                         .unwrap();
 

--- a/aggregator/src/bin/janus_cli.rs
+++ b/aggregator/src/bin/janus_cli.rs
@@ -674,6 +674,7 @@ mod tests {
         let replacement_task = TaskBuilder::new(
             QueryType::FixedSize {
                 max_batch_size: 100,
+                batch_time_window_size: None,
             },
             VdafInstance::Prio3CountVec { length: 4 },
             Role::Leader,

--- a/aggregator_api/src/lib.rs
+++ b/aggregator_api/src/lib.rs
@@ -1414,6 +1414,7 @@ mod tests {
                 peer_aggregator_endpoint: "https://example.com/".parse().unwrap(),
                 query_type: QueryType::FixedSize {
                     max_batch_size: 999,
+                    batch_time_window_size: None,
                 },
                 vdaf: VdafInstance::Prio3CountVec { length: 5 },
                 role: Role::Helper,
@@ -1442,10 +1443,12 @@ mod tests {
                 Token::StructVariant {
                     name: "QueryType",
                     variant: "FixedSize",
-                    len: 1,
+                    len: 2,
                 },
                 Token::Str("max_batch_size"),
                 Token::U64(999),
+                Token::Str("batch_time_window_size"),
+                Token::None,
                 Token::StructVariantEnd,
                 Token::Str("vdaf"),
                 Token::StructVariant {
@@ -1512,6 +1515,7 @@ mod tests {
                 peer_aggregator_endpoint: "https://example.com/".parse().unwrap(),
                 query_type: QueryType::FixedSize {
                     max_batch_size: 999,
+                    batch_time_window_size: None,
                 },
                 vdaf: VdafInstance::Prio3CountVec { length: 5 },
                 role: Role::Leader,
@@ -1540,10 +1544,12 @@ mod tests {
                 Token::StructVariant {
                     name: "QueryType",
                     variant: "FixedSize",
-                    len: 1,
+                    len: 2,
                 },
                 Token::Str("max_batch_size"),
                 Token::U64(999),
+                Token::Str("batch_time_window_size"),
+                Token::None,
                 Token::StructVariantEnd,
                 Token::Str("vdaf"),
                 Token::StructVariant {
@@ -1618,6 +1624,7 @@ mod tests {
             ]),
             QueryType::FixedSize {
                 max_batch_size: 999,
+                batch_time_window_size: None,
             },
             VdafInstance::Prio3CountVec { length: 5 },
             Role::Leader,
@@ -1668,10 +1675,12 @@ mod tests {
                 Token::StructVariant {
                     name: "QueryType",
                     variant: "FixedSize",
-                    len: 1,
+                    len: 2,
                 },
                 Token::Str("max_batch_size"),
                 Token::U64(999),
+                Token::Str("batch_time_window_size"),
+                Token::None,
                 Token::StructVariantEnd,
                 Token::Str("vdaf"),
                 Token::StructVariant {

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -903,14 +903,20 @@ async fn count_client_reports_for_batch_id(ephemeral_datastore: EphemeralDatasto
     let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
     let task = TaskBuilder::new(
-        task::QueryType::FixedSize { max_batch_size: 10 },
+        task::QueryType::FixedSize {
+            max_batch_size: 10,
+            batch_time_window_size: None,
+        },
         VdafInstance::Fake,
         Role::Leader,
     )
     .with_report_expiry_age(Some(REPORT_EXPIRY_AGE))
     .build();
     let unrelated_task = TaskBuilder::new(
-        task::QueryType::FixedSize { max_batch_size: 10 },
+        task::QueryType::FixedSize {
+            max_batch_size: 10,
+            batch_time_window_size: None,
+        },
         VdafInstance::Fake,
         Role::Leader,
     )
@@ -1182,7 +1188,10 @@ async fn roundtrip_aggregation_job(ephemeral_datastore: EphemeralDatastore) {
     // We use a dummy VDAF & fixed-size task for this test, to better exercise the
     // serialization/deserialization roundtrip of the batch_identifier & aggregation_param.
     let task = TaskBuilder::new(
-        task::QueryType::FixedSize { max_batch_size: 10 },
+        task::QueryType::FixedSize {
+            max_batch_size: 10,
+            batch_time_window_size: None,
+        },
         VdafInstance::Fake,
         Role::Leader,
     )
@@ -1781,7 +1790,10 @@ async fn get_aggregation_jobs_for_task(ephemeral_datastore: EphemeralDatastore) 
     // We use a dummy VDAF & fixed-size task for this test, to better exercise the
     // serialization/deserialization roundtrip of the batch_identifier & aggregation_param.
     let task = TaskBuilder::new(
-        task::QueryType::FixedSize { max_batch_size: 10 },
+        task::QueryType::FixedSize {
+            max_batch_size: 10,
+            batch_time_window_size: None,
+        },
         VdafInstance::Fake,
         Role::Leader,
     )
@@ -1833,7 +1845,10 @@ async fn get_aggregation_jobs_for_task(ephemeral_datastore: EphemeralDatastore) 
             // Also write an unrelated aggregation job with a different task ID to check that it
             // is not returned.
             let unrelated_task = TaskBuilder::new(
-                task::QueryType::FixedSize { max_batch_size: 10 },
+                task::QueryType::FixedSize {
+                    max_batch_size: 10,
+                    batch_time_window_size: None,
+                },
                 VdafInstance::Fake,
                 Role::Leader,
             )
@@ -3002,7 +3017,10 @@ async fn fixed_size_collection_job_acquire_release_happy_path(
         &ds,
         CollectionJobAcquireTestCase {
             task_ids: Vec::from([task_id]),
-            query_type: task::QueryType::FixedSize { max_batch_size: 10 },
+            query_type: task::QueryType::FixedSize {
+                max_batch_size: 10,
+                batch_time_window_size: None,
+            },
             reports,
             aggregation_jobs,
             report_aggregations,
@@ -4035,7 +4053,10 @@ async fn roundtrip_batch_aggregation_fixed_size(ephemeral_datastore: EphemeralDa
     let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
     let task = TaskBuilder::new(
-        task::QueryType::FixedSize { max_batch_size: 10 },
+        task::QueryType::FixedSize {
+            max_batch_size: 10,
+            batch_time_window_size: None,
+        },
         VdafInstance::Fake,
         Role::Leader,
     )
@@ -4044,13 +4065,15 @@ async fn roundtrip_batch_aggregation_fixed_size(ephemeral_datastore: EphemeralDa
     let batch_id = random();
     let aggregate_share = AggregateShare(23);
     let aggregation_param = AggregationParam(12);
-
     let batch_aggregation = ds
         .run_tx(|tx| {
             let task = task.clone();
             Box::pin(async move {
                 let other_task = TaskBuilder::new(
-                    task::QueryType::FixedSize { max_batch_size: 10 },
+                    task::QueryType::FixedSize {
+                        max_batch_size: 10,
+                        batch_time_window_size: None,
+                    },
                     VdafInstance::Fake,
                     Role::Leader,
                 )
@@ -4433,7 +4456,10 @@ async fn roundtrip_aggregate_share_job_fixed_size(ephemeral_datastore: Ephemeral
         .run_tx(|tx| {
             Box::pin(async move {
                 let task = TaskBuilder::new(
-                    task::QueryType::FixedSize { max_batch_size: 10 },
+                    task::QueryType::FixedSize {
+                        max_batch_size: 10,
+                        batch_time_window_size: None,
+                    },
                     VdafInstance::Fake,
                     Role::Helper,
                 )
@@ -4567,23 +4593,32 @@ async fn roundtrip_outstanding_batch(ephemeral_datastore: EphemeralDatastore) {
     let clock = MockClock::new(OLDEST_ALLOWED_REPORT_TIMESTAMP);
     let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
-    let (task_id, batch_id) = ds
+    let batch_time_window_size = Duration::from_hours(24).unwrap();
+    let time_bucket_start = clock
+        .now()
+        .to_batch_interval_start(&batch_time_window_size)
+        .unwrap();
+
+    let (task_id_1, batch_id_1, task_id_2, batch_id_2) = ds
         .run_tx(|tx| {
             let clock = clock.clone();
             Box::pin(async move {
-                let task = TaskBuilder::new(
-                    task::QueryType::FixedSize { max_batch_size: 10 },
+                let task_1 = TaskBuilder::new(
+                    task::QueryType::FixedSize {
+                        max_batch_size: 10,
+                        batch_time_window_size: None,
+                    },
                     VdafInstance::Fake,
                     Role::Leader,
                 )
                 .with_report_expiry_age(Some(REPORT_EXPIRY_AGE))
                 .build();
-                tx.put_task(&task).await?;
-                let batch_id = random();
+                tx.put_task(&task_1).await?;
+                let batch_id_1 = random();
 
                 tx.put_batch(&Batch::<0, FixedSize, dummy_vdaf::Vdaf>::new(
-                    *task.id(),
-                    batch_id,
+                    *task_1.id(),
+                    batch_id_1,
                     AggregationParam(0),
                     BatchState::Closed,
                     0,
@@ -4591,22 +4626,49 @@ async fn roundtrip_outstanding_batch(ephemeral_datastore: EphemeralDatastore) {
                         .unwrap(),
                 ))
                 .await?;
-                tx.put_outstanding_batch(task.id(), &batch_id).await?;
+                tx.put_outstanding_batch(task_1.id(), &batch_id_1, &None)
+                    .await?;
+
+                let task_2 = TaskBuilder::new(
+                    task::QueryType::FixedSize {
+                        max_batch_size: 10,
+                        batch_time_window_size: Some(batch_time_window_size),
+                    },
+                    VdafInstance::Fake,
+                    Role::Leader,
+                )
+                .with_report_expiry_age(Some(REPORT_EXPIRY_AGE))
+                .build();
+                tx.put_task(&task_2).await?;
+                let batch_id_2 = random();
+
+                tx.put_batch(&Batch::<0, FixedSize, dummy_vdaf::Vdaf>::new(
+                    *task_2.id(),
+                    batch_id_2,
+                    AggregationParam(0),
+                    BatchState::Closed,
+                    0,
+                    Interval::new(OLDEST_ALLOWED_REPORT_TIMESTAMP, Duration::from_seconds(1))
+                        .unwrap(),
+                ))
+                .await?;
+                tx.put_outstanding_batch(task_2.id(), &batch_id_2, &Some(time_bucket_start))
+                    .await?;
 
                 // Write a few aggregation jobs & report aggregations to produce useful
                 // min_size/max_size values to validate later.
                 let aggregation_job_0 = AggregationJob::<0, FixedSize, dummy_vdaf::Vdaf>::new(
-                    *task.id(),
+                    *task_1.id(),
                     random(),
                     AggregationParam(0),
-                    batch_id,
+                    batch_id_1,
                     Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                         .unwrap(),
                     AggregationJobState::Finished,
                     AggregationJobRound::from(1),
                 );
                 let report_aggregation_0_0 = ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
-                    *task.id(),
+                    *task_1.id(),
                     *aggregation_job_0.id(),
                     random(),
                     clock.now(),
@@ -4615,7 +4677,7 @@ async fn roundtrip_outstanding_batch(ephemeral_datastore: EphemeralDatastore) {
                     ReportAggregationState::Start, // Counted among max_size.
                 );
                 let report_aggregation_0_1 = ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
-                    *task.id(),
+                    *task_1.id(),
                     *aggregation_job_0.id(),
                     random(),
                     clock.now(),
@@ -4624,7 +4686,7 @@ async fn roundtrip_outstanding_batch(ephemeral_datastore: EphemeralDatastore) {
                     ReportAggregationState::Waiting(dummy_vdaf::PrepareState::default(), Some(())), // Counted among max_size.
                 );
                 let report_aggregation_0_2 = ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
-                    *task.id(),
+                    *task_1.id(),
                     *aggregation_job_0.id(),
                     random(),
                     clock.now(),
@@ -4634,17 +4696,17 @@ async fn roundtrip_outstanding_batch(ephemeral_datastore: EphemeralDatastore) {
                 );
 
                 let aggregation_job_1 = AggregationJob::<0, FixedSize, dummy_vdaf::Vdaf>::new(
-                    *task.id(),
+                    *task_1.id(),
                     random(),
                     AggregationParam(0),
-                    batch_id,
+                    batch_id_1,
                     Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                         .unwrap(),
                     AggregationJobState::Finished,
                     AggregationJobRound::from(1),
                 );
                 let report_aggregation_1_0 = ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
-                    *task.id(),
+                    *task_1.id(),
                     *aggregation_job_1.id(),
                     random(),
                     clock.now(),
@@ -4653,7 +4715,7 @@ async fn roundtrip_outstanding_batch(ephemeral_datastore: EphemeralDatastore) {
                     ReportAggregationState::Finished, // Counted among min_size and max_size.
                 );
                 let report_aggregation_1_1 = ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
-                    *task.id(),
+                    *task_1.id(),
                     *aggregation_job_1.id(),
                     random(),
                     clock.now(),
@@ -4662,7 +4724,7 @@ async fn roundtrip_outstanding_batch(ephemeral_datastore: EphemeralDatastore) {
                     ReportAggregationState::Finished, // Counted among min_size and max_size.
                 );
                 let report_aggregation_1_2 = ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
-                    *task.id(),
+                    *task_1.id(),
                     *aggregation_job_1.id(),
                     random(),
                     clock.now(),
@@ -4671,7 +4733,27 @@ async fn roundtrip_outstanding_batch(ephemeral_datastore: EphemeralDatastore) {
                     ReportAggregationState::Failed(ReportShareError::VdafPrepError), // Not counted among min_size or max_size.
                 );
 
-                for aggregation_job in &[aggregation_job_0, aggregation_job_1] {
+                let aggregation_job_2 = AggregationJob::<0, FixedSize, dummy_vdaf::Vdaf>::new(
+                    *task_2.id(),
+                    random(),
+                    AggregationParam(0),
+                    batch_id_2,
+                    Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
+                        .unwrap(),
+                    AggregationJobState::Finished,
+                    AggregationJobRound::from(1),
+                );
+                let report_aggregation_2_0 = ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
+                    *task_2.id(),
+                    *aggregation_job_2.id(),
+                    random(),
+                    clock.now(),
+                    0,
+                    None,
+                    ReportAggregationState::Start,
+                );
+
+                for aggregation_job in &[aggregation_job_0, aggregation_job_1, aggregation_job_2] {
                     tx.put_aggregation_job(aggregation_job).await?;
                 }
                 for report_aggregation in &[
@@ -4681,6 +4763,7 @@ async fn roundtrip_outstanding_batch(ephemeral_datastore: EphemeralDatastore) {
                     report_aggregation_1_0,
                     report_aggregation_1_1,
                     report_aggregation_1_2,
+                    report_aggregation_2_0,
                 ] {
                     tx.put_client_report(
                         &dummy_vdaf::Vdaf::new(),
@@ -4706,8 +4789,8 @@ async fn roundtrip_outstanding_batch(ephemeral_datastore: EphemeralDatastore) {
                 }
 
                 tx.put_batch_aggregation(&BatchAggregation::<0, FixedSize, dummy_vdaf::Vdaf>::new(
-                    *task.id(),
-                    batch_id,
+                    *task_1.id(),
+                    batch_id_1,
                     AggregationParam(0),
                     0,
                     BatchAggregationState::Aggregating,
@@ -4719,8 +4802,8 @@ async fn roundtrip_outstanding_batch(ephemeral_datastore: EphemeralDatastore) {
                 ))
                 .await?;
                 tx.put_batch_aggregation(&BatchAggregation::<0, FixedSize, dummy_vdaf::Vdaf>::new(
-                    *task.id(),
-                    batch_id,
+                    *task_1.id(),
+                    batch_id_1,
                     AggregationParam(0),
                     1,
                     BatchAggregationState::Aggregating,
@@ -4732,7 +4815,7 @@ async fn roundtrip_outstanding_batch(ephemeral_datastore: EphemeralDatastore) {
                 ))
                 .await?;
 
-                Ok((*task.id(), batch_id))
+                Ok((*task_1.id(), batch_id_1, *task_2.id(), batch_id_2))
             })
         })
         .await
@@ -4741,41 +4824,69 @@ async fn roundtrip_outstanding_batch(ephemeral_datastore: EphemeralDatastore) {
     // Advance the clock to "enable" report expiry.
     clock.advance(&REPORT_EXPIRY_AGE);
 
-    let (outstanding_batches, outstanding_batch_1, outstanding_batch_2, outstanding_batch_3) = ds
+    let (
+        outstanding_batches_task_1,
+        outstanding_batch_1,
+        outstanding_batch_2,
+        outstanding_batch_3,
+        outstanding_batches_task_2,
+        outstanding_batches_empty_time_bucket,
+    ) = ds
         .run_tx(|tx| {
             Box::pin(async move {
-                let outstanding_batches = tx.get_outstanding_batches_for_task(&task_id).await?;
-                let outstanding_batch_1 = tx.get_filled_outstanding_batch(&task_id, 1).await?;
-                let outstanding_batch_2 = tx.get_filled_outstanding_batch(&task_id, 2).await?;
-                let outstanding_batch_3 = tx.get_filled_outstanding_batch(&task_id, 3).await?;
+                let outstanding_batches_task_1 =
+                    tx.get_outstanding_batches(&task_id_1, &None).await?;
+                let outstanding_batch_1 = tx.get_filled_outstanding_batch(&task_id_1, 1).await?;
+                let outstanding_batch_2 = tx.get_filled_outstanding_batch(&task_id_1, 2).await?;
+                let outstanding_batch_3 = tx.get_filled_outstanding_batch(&task_id_1, 3).await?;
+                let outstanding_batches_task_2 = tx
+                    .get_outstanding_batches(&task_id_2, &Some(time_bucket_start))
+                    .await?;
+                let outstanding_batches_empty_time_bucket = tx
+                    .get_outstanding_batches(
+                        &task_id_2,
+                        &Some(time_bucket_start.add(&Duration::from_hours(24)?)?),
+                    )
+                    .await?;
                 Ok((
-                    outstanding_batches,
+                    outstanding_batches_task_1,
                     outstanding_batch_1,
                     outstanding_batch_2,
                     outstanding_batch_3,
+                    outstanding_batches_task_2,
+                    outstanding_batches_empty_time_bucket,
                 ))
             })
         })
         .await
         .unwrap();
     assert_eq!(
-        outstanding_batches,
+        outstanding_batches_task_1,
         Vec::from([OutstandingBatch::new(
-            task_id,
-            batch_id,
+            task_id_1,
+            batch_id_1,
             RangeInclusive::new(2, 4)
         )])
     );
-    assert_eq!(outstanding_batch_1, Some(batch_id));
-    assert_eq!(outstanding_batch_2, Some(batch_id));
+    assert_eq!(outstanding_batch_1, Some(batch_id_1));
+    assert_eq!(outstanding_batch_2, Some(batch_id_1));
     assert_eq!(outstanding_batch_3, None);
+    assert_eq!(
+        outstanding_batches_task_2,
+        Vec::from([OutstandingBatch::new(
+            task_id_2,
+            batch_id_2,
+            RangeInclusive::new(0, 1)
+        )])
+    );
+    assert_eq!(outstanding_batches_empty_time_bucket, Vec::new());
 
     // Advance the clock further to trigger expiration of the written batches.
     clock.advance(&REPORT_EXPIRY_AGE);
 
     // Verify that the batch is no longer available.
     let outstanding_batches = ds
-        .run_tx(|tx| Box::pin(async move { tx.get_outstanding_batches_for_task(&task_id).await }))
+        .run_tx(|tx| Box::pin(async move { tx.get_outstanding_batches(&task_id_1, &None).await }))
         .await
         .unwrap();
     assert!(outstanding_batches.is_empty());
@@ -4784,12 +4895,14 @@ async fn roundtrip_outstanding_batch(ephemeral_datastore: EphemeralDatastore) {
     clock.set(OLDEST_ALLOWED_REPORT_TIMESTAMP);
 
     // Delete the outstanding batch, then check that it is no longer available.
-    ds.run_tx(|tx| Box::pin(async move { tx.delete_outstanding_batch(&task_id, &batch_id).await }))
-        .await
-        .unwrap();
+    ds.run_tx(|tx| {
+        Box::pin(async move { tx.delete_outstanding_batch(&task_id_1, &batch_id_1).await })
+    })
+    .await
+    .unwrap();
 
     let outstanding_batches = ds
-        .run_tx(|tx| Box::pin(async move { tx.get_outstanding_batches_for_task(&task_id).await }))
+        .run_tx(|tx| Box::pin(async move { tx.get_outstanding_batches(&task_id_1, &None).await }))
         .await
         .unwrap();
     assert!(outstanding_batches.is_empty());
@@ -4817,7 +4930,10 @@ async fn roundtrip_batch(ephemeral_datastore: EphemeralDatastore) {
         Box::pin(async move {
             tx.put_task(
                 &TaskBuilder::new(
-                    task::QueryType::FixedSize { max_batch_size: 10 },
+                    task::QueryType::FixedSize {
+                        max_batch_size: 10,
+                        batch_time_window_size: None,
+                    },
                     VdafInstance::Fake,
                     Role::Leader,
                 )
@@ -4939,6 +5055,7 @@ trait ExpirationQueryTypeExt: CollectableQueryType {
         tx: &Transaction<MockClock>,
         task_id: &TaskId,
         batch_identifier: &Self::BatchIdentifier,
+        time_bucket_start: &Option<Time>,
     ) -> Option<(TaskId, BatchId)>;
 }
 
@@ -4974,6 +5091,7 @@ impl ExpirationQueryTypeExt for TimeInterval {
         _: &Transaction<MockClock>,
         _: &TaskId,
         _: &Self::BatchIdentifier,
+        _: &Option<Time>,
     ) -> Option<(TaskId, BatchId)> {
         None
     }
@@ -4995,8 +5113,9 @@ impl ExpirationQueryTypeExt for FixedSize {
         tx: &Transaction<MockClock>,
         task_id: &TaskId,
         batch_identifier: &Self::BatchIdentifier,
+        time_bucket_start: &Option<Time>,
     ) -> Option<(TaskId, BatchId)> {
-        tx.put_outstanding_batch(task_id, batch_identifier)
+        tx.put_outstanding_batch(task_id, batch_identifier, time_bucket_start)
             .await
             .unwrap();
         Some((*task_id, *batch_identifier))
@@ -5204,14 +5323,20 @@ async fn delete_expired_aggregation_artifacts(ephemeral_datastore: EphemeralData
                 .with_report_expiry_age(Some(REPORT_EXPIRY_AGE))
                 .build();
                 let leader_fixed_size_task = TaskBuilder::new(
-                    task::QueryType::FixedSize { max_batch_size: 10 },
+                    task::QueryType::FixedSize {
+                        max_batch_size: 10,
+                        batch_time_window_size: None,
+                    },
                     VdafInstance::Fake,
                     Role::Leader,
                 )
                 .with_report_expiry_age(Some(REPORT_EXPIRY_AGE))
                 .build();
                 let helper_fixed_size_task = TaskBuilder::new(
-                    task::QueryType::FixedSize { max_batch_size: 10 },
+                    task::QueryType::FixedSize {
+                        max_batch_size: 10,
+                        batch_time_window_size: None,
+                    },
                     VdafInstance::Fake,
                     Role::Helper,
                 )
@@ -5581,6 +5706,7 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
         Option<(TaskId, Vec<u8>)>, // batch ID (task ID, encoded batch identifier)
         Option<(TaskId, BatchId)>, // outstanding batch ID
         Option<(TaskId, Vec<u8>)>, // batch aggregation ID (task ID, encoded batch identifier)
+        Option<Time>,              // time bucket start
     ) {
         let batch_identifier = Q::batch_identifier_for_client_timestamps(client_timestamps);
         let client_timestamp_interval = client_timestamps
@@ -5623,8 +5749,34 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
             );
             tx.put_collection_job(&collection_job).await.unwrap();
 
+            let time_bucket_start = match task.query_type() {
+                task::QueryType::TimeInterval
+                | task::QueryType::FixedSize {
+                    batch_time_window_size: None,
+                    ..
+                } => None,
+                task::QueryType::FixedSize {
+                    batch_time_window_size: Some(batch_time_window_size),
+                    ..
+                } => {
+                    let time_bucket_start = client_timestamps[0]
+                        .to_batch_interval_start(batch_time_window_size)
+                        .unwrap();
+                    let same_bucket = client_timestamps.iter().all(|ts| {
+                        ts.to_batch_interval_start(batch_time_window_size).unwrap()
+                            == time_bucket_start
+                    });
+                    assert!(
+                        same_bucket,
+                        "client timestamps do not all fall in the same time bucket"
+                    );
+                    Some(time_bucket_start)
+                }
+            };
+
             let outstanding_batch_id =
-                Q::write_outstanding_batch(tx, task.id(), &batch_identifier).await;
+                Q::write_outstanding_batch(tx, task.id(), &batch_identifier, &time_bucket_start)
+                    .await;
 
             return (
                 Some(*collection_job.id()),
@@ -5632,6 +5784,7 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                 Some((*task.id(), batch_identifier.get_encoded())),
                 outstanding_batch_id,
                 Some((*task.id(), batch_identifier.get_encoded())),
+                time_bucket_start,
             );
         } else {
             tx.put_aggregate_share_job::<0, Q, dummy_vdaf::Vdaf>(&AggregateShareJob::new(
@@ -5651,6 +5804,7 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                 Some((*task.id(), batch_identifier.get_encoded())),
                 None,
                 Some((*task.id(), batch_identifier.get_encoded())),
+                None,
             );
         }
     }
@@ -5660,12 +5814,14 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
         helper_time_interval_task_id,
         leader_fixed_size_task_id,
         helper_fixed_size_task_id,
+        leader_fixed_size_time_bucketed_task_id,
         other_task_id,
         want_batch_ids,
         want_collection_job_ids,
         want_aggregate_share_job_ids,
         want_outstanding_batch_ids,
         want_batch_aggregation_ids,
+        time_bucket_starts,
     ) = ds
         .run_tx(|tx| {
             Box::pin(async move {
@@ -5684,16 +5840,32 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                 .with_report_expiry_age(Some(REPORT_EXPIRY_AGE))
                 .build();
                 let leader_fixed_size_task = TaskBuilder::new(
-                    task::QueryType::FixedSize { max_batch_size: 10 },
+                    task::QueryType::FixedSize {
+                        max_batch_size: 10,
+                        batch_time_window_size: None,
+                    },
                     VdafInstance::Fake,
                     Role::Leader,
                 )
                 .with_report_expiry_age(Some(REPORT_EXPIRY_AGE))
                 .build();
                 let helper_fixed_size_task = TaskBuilder::new(
-                    task::QueryType::FixedSize { max_batch_size: 10 },
+                    task::QueryType::FixedSize {
+                        max_batch_size: 10,
+                        batch_time_window_size: None,
+                    },
                     VdafInstance::Fake,
                     Role::Helper,
+                )
+                .with_report_expiry_age(Some(REPORT_EXPIRY_AGE))
+                .build();
+                let leader_fixed_size_time_bucketed_task = TaskBuilder::new(
+                    task::QueryType::FixedSize {
+                        max_batch_size: 10,
+                        batch_time_window_size: Some(Duration::from_hours(24)?),
+                    },
+                    VdafInstance::Fake,
+                    Role::Leader,
                 )
                 .with_report_expiry_age(Some(REPORT_EXPIRY_AGE))
                 .build();
@@ -5708,6 +5880,7 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                 tx.put_task(&helper_time_interval_task).await?;
                 tx.put_task(&leader_fixed_size_task).await?;
                 tx.put_task(&helper_fixed_size_task).await?;
+                tx.put_task(&leader_fixed_size_time_bucketed_task).await?;
                 tx.put_task(&other_task).await?;
 
                 let mut collection_job_ids = HashSet::new();
@@ -5715,6 +5888,7 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                 let mut batch_ids = HashSet::new();
                 let mut outstanding_batch_ids = HashSet::new();
                 let mut batch_aggregation_ids = HashSet::new();
+                let mut time_bucket_starts = HashSet::new();
 
                 // Leader, time-interval collection artifacts with old reports. [GC'ed]
                 write_collect_artifacts::<TimeInterval>(
@@ -5738,6 +5912,7 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                     batch_id,
                     outstanding_batch_id,
                     batch_aggregation_id,
+                    _,
                 ) = write_collect_artifacts::<TimeInterval>(
                     tx,
                     &leader_time_interval_task,
@@ -5764,6 +5939,7 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                     batch_id,
                     outstanding_batch_id,
                     batch_aggregation_id,
+                    _,
                 ) = write_collect_artifacts::<TimeInterval>(
                     tx,
                     &leader_time_interval_task,
@@ -5799,7 +5975,7 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                 .await;
 
                 // Helper, time-interval collection artifacts with old & new reports. [aggregate share job job GC'ed, remainder not GC'ed]
-                let (_, _, batch_id, outstanding_batch_id, batch_aggregation_id) =
+                let (_, _, batch_id, outstanding_batch_id, batch_aggregation_id, _) =
                     write_collect_artifacts::<TimeInterval>(
                         tx,
                         &helper_time_interval_task,
@@ -5826,6 +6002,7 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                     batch_id,
                     outstanding_batch_id,
                     batch_aggregation_id,
+                    _,
                 ) = write_collect_artifacts::<TimeInterval>(
                     tx,
                     &helper_time_interval_task,
@@ -5867,6 +6044,7 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                     batch_id,
                     outstanding_batch_id,
                     batch_aggregation_id,
+                    _,
                 ) = write_collect_artifacts::<FixedSize>(
                     tx,
                     &leader_fixed_size_task,
@@ -5893,6 +6071,7 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                     batch_id,
                     outstanding_batch_id,
                     batch_aggregation_id,
+                    _,
                 ) = write_collect_artifacts::<FixedSize>(
                     tx,
                     &leader_fixed_size_task,
@@ -5934,6 +6113,7 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                     batch_id,
                     outstanding_batch_id,
                     batch_aggregation_id,
+                    _,
                 ) = write_collect_artifacts::<FixedSize>(
                     tx,
                     &helper_fixed_size_task,
@@ -5960,6 +6140,7 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                     batch_id,
                     outstanding_batch_id,
                     batch_aggregation_id,
+                    _,
                 ) = write_collect_artifacts::<FixedSize>(
                     tx,
                     &helper_fixed_size_task,
@@ -5979,6 +6160,81 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                 outstanding_batch_ids.extend(outstanding_batch_id);
                 batch_aggregation_ids.extend(batch_aggregation_id);
 
+                // Leader, fixed-size time bucketed collection artifacts with old reports.
+                // [GC'ed]
+                let (_, _, _, _, _, time_bucket_start) = write_collect_artifacts::<FixedSize>(
+                    tx,
+                    &leader_fixed_size_time_bucketed_task,
+                    &[
+                        OLDEST_ALLOWED_REPORT_TIMESTAMP
+                            .sub(&Duration::from_seconds(10))
+                            .unwrap(),
+                        OLDEST_ALLOWED_REPORT_TIMESTAMP
+                            .sub(&Duration::from_seconds(9))
+                            .unwrap(),
+                    ],
+                )
+                .await;
+                time_bucket_starts.extend(time_bucket_start);
+
+                // Leader, fixed-size time bucketed collection artifacts with old and new
+                // reports. [not GC'ed]
+                let (
+                    collection_job_id,
+                    aggregate_share_job_id,
+                    batch_id,
+                    outstanding_batch_id,
+                    batch_aggregation_id,
+                    time_bucket_start,
+                ) = write_collect_artifacts::<FixedSize>(
+                    tx,
+                    &leader_fixed_size_time_bucketed_task,
+                    &[
+                        OLDEST_ALLOWED_REPORT_TIMESTAMP
+                            .sub(&Duration::from_seconds(5))
+                            .unwrap(),
+                        OLDEST_ALLOWED_REPORT_TIMESTAMP
+                            .add(&Duration::from_seconds(5))
+                            .unwrap(),
+                    ],
+                )
+                .await;
+                collection_job_ids.extend(collection_job_id);
+                aggregate_share_job_ids.extend(aggregate_share_job_id);
+                batch_ids.extend(batch_id);
+                outstanding_batch_ids.extend(outstanding_batch_id);
+                batch_aggregation_ids.extend(batch_aggregation_id);
+                time_bucket_starts.extend(time_bucket_start);
+
+                // Leader, fixed-size time bucketed collection artifacts with new reports [not
+                // GC'ed]
+                let (
+                    collection_job_id,
+                    aggregate_share_job_id,
+                    batch_id,
+                    outstanding_batch_id,
+                    batch_aggregation_id,
+                    time_bucket_start,
+                ) = write_collect_artifacts::<FixedSize>(
+                    tx,
+                    &leader_fixed_size_time_bucketed_task,
+                    &[
+                        OLDEST_ALLOWED_REPORT_TIMESTAMP
+                            .add(&Duration::from_seconds(9))
+                            .unwrap(),
+                        OLDEST_ALLOWED_REPORT_TIMESTAMP
+                            .add(&Duration::from_seconds(10))
+                            .unwrap(),
+                    ],
+                )
+                .await;
+                collection_job_ids.extend(collection_job_id);
+                aggregate_share_job_ids.extend(aggregate_share_job_id);
+                batch_ids.extend(batch_id);
+                outstanding_batch_ids.extend(outstanding_batch_id);
+                batch_aggregation_ids.extend(batch_aggregation_id);
+                time_bucket_starts.extend(time_bucket_start);
+
                 // Collection artifacts for different task. [not GC'ed]
                 let (
                     collection_job_id,
@@ -5986,6 +6242,7 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                     batch_id,
                     outstanding_batch_id,
                     batch_aggregation_id,
+                    _,
                 ) = write_collect_artifacts::<TimeInterval>(
                     tx,
                     &other_task,
@@ -6010,12 +6267,14 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                     *helper_time_interval_task.id(),
                     *leader_fixed_size_task.id(),
                     *helper_fixed_size_task.id(),
+                    *leader_fixed_size_time_bucketed_task.id(),
                     *other_task.id(),
                     batch_ids,
                     collection_job_ids,
                     aggregate_share_job_ids,
                     outstanding_batch_ids,
                     batch_aggregation_ids,
+                    time_bucket_starts,
                 ))
             })
         })
@@ -6052,6 +6311,12 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
             )
             .await
             .unwrap();
+            tx.delete_expired_collection_artifacts(
+                &leader_fixed_size_time_bucketed_task_id,
+                u64::try_from(i64::MAX)?,
+            )
+            .await
+            .unwrap();
             Ok(())
         })
     })
@@ -6070,6 +6335,7 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
         got_batch_aggregation_ids,
     ) = ds
         .run_tx(|tx| {
+            let time_bucket_starts = time_bucket_starts.clone();
             Box::pin(async move {
                 let vdaf = dummy_vdaf::Vdaf::new();
 
@@ -6105,6 +6371,14 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                     .unwrap()
                     .into_iter()
                     .map(|batch| (*batch.task_id(), batch.batch_identifier().get_encoded()));
+                let leader_fixed_size_time_bucketed_batch_ids = tx
+                    .get_batches_for_task::<0, FixedSize, dummy_vdaf::Vdaf>(
+                        &leader_fixed_size_time_bucketed_task_id,
+                    )
+                    .await
+                    .unwrap()
+                    .into_iter()
+                    .map(|batch| (*batch.task_id(), batch.batch_identifier().get_encoded()));
                 let other_task_batch_ids = tx
                     .get_batches_for_task::<0, TimeInterval, dummy_vdaf::Vdaf>(&other_task_id)
                     .await
@@ -6115,6 +6389,7 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                     .chain(helper_time_interval_batch_ids)
                     .chain(leader_fixed_size_batch_ids)
                     .chain(helper_fixed_size_batch_ids)
+                    .chain(leader_fixed_size_time_bucketed_batch_ids)
                     .chain(other_task_batch_ids)
                     .collect();
 
@@ -6154,6 +6429,15 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                     .unwrap()
                     .into_iter()
                     .map(|collection_job| *collection_job.id());
+                let leader_fixed_size_time_bucketed_collection_job_ids = tx
+                    .get_collection_jobs_for_task::<0, FixedSize, dummy_vdaf::Vdaf>(
+                        &vdaf,
+                        &leader_fixed_size_time_bucketed_task_id,
+                    )
+                    .await
+                    .unwrap()
+                    .into_iter()
+                    .map(|collection_job| *collection_job.id());
                 let other_task_collection_job_ids = tx
                     .get_collection_jobs_for_task::<0, TimeInterval, dummy_vdaf::Vdaf>(
                         &vdaf,
@@ -6167,6 +6451,7 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                     .chain(helper_time_interval_collection_job_ids)
                     .chain(leader_fixed_size_collection_job_ids)
                     .chain(helper_fixed_size_collection_job_ids)
+                    .chain(leader_fixed_size_time_bucketed_collection_job_ids)
                     .chain(other_task_collection_job_ids)
                     .collect();
 
@@ -6206,6 +6491,15 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                     .unwrap()
                     .into_iter()
                     .map(|job| (*job.task_id(), job.batch_identifier().get_encoded()));
+                let leader_fixed_size_time_bucketed_aggregate_share_job_ids = tx
+                    .get_aggregate_share_jobs_for_task::<0, FixedSize, dummy_vdaf::Vdaf>(
+                        &vdaf,
+                        &leader_fixed_size_time_bucketed_task_id,
+                    )
+                    .await
+                    .unwrap()
+                    .into_iter()
+                    .map(|job| (*job.task_id(), job.batch_identifier().get_encoded()));
                 let other_task_aggregate_share_job_ids = tx
                     .get_aggregate_share_jobs_for_task::<0, TimeInterval, dummy_vdaf::Vdaf>(
                         &vdaf,
@@ -6219,35 +6513,51 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                     .chain(helper_time_interval_aggregate_share_job_ids)
                     .chain(leader_fixed_size_aggregate_share_job_ids)
                     .chain(helper_fixed_size_aggregate_share_job_ids)
+                    .chain(leader_fixed_size_time_bucketed_aggregate_share_job_ids)
                     .chain(other_task_aggregate_share_job_ids)
                     .collect();
 
                 let leader_time_interval_outstanding_batch_ids = tx
-                    .get_outstanding_batches_for_task(&leader_time_interval_task_id)
+                    .get_outstanding_batches(&leader_time_interval_task_id, &None)
                     .await
                     .unwrap()
                     .into_iter()
                     .map(|batch| (*batch.task_id(), *batch.id()));
                 let helper_time_interval_outstanding_batch_ids = tx
-                    .get_outstanding_batches_for_task(&helper_time_interval_task_id)
+                    .get_outstanding_batches(&helper_time_interval_task_id, &None)
                     .await
                     .unwrap()
                     .into_iter()
                     .map(|batch| (*batch.task_id(), *batch.id()));
                 let leader_fixed_size_outstanding_batch_ids = tx
-                    .get_outstanding_batches_for_task(&leader_fixed_size_task_id)
+                    .get_outstanding_batches(&leader_fixed_size_task_id, &None)
                     .await
                     .unwrap()
                     .into_iter()
                     .map(|batch| (*batch.task_id(), *batch.id()));
                 let helper_fixed_size_outstanding_batch_ids = tx
-                    .get_outstanding_batches_for_task(&helper_fixed_size_task_id)
+                    .get_outstanding_batches(&helper_fixed_size_task_id, &None)
                     .await
                     .unwrap()
                     .into_iter()
                     .map(|batch| (*batch.task_id(), *batch.id()));
+                let leader_fixed_size_time_bucketed_outstanding_batch_ids =
+                    try_join_all(time_bucket_starts.iter().copied().map(
+                        |time_bucket_start| async move {
+                            tx.get_outstanding_batches(
+                                &leader_fixed_size_time_bucketed_task_id,
+                                &Some(time_bucket_start),
+                            )
+                            .await
+                        },
+                    ))
+                    .await
+                    .unwrap()
+                    .into_iter()
+                    .flatten()
+                    .map(|batch| (*batch.task_id(), *batch.id()));
                 let other_task_outstanding_batch_ids = tx
-                    .get_outstanding_batches_for_task(&other_task_id)
+                    .get_outstanding_batches(&other_task_id, &None)
                     .await
                     .unwrap()
                     .into_iter()
@@ -6256,6 +6566,7 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                     .chain(helper_time_interval_outstanding_batch_ids)
                     .chain(leader_fixed_size_outstanding_batch_ids)
                     .chain(helper_fixed_size_outstanding_batch_ids)
+                    .chain(leader_fixed_size_time_bucketed_outstanding_batch_ids)
                     .chain(other_task_outstanding_batch_ids)
                     .collect();
 
@@ -6295,6 +6606,15 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                     .unwrap()
                     .into_iter()
                     .map(|agg| (*agg.task_id(), agg.batch_identifier().get_encoded()));
+                let leader_fixed_size_time_bucketed_batch_aggregation_ids = tx
+                    .get_batch_aggregations_for_task::<0, FixedSize, dummy_vdaf::Vdaf>(
+                        &vdaf,
+                        &leader_fixed_size_time_bucketed_task_id,
+                    )
+                    .await
+                    .unwrap()
+                    .into_iter()
+                    .map(|agg| (*agg.task_id(), agg.batch_identifier().get_encoded()));
                 let other_task_batch_aggregation_ids = tx
                     .get_batch_aggregations_for_task::<0, TimeInterval, dummy_vdaf::Vdaf>(
                         &vdaf,
@@ -6308,6 +6628,7 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                     .chain(helper_time_interval_batch_aggregation_ids)
                     .chain(leader_fixed_size_batch_aggregation_ids)
                     .chain(helper_fixed_size_batch_aggregation_ids)
+                    .chain(leader_fixed_size_time_bucketed_batch_aggregation_ids)
                     .chain(other_task_batch_aggregation_ids)
                     .collect();
 

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -39,11 +39,20 @@ pub enum QueryType {
     /// Time-interval: used to support a collection style based on fixed time intervals.
     TimeInterval,
 
-    /// Fixed-size: used to support collection of batches as quickly as possible, without aligning
-    /// to a fixed batch window.
+    /// Fixed-size: used to support collection of batches as quickly as possible, without the
+    /// latency of waiting for batch time intervals to pass, and with direct control over the number
+    /// of reports per batch.
     FixedSize {
         /// The maximum number of reports in a batch to allow it to be collected.
         max_batch_size: u64,
+        /// If present, reports will be separated into different batches by timestamp, such that
+        /// the client timestamp interval duration will not exceed this value. The minimum and
+        /// maximum allowed report timestamps for each batch will be multiples of this value as
+        /// well. This must be a multiple of the task's time precision.
+        ///
+        /// This is an implementation-specific configuration parameter, and not part of the query
+        /// type as defined in DAP.
+        batch_time_window_size: Option<Duration>,
     },
 }
 
@@ -193,9 +202,18 @@ impl Task {
         if self.hpke_keys.is_empty() {
             return Err(Error::InvalidParameter("hpke_keys"));
         }
-        if let QueryType::FixedSize { max_batch_size } = self.query_type() {
+        if let QueryType::FixedSize {
+            max_batch_size,
+            batch_time_window_size,
+        } = self.query_type()
+        {
             if *max_batch_size < self.min_batch_size() {
                 return Err(Error::InvalidParameter("max_batch_size"));
+            }
+            if let Some(batch_time_window_size) = batch_time_window_size {
+                if batch_time_window_size.as_seconds() % self.time_precision().as_seconds() != 0 {
+                    return Err(Error::InvalidParameter("batch_time_window_size"));
+                }
             }
         }
         Ok(())
@@ -299,7 +317,7 @@ impl Task {
                 // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-02.html#section-4.5.6.1.2
                 batch_size >= self.min_batch_size()
             }
-            QueryType::FixedSize { max_batch_size } => {
+            QueryType::FixedSize { max_batch_size, .. } => {
                 // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-02.html#section-4.5.6.2.2
                 batch_size >= self.min_batch_size() && batch_size <= max_batch_size
             }
@@ -782,6 +800,7 @@ mod tests {
         task::{test_util::TaskBuilder, QueryType, Task, VdafInstance},
         SecretBytes,
     };
+    use assert_matches::assert_matches;
     use janus_core::{
         hpke::{test_util::generate_test_hpke_config_and_private_key, HpkeKeypair, HpkePrivateKey},
         task::{AuthenticationToken, DapAuthToken, PRIO3_VERIFY_KEY_LENGTH},
@@ -793,7 +812,8 @@ mod tests {
         TaskId,
     };
     use rand::random;
-    use serde_test::{assert_tokens, Token};
+    use serde_json::json;
+    use serde_test::{assert_de_tokens, assert_tokens, Token};
     use url::Url;
 
     #[test]
@@ -1180,7 +1200,10 @@ mod tests {
                     "https://example.com/".parse().unwrap(),
                     "https://example.net/".parse().unwrap(),
                 ]),
-                QueryType::FixedSize { max_batch_size: 10 },
+                QueryType::FixedSize {
+                    max_batch_size: 10,
+                    batch_time_window_size: None,
+                },
                 VdafInstance::Prio3CountVec { length: 8 },
                 Role::Helper,
                 Vec::from([SecretBytes::new(b"1234567812345678".to_vec())]),
@@ -1228,10 +1251,12 @@ mod tests {
                 Token::StructVariant {
                     name: "QueryType",
                     variant: "FixedSize",
-                    len: 1,
+                    len: 2,
                 },
                 Token::Str("max_batch_size"),
                 Token::U64(10),
+                Token::Str("batch_time_window_size"),
+                Token::None,
                 Token::StructVariantEnd,
                 Token::Str("vdaf"),
                 Token::StructVariant {
@@ -1350,6 +1375,87 @@ mod tests {
                 Token::SeqEnd,
                 Token::StructEnd,
             ],
+        );
+    }
+
+    #[test]
+    fn query_type_serde() {
+        assert_tokens(
+            &QueryType::TimeInterval,
+            &[Token::UnitVariant {
+                name: "QueryType",
+                variant: "TimeInterval",
+            }],
+        );
+        assert_tokens(
+            &QueryType::FixedSize {
+                max_batch_size: 10,
+                batch_time_window_size: None,
+            },
+            &[
+                Token::StructVariant {
+                    name: "QueryType",
+                    variant: "FixedSize",
+                    len: 2,
+                },
+                Token::Str("max_batch_size"),
+                Token::U64(10),
+                Token::Str("batch_time_window_size"),
+                Token::None,
+                Token::StructVariantEnd,
+            ],
+        );
+        assert_tokens(
+            &QueryType::FixedSize {
+                max_batch_size: 10,
+                batch_time_window_size: Some(Duration::from_hours(1).unwrap()),
+            },
+            &[
+                Token::StructVariant {
+                    name: "QueryType",
+                    variant: "FixedSize",
+                    len: 2,
+                },
+                Token::Str("max_batch_size"),
+                Token::U64(10),
+                Token::Str("batch_time_window_size"),
+                Token::Some,
+                Token::NewtypeStruct { name: "Duration" },
+                Token::U64(3600),
+                Token::StructVariantEnd,
+            ],
+        );
+
+        // Backwards compatibility cases:
+        assert_de_tokens(
+            &QueryType::FixedSize {
+                max_batch_size: 10,
+                batch_time_window_size: None,
+            },
+            &[
+                Token::StructVariant {
+                    name: "QueryType",
+                    variant: "FixedSize",
+                    len: 2,
+                },
+                Token::Str("max_batch_size"),
+                Token::U64(10),
+                Token::StructVariantEnd,
+            ],
+        );
+        assert_matches!(
+            serde_json::from_value(json!({ "FixedSize": { "max_batch_size": 10 } })),
+            Ok(QueryType::FixedSize {
+                max_batch_size: 10,
+                batch_time_window_size: None,
+            })
+        );
+        assert_matches!(
+            serde_yaml::from_str("!FixedSize { max_batch_size: 10 }"),
+            Ok(QueryType::FixedSize {
+                max_batch_size: 10,
+                batch_time_window_size: None,
+            })
         );
     }
 }

--- a/db/00000000000014_fixed_size_time_bucketing.down.sql
+++ b/db/00000000000014_fixed_size_time_bucketing.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX outstanding_batches_task_and_time_bucket_index;
+ALTER TABLE outstanding_batches DROP COLUMN time_bucket_start;

--- a/db/00000000000014_fixed_size_time_bucketing.down.sql
+++ b/db/00000000000014_fixed_size_time_bucketing.down.sql
@@ -1,2 +1,4 @@
 DROP INDEX outstanding_batches_task_and_time_bucket_index;
 ALTER TABLE outstanding_batches DROP COLUMN time_bucket_start;
+CREATE INDEX client_reports_task_unaggregated ON client_reports (task_id) WHERE aggregation_started = FALSE;
+DROP INDEX client_reports_task_and_timestamp_unaggregated_index CASCADE;

--- a/db/00000000000014_fixed_size_time_bucketing.up.sql
+++ b/db/00000000000014_fixed_size_time_bucketing.up.sql
@@ -1,2 +1,4 @@
 ALTER TABLE outstanding_batches ADD COLUMN time_bucket_start TIMESTAMP;
 CREATE INDEX outstanding_batches_task_and_time_bucket_index ON outstanding_batches (task_id, time_bucket_start);
+DROP INDEX client_reports_task_unaggregated CASCADE;
+CREATE INDEX client_reports_task_and_timestamp_unaggregated_index ON client_reports (task_id, client_timestamp) WHERE aggregation_started = FALSE;

--- a/db/00000000000014_fixed_size_time_bucketing.up.sql
+++ b/db/00000000000014_fixed_size_time_bucketing.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE outstanding_batches ADD COLUMN time_bucket_start TIMESTAMP;
+CREATE INDEX outstanding_batches_task_and_time_bucket_index ON outstanding_batches (task_id, time_bucket_start);

--- a/docs/samples/tasks.yaml
+++ b/docs/samples/tasks.yaml
@@ -109,6 +109,7 @@
   # parameter must be provided.
   query_type: !FixedSize
     max_batch_size: 100
+    batch_time_window_size: null
   vdaf: Prio3Count
   role: Helper
   vdaf_verify_keys:

--- a/integration_tests/tests/in_cluster.rs
+++ b/integration_tests/tests/in_cluster.rs
@@ -152,7 +152,7 @@ impl InClusterJanusPair {
             min_batch_size: task.min_batch_size(),
             max_batch_size: match task.query_type() {
                 QueryType::TimeInterval => None,
-                QueryType::FixedSize { max_batch_size } => Some(*max_batch_size),
+                QueryType::FixedSize { max_batch_size, .. } => Some(*max_batch_size),
             },
             expiration: "3000-01-01T00:00:00Z".to_owned(),
             time_precision_seconds: task.time_precision().as_seconds(),
@@ -286,6 +286,7 @@ async fn in_cluster_fixed_size() {
         VdafInstance::Prio3Count,
         QueryType::FixedSize {
             max_batch_size: 110,
+            batch_time_window_size: None,
         },
     )
     .await;

--- a/integration_tests/tests/janus.rs
+++ b/integration_tests/tests/janus.rs
@@ -148,7 +148,10 @@ async fn janus_janus_fixed_size() {
     let janus_pair = JanusPair::new(
         &container_client,
         VdafInstance::Prio3Count,
-        QueryType::FixedSize { max_batch_size: 50 },
+        QueryType::FixedSize {
+            max_batch_size: 50,
+            batch_time_window_size: None,
+        },
     )
     .await;
 

--- a/interop_binaries/src/bin/janus_interop_aggregator.rs
+++ b/interop_binaries/src/bin/janus_interop_aggregator.rs
@@ -80,6 +80,7 @@ async fn handle_add_task(
             max_batch_size: request
                 .max_batch_size
                 .ok_or_else(|| anyhow::anyhow!("\"max_batch_size\" is missing"))?,
+            batch_time_window_size: None,
         },
         _ => {
             return Err(anyhow::anyhow!(

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -281,7 +281,7 @@ impl From<Task> for AggregatorAddTaskRequest {
     fn from(task: Task) -> Self {
         let (query_type, max_batch_size) = match task.query_type() {
             QueryType::TimeInterval => (TimeInterval::CODE as u8, None),
-            QueryType::FixedSize { max_batch_size } => {
+            QueryType::FixedSize { max_batch_size, .. } => {
                 (FixedSize::CODE as u8, Some(*max_batch_size))
             }
         };


### PR DESCRIPTION
This resolves #1574, adding a per-task configuration option to control how fixed size batches are constructed, by dividing reports into time buckets and only putting reports from the same bucket in each batch. The aggregation job creator logic is refactored so it can work in a streaming manner, and then unaggregated reports are fed through this, with a different instance for each time bucket (if applicable). There is a database change to add a new column on `outstanding_batches`. Note that once a fixed size batch has been finalized, the time bucketing setting is no longer relevant, and we already otherwise track client timestamp intervals on batches themselves. The change to the query type enum affects the `tasks.query_type` jsonb column in the database, the task definition YAML format, and the aggregator API, but in a backwards compatible way.