### PR TITLE
Remove `std::hash::Hash` bound on agg parameters

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -35,7 +35,6 @@ use prio::{
 use reqwest::Method;
 use std::{
     collections::{HashMap, HashSet},
-    hash::Hash,
     sync::Arc,
     time::Duration,
 };
@@ -127,7 +126,7 @@ impl AggregationJobDriver {
     ) -> Result<()>
     where
         A: 'static + Send + Sync,
-        A::AggregationParam: Send + Sync + PartialEq + Eq + Hash,
+        A::AggregationParam: Send + Sync + PartialEq + Eq,
         A::AggregateShare: Send + Sync,
         A::OutputShare: PartialEq + Eq + Send + Sync,
         for<'a> A::PrepareState:
@@ -295,7 +294,7 @@ impl AggregationJobDriver {
     ) -> Result<()>
     where
         A: 'static,
-        A::AggregationParam: Send + Sync + PartialEq + Eq + Hash,
+        A::AggregationParam: Send + Sync + PartialEq + Eq,
         A::AggregateShare: Send + Sync,
         A::OutputShare: PartialEq + Eq + Send + Sync,
         A::PrepareState: PartialEq + Eq + Send + Sync + Encode,
@@ -441,7 +440,7 @@ impl AggregationJobDriver {
     ) -> Result<()>
     where
         A: 'static,
-        A::AggregationParam: Send + Sync + PartialEq + Eq + Hash,
+        A::AggregationParam: Send + Sync + PartialEq + Eq,
         A::AggregateShare: Send + Sync,
         A::OutputShare: Send + Sync,
         A::PrepareState: Send + Sync + Encode,
@@ -557,7 +556,7 @@ impl AggregationJobDriver {
     ) -> Result<()>
     where
         A: 'static,
-        A::AggregationParam: Send + Sync + Eq + PartialEq + Hash,
+        A::AggregationParam: Send + Sync + Eq + PartialEq,
         A::AggregateShare: Send + Sync,
         A::OutputShare: Send + Sync,
         A::PrepareMessage: Send + Sync,
@@ -765,7 +764,7 @@ impl AggregationJobDriver {
     where
         A: Send + Sync + 'static,
         A::AggregateShare: Send + Sync,
-        A::AggregationParam: Send + Sync + PartialEq + Eq + Hash,
+        A::AggregationParam: Send + Sync + PartialEq + Eq,
         A::PrepareMessage: Send + Sync,
         for<'a> A::PrepareState: Send + Sync + Encode + ParameterizedDecode<(&'a A, usize)>,
     {

--- a/aggregator/src/aggregator/aggregation_job_writer.rs
+++ b/aggregator/src/aggregator/aggregation_job_writer.rs
@@ -19,7 +19,6 @@ use prio::{codec::Encode, vdaf};
 use std::{
     borrow::Cow,
     collections::{HashMap, HashSet},
-    hash::Hash,
     sync::{Arc, Mutex},
 };
 use tokio::try_join;
@@ -162,7 +161,7 @@ impl<const SEED_SIZE: usize, Q: CollectableQueryType, A: vdaf::Aggregator<SEED_S
     where
         C: Clock,
         A: Send + Sync,
-        A::AggregationParam: PartialEq + Eq + Hash,
+        A::AggregationParam: PartialEq + Eq,
         A::PrepareState: Encode,
     {
         // Create a copy-on-write instance of our state to allow efficient imperative updates.


### PR DESCRIPTION
Somewhere along the way, `AggregationJobWriter::write` picked up a trait bound requiring `std::hash::Hash` on `Vdaf::AggregationParam`. This trait isn't actually needed and also breaks Poplar1: `Hash` is implemented on `Prio3*::AggregationParam` (i.e., `()`), but not on `Poplar1AggregationParam`.