### PR TITLE
Account max_batch_query_count against distinct requests.

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -76,6 +76,7 @@ use std::{
     borrow::Borrow,
     collections::{hash_map::Entry, HashMap, HashSet},
     fmt::Debug,
+    hash::Hash,
     panic,
     sync::Arc,
     time::{Duration as StdDuration, Instant},
@@ -2165,7 +2166,7 @@ impl VdafOps {
         req_bytes: &[u8],
     ) -> Result<(), Error>
     where
-        A::AggregationParam: 'static + Send + Sync + PartialEq + Eq,
+        A::AggregationParam: 'static + Send + Sync + PartialEq + Eq + Hash,
         A::AggregateShare: Send + Sync,
     {
         let req = Arc::new(CollectionReq::<Q>::get_decoded(req_bytes)?);
@@ -2236,7 +2237,8 @@ impl VdafOps {
                             tx,
                             &vdaf,
                             &task,
-                            &collection_identifier
+                            &collection_identifier,
+                            &aggregation_param,
                         ),
                         Q::count_client_reports(tx, &task, &collection_identifier),
                         try_join_all(
@@ -2729,7 +2731,7 @@ impl VdafOps {
         collector_hpke_config: &HpkeConfig,
     ) -> Result<AggregateShare, Error>
     where
-        A::AggregationParam: Send + Sync,
+        A::AggregationParam: Send + Sync + Eq + Hash,
         A::AggregateShare: Send + Sync,
     {
         // Decode request, and verify that it is for the current task. We use an assert to check
@@ -2816,6 +2818,7 @@ impl VdafOps {
                                     vdaf.as_ref(),
                                     &task,
                                     aggregate_share_req.batch_selector().batch_identifier(),
+                                    &aggregation_param,
                                 )
                             )?;
 

--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -33,7 +33,7 @@ use janus_messages::{
 use prio::codec::{Decode, Encode};
 use rand::random;
 use serde_json::json;
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 use trillium::{Handler, KnownHeaderName, Status};
 use trillium_testing::{
     prelude::{post, put},
@@ -487,6 +487,65 @@ async fn collection_job_put_idempotence_time_interval() {
                     .unwrap();
                 assert_eq!(collection_jobs.len(), 1);
                 assert_eq!(collection_jobs[0].id(), &collection_job_id);
+
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn collection_job_put_idempotence_time_interval_varied_collection_id() {
+    // This test sends repeated, identical collection requests with differing collection job IDs and
+    // validates that they are accepted. They should be accepted because calculation of the query
+    // count for max_batch_query_count testing is based on the number of distinct aggregation
+    // parameters that the batch has been collected against.
+
+    let test_case = setup_collection_job_test_case(Role::Leader, QueryType::TimeInterval).await;
+
+    let collection_job_ids = HashSet::from(random::<[CollectionJobId; 2]>());
+    let request = CollectionReq::new(
+        Query::new_time_interval(
+            Interval::new(
+                Time::from_seconds_since_epoch(0),
+                *test_case.task.time_precision(),
+            )
+            .unwrap(),
+        ),
+        AggregationParam::default().get_encoded(),
+    );
+
+    for collection_job_id in &collection_job_ids {
+        let response = test_case
+            .put_collection_job(collection_job_id, &request)
+            .await;
+        assert_eq!(response.status(), Some(Status::Created));
+    }
+
+    test_case
+        .datastore
+        .run_tx(|tx| {
+            let task_id = *test_case.task.id();
+            let collection_job_ids = collection_job_ids.clone();
+
+            Box::pin(async move {
+                let collection_jobs = tx
+                    .get_collection_jobs_for_task::<0, TimeInterval, dummy_vdaf::Vdaf>(
+                        &dummy_vdaf::Vdaf::new(),
+                        &task_id,
+                    )
+                    .await
+                    .unwrap();
+
+                assert_eq!(collection_jobs.len(), 2);
+                assert_eq!(
+                    collection_jobs
+                        .into_iter()
+                        .map(|job| *job.id())
+                        .collect::<HashSet<_>>(),
+                    collection_job_ids
+                );
 
                 Ok(())
             })

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -1084,6 +1084,11 @@ impl<const SEED_SIZE: usize, Q: QueryType, A: vdaf::Aggregator<SEED_SIZE, 16>>
         &self.aggregation_parameter
     }
 
+    /// Takes the aggregation parameter associated with this collection job, consuming the job.
+    pub fn take_aggregation_parameter(self) -> A::AggregationParam {
+        self.aggregation_parameter
+    }
+
     /// Returns the state associated with this collection job.
     pub fn state(&self) -> &CollectionJobState<SEED_SIZE, A> {
         &self.state
@@ -1301,6 +1306,11 @@ impl<const SEED_SIZE: usize, Q: QueryType, A: vdaf::Aggregator<SEED_SIZE, 16>>
     /// Gets the aggregation parameter associated with this aggregate share job.
     pub fn aggregation_parameter(&self) -> &A::AggregationParam {
         &self.aggregation_parameter
+    }
+
+    /// Takes the aggregation parameter associated with this aggregate share job, consuming the job.
+    pub fn take_aggregation_parameter(self) -> A::AggregationParam {
+        self.aggregation_parameter
     }
 
     /// Gets the helper aggregate share associated with this aggregate share job.

--- a/db/00000000000001_initial_schema.down.sql
+++ b/db/00000000000001_initial_schema.down.sql
@@ -4,6 +4,7 @@ DROP INDEX aggregate_share_jobs_interval_containment_index CASCADE;
 DROP TABLE aggregate_share_jobs CASCADE;
 DROP INDEX collection_jobs_interval_containment_index CASCADE;
 DROP INDEX collection_jobs_state_and_lease_expiry CASCADE;
+DROP INDEX collection_jobs_task_id_batch_id CASCADE;
 DROP TABLE collection_jobs CASCADE;
 DROP TYPE COLLECTION_JOB_STATE CASCADE;
 DROP TABLE batch_aggregations CASCADE;

--- a/db/00000000000001_initial_schema.up.sql
+++ b/db/00000000000001_initial_schema.up.sql
@@ -291,9 +291,9 @@ CREATE TABLE collection_jobs(
     lease_token             BYTEA,                                             -- a value identifying the current leaseholder; NULL implies no current lease
     lease_attempts          BIGINT NOT NULL DEFAULT 0,                         -- the number of lease acquiries since the last successful lease release
 
-    CONSTRAINT collection_jobs_unique_task_id_batch_id_aggregation_param UNIQUE(task_id, batch_identifier, aggregation_param),
     CONSTRAINT fk_task_id FOREIGN KEY(task_id) REFERENCES tasks(id) ON DELETE CASCADE
 );
+CREATE INDEX collection_jobs_task_id_batch_id ON collection_jobs(task_id, batch_identifier);
 -- TODO(#224): verify that this index is optimal for purposes of acquiring collection jobs.
 CREATE INDEX collection_jobs_state_and_lease_expiry ON collection_jobs(state, lease_expiry) WHERE state = 'COLLECTABLE';
 CREATE INDEX collection_jobs_interval_containment_index ON collection_jobs USING gist (task_id, batch_interval);


### PR DESCRIPTION
Before, the Leader would account for `max_batch_query_count` over all requests, so multiple identical requests would count as multiple queries.

If this is acceptable for Janus, we should consider a change to DAP to clarify that `max_batch_query_count` is accounted for by distinct aggregation parameters; currently, the text is ambiguous and permits both the preexisting behavior & the behavior in this PR.

Likely obviates the need for #1655. Inspired by & hopefully simplifies #1796.