### PR TITLE
Fix Content-Type of problem details responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4779,9 +4779,9 @@ dependencies = [
 
 [[package]]
 name = "trillium-api"
-version = "0.2.0-rc.3"
+version = "0.2.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9f41bf4e58d42642f4ba58d0d609d7d06499fea2df21d66f371a63f2849f8a"
+checksum = "09858200af96cce5cb8c5353df2ed6f5048b62856b35c733af4eecae8479211c"
 dependencies = [
  "log",
  "mime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ rstest = "0.17.0"
 thiserror = "1.0"
 tokio = { version = "1.29", features = ["full", "tracing"] }
 trillium = "0.2.9"
-trillium-api = { version = "0.2.0-rc.3", default-features = false }
+trillium-api = { version = "0.2.0-rc.4", default-features = false }
 trillium-caching-headers = "0.2.1"
 trillium-head = "0.2.0"
 trillium-opentelemetry = "0.2.0"

--- a/aggregator/src/aggregator/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/aggregation_job_continue.rs
@@ -339,12 +339,12 @@ pub mod test_util {
         request: &AggregationJobContinueReq,
         handler: &impl Handler,
         want_status: Status,
-    ) -> Option<trillium::Body> {
-        let mut test_conn = post_aggregation_job(task, aggregation_job_id, request, handler).await;
+    ) -> TestConn {
+        let test_conn = post_aggregation_job(task, aggregation_job_id, request, handler).await;
 
         assert_eq!(want_status, test_conn.status().unwrap());
 
-        test_conn.take_response_body()
+        test_conn
     }
 
     pub async fn post_aggregation_job_expecting_error(
@@ -356,7 +356,7 @@ pub mod test_util {
         want_error_type: &str,
         want_error_title: &str,
     ) {
-        let body = post_aggregation_job_expecting_status(
+        let mut test_conn = post_aggregation_job_expecting_status(
             task,
             aggregation_job_id,
             request,
@@ -364,6 +364,16 @@ pub mod test_util {
             want_status,
         )
         .await;
+
+        assert_eq!(
+            test_conn
+                .response_headers()
+                .get(KnownHeaderName::ContentType)
+                .unwrap(),
+            "application/problem+json"
+        );
+
+        let body = test_conn.take_response_body();
 
         let problem_details: serde_json::Value =
             serde_json::from_slice(&body.unwrap().into_bytes().await.unwrap()).unwrap();

--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -422,6 +422,13 @@ async fn collection_job_success_fixed_size() {
         .put_collection_job(&collection_job_id, &request)
         .await;
     assert_eq!(test_conn.status(), Some(Status::BadRequest));
+    assert_eq!(
+        test_conn
+            .response_headers()
+            .get(KnownHeaderName::ContentType)
+            .unwrap(),
+        "application/problem+json"
+    );
     let problem_details: serde_json::Value = serde_json::from_slice(
         &test_conn
             .take_response_body()

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -657,6 +657,13 @@ mod tests {
         let mut test_conn = get("/hpke_config").run_async(&handler).await;
         assert_eq!(test_conn.status(), Some(Status::BadRequest));
         assert_eq!(
+            test_conn
+                .response_headers()
+                .get(KnownHeaderName::ContentType)
+                .unwrap(),
+            "application/problem+json"
+        );
+        assert_eq!(
             take_problem_details(&mut test_conn).await,
             json!({
                 "status": 400u16,
@@ -672,6 +679,13 @@ mod tests {
         // Expected status and problem type should be per the protocol
         // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-02.html#section-4.3.1
         assert_eq!(test_conn.status(), Some(Status::BadRequest));
+        assert_eq!(
+            test_conn
+                .response_headers()
+                .get(KnownHeaderName::ContentType)
+                .unwrap(),
+            "application/problem+json"
+        );
         assert_eq!(
             take_problem_details(&mut test_conn).await,
             json!({
@@ -5401,6 +5415,13 @@ mod tests {
     }
 
     async fn take_problem_details(test_conn: &mut TestConn) -> serde_json::Value {
+        assert_eq!(
+            test_conn
+                .response_headers()
+                .get(KnownHeaderName::ContentType)
+                .unwrap(),
+            "application/problem+json"
+        );
         serde_json::from_slice(&take_response_body(test_conn).await).unwrap()
     }
 }


### PR DESCRIPTION
This fixes #1687 by ~~reordering two calls~~ updating trillium-api. ~~The `with_json()` method from an extension trait also sets the Content-Type header, so it was stomping on the previously-set header.~~ All tests that check problem details response bodies now also check the Content-Type header.