### PR TITLE
Aggregator API endpoints for global HPKE key management

### DIFF
--- a/aggregator_api/src/lib.rs
+++ b/aggregator_api/src/lib.rs
@@ -1693,7 +1693,7 @@ mod tests {
     async fn get_global_hpke_keypairs() {
         let (handler, _ephemeral_datastore, ds) = setup_api_test().await;
 
-        let mut conn = get("/global-hpke-keypairs")
+        let mut conn = get("/hpke_configs")
             .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
             .with_request_header("Accept", CONTENT_TYPE)
             .with_request_header("Content-Type", CONTENT_TYPE)
@@ -1732,7 +1732,7 @@ mod tests {
         .await
         .unwrap();
 
-        let mut conn = get("/global-hpke-keypairs")
+        let mut conn = get("/hpke_configs")
             .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
             .with_request_header("Accept", CONTENT_TYPE)
             .with_request_header("Content-Type", CONTENT_TYPE)
@@ -1766,7 +1766,7 @@ mod tests {
 
         // Verify: unauthorized requests are denied appropriately.
         assert_response!(
-            put("/global-hpke-keypairs")
+            put("/hpke_configs")
                 .with_request_header("Accept", CONTENT_TYPE)
                 .run_async(&handler)
                 .await,
@@ -1781,7 +1781,7 @@ mod tests {
 
         // Verify: non-existent key.
         assert_response!(
-            get("/global-hpke-keypairs/123")
+            get("/hpke_configs/123")
                 .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
                 .with_request_header("Accept", CONTENT_TYPE)
                 .with_request_header("Content-Type", CONTENT_TYPE)
@@ -1792,7 +1792,7 @@ mod tests {
 
         // Verify: overflow u8.
         assert_response!(
-            get("/global-hpke-keypairs/1234310294")
+            get("/hpke_configs/1234310294")
                 .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
                 .with_request_header("Accept", CONTENT_TYPE)
                 .with_request_header("Content-Type", CONTENT_TYPE)
@@ -1803,7 +1803,7 @@ mod tests {
 
         // Verify: unauthorized requests are denied appropriately.
         assert_response!(
-            put("/global-hpke-keypairs/123")
+            put("/hpke_configs/123")
                 .with_request_header("Accept", CONTENT_TYPE)
                 .run_async(&handler)
                 .await,
@@ -1836,7 +1836,7 @@ mod tests {
             (keypair1, HpkeKeyState::Pending),
             (keypair2, HpkeKeyState::Active),
         ] {
-            let mut conn = get(&format!("/global-hpke-keypairs/{}", key.config().id()))
+            let mut conn = get(&format!("/hpke_configs/{}", key.config().id()))
                 .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
                 .with_request_header("Accept", CONTENT_TYPE)
                 .with_request_header("Content-Type", CONTENT_TYPE)
@@ -1867,7 +1867,7 @@ mod tests {
         let (handler, _ephemeral_datastore, ds) = setup_api_test().await;
 
         // No custom parameters.
-        let mut key1_resp = put("/global-hpke-keypairs")
+        let mut key1_resp = put("/hpke_configs")
             .with_request_body("{}")
             .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
             .with_request_header("Accept", CONTENT_TYPE)
@@ -1892,7 +1892,7 @@ mod tests {
             kdf_id: Some(HpkeKdfId::HkdfSha512),
             aead_id: Some(HpkeAeadId::ChaCha20Poly1305),
         };
-        let mut key2_resp = put("/global-hpke-keypairs")
+        let mut key2_resp = put("/hpke_configs")
             .with_request_body(serde_json::to_vec(&key2_req).unwrap())
             .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
             .with_request_header("Accept", CONTENT_TYPE)
@@ -1943,7 +1943,7 @@ mod tests {
 
         // Verify: unauthorized requests are denied appropriately.
         assert_response!(
-            put("/global-hpke-keypairs")
+            put("/hpke_configs")
                 .with_request_header("Accept", CONTENT_TYPE)
                 .run_async(&handler)
                 .await,
@@ -1962,7 +1962,7 @@ mod tests {
 
         // Verify: non-existent key.
         assert_response!(
-            patch("/global-hpke-keypairs/123")
+            patch("/hpke_configs/123")
                 .with_request_body(serde_json::to_vec(&req).unwrap())
                 .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
                 .with_request_header("Accept", CONTENT_TYPE)
@@ -1974,7 +1974,7 @@ mod tests {
 
         // Verify: overflow u8.
         assert_response!(
-            patch("/global-hpke-keypairs/1234310294")
+            patch("/hpke_configs/1234310294")
                 .with_request_body(serde_json::to_vec(&req).unwrap())
                 .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
                 .with_request_header("Accept", CONTENT_TYPE)
@@ -1986,7 +1986,7 @@ mod tests {
 
         // Verify: invalid body.
         assert_response!(
-            patch("/global-hpke-keypairs/1234310294")
+            patch("/hpke_configs/1234310294")
                 .with_request_body("{}")
                 .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
                 .with_request_header("Accept", CONTENT_TYPE)
@@ -1998,7 +1998,7 @@ mod tests {
 
         // Verify: unauthorized requests are denied appropriately.
         assert_response!(
-            patch("/global-hpke-keypairs/123")
+            patch("/hpke_configs/123")
                 .with_request_body(serde_json::to_vec(&req).unwrap())
                 .with_request_header("Accept", CONTENT_TYPE)
                 .run_async(&handler)
@@ -2015,7 +2015,7 @@ mod tests {
         .await
         .unwrap();
 
-        let conn = patch(&format!("/global-hpke-keypairs/{}", keypair.config().id()))
+        let conn = patch(&format!("/hpke_configs/{}", keypair.config().id()))
             .with_request_body(serde_json::to_vec(&req).unwrap())
             .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
             .with_request_header("Accept", CONTENT_TYPE)
@@ -2045,7 +2045,7 @@ mod tests {
 
         // Verify: non-existent key.
         assert_response!(
-            delete("/global-hpke-keypairs/123")
+            delete("/hpke_configs/123")
                 .with_request_body(serde_json::to_vec(&req).unwrap())
                 .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
                 .with_request_header("Accept", CONTENT_TYPE)
@@ -2057,7 +2057,7 @@ mod tests {
 
         // Verify: overflow u8.
         assert_response!(
-            delete("/global-hpke-keypairs/1234310294")
+            delete("/hpke_configs/1234310294")
                 .with_request_body(serde_json::to_vec(&req).unwrap())
                 .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
                 .with_request_header("Accept", CONTENT_TYPE)
@@ -2069,7 +2069,7 @@ mod tests {
 
         // Verify: unauthorized requests are denied appropriately.
         assert_response!(
-            delete("/global-hpke-keypairs/123")
+            delete("/hpke_configs/123")
                 .with_request_body(serde_json::to_vec(&req).unwrap())
                 .with_request_header("Accept", CONTENT_TYPE)
                 .run_async(&handler)
@@ -2086,7 +2086,7 @@ mod tests {
         .await
         .unwrap();
 
-        let conn = delete(&format!("/global-hpke-keypairs/{}", keypair.config().id()))
+        let conn = delete(&format!("/hpke_configs/{}", keypair.config().id()))
             .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
             .with_request_header("Accept", CONTENT_TYPE)
             .with_request_header("Content-Type", CONTENT_TYPE)

--- a/aggregator_api/src/lib.rs
+++ b/aggregator_api/src/lib.rs
@@ -1,6 +1,5 @@
 //! This crate implements the Janus Aggregator API.
 
-use crate::models::{GetTaskIdsResp, PostTaskReq};
 use async_trait::async_trait;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use janus_aggregator_core::{
@@ -13,11 +12,15 @@ use janus_core::{
     hpke::generate_hpke_config_and_private_key, http::extract_bearer_token,
     task::AuthenticationToken, time::Clock,
 };
+use janus_messages::HpkeConfigId;
 use janus_messages::{
     query_type::Code as SupportedQueryType, Duration, HpkeAeadId, HpkeKdfId, HpkeKemId, Role,
     TaskId,
 };
-use models::{AggregatorApiConfig, AggregatorRole, GetTaskMetricsResp, SupportedVdaf, TaskResp};
+use models::{
+    AggregatorApiConfig, AggregatorRole, GetTaskIdsResp, GetTaskMetricsResp, GlobalHpkeKeypairResp,
+    PatchGlobalHpkeKeypairReq, PostTaskReq, PutGlobalHpkeKeypairReq, SupportedVdaf, TaskResp,
+};
 use querystring::querify;
 use rand::random;
 use ring::{
@@ -100,6 +103,26 @@ pub fn aggregator_api_handler<C: Clock>(ds: Arc<Datastore<C>>, cfg: Config) -> i
             .get(
                 "/tasks/:task_id/metrics",
                 instrumented(api(get_task_metrics::<C>)),
+            )
+            .get(
+                "/global-hpke-keypairs",
+                instrumented(api(get_global_hpke_keypairs::<C>)),
+            )
+            .get(
+                "/global-hpke-keypairs/:config_id",
+                instrumented(api(get_global_hpke_keypair::<C>)),
+            )
+            .put(
+                "/global-hpke-keypairs",
+                instrumented(api(put_global_hpke_keypair::<C>)),
+            )
+            .patch(
+                "/global-hpke-keypairs/:config_id",
+                instrumented(api(patch_global_hpke_keypair::<C>)),
+            )
+            .delete(
+                "/global-hpke-keypairs/:config_id",
+                instrumented(api(delete_global_hpke_keypair::<C>)),
             ),
     )
 }
@@ -435,12 +458,153 @@ async fn get_task_metrics<C: Clock>(
     }))
 }
 
+async fn get_global_hpke_keypairs<C: Clock>(
+    _: &mut Conn,
+    State(ds): State<Arc<Datastore<C>>>,
+) -> Result<impl Handler, Status> {
+    Ok(Json(
+        ds.run_tx_with_name("get_global_hpke_keypairs", |tx| {
+            Box::pin(async move { tx.get_global_hpke_keypairs().await })
+        })
+        .await
+        .map_err(|err| {
+            error!(err = %err, "Database transaction error");
+            Status::InternalServerError
+        })?
+        .into_iter()
+        .map(GlobalHpkeKeypairResp::from)
+        .collect::<Vec<_>>(),
+    ))
+}
+
+async fn get_global_hpke_keypair<C: Clock>(
+    conn: &mut Conn,
+    State(ds): State<Arc<Datastore<C>>>,
+) -> Result<impl Handler, Status> {
+    let config_id = conn.hpke_config_id_param()?;
+    Ok(Json(GlobalHpkeKeypairResp::from(
+        ds.run_tx_with_name("get_global_hpke_keypair", |tx| {
+            Box::pin(async move { tx.get_global_hpke_keypair(&config_id).await })
+        })
+        .await
+        .map_err(|err| {
+            error!(err = %err, "Database transaction error");
+            Status::InternalServerError
+        })?
+        .ok_or(Status::NotFound)?,
+    )))
+}
+
+async fn put_global_hpke_keypair<C: Clock>(
+    _: &mut Conn,
+    (State(ds), Json(req)): (State<Arc<Datastore<C>>>, Json<PutGlobalHpkeKeypairReq>),
+) -> Result<impl Handler, Status> {
+    let existing_keypairs = ds
+        .run_tx_with_name("put_global_hpke_keypair_determine_id", |tx| {
+            Box::pin(async move { tx.get_global_hpke_keypairs().await })
+        })
+        .await
+        .map_err(|err| {
+            error!(err = %err, "Database transaction error");
+            Status::InternalServerError
+        })?
+        .iter()
+        .map(|keypair| u8::from(*keypair.hpke_keypair().config().id()))
+        .collect::<Vec<_>>();
+
+    let config_id = HpkeConfigId::from(
+        (0..u8::MAX)
+            .find(|i| !existing_keypairs.contains(i))
+            .ok_or_else(|| {
+                warn!("All possible IDs for global HPKE key have been taken");
+                Status::Conflict
+            })?,
+    );
+    let keypair = generate_hpke_config_and_private_key(
+        config_id,
+        req.kem_id.unwrap_or(HpkeKemId::X25519HkdfSha256),
+        req.kdf_id.unwrap_or(HpkeKdfId::HkdfSha256),
+        req.aead_id.unwrap_or(HpkeAeadId::Aes128Gcm),
+    );
+
+    let inserted_keypair = ds
+        .run_tx_with_name("put_global_hpke_keypair", |tx| {
+            let keypair = keypair.clone();
+            Box::pin(async move {
+                tx.put_global_hpke_keypair(&keypair).await?;
+                tx.get_global_hpke_keypair(&config_id).await
+            })
+        })
+        .await
+        .map_err(|err| {
+            error!(err = %err, "Database transaction error");
+            Status::InternalServerError
+        })?
+        .ok_or_else(|| {
+            error!(config_id = %config_id, "Newly inserted key disappeared");
+            Status::InternalServerError
+        })?;
+
+    Ok((
+        Status::Created,
+        Json(GlobalHpkeKeypairResp::from(inserted_keypair)),
+    ))
+}
+
+async fn patch_global_hpke_keypair<C: Clock>(
+    conn: &mut Conn,
+    (State(ds), Json(req)): (State<Arc<Datastore<C>>>, Json<PatchGlobalHpkeKeypairReq>),
+) -> Result<impl Handler, Status> {
+    let config_id = conn.hpke_config_id_param()?;
+
+    ds.run_tx_with_name("patch_hpke_global_keypair", |tx| {
+        let config_id = config_id;
+        Box::pin(async move {
+            tx.set_global_hpke_keypair_state(&config_id, &req.state)
+                .await
+        })
+    })
+    .await
+    .map_err(|err| match err {
+        datastore::Error::MutationTargetNotFound => Status::NotFound,
+        _ => {
+            error!(err = %err, "Database transaction error");
+            Status::InternalServerError
+        }
+    })?;
+
+    Ok(Status::Ok)
+}
+
+async fn delete_global_hpke_keypair<C: Clock>(
+    conn: &mut Conn,
+    State(ds): State<Arc<Datastore<C>>>,
+) -> Result<impl Handler, Status> {
+    let config_id = conn.hpke_config_id_param()?;
+    ds.run_tx_with_name("delete_global_hpke_keypair", |tx| {
+        Box::pin(async move { tx.delete_global_hpke_keypair(&config_id).await })
+    })
+    .await
+    .map_err(|err| match err {
+        datastore::Error::MutationTargetNotFound => Status::NotFound,
+        _ => {
+            error!(err = %err, "Database transaction error");
+            Status::InternalServerError
+        }
+    })?;
+    Ok(Status::NoContent)
+}
+
 mod models {
     use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-    use janus_aggregator_core::task::{QueryType, Task};
+    use janus_aggregator_core::{
+        datastore::models::{GlobalHpkeKeypair, HpkeKeyState},
+        task::{QueryType, Task},
+    };
     use janus_core::task::{AuthenticationToken, VdafInstance};
     use janus_messages::{
-        query_type::Code as SupportedQueryType, Duration, HpkeConfig, Role, TaskId, Time,
+        query_type::Code as SupportedQueryType, Duration, HpkeAeadId, HpkeConfig, HpkeKdfId,
+        HpkeKemId, Role, TaskId, Time,
     };
     use serde::{Deserialize, Serialize};
     use url::Url;
@@ -627,10 +791,38 @@ mod models {
         pub(crate) reports: u64,
         pub(crate) report_aggregations: u64,
     }
+
+    #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+    pub(crate) struct GlobalHpkeKeypairResp {
+        pub(crate) config: HpkeConfig,
+        pub(crate) state: HpkeKeyState,
+    }
+
+    impl From<GlobalHpkeKeypair> for GlobalHpkeKeypairResp {
+        fn from(value: GlobalHpkeKeypair) -> Self {
+            Self {
+                config: value.hpke_keypair().config().clone(),
+                state: *value.state(),
+            }
+        }
+    }
+
+    #[derive(Serialize, Deserialize)]
+    pub(crate) struct PutGlobalHpkeKeypairReq {
+        pub(crate) kem_id: Option<HpkeKemId>,
+        pub(crate) kdf_id: Option<HpkeKdfId>,
+        pub(crate) aead_id: Option<HpkeAeadId>,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    pub(crate) struct PatchGlobalHpkeKeypairReq {
+        pub(crate) state: HpkeKeyState,
+    }
 }
 
 trait ConnExt {
     fn task_id_param(&self) -> Result<TaskId, Status>;
+    fn hpke_config_id_param(&self) -> Result<HpkeConfigId, Status>;
 }
 
 impl ConnExt for Conn {
@@ -644,13 +836,31 @@ impl ConnExt for Conn {
             Status::BadRequest
         })
     }
+
+    fn hpke_config_id_param(&self) -> Result<HpkeConfigId, Status> {
+        Ok(HpkeConfigId::from(
+            self.param("config_id")
+                .ok_or_else(|| {
+                    error!("No config_id parameter");
+                    Status::InternalServerError
+                })?
+                .parse::<u8>()
+                .map_err(|err| {
+                    warn!(err = ?err, "Couldn't parse config_id parameter");
+                    Status::BadRequest
+                })?,
+        ))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::{
         aggregator_api_handler,
-        models::{GetTaskIdsResp, GetTaskMetricsResp, PostTaskReq, TaskResp},
+        models::{
+            GetTaskIdsResp, GetTaskMetricsResp, GlobalHpkeKeypairResp, PatchGlobalHpkeKeypairReq,
+            PostTaskReq, PutGlobalHpkeKeypairReq, TaskResp,
+        },
         Config, CONTENT_TYPE,
     };
     use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
@@ -658,8 +868,8 @@ mod tests {
     use janus_aggregator_core::{
         datastore::{
             models::{
-                AggregationJob, AggregationJobState, LeaderStoredReport, ReportAggregation,
-                ReportAggregationState,
+                AggregationJob, AggregationJobState, HpkeKeyState, LeaderStoredReport,
+                ReportAggregation, ReportAggregationState,
             },
             test_util::{ephemeral_datastore, EphemeralDatastore},
             Datastore,
@@ -668,7 +878,10 @@ mod tests {
         SecretBytes,
     };
     use janus_core::{
-        hpke::{generate_hpke_config_and_private_key, HpkeKeypair, HpkePrivateKey},
+        hpke::{
+            generate_hpke_config_and_private_key,
+            test_util::generate_test_hpke_config_and_private_key, HpkeKeypair, HpkePrivateKey,
+        },
         task::{AuthenticationToken, VdafInstance},
         test_util::{
             dummy_vdaf::{self, AggregationParam},
@@ -686,7 +899,7 @@ mod tests {
     use trillium::{Handler, Status};
     use trillium_testing::{
         assert_response, assert_status,
-        prelude::{delete, get, post},
+        prelude::{delete, get, patch, post, put},
     };
 
     const AUTH_TOKEN: &str = "Y29sbGVjdG9yLWFiY2RlZjAw";
@@ -1473,6 +1686,419 @@ mod tests {
                 .await,
             Status::Unauthorized,
             "",
+        );
+    }
+
+    #[tokio::test]
+    async fn get_global_hpke_keypairs() {
+        let (handler, _ephemeral_datastore, ds) = setup_api_test().await;
+
+        let mut conn = get("/global-hpke-keypairs")
+            .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
+            .with_request_header("Accept", CONTENT_TYPE)
+            .with_request_header("Content-Type", CONTENT_TYPE)
+            .run_async(&handler)
+            .await;
+        assert_response!(conn, Status::Ok);
+        let resp: Vec<GlobalHpkeKeypairResp> = serde_json::from_slice(
+            &conn
+                .take_response_body()
+                .unwrap()
+                .into_bytes()
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(resp, vec![]);
+
+        let keypair1 = generate_test_hpke_config_and_private_key();
+        let keypair2 = generate_hpke_config_and_private_key(
+            random(),
+            HpkeKemId::P256HkdfSha256,
+            HpkeKdfId::HkdfSha384,
+            HpkeAeadId::Aes128Gcm,
+        );
+        ds.run_tx(|tx| {
+            let keypair1 = keypair1.clone();
+            let keypair2 = keypair2.clone();
+            Box::pin(async move {
+                tx.put_global_hpke_keypair(&keypair1).await?;
+                tx.put_global_hpke_keypair(&keypair2).await?;
+                tx.set_global_hpke_keypair_state(keypair2.config().id(), &HpkeKeyState::Active)
+                    .await?;
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
+
+        let mut conn = get("/global-hpke-keypairs")
+            .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
+            .with_request_header("Accept", CONTENT_TYPE)
+            .with_request_header("Content-Type", CONTENT_TYPE)
+            .run_async(&handler)
+            .await;
+        assert_response!(conn, Status::Ok);
+        let mut resp: Vec<GlobalHpkeKeypairResp> = serde_json::from_slice(
+            &conn
+                .take_response_body()
+                .unwrap()
+                .into_bytes()
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        resp.sort_by(|a, b| a.config.id().cmp(b.config.id()));
+
+        let mut expected = vec![
+            GlobalHpkeKeypairResp {
+                config: keypair1.config().clone(),
+                state: HpkeKeyState::Pending,
+            },
+            GlobalHpkeKeypairResp {
+                config: keypair2.config().clone(),
+                state: HpkeKeyState::Active,
+            },
+        ];
+        expected.sort_by(|a, b| a.config.id().cmp(b.config.id()));
+
+        assert_eq!(resp, expected);
+
+        // Verify: unauthorized requests are denied appropriately.
+        assert_response!(
+            put("/global-hpke-keypairs")
+                .with_request_header("Accept", CONTENT_TYPE)
+                .run_async(&handler)
+                .await,
+            Status::Unauthorized,
+            "",
+        );
+    }
+
+    #[tokio::test]
+    async fn get_global_hpke_keypair() {
+        let (handler, _ephemeral_datastore, ds) = setup_api_test().await;
+
+        // Verify: non-existent key.
+        assert_response!(
+            get("/global-hpke-keypairs/123")
+                .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
+                .with_request_header("Accept", CONTENT_TYPE)
+                .with_request_header("Content-Type", CONTENT_TYPE)
+                .run_async(&handler)
+                .await,
+            Status::NotFound
+        );
+
+        // Verify: overflow u8.
+        assert_response!(
+            get("/global-hpke-keypairs/1234310294")
+                .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
+                .with_request_header("Accept", CONTENT_TYPE)
+                .with_request_header("Content-Type", CONTENT_TYPE)
+                .run_async(&handler)
+                .await,
+            Status::BadRequest
+        );
+
+        // Verify: unauthorized requests are denied appropriately.
+        assert_response!(
+            put("/global-hpke-keypairs/123")
+                .with_request_header("Accept", CONTENT_TYPE)
+                .run_async(&handler)
+                .await,
+            Status::Unauthorized,
+            "",
+        );
+
+        let keypair1 = generate_test_hpke_config_and_private_key();
+        let keypair2 = generate_hpke_config_and_private_key(
+            random(),
+            HpkeKemId::P256HkdfSha256,
+            HpkeKdfId::HkdfSha384,
+            HpkeAeadId::Aes128Gcm,
+        );
+        ds.run_tx(|tx| {
+            let keypair1 = keypair1.clone();
+            let keypair2 = keypair2.clone();
+            Box::pin(async move {
+                tx.put_global_hpke_keypair(&keypair1).await?;
+                tx.put_global_hpke_keypair(&keypair2).await?;
+                tx.set_global_hpke_keypair_state(keypair2.config().id(), &HpkeKeyState::Active)
+                    .await?;
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
+
+        for (key, state) in [
+            (keypair1, HpkeKeyState::Pending),
+            (keypair2, HpkeKeyState::Active),
+        ] {
+            let mut conn = get(&format!("/global-hpke-keypairs/{}", key.config().id()))
+                .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
+                .with_request_header("Accept", CONTENT_TYPE)
+                .with_request_header("Content-Type", CONTENT_TYPE)
+                .run_async(&handler)
+                .await;
+            assert_response!(conn, Status::Ok);
+            let resp: GlobalHpkeKeypairResp = serde_json::from_slice(
+                &conn
+                    .take_response_body()
+                    .unwrap()
+                    .into_bytes()
+                    .await
+                    .unwrap(),
+            )
+            .unwrap();
+            assert_eq!(
+                resp,
+                GlobalHpkeKeypairResp {
+                    config: key.config().clone(),
+                    state,
+                },
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn put_global_hpke_keypair() {
+        let (handler, _ephemeral_datastore, ds) = setup_api_test().await;
+
+        // No custom parameters.
+        let mut key1_resp = put("/global-hpke-keypairs")
+            .with_request_body("{}")
+            .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
+            .with_request_header("Accept", CONTENT_TYPE)
+            .with_request_header("Content-Type", CONTENT_TYPE)
+            .run_async(&handler)
+            .await;
+
+        assert_response!(key1_resp, Status::Created);
+        let key1: GlobalHpkeKeypairResp = serde_json::from_slice(
+            &key1_resp
+                .take_response_body()
+                .unwrap()
+                .into_bytes()
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+
+        // Choose some custom non-default ciphers.
+        let key2_req = PutGlobalHpkeKeypairReq {
+            kem_id: Some(HpkeKemId::X25519HkdfSha256),
+            kdf_id: Some(HpkeKdfId::HkdfSha512),
+            aead_id: Some(HpkeAeadId::ChaCha20Poly1305),
+        };
+        let mut key2_resp = put("/global-hpke-keypairs")
+            .with_request_body(serde_json::to_vec(&key2_req).unwrap())
+            .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
+            .with_request_header("Accept", CONTENT_TYPE)
+            .with_request_header("Content-Type", CONTENT_TYPE)
+            .run_async(&handler)
+            .await;
+
+        assert_response!(key1_resp, Status::Created);
+        let key2: GlobalHpkeKeypairResp = serde_json::from_slice(
+            &key2_resp
+                .take_response_body()
+                .unwrap()
+                .into_bytes()
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+
+        let (got_key1, got_key2) = ds
+            .run_tx(|tx| {
+                let key1 = key1.config.clone();
+                let key2 = key2.config.clone();
+                Box::pin(async move {
+                    Ok((
+                        tx.get_global_hpke_keypair(key1.id()).await?,
+                        tx.get_global_hpke_keypair(key2.id()).await?,
+                    ))
+                })
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            key1,
+            GlobalHpkeKeypairResp {
+                config: got_key1.unwrap().hpke_keypair().config().clone(),
+                state: HpkeKeyState::Pending,
+            }
+        );
+
+        assert_eq!(
+            key2,
+            GlobalHpkeKeypairResp {
+                config: got_key2.unwrap().hpke_keypair().config().clone(),
+                state: HpkeKeyState::Pending,
+            }
+        );
+
+        // Verify: unauthorized requests are denied appropriately.
+        assert_response!(
+            put("/global-hpke-keypairs")
+                .with_request_header("Accept", CONTENT_TYPE)
+                .run_async(&handler)
+                .await,
+            Status::Unauthorized,
+            "",
+        );
+    }
+
+    #[tokio::test]
+    async fn patch_global_hpke_keypair() {
+        let (handler, _ephemeral_datastore, ds) = setup_api_test().await;
+
+        let req = PatchGlobalHpkeKeypairReq {
+            state: HpkeKeyState::Active,
+        };
+
+        // Verify: non-existent key.
+        assert_response!(
+            patch("/global-hpke-keypairs/123")
+                .with_request_body(serde_json::to_vec(&req).unwrap())
+                .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
+                .with_request_header("Accept", CONTENT_TYPE)
+                .with_request_header("Content-Type", CONTENT_TYPE)
+                .run_async(&handler)
+                .await,
+            Status::NotFound
+        );
+
+        // Verify: overflow u8.
+        assert_response!(
+            patch("/global-hpke-keypairs/1234310294")
+                .with_request_body(serde_json::to_vec(&req).unwrap())
+                .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
+                .with_request_header("Accept", CONTENT_TYPE)
+                .with_request_header("Content-Type", CONTENT_TYPE)
+                .run_async(&handler)
+                .await,
+            Status::BadRequest
+        );
+
+        // Verify: invalid body.
+        assert_response!(
+            patch("/global-hpke-keypairs/1234310294")
+                .with_request_body("{}")
+                .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
+                .with_request_header("Accept", CONTENT_TYPE)
+                .with_request_header("Content-Type", CONTENT_TYPE)
+                .run_async(&handler)
+                .await,
+            Status::UnprocessableEntity
+        );
+
+        // Verify: unauthorized requests are denied appropriately.
+        assert_response!(
+            patch("/global-hpke-keypairs/123")
+                .with_request_body(serde_json::to_vec(&req).unwrap())
+                .with_request_header("Accept", CONTENT_TYPE)
+                .run_async(&handler)
+                .await,
+            Status::Unauthorized,
+            "",
+        );
+
+        let keypair = generate_test_hpke_config_and_private_key();
+        ds.run_tx(|tx| {
+            let keypair = keypair.clone();
+            Box::pin(async move { tx.put_global_hpke_keypair(&keypair).await })
+        })
+        .await
+        .unwrap();
+
+        let conn = patch(&format!("/global-hpke-keypairs/{}", keypair.config().id()))
+            .with_request_body(serde_json::to_vec(&req).unwrap())
+            .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
+            .with_request_header("Accept", CONTENT_TYPE)
+            .with_request_header("Content-Type", CONTENT_TYPE)
+            .run_async(&handler)
+            .await;
+        assert_response!(conn, Status::Ok);
+
+        let got_key = ds
+            .run_tx(|tx| {
+                let keypair = keypair.clone();
+                Box::pin(async move { tx.get_global_hpke_keypair(keypair.config().id()).await })
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got_key.state(), &HpkeKeyState::Active);
+    }
+
+    #[tokio::test]
+    async fn delete_global_hpke_keypair() {
+        let (handler, _ephemeral_datastore, ds) = setup_api_test().await;
+
+        let req = PatchGlobalHpkeKeypairReq {
+            state: HpkeKeyState::Active,
+        };
+
+        // Verify: non-existent key.
+        assert_response!(
+            delete("/global-hpke-keypairs/123")
+                .with_request_body(serde_json::to_vec(&req).unwrap())
+                .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
+                .with_request_header("Accept", CONTENT_TYPE)
+                .with_request_header("Content-Type", CONTENT_TYPE)
+                .run_async(&handler)
+                .await,
+            Status::NotFound
+        );
+
+        // Verify: overflow u8.
+        assert_response!(
+            delete("/global-hpke-keypairs/1234310294")
+                .with_request_body(serde_json::to_vec(&req).unwrap())
+                .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
+                .with_request_header("Accept", CONTENT_TYPE)
+                .with_request_header("Content-Type", CONTENT_TYPE)
+                .run_async(&handler)
+                .await,
+            Status::BadRequest
+        );
+
+        // Verify: unauthorized requests are denied appropriately.
+        assert_response!(
+            delete("/global-hpke-keypairs/123")
+                .with_request_body(serde_json::to_vec(&req).unwrap())
+                .with_request_header("Accept", CONTENT_TYPE)
+                .run_async(&handler)
+                .await,
+            Status::Unauthorized,
+            "",
+        );
+
+        let keypair = generate_test_hpke_config_and_private_key();
+        ds.run_tx(|tx| {
+            let keypair = keypair.clone();
+            Box::pin(async move { tx.put_global_hpke_keypair(&keypair).await })
+        })
+        .await
+        .unwrap();
+
+        let conn = delete(&format!("/global-hpke-keypairs/{}", keypair.config().id()))
+            .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
+            .with_request_header("Accept", CONTENT_TYPE)
+            .with_request_header("Content-Type", CONTENT_TYPE)
+            .run_async(&handler)
+            .await;
+        assert_response!(conn, Status::NoContent);
+
+        assert_eq!(
+            ds.run_tx(|tx| Box::pin(async move { tx.get_global_hpke_keypairs().await }))
+                .await
+                .unwrap(),
+            vec![]
         );
     }
 

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -25,6 +25,7 @@ use prio::{
     vdaf::{self, Aggregatable},
 };
 use rand::{distributions::Standard, prelude::Distribution};
+use serde::{Deserialize, Serialize};
 use std::{
     fmt::{Debug, Display, Formatter},
     hash::{Hash, Hasher},
@@ -1681,8 +1682,9 @@ impl ToSql for SqlInterval {
 }
 
 /// The state of an HPKE key pair, corresponding to the HPKE_KEY_STATE enum in the schema.
-#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, ToSql, FromSql)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, ToSql, FromSql, Serialize, Deserialize)]
 #[postgres(name = "hpke_key_state")]
+#[serde(rename_all = "snake_case")]
 pub enum HpkeKeyState {
     /// The key should be advertised to DAP clients, and is the preferred key
     /// for new reports to be encrypted with.


### PR DESCRIPTION
Supports https://github.com/divviup/janus/issues/1568.

This lets us manage the global HPKE keys configuration in the database.

We opted to have this in the aggregator API to keep from having `janus_cli` operate directly on the database. If `janus_cli` works that way, then the operator has to somehow acquire the datastore key. Using the aggregator API effectively replaces datastore key management with aggregator API key management, which is much nicer since aggregator API key is trivially rotateable.

I didn't add functionality to janus_cli to keep this PR small, and to be mindful of time constraints of our upcoming integration tests. In lieu of janus_cli functionality, we can use `curl`.

This does extend the privileges of the aggregator API. The primary risk is to availability of the system--divviup-api will now have the power to force a rotation of HPKE configs or delete in-use HPKE configs, causing report decryption to fail. I don't think this is a meaningful increase in risk, since the holder of the aggregator API token can also compromise availability by just deleting all tasks.