### PR TITLE
in-cluster test: deal with agg config API

### DIFF
--- a/integration_tests/src/divviup_api_client.rs
+++ b/integration_tests/src/divviup_api_client.rs
@@ -67,10 +67,8 @@ pub struct DivviUpApiTask {
 /// Request to pair an aggregator with divviup-api
 #[derive(Serialize)]
 pub struct NewAggregatorRequest {
-    pub role: String,
     pub name: String,
     pub api_url: String,
-    pub dap_url: String,
     /// Bearer token for authenticating requests to this aggregator's aggregator API
     pub bearer_token: String,
 }

--- a/integration_tests/tests/in_cluster.rs
+++ b/integration_tests/tests/in_cluster.rs
@@ -123,10 +123,8 @@ impl InClusterJanusPair {
         //   is necessary for the task we later provision to pass a validity check.
         let paired_leader_aggregator = divviup_api
             .pair_global_aggregator(&NewAggregatorRequest {
-                role: "Leader".to_string(),
                 name: "leader".to_string(),
                 api_url: Self::in_cluster_aggregator_api_url(&leader_namespace).to_string(),
-                dap_url: Self::in_cluster_aggregator_dap_url(&leader_namespace).to_string(),
                 bearer_token: leader_aggregator_api_auth_token,
             })
             .await;
@@ -135,10 +133,8 @@ impl InClusterJanusPair {
             .pair_aggregator(
                 &account,
                 &NewAggregatorRequest {
-                    role: "Helper".to_string(),
                     name: "helper".to_string(),
                     api_url: Self::in_cluster_aggregator_api_url(&helper_namespace).to_string(),
-                    dap_url: Self::in_cluster_aggregator_dap_url(&helper_namespace).to_string(),
                     bearer_token: helper_aggregator_api_auth_token,
                 },
             )

--- a/integration_tests/tests/in_cluster.rs
+++ b/integration_tests/tests/in_cluster.rs
@@ -182,13 +182,6 @@ impl InClusterJanusPair {
         }
     }
 
-    fn in_cluster_aggregator_dap_url(namespace: &str) -> Url {
-        Url::parse(&format!(
-            "http://aggregator.{namespace}.svc.cluster.local:80"
-        ))
-        .unwrap()
-    }
-
     fn in_cluster_aggregator_api_url(namespace: &str) -> Url {
         Url::parse(&format!(
             "http://aggregator.{namespace}.svc.cluster.local:80/aggregator-api/"


### PR DESCRIPTION
With the latest `divviup-api` and `janus` changes ([1], [2]), we no longer tell `divviup-api` what DAP roles an aggregator supports nor the URL of its DAP API. Those configuration items are instead discovered during aggregator pairing. This updates the `divviup-api` client used in the `in-cluster` integration tests accordingly.

[1]: https://github.com/divviup/janus/pull/1646
[2]: https://github.com/divviup/divviup-api/pull/340