### PR TITLE
Release Janus `0.subscriber-01.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1746,7 +1746,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "janus_aggregator"
-version = "0.5.12-subscriber-01.1"
+version = "0.5.12-subscriber-01.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "janus_aggregator_api"
-version = "0.5.12-subscriber-01.1"
+version = "0.5.12-subscriber-01.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "janus_aggregator_core"
-version = "0.5.12-subscriber-01.1"
+version = "0.5.12-subscriber-01.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1912,14 +1912,14 @@ dependencies = [
 
 [[package]]
 name = "janus_build_script_utils"
-version = "0.5.12-subscriber-01.1"
+version = "0.5.12-subscriber-01.2"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "janus_client"
-version = "0.5.12-subscriber-01.1"
+version = "0.5.12-subscriber-01.2"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "janus_collector"
-version = "0.5.12-subscriber-01.1"
+version = "0.5.12-subscriber-01.2"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -1965,7 +1965,7 @@ dependencies = [
 
 [[package]]
 name = "janus_core"
-version = "0.5.12-subscriber-01.1"
+version = "0.5.12-subscriber-01.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2008,7 +2008,7 @@ dependencies = [
 
 [[package]]
 name = "janus_integration_tests"
-version = "0.5.12-subscriber-01.1"
+version = "0.5.12-subscriber-01.2"
 dependencies = [
  "anyhow",
  "backoff",
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "janus_interop_binaries"
-version = "0.5.12-subscriber-01.1"
+version = "0.5.12-subscriber-01.2"
 dependencies = [
  "anyhow",
  "backoff",
@@ -2080,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "janus_messages"
-version = "0.5.12-subscriber-01.1"
+version = "0.5.12-subscriber-01.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "janus_tools"
-version = "0.5.12-subscriber-01.1"
+version = "0.5.12-subscriber-01.2"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://divviup.org"
 license = "MPL-2.0"
 repository = "https://github.com/divviup/janus"
 rust-version = "1.65.0"
-version = "0.5.12-subscriber-01.1"
+version = "0.5.12-subscriber-01.2"
 
 [workspace.dependencies]
 anyhow = "1"
@@ -29,16 +29,16 @@ anyhow = "1"
 # https://docs.rs/chrono/latest/chrono/#duration
 chrono = { version = "0.4", default-features = false }
 itertools = "0.10"
-janus_aggregator = { version = "0.5.12-subscriber-01.1", path = "aggregator" }
-janus_aggregator_api = { version = "0.5.12-subscriber-01.1", path = "aggregator_api" }
-janus_aggregator_core = { version = "0.5.12-subscriber-01.1", path = "aggregator_core" }
-janus_build_script_utils = { version = "0.5.12-subscriber-01.1", path = "build_script_utils" }
-janus_client = { version = "0.5.12-subscriber-01.1", path = "client" }
-janus_collector = { version = "0.5.12-subscriber-01.1", path = "collector" }
-janus_core = { version = "0.5.12-subscriber-01.1", path = "core" }
-janus_integration_tests = { version = "0.5.12-subscriber-01.1", path = "integration_tests" }
-janus_interop_binaries = { version = "0.5.12-subscriber-01.1", path = "interop_binaries" }
-janus_messages = { version = "0.5.12-subscriber-01.1", path = "messages" }
+janus_aggregator = { version = "0.5.12-subscriber-01.2", path = "aggregator" }
+janus_aggregator_api = { version = "0.5.12-subscriber-01.2", path = "aggregator_api" }
+janus_aggregator_core = { version = "0.5.12-subscriber-01.2", path = "aggregator_core" }
+janus_build_script_utils = { version = "0.5.12-subscriber-01.2", path = "build_script_utils" }
+janus_client = { version = "0.5.12-subscriber-01.2", path = "client" }
+janus_collector = { version = "0.5.12-subscriber-01.2", path = "collector" }
+janus_core = { version = "0.5.12-subscriber-01.2", path = "core" }
+janus_integration_tests = { version = "0.5.12-subscriber-01.2", path = "integration_tests" }
+janus_interop_binaries = { version = "0.5.12-subscriber-01.2", path = "interop_binaries" }
+janus_messages = { version = "0.5.12-subscriber-01.2", path = "messages" }
 k8s-openapi = { version = "0.18.0", features = ["v1_24"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
 kube = { version = "0.82.2", default-features = false, features = ["client", "rustls-tls"] }
 opentelemetry = { version = "0.20", features = ["metrics"] }


### PR DESCRIPTION
a.k.a. `0.5.12-subscriber-01.2` for the crate version