### PR TITLE
Don't specify service.name with OTLP exporters

### DIFF
--- a/aggregator/src/metrics.rs
+++ b/aggregator/src/metrics.rs
@@ -23,13 +23,8 @@ use {
 
 #[cfg(feature = "otlp")]
 use {
-    opentelemetry::{
-        runtime::Tokio,
-        sdk::{metrics::controllers::BasicController, Resource},
-        KeyValue,
-    },
+    opentelemetry::{runtime::Tokio, sdk::metrics::controllers::BasicController},
     opentelemetry_otlp::WithExportConfig,
-    opentelemetry_semantic_conventions::resource::SERVICE_NAME,
     tonic::metadata::{MetadataKey, MetadataMap, MetadataValue},
 };
 
@@ -204,10 +199,6 @@ pub async fn install_metrics_exporter(
                     stateless_temporality_selector(),
                     Tokio,
                 )
-                .with_resource(Resource::new([KeyValue::new(
-                    SERVICE_NAME,
-                    "janus_aggregator",
-                )]))
                 .with_exporter(
                     opentelemetry_otlp::new_exporter()
                         .tonic()

--- a/aggregator/src/trace.rs
+++ b/aggregator/src/trace.rs
@@ -10,12 +10,7 @@ use tracing_subscriber::{filter::FromEnvError, layer::SubscriberExt, EnvFilter, 
 
 #[cfg(feature = "otlp")]
 use {
-    opentelemetry::{
-        sdk::{trace, Resource},
-        KeyValue,
-    },
     opentelemetry_otlp::WithExportConfig,
-    opentelemetry_semantic_conventions::resource::SERVICE_NAME,
     std::str::FromStr,
     tonic::metadata::{MetadataKey, MetadataMap, MetadataValue},
 };
@@ -205,9 +200,6 @@ pub fn install_trace_subscriber(config: &TraceConfiguration) -> Result<TraceGuar
                     .with_endpoint(otlp_config.endpoint.clone())
                     .with_metadata(map),
             )
-            .with_trace_config(trace::config().with_resource(Resource::new(Vec::from([
-                KeyValue::new(SERVICE_NAME, "janus_aggregator"),
-            ]))))
             .install_batch(opentelemetry::runtime::Tokio)?;
 
         let telemetry = tracing_opentelemetry::layer()


### PR DESCRIPTION
Currently, we specify `service.name` to be "janus_aggregator" when constructing a OTLP metrics exporter and OTLP trace exporter (but not the Prometheus metrics exporter). This PR removes these settings so that we can use the `OTEL_SERVICE_NAME` environment variable to control this setting for all exporters.

cc @simon-friedberger