### PR TITLE
Release Janus 0.5.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,7 +1818,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "janus_aggregator"
-version = "0.5.14"
+version = "0.5.16"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1901,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "janus_aggregator_api"
-version = "0.5.14"
+version = "0.5.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "janus_aggregator_core"
-version = "0.5.14"
+version = "0.5.16"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1985,14 +1985,14 @@ dependencies = [
 
 [[package]]
 name = "janus_build_script_utils"
-version = "0.5.14"
+version = "0.5.16"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "janus_client"
-version = "0.5.14"
+version = "0.5.16"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -2015,7 +2015,7 @@ dependencies = [
 
 [[package]]
 name = "janus_collector"
-version = "0.5.14"
+version = "0.5.16"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -2040,7 +2040,7 @@ dependencies = [
 
 [[package]]
 name = "janus_core"
-version = "0.5.14"
+version = "0.5.16"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2084,7 +2084,7 @@ dependencies = [
 
 [[package]]
 name = "janus_integration_tests"
-version = "0.5.14"
+version = "0.5.16"
 dependencies = [
  "anyhow",
  "backoff",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "janus_interop_binaries"
-version = "0.5.14"
+version = "0.5.16"
 dependencies = [
  "anyhow",
  "backoff",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "janus_messages"
-version = "0.5.14"
+version = "0.5.16"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2176,7 +2176,7 @@ dependencies = [
 
 [[package]]
 name = "janus_tools"
-version = "0.5.14"
+version = "0.5.16"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://divviup.org"
 license = "MPL-2.0"
 repository = "https://github.com/divviup/janus"
 rust-version = "1.65.0"
-version = "0.5.14"
+version = "0.5.16"
 
 [workspace.dependencies]
 anyhow = "1"


### PR DESCRIPTION
We go to 0.5.16 because I forgot to bump the crate version before cutting a GitHub release and burned 0.5.15.