### PR TITLE
Allow decrypting with global key on report upload

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -8,6 +8,7 @@ use crate::{
         query_type::{CollectableQueryType, UploadableQueryType},
         report_writer::{ReportWriteBatcher, WritableReport},
     },
+    cache::GlobalHpkeKeypairCache,
     config::TaskprovConfig,
     Operation,
 };
@@ -27,8 +28,7 @@ use janus_aggregator_core::{
         models::{
             AggregateShareJob, AggregationJob, AggregationJobState, Batch, BatchAggregation,
             BatchAggregationState, BatchState, CollectionJob, CollectionJobState,
-            GlobalHpkeKeypair, HpkeKeyState, LeaderStoredReport, ReportAggregation,
-            ReportAggregationState,
+            LeaderStoredReport, ReportAggregation, ReportAggregationState,
         },
         Datastore, Transaction,
     },
@@ -49,9 +49,9 @@ use janus_messages::{
     AggregateShare, AggregateShareAad, AggregateShareReq, AggregationJobContinueReq,
     AggregationJobId, AggregationJobInitializeReq, AggregationJobResp, AggregationJobRound,
     BatchSelector, Collection, CollectionJobId, CollectionReq, Duration, HpkeCiphertext,
-    HpkeConfig, HpkeConfigId, HpkeConfigList, InputShareAad, Interval, PartialBatchSelector,
-    PlaintextInputShare, PrepareStep, PrepareStepResult, Report, ReportIdChecksum, ReportShare,
-    ReportShareError, Role, TaskId,
+    HpkeConfigList, InputShareAad, Interval, PartialBatchSelector, PlaintextInputShare,
+    PrepareStep, PrepareStepResult, Report, ReportIdChecksum, ReportShare, ReportShareError, Role,
+    TaskId,
 };
 use opentelemetry::{
     metrics::{Counter, Histogram, Meter},
@@ -75,11 +75,11 @@ use std::{
     collections::{hash_map::Entry, HashMap, HashSet},
     fmt::Debug,
     panic,
-    sync::{Arc, Mutex as StdMutex},
+    sync::Arc,
     time::{Duration as StdDuration, Instant},
 };
-use tokio::{spawn, sync::Mutex, task::JoinHandle, time::sleep, try_join};
-use tracing::{debug, error, info, trace_span, warn};
+use tokio::{sync::Mutex, try_join};
+use tracing::{debug, info, trace_span, warn};
 use url::Url;
 
 pub mod accumulator;
@@ -199,123 +199,6 @@ impl Default for Config {
             global_hpke_configs_refresh_interval: GlobalHpkeKeypairCache::DEFAULT_REFRESH_INTERVAL,
             taskprov_config: TaskprovConfig::default(),
         }
-    }
-}
-
-type HpkeConfigs = Arc<Vec<HpkeConfig>>;
-type HpkeKeypairs = HashMap<HpkeConfigId, Arc<HpkeKeypair>>;
-
-#[derive(Debug)]
-pub struct GlobalHpkeKeypairCache {
-    // We use a std::sync::Mutex in this cache because we won't hold locks across
-    // `.await` boundaries. StdMutex is lighter weight than `tokio::sync::Mutex`.
-    /// Cache of HPKE configs for advertisement.
-    configs: Arc<StdMutex<HpkeConfigs>>,
-
-    // Cache of HPKE keypairs for report decryption.
-    keypairs: Arc<StdMutex<HpkeKeypairs>>,
-
-    /// Handle for task responsible for periodically refreshing the cache.
-    refresh_handle: JoinHandle<()>,
-}
-
-impl GlobalHpkeKeypairCache {
-    pub const DEFAULT_REFRESH_INTERVAL: StdDuration =
-        StdDuration::from_secs(60 * 30 /* 30 minutes */);
-
-    pub async fn new<C: Clock>(
-        datastore: Arc<Datastore<C>>,
-        refresh_interval: StdDuration,
-    ) -> Result<Self, Error> {
-        // Initial cache load.
-        let global_keypairs = Self::get_global_keypairs(&datastore).await?;
-        let configs = Arc::new(StdMutex::new(Self::filter_active_configs(&global_keypairs)));
-        let keypairs = Arc::new(StdMutex::new(Self::map_keypairs(&global_keypairs)));
-
-        // Start refresh task.
-        let refresh_configs = configs.clone();
-        let refresh_keypairs = keypairs.clone();
-        let refresh_handle = spawn(async move {
-            loop {
-                sleep(refresh_interval).await;
-
-                match Self::get_global_keypairs(&datastore).await {
-                    Ok(global_keypairs) => {
-                        let new_configs = Self::filter_active_configs(&global_keypairs);
-                        let new_keypairs = Self::map_keypairs(&global_keypairs);
-                        {
-                            let mut configs = refresh_configs.lock().unwrap();
-                            *configs = new_configs;
-                        }
-                        {
-                            let mut keypairs = refresh_keypairs.lock().unwrap();
-                            *keypairs = new_keypairs;
-                        }
-                    }
-                    Err(err) => {
-                        error!(?err, "failed to refresh HPKE config cache");
-                    }
-                }
-            }
-        });
-
-        Ok(Self {
-            configs,
-            keypairs,
-            refresh_handle,
-        })
-    }
-
-    fn filter_active_configs(global_keypairs: &[GlobalHpkeKeypair]) -> HpkeConfigs {
-        Arc::new(
-            global_keypairs
-                .iter()
-                .filter_map(|keypair| match keypair.state() {
-                    HpkeKeyState::Active => Some(keypair.hpke_keypair().config().clone()),
-                    _ => None,
-                })
-                .collect(),
-        )
-    }
-
-    fn map_keypairs(global_keypairs: &[GlobalHpkeKeypair]) -> HpkeKeypairs {
-        global_keypairs
-            .iter()
-            .map(|keypair| {
-                let keypair = keypair.hpke_keypair().clone();
-                (*keypair.config().id(), Arc::new(keypair))
-            })
-            .collect()
-    }
-
-    async fn get_global_keypairs<C: Clock>(
-        datastore: &Datastore<C>,
-    ) -> Result<Vec<GlobalHpkeKeypair>, Error> {
-        Ok(datastore
-            .run_tx_with_name("refresh_global_hpke_configs_cache", |tx| {
-                Box::pin(async move { tx.get_global_hpke_keypairs().await })
-            })
-            .await?)
-    }
-
-    /// Retrieve active configs for config advertisement. This only returns configs
-    /// for keypairs that are in the `[HpkeKeyState::Active]` state.
-    pub fn configs(&self) -> HpkeConfigs {
-        let configs = self.configs.lock().unwrap();
-        configs.clone()
-    }
-
-    /// Retrieve a keypair by ID for report decryption. This retrieves keypairs that
-    /// are in any state.
-    pub fn keypair(&self, id: &HpkeConfigId) -> Option<Arc<HpkeKeypair>> {
-        let keypairs = self.keypairs.lock().unwrap();
-        keypairs.get(id).cloned()
-    }
-}
-
-impl Drop for GlobalHpkeKeypairCache {
-    fn drop(&mut self) {
-        self.refresh_handle.abort()
     }
 }
 

