### PR TITLE
Use ContainerLogsDropGuard instead of custom Drop impls

### DIFF
--- a/integration_tests/src/client.rs
+++ b/integration_tests/src/client.rs
@@ -265,7 +265,7 @@ where
                 .with_network(network)
                 .with_container_name(client_container_name),
         );
-        let container = ContainerLogsDropGuard::new(container);
+        let container = ContainerLogsDropGuard::new_janus(container);
         let host_port = container.get_host_port_ipv4(8080);
         let http_client = reqwest::Client::new();
         let (leader_aggregator_endpoint, helper_aggregator_endpoint) = task_parameters

--- a/integration_tests/src/daphne.rs
+++ b/integration_tests/src/daphne.rs
@@ -2,22 +2,17 @@
 
 use crate::interop_api;
 use janus_aggregator_core::task::{test_util::TaskBuilder, Task};
-use janus_interop_binaries::log_export_path;
-use janus_interop_binaries::test_util::await_http_server;
-use janus_messages::{Role, Time};
-use std::{
-    fs::{create_dir_all, File},
-    process::{Command, Stdio},
-    thread::panicking,
+use janus_interop_binaries::{
+    test_util::await_http_server, ContainerLogsDropGuard, ContainerLogsSource,
 };
-use testcontainers::{clients::Cli, images::generic::GenericImage, Container, RunnableImage};
+use janus_messages::{Role, Time};
+use testcontainers::{clients::Cli, images::generic::GenericImage, RunnableImage};
 
 const DAPHNE_HELPER_IMAGE_NAME_AND_TAG: &str = "cloudflare/daphne-worker-helper:sha-f6b3ef1";
 
 /// Represents a running Daphne test instance.
 pub struct Daphne<'a> {
-    daphne_container: Container<'a, GenericImage>,
-    role: Role,
+    daphne_container: ContainerLogsDropGuard<'a, GenericImage>,
 }
 
 impl<'a> Daphne<'a> {
@@ -40,7 +35,10 @@ impl<'a> Daphne<'a> {
         let runnable_image = RunnableImage::from(GenericImage::new(image_name, image_tag))
             .with_network(network)
             .with_container_name(endpoint.host_str().unwrap());
-        let daphne_container = container_client.run(runnable_image);
+        let daphne_container = ContainerLogsDropGuard::new(
+            container_client.run(runnable_image),
+            ContainerLogsSource::Docker,
+        );
         let port = daphne_container.get_host_port_ipv4(Self::INTERNAL_SERVING_PORT);
 
         // Wait for Daphne container to begin listening on the port.
@@ -55,45 +53,16 @@ impl<'a> Daphne<'a> {
         } else {
             task.clone()
         };
-        let role = *task.role();
 
         // Write the given task to the Daphne instance we started.
         interop_api::aggregator_add_task(port, task).await;
 
-        Self {
-            daphne_container,
-            role,
-        }
+        Self { daphne_container }
     }
 
     /// Returns the port of the aggregator on the host.
     pub fn port(&self) -> u16 {
         self.daphne_container
             .get_host_port_ipv4(Self::INTERNAL_SERVING_PORT)
-    }
-}
-
-impl<'a> Drop for Daphne<'a> {
-    fn drop(&mut self) {
-        // We assume that if a Daphne value is dropped during a panic, we are in the middle of
-        // test failure. In this case, export logs if logs_path() suggests doing so.
-        if !panicking() {
-            return;
-        }
-        if let Some(mut destination_path) = log_export_path() {
-            destination_path.push(format!("{}-{}", self.role, self.daphne_container.id()));
-            create_dir_all(&destination_path).unwrap();
-            let docker_logs_status = Command::new("docker")
-                .args(["logs", "--timestamps", self.daphne_container.id()])
-                .stdin(Stdio::null())
-                .stdout(File::create(destination_path.join("stdout.log")).unwrap())
-                .stderr(File::create(destination_path.join("stderr.log")).unwrap())
-                .status()
-                .expect("Failed to execute `docker logs`");
-            assert!(
-                docker_logs_status.success(),
-                "`docker logs` failed with status {docker_logs_status:?}"
-            );
-        }
     }
 }

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -3,19 +3,14 @@
 use crate::interop_api;
 use janus_aggregator_core::task::Task;
 use janus_interop_binaries::{
-    log_export_path, test_util::await_http_server, testcontainer::Aggregator,
+    test_util::await_http_server, testcontainer::Aggregator, ContainerLogsDropGuard,
 };
 use janus_messages::Role;
-use std::{
-    process::{Command, Stdio},
-    thread::panicking,
-};
-use testcontainers::{clients::Cli, Container, RunnableImage};
+use testcontainers::{clients::Cli, RunnableImage};
 
 /// Represents a running Janus test instance in a container.
 pub struct Janus<'a> {
