### PR TITLE
Fix bug with trailing slashes in URL

### DIFF
--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -45,7 +45,7 @@ pub enum Error {
 
 /// Wire-representation of an ASCII-encoded URL with minimum length 1 and maximum
 /// length 2^16 - 1.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Url(Vec<u8>);
 
 impl Url {
@@ -68,10 +68,16 @@ impl Decode for Url {
     }
 }
 
-impl Display for Url {
+impl Debug for Url {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         // This isn't actually lossy, since this type cannot be constructed from
         // non-ASCII bytes.
+        write!(f, "Url: {}", String::from_utf8_lossy(&self.0))
+    }
+}
+
+impl Display for Url {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}", String::from_utf8_lossy(&self.0))
     }
 }

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -44,37 +44,21 @@ pub enum Error {
 }
 
 /// Wire-representation of an ASCII-encoded URL with minimum length 1 and maximum
-/// length 2^16 - 1. This is a newtype for [`url::Url`] for adding encoding and
-/// decoding traits.
-///
-/// Note that because [`url::Url::parse`] is used while decoding, this type has more
-/// restrictions on it than specified in DAP. See [`url::ParseError`] for the additional
-/// ways decoding can fail.
-///
-/// Also note that the encoding of a URL may not precisely match what it was decoded
-/// from. In particular, the in-memory representation of [`url::Url`] adds a trailing
-/// slash if it is appropriate to do so, e.g. `https://example.com -> https://example.com/`.
-/// This does not affect the parseability of the resulting encoded Url, but may result
-/// in an increase in size of the encoding.
+/// length 2^16 - 1.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Url(url::Url);
+pub struct Url(Vec<u8>);
 
 impl Url {
     const MAX_LEN: usize = 2usize.pow(16) - 1;
-
-    // Access the underlying [`url::Url`].
-    pub fn url(&self) -> &url::Url {
-        &self.0
-    }
 }
 
 impl Encode for Url {
     fn encode(&self, bytes: &mut Vec<u8>) {
-        encode_u16_items(bytes, &(), self.0.as_str().as_bytes())
+        encode_u16_items(bytes, &(), &self.0)
     }
 
     fn encoded_len(&self) -> Option<usize> {
-        Some(2 + self.0.as_str().len())
+        Some(2 + self.0.len())
     }
 }
 
@@ -86,7 +70,9 @@ impl Decode for Url {
 
 impl Display for Url {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        (&self.0 as &dyn Display).fmt(f)
+        // This isn't actually lossy, since this type cannot be constructed from
+        // non-ASCII bytes.
+        write!(f, "{}", String::from_utf8_lossy(&self.0))
     }
 }
 
@@ -107,13 +93,18 @@ impl TryFrom<&[u8]> for Url {
                 anyhow!("Url must be ASCII encoded").into(),
             ))
         } else {
-            Ok(Self(
-                // Unwrap safety: we just verified that the Url contains ASCII
-                // characters only. UTF8 is backwards compatible with ASCII.
-                url::Url::parse(str::from_utf8(value).unwrap())
-                    .map_err(|err| CodecError::Other(err.into()))?,
-            ))
+            Ok(Self(Vec::from(value)))
         }
+    }
+}
+
+impl TryInto<url::Url> for Url {
+    type Error = url::ParseError;
+
+    fn try_into(self) -> Result<url::Url, Self::Error> {
+        // Unwrap safety: this type can't be constructed without being validated
+        // as consisting only of ASCII.
+        url::Url::parse(str::from_utf8(&self.0).unwrap())
     }
 }
 
@@ -2755,6 +2746,7 @@ mod tests {
     fn roundtrip_url() {
         for (test, len) in [
             ("https://example.com/", [0u8, 20]),
+            ("https://example.com", [0u8, 19]),
             (
                 &("http://".to_string()
                     + &"h".repeat(Into::<usize>::into(u16::MAX) - "http://".len() - 1)

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -70,15 +70,21 @@ impl Decode for Url {
 
 impl Debug for Url {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        // This isn't actually lossy, since this type cannot be constructed from
-        // non-ASCII bytes.
-        write!(f, "Url: {}", String::from_utf8_lossy(&self.0))
+        write!(
+            f,
+            "{}",
+            str::from_utf8(&self.0).map_err(|_| std::fmt::Error)?
+        )
     }
 }
 
 impl Display for Url {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", String::from_utf8_lossy(&self.0))
+        write!(
+            f,
+            "{}",
+            str::from_utf8(&self.0).map_err(|_| std::fmt::Error)?
+        )
     }
 }
 

--- a/messages/src/taskprov.rs
+++ b/messages/src/taskprov.rs
@@ -724,10 +724,10 @@ mod tests {
                     ),
                     concat!(
                         // aggregator_endpoints
-                        "0016", // length of all vector contents
+                        "0015", // length of all vector contents
                         concat!(
-                            "0014",                                     // length
-                            "68747470733A2F2F6578616D706C652E636F6D2F"  // contents
+                            "0013",                                   // length
+                            "68747470733A2F2F6578616D706C652E636F6D"  // contents
                         ),
                     ),
                     concat!(


### PR DESCRIPTION
In https://github.com/divviup/janus/pull/1579#discussion_r1261499802 I identified cases where `https://example.com` would be encoded as `https://example.com/` (notice the trailing slash). At the time I didn't think this was relevant, but it turns out to affect task ID derivation.

Task ID derivation is `sha256sum(encoded_task_config)`. If we are peered with a non-janus aggregator and if we introduce trailing slashes, Janus could derive a different task ID than its peer. (This is actually somewhat unlikely since we'd derive task ID directly from the encoded bytes, but is a subtle inconsistency that could hit us later).

Instead, provide `TryInto<url::Url>` to ease converting DAP Urls to a more useful type.