--- a/aggregator/src/bin/aggregator.rs
+++ b/aggregator/src/bin/aggregator.rs
@@ -281,7 +281,7 @@ struct Config {
 
     /// Defines how often to refresh the global HPKE configs cache in milliseconds. This affects
     /// how often an aggregator becomes aware of key state changes. If unspecified, default is
-    /// defined by [`GlobalHpkeConfigCache::DEFAULT_REFRESH_INTERVAL`]. You shouldn't normally
+    /// defined by [`GlobalHpkeKeypairCache::DEFAULT_REFRESH_INTERVAL`]. You shouldn't normally
     /// have to specify this.
     #[serde(default)]
     global_hpke_configs_refresh_interval: Option<u64>,

--- a/aggregator/src/bin/aggregator.rs
+++ b/aggregator/src/bin/aggregator.rs
@@ -2,10 +2,11 @@ use anyhow::{Context, Result};
 use base64::{engine::general_purpose::STANDARD, Engine};
 use clap::Parser;
 use janus_aggregator::{
-    aggregator::{self, http_handlers::aggregator_handler, GlobalHpkeKeypairCache},
+    aggregator::{self, garbage_collector::GarbageCollector, http_handlers::aggregator_handler},
     binary_utils::{
         janus_main, setup_server, setup_signal_handler, BinaryOptions, CommonBinaryOptions,
     },
+    cache::GlobalHpkeKeypairCache,
     config::{BinaryConfig, CommonConfig, TaskprovConfig},
 };
 use janus_aggregator_api::{self, aggregator_api_handler};

--- a/aggregator/src/bin/aggregator.rs
+++ b/aggregator/src/bin/aggregator.rs
@@ -2,10 +2,7 @@ use anyhow::{Context, Result};
 use base64::{engine::general_purpose::STANDARD, Engine};
 use clap::Parser;
 use janus_aggregator::{
-    aggregator::{
-        self, garbage_collector::GarbageCollector, http_handlers::aggregator_handler,
-        GlobalHpkeConfigCache,
-    },
+    aggregator::{self, http_handlers::aggregator_handler, GlobalHpkeKeypairCache},
     binary_utils::{
         janus_main, setup_server, setup_signal_handler, BinaryOptions, CommonBinaryOptions,
     },
@@ -331,7 +328,7 @@ impl Config {
             taskprov_config: self.taskprov_config.clone(),
             global_hpke_configs_refresh_interval: match self.global_hpke_configs_refresh_interval {
                 Some(duration) => Duration::from_millis(duration),
-                None => GlobalHpkeConfigCache::DEFAULT_REFRESH_INTERVAL,
+                None => GlobalHpkeKeypairCache::DEFAULT_REFRESH_INTERVAL,
             },
         }
     }

--- a/aggregator/src/cache.rs
+++ b/aggregator/src/cache.rs
@@ -27,7 +27,7 @@ pub struct GlobalHpkeKeypairCache {
     /// Cache of HPKE configs for advertisement.
     configs: Arc<StdMutex<HpkeConfigs>>,
 
-    // Cache of HPKE keypairs for report decryption.
+    /// Cache of HPKE keypairs for report decryption.
     keypairs: Arc<StdMutex<HpkeKeypairs>>,
 
     /// Handle for task responsible for periodically refreshing the cache.

--- a/aggregator/src/cache.rs
+++ b/aggregator/src/cache.rs
@@ -1,0 +1,135 @@
+use janus_aggregator_core::datastore::{
+    models::{GlobalHpkeKeypair, HpkeKeyState},
+    Datastore,
+};
+
+use janus_core::{hpke::HpkeKeypair, time::Clock};
+use janus_messages::{HpkeConfig, HpkeConfigId};
+
+use std::{
+    collections::HashMap,
+    fmt::Debug,
+    sync::{Arc, Mutex as StdMutex},
+    time::Duration as StdDuration,
+};
+use tokio::{spawn, task::JoinHandle, time::sleep};
+use tracing::error;
+
+use crate::aggregator::Error;
+
+type HpkeConfigs = Arc<Vec<HpkeConfig>>;
+type HpkeKeypairs = HashMap<HpkeConfigId, Arc<HpkeKeypair>>;
+
+#[derive(Debug)]
+pub struct GlobalHpkeKeypairCache {
+    // We use a std::sync::Mutex in this cache because we won't hold locks across
+    // `.await` boundaries. StdMutex is lighter weight than `tokio::sync::Mutex`.
+    /// Cache of HPKE configs for advertisement.
+    configs: Arc<StdMutex<HpkeConfigs>>,
+
+    // Cache of HPKE keypairs for report decryption.
+    keypairs: Arc<StdMutex<HpkeKeypairs>>,
+
+    /// Handle for task responsible for periodically refreshing the cache.
+    refresh_handle: JoinHandle<()>,
+}
+
+impl GlobalHpkeKeypairCache {
+    pub const DEFAULT_REFRESH_INTERVAL: StdDuration =
+        StdDuration::from_secs(60 * 30 /* 30 minutes */);
+
+    pub async fn new<C: Clock>(
+        datastore: Arc<Datastore<C>>,
+        refresh_interval: StdDuration,
+    ) -> Result<Self, Error> {
+        // Initial cache load.
+        let global_keypairs = Self::get_global_keypairs(&datastore).await?;
+        let configs = Arc::new(StdMutex::new(Self::filter_active_configs(&global_keypairs)));
+        let keypairs = Arc::new(StdMutex::new(Self::map_keypairs(&global_keypairs)));
+
+        // Start refresh task.
+        let refresh_configs = configs.clone();
+        let refresh_keypairs = keypairs.clone();
+        let refresh_handle = spawn(async move {
+            loop {
+                sleep(refresh_interval).await;
+
+                match Self::get_global_keypairs(&datastore).await {
+                    Ok(global_keypairs) => {
+                        let new_configs = Self::filter_active_configs(&global_keypairs);
+                        let new_keypairs = Self::map_keypairs(&global_keypairs);
+                        {
+                            let mut configs = refresh_configs.lock().unwrap();
+                            *configs = new_configs;
+                        }
+                        {
+                            let mut keypairs = refresh_keypairs.lock().unwrap();
+                            *keypairs = new_keypairs;
+                        }
+                    }
+                    Err(err) => {
+                        error!(?err, "failed to refresh HPKE config cache");
+                    }
+                }
+            }
+        });
+
+        Ok(Self {
+            configs,
+            keypairs,
+            refresh_handle,
+        })
+    }
+
+    fn filter_active_configs(global_keypairs: &[GlobalHpkeKeypair]) -> HpkeConfigs {
+        Arc::new(
+            global_keypairs
+                .iter()
+                .filter_map(|keypair| match keypair.state() {
+                    HpkeKeyState::Active => Some(keypair.hpke_keypair().config().clone()),
+                    _ => None,
+                })
+                .collect(),
+        )
+    }
+
+    fn map_keypairs(global_keypairs: &[GlobalHpkeKeypair]) -> HpkeKeypairs {
+        global_keypairs
+            .iter()
+            .map(|keypair| {
+                let keypair = keypair.hpke_keypair().clone();
+                (*keypair.config().id(), Arc::new(keypair))
+            })
+            .collect()
+    }
+
+    async fn get_global_keypairs<C: Clock>(
+        datastore: &Datastore<C>,
+    ) -> Result<Vec<GlobalHpkeKeypair>, Error> {
+        Ok(datastore
+            .run_tx_with_name("refresh_global_hpke_configs_cache", |tx| {
+                Box::pin(async move { tx.get_global_hpke_keypairs().await })
+            })
+            .await?)
+    }
+
+    /// Retrieve active configs for config advertisement. This only returns configs
+    /// for keypairs that are in the `[HpkeKeyState::Active]` state.
+    pub fn configs(&self) -> HpkeConfigs {
+        let configs = self.configs.lock().unwrap();
+        configs.clone()
+    }
+
+    /// Retrieve a keypair by ID for report decryption. This retrieves keypairs that
+    /// are in any state.
+    pub fn keypair(&self, id: &HpkeConfigId) -> Option<Arc<HpkeKeypair>> {
+        let keypairs = self.keypairs.lock().unwrap();
+        keypairs.get(id).cloned()
+    }
+}
+
+impl Drop for GlobalHpkeKeypairCache {
+    fn drop(&mut self) {
+        self.refresh_handle.abort()
+    }
+}

--- a/aggregator/src/cache.rs
+++ b/aggregator/src/cache.rs
@@ -1,11 +1,12 @@
+//! Various in-memory caches that can be used by an aggregator.
+
+use crate::aggregator::Error;
 use janus_aggregator_core::datastore::{
     models::{GlobalHpkeKeypair, HpkeKeyState},
     Datastore,
 };
-
 use janus_core::{hpke::HpkeKeypair, time::Clock};
 use janus_messages::{HpkeConfig, HpkeConfigId};
-
 use std::{
     collections::HashMap,
     fmt::Debug,
@@ -14,8 +15,6 @@ use std::{
 };
 use tokio::{spawn, task::JoinHandle, time::sleep};
 use tracing::error;
-
-use crate::aggregator::Error;
 
 type HpkeConfigs = Arc<Vec<HpkeConfig>>;
 type HpkeKeypairs = HashMap<HpkeConfigId, Arc<HpkeKeypair>>;

--- a/aggregator/src/lib.rs
+++ b/aggregator/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod aggregator;
 pub mod binary_utils;
+pub mod cache;
 pub mod config;
 pub mod metrics;
 pub mod trace;


### PR DESCRIPTION
Follow up to https://github.com/divviup/janus/pull/1610, supports https://github.com/divviup/janus/issues/1568.

All code paths involving report decryption should now be able to use a global HPKE keypair to attempt decryption of a report. If  a config ID is given that matches both a task and global key, trial decryption is used.

The keypair is cached using the same mechanism in https://github.com/divviup/janus/pull/1610. Importantly, this has cache invalidation. Because we have the `Pending` state, we can safely refresh keys without worrying about them being advertised before all aggregators have picked up on the new key. This means that the key rotation strategy is:
1. Add a new key to DB
2. Wait ~30 minutes (plus some safety factor) for all aggregators to pick up on the new key OR restart the application. Because the key isn't being advertised, we don't have to worry about reports encrypted with a key that an aggregator hasn't become aware of.
3. Set new key to the active state.
4. Wait ~30 minutes for all aggregators to have this new key be active before retiring any old keys.

I've renamed the cache to `GlobalHpkeKeypairCache` to denote that it does store the private key in memory (`Config` could imply that it doesn't).