### PR TITLE
Rename test function create_report_with_id to create_report_custom

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -2838,7 +2838,7 @@ mod tests {
         }
     }
 
-    pub(super) fn create_report_with_id(
+    pub(super) fn create_report_custom(
         task: &Task,
         report_timestamp: Time,
         id: ReportId,
@@ -2880,7 +2880,7 @@ mod tests {
     }
 
     pub(super) fn create_report(task: &Task, report_timestamp: Time) -> Report {
-        create_report_with_id(task, report_timestamp, random(), task.current_hpke_key())
+        create_report_custom(task, report_timestamp, random(), task.current_hpke_key())
     }
 
     async fn setup_upload_test(
@@ -2958,7 +2958,7 @@ mod tests {
             .unwrap();
 
         // Reports may not be mutated
-        let mutated_report = create_report_with_id(
+        let mutated_report = create_report_custom(
             &task,
             clock.now(),
             *report.metadata().id(),
@@ -3223,8 +3223,8 @@ mod tests {
 
         for report in [
             create_report(&task, clock.now()),
-            create_report_with_id(&task, clock.now(), random(), &global_hpke_keypair_same_id),
-            create_report_with_id(
+            create_report_custom(&task, clock.now(), random(), &global_hpke_keypair_same_id),
+            create_report_custom(
                 &task,
                 clock.now(),
                 random(),

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -556,7 +556,7 @@ mod tests {
         empty_batch_aggregations,
         http_handlers::aggregator_handler,
         tests::{
-            create_report, create_report_with_id, default_aggregator_config,
+            create_report, create_report_custom, default_aggregator_config,
             generate_helper_report_share, generate_helper_report_share_for_plaintext,
             BATCH_AGGREGATION_SHARD_COUNT,
         },
@@ -976,7 +976,7 @@ mod tests {
         let accepted_report_id = report.metadata().id();
 
         // Verify that new reports using an existing report ID are rejected with reportRejected
-        let duplicate_id_report = create_report_with_id(
+        let duplicate_id_report = create_report_custom(
             &task,
             clock.now(),
             *accepted_report_id,


### PR DESCRIPTION
Follow up to https://github.com/divviup/janus/pull/1648#pullrequestreview-1548667598. I went with `create_report_custom` rather than `create_report_with_key`, since this function allows specifying a non-random ID and key and it's used for each of those purposes independently. My thought is this can just be a catch-all function for the rare case that a test requires a non-arbitrary report.