### PR TITLE
`release/0.subscriber-01`: Bump crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,7 +1818,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "janus_aggregator"
-version = "0.5.12"
+version = "0.5.12-subscriber-01.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1901,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "janus_aggregator_api"
-version = "0.5.12"
+version = "0.5.12-subscriber-01.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "janus_aggregator_core"
-version = "0.5.12"
+version = "0.5.12-subscriber-01.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1985,14 +1985,14 @@ dependencies = [
 
 [[package]]
 name = "janus_build_script_utils"
-version = "0.5.12"
+version = "0.5.12-subscriber-01.1"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "janus_client"
-version = "0.5.12"
+version = "0.5.12-subscriber-01.1"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -2015,7 +2015,7 @@ dependencies = [
 
 [[package]]
 name = "janus_collector"
-version = "0.5.12"
+version = "0.5.12-subscriber-01.1"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -2040,7 +2040,7 @@ dependencies = [
 
 [[package]]
 name = "janus_core"
-version = "0.5.12"
+version = "0.5.12-subscriber-01.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2084,7 +2084,7 @@ dependencies = [
 
 [[package]]
 name = "janus_integration_tests"
-version = "0.5.12"
+version = "0.5.12-subscriber-01.1"
 dependencies = [
  "anyhow",
  "backoff",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "janus_interop_binaries"
-version = "0.5.12"
+version = "0.5.12-subscriber-01.1"
 dependencies = [
  "anyhow",
  "backoff",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "janus_messages"
-version = "0.5.12"
+version = "0.5.12-subscriber-01.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2176,7 +2176,7 @@ dependencies = [
 
 [[package]]
 name = "janus_tools"
-version = "0.5.12"
+version = "0.5.12-subscriber-01.1"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://divviup.org"
 license = "MPL-2.0"
 repository = "https://github.com/divviup/janus"
 rust-version = "1.65.0"
-version = "0.5.12"
+version = "0.5.12-subscriber-01.1"
 
 [workspace.dependencies]
 anyhow = "1"
@@ -29,16 +29,16 @@ anyhow = "1"
 # https://docs.rs/chrono/latest/chrono/#duration
 chrono = { version = "0.4", default-features = false }
 itertools = "0.10"
-janus_aggregator = { version = "0.5", path = "aggregator" }
-janus_aggregator_api = { version = "0.5", path = "aggregator_api" }
-janus_aggregator_core = { version = "0.5", path = "aggregator_core" }
-janus_build_script_utils = { version = "0.5", path = "build_script_utils" }
-janus_client = { version = "0.5", path = "client" }
-janus_collector = { version = "0.5", path = "collector" }
-janus_core = { version = "0.5", path = "core" }
-janus_integration_tests = { version = "0.5", path = "integration_tests" }
-janus_interop_binaries = { version = "0.5", path = "interop_binaries" }
-janus_messages = { version = "0.5", path = "messages" }
+janus_aggregator = { version = "0.5.12-subscriber-01.1", path = "aggregator" }
+janus_aggregator_api = { version = "0.5.12-subscriber-01.1", path = "aggregator_api" }
+janus_aggregator_core = { version = "0.5.12-subscriber-01.1", path = "aggregator_core" }
+janus_build_script_utils = { version = "0.5.12-subscriber-01.1", path = "build_script_utils" }
+janus_client = { version = "0.5.12-subscriber-01.1", path = "client" }
+janus_collector = { version = "0.5.12-subscriber-01.1", path = "collector" }
+janus_core = { version = "0.5.12-subscriber-01.1", path = "core" }
+janus_integration_tests = { version = "0.5.12-subscriber-01.1", path = "integration_tests" }
+janus_interop_binaries = { version = "0.5.12-subscriber-01.1", path = "interop_binaries" }
+janus_messages = { version = "0.5.12-subscriber-01.1", path = "messages" }
 k8s-openapi = { version = "0.18.0", features = ["v1_24"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
 kube = { version = "0.82.2", default-features = false, features = ["client", "rustls-tls"] }
 opentelemetry = { version = "0.19", features = ["metrics"] }


### PR DESCRIPTION
Cargo versions must be SemVer compatible, which means that a version like `0.subscriber-01.1` is not valid, so instead we set `0.5.12-subscriber-01.1`. This reflects the release this branched from (`0.5.12`), the specific purpose of this series of releases (`subscriber-01`), and allows us to increment versions (`.1`).

What's unfortunate about this is that it doesn't match the git tags we were planning to cut (which look like `0.subscriber-01.1`). We don't publish crates from this release branch, so that might not matter: the Cargo version may only ever show up in log lines. However we could choose to change our tagging scheme to match the Cargo versions, at which point there would be a mismatch with the branch name.