### PR TITLE
Support for publishing SQL schema from scratch, and publishing from a branch

### DIFF
--- a/.github/workflows/publish-sql-schema.yml
+++ b/.github/workflows/publish-sql-schema.yml
@@ -25,36 +25,56 @@ jobs:
       with:
         workload_identity_provider: ${{ vars.GCP_ARTIFACT_PUBLISHER_WORKLOAD_IDENTITY_PROVIDER }}
         service_account: ${{ vars.GCP_ARTIFACT_PUBLISHER_DEPLOY_SERVICE_ACCOUNT }}
+        create_credentials_file: true
+        export_environment_variables: true
+    - name: Configure rclone
+      run: |
+        sudo apt-get install rclone
+        mkdir -p ~/.config/rclone
+        cat >~/.config/rclone/rclone.conf <<-EOF
+          [gs]
+          type = google cloud storage
+          env_auth = true
+          bucket_policy_only = true
+        EOF
     - name: Get the version
       id: get_version
       run: |
-        VERSION=${GITHUB_REF/refs\/tags\//}
-        echo "minor_version=$(echo ${VERSION} | awk -F'.' '{if (NF != 3) {exit 1}; printf "%s.%s", $1, $2}')" >> $GITHUB_OUTPUT
+        if grep -P "^refs/tags/" <<<"$GITHUB_REF" >/dev/null; then
+          VERSION=${GITHUB_REF/refs\/tags\//}
+          MINOR_VERSION="$(echo "$VERSION" | awk -F'.' '{if (NF != 3) {exit 1}; printf "%s.%s", $1, $2}')"
+          echo "version=$MINOR_VERSION" >>"$GITHUB_OUTPUT"
+        elif grep -P "^refs/heads/" <<<"$GITHUB_REF" >/dev/null; then
+          BRANCH=${GITHUB_REF/refs\/heads\//}
+          echo "version=$BRANCH" >>"$GITHUB_OUTPUT"
+        else
+          echo "Unable to parse version information"
+          exit 1
+        fi
     - name: Check validity of migrations
       uses: "./.github/actions/validate-migrations"
     - name: Check that existing migrations have not changed
       if: '!inputs.force'
       run: |
         TEMP=$(mktemp -d)
-        gcloud alpha storage cp --recursive \
-          "gs://janus-artifacts-sql-schemas/${{ steps.get_version.outputs.minor_version }}/db" \
+        rclone copy --verbose \
+          "gs:/janus-artifacts-sql-schemas/${{ steps.get_version.outputs.version }}/db/" \
           "$TEMP"
 
         # --diff-filter=a includes all differences except added files.
-        if ! git diff --no-index --diff-filter=a "$TEMP/db" "./db"; then
+        if ! git diff --no-index --diff-filter=a "$TEMP/" "./db"; then
           echo "fatal: migrations cannot be modified or removed, only added"
           exit 1
         fi
     - name: "Upload schema file(s)"
       if: '!inputs.force'
       run: |-
-        gcloud alpha storage cp --recursive --no-clobber \
-          db \
-          gs://janus-artifacts-sql-schemas/${{ steps.get_version.outputs.minor_version }}/
+        rclone copy --ignore-existing --verbose \
+          "db/" \
+          "gs://janus-artifacts-sql-schemas/${{ steps.get_version.outputs.version }}/db/"
     - name: "Overwrite schema file(s)"
       if: inputs.force
       run: |-
-        gcloud alpha storage rm --recursive gs://janus-artifacts-sql-schemas/${{ steps.get_version.outputs.minor_version }}/
-        gcloud alpha storage cp --recursive \
-          db \
-          gs://janus-artifacts-sql-schemas/${{ steps.get_version.outputs.minor_version }}/
+        rclone sync --verbose \
+          "db/" \
+          "gs://janus-artifacts-sql-schemas/${{ steps.get_version.outputs.version }}/db/"


### PR DESCRIPTION
Fixes https://github.com/divviup/janus/issues/1735.

Appropriately handle the case where we're starting a new release and need to have the migrations directory created. The force flag is not required for this operation (nor should it IMO).

I also fix the job to allow us deploying from a branch, in which case the directory will just be the branch name. This is mainly for testing this PR but I can see it being useful in niche circumstances.

To cleanly accomplish this I replace `gcloud` with `rclone`, for a few reasons:
- `rclone` is a stable interface, `gcloud alpha` is not.
- `rclone` has more predictable and favorable semantics, i.e. we don't need any special handling for the case where the remote migrations directory doesn't exist.
- `gcloud alpha` doesn't have a directory existence test function, nor does it provide any sensible way of parsing the kind of error that occurs. So to ignore a missing remote directory we have to do `|| true` or do `if grep "not found" <<<$OUTPUT`, neither of which are very good solutions.

<details open>
<summary>
Expand for details on the testing I did for this:
</summary>

- Setting up schema from scratch https://github.com/divviup/janus/actions/runs/5906546433/job/16022784957.
  ```
  🐧 rclone ls --verbose gs:/janus-artifacts-sql-schemas | grep inahga/test
       1734 inahga/test-1735/db/00000000000001_initial_schema.down.sql
      24634 inahga/test-1735/db/00000000000001_initial_schema.up.sql
  ```
- Add new migration to existing schema https://github.com/divviup/janus/actions/runs/5906561538/job/16022835739
  ```
  🐧 rclone ls --verbose gs:/janus-artifacts-sql-schemas | grep inahga/test
       1734 inahga/test-1735/db/00000000000001_initial_schema.down.sql
      24634 inahga/test-1735/db/00000000000001_initial_schema.up.sql
          4 inahga/test-1735/db/00000000000002_foo.down.sql
          4 inahga/test-1735/db/00000000000002_foo.up.sql
  ```
- Attempt modifying existing schema, fails as expected. https://github.com/divviup/janus/actions/runs/5906574446/job/1602287765. (output was same as above).
- I assert that I know what I'm doing, and force the migration to continue anyway with the `force` flag. https://github.com/divviup/janus/actions/runs/5906628503/job/16023031038
  ```
  🐧 rclone ls --verbose gs:/janus-artifacts-sql-schemas | grep inahga/test
       1734 inahga/test-1735/db/00000000000001_initial_schema.down.sql
          4 inahga/test-1735/db/00000000000001_initial_schema.up.sql
          4 inahga/test-1735/db/00000000000002_foo.down.sql
          4 inahga/test-1735/db/00000000000002_foo.up.sql
  ```
- Isolation test that asserts the version parsing changes haven't broken anything:
  ```bash
  🐧 cat test.sh
  #!/usr/bin/env bash
  
  if grep -P "^refs/tags/" <<<"$GITHUB_REF" >/dev/null; then
          VERSION=${GITHUB_REF/refs\/tags\//}
          MINOR_VERSION="$(echo "$VERSION" | awk -F'.' '{if (NF != 3) {exit 1}; printf "%s.%s", $1, $2}')"
          echo "version=$MINOR_VERSION"
  elif grep -P "^refs/heads/" <<<"$GITHUB_REF" >/dev/null; then
          BRANCH=${GITHUB_REF/refs\/heads\//}
          echo "version=$BRANCH"
  else
          echo "Unable to parse version information"
          exit 1
  fi
  
  🐧 GITHUB_REF=refs/tags/0.1.2 ./test.sh
  version=0.1
  🐧 GITHUB_REF=refs/tags/0.subscriber-01.2 ./test.sh
  version=0.subscriber-01
  🐧 GITHUB_REF=refs/heads/inahga/test ./test.sh
  version=inahga/test
  🐧 GITHUB_REF=refs/heads/inahga/test/foo/bar ./test.sh
  version=inahga/test/foo/bar
  🐧 GITHUB_REF=refs/heads/branch ./test.sh
  version=branch
  🐧 GITHUB_REF=idk/wtf ./test.sh
  Unable to parse version information
  ```