### PR TITLE
Metrics name/unit fixes, subscriber-01

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -49,7 +49,7 @@ use janus_messages::{
     PrepareStepResult, Report, ReportIdChecksum, ReportShare, ReportShareError, Role, TaskId,
 };
 use opentelemetry::{
-    metrics::{Counter, Histogram, Meter},
+    metrics::{Counter, Histogram, Meter, Unit},
     KeyValue,
 };
 #[cfg(feature = "test-util")]
@@ -105,6 +105,7 @@ pub(crate) fn aggregate_step_failure_counter(meter: &Meter) -> Counter<u64> {
             "Failures while stepping aggregation jobs; these failures are ",
             "related to individual client reports rather than entire aggregation jobs."
         ))
+        .with_unit(Unit::new("{error}"))
         .init();
 
     // Initialize counters with desired status labels. This causes Prometheus to see the first
@@ -215,12 +216,14 @@ impl<C: Clock> Aggregator<C> {
         let upload_decrypt_failure_counter = meter
             .u64_counter("janus_upload_decrypt_failures")
             .with_description("Number of decryption failures in the /upload endpoint.")
+            .with_unit(Unit::new("{error}"))
             .init();
         upload_decrypt_failure_counter.add(0, &[]);
 
         let upload_decode_failure_counter = meter
             .u64_counter("janus_upload_decode_failures")
             .with_description("Number of message decode failures in the /upload endpoint.")
+            .with_unit(Unit::new("{error}"))
             .init();
         upload_decode_failure_counter.add(0, &[]);
 

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -88,13 +88,13 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
             .meter
             .f64_histogram("janus_task_update_time")
             .with_description("Time spent updating tasks.")
-            .with_unit(Unit::new("seconds"))
+            .with_unit(Unit::new("s"))
             .init();
         let job_creation_time_histogram = self
             .meter
             .f64_histogram("janus_job_creation_time")
             .with_description("Time spent creating aggregation jobs.")
-            .with_unit(Unit::new("seconds"))
+            .with_unit(Unit::new("s"))
             .init();
 
         // Set up an interval to occasionally update our view of tasks in the DB.

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -62,12 +62,14 @@ impl AggregationJobDriver {
         let job_cancel_counter = meter
             .u64_counter("janus_job_cancellations")
             .with_description("Count of cancelled jobs.")
+            .with_unit(Unit::new("{job}"))
             .init();
         job_cancel_counter.add(0, &[]);
 
         let job_retry_counter = meter
             .u64_counter("janus_job_retries")
             .with_description("Count of retried job steps.")
+            .with_unit(Unit::new("{step}"))
             .init();
         job_retry_counter.add(0, &[]);
 

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -76,7 +76,7 @@ impl AggregationJobDriver {
             .with_description(
                 "The amount of time elapsed while making an HTTP request to a helper.",
             )
-            .with_unit(Unit::new("seconds"))
+            .with_unit(Unit::new("s"))
             .init();
 
         AggregationJobDriver {

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -448,7 +448,7 @@ impl CollectionJobDriverMetrics {
             .with_description(
                 "The amount of time elapsed while making an HTTP request to a helper.",
             )
-            .with_unit(Unit::new("seconds"))
+            .with_unit(Unit::new("s"))
             .init();
 
         let jobs_abandoned_counter = meter

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -440,6 +440,7 @@ impl CollectionJobDriverMetrics {
         let jobs_finished_counter = meter
             .u64_counter("janus_collection_jobs_finished")
             .with_description("Count of finished collection jobs.")
+            .with_unit(Unit::new("{job}"))
             .init();
         jobs_finished_counter.add(0, &[]);
 
@@ -454,6 +455,7 @@ impl CollectionJobDriverMetrics {
         let jobs_abandoned_counter = meter
             .u64_counter("janus_collection_jobs_abandoned")
             .with_description("Count of abandoned collection jobs.")
+            .with_unit(Unit::new("{job}"))
             .init();
         jobs_abandoned_counter.add(0, &[]);
 
@@ -463,6 +465,7 @@ impl CollectionJobDriverMetrics {
                 "Count of collection jobs for which a lease was acquired but were already \
                  finished.",
             )
+            .with_unit(Unit::new("{job}"))
             .init();
         jobs_already_finished_counter.add(0, &[]);
 
@@ -472,6 +475,7 @@ impl CollectionJobDriverMetrics {
                 "Count of collection jobs that were run to completion but found to have been \
                  deleted.",
             )
+            .with_unit(Unit::new("{job}"))
             .init();
         deleted_jobs_encountered_counter.add(0, &[]);
 
@@ -481,12 +485,14 @@ impl CollectionJobDriverMetrics {
                 "Count of collection jobs that were run to completion but found in an unexpected \
                  state.",
             )
+            .with_unit(Unit::new("{job}"))
             .init();
         unexpected_job_state_counter.add(0, &[]);
 
         let job_steps_retried_counter = meter
             .u64_counter("janus_job_retries")
             .with_description("Count of retried job steps.")
+            .with_unit(Unit::new("{step}"))
             .init();
         job_steps_retried_counter.add(0, &[]);
 

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -16,7 +16,7 @@ use janus_messages::{
     Report, TaskId,
 };
 use opentelemetry::{
-    metrics::{Counter, Meter},
+    metrics::{Counter, Meter, Unit},
     KeyValue,
 };
 use prio::codec::{Decode, Encode};
@@ -175,6 +175,7 @@ impl StatusCounter {
                 .with_description(
                     "Count of requests handled by the aggregator, by method, route, and response status.",
                 )
+                .with_unit(Unit::new("{request}"))
                 .init(),
         )
     }

--- a/aggregator/src/aggregator/problem_details.rs
+++ b/aggregator/src/aggregator/problem_details.rs
@@ -72,6 +72,7 @@ mod tests {
         problem_type::{DapProblemType, DapProblemTypeParseError},
         Duration, HpkeConfigId, Interval, ReportIdChecksum,
     };
+    use opentelemetry::metrics::Unit;
     use rand::random;
     use reqwest::Client;
     use std::{borrow::Cow, sync::Arc};
@@ -103,7 +104,8 @@ mod tests {
     #[tokio::test]
     async fn problem_details_round_trip() {
         let request_histogram = noop_meter()
-            .f64_histogram("janus_http_request_duration_seconds")
+            .f64_histogram("janus_http_request_duration")
+            .with_unit(Unit::new("s"))
             .init();
 
         struct TestCase {

--- a/aggregator/src/binary_utils/job_driver.rs
+++ b/aggregator/src/binary_utils/job_driver.rs
@@ -106,13 +106,13 @@ where
             .meter
             .f64_histogram("janus_job_acquire_time")
             .with_description("Time spent acquiring jobs.")
-            .with_unit(Unit::new("seconds"))
+            .with_unit(Unit::new("s"))
             .init();
         let job_step_time_histogram = self
             .meter
             .f64_histogram("janus_job_step_time")
             .with_description("Time spent stepping jobs.")
-            .with_unit(Unit::new("seconds"))
+            .with_unit(Unit::new("s"))
             .init();
 
         // Set up state for the job driver run.

--- a/aggregator/src/metrics.rs
+++ b/aggregator/src/metrics.rs
@@ -18,13 +18,13 @@ use {
 
 #[cfg(feature = "otlp")]
 use {
-    opentelemetry::{runtime::Tokio, sdk::metrics::MeterProvider},
+    opentelemetry::runtime::Tokio,
     opentelemetry_otlp::WithExportConfig,
     tonic::metadata::{MetadataKey, MetadataMap, MetadataValue},
 };
 
 #[cfg(any(feature = "otlp", feature = "prometheus"))]
-use std::str::FromStr;
+use {opentelemetry::sdk::metrics::MeterProvider, std::str::FromStr};
 
 /// Errors from initializing metrics provider, registry, and exporter.
 #[derive(Debug, thiserror::Error)]

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -164,6 +164,7 @@ impl<C: Clock> Datastore<C> {
         let transaction_status_counter = meter
             .u64_counter("janus_database_transactions")
             .with_description("Count of database transactions run, with their status.")
+            .with_unit(Unit::new("{transaction}"))
             .init();
         let rollback_error_counter = meter
             .u64_counter("janus_database_rollback_errors")
@@ -171,6 +172,7 @@ impl<C: Clock> Datastore<C> {
                 "Count of errors received when rolling back a database transaction, ",
                 "with their PostgreSQL error code.",
             ))
+            .with_unit(Unit::new("{error}"))
             .init();
         let transaction_duration_histogram = meter
             .f64_histogram("janus_database_transaction_duration")

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -29,7 +29,7 @@ use janus_messages::{
     Time,
 };
 use opentelemetry::{
-    metrics::{Counter, Histogram, Meter},
+    metrics::{Counter, Histogram, Meter, Unit},
     KeyValue,
 };
 use postgres_types::{FromSql, Json, ToSql};
@@ -173,8 +173,9 @@ impl<C: Clock> Datastore<C> {
             ))
             .init();
         let transaction_duration_histogram = meter
-            .f64_histogram("janus_database_transaction_duration_seconds")
+            .f64_histogram("janus_database_transaction_duration")
             .with_description("Duration of database transactions.")
+            .with_unit(Unit::new("s"))
             .init();
 
         Self {


### PR DESCRIPTION
This backports #1788 to the subscriber-01 branch.