### PR TITLE
More aggregator test cleanup 

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/aggregation_job_continue.rs
@@ -284,7 +284,7 @@ pub mod test_util {
     use prio::codec::Encode;
     use serde_json::json;
     use trillium::{Handler, KnownHeaderName, Status};
-    use trillium_testing::{prelude::post, TestConn};
+    use trillium_testing::{assert_headers, prelude::post, TestConn};
 
     async fn post_aggregation_job(
         task: &Task,
@@ -315,13 +315,7 @@ pub mod test_util {
         let mut test_conn = post_aggregation_job(task, aggregation_job_id, request, handler).await;
 
         assert_eq!(test_conn.status(), Some(Status::Ok));
-        assert_eq!(
-            test_conn
-                .response_headers()
-                .get(KnownHeaderName::ContentType)
-                .unwrap(),
-            AggregationJobResp::MEDIA_TYPE
-        );
+        assert_headers!(&test_conn, "content-type" => (AggregationJobResp::MEDIA_TYPE));
         decode_response_body::<AggregationJobResp>(&mut test_conn).await
     }
 
@@ -357,13 +351,6 @@ pub mod test_util {
         )
         .await;
 
-        assert_eq!(
-            test_conn
-                .response_headers()
-                .get(KnownHeaderName::ContentType)
-                .unwrap(),
-            "application/problem+json"
-        );
         assert_eq!(
             take_problem_details(&mut test_conn).await,
             json!({

--- a/aggregator/src/aggregator/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/aggregation_job_continue.rs
@@ -278,10 +278,10 @@ impl VdafOps {
 #[cfg(feature = "test-util")]
 #[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
 pub mod test_util {
-    use crate::aggregator::http_handlers::test_util::{take_problem_details, take_response_body};
+    use crate::aggregator::http_handlers::test_util::{decode_response_body, take_problem_details};
     use janus_aggregator_core::task::Task;
     use janus_messages::{AggregationJobContinueReq, AggregationJobId, AggregationJobResp};
-    use prio::codec::{Decode, Encode};
+    use prio::codec::Encode;
     use serde_json::json;
     use trillium::{Handler, KnownHeaderName, Status};
     use trillium_testing::{prelude::post, TestConn};
@@ -322,8 +322,7 @@ pub mod test_util {
                 .unwrap(),
             AggregationJobResp::MEDIA_TYPE
         );
-        let body_bytes = take_response_body(&mut test_conn).await;
-        AggregationJobResp::get_decoded(&body_bytes).unwrap()
+        decode_response_body::<AggregationJobResp>(&mut test_conn).await
     }
 
     pub async fn post_aggregation_job_expecting_status(

--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -1,7 +1,7 @@
 use crate::aggregator::{
     http_handlers::{
         aggregator_handler,
-        test_util::{take_problem_details, take_response_body},
+        test_util::{decode_response_body, take_problem_details},
     },
     Config,
 };
@@ -361,8 +361,7 @@ async fn collection_job_success_fixed_size() {
                 .unwrap(),
             Collection::<FixedSize>::MEDIA_TYPE
         );
-        let body_bytes = take_response_body(&mut test_conn).await;
-        let collect_resp = Collection::<FixedSize>::get_decoded(body_bytes.as_ref()).unwrap();
+        let collect_resp: Collection<FixedSize> = decode_response_body(&mut test_conn).await;
 
         assert_eq!(
             collect_resp.report_count(),

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -2,7 +2,7 @@ use crate::{
     aggregator::{
         http_handlers::{
             aggregator_handler,
-            test_util::{take_problem_details, take_response_body},
+            test_util::{decode_response_body, take_problem_details},
         },
         tests::generate_helper_report_share,
         Config,
@@ -287,8 +287,7 @@ async fn taskprov_aggregate_init() {
         &test_conn,
         "content-type" => (AggregationJobResp::MEDIA_TYPE)
     );
-    let body_bytes = take_response_body(&mut test_conn).await;
-    let aggregate_resp = AggregationJobResp::get_decoded(&body_bytes).unwrap();
+    let aggregate_resp: AggregationJobResp = decode_response_body(&mut test_conn).await;
 
     assert_eq!(aggregate_resp.prepare_steps().len(), 1);
     let prepare_step = aggregate_resp.prepare_steps().get(0).unwrap();
@@ -812,8 +811,7 @@ async fn taskprov_aggregate_continue() {
             .unwrap(),
         AggregationJobResp::MEDIA_TYPE
     );
-    let body_bytes = take_response_body(&mut test_conn).await;
-    let aggregate_resp = AggregationJobResp::get_decoded(&body_bytes).unwrap();
+    let aggregate_resp: AggregationJobResp = decode_response_body(&mut test_conn).await;
 
     // We'll only validate the response. Taskprov doesn't touch functionality beyond the authorization
     // of the request.
@@ -931,8 +929,7 @@ async fn taskprov_aggregate_share() {
         &test_conn,
         "content-type" => (AggregateShareMessage::MEDIA_TYPE)
     );
-    let body_bytes = take_response_body(&mut test_conn).await;
-    let aggregate_share_resp = AggregateShareMessage::get_decoded(&body_bytes).unwrap();
+    let aggregate_share_resp: AggregateShareMessage = decode_response_body(&mut test_conn).await;
 
     hpke::open(
         test.collector_hpke_keypair.config(),
@@ -983,8 +980,7 @@ async fn end_to_end() {
 
     assert_eq!(test_conn.status(), Some(Status::Ok));
     assert_headers!(&test_conn, "content-type" => (AggregationJobResp::MEDIA_TYPE));
-    let body_bytes = take_response_body(&mut test_conn).await;
-    let aggregation_job_resp = AggregationJobResp::get_decoded(&body_bytes).unwrap();
+    let aggregation_job_resp: AggregationJobResp = decode_response_body(&mut test_conn).await;
 
     assert_eq!(aggregation_job_resp.prepare_steps().len(), 1);
     let prepare_step = &aggregation_job_resp.prepare_steps()[0];
@@ -1027,8 +1023,7 @@ async fn end_to_end() {
 
     assert_eq!(test_conn.status(), Some(Status::Ok));
     assert_headers!(&test_conn, "content-type" => (AggregationJobResp::MEDIA_TYPE));
-    let body_bytes = take_response_body(&mut test_conn).await;
-    let aggregation_job_resp = AggregationJobResp::get_decoded(&body_bytes).unwrap();
+    let aggregation_job_resp: AggregationJobResp = decode_response_body(&mut test_conn).await;
 
     assert_eq!(aggregation_job_resp.prepare_steps().len(), 1);
     let prepare_step = &aggregation_job_resp.prepare_steps()[0];
@@ -1059,8 +1054,7 @@ async fn end_to_end() {
 
     assert_eq!(test_conn.status(), Some(Status::Ok));
     assert_headers!(&test_conn, "content-type" => (AggregateShareMessage::MEDIA_TYPE));
-    let body_bytes = take_response_body(&mut test_conn).await;
-    let aggregate_share_resp = AggregateShareMessage::get_decoded(&body_bytes).unwrap();
+    let aggregate_share_resp: AggregateShareMessage = decode_response_body(&mut test_conn).await;
 
     let plaintext = hpke::open(
         test.collector_hpke_keypair.config(),

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -804,13 +804,7 @@ async fn taskprov_aggregate_continue() {
     .await;
 
     assert_eq!(test_conn.status(), Some(Status::Ok));
-    assert_eq!(
-        test_conn
-            .response_headers()
-            .get(KnownHeaderName::ContentType)
-            .unwrap(),
-        AggregationJobResp::MEDIA_TYPE
-    );
+    assert_headers!(&test_conn, "content-type" => (AggregationJobResp::MEDIA_TYPE));
     let aggregate_resp: AggregationJobResp = decode_response_body(&mut test_conn).await;
 
     // We'll only validate the response. Taskprov doesn't touch functionality beyond the authorization


### PR DESCRIPTION
Follow up to https://github.com/divviup/janus/pull/1765#discussion_r1300693529.

Also noticed some places where we could use `assert_headers!` instead of manually checking headers. 