-    role: Role,
-    container: Container<'a, Aggregator>,
+    container: ContainerLogsDropGuard<'a, Aggregator>,
 }
 
 impl<'a> Janus<'a> {
@@ -28,10 +23,12 @@ impl<'a> Janus<'a> {
             Role::Helper => task.helper_aggregator_endpoint(),
             _ => panic!("unexpected task role"),
         };
-        let container = container_client.run(
-            RunnableImage::from(Aggregator::default())
-                .with_network(network)
-                .with_container_name(endpoint.host_str().unwrap()),
+        let container = ContainerLogsDropGuard::new_janus(
+            container_client.run(
+                RunnableImage::from(Aggregator::default())
+                    .with_network(network)
+                    .with_container_name(endpoint.host_str().unwrap()),
+            ),
         );
         let port = container.get_host_port_ipv4(Aggregator::INTERNAL_SERVING_PORT);
 
@@ -41,46 +38,12 @@ impl<'a> Janus<'a> {
         // Write the given task to the Janus instance we started.
         interop_api::aggregator_add_task(port, task.clone()).await;
 
-        Self {
-            role: *task.role(),
-            container,
-        }
+        Self { container }
     }
 
     /// Returns the port of the aggregator on the host.
     pub fn port(&self) -> u16 {
         self.container
             .get_host_port_ipv4(Aggregator::INTERNAL_SERVING_PORT)
-    }
-}
-
-impl<'a> Drop for Janus<'a> {
-    fn drop(&mut self) {
-        // We assume that if a Janus value is dropped during a panic, we are in the middle of
-        // test failure. In this case, export logs if log_export_path() suggests doing so.
-
-        if !panicking() {
-            return;
-        }
-        if let Some(mut destination_path) = log_export_path() {
-            destination_path.push(format!("{}-{}", self.role, self.container.id()));
-            if let Ok(docker_cp_status) = Command::new("docker")
-                .args([
-                    "cp",
-                    &format!("{}:logs/", self.container.id()),
-                    destination_path.as_os_str().to_str().unwrap(),
-                ])
-                .stdin(Stdio::null())
-                .stdout(Stdio::null())
-                .stderr(Stdio::null())
-                .status()
-            {
-                if !docker_cp_status.success() {
-                    println!("`docker cp` failed with status {docker_cp_status:?}");
-                }
-            } else {
-                println!("Failed to execute `docker cp`");
-            }
-        }
     }
 }

--- a/integration_tests/tests/daphne.rs
+++ b/integration_tests/tests/daphne.rs
@@ -49,7 +49,7 @@ async fn daphne_janus() {
 
 // This test places Janus in the leader role & Daphne in the helper role.
 #[tokio::test(flavor = "multi_thread")]
-// #[ignore = "Daphne does not currently support DAP-05 (issue #1669)"]
+#[ignore = "Daphne does not currently support DAP-05 (issue #1669)"]
 async fn janus_daphne() {
     install_test_trace_subscriber();
 

--- a/integration_tests/tests/daphne.rs
+++ b/integration_tests/tests/daphne.rs
@@ -49,7 +49,7 @@ async fn daphne_janus() {
 
 // This test places Janus in the leader role & Daphne in the helper role.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "Daphne does not currently support DAP-05 (issue #1669)"]
+// #[ignore = "Daphne does not currently support DAP-05 (issue #1669)"]
 async fn janus_daphne() {
     install_test_trace_subscriber();
 

--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -60,7 +60,7 @@ async fn run(
     let container_client = container_client();
     let network = generate_network_name();
 
-    let client_container = ContainerLogsDropGuard::new(
+    let client_container = ContainerLogsDropGuard::new_janus(
         container_client.run(
             RunnableImage::from(Client::default())
                 .with_network(&network)
@@ -70,7 +70,7 @@ async fn run(
     let client_port = client_container.get_host_port_ipv4(Client::INTERNAL_SERVING_PORT);
 
     let leader_name = generate_unique_name("leader");
-    let leader_container = ContainerLogsDropGuard::new(
+    let leader_container = ContainerLogsDropGuard::new_janus(
         container_client.run(
             RunnableImage::from(Aggregator::default())
                 .with_network(&network)
@@ -80,7 +80,7 @@ async fn run(
     let leader_port = leader_container.get_host_port_ipv4(Aggregator::INTERNAL_SERVING_PORT);
 
     let helper_name = generate_unique_name("helper");
-    let helper_container = ContainerLogsDropGuard::new(
+    let helper_container = ContainerLogsDropGuard::new_janus(
         container_client.run(
             RunnableImage::from(Aggregator::default())
                 .with_network(&network)
@@ -89,7 +89,7 @@ async fn run(
     );
     let helper_port = helper_container.get_host_port_ipv4(Aggregator::INTERNAL_SERVING_PORT);
 
-    let collector_container = ContainerLogsDropGuard::new(
+    let collector_container = ContainerLogsDropGuard::new_janus(
         container_client.run(
             RunnableImage::from(Collector::default())
                 .with_network(&network)


### PR DESCRIPTION
Minor cleanup: use [`ContainerLogsDropGuard`](https://github.com/divviup/janus/blob/main/interop_binaries/src/lib.rs#L391) instead of these custom Drop impls. It's already used for the [client container](https://github.com/divviup/janus/blob/main/integration_tests/src/client.rs#L189), not sure why it's not used for the other containers.

