### PR TITLE
Build release containers with OTLP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
 COPY --from=planner /src/recipe.json /src/recipe.json
-RUN cargo chef cook --release -p janus_aggregator --features=prometheus
+RUN cargo chef cook --release -p janus_aggregator --features=prometheus,otlp
 COPY Cargo.toml Cargo.lock /src/
 COPY aggregator /src/aggregator
 COPY aggregator_api /src/aggregator_api
@@ -39,7 +39,7 @@ COPY tools /src/tools
 ARG BINARY=aggregator
 ARG GIT_REVISION=unknown
 ENV GIT_REVISION ${GIT_REVISION}
-RUN cargo build --release -p janus_aggregator --bin $BINARY --features=prometheus
+RUN cargo build --release -p janus_aggregator --bin $BINARY --features=prometheus,otlp
 
 FROM alpine:3.18.2 AS final
 ARG BINARY=aggregator


### PR DESCRIPTION
This PR enables the `otlp` feature when building release images. Mozilla currently uses this for tracing, and we should eventually as well.