### PR TITLE
Add database columns to jobs for W3C trace context, 0.5 backport

### DIFF
--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -100,7 +100,7 @@ macro_rules! supported_schema_versions {
 // version is seen, [`Datastore::new`] fails.
 //
 // Note that the latest supported version must be first in the list.
-supported_schema_versions!(15);
+supported_schema_versions!(16, 15);
 
 /// Datastore represents a datastore for Janus, with support for transactional reads and writes.
 /// In practice, Datastore instances are currently backed by a PostgreSQL database.

--- a/db/00000000000016_trace_context.down.sql
+++ b/db/00000000000016_trace_context.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE aggregation_jobs DROP COLUMN trace_context;
+ALTER TABLE collection_jobs DROP COLUMN trace_context;

--- a/db/00000000000016_trace_context.up.sql
+++ b/db/00000000000016_trace_context.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE aggregation_jobs ADD COLUMN trace_context jsonb;
+ALTER TABLE collection_jobs ADD COLUMN trace_context jsonb;


### PR DESCRIPTION
This adds `jsonb` database columns to aggregation jobs and collection jobs to propagate distributed tracing metadata through our job queue system. This is a backport of #1800, and part of #1628.