### PR TITLE
Change example port from 80 to 8080, to allow non-root usage

### DIFF
--- a/docs/samples/advanced_config/aggregator.yaml
+++ b/docs/samples/advanced_config/aggregator.yaml
@@ -65,7 +65,7 @@ metrics_config:
 # Aggregator-specific parameters:
 
 # Socket address for DAP requests. (required)
-listen_address: "0.0.0.0:80"
+listen_address: "0.0.0.0:8080"
 
 # How to serve the Janus aggregator API. If not set, Janus aggregator API is not served. (optional)
 aggregator_api:

--- a/docs/samples/basic_config/aggregator.yaml
+++ b/docs/samples/basic_config/aggregator.yaml
@@ -10,7 +10,7 @@ health_check_listen_address: "0.0.0.0:8000"
 # Aggregator-specific parameters:
 
 # Socket address for DAP requests. (required)
-listen_address: "0.0.0.0:80"
+listen_address: "0.0.0.0:8080"
 
 # Maximum number of uploaded reports per batching transaction. (required)
 max_upload_batch_size: 100


### PR DESCRIPTION
Minor annoyance: port 80 is a privileged port in Linux, so non-root users can't bind to it (without modifying their system). This just makes it easier to bring up a quick aggregator `DATASTORE_KEYS=foobar cargo run --bin aggregator -- --config-file samples/basic_config/aggregator.yaml`.