### PR TITLE
Always run ci-migrations check

### DIFF
--- a/.github/workflows/ci-migrations.yml
+++ b/.github/workflows/ci-migrations.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [ main, release/** ]
   pull_request:
-    paths:
-      - "db/**"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This is so that we can have it be a required check. Unfortunately GitHub isn't able to ignore required checks that aren't applicable to a given PR.