### PR TITLE
Allow skipping migrations validity check

### DIFF
--- a/.github/workflows/ci-migrations.yml
+++ b/.github/workflows/ci-migrations.yml
@@ -14,7 +14,9 @@ jobs:
       with:
         fetch-depth: 0
     - name: Check that existing migrations have not changed
-      if: github.event_name == 'pull_request'
+      if: |
+        github.event_name == 'pull_request' && 
+        !contains(github.event.pull_request.labels.*.name, 'allow-changed-migrations')
       env:
         BASE_SHA: "${{ github.event.pull_request.base.sha }}"
       run: |


### PR DESCRIPTION
Allows the ci-migrations check to be overridden by the label `allow-changed-migrations`. Note that it the job will still check the validity of migrations, but it will ignore if there were changes to existing migrations.

Using this label asserts that we know what we're doing and that changing an existing migration is actually safe, and signals to reviewers to scrutinize the safety of the operation.

For the best experience, you should open a PR with this label already applied. If you retroactively apply this label, you'll need to make another push to the repository, because retrying a failed job submits the job with the same parameters as its original attempt.

Note that we will still have to use the `force` flag when deploying migrations to GCS.