### PR TITLE
Minor aggregator API cleanup

### DIFF
--- a/aggregator_api/src/routes.rs
+++ b/aggregator_api/src/routes.rs
@@ -289,7 +289,7 @@ pub(super) async fn delete_task<C: Clock>(
     })
     .await
     .map_err(|err| match err {
-        datastore::Error::MutationTargetNotFound => Status::NotFound,
+        datastore::Error::MutationTargetNotFound => Status::NoContent,
         _ => {
             error!(err = %err, "Database transaction error");
             Status::InternalServerError
@@ -450,7 +450,7 @@ pub(super) async fn delete_global_hpke_config<C: Clock>(
     })
     .await
     .map_err(|err| match err {
-        datastore::Error::MutationTargetNotFound => Status::NotFound,
+        datastore::Error::MutationTargetNotFound => Status::NoContent,
         _ => {
             error!(err = %err, "Database transaction error");
             Status::InternalServerError

--- a/aggregator_api/src/routes.rs
+++ b/aggregator_api/src/routes.rs
@@ -24,7 +24,7 @@ use rand::random;
 use ring::digest::{digest, SHA256};
 use std::{str::FromStr, sync::Arc, unreachable};
 use tracing::{error, warn};
-use trillium::{Conn, Handler, Status};
+use trillium::{Conn, Status};
 use trillium_api::{Halt, Json, State};
 
 use url::Url;
@@ -53,7 +53,7 @@ pub(super) async fn get_config(
 pub(super) async fn get_task_ids<C: Clock>(
     conn: &mut Conn,
     State(ds): State<Arc<Datastore<C>>>,
-) -> Result<impl Handler, Status> {
+) -> Result<(Json<GetTaskIdsResp>, Halt), Status> {
     const PAGINATION_TOKEN_KEY: &str = "pagination_token";
     let lower_bound = querify(conn.querystring())
         .into_iter()
@@ -88,7 +88,7 @@ pub(super) async fn get_task_ids<C: Clock>(
 pub(super) async fn post_task<C: Clock>(
     _: &mut Conn,
     (State(ds), Json(req)): (State<Arc<Datastore<C>>>, Json<PostTaskReq>),
-) -> Result<impl Handler, Error> {
+) -> Result<Json<TaskResp>, Error> {
     // We have to resolve impedance mismatches between the aggregator API's view of a task and
     // `aggregator_core::task::Task`. For now, we deal with this in code, but someday the two
     // representations will be harmonized.
@@ -258,7 +258,7 @@ pub(super) async fn post_task<C: Clock>(
 pub(super) async fn get_task<C: Clock>(
     conn: &mut Conn,
     State(ds): State<Arc<Datastore<C>>>,
-) -> Result<impl Handler, Status> {
+) -> Result<Json<TaskResp>, Status> {
     let task_id = conn.task_id_param()?;
 
     let task = ds
@@ -281,7 +281,7 @@ pub(super) async fn get_task<C: Clock>(
 pub(super) async fn delete_task<C: Clock>(
     conn: &mut Conn,
     State(ds): State<Arc<Datastore<C>>>,
-) -> Result<impl Handler, Status> {
+) -> Result<Status, Status> {
     let task_id = conn.task_id_param()?;
 
     ds.run_tx_with_name("delete_task", |tx| {
@@ -302,7 +302,7 @@ pub(super) async fn delete_task<C: Clock>(
 pub(super) async fn get_task_metrics<C: Clock>(
     conn: &mut Conn,
     State(ds): State<Arc<Datastore<C>>>,
-) -> Result<impl Handler, Status> {
+) -> Result<Json<GetTaskMetricsResp>, Status> {
     let task_id = conn.task_id_param()?;
 
     let (reports, report_aggregations) = ds

--- a/aggregator_api/src/routes.rs
+++ b/aggregator_api/src/routes.rs
@@ -25,7 +25,7 @@ use ring::digest::{digest, SHA256};
 use std::{str::FromStr, sync::Arc, unreachable};
 use tracing::{error, warn};
 use trillium::{Conn, Status};
-use trillium_api::{Halt, Json, State};
+use trillium_api::{Json, State};
 
 use url::Url;
 
@@ -53,7 +53,7 @@ pub(super) async fn get_config(
 pub(super) async fn get_task_ids<C: Clock>(
     conn: &mut Conn,
     State(ds): State<Arc<Datastore<C>>>,
-) -> Result<(Json<GetTaskIdsResp>, Halt), Status> {
+) -> Result<Json<GetTaskIdsResp>, Status> {
     const PAGINATION_TOKEN_KEY: &str = "pagination_token";
     let lower_bound = querify(conn.querystring())
         .into_iter()
@@ -76,13 +76,10 @@ pub(super) async fn get_task_ids<C: Clock>(
         })?;
     let pagination_token = task_ids.last().cloned();
 
-    Ok((
-        Json(GetTaskIdsResp {
-            task_ids,
-            pagination_token,
-        }),
-        Halt,
-    ))
+    Ok(Json(GetTaskIdsResp {
+        task_ids,
+        pagination_token,
+    }))
 }
 
 pub(super) async fn post_task<C: Clock>(

--- a/aggregator_api/src/tests.rs
+++ b/aggregator_api/src/tests.rs
@@ -688,25 +688,25 @@ async fn delete_task() {
     .await
     .unwrap();
 
-    // Verify: deleting a task twice returns NotFound.
+    // Verify: deleting a task twice returns NoContent.
     assert_response!(
         delete(&format!("/tasks/{}", &task_id))
             .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
             .with_request_header("Accept", CONTENT_TYPE)
             .run_async(&handler)
             .await,
-        Status::NotFound,
+        Status::NoContent,
         "",
     );
 
-    // Verify: deleting an arbitrary nonexistent task ID returns NotFound.
+    // Verify: deleting an arbitrary nonexistent task ID returns NoContent.
     assert_response!(
         delete(&format!("/tasks/{}", &random::<TaskId>()))
             .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
             .with_request_header("Accept", CONTENT_TYPE)
             .run_async(&handler)
             .await,
-        Status::NotFound,
+        Status::NoContent,
         "",
     );
 
@@ -805,7 +805,7 @@ async fn get_task_metrics() {
 
     // Verify: requesting metrics on a nonexistent task returns NotFound.
     assert_response!(
-        delete(&format!("/tasks/{}", &random::<TaskId>()))
+        get(&format!("/tasks/{}/metrics", &random::<TaskId>()))
             .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
             .with_request_header("Accept", CONTENT_TYPE)
             .run_async(&handler)
@@ -1188,7 +1188,7 @@ async fn delete_global_hpke_config() {
             .with_request_header("Content-Type", CONTENT_TYPE)
             .run_async(&handler)
             .await,
-        Status::NotFound
+        Status::NoContent
     );
 
     // Verify: overflow u8.


### PR DESCRIPTION
- Deletion should return 204 on not found, not 404.

    Supports https://github.com/divviup/janus/issues/1691.

- Provide explicit return type in routes

    From conversation in https://github.com/divviup/janus/pull/1686#discussion_r1290401987.

- Remove needless Halt

    I'm not sure why this is here--no other routes use Halt in this manner (should they)?
