### PR TITLE
add GET {aggregator_api}/ → AggregatorApiConfig

### DIFF
--- a/aggregator/tests/graceful_shutdown.rs
+++ b/aggregator/tests/graceful_shutdown.rs
@@ -248,6 +248,7 @@ async fn aggregator_shutdown() {
         "listen_address".into(),
         format!("{aggregator_api_listen_address}").into(),
     );
+    aggregator_api.insert("public_dap_url".into(), "https://public.dap.url".into());
     config.insert("aggregator_api".into(), Value::Mapping(aggregator_api));
     config.insert("max_upload_batch_size".into(), 100.into());
     config.insert("max_upload_batch_write_delay_ms".into(), 250.into());

--- a/aggregator_core/src/lib.rs
+++ b/aggregator_core/src/lib.rs
@@ -70,7 +70,7 @@ impl<H: Handler> InstrumentedHandler<H> {
 
     async fn before_send(&self, conn: Conn) -> Conn {
         if let Some(span) = conn.state::<InstrumentedHandlerSpan>() {
-            let conn = self.0.before_send(conn).instrument(span.0).await;
+            let conn = self.0.before_send(conn).instrument(span.0.clone()).await;
             span.0.in_scope(|| {
                 let status = conn
                     .status()

--- a/aggregator_core/src/lib.rs
+++ b/aggregator_core/src/lib.rs
@@ -68,8 +68,8 @@ impl<H: Handler> InstrumentedHandler<H> {
         self.0.run(conn).instrument(span).await
     }
 
-    async fn before_send(&self, conn: Conn) -> Conn {
-        if let Some(span) = conn.state::<InstrumentedHandlerSpan>() {
+    async fn before_send(&self, mut conn: Conn) -> Conn {
+        if let Some(span) = conn.take_state::<InstrumentedHandlerSpan>() {
             let conn = self.0.before_send(conn).instrument(span.0.clone()).await;
             span.0.in_scope(|| {
                 let status = conn

--- a/docs/samples/advanced_config/aggregator.yaml
+++ b/docs/samples/advanced_config/aggregator.yaml
@@ -74,6 +74,10 @@ aggregator_api:
   # Alternately, the aggregator API may be served on `listen_address`, at an arbitrary path prefix.
   # path_prefix: "aggregator-api"
 
+  # Resource location at which the DAP service managed by this
+  # aggregator api can be found on the public internet. Required.
+  public_dap_url: "https://dap.test"
+
 # Maximum number of uploaded reports per batching transaction. (required)
 max_upload_batch_size: 100
 


### PR DESCRIPTION
Pairs with https://github.com/divviup/divviup-api/pull/340

Explanation of changes:

* Previously the aggregator-api handler was unconditionally built and discarded, but as of this PR, we require the aggregator-api config in order to build the aggregator-api handler. This seems more generally correct and adaptable to other configuration keys that are mandatory if and only if aggregator-api is enabled
* Previously, the BinaryContext was partially moved in order to move the non-clone datastore into an Arc, but that did not work well with extracting behvior to a function. To address this, we now destructure the BinaryContext and explicitly take or borrow fields from it as needed.
* `Box::pin(async {})` was replaced with `Box::pin(std::future::ready(()))`
* This PR puts Config back into the Conn in auth_check in order to use it in the get_config endpoint