### PR TITLE
DAP-05 ping-pong

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2937,9 +2937,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prio"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7591b152d20a8a992f8b3a5daf6bc9e38e7fb347e3694ed9238eddc7e57332"
+checksum = "e2e546dc580118e2120309c8aa7bb0da8deabd4b848289c486e9429a27c05594"
 dependencies = [
  "aes",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ version = "0.6.0"
 
 [workspace.dependencies]
 anyhow = "1"
+base64 = "0.21.3"
 # Disable default features to disable compatibility with the old `time` crate, and we also don't
 # (yet) need other default features.
 # https://docs.rs/chrono/latest/chrono/#duration
@@ -42,7 +43,7 @@ janus_messages = { version = "0.6", path = "messages" }
 k8s-openapi = { version = "0.18.0", features = ["v1_24"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
 kube = { version = "0.82.2", default-features = false, features = ["client", "rustls-tls"] }
 opentelemetry = { version = "0.20", features = ["metrics"] }
-prio = { version = "0.15.0", features = ["multithreaded"] }
+prio = { version = "0.15.1", features = ["multithreaded", "experimental"] }
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.106"
 serde_test = "1.0.175"

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -35,7 +35,7 @@ test-util = [
 async-trait = "0.1"
 anyhow.workspace = true
 backoff = { version = "0.4.0", features = ["tokio"] }
-base64 = "0.21.4"
+base64.workspace = true
 bytes = "1.5.0"
 chrono.workspace = true
 clap = { version = "4.4.2", features = ["derive", "env"] }

--- a/aggregator/src/aggregator/accumulator.rs
+++ b/aggregator/src/aggregator/accumulator.rs
@@ -40,7 +40,7 @@ pub struct Accumulator<
     aggregations: HashMap<Q::BatchIdentifier, BatchData<SEED_SIZE, Q, A>>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct BatchData<
     const SEED_SIZE: usize,
     Q: AccumulableQueryType,

--- a/aggregator/src/aggregator/aggregate_init_tests.rs
+++ b/aggregator/src/aggregator/aggregate_init_tests.rs
@@ -1,6 +1,9 @@
 use crate::aggregator::{
-    http_handlers::aggregator_handler, tests::generate_helper_report_share, Config,
+    http_handlers::{aggregator_handler, test_util::decode_response_body},
+    tests::generate_helper_report_share,
+    Config,
 };
+use assert_matches::assert_matches;
 use janus_aggregator_core::{
     datastore::{
         test_util::{ephemeral_datastore, EphemeralDatastore},
@@ -15,92 +18,156 @@ use janus_core::{
     time::{Clock, MockClock, TimeExt as _},
 };
 use janus_messages::{
-    query_type::TimeInterval, AggregationJobId, AggregationJobInitializeReq, PartialBatchSelector,
-    ReportMetadata, ReportShare, Role,
+    query_type::TimeInterval, AggregationJobId, AggregationJobInitializeReq, AggregationJobResp,
+    PartialBatchSelector, PrepareInit, PrepareStepResult, ReportMetadata, Role,
 };
-use prio::codec::Encode;
+use prio::{
+    codec::Encode,
+    idpf::IdpfInput,
+    vdaf::{
+        self,
+        poplar1::{Poplar1, Poplar1AggregationParam},
+        xof::XofShake128,
+    },
+};
 use rand::random;
 use std::sync::Arc;
 use trillium::{Handler, KnownHeaderName, Status};
 use trillium_testing::{prelude::put, TestConn};
 
-pub(super) struct ReportShareGenerator {
+pub(super) struct PrepareInitGenerator<const VERIFY_KEY_SIZE: usize, V>
+where
+    V: vdaf::Vdaf,
+{
     clock: MockClock,
     task: Task,
-    aggregation_param: dummy_vdaf::AggregationParam,
-    vdaf: dummy_vdaf::Vdaf,
+    vdaf: V,
+    aggregation_param: V::AggregationParam,
 }
 
-impl ReportShareGenerator {
+impl<const VERIFY_KEY_SIZE: usize, V> PrepareInitGenerator<VERIFY_KEY_SIZE, V>
+where
+    V: vdaf::Vdaf + vdaf::Aggregator<VERIFY_KEY_SIZE, 16> + vdaf::Client<16>,
+{
     pub(super) fn new(
         clock: MockClock,
         task: Task,
-        aggregation_param: dummy_vdaf::AggregationParam,
+        vdaf: V,
+        aggregation_param: V::AggregationParam,
     ) -> Self {
         Self {
             clock,
             task,
+            vdaf,
             aggregation_param,
-            vdaf: dummy_vdaf::Vdaf::new(),
         }
     }
 
-    fn with_vdaf(mut self, vdaf: dummy_vdaf::Vdaf) -> Self {
-        self.vdaf = vdaf;
-        self
-    }
-
-    pub(super) fn next(&self) -> (ReportShare, VdafTranscript<0, dummy_vdaf::Vdaf>) {
-        self.next_with_metadata(ReportMetadata::new(
-            random(),
-            self.clock
-                .now()
-                .to_batch_interval_start(self.task.time_precision())
-                .unwrap(),
-        ))
+    pub(super) fn next(
+        &self,
+        measurement: &V::Measurement,
+    ) -> (PrepareInit, VdafTranscript<VERIFY_KEY_SIZE, V>) {
+        self.next_with_metadata(
+            ReportMetadata::new(
+                random(),
+                self.clock
+                    .now()
+                    .to_batch_interval_start(self.task.time_precision())
+                    .unwrap(),
+            ),
+            measurement,
+        )
     }
 
     pub(super) fn next_with_metadata(
         &self,
         report_metadata: ReportMetadata,
-    ) -> (ReportShare, VdafTranscript<0, dummy_vdaf::Vdaf>) {
+        measurement: &V::Measurement,
+    ) -> (PrepareInit, VdafTranscript<VERIFY_KEY_SIZE, V>) {
         let transcript = run_vdaf(
             &self.vdaf,
             self.task.primary_vdaf_verify_key().unwrap().as_bytes(),
             &self.aggregation_param,
             report_metadata.id(),
-            &(),
+            measurement,
         );
-        let report_share = generate_helper_report_share::<dummy_vdaf::Vdaf>(
+        let report_share = generate_helper_report_share::<V>(
             *self.task.id(),
             report_metadata,
             self.task.current_hpke_key().config(),
             &transcript.public_share,
             Vec::new(),
-            &transcript.input_shares[1],
+            &transcript.helper_input_share,
         );
-
-        (report_share, transcript)
+        (
+            PrepareInit::new(
+                report_share,
+                transcript.leader_prepare_transitions[0].message.clone(),
+            ),
+            transcript,
+        )
     }
 }
 
-pub(super) struct AggregationJobInitTestCase {
+pub(super) struct AggregationJobInitTestCase<
+    const VERIFY_KEY_SIZE: usize,
+    V: vdaf::Aggregator<VERIFY_KEY_SIZE, 16>,
+> {
     pub(super) clock: MockClock,
     pub(super) task: Task,
-    pub(super) report_share_generator: ReportShareGenerator,
-    pub(super) report_shares: Vec<ReportShare>,
+    pub(super) prepare_init_generator: PrepareInitGenerator<VERIFY_KEY_SIZE, V>,
+    pub(super) prepare_inits: Vec<PrepareInit>,
     pub(super) aggregation_job_id: AggregationJobId,
     aggregation_job_init_req: AggregationJobInitializeReq<TimeInterval>,
-    pub(super) aggregation_param: dummy_vdaf::AggregationParam,
+    aggregation_job_init_resp: Option<AggregationJobResp>,
+    pub(super) aggregation_param: V::AggregationParam,
     pub(super) handler: Box<dyn Handler>,
     pub(super) datastore: Arc<Datastore<MockClock>>,
     _ephemeral_datastore: EphemeralDatastore,
 }
 
-pub(super) async fn setup_aggregate_init_test() -> AggregationJobInitTestCase {
-    let test_case = setup_aggregate_init_test_without_sending_request().await;
+pub(super) async fn setup_aggregate_init_test() -> AggregationJobInitTestCase<0, dummy_vdaf::Vdaf> {
+    setup_aggregate_init_test_for_vdaf(
+        dummy_vdaf::Vdaf::new(),
+        VdafInstance::Fake,
+        dummy_vdaf::AggregationParam(0),
+        (),
+    )
+    .await
+}
 
-    let response = put_aggregation_job(
+async fn setup_poplar1_aggregate_init_test(
+) -> AggregationJobInitTestCase<16, Poplar1<XofShake128, 16>> {
+    let aggregation_param =
+        Poplar1AggregationParam::try_from_prefixes(Vec::from([IdpfInput::from_bools(&[false])]))
+            .unwrap();
+    setup_aggregate_init_test_for_vdaf(
+        Poplar1::new_shake128(1),
+        VdafInstance::Poplar1 { bits: 1 },
+        aggregation_param,
+        IdpfInput::from_bools(&[true]),
+    )
+    .await
+}
+
+async fn setup_aggregate_init_test_for_vdaf<
+    const VERIFY_KEY_SIZE: usize,
+    V: vdaf::Aggregator<VERIFY_KEY_SIZE, 16> + vdaf::Client<16>,
+>(
+    vdaf: V,
+    vdaf_instance: VdafInstance,
+    aggregation_param: V::AggregationParam,
+    measurement: V::Measurement,
+) -> AggregationJobInitTestCase<VERIFY_KEY_SIZE, V> {
+    let mut test_case = setup_aggregate_init_test_without_sending_request(
+        vdaf,
+        vdaf_instance,
+        aggregation_param,
+        measurement,
+    )
+    .await;
+
+    let mut response = put_aggregation_job(
         &test_case.task,
         &test_case.aggregation_job_id,
         &test_case.aggregation_job_init_req,
@@ -109,13 +176,32 @@ pub(super) async fn setup_aggregate_init_test() -> AggregationJobInitTestCase {
     .await;
     assert_eq!(response.status(), Some(Status::Ok));
 
+    let aggregation_job_init_resp: AggregationJobResp = decode_response_body(&mut response).await;
+    assert_eq!(
+        aggregation_job_init_resp.prepare_resps().len(),
+        test_case.aggregation_job_init_req.prepare_inits().len(),
+    );
+    assert_matches!(
+        aggregation_job_init_resp.prepare_resps()[0].result(),
+        &PrepareStepResult::Continue { .. }
+    );
+
+    test_case.aggregation_job_init_resp = Some(aggregation_job_init_resp);
     test_case
 }
 
-async fn setup_aggregate_init_test_without_sending_request() -> AggregationJobInitTestCase {
+async fn setup_aggregate_init_test_without_sending_request<
+    const VERIFY_KEY_SIZE: usize,
+    V: vdaf::Aggregator<VERIFY_KEY_SIZE, 16> + vdaf::Client<16>,
+>(
+    vdaf: V,
+    vdaf_instance: VdafInstance,
+    aggregation_param: V::AggregationParam,
+    measurement: V::Measurement,
+) -> AggregationJobInitTestCase<VERIFY_KEY_SIZE, V> {
     install_test_trace_subscriber();
 
-    let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Helper).build();
+    let task = TaskBuilder::new(QueryType::TimeInterval, vdaf_instance, Role::Helper).build();
     let clock = MockClock::default();
     let ephemeral_datastore = ephemeral_datastore().await;
     let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
@@ -131,30 +217,29 @@ async fn setup_aggregate_init_test_without_sending_request() -> AggregationJobIn
     .await
     .unwrap();
 
-    let aggregation_param = dummy_vdaf::AggregationParam(0);
+    let prepare_init_generator =
+        PrepareInitGenerator::new(clock.clone(), task.clone(), vdaf, aggregation_param.clone());
 
-    let report_share_generator =
-        ReportShareGenerator::new(clock.clone(), task.clone(), aggregation_param);
-
-    let report_shares = Vec::from([
-        report_share_generator.next().0,
-        report_share_generator.next().0,
+    let prepare_inits = Vec::from([
+        prepare_init_generator.next(&measurement).0,
+        prepare_init_generator.next(&measurement).0,
     ]);
 
     let aggregation_job_id = random();
     let aggregation_job_init_req = AggregationJobInitializeReq::new(
         aggregation_param.get_encoded(),
         PartialBatchSelector::new_time_interval(),
-        report_shares.clone(),
+        prepare_inits.clone(),
     );
 
     AggregationJobInitTestCase {
         clock,
         task,
-        report_shares,
-        report_share_generator,
+        prepare_inits,
+        prepare_init_generator,
         aggregation_job_id,
         aggregation_job_init_req,
+        aggregation_job_init_resp: None,
         aggregation_param,
         handler: Box::new(handler),
         datastore,
@@ -184,7 +269,13 @@ pub(crate) async fn put_aggregation_job(
 
 #[tokio::test]
 async fn aggregation_job_init_authorization_dap_auth_token() {
-    let test_case = setup_aggregate_init_test_without_sending_request().await;
+    let test_case = setup_aggregate_init_test_without_sending_request(
+        dummy_vdaf::Vdaf::new(),
+        VdafInstance::Fake,
+        dummy_vdaf::AggregationParam(0),
+        (),
+    )
+    .await;
     // Find a DapAuthToken among the task's aggregator auth tokens
     let (auth_header, auth_value) = test_case
         .task
@@ -216,7 +307,13 @@ async fn aggregation_job_init_authorization_dap_auth_token() {
 #[case::not_base64("Bearer: ")]
 #[tokio::test]
 async fn aggregation_job_init_malformed_authorization_header(#[case] header_value: &'static str) {
-    let test_case = setup_aggregate_init_test_without_sending_request().await;
+    let test_case = setup_aggregate_init_test_without_sending_request(
+        dummy_vdaf::Vdaf::new(),
+        VdafInstance::Fake,
+        dummy_vdaf::AggregationParam(0),
+        (),
+    )
+    .await;
 
     let response = put(test_case
         .task
@@ -254,7 +351,7 @@ async fn aggregation_job_mutation_aggregation_job() {
     let mutated_aggregation_job_init_req = AggregationJobInitializeReq::new(
         dummy_vdaf::AggregationParam(1).get_encoded(),
         PartialBatchSelector::new_time_interval(),
-        test_case.report_shares,
+        test_case.prepare_inits,
     );
 
     let response = put_aggregation_job(
@@ -273,28 +370,28 @@ async fn aggregation_job_mutation_report_shares() {
 
     // Put the aggregation job again, mutating the associated report shares' metadata such that
     // uniqueness constraints on client_reports are violated
-    for mutated_report_shares in [
+    for mutated_prepare_inits in [
         // Omit a report share that was included previously
-        Vec::from(&test_case.report_shares[0..test_case.report_shares.len() - 1]),
+        Vec::from(&test_case.prepare_inits[0..test_case.prepare_inits.len() - 1]),
         // Include a different report share than was included previously
         [
-            &test_case.report_shares[0..test_case.report_shares.len() - 1],
-            &[test_case.report_share_generator.next().0],
+            &test_case.prepare_inits[0..test_case.prepare_inits.len() - 1],
+            &[test_case.prepare_init_generator.next(&()).0],
         ]
         .concat(),
         // Include an extra report share than was included previously
         [
-            test_case.report_shares.as_slice(),
-            &[test_case.report_share_generator.next().0],
+            test_case.prepare_inits.as_slice(),
+            &[test_case.prepare_init_generator.next(&()).0],
         ]
         .concat(),
         // Reverse the order of the reports
-        test_case.report_shares.into_iter().rev().collect(),
+        test_case.prepare_inits.into_iter().rev().collect(),
     ] {
         let mutated_aggregation_job_init_req = AggregationJobInitializeReq::new(
             test_case.aggregation_param.get_encoded(),
             PartialBatchSelector::new_time_interval(),
-            mutated_report_shares,
+            mutated_prepare_inits,
         );
         let response = put_aggregation_job(
             &test_case.task,
@@ -309,20 +406,22 @@ async fn aggregation_job_mutation_report_shares() {
 
 #[tokio::test]
 async fn aggregation_job_mutation_report_aggregations() {
-    let test_case = setup_aggregate_init_test().await;
+    // We must run Poplar1 in this test so that the aggregation job won't finish on the first step
+    let test_case = setup_poplar1_aggregate_init_test().await;
 
-    // Generate some new reports using the existing reports' metadata, but varying the input shares
-    // such that the prepare state computed during aggregation initializaton won't match the first
-    // aggregation job.
-    let mutated_report_shares_generator = test_case
-        .report_share_generator
-        .with_vdaf(dummy_vdaf::Vdaf::new().with_input_share(dummy_vdaf::InputShare(1)));
-    let mutated_report_shares = test_case
-        .report_shares
+    // Generate some new reports using the existing reports' metadata, but varying the measurement
+    // values such that the prepare state computed during aggregation initializaton won't match the
+    // first aggregation job.
+    let mutated_prepare_inits = test_case
+        .prepare_inits
         .iter()
         .map(|s| {
-            mutated_report_shares_generator
-                .next_with_metadata(s.metadata().clone())
+            test_case
+                .prepare_init_generator
+                .next_with_metadata(
+                    s.report_share().metadata().clone(),
+                    &IdpfInput::from_bools(&[false]),
+                )
                 .0
         })
         .collect();
@@ -330,8 +429,9 @@ async fn aggregation_job_mutation_report_aggregations() {
     let mutated_aggregation_job_init_req = AggregationJobInitializeReq::new(
         test_case.aggregation_param.get_encoded(),
         PartialBatchSelector::new_time_interval(),
-        mutated_report_shares,
+        mutated_prepare_inits,
     );
+
     let response = put_aggregation_job(
         &test_case.task,
         &test_case.aggregation_job_id,
@@ -340,4 +440,25 @@ async fn aggregation_job_mutation_report_aggregations() {
     )
     .await;
     assert_eq!(response.status(), Some(Status::Conflict));
+}
+
+#[tokio::test]
+async fn aggregation_job_init_two_round_vdaf_idempotence() {
+    // We must run Poplar1 in this test so that the aggregation job won't finish on the first step
+    let test_case = setup_poplar1_aggregate_init_test().await;
+
+    // Send the aggregation job init request again. We should get an identical response back.
+    let mut response = put_aggregation_job(
+        &test_case.task,
+        &test_case.aggregation_job_id,
+        &test_case.aggregation_job_init_req,
+        &test_case.handler,
+    )
+    .await;
+
+    let aggregation_job_resp: AggregationJobResp = decode_response_body(&mut response).await;
+    assert_eq!(
+        aggregation_job_resp,
+        test_case.aggregation_job_init_resp.unwrap()
+    );
 }

--- a/aggregator/src/aggregator/aggregation_job_writer.rs
+++ b/aggregator/src/aggregator/aggregation_job_writer.rs
@@ -14,7 +14,7 @@ use janus_aggregator_core::{
     task::Task,
 };
 use janus_core::time::{Clock, IntervalExt};
-use janus_messages::{AggregationJobId, Interval, ReportId, ReportShareError};
+use janus_messages::{AggregationJobId, Interval, PrepareError, ReportId};
 use prio::{codec::Encode, vdaf};
 use std::{
     borrow::Cow,
@@ -260,7 +260,7 @@ impl<const SEED_SIZE: usize, Q: CollectableQueryType, A: vdaf::Aggregator<SEED_S
                     unwritable_report_ids.insert(*report_aggregation.report_id());
                     *report_aggregation =
                         Cow::Owned(report_aggregation.as_ref().clone().with_state(
-                            ReportAggregationState::Failed(ReportShareError::BatchCollected),
+                            ReportAggregationState::Failed(PrepareError::BatchCollected),
                         ));
                 }
             }

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -640,7 +640,9 @@ pub mod test_util {
 mod tests {
     use crate::{
         aggregator::{
-            aggregate_init_tests::{put_aggregation_job, setup_aggregate_init_test},
+            aggregate_init_tests::{
+                put_aggregation_job, setup_aggregate_init_test, PrepareInitGenerator,
+            },
             aggregation_job_continue::test_util::{
                 post_aggregation_job_and_decode, post_aggregation_job_expecting_error,
             },
@@ -696,15 +698,18 @@ mod tests {
         AggregationJobInitializeReq, AggregationJobResp, AggregationJobRound, BatchSelector,
         Collection, CollectionJobId, CollectionReq, Duration, Extension, ExtensionType,
         HpkeCiphertext, HpkeConfigId, HpkeConfigList, InputShareAad, Interval,
-        PartialBatchSelector, PrepareStep, PrepareStepResult, Query, Report, ReportId,
-        ReportIdChecksum, ReportMetadata, ReportShare, ReportShareError, Role, TaskId, Time,
+        PartialBatchSelector, PrepareContinue, PrepareError, PrepareInit, PrepareResp,
+        PrepareStepResult, Query, Report, ReportId, ReportIdChecksum, ReportMetadata, ReportShare,
+        Role, TaskId, Time,
     };
     use prio::{
         codec::{Decode, Encode},
-        field::Field64,
+        idpf::IdpfInput,
+        topology::ping_pong::PingPongMessage,
         vdaf::{
-            prio3::{Prio3, Prio3Count},
-            AggregateShare, Aggregator, OutputShare,
+            poplar1::{Poplar1, Poplar1AggregationParam},
+            xof::XofShake128,
+            Aggregator,
         },
     };
     use rand::random;
@@ -1494,9 +1499,9 @@ mod tests {
     }
 
     #[tokio::test]
-    // Silence the unit_arg lint so that we can work with dummy_vdaf::Vdaf::InputShare values (whose
-    // type is ()).
-    #[allow(clippy::unit_arg)]
+    // Silence the unit_arg lint so that we can work with dummy_vdaf::Vdaf::{InputShare,
+    // Measurement} values (whose type is ()).
+    #[allow(clippy::unit_arg, clippy::let_unit_value)]
     async fn aggregate_init() {
         let (clock, _ephemeral_datastore, datastore, handler) = setup_http_handler_test().await;
 
@@ -1506,55 +1511,21 @@ mod tests {
         let vdaf = dummy_vdaf::Vdaf::new();
         let verify_key: VerifyKey<0> = task.primary_vdaf_verify_key().unwrap();
         let hpke_key = task.current_hpke_key();
+        let measurement = ();
+        let prep_init_generator = PrepareInitGenerator::new(
+            clock.clone(),
+            task.clone(),
+            vdaf.clone(),
+            dummy_vdaf::AggregationParam(0),
+        );
 
-        // report_share_0 is a "happy path" report.
-        let report_metadata_0 = ReportMetadata::new(
-            random(),
-            clock
-                .now()
-                .to_batch_interval_start(task.time_precision())
-                .unwrap(),
-        );
-        let transcript = run_vdaf(
-            &vdaf,
-            verify_key.as_bytes(),
-            &dummy_vdaf::AggregationParam(0),
-            report_metadata_0.id(),
-            &(),
-        );
-        let report_share_0 = generate_helper_report_share::<dummy_vdaf::Vdaf>(
-            *task.id(),
-            report_metadata_0,
-            hpke_key.config(),
-            &transcript.public_share,
-            Vec::new(),
-            &transcript.input_shares[1],
-        );
+        // prepare_init_0 is a "happy path" report.
+        let (prepare_init_0, transcript_0) = prep_init_generator.next(&measurement);
 
         // report_share_1 fails decryption.
-        let report_metadata_1 = ReportMetadata::new(
-            random(),
-            clock
-                .now()
-                .to_batch_interval_start(task.time_precision())
-                .unwrap(),
-        );
-        let transcript = run_vdaf(
-            &vdaf,
-            verify_key.as_bytes(),
-            &dummy_vdaf::AggregationParam(0),
-            report_metadata_1.id(),
-            &(),
-        );
-        let report_share_1 = generate_helper_report_share::<dummy_vdaf::Vdaf>(
-            *task.id(),
-            report_metadata_1.clone(),
-            hpke_key.config(),
-            &transcript.public_share,
-            Vec::new(),
-            &transcript.input_shares[1],
-        );
-        let encrypted_input_share = report_share_1.encrypted_input_share();
+        let (prepare_init_1, transcript_1) = prep_init_generator.next(&measurement);
+
+        let encrypted_input_share = prepare_init_1.report_share().encrypted_input_share();
         let mut corrupted_payload = encrypted_input_share.payload().to_vec();
         corrupted_payload[0] ^= 0xFF;
         let corrupted_input_share = HpkeCiphertext::new(
@@ -1562,53 +1533,39 @@ mod tests {
             encrypted_input_share.encapsulated_key().to_vec(),
             corrupted_payload,
         );
-        let encoded_public_share = transcript.public_share.get_encoded();
-        let report_share_1 = ReportShare::new(
-            report_metadata_1,
-            encoded_public_share.clone(),
-            corrupted_input_share,
+
+        let prepare_init_1 = PrepareInit::new(
+            ReportShare::new(
+                prepare_init_1.report_share().metadata().clone(),
+                transcript_1.public_share.get_encoded(),
+                corrupted_input_share,
+            ),
+            prepare_init_1.message().clone(),
         );
 
-        // report_share_2 fails decoding due to an issue with the input share.
-        let report_metadata_2 = ReportMetadata::new(
-            random(),
-            clock
-                .now()
-                .to_batch_interval_start(task.time_precision())
-                .unwrap(),
-        );
-        let transcript = run_vdaf(
-            &vdaf,
-            verify_key.as_bytes(),
-            &dummy_vdaf::AggregationParam(0),
-            report_metadata_2.id(),
-            &(),
-        );
-        let mut input_share_bytes = transcript.input_shares[1].get_encoded();
+        // prepare_init_2 fails decoding due to an issue with the input share.
+        let (prepare_init_2, transcript_2) = prep_init_generator.next(&measurement);
+
+        let mut input_share_bytes = transcript_2.helper_input_share.get_encoded();
         input_share_bytes.push(0); // can no longer be decoded.
         let report_share_2 = generate_helper_report_share_for_plaintext(
-            report_metadata_2.clone(),
+            prepare_init_2.report_share().metadata().clone(),
             hpke_key.config(),
-            encoded_public_share.clone(),
+            transcript_2.public_share.get_encoded(),
             &input_share_bytes,
-            &InputShareAad::new(*task.id(), report_metadata_2, encoded_public_share).get_encoded(),
+            &InputShareAad::new(
+                *task.id(),
+                prepare_init_2.report_share().metadata().clone(),
+                transcript_2.public_share.get_encoded(),
+            )
+            .get_encoded(),
         );
 
-        // report_share_3 has an unknown HPKE config ID.
-        let report_metadata_3 = ReportMetadata::new(
-            random(),
-            clock
-                .now()
-                .to_batch_interval_start(task.time_precision())
-                .unwrap(),
-        );
-        let transcript = run_vdaf(
-            &vdaf,
-            verify_key.as_bytes(),
-            &dummy_vdaf::AggregationParam(0),
-            report_metadata_3.id(),
-            &(),
-        );
+        let prepare_init_2 = PrepareInit::new(report_share_2, prepare_init_2.message().clone());
+
+        // prepare_init_3 has an unknown HPKE config ID.
+        let (prepare_init_3, transcript_3) = prep_init_generator.next(&measurement);
+
         let wrong_hpke_config = loop {
             let hpke_config = generate_test_hpke_config_and_private_key().config().clone();
             if task.hpke_keys().contains_key(hpke_config.id()) {
@@ -1616,41 +1573,23 @@ mod tests {
             }
             break hpke_config;
         };
+
         let report_share_3 = generate_helper_report_share::<dummy_vdaf::Vdaf>(
             *task.id(),
-            report_metadata_3,
+            prepare_init_3.report_share().metadata().clone(),
             &wrong_hpke_config,
-            &transcript.public_share,
+            &transcript_3.public_share,
             Vec::new(),
-            &transcript.input_shares[1],
+            &transcript_3.helper_input_share,
         );
 
-        // report_share_4 has already been aggregated in another aggregation job, with the same
+        let prepare_init_3 = PrepareInit::new(report_share_3, prepare_init_3.message().clone());
+
+        // prepare_init_4 has already been aggregated in another aggregation job, with the same
         // aggregation parameter.
-        let report_metadata_4 = ReportMetadata::new(
-            random(),
-            clock
-                .now()
-                .to_batch_interval_start(task.time_precision())
-                .unwrap(),
-        );
-        let transcript = run_vdaf(
-            &vdaf,
-            verify_key.as_bytes(),
-            &dummy_vdaf::AggregationParam(0),
-            report_metadata_4.id(),
-            &(),
-        );
-        let report_share_4 = generate_helper_report_share::<dummy_vdaf::Vdaf>(
-            *task.id(),
-            report_metadata_4,
-            hpke_key.config(),
-            &transcript.public_share,
-            Vec::new(),
-            &transcript.input_shares[1],
-        );
+        let (prepare_init_4, _) = prep_init_generator.next(&measurement);
 
-        // report_share_5 falls into a batch that has already been collected.
+        // prepare_init_5 falls into a batch that has already been collected.
         let past_clock = MockClock::new(Time::from_seconds_since_epoch(
             task.time_precision().as_seconds() / 2,
         ));
@@ -1661,23 +1600,28 @@ mod tests {
                 .to_batch_interval_start(task.time_precision())
                 .unwrap(),
         );
-        let transcript = run_vdaf(
+        let transcript_5 = run_vdaf(
             &vdaf,
             verify_key.as_bytes(),
             &dummy_vdaf::AggregationParam(0),
             report_metadata_5.id(),
-            &(),
+            &measurement,
         );
         let report_share_5 = generate_helper_report_share::<dummy_vdaf::Vdaf>(
             *task.id(),
             report_metadata_5,
             hpke_key.config(),
-            &transcript.public_share,
+            &transcript_5.public_share,
             Vec::new(),
-            &transcript.input_shares[1],
+            &transcript_5.helper_input_share,
         );
 
-        // report_share_6 fails decoding due to an issue with the public share.
+        let prepare_init_5 = PrepareInit::new(
+            report_share_5,
+            transcript_5.leader_prepare_transitions[0].message.clone(),
+        );
+
+        // prepare_init_6 fails decoding due to an issue with the public share.
         let public_share_6 = Vec::from([0]);
         let report_metadata_6 = ReportMetadata::new(
             random(),
@@ -1686,22 +1630,27 @@ mod tests {
                 .to_batch_interval_start(task.time_precision())
                 .unwrap(),
         );
-        let transcript = run_vdaf(
+        let transcript_6 = run_vdaf(
             &vdaf,
             verify_key.as_bytes(),
             &dummy_vdaf::AggregationParam(0),
             report_metadata_6.id(),
-            &(),
+            &measurement,
         );
         let report_share_6 = generate_helper_report_share_for_plaintext(
             report_metadata_6.clone(),
             hpke_key.config(),
             public_share_6.clone(),
-            &transcript.input_shares[1].get_encoded(),
+            &transcript_6.helper_input_share.get_encoded(),
             &InputShareAad::new(*task.id(), report_metadata_6, public_share_6).get_encoded(),
         );
 
-        // report_share_7 fails due to having repeated extensions.
+        let prepare_init_6 = PrepareInit::new(
+            report_share_6,
+            transcript_6.leader_prepare_transitions[0].message.clone(),
+        );
+
+        // prepare_init_7 fails due to having repeated extensions.
         let report_metadata_7 = ReportMetadata::new(
             random(),
             clock
@@ -1709,56 +1658,40 @@ mod tests {
                 .to_batch_interval_start(task.time_precision())
                 .unwrap(),
         );
-        let transcript = run_vdaf(
+        let transcript_7 = run_vdaf(
             &vdaf,
             verify_key.as_bytes(),
             &dummy_vdaf::AggregationParam(0),
             report_metadata_7.id(),
-            &(),
+            &measurement,
         );
         let report_share_7 = generate_helper_report_share::<dummy_vdaf::Vdaf>(
             *task.id(),
             report_metadata_7,
             hpke_key.config(),
-            &transcript.public_share,
+            &transcript_7.public_share,
             Vec::from([
                 Extension::new(ExtensionType::Tbd, Vec::new()),
                 Extension::new(ExtensionType::Tbd, Vec::new()),
             ]),
-            &transcript.input_shares[0],
+            &transcript_7.helper_input_share,
         );
 
-        // report_share_8 has already been aggregated in another aggregation job, with a different
+        let prepare_init_7 = PrepareInit::new(
+            report_share_7,
+            transcript_7.leader_prepare_transitions[0].message.clone(),
+        );
+
+        // prepare_init_8 has already been aggregated in another aggregation job, with a different
         // aggregation parameter.
-        let report_metadata_8 = ReportMetadata::new(
-            random(),
-            clock
-                .now()
-                .to_batch_interval_start(task.time_precision())
-                .unwrap(),
-        );
-        let transcript = run_vdaf(
-            &vdaf,
-            verify_key.as_bytes(),
-            &dummy_vdaf::AggregationParam(1),
-            report_metadata_8.id(),
-            &(),
-        );
-        let report_share_8 = generate_helper_report_share::<dummy_vdaf::Vdaf>(
-            *task.id(),
-            report_metadata_8,
-            hpke_key.config(),
-            &transcript.public_share,
-            Vec::new(),
-            &transcript.input_shares[1],
-        );
+        let (prepare_init_8, transcript_8) = prep_init_generator.next(&measurement);
 
         let (conflicting_aggregation_job, non_conflicting_aggregation_job) = datastore
             .run_tx(|tx| {
                 let task = task.clone();
-                let report_share_4 = report_share_4.clone();
-                let report_share_5 = report_share_5.clone();
-                let report_share_8 = report_share_8.clone();
+                let report_share_4 = prepare_init_4.report_share().clone();
+                let report_share_5 = prepare_init_5.report_share().clone();
+                let report_share_8 = prepare_init_8.report_share().clone();
                 Box::pin(async move {
                     tx.put_task(&task).await?;
 
@@ -1856,15 +1789,15 @@ mod tests {
             dummy_vdaf::AggregationParam(0).get_encoded(),
             PartialBatchSelector::new_time_interval(),
             Vec::from([
-                report_share_0.clone(),
-                report_share_1.clone(),
-                report_share_2.clone(),
-                report_share_3.clone(),
-                report_share_4.clone(),
-                report_share_5.clone(),
-                report_share_6.clone(),
-                report_share_7.clone(),
-                report_share_8.clone(),
+                prepare_init_0.clone(),
+                prepare_init_1.clone(),
+                prepare_init_2.clone(),
+                prepare_init_3.clone(),
+                prepare_init_4.clone(),
+                prepare_init_5.clone(),
+                prepare_init_6.clone(),
+                prepare_init_7.clone(),
+                prepare_init_8.clone(),
             ]),
         );
 
@@ -1881,64 +1814,95 @@ mod tests {
             let aggregate_resp: AggregationJobResp = decode_response_body(&mut test_conn).await;
 
             // Validate response.
-            assert_eq!(aggregate_resp.prepare_steps().len(), 9);
+            assert_eq!(aggregate_resp.prepare_resps().len(), 9);
 
-            let prepare_step_0 = aggregate_resp.prepare_steps().get(0).unwrap();
-            assert_eq!(prepare_step_0.report_id(), report_share_0.metadata().id());
-            assert_matches!(prepare_step_0.result(), &PrepareStepResult::Continued(..));
+            let prepare_step_0 = aggregate_resp.prepare_resps().get(0).unwrap();
+            assert_eq!(
+                prepare_step_0.report_id(),
+                prepare_init_0.report_share().metadata().id()
+            );
+            assert_matches!(prepare_step_0.result(), PrepareStepResult::Continue { message } => {
+                assert_eq!(message, &transcript_0.helper_prepare_transitions[0].message);
+            });
 
-            let prepare_step_1 = aggregate_resp.prepare_steps().get(1).unwrap();
-            assert_eq!(prepare_step_1.report_id(), report_share_1.metadata().id());
+            let prepare_step_1 = aggregate_resp.prepare_resps().get(1).unwrap();
+            assert_eq!(
+                prepare_step_1.report_id(),
+                prepare_init_1.report_share().metadata().id()
+            );
             assert_matches!(
                 prepare_step_1.result(),
-                &PrepareStepResult::Failed(ReportShareError::HpkeDecryptError)
+                &PrepareStepResult::Reject(PrepareError::HpkeDecryptError)
             );
 
-            let prepare_step_2 = aggregate_resp.prepare_steps().get(2).unwrap();
-            assert_eq!(prepare_step_2.report_id(), report_share_2.metadata().id());
+            let prepare_step_2 = aggregate_resp.prepare_resps().get(2).unwrap();
+            assert_eq!(
+                prepare_step_2.report_id(),
+                prepare_init_2.report_share().metadata().id()
+            );
             assert_matches!(
                 prepare_step_2.result(),
-                &PrepareStepResult::Failed(ReportShareError::UnrecognizedMessage)
+                &PrepareStepResult::Reject(PrepareError::UnrecognizedMessage)
             );
 
-            let prepare_step_3 = aggregate_resp.prepare_steps().get(3).unwrap();
-            assert_eq!(prepare_step_3.report_id(), report_share_3.metadata().id());
+            let prepare_step_3 = aggregate_resp.prepare_resps().get(3).unwrap();
+            assert_eq!(
+                prepare_step_3.report_id(),
+                prepare_init_3.report_share().metadata().id()
+            );
             assert_matches!(
                 prepare_step_3.result(),
-                &PrepareStepResult::Failed(ReportShareError::HpkeUnknownConfigId)
+                &PrepareStepResult::Reject(PrepareError::HpkeUnknownConfigId)
             );
 
-            let prepare_step_4 = aggregate_resp.prepare_steps().get(4).unwrap();
-            assert_eq!(prepare_step_4.report_id(), report_share_4.metadata().id());
+            let prepare_step_4 = aggregate_resp.prepare_resps().get(4).unwrap();
+            assert_eq!(
+                prepare_step_4.report_id(),
+                prepare_init_4.report_share().metadata().id()
+            );
             assert_eq!(
                 prepare_step_4.result(),
-                &PrepareStepResult::Failed(ReportShareError::ReportReplayed)
+                &PrepareStepResult::Reject(PrepareError::ReportReplayed)
             );
 
-            let prepare_step_5 = aggregate_resp.prepare_steps().get(5).unwrap();
-            assert_eq!(prepare_step_5.report_id(), report_share_5.metadata().id());
+            let prepare_step_5 = aggregate_resp.prepare_resps().get(5).unwrap();
+            assert_eq!(
+                prepare_step_5.report_id(),
+                prepare_init_5.report_share().metadata().id()
+            );
             assert_eq!(
                 prepare_step_5.result(),
-                &PrepareStepResult::Failed(ReportShareError::BatchCollected)
+                &PrepareStepResult::Reject(PrepareError::BatchCollected)
             );
 
-            let prepare_step_6 = aggregate_resp.prepare_steps().get(6).unwrap();
-            assert_eq!(prepare_step_6.report_id(), report_share_6.metadata().id());
+            let prepare_step_6 = aggregate_resp.prepare_resps().get(6).unwrap();
+            assert_eq!(
+                prepare_step_6.report_id(),
+                prepare_init_6.report_share().metadata().id()
+            );
             assert_eq!(
                 prepare_step_6.result(),
-                &PrepareStepResult::Failed(ReportShareError::UnrecognizedMessage),
+                &PrepareStepResult::Reject(PrepareError::UnrecognizedMessage),
             );
 
-            let prepare_step_7 = aggregate_resp.prepare_steps().get(7).unwrap();
-            assert_eq!(prepare_step_7.report_id(), report_share_7.metadata().id());
+            let prepare_step_7 = aggregate_resp.prepare_resps().get(7).unwrap();
+            assert_eq!(
+                prepare_step_7.report_id(),
+                prepare_init_7.report_share().metadata().id()
+            );
             assert_eq!(
                 prepare_step_7.result(),
-                &PrepareStepResult::Failed(ReportShareError::UnrecognizedMessage),
+                &PrepareStepResult::Reject(PrepareError::UnrecognizedMessage),
             );
 
-            let prepare_step_8 = aggregate_resp.prepare_steps().get(8).unwrap();
-            assert_eq!(prepare_step_8.report_id(), report_share_8.metadata().id());
-            assert_matches!(prepare_step_8.result(), &PrepareStepResult::Continued(..));
+            let prepare_step_8 = aggregate_resp.prepare_resps().get(8).unwrap();
+            assert_eq!(
+                prepare_step_8.report_id(),
+                prepare_init_8.report_share().metadata().id()
+            );
+            assert_matches!(prepare_step_8.result(), PrepareStepResult::Continue { message } => {
+                assert_eq!(message, &transcript_8.helper_prepare_transitions[0].message);
+            });
 
             // Check aggregation job in datastore.
             let aggregation_jobs = datastore
@@ -1968,7 +1932,7 @@ mod tests {
                 } else if aggregation_job.task_id().eq(task.id())
                     && aggregation_job.id().eq(&aggregation_job_id)
                     && aggregation_job.partial_batch_identifier().eq(&())
-                    && aggregation_job.state().eq(&AggregationJobState::InProgress)
+                    && aggregation_job.state().eq(&AggregationJobState::Finished)
                 {
                     saw_new_aggregation_job = true;
                 }
@@ -1988,6 +1952,10 @@ mod tests {
         let task =
             TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Helper).build();
         datastore.put_task(&task).await.unwrap();
+        let vdaf = dummy_vdaf::Vdaf::new();
+        let aggregation_param = dummy_vdaf::AggregationParam(0);
+        let prep_init_generator =
+            PrepareInitGenerator::new(clock.clone(), task.clone(), vdaf.clone(), aggregation_param);
 
         // Insert some global HPKE keys.
         // Same ID as the task to test having both keys to choose from.
@@ -2028,59 +1996,20 @@ mod tests {
         .await
         .unwrap();
 
-        let vdaf = dummy_vdaf::Vdaf::new();
         let verify_key: VerifyKey<0> = task.primary_vdaf_verify_key().unwrap();
 
         // This report was encrypted with a global HPKE config that has the same config
         // ID as the task's HPKE config.
-        let report_metadata_same_id = ReportMetadata::new(
-            random(),
-            clock
-                .now()
-                .to_batch_interval_start(task.time_precision())
-                .unwrap(),
-        );
-        let transcript = run_vdaf(
-            &vdaf,
-            verify_key.as_bytes(),
-            &dummy_vdaf::AggregationParam(0),
-            report_metadata_same_id.id(),
-            &(),
-        );
-        let report_share_same_id = generate_helper_report_share::<dummy_vdaf::Vdaf>(
-            *task.id(),
-            report_metadata_same_id,
-            global_hpke_keypair_same_id.config(),
-            &transcript.public_share,
-            Vec::new(),
-            &transcript.input_shares[1],
-        );
+        let (prepare_init_same_id, transcript_same_id) = prep_init_generator.next(&());
 
         // This report was encrypted with a global HPKE config that has the same config
         // ID as the task's HPKE config, but will fail to decrypt.
-        let report_metadata_same_id_corrupted = ReportMetadata::new(
-            random(),
-            clock
-                .now()
-                .to_batch_interval_start(task.time_precision())
-                .unwrap(),
-        );
-        let transcript = run_vdaf(
-            &vdaf,
-            verify_key.as_bytes(),
-            &dummy_vdaf::AggregationParam(0),
-            report_metadata_same_id_corrupted.id(),
-            &(),
-        );
-        let report_share_same_id_corrupted = generate_helper_report_share::<dummy_vdaf::Vdaf>(
-            *task.id(),
-            report_metadata_same_id_corrupted.clone(),
-            global_hpke_keypair_same_id.config(),
-            &transcript.public_share,
-            Vec::new(),
-            &transcript.input_shares[1],
-        );
-        let encrypted_input_share = report_share_same_id_corrupted.encrypted_input_share();
+        let (prepare_init_same_id_corrupted, transcript_same_id_corrupted) =
+            prep_init_generator.next(&());
+
+        let encrypted_input_share = prepare_init_same_id_corrupted
+            .report_share()
+            .encrypted_input_share();
         let mut corrupted_payload = encrypted_input_share.payload().to_vec();
         corrupted_payload[0] ^= 0xFF;
         let corrupted_input_share = HpkeCiphertext::new(
@@ -2088,11 +2017,17 @@ mod tests {
             encrypted_input_share.encapsulated_key().to_vec(),
             corrupted_payload,
         );
-        let encoded_public_share = transcript.public_share.get_encoded();
-        let report_share_same_id_corrupted = ReportShare::new(
-            report_metadata_same_id_corrupted,
-            encoded_public_share.clone(),
-            corrupted_input_share,
+
+        let prepare_init_same_id_corrupted = PrepareInit::new(
+            ReportShare::new(
+                prepare_init_same_id_corrupted
+                    .report_share()
+                    .metadata()
+                    .clone(),
+                transcript_same_id_corrupted.public_share.get_encoded(),
+                corrupted_input_share,
+            ),
+            prepare_init_same_id_corrupted.message().clone(),
         );
 
         // This report was encrypted with a global HPKE config that doesn't collide
@@ -2104,7 +2039,7 @@ mod tests {
                 .to_batch_interval_start(task.time_precision())
                 .unwrap(),
         );
-        let transcript = run_vdaf(
+        let transcript_different_id = run_vdaf(
             &vdaf,
             verify_key.as_bytes(),
             &dummy_vdaf::AggregationParam(0),
@@ -2115,9 +2050,16 @@ mod tests {
             *task.id(),
             report_metadata_different_id,
             global_hpke_keypair_different_id.config(),
-            &transcript.public_share,
+            &transcript_different_id.public_share,
             Vec::new(),
-            &transcript.input_shares[1],
+            &transcript_different_id.helper_input_share,
+        );
+
+        let prepare_init_different_id = PrepareInit::new(
+            report_share_different_id,
+            transcript_different_id.leader_prepare_transitions[0]
+                .message
+                .clone(),
         );
 
         // This report was encrypted with a global HPKE config that doesn't collide
@@ -2129,7 +2071,7 @@ mod tests {
                 .to_batch_interval_start(task.time_precision())
                 .unwrap(),
         );
-        let transcript = run_vdaf(
+        let transcript_different_id_corrupted = run_vdaf(
             &vdaf,
             verify_key.as_bytes(),
             &dummy_vdaf::AggregationParam(0),
@@ -2140,9 +2082,9 @@ mod tests {
             *task.id(),
             report_metadata_different_id_corrupted.clone(),
             global_hpke_keypair_different_id.config(),
-            &transcript.public_share,
+            &transcript_different_id_corrupted.public_share,
             Vec::new(),
-            &transcript.input_shares[1],
+            &transcript_different_id_corrupted.helper_input_share,
         );
         let encrypted_input_share = report_share_different_id_corrupted.encrypted_input_share();
         let mut corrupted_payload = encrypted_input_share.payload().to_vec();
@@ -2152,11 +2094,17 @@ mod tests {
             encrypted_input_share.encapsulated_key().to_vec(),
             corrupted_payload,
         );
-        let encoded_public_share = transcript.public_share.get_encoded();
-        let report_share_different_id_corrupted = ReportShare::new(
-            report_metadata_different_id_corrupted,
-            encoded_public_share.clone(),
-            corrupted_input_share,
+        let encoded_public_share = transcript_different_id_corrupted.public_share.get_encoded();
+
+        let prepare_init_different_id_corrupted = PrepareInit::new(
+            ReportShare::new(
+                report_metadata_different_id_corrupted,
+                encoded_public_share.clone(),
+                corrupted_input_share,
+            ),
+            transcript_different_id_corrupted.leader_prepare_transitions[0]
+                .message
+                .clone(),
         );
 
         let aggregation_job_id: AggregationJobId = random();
@@ -2164,10 +2112,10 @@ mod tests {
             dummy_vdaf::AggregationParam(0).get_encoded(),
             PartialBatchSelector::new_time_interval(),
             Vec::from([
-                report_share_same_id.clone(),
-                report_share_different_id.clone(),
-                report_share_same_id_corrupted.clone(),
-                report_share_different_id_corrupted.clone(),
+                prepare_init_same_id.clone(),
+                prepare_init_different_id.clone(),
+                prepare_init_same_id_corrupted.clone(),
+                prepare_init_different_id_corrupted.clone(),
             ]),
         );
 
@@ -2177,46 +2125,53 @@ mod tests {
         let aggregate_resp: AggregationJobResp = decode_response_body(&mut test_conn).await;
 
         // Validate response.
-        assert_eq!(aggregate_resp.prepare_steps().len(), 4);
+        assert_eq!(aggregate_resp.prepare_resps().len(), 4);
 
-        let prepare_step_same_id = aggregate_resp.prepare_steps().get(0).unwrap();
+        let prepare_step_same_id = aggregate_resp.prepare_resps().get(0).unwrap();
         assert_eq!(
             prepare_step_same_id.report_id(),
-            report_share_same_id.metadata().id()
+            prepare_init_same_id.report_share().metadata().id()
         );
-        assert_matches!(
-            prepare_step_same_id.result(),
-            &PrepareStepResult::Continued(..)
-        );
+        assert_matches!(prepare_step_same_id.result(), PrepareStepResult::Continue { message } => {
+            assert_eq!(message, &transcript_same_id.helper_prepare_transitions[0].message);
+        });
 
-        let prepare_step_different_id = aggregate_resp.prepare_steps().get(1).unwrap();
+        let prepare_step_different_id = aggregate_resp.prepare_resps().get(1).unwrap();
         assert_eq!(
             prepare_step_different_id.report_id(),
-            report_share_different_id.metadata().id()
+            prepare_init_different_id.report_share().metadata().id()
         );
         assert_matches!(
             prepare_step_different_id.result(),
-            &PrepareStepResult::Continued(..)
+            PrepareStepResult::Continue { message } => {
+                assert_eq!(message, &transcript_different_id.helper_prepare_transitions[0].message);
+            }
         );
 
-        let prepare_step_same_id_corrupted = aggregate_resp.prepare_steps().get(2).unwrap();
+        let prepare_step_same_id_corrupted = aggregate_resp.prepare_resps().get(2).unwrap();
         assert_eq!(
             prepare_step_same_id_corrupted.report_id(),
-            report_share_same_id_corrupted.metadata().id()
+            prepare_init_same_id_corrupted
+                .report_share()
+                .metadata()
+                .id(),
         );
         assert_matches!(
             prepare_step_same_id_corrupted.result(),
-            &PrepareStepResult::Failed(ReportShareError::HpkeDecryptError)
+            &PrepareStepResult::Reject(PrepareError::HpkeDecryptError)
         );
 
-        let prepare_step_different_id_corrupted = aggregate_resp.prepare_steps().get(3).unwrap();
+        let prepare_step_different_id_corrupted = aggregate_resp.prepare_resps().get(3).unwrap();
         assert_eq!(
             prepare_step_different_id_corrupted.report_id(),
-            report_share_different_id_corrupted.metadata().id()
+            prepare_init_different_id_corrupted
+                .report_share()
+                .metadata()
+                .id()
         );
         assert_matches!(
             prepare_step_different_id_corrupted.result(),
-            &PrepareStepResult::Failed(ReportShareError::HpkeDecryptError)
+            &PrepareStepResult::Reject(PrepareError::HpkeDecryptError)
         );
     }
 
@@ -2230,24 +2185,23 @@ mod tests {
 
         // This report has the same ID as the previous one, but a different timestamp.
         let mutated_timestamp_report_metadata = ReportMetadata::new(
-            *test_case.report_shares[0].metadata().id(),
+            *test_case.prepare_inits[0].report_share().metadata().id(),
             test_case
                 .clock
                 .now()
                 .add(test_case.task.time_precision())
                 .unwrap(),
         );
-        let mutated_timestamp_report_share = test_case
-            .report_share_generator
-            .next_with_metadata(mutated_timestamp_report_metadata)
-            .0;
+        let (mutated_timestamp_prepare_init, _) = test_case
+            .prepare_init_generator
+            .next_with_metadata(mutated_timestamp_report_metadata, &());
 
         // Send another aggregate job re-using the same report ID but with a different timestamp. It
         // should be flagged as a replay.
         let request = AggregationJobInitializeReq::new(
             other_aggregation_parameter.get_encoded(),
             PartialBatchSelector::new_time_interval(),
-            Vec::from([mutated_timestamp_report_share.clone()]),
+            Vec::from([mutated_timestamp_prepare_init.clone()]),
         );
 
         let mut test_conn =
@@ -2255,16 +2209,19 @@ mod tests {
         assert_eq!(test_conn.status(), Some(Status::Ok));
         let aggregate_resp: AggregationJobResp = decode_response_body(&mut test_conn).await;
 
-        assert_eq!(aggregate_resp.prepare_steps().len(), 1);
+        assert_eq!(aggregate_resp.prepare_resps().len(), 1);
 
-        let prepare_step = aggregate_resp.prepare_steps().get(0).unwrap();
+        let prepare_step = aggregate_resp.prepare_resps().get(0).unwrap();
         assert_eq!(
             prepare_step.report_id(),
-            mutated_timestamp_report_share.metadata().id()
+            mutated_timestamp_prepare_init
+                .report_share()
+                .metadata()
+                .id(),
         );
         assert_matches!(
             prepare_step.result(),
-            &PrepareStepResult::Failed(ReportShareError::ReportReplayed)
+            &PrepareStepResult::Reject(PrepareError::ReportReplayed)
         );
 
         // The attempt to mutate the report share timestamp should not cause any change in the
@@ -2282,8 +2239,14 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(client_reports.len(), 2);
-        assert_eq!(&client_reports[0], test_case.report_shares[0].metadata());
-        assert_eq!(&client_reports[1], test_case.report_shares[1].metadata());
+        assert_eq!(
+            &client_reports[0],
+            test_case.prepare_inits[0].report_share().metadata()
+        );
+        assert_eq!(
+            &client_reports[1],
+            test_case.prepare_inits[1].report_share().metadata()
+        );
     }
 
     #[tokio::test]
@@ -2296,27 +2259,20 @@ mod tests {
             Role::Helper,
         )
         .build();
-        datastore.put_task(&task).await.unwrap();
-        let hpke_key = task.current_hpke_key();
-
-        let report_share = generate_helper_report_share::<dummy_vdaf::Vdaf>(
-            *task.id(),
-            ReportMetadata::new(
-                random(),
-                clock
-                    .now()
-                    .to_batch_interval_start(task.time_precision())
-                    .unwrap(),
-            ),
-            hpke_key.config(),
-            &(),
-            Vec::new(),
-            &dummy_vdaf::InputShare::default(),
+        let prep_init_generator = PrepareInitGenerator::new(
+            clock.clone(),
+            task.clone(),
+            dummy_vdaf::Vdaf::new(),
+            dummy_vdaf::AggregationParam(0),
         );
+
+        datastore.put_task(&task).await.unwrap();
+
+        let (prepare_init, _) = prep_init_generator.next(&());
         let request = AggregationJobInitializeReq::new(
             dummy_vdaf::AggregationParam(0).get_encoded(),
             PartialBatchSelector::new_time_interval(),
-            Vec::from([report_share.clone()]),
+            Vec::from([prepare_init.clone()]),
         );
 
         // Send request, and parse response.
@@ -2331,13 +2287,16 @@ mod tests {
         let aggregate_resp: AggregationJobResp = decode_response_body(&mut test_conn).await;
 
         // Validate response.
-        assert_eq!(aggregate_resp.prepare_steps().len(), 1);
+        assert_eq!(aggregate_resp.prepare_resps().len(), 1);
 
-        let prepare_step = aggregate_resp.prepare_steps().get(0).unwrap();
-        assert_eq!(prepare_step.report_id(), report_share.metadata().id());
+        let prepare_step = aggregate_resp.prepare_resps().get(0).unwrap();
+        assert_eq!(
+            prepare_step.report_id(),
+            prepare_init.report_share().metadata().id()
+        );
         assert_matches!(
             prepare_step.result(),
-            &PrepareStepResult::Failed(ReportShareError::VdafPrepError)
+            &PrepareStepResult::Reject(PrepareError::VdafPrepError)
         );
     }
 
@@ -2347,31 +2306,24 @@ mod tests {
 
         let task = TaskBuilder::new(
             QueryType::TimeInterval,
-            VdafInstance::FakeFailsPrepInit,
+            VdafInstance::FakeFailsPrepStep,
             Role::Helper,
         )
         .build();
-        let hpke_key = task.current_hpke_key();
+        let prep_init_generator = PrepareInitGenerator::new(
+            clock.clone(),
+            task.clone(),
+            dummy_vdaf::Vdaf::new(),
+            dummy_vdaf::AggregationParam(0),
+        );
+
         datastore.put_task(&task).await.unwrap();
 
-        let report_share = generate_helper_report_share::<dummy_vdaf::Vdaf>(
-            *task.id(),
-            ReportMetadata::new(
-                random(),
-                clock
-                    .now()
-                    .to_batch_interval_start(task.time_precision())
-                    .unwrap(),
-            ),
-            hpke_key.config(),
-            &(),
-            Vec::new(),
-            &dummy_vdaf::InputShare::default(),
-        );
+        let (prepare_init, _) = prep_init_generator.next(&());
         let request = AggregationJobInitializeReq::new(
             dummy_vdaf::AggregationParam(0).get_encoded(),
             PartialBatchSelector::new_time_interval(),
-            Vec::from([report_share.clone()]),
+            Vec::from([prepare_init.clone()]),
         );
 
         let aggregation_job_id: AggregationJobId = random();
@@ -2385,46 +2337,40 @@ mod tests {
         let aggregate_resp: AggregationJobResp = decode_response_body(&mut test_conn).await;
 
         // Validate response.
-        assert_eq!(aggregate_resp.prepare_steps().len(), 1);
+        assert_eq!(aggregate_resp.prepare_resps().len(), 1);
 
-        let prepare_step = aggregate_resp.prepare_steps().get(0).unwrap();
-        assert_eq!(prepare_step.report_id(), report_share.metadata().id());
+        let prepare_step = aggregate_resp.prepare_resps().get(0).unwrap();
+        assert_eq!(
+            prepare_step.report_id(),
+            prepare_init.report_share().metadata().id()
+        );
         assert_matches!(
             prepare_step.result(),
-            &PrepareStepResult::Failed(ReportShareError::VdafPrepError)
+            &PrepareStepResult::Reject(PrepareError::VdafPrepError)
         );
     }
 
     #[tokio::test]
     async fn aggregate_init_duplicated_report_id() {
-        let (_, _ephemeral_datastore, datastore, handler) = setup_http_handler_test().await;
+        let (clock, _ephemeral_datastore, datastore, handler) = setup_http_handler_test().await;
 
-        let task = TaskBuilder::new(
-            QueryType::TimeInterval,
-            VdafInstance::FakeFailsPrepInit,
-            Role::Helper,
-        )
-        .build();
+        let task =
+            TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Helper).build();
+        let prep_init_generator = PrepareInitGenerator::new(
+            clock.clone(),
+            task.clone(),
+            dummy_vdaf::Vdaf::new(),
+            dummy_vdaf::AggregationParam(0),
+        );
+
         datastore.put_task(&task).await.unwrap();
 
-        let report_share = ReportShare::new(
-            ReportMetadata::new(
-                ReportId::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
-                Time::from_seconds_since_epoch(54321),
-            ),
-            Vec::from("PUBLIC"),
-            HpkeCiphertext::new(
-                // bogus, but we never get far enough to notice
-                HpkeConfigId::from(42),
-                Vec::from("012345"),
-                Vec::from("543210"),
-            ),
-        );
+        let (prepare_init, _) = prep_init_generator.next(&());
 
         let request = AggregationJobInitializeReq::new(
             dummy_vdaf::AggregationParam(0).get_encoded(),
             PartialBatchSelector::new_time_interval(),
-            Vec::from([report_share.clone(), report_share]),
+            Vec::from([prepare_init.clone(), prepare_init]),
         );
         let aggregation_job_id: AggregationJobId = random();
 
@@ -2451,14 +2397,17 @@ mod tests {
         let aggregation_job_id = random();
         let task = TaskBuilder::new(
             QueryType::TimeInterval,
-            VdafInstance::Prio3Count,
+            VdafInstance::Poplar1 { bits: 1 },
             Role::Helper,
         )
         .build();
 
-        let vdaf = Arc::new(Prio3::new_count(2).unwrap());
+        let vdaf = Arc::new(Poplar1::<XofShake128, 16>::new(1));
         let verify_key: VerifyKey<VERIFY_KEY_LENGTH> = task.primary_vdaf_verify_key().unwrap();
         let hpke_key = task.current_hpke_key();
+        let measurement = IdpfInput::from_bools(&[true]);
+        let aggregation_param =
+            Poplar1AggregationParam::try_from_prefixes(vec![measurement.clone()]).unwrap();
 
         // report_share_0 is a "happy path" report.
         let report_metadata_0 = ReportMetadata::new(
@@ -2471,19 +2420,19 @@ mod tests {
         let transcript_0 = run_vdaf(
             vdaf.as_ref(),
             verify_key.as_bytes(),
-            &(),
+            &aggregation_param,
             report_metadata_0.id(),
-            &0,
+            &measurement,
         );
-        let (prep_state_0, _) = transcript_0.helper_prep_state(0);
-        let prep_msg_0 = transcript_0.prepare_messages[0].clone();
-        let report_share_0 = generate_helper_report_share::<Prio3Count>(
+        let helper_prep_state_0 = transcript_0.helper_prepare_transitions[0].prepare_state();
+        let leader_prep_message_0 = &transcript_0.leader_prepare_transitions[1].message;
+        let report_share_0 = generate_helper_report_share::<Poplar1<XofShake128, 16>>(
             *task.id(),
             report_metadata_0.clone(),
             hpke_key.config(),
             &transcript_0.public_share,
             Vec::new(),
-            &transcript_0.input_shares[1],
+            &transcript_0.helper_input_share,
         );
 
         // report_share_1 is omitted by the leader's request.
@@ -2497,19 +2446,19 @@ mod tests {
         let transcript_1 = run_vdaf(
             vdaf.as_ref(),
             verify_key.as_bytes(),
-            &(),
+            &aggregation_param,
             report_metadata_1.id(),
-            &0,
+            &measurement,
         );
 
-        let (prep_state_1, _) = transcript_1.helper_prep_state(0);
-        let report_share_1 = generate_helper_report_share::<Prio3Count>(
+        let helper_prep_state_1 = transcript_1.helper_prepare_transitions[0].prepare_state();
+        let report_share_1 = generate_helper_report_share::<Poplar1<XofShake128, 16>>(
             *task.id(),
             report_metadata_1.clone(),
             hpke_key.config(),
             &transcript_1.public_share,
             Vec::new(),
-            &transcript_1.input_shares[1],
+            &transcript_1.helper_input_share,
         );
 
         // report_share_2 falls into a batch that has already been collected.
@@ -2526,19 +2475,19 @@ mod tests {
         let transcript_2 = run_vdaf(
             vdaf.as_ref(),
             verify_key.as_bytes(),
-            &(),
+            &aggregation_param,
             report_metadata_2.id(),
-            &0,
+            &measurement,
         );
-        let (prep_state_2, _) = transcript_2.helper_prep_state(0);
-        let prep_msg_2 = transcript_2.prepare_messages[0].clone();
-        let report_share_2 = generate_helper_report_share::<Prio3Count>(
+        let helper_prep_state_2 = transcript_2.helper_prepare_transitions[0].prepare_state();
+        let leader_prep_message_2 = &transcript_2.leader_prepare_transitions[1].message;
+        let report_share_2 = generate_helper_report_share::<Poplar1<XofShake128, 16>>(
             *task.id(),
             report_metadata_2.clone(),
             hpke_key.config(),
             &transcript_2.public_share,
             Vec::new(),
-            &transcript_2.input_shares[1],
+            &transcript_2.helper_input_share,
         );
 
         datastore
@@ -2549,16 +2498,18 @@ mod tests {
                     report_share_1.clone(),
                     report_share_2.clone(),
                 );
-                let (prep_state_0, prep_state_1, prep_state_2) = (
-                    prep_state_0.clone(),
-                    prep_state_1.clone(),
-                    prep_state_2.clone(),
+                let (helper_prep_state_0, helper_prep_state_1, helper_prep_state_2) = (
+                    helper_prep_state_0.clone(),
+                    helper_prep_state_1.clone(),
+                    helper_prep_state_2.clone(),
                 );
                 let (report_metadata_0, report_metadata_1, report_metadata_2) = (
                     report_metadata_0.clone(),
                     report_metadata_1.clone(),
                     report_metadata_2.clone(),
                 );
+                let aggregation_param = aggregation_param.clone();
+                let helper_aggregate_share = transcript_0.helper_aggregate_share.clone();
 
                 Box::pin(async move {
                     tx.put_task(&task).await?;
@@ -2570,11 +2521,11 @@ mod tests {
                     tx.put_aggregation_job(&AggregationJob::<
                         VERIFY_KEY_LENGTH,
                         TimeInterval,
-                        Prio3Count,
+                        Poplar1<XofShake128, 16>,
                     >::new(
                         *task.id(),
                         aggregation_job_id,
-                        (),
+                        aggregation_param.clone(),
                         (),
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
@@ -2583,7 +2534,7 @@ mod tests {
                     ))
                     .await?;
 
-                    tx.put_report_aggregation::<VERIFY_KEY_LENGTH, Prio3Count>(
+                    tx.put_report_aggregation::<VERIFY_KEY_LENGTH, Poplar1<XofShake128, 16>>(
                         &ReportAggregation::new(
                             *task.id(),
                             aggregation_job_id,
@@ -2591,11 +2542,11 @@ mod tests {
                             *report_metadata_0.time(),
                             0,
                             None,
-                            ReportAggregationState::Waiting(prep_state_0, None),
+                            ReportAggregationState::WaitingHelper(helper_prep_state_0),
                         ),
                     )
                     .await?;
-                    tx.put_report_aggregation::<VERIFY_KEY_LENGTH, Prio3Count>(
+                    tx.put_report_aggregation::<VERIFY_KEY_LENGTH, Poplar1<XofShake128, 16>>(
                         &ReportAggregation::new(
                             *task.id(),
                             aggregation_job_id,
@@ -2603,11 +2554,11 @@ mod tests {
                             *report_metadata_1.time(),
                             1,
                             None,
-                            ReportAggregationState::Waiting(prep_state_1, None),
+                            ReportAggregationState::WaitingHelper(helper_prep_state_1),
                         ),
                     )
                     .await?;
-                    tx.put_report_aggregation::<VERIFY_KEY_LENGTH, Prio3Count>(
+                    tx.put_report_aggregation::<VERIFY_KEY_LENGTH, Poplar1<XofShake128, 16>>(
                         &ReportAggregation::new(
                             *task.id(),
                             aggregation_job_id,
@@ -2615,12 +2566,12 @@ mod tests {
                             *report_metadata_2.time(),
                             2,
                             None,
-                            ReportAggregationState::Waiting(prep_state_2, None),
+                            ReportAggregationState::WaitingHelper(helper_prep_state_2),
                         ),
                     )
                     .await?;
 
-                    tx.put_aggregate_share_job::<VERIFY_KEY_LENGTH, TimeInterval, Prio3Count>(
+                    tx.put_aggregate_share_job::<VERIFY_KEY_LENGTH, TimeInterval, Poplar1<XofShake128, 16>>(
                         &AggregateShareJob::new(
                             *task.id(),
                             Interval::new(
@@ -2628,8 +2579,8 @@ mod tests {
                                 *task.time_precision(),
                             )
                             .unwrap(),
-                            (),
-                            AggregateShare::from(OutputShare::from(Vec::from([Field64::from(7)]))),
+                            aggregation_param.clone(),
+                            helper_aggregate_share,
                             0,
                             ReportIdChecksum::default(),
                         ),
@@ -2643,14 +2594,8 @@ mod tests {
         let request = AggregationJobContinueReq::new(
             AggregationJobRound::from(1),
             Vec::from([
-                PrepareStep::new(
-                    *report_metadata_0.id(),
-                    PrepareStepResult::Continued(prep_msg_0.get_encoded()),
-                ),
-                PrepareStep::new(
-                    *report_metadata_2.id(),
-                    PrepareStepResult::Continued(prep_msg_2.get_encoded()),
-                ),
+                PrepareContinue::new(*report_metadata_0.id(), leader_prep_message_0.clone()),
+                PrepareContinue::new(*report_metadata_2.id(), leader_prep_message_2.clone()),
             ]),
         );
 
@@ -2662,10 +2607,10 @@ mod tests {
         assert_eq!(
             aggregate_resp,
             AggregationJobResp::new(Vec::from([
-                PrepareStep::new(*report_metadata_0.id(), PrepareStepResult::Finished),
-                PrepareStep::new(
+                PrepareResp::new(*report_metadata_0.id(), PrepareStepResult::Finished),
+                PrepareResp::new(
                     *report_metadata_2.id(),
-                    PrepareStepResult::Failed(ReportShareError::BatchCollected),
+                    PrepareStepResult::Reject(PrepareError::BatchCollected),
                 )
             ]))
         );
@@ -2676,7 +2621,7 @@ mod tests {
                 let (vdaf, task) = (Arc::clone(&vdaf), task.clone());
                 Box::pin(async move {
                     let aggregation_job = tx
-                        .get_aggregation_job::<VERIFY_KEY_LENGTH, TimeInterval, Prio3Count>(
+                        .get_aggregation_job::<VERIFY_KEY_LENGTH, TimeInterval, Poplar1<XofShake128, 16>>(
                             task.id(),
                             &aggregation_job_id,
                         )
@@ -2703,7 +2648,7 @@ mod tests {
             AggregationJob::new(
                 *task.id(),
                 aggregation_job_id,
-                (),
+                aggregation_param,
                 (),
                 Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                     .unwrap(),
@@ -2721,7 +2666,7 @@ mod tests {
                     *report_metadata_0.id(),
                     *report_metadata_0.time(),
                     0,
-                    Some(PrepareStep::new(
+                    Some(PrepareResp::new(
                         *report_metadata_0.id(),
                         PrepareStepResult::Finished
                     )),
@@ -2734,7 +2679,7 @@ mod tests {
                     *report_metadata_1.time(),
                     1,
                     None,
-                    ReportAggregationState::Failed(ReportShareError::ReportDropped),
+                    ReportAggregationState::Failed(PrepareError::ReportDropped),
                 ),
                 ReportAggregation::new(
                     *task.id(),
@@ -2742,11 +2687,11 @@ mod tests {
                     *report_metadata_2.id(),
                     *report_metadata_2.time(),
                     2,
-                    Some(PrepareStep::new(
+                    Some(PrepareResp::new(
                         *report_metadata_2.id(),
-                        PrepareStepResult::Failed(ReportShareError::BatchCollected)
+                        PrepareStepResult::Reject(PrepareError::BatchCollected)
                     )),
-                    ReportAggregationState::Failed(ReportShareError::BatchCollected),
+                    ReportAggregationState::Failed(PrepareError::BatchCollected),
                 )
             ])
         );
@@ -2758,7 +2703,7 @@ mod tests {
 
         let task = TaskBuilder::new(
             QueryType::TimeInterval,
-            VdafInstance::Prio3Count,
+            VdafInstance::Poplar1 { bits: 1 },
             Role::Helper,
         )
         .build();
@@ -2772,9 +2717,12 @@ mod tests {
                 .unwrap(),
         );
 
-        let vdaf = Prio3::new_count(2).unwrap();
+        let vdaf = Poplar1::new(1);
         let verify_key: VerifyKey<VERIFY_KEY_LENGTH> = task.primary_vdaf_verify_key().unwrap();
         let hpke_key = task.current_hpke_key();
+        let measurement = IdpfInput::from_bools(&[true]);
+        let aggregation_param =
+            Poplar1AggregationParam::try_from_prefixes(vec![measurement.clone()]).unwrap();
 
         // report_share_0 is a "happy path" report.
         let report_metadata_0 = ReportMetadata::new(
@@ -2787,20 +2735,19 @@ mod tests {
         let transcript_0 = run_vdaf(
             &vdaf,
             verify_key.as_bytes(),
-            &(),
+            &aggregation_param,
             report_metadata_0.id(),
-            &0,
+            &measurement,
         );
-        let (prep_state_0, _) = transcript_0.helper_prep_state(0);
-        let out_share_0 = transcript_0.output_share(Role::Helper);
-        let prep_msg_0 = transcript_0.prepare_messages[0].clone();
-        let report_share_0 = generate_helper_report_share::<Prio3Count>(
+        let helper_prep_state_0 = transcript_0.helper_prepare_transitions[0].prepare_state();
+        let ping_pong_leader_message_0 = &transcript_0.leader_prepare_transitions[1].message;
+        let report_share_0 = generate_helper_report_share::<Poplar1<XofShake128, 16>>(
             *task.id(),
             report_metadata_0.clone(),
             hpke_key.config(),
             &transcript_0.public_share,
             Vec::new(),
-            &transcript_0.input_shares[1],
+            &transcript_0.helper_input_share,
         );
 
         // report_share_1 is another "happy path" report to exercise in-memory accumulation of
@@ -2815,20 +2762,19 @@ mod tests {
         let transcript_1 = run_vdaf(
             &vdaf,
             verify_key.as_bytes(),
-            &(),
+            &aggregation_param,
             report_metadata_1.id(),
-            &0,
+            &measurement,
         );
-        let (prep_state_1, _) = transcript_1.helper_prep_state(0);
-        let out_share_1 = transcript_1.output_share(Role::Helper);
-        let prep_msg_1 = transcript_1.prepare_messages[0].clone();
-        let report_share_1 = generate_helper_report_share::<Prio3Count>(
+        let helper_prep_state_1 = transcript_1.helper_prepare_transitions[0].prepare_state();
+        let ping_pong_leader_message_1 = &transcript_1.leader_prepare_transitions[1].message;
+        let report_share_1 = generate_helper_report_share::<Poplar1<XofShake128, 16>>(
             *task.id(),
             report_metadata_1.clone(),
             hpke_key.config(),
             &transcript_1.public_share,
             Vec::new(),
-            &transcript_1.input_shares[1],
+            &transcript_1.helper_input_share,
         );
 
         // report_share_2 aggregates successfully, but into a distinct batch aggregation which has
@@ -2843,19 +2789,19 @@ mod tests {
         let transcript_2 = run_vdaf(
             &vdaf,
             verify_key.as_bytes(),
-            &(),
+            &aggregation_param,
             report_metadata_2.id(),
-            &0,
+            &measurement,
         );
-        let (prep_state_2, _) = transcript_2.helper_prep_state(0);
-        let prep_msg_2 = transcript_2.prepare_messages[0].clone();
-        let report_share_2 = generate_helper_report_share::<Prio3Count>(
+        let helper_prep_state_2 = transcript_2.helper_prepare_transitions[0].prepare_state();
+        let ping_pong_leader_message_2 = &transcript_2.leader_prepare_transitions[1].message;
+        let report_share_2 = generate_helper_report_share::<Poplar1<XofShake128, 16>>(
             *task.id(),
             report_metadata_2.clone(),
             hpke_key.config(),
             &transcript_2.public_share,
             Vec::new(),
-            &transcript_2.input_shares[1],
+            &transcript_2.helper_input_share,
         );
 
         let first_batch_identifier = Interval::new(
@@ -2875,11 +2821,11 @@ mod tests {
         )
         .unwrap();
         let second_batch_want_batch_aggregations =
-            empty_batch_aggregations::<VERIFY_KEY_LENGTH, TimeInterval, Prio3Count>(
+            empty_batch_aggregations::<VERIFY_KEY_LENGTH, TimeInterval, Poplar1<XofShake128, 16>>(
                 &task,
                 BATCH_AGGREGATION_SHARD_COUNT,
                 &second_batch_identifier,
-                &(),
+                &aggregation_param,
                 &[],
             );
 
@@ -2891,16 +2837,17 @@ mod tests {
                     report_share_1.clone(),
                     report_share_2.clone(),
                 );
-                let (prep_state_0, prep_state_1, prep_state_2) = (
-                    prep_state_0.clone(),
-                    prep_state_1.clone(),
-                    prep_state_2.clone(),
+                let (helper_prep_state_0, helper_prep_state_1, helper_prep_state_2) = (
+                    helper_prep_state_0.clone(),
+                    helper_prep_state_1.clone(),
+                    helper_prep_state_2.clone(),
                 );
                 let (report_metadata_0, report_metadata_1, report_metadata_2) = (
                     report_metadata_0.clone(),
                     report_metadata_1.clone(),
                     report_metadata_2.clone(),
                 );
+                let aggregation_param = aggregation_param.clone();
                 let second_batch_want_batch_aggregations =
                     second_batch_want_batch_aggregations.clone();
 
@@ -2914,11 +2861,11 @@ mod tests {
                     tx.put_aggregation_job(&AggregationJob::<
                         VERIFY_KEY_LENGTH,
                         TimeInterval,
-                        Prio3Count,
+                        Poplar1<XofShake128, 16>,
                     >::new(
                         *task.id(),
                         aggregation_job_id_0,
-                        (),
+                        aggregation_param.clone(),
                         (),
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
@@ -2927,48 +2874,55 @@ mod tests {
                     ))
                     .await?;
 
-                    tx.put_report_aggregation(
-                        &ReportAggregation::<VERIFY_KEY_LENGTH, Prio3Count>::new(
-                            *task.id(),
-                            aggregation_job_id_0,
-                            *report_metadata_0.id(),
-                            *report_metadata_0.time(),
-                            0,
-                            None,
-                            ReportAggregationState::Waiting(prep_state_0, None),
-                        ),
-                    )
+                    tx.put_report_aggregation(&ReportAggregation::<
+                        VERIFY_KEY_LENGTH,
+                        Poplar1<XofShake128, 16>,
+                    >::new(
+                        *task.id(),
+                        aggregation_job_id_0,
+                        *report_metadata_0.id(),
+                        *report_metadata_0.time(),
+                        0,
+                        None,
+                        ReportAggregationState::WaitingHelper(helper_prep_state_0),
+                    ))
                     .await?;
-                    tx.put_report_aggregation(
-                        &ReportAggregation::<VERIFY_KEY_LENGTH, Prio3Count>::new(
-                            *task.id(),
-                            aggregation_job_id_0,
-                            *report_metadata_1.id(),
-                            *report_metadata_1.time(),
-                            1,
-                            None,
-                            ReportAggregationState::Waiting(prep_state_1, None),
-                        ),
-                    )
+                    tx.put_report_aggregation(&ReportAggregation::<
+                        VERIFY_KEY_LENGTH,
+                        Poplar1<XofShake128, 16>,
+                    >::new(
+                        *task.id(),
+                        aggregation_job_id_0,
+                        *report_metadata_1.id(),
+                        *report_metadata_1.time(),
+                        1,
+                        None,
+                        ReportAggregationState::WaitingHelper(helper_prep_state_1),
+                    ))
                     .await?;
-                    tx.put_report_aggregation(
-                        &ReportAggregation::<VERIFY_KEY_LENGTH, Prio3Count>::new(
-                            *task.id(),
-                            aggregation_job_id_0,
-                            *report_metadata_2.id(),
-                            *report_metadata_2.time(),
-                            2,
-                            None,
-                            ReportAggregationState::Waiting(prep_state_2, None),
-                        ),
-                    )
+                    tx.put_report_aggregation(&ReportAggregation::<
+                        VERIFY_KEY_LENGTH,
+                        Poplar1<XofShake128, 16>,
+                    >::new(
+                        *task.id(),
+                        aggregation_job_id_0,
+                        *report_metadata_2.id(),
+                        *report_metadata_2.time(),
+                        2,
+                        None,
+                        ReportAggregationState::WaitingHelper(helper_prep_state_2),
+                    ))
                     .await?;
 
                     for batch_identifier in [first_batch_identifier, second_batch_identifier] {
-                        tx.put_batch(&Batch::<VERIFY_KEY_LENGTH, TimeInterval, Prio3Count>::new(
+                        tx.put_batch(&Batch::<
+                            VERIFY_KEY_LENGTH,
+                            TimeInterval,
+                            Poplar1<XofShake128, 16>,
+                        >::new(
                             *task.id(),
                             batch_identifier,
-                            (),
+                            aggregation_param.clone(),
                             BatchState::Closed,
                             0,
                             batch_identifier,
@@ -2994,18 +2948,9 @@ mod tests {
         let request = AggregationJobContinueReq::new(
             AggregationJobRound::from(1),
             Vec::from([
-                PrepareStep::new(
-                    *report_metadata_0.id(),
-                    PrepareStepResult::Continued(prep_msg_0.get_encoded()),
-                ),
-                PrepareStep::new(
-                    *report_metadata_1.id(),
-                    PrepareStepResult::Continued(prep_msg_1.get_encoded()),
-                ),
-                PrepareStep::new(
-                    *report_metadata_2.id(),
-                    PrepareStepResult::Continued(prep_msg_2.get_encoded()),
-                ),
+                PrepareContinue::new(*report_metadata_0.id(), ping_pong_leader_message_0.clone()),
+                PrepareContinue::new(*report_metadata_1.id(), ping_pong_leader_message_1.clone()),
+                PrepareContinue::new(*report_metadata_2.id(), ping_pong_leader_message_2.clone()),
             ]),
         );
 
@@ -3016,12 +2961,16 @@ mod tests {
         // Map the batch aggregation ordinal value to 0, as it may vary due to sharding.
         let first_batch_got_batch_aggregations: Vec<_> = datastore
             .run_tx(|tx| {
-                let (task, vdaf, report_metadata_0) =
-                    (task.clone(), vdaf.clone(), report_metadata_0.clone());
+                let (task, vdaf, report_metadata_0, aggregation_param) = (
+                    task.clone(),
+                    vdaf.clone(),
+                    report_metadata_0.clone(),
+                    aggregation_param.clone(),
+                );
                 Box::pin(async move {
                     TimeInterval::get_batch_aggregations_for_collection_identifier::<
                         VERIFY_KEY_LENGTH,
-                        Prio3Count,
+                        Poplar1<XofShake128, 16>,
                         _,
                     >(
                         tx,
@@ -3035,7 +2984,7 @@ mod tests {
                             *task.time_precision(),
                         )
                         .unwrap(),
-                        &(),
+                        &aggregation_param,
                     )
                     .await
                 })
@@ -3044,10 +2993,10 @@ mod tests {
             .unwrap()
             .into_iter()
             .map(|agg| {
-                BatchAggregation::<VERIFY_KEY_LENGTH, TimeInterval, Prio3Count>::new(
+                BatchAggregation::<VERIFY_KEY_LENGTH, TimeInterval, Poplar1<XofShake128, 16>>::new(
                     *agg.task_id(),
                     *agg.batch_identifier(),
-                    (),
+                    agg.aggregation_parameter().clone(),
                     0,
                     BatchAggregationState::Aggregating,
                     agg.aggregate_share().cloned(),
@@ -3059,7 +3008,13 @@ mod tests {
             .collect();
 
         let aggregate_share = vdaf
-            .aggregate(&(), [out_share_0.clone(), out_share_1.clone()])
+            .aggregate(
+                &aggregation_param,
+                [
+                    transcript_0.helper_output_share.clone(),
+                    transcript_1.helper_output_share.clone(),
+                ],
+            )
             .unwrap();
         let checksum = ReportIdChecksum::for_report_id(report_metadata_0.id())
             .updated_with(report_metadata_1.id());
@@ -3076,7 +3031,7 @@ mod tests {
                     *task.time_precision()
                 )
                 .unwrap(),
-                (),
+                aggregation_param.clone(),
                 0,
                 BatchAggregationState::Aggregating,
                 Some(aggregate_share),
@@ -3088,12 +3043,16 @@ mod tests {
 
         let second_batch_got_batch_aggregations = datastore
             .run_tx(|tx| {
-                let (task, vdaf, report_metadata_2) =
-                    (task.clone(), vdaf.clone(), report_metadata_2.clone());
+                let (task, vdaf, report_metadata_2, aggregation_param) = (
+                    task.clone(),
+                    vdaf.clone(),
+                    report_metadata_2.clone(),
+                    aggregation_param.clone(),
+                );
                 Box::pin(async move {
                     TimeInterval::get_batch_aggregations_for_collection_identifier::<
                         VERIFY_KEY_LENGTH,
-                        Prio3Count,
+                        Poplar1<XofShake128, 16>,
                         _,
                     >(
                         tx,
@@ -3107,7 +3066,7 @@ mod tests {
                             Duration::from_seconds(task.time_precision().as_seconds()),
                         )
                         .unwrap(),
-                        &(),
+                        &aggregation_param,
                     )
                     .await
                 })
@@ -3132,20 +3091,19 @@ mod tests {
         let transcript_3 = run_vdaf(
             &vdaf,
             verify_key.as_bytes(),
-            &(),
+            &aggregation_param,
             report_metadata_3.id(),
-            &0,
+            &measurement,
         );
-        let (prep_state_3, _) = transcript_3.helper_prep_state(0);
-        let out_share_3 = transcript_3.output_share(Role::Helper);
-        let prep_msg_3 = transcript_3.prepare_messages[0].clone();
-        let report_share_3 = generate_helper_report_share::<Prio3Count>(
+        let helper_prep_state_3 = transcript_3.helper_prepare_transitions[0].prepare_state();
+        let ping_pong_leader_message_3 = &transcript_3.leader_prepare_transitions[1].message;
+        let report_share_3 = generate_helper_report_share::<Poplar1<XofShake128, 16>>(
             *task.id(),
             report_metadata_3.clone(),
             hpke_key.config(),
             &transcript_3.public_share,
             Vec::new(),
-            &transcript_3.input_shares[1],
+            &transcript_3.helper_input_share,
         );
 
         // report_share_4 gets aggregated into the second batch interval (which has already been
@@ -3160,19 +3118,19 @@ mod tests {
         let transcript_4 = run_vdaf(
             &vdaf,
             verify_key.as_bytes(),
-            &(),
+            &aggregation_param,
             report_metadata_4.id(),
-            &0,
+            &measurement,
         );
-        let (prep_state_4, _) = transcript_4.helper_prep_state(0);
-        let prep_msg_4 = transcript_4.prepare_messages[0].clone();
-        let report_share_4 = generate_helper_report_share::<Prio3Count>(
+        let helper_prep_state_4 = transcript_4.helper_prepare_transitions[0].prepare_state();
+        let ping_pong_leader_message_4 = &transcript_4.leader_prepare_transitions[1].message;
+        let report_share_4 = generate_helper_report_share::<Poplar1<XofShake128, 16>>(
             *task.id(),
             report_metadata_4.clone(),
             hpke_key.config(),
             &transcript_4.public_share,
             Vec::new(),
-            &transcript_4.input_shares[1],
+            &transcript_4.helper_input_share,
         );
 
         // report_share_5 also gets aggregated into the second batch interval (which has already
@@ -3187,19 +3145,19 @@ mod tests {
         let transcript_5 = run_vdaf(
             &vdaf,
             verify_key.as_bytes(),
-            &(),
+            &aggregation_param,
             report_metadata_5.id(),
-            &0,
+            &measurement,
         );
-        let (prep_state_5, _) = transcript_5.helper_prep_state(0);
-        let prep_msg_5 = transcript_5.prepare_messages[0].clone();
-        let report_share_5 = generate_helper_report_share::<Prio3Count>(
+        let helper_prep_state_5 = transcript_5.helper_prepare_transitions[0].prepare_state();
+        let ping_pong_leader_message_5 = &transcript_5.leader_prepare_transitions[1].message;
+        let report_share_5 = generate_helper_report_share::<Poplar1<XofShake128, 16>>(
             *task.id(),
             report_metadata_5.clone(),
             hpke_key.config(),
             &transcript_5.public_share,
             Vec::new(),
-            &transcript_5.input_shares[1],
+            &transcript_5.helper_input_share,
         );
 
         datastore
@@ -3210,16 +3168,17 @@ mod tests {
                     report_share_4.clone(),
                     report_share_5.clone(),
                 );
-                let (prep_state_3, prep_state_4, prep_state_5) = (
-                    prep_state_3.clone(),
-                    prep_state_4.clone(),
-                    prep_state_5.clone(),
+                let (helper_prep_state_3, helper_prep_state_4, helper_prep_state_5) = (
+                    helper_prep_state_3.clone(),
+                    helper_prep_state_4.clone(),
+                    helper_prep_state_5.clone(),
                 );
                 let (report_metadata_3, report_metadata_4, report_metadata_5) = (
                     report_metadata_3.clone(),
                     report_metadata_4.clone(),
                     report_metadata_5.clone(),
                 );
+                let aggregation_param = aggregation_param.clone();
 
                 Box::pin(async move {
                     tx.put_report_share(task.id(), &report_share_3).await?;
@@ -3229,11 +3188,11 @@ mod tests {
                     tx.put_aggregation_job(&AggregationJob::<
                         VERIFY_KEY_LENGTH,
                         TimeInterval,
-                        Prio3Count,
+                        Poplar1<XofShake128, 16>,
                     >::new(
                         *task.id(),
                         aggregation_job_id_1,
-                        (),
+                        aggregation_param,
                         (),
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
@@ -3242,41 +3201,44 @@ mod tests {
                     ))
                     .await?;
 
-                    tx.put_report_aggregation(
-                        &ReportAggregation::<VERIFY_KEY_LENGTH, Prio3Count>::new(
-                            *task.id(),
-                            aggregation_job_id_1,
-                            *report_metadata_3.id(),
-                            *report_metadata_3.time(),
-                            3,
-                            None,
-                            ReportAggregationState::Waiting(prep_state_3, None),
-                        ),
-                    )
+                    tx.put_report_aggregation(&ReportAggregation::<
+                        VERIFY_KEY_LENGTH,
+                        Poplar1<XofShake128, 16>,
+                    >::new(
+                        *task.id(),
+                        aggregation_job_id_1,
+                        *report_metadata_3.id(),
+                        *report_metadata_3.time(),
+                        3,
+                        None,
+                        ReportAggregationState::WaitingHelper(helper_prep_state_3),
+                    ))
                     .await?;
-                    tx.put_report_aggregation(
-                        &ReportAggregation::<VERIFY_KEY_LENGTH, Prio3Count>::new(
-                            *task.id(),
-                            aggregation_job_id_1,
-                            *report_metadata_4.id(),
-                            *report_metadata_4.time(),
-                            4,
-                            None,
-                            ReportAggregationState::Waiting(prep_state_4, None),
-                        ),
-                    )
+                    tx.put_report_aggregation(&ReportAggregation::<
+                        VERIFY_KEY_LENGTH,
+                        Poplar1<XofShake128, 16>,
+                    >::new(
+                        *task.id(),
+                        aggregation_job_id_1,
+                        *report_metadata_4.id(),
+                        *report_metadata_4.time(),
+                        4,
+                        None,
+                        ReportAggregationState::WaitingHelper(helper_prep_state_4),
+                    ))
                     .await?;
-                    tx.put_report_aggregation(
-                        &ReportAggregation::<VERIFY_KEY_LENGTH, Prio3Count>::new(
-                            *task.id(),
-                            aggregation_job_id_1,
-                            *report_metadata_5.id(),
-                            *report_metadata_5.time(),
-                            5,
-                            None,
-                            ReportAggregationState::Waiting(prep_state_5, None),
-                        ),
-                    )
+                    tx.put_report_aggregation(&ReportAggregation::<
+                        VERIFY_KEY_LENGTH,
+                        Poplar1<XofShake128, 16>,
+                    >::new(
+                        *task.id(),
+                        aggregation_job_id_1,
+                        *report_metadata_5.id(),
+                        *report_metadata_5.time(),
+                        5,
+                        None,
+                        ReportAggregationState::WaitingHelper(helper_prep_state_5),
+                    ))
                     .await?;
 
                     Ok(())
@@ -3288,18 +3250,9 @@ mod tests {
         let request = AggregationJobContinueReq::new(
             AggregationJobRound::from(1),
             Vec::from([
-                PrepareStep::new(
-                    *report_metadata_3.id(),
-                    PrepareStepResult::Continued(prep_msg_3.get_encoded()),
-                ),
-                PrepareStep::new(
-                    *report_metadata_4.id(),
-                    PrepareStepResult::Continued(prep_msg_4.get_encoded()),
-                ),
-                PrepareStep::new(
-                    *report_metadata_5.id(),
-                    PrepareStepResult::Continued(prep_msg_5.get_encoded()),
-                ),
+                PrepareContinue::new(*report_metadata_3.id(), ping_pong_leader_message_3.clone()),
+                PrepareContinue::new(*report_metadata_4.id(), ping_pong_leader_message_4.clone()),
+                PrepareContinue::new(*report_metadata_5.id(), ping_pong_leader_message_5.clone()),
             ]),
         );
 
@@ -3311,12 +3264,16 @@ mod tests {
         // be the same)
         let merged_first_batch_aggregation = datastore
             .run_tx(|tx| {
-                let (task, vdaf, report_metadata_0) =
-                    (task.clone(), vdaf.clone(), report_metadata_0.clone());
+                let (task, vdaf, report_metadata_0, aggregation_param) = (
+                    task.clone(),
+                    vdaf.clone(),
+                    report_metadata_0.clone(),
+                    aggregation_param.clone(),
+                );
                 Box::pin(async move {
                     TimeInterval::get_batch_aggregations_for_collection_identifier::<
                         VERIFY_KEY_LENGTH,
-                        Prio3Count,
+                        Poplar1<XofShake128, 16>,
                         _,
                     >(
                         tx,
@@ -3330,7 +3287,7 @@ mod tests {
                             Duration::from_seconds(task.time_precision().as_seconds()),
                         )
                         .unwrap(),
-                        &(),
+                        &aggregation_param,
                     )
                     .await
                 })
@@ -3339,10 +3296,10 @@ mod tests {
             .unwrap()
             .into_iter()
             .map(|agg| {
-                BatchAggregation::<VERIFY_KEY_LENGTH, TimeInterval, Prio3Count>::new(
+                BatchAggregation::<VERIFY_KEY_LENGTH, TimeInterval, Poplar1<XofShake128, 16>>::new(
                     *agg.task_id(),
                     *agg.batch_identifier(),
-                    (),
+                    agg.aggregation_parameter().clone(),
                     0,
                     BatchAggregationState::Aggregating,
                     agg.aggregate_share().cloned(),
@@ -3356,8 +3313,14 @@ mod tests {
 
         let first_aggregate_share = vdaf
             .aggregate(
-                &(),
-                [out_share_0, out_share_1, out_share_3].into_iter().cloned(),
+                &aggregation_param,
+                [
+                    &transcript_0.helper_output_share,
+                    &transcript_1.helper_output_share,
+                    &transcript_3.helper_output_share,
+                ]
+                .into_iter()
+                .cloned(),
             )
             .unwrap();
         let first_checksum = ReportIdChecksum::for_report_id(report_metadata_0.id())
@@ -3376,7 +3339,7 @@ mod tests {
                     *task.time_precision()
                 )
                 .unwrap(),
-                (),
+                aggregation_param.clone(),
                 0,
                 BatchAggregationState::Aggregating,
                 Some(first_aggregate_share),
@@ -3388,12 +3351,16 @@ mod tests {
 
         let second_batch_got_batch_aggregations = datastore
             .run_tx(|tx| {
-                let (task, vdaf, report_metadata_2) =
-                    (task.clone(), vdaf.clone(), report_metadata_2.clone());
+                let (task, vdaf, report_metadata_2, aggregation_param) = (
+                    task.clone(),
+                    vdaf.clone(),
+                    report_metadata_2.clone(),
+                    aggregation_param.clone(),
+                );
                 Box::pin(async move {
                     TimeInterval::get_batch_aggregations_for_collection_identifier::<
                         VERIFY_KEY_LENGTH,
-                        Prio3Count,
+                        Poplar1<XofShake128, 16>,
                         _,
                     >(
                         tx,
@@ -3407,7 +3374,7 @@ mod tests {
                             Duration::from_seconds(task.time_precision().as_seconds()),
                         )
                         .unwrap(),
-                        &(),
+                        &aggregation_param,
                     )
                     .await
                 })
@@ -3421,100 +3388,28 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn aggregate_continue_leader_sends_non_continue_transition() {
-        let (_, _ephemeral_datastore, datastore, handler) = setup_http_handler_test().await;
-
-        // Prepare parameters.
-        let task =
-            TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Helper).build();
-        let aggregation_job_id = random();
-        let report_metadata = ReportMetadata::new(
-            ReportId::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
-            Time::from_seconds_since_epoch(54321),
-        );
-
-        // Setup datastore.
-        datastore
-            .run_tx(|tx| {
-                let (task, report_metadata) = (task.clone(), report_metadata.clone());
-                Box::pin(async move {
-                    tx.put_task(&task).await?;
-                    tx.put_report_share(
-                        task.id(),
-                        &ReportShare::new(
-                            report_metadata.clone(),
-                            Vec::from("Public Share"),
-                            HpkeCiphertext::new(
-                                HpkeConfigId::from(42),
-                                Vec::from("012345"),
-                                Vec::from("543210"),
-                            ),
-                        ),
-                    )
-                    .await?;
-
-                    tx.put_aggregation_job(
-                        &AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
-                            *task.id(),
-                            aggregation_job_id,
-                            dummy_vdaf::AggregationParam(0),
-                            (),
-                            Interval::new(
-                                Time::from_seconds_since_epoch(0),
-                                Duration::from_seconds(1),
-                            )
-                            .unwrap(),
-                            AggregationJobState::InProgress,
-                            AggregationJobRound::from(0),
-                        ),
-                    )
-                    .await?;
-                    tx.put_report_aggregation(&ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
-                        *task.id(),
-                        aggregation_job_id,
-                        *report_metadata.id(),
-                        *report_metadata.time(),
-                        0,
-                        None,
-                        ReportAggregationState::Waiting(dummy_vdaf::PrepareState::default(), None),
-                    ))
-                    .await
-                })
-            })
-            .await
-            .unwrap();
-
-        // Make request.
-        let request = AggregationJobContinueReq::new(
-            AggregationJobRound::from(1),
-            Vec::from([PrepareStep::new(
-                *report_metadata.id(),
-                PrepareStepResult::Finished,
-            )]),
-        );
-        post_aggregation_job_expecting_error(
-            &task,
-            &aggregation_job_id,
-            &request,
-            &handler,
-            Status::BadRequest,
-            "urn:ietf:params:ppm:dap:error:unrecognizedMessage",
-            "The message type for a response was incorrect or the payload was malformed.",
-        )
-        .await;
-    }
-
-    #[tokio::test]
-    async fn aggregate_continue_prep_step_fails() {
+    async fn aggregate_continue_leader_sends_non_continue_or_finish_transition() {
         let (_, _ephemeral_datastore, datastore, handler) = setup_http_handler_test().await;
 
         // Prepare parameters.
         let task = TaskBuilder::new(
             QueryType::TimeInterval,
-            VdafInstance::FakeFailsPrepStep,
+            VdafInstance::Poplar1 { bits: 1 },
             Role::Helper,
         )
         .build();
+        let report_id = random();
+        let aggregation_param = Poplar1AggregationParam::try_from_prefixes(Vec::from([
+            IdpfInput::from_bools(&[false]),
+        ]))
+        .unwrap();
+        let transcript = run_vdaf(
+            &Poplar1::new_shake128(1),
+            task.primary_vdaf_verify_key().unwrap().as_bytes(),
+            &aggregation_param,
+            &report_id,
+            &IdpfInput::from_bools(&[false]),
+        );
         let aggregation_job_id = random();
         let report_metadata = ReportMetadata::new(
             ReportId::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
@@ -3524,8 +3419,12 @@ mod tests {
         // Setup datastore.
         datastore
             .run_tx(|tx| {
-                let (task, report_metadata) = (task.clone(), report_metadata.clone());
-
+                let (task, aggregation_param, report_metadata, transcript) = (
+                    task.clone(),
+                    aggregation_param.clone(),
+                    report_metadata.clone(),
+                    transcript.clone(),
+                );
                 Box::pin(async move {
                     tx.put_task(&task).await?;
                     tx.put_report_share(
@@ -3541,31 +3440,37 @@ mod tests {
                         ),
                     )
                     .await?;
-                    tx.put_aggregation_job(
-                        &AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
-                            *task.id(),
-                            aggregation_job_id,
-                            dummy_vdaf::AggregationParam(0),
-                            (),
-                            Interval::new(
-                                Time::from_seconds_since_epoch(0),
-                                Duration::from_seconds(1),
-                            )
-                            .unwrap(),
-                            AggregationJobState::InProgress,
-                            AggregationJobRound::from(0),
-                        ),
-                    )
-                    .await?;
-                    tx.put_report_aggregation(&ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
+
+                    tx.put_aggregation_job(&AggregationJob::<
+                        16,
+                        TimeInterval,
+                        Poplar1<XofShake128, 16>,
+                    >::new(
                         *task.id(),
                         aggregation_job_id,
-                        *report_metadata.id(),
-                        *report_metadata.time(),
-                        0,
-                        None,
-                        ReportAggregationState::Waiting(dummy_vdaf::PrepareState::default(), None),
+                        aggregation_param,
+                        (),
+                        Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
+                            .unwrap(),
+                        AggregationJobState::InProgress,
+                        AggregationJobRound::from(0),
                     ))
+                    .await?;
+                    tx.put_report_aggregation(
+                        &ReportAggregation::<16, Poplar1<XofShake128, 16>>::new(
+                            *task.id(),
+                            aggregation_job_id,
+                            *report_metadata.id(),
+                            *report_metadata.time(),
+                            0,
+                            None,
+                            ReportAggregationState::WaitingHelper(
+                                transcript.helper_prepare_transitions[0]
+                                    .prepare_state()
+                                    .clone(),
+                            ),
+                        ),
+                    )
                     .await
                 })
             })
@@ -3575,9 +3480,121 @@ mod tests {
         // Make request.
         let request = AggregationJobContinueReq::new(
             AggregationJobRound::from(1),
-            Vec::from([PrepareStep::new(
+            Vec::from([PrepareContinue::new(
                 *report_metadata.id(),
-                PrepareStepResult::Continued(Vec::new()),
+                // An AggregationJobContinueReq should only ever contain Continue or Finished
+                PingPongMessage::Initialize {
+                    prep_share: Vec::new(),
+                },
+            )]),
+        );
+
+        let resp =
+            post_aggregation_job_and_decode(&task, &aggregation_job_id, &request, &handler).await;
+        assert_eq!(resp.prepare_resps().len(), 1);
+        assert_eq!(
+            resp.prepare_resps()[0],
+            PrepareResp::new(
+                *report_metadata.id(),
+                PrepareStepResult::Reject(PrepareError::VdafPrepError),
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn aggregate_continue_prep_step_fails() {
+        let (_, _ephemeral_datastore, datastore, handler) = setup_http_handler_test().await;
+
+        // Prepare parameters.
+        let task = TaskBuilder::new(
+            QueryType::TimeInterval,
+            VdafInstance::Poplar1 { bits: 1 },
+            Role::Helper,
+        )
+        .build();
+        let vdaf = Poplar1::new_shake128(1);
+        let report_id = random();
+        let aggregation_param = Poplar1AggregationParam::try_from_prefixes(Vec::from([
+            IdpfInput::from_bools(&[false]),
+        ]))
+        .unwrap();
+        let transcript = run_vdaf(
+            &vdaf,
+            task.primary_vdaf_verify_key().unwrap().as_bytes(),
+            &aggregation_param,
+            &report_id,
+            &IdpfInput::from_bools(&[false]),
+        );
+        let aggregation_job_id = random();
+        let report_metadata = ReportMetadata::new(report_id, Time::from_seconds_since_epoch(54321));
+        let helper_report_share = generate_helper_report_share::<Poplar1<XofShake128, 16>>(
+            *task.id(),
+            report_metadata.clone(),
+            task.current_hpke_key().config(),
+            &transcript.public_share,
+            Vec::new(),
+            &transcript.helper_input_share,
+        );
+
+        // Setup datastore.
+        datastore
+            .run_tx(|tx| {
+                let (task, aggregation_param, report_metadata, transcript, helper_report_share) = (
+                    task.clone(),
+                    aggregation_param.clone(),
+                    report_metadata.clone(),
+                    transcript.clone(),
+                    helper_report_share.clone(),
+                );
+
+                Box::pin(async move {
+                    tx.put_task(&task).await?;
+                    tx.put_report_share(task.id(), &helper_report_share).await?;
+                    tx.put_aggregation_job(&AggregationJob::<
+                        16,
+                        TimeInterval,
+                        Poplar1<XofShake128, 16>,
+                    >::new(
+                        *task.id(),
+                        aggregation_job_id,
+                        aggregation_param,
+                        (),
+                        Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
+                            .unwrap(),
+                        AggregationJobState::InProgress,
+                        AggregationJobRound::from(0),
+                    ))
+                    .await?;
+                    tx.put_report_aggregation(
+                        &ReportAggregation::<16, Poplar1<XofShake128, 16>>::new(
+                            *task.id(),
+                            aggregation_job_id,
+                            *report_metadata.id(),
+                            *report_metadata.time(),
+                            0,
+                            None,
+                            ReportAggregationState::WaitingHelper(
+                                transcript.helper_prepare_transitions[0]
+                                    .prepare_state()
+                                    .clone(),
+                            ),
+                        ),
+                    )
+                    .await
+                })
+            })
+            .await
+            .unwrap();
+
+        // Make request.
+        let request = AggregationJobContinueReq::new(
+            AggregationJobRound::from(1),
+            Vec::from([PrepareContinue::new(
+                *report_metadata.id(),
+                PingPongMessage::Continue {
+                    prep_msg: Vec::new(),
+                    prep_share: Vec::new(),
+                },
             )]),
         );
 
@@ -3585,19 +3602,20 @@ mod tests {
             post_aggregation_job_and_decode(&task, &aggregation_job_id, &request, &handler).await;
         assert_eq!(
             aggregate_resp,
-            AggregationJobResp::new(Vec::from([PrepareStep::new(
+            AggregationJobResp::new(Vec::from([PrepareResp::new(
                 *report_metadata.id(),
-                PrepareStepResult::Failed(ReportShareError::VdafPrepError),
+                PrepareStepResult::Reject(PrepareError::VdafPrepError),
             )]),)
         );
 
         // Check datastore state.
         let (aggregation_job, report_aggregation) = datastore
             .run_tx(|tx| {
-                let (task, report_metadata) = (task.clone(), report_metadata.clone());
+                let (vdaf, task, report_metadata) =
+                    (vdaf.clone(), task.clone(), report_metadata.clone());
                 Box::pin(async move {
                     let aggregation_job = tx
-                        .get_aggregation_job::<0, TimeInterval, dummy_vdaf::Vdaf>(
+                        .get_aggregation_job::<16, TimeInterval, Poplar1<XofShake128, 16>>(
                             task.id(),
                             &aggregation_job_id,
                         )
@@ -3606,10 +3624,11 @@ mod tests {
                         .unwrap();
                     let report_aggregation = tx
                         .get_report_aggregation(
-                            &dummy_vdaf::Vdaf::default(),
+                            &vdaf,
                             &Role::Helper,
                             task.id(),
                             &aggregation_job_id,
+                            aggregation_job.aggregation_parameter(),
                             report_metadata.id(),
                         )
                         .await
@@ -3626,7 +3645,7 @@ mod tests {
             AggregationJob::new(
                 *task.id(),
                 aggregation_job_id,
-                dummy_vdaf::AggregationParam(0),
+                aggregation_param,
                 (),
                 Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                     .unwrap(),
@@ -3643,11 +3662,11 @@ mod tests {
                 *report_metadata.id(),
                 *report_metadata.time(),
                 0,
-                Some(PrepareStep::new(
+                Some(PrepareResp::new(
                     *report_metadata.id(),
-                    PrepareStepResult::Failed(ReportShareError::VdafPrepError)
+                    PrepareStepResult::Reject(PrepareError::VdafPrepError)
                 )),
-                ReportAggregationState::Failed(ReportShareError::VdafPrepError),
+                ReportAggregationState::Failed(PrepareError::VdafPrepError),
             )
         );
     }
@@ -3657,18 +3676,36 @@ mod tests {
         let (_, _ephemeral_datastore, datastore, handler) = setup_http_handler_test().await;
 
         // Prepare parameters.
-        let task =
-            TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Helper).build();
-        let aggregation_job_id = random();
-        let report_metadata = ReportMetadata::new(
-            ReportId::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
-            Time::from_seconds_since_epoch(54321),
+        let task = TaskBuilder::new(
+            QueryType::TimeInterval,
+            VdafInstance::Poplar1 { bits: 1 },
+            Role::Helper,
+        )
+        .build();
+        let report_id = random();
+        let aggregation_param = Poplar1AggregationParam::try_from_prefixes(Vec::from([
+            IdpfInput::from_bools(&[false]),
+        ]))
+        .unwrap();
+        let transcript = run_vdaf(
+            &Poplar1::new_shake128(1),
+            task.primary_vdaf_verify_key().unwrap().as_bytes(),
+            &aggregation_param,
+            &report_id,
+            &IdpfInput::from_bools(&[false]),
         );
+        let aggregation_job_id = random();
+        let report_metadata = ReportMetadata::new(report_id, Time::from_seconds_since_epoch(54321));
 
         // Setup datastore.
         datastore
             .run_tx(|tx| {
-                let (task, report_metadata) = (task.clone(), report_metadata.clone());
+                let (task, aggregation_param, report_metadata, transcript) = (
+                    task.clone(),
+                    aggregation_param.clone(),
+                    report_metadata.clone(),
+                    transcript.clone(),
+                );
 
                 Box::pin(async move {
                     tx.put_task(&task).await?;
@@ -3685,31 +3722,36 @@ mod tests {
                         ),
                     )
                     .await?;
-                    tx.put_aggregation_job(
-                        &AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
-                            *task.id(),
-                            aggregation_job_id,
-                            dummy_vdaf::AggregationParam(0),
-                            (),
-                            Interval::new(
-                                Time::from_seconds_since_epoch(0),
-                                Duration::from_seconds(1),
-                            )
-                            .unwrap(),
-                            AggregationJobState::InProgress,
-                            AggregationJobRound::from(0),
-                        ),
-                    )
-                    .await?;
-                    tx.put_report_aggregation(&ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
+                    tx.put_aggregation_job(&AggregationJob::<
+                        16,
+                        TimeInterval,
+                        Poplar1<XofShake128, 16>,
+                    >::new(
                         *task.id(),
                         aggregation_job_id,
-                        *report_metadata.id(),
-                        *report_metadata.time(),
-                        0,
-                        None,
-                        ReportAggregationState::Waiting(dummy_vdaf::PrepareState::default(), None),
+                        aggregation_param,
+                        (),
+                        Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
+                            .unwrap(),
+                        AggregationJobState::InProgress,
+                        AggregationJobRound::from(0),
                     ))
+                    .await?;
+                    tx.put_report_aggregation(
+                        &ReportAggregation::<16, Poplar1<XofShake128, 16>>::new(
+                            *task.id(),
+                            aggregation_job_id,
+                            *report_metadata.id(),
+                            *report_metadata.time(),
+                            0,
+                            None,
+                            ReportAggregationState::WaitingHelper(
+                                transcript.helper_prepare_transitions[0]
+                                    .prepare_state()
+                                    .clone(),
+                            ),
+                        ),
+                    )
                     .await
                 })
             })
@@ -3719,11 +3761,14 @@ mod tests {
         // Make request.
         let request = AggregationJobContinueReq::new(
             AggregationJobRound::from(1),
-            Vec::from([PrepareStep::new(
+            Vec::from([PrepareContinue::new(
                 ReportId::from(
                     [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1], // not the same as above
                 ),
-                PrepareStepResult::Continued(Vec::new()),
+                PingPongMessage::Continue {
+                    prep_msg: Vec::new(),
+                    prep_share: Vec::new(),
+                },
             )]),
         );
 
@@ -3744,25 +3789,55 @@ mod tests {
         let (_, _ephemeral_datastore, datastore, handler) = setup_http_handler_test().await;
 
         // Prepare parameters.
-        let task =
-            TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Helper).build();
+        let task = TaskBuilder::new(
+            QueryType::TimeInterval,
+            VdafInstance::Poplar1 { bits: 1 },
+            Role::Helper,
+        )
+        .build();
+        let report_id_0 = random();
+        let aggregation_param = Poplar1AggregationParam::try_from_prefixes(Vec::from([
+            IdpfInput::from_bools(&[false]),
+        ]))
+        .unwrap();
+        let transcript_0 = run_vdaf(
+            &Poplar1::new_shake128(1),
+            task.primary_vdaf_verify_key().unwrap().as_bytes(),
+            &aggregation_param,
+            &report_id_0,
+            &IdpfInput::from_bools(&[false]),
+        );
+        let report_metadata_0 =
+            ReportMetadata::new(report_id_0, Time::from_seconds_since_epoch(54321));
+        let report_id_1 = random();
+        let transcript_1 = run_vdaf(
+            &Poplar1::new_shake128(1),
+            task.primary_vdaf_verify_key().unwrap().as_bytes(),
+            &aggregation_param,
+            &report_id_1,
+            &IdpfInput::from_bools(&[false]),
+        );
+        let report_metadata_1 =
+            ReportMetadata::new(report_id_1, Time::from_seconds_since_epoch(54321));
         let aggregation_job_id = random();
-        let report_metadata_0 = ReportMetadata::new(
-            ReportId::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
-            Time::from_seconds_since_epoch(54321),
-        );
-        let report_metadata_1 = ReportMetadata::new(
-            ReportId::from([16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]),
-            Time::from_seconds_since_epoch(54321),
-        );
 
         // Setup datastore.
         datastore
             .run_tx(|tx| {
-                let (task, report_metadata_0, report_metadata_1) = (
+                let (
+                    task,
+                    aggregation_param,
+                    report_metadata_0,
+                    report_metadata_1,
+                    transcript_0,
+                    transcript_1,
+                ) = (
                     task.clone(),
+                    aggregation_param.clone(),
                     report_metadata_0.clone(),
                     report_metadata_1.clone(),
+                    transcript_0.clone(),
+                    transcript_1.clone(),
                 );
 
                 Box::pin(async move {
@@ -3795,42 +3870,53 @@ mod tests {
                     )
                     .await?;
 
-                    tx.put_aggregation_job(
-                        &AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
+                    tx.put_aggregation_job(&AggregationJob::<
+                        16,
+                        TimeInterval,
+                        Poplar1<XofShake128, 16>,
+                    >::new(
+                        *task.id(),
+                        aggregation_job_id,
+                        aggregation_param.clone(),
+                        (),
+                        Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
+                            .unwrap(),
+                        AggregationJobState::InProgress,
+                        AggregationJobRound::from(0),
+                    ))
+                    .await?;
+
+                    tx.put_report_aggregation(
+                        &ReportAggregation::<16, Poplar1<XofShake128, 16>>::new(
                             *task.id(),
                             aggregation_job_id,
-                            dummy_vdaf::AggregationParam(0),
-                            (),
-                            Interval::new(
-                                Time::from_seconds_since_epoch(0),
-                                Duration::from_seconds(1),
-                            )
-                            .unwrap(),
-                            AggregationJobState::InProgress,
-                            AggregationJobRound::from(0),
+                            *report_metadata_0.id(),
+                            *report_metadata_0.time(),
+                            0,
+                            None,
+                            ReportAggregationState::WaitingHelper(
+                                transcript_0.helper_prepare_transitions[0]
+                                    .prepare_state()
+                                    .clone(),
+                            ),
                         ),
                     )
                     .await?;
-
-                    tx.put_report_aggregation(&ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
-                        *task.id(),
-                        aggregation_job_id,
-                        *report_metadata_0.id(),
-                        *report_metadata_0.time(),
-                        0,
-                        None,
-                        ReportAggregationState::Waiting(dummy_vdaf::PrepareState::default(), None),
-                    ))
-                    .await?;
-                    tx.put_report_aggregation(&ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
-                        *task.id(),
-                        aggregation_job_id,
-                        *report_metadata_1.id(),
-                        *report_metadata_1.time(),
-                        1,
-                        None,
-                        ReportAggregationState::Waiting(dummy_vdaf::PrepareState::default(), None),
-                    ))
+                    tx.put_report_aggregation(
+                        &ReportAggregation::<16, Poplar1<XofShake128, 16>>::new(
+                            *task.id(),
+                            aggregation_job_id,
+                            *report_metadata_1.id(),
+                            *report_metadata_1.time(),
+                            1,
+                            None,
+                            ReportAggregationState::WaitingHelper(
+                                transcript_1.helper_prepare_transitions[0]
+                                    .prepare_state()
+                                    .clone(),
+                            ),
+                        ),
+                    )
                     .await
                 })
             })
@@ -3842,13 +3928,19 @@ mod tests {
             AggregationJobRound::from(1),
             Vec::from([
                 // Report IDs are in opposite order to what was stored in the datastore.
-                PrepareStep::new(
+                PrepareContinue::new(
                     *report_metadata_1.id(),
-                    PrepareStepResult::Continued(Vec::new()),
+                    PingPongMessage::Continue {
+                        prep_msg: Vec::new(),
+                        prep_share: Vec::new(),
+                    },
                 ),
-                PrepareStep::new(
+                PrepareContinue::new(
                     *report_metadata_0.id(),
-                    PrepareStepResult::Continued(Vec::new()),
+                    PingPongMessage::Continue {
+                        prep_msg: Vec::new(),
+                        prep_share: Vec::new(),
+                    },
                 ),
             ]),
         );
@@ -3919,7 +4011,7 @@ mod tests {
                         *report_metadata.time(),
                         0,
                         None,
-                        ReportAggregationState::Failed(ReportShareError::VdafPrepError),
+                        ReportAggregationState::Failed(PrepareError::VdafPrepError),
                     ))
                     .await
                 })
@@ -3930,9 +4022,12 @@ mod tests {
         // Make request.
         let request = AggregationJobContinueReq::new(
             AggregationJobRound::from(1),
-            Vec::from([PrepareStep::new(
+            Vec::from([PrepareContinue::new(
                 ReportId::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
-                PrepareStepResult::Continued(Vec::new()),
+                PingPongMessage::Continue {
+                    prep_msg: Vec::new(),
+                    prep_share: Vec::new(),
+                },
             )]),
         );
         post_aggregation_job_expecting_error(

--- a/aggregator_api/Cargo.toml
+++ b/aggregator_api/Cargo.toml
@@ -11,7 +11,7 @@ version.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait = "0.1"
-base64 = "0.21.4"
+base64.workspace = true
 janus_aggregator_core.workspace = true
 janus_core.workspace = true
 janus_messages.workspace = true

--- a/aggregator_core/Cargo.toml
+++ b/aggregator_core/Cargo.toml
@@ -16,7 +16,7 @@ test-util = ["dep:hex", "dep:sqlx", "dep:testcontainers", "janus_core/test-util"
 anyhow.workspace = true
 async-trait = "0.1"
 backoff = { version = "0.4.0", features = ["tokio"] }
-base64 = "0.21.4"
+base64.workspace = true
 bytes = "1.5.0"
 chrono = "0.4"
 deadpool = { version = "0.9.5", features = ["rt_tokio_1"] }

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -705,14 +705,14 @@ mod tests {
             hpke::seal(
                 &parameters.hpke_config,
                 &HpkeApplicationInfo::new(&Label::AggregateShare, &Role::Leader, &Role::Collector),
-                &transcript.aggregate_shares[0].get_encoded(),
+                &transcript.leader_aggregate_share.get_encoded(),
                 &associated_data.get_encoded(),
             )
             .unwrap(),
             hpke::seal(
                 &parameters.hpke_config,
                 &HpkeApplicationInfo::new(&Label::AggregateShare, &Role::Helper, &Role::Collector),
-                &transcript.aggregate_shares[1].get_encoded(),
+                &transcript.helper_aggregate_share.get_encoded(),
                 &associated_data.get_encoded(),
             )
             .unwrap(),
@@ -733,14 +733,14 @@ mod tests {
             hpke::seal(
                 &parameters.hpke_config,
                 &HpkeApplicationInfo::new(&Label::AggregateShare, &Role::Leader, &Role::Collector),
-                &transcript.aggregate_shares[0].get_encoded(),
+                &transcript.leader_aggregate_share.get_encoded(),
                 &associated_data.get_encoded(),
             )
             .unwrap(),
             hpke::seal(
                 &parameters.hpke_config,
                 &HpkeApplicationInfo::new(&Label::AggregateShare, &Role::Helper, &Role::Collector),
-                &transcript.aggregate_shares[1].get_encoded(),
+                &transcript.helper_aggregate_share.get_encoded(),
                 &associated_data.get_encoded(),
             )
             .unwrap(),

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -34,7 +34,7 @@ test-util = [
 anyhow.workspace = true
 assert_matches = { version = "1", optional = true }
 backoff = { version = "0.4.0", features = ["tokio"] }
-base64 = "0.21.4"
+base64.workspace = true
 chrono = { workspace = true, features = ["clock"] }
 derivative = "2.2.0"
 futures = "0.3.28"

--- a/db/00000000000001_initial_schema.up.sql
+++ b/db/00000000000001_initial_schema.up.sql
@@ -206,12 +206,10 @@ CREATE TABLE report_aggregations(
     client_timestamp    TIMESTAMP NOT NULL,                 -- the client timestamp this report aggregation is associated with
     ord                 BIGINT NOT NULL,                    -- a value used to specify the ordering of client reports in the aggregation job
     state               REPORT_AGGREGATION_STATE NOT NULL,  -- the current state of this report aggregation
-    prep_state          BYTEA,                              -- the current preparation state (opaque VDAF message, only if in state WAITING)
-    prep_msg            BYTEA,                              -- for the leader, the next preparation message to be sent to the helper (opaque VDAF message)
-                                                            -- for the helper, the next preparation share to be sent to the leader (opaque VDAF message)
-                                                            -- only non-NULL if in state WAITING
+    helper_prep_state   BYTEA,                              -- the current VDAF prepare state (opaque VDAF message, only if in state WAITING, only populated for helper)
+    leader_prep_transition BYTEA,                           -- the current VDAF prepare transition (opaque VDAF message, only if in state WAITING, only populated for leader)
     error_code          SMALLINT,                           -- error code corresponding to a DAP ReportShareError value; null if in a state other than FAILED
-    last_prep_step      BYTEA,                              -- the last PreparationStep message sent to the Leader, to assist in replay (opaque VDAF message, populated for Helper only)
+    last_prep_resp      BYTEA,                              -- the last PrepareResp message sent to the Leader, to assist in replay (opaque VDAF message, populated for Helper only)
 
     CONSTRAINT report_aggregations_unique_ord UNIQUE(aggregation_job_id, ord),
     CONSTRAINT fk_aggregation_job_id FOREIGN KEY(aggregation_job_id) REFERENCES aggregation_jobs(id) ON DELETE CASCADE

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -14,10 +14,11 @@ in-cluster = ["dep:k8s-openapi", "dep:kube"]
 [dependencies]
 anyhow.workspace = true
 backoff = { version = "0.4", features = ["tokio"] }
-base64 = "0.21.4"
+base64.workspace = true
 futures = "0.3.28"
 hex = "0.4"
 http = "0.2"
+itertools.workspace = true
 janus_aggregator = { workspace = true, features = ["test-util"] }
 janus_aggregator_core = { workspace = true, features = ["test-util"] }
 janus_client.workspace = true
@@ -37,6 +38,5 @@ tokio.workspace = true
 url = { version = "2.4.1", features = ["serde"] }
 
 [dev-dependencies]
-itertools.workspace = true
 janus_collector = { workspace = true, features = ["test-util"] }
 tempfile = "3"

--- a/interop_binaries/Cargo.toml
+++ b/interop_binaries/Cargo.toml
@@ -24,7 +24,7 @@ testcontainer = [
 [dependencies]
 anyhow.workspace = true
 backoff = { version = "0.4", features = ["tokio"] }
-base64 = "0.21.4"
+base64.workspace = true
 clap = "4.4.2"
 futures = { version = "0.3.28", optional = true }
 fixed = { version = "1.23", optional = true }

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -14,13 +14,13 @@ test-util = []
 
 [dependencies]
 anyhow.workspace = true
-base64 = "0.21.4"
+base64.workspace = true
 derivative = "2.2.0"
 hex = "0.4"
 num_enum = "0.7.0"
 # We can't pull prio in from the workspace because that would enable default features, and we do not
 # want prio/crypto-dependencies
-prio = { version = "0.15.0", default-features = false, features = ["multithreaded"] }
+prio = { version = "0.15.1", default-features = false, features = ["multithreaded", "experimental"] }
 rand = "0.8"
 serde.workspace = true
 thiserror.workspace = true

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -13,7 +13,7 @@ fpvec_bounded_l2 = ["dep:fixed", "janus_collector/fpvec_bounded_l2", "prio/exper
 
 [dependencies]
 anyhow = "1"
-base64 = "0.21.4"
+base64.workspace = true
 clap = { version = "4.4.2", features = ["cargo", "derive", "env"] }
 derivative = "2.2.0"
 fixed = { version = "1.23", optional = true }


### PR DESCRIPTION
This change implements the DAP-05 ping-pong topology in which aggregators take turns preprocessing prepare shares into prepare messages. While this topology first appeared in DAP-05, this implementation follows the changes in [1], which should appear in DAP-06.

This change depends on the implementation of the VDAF ping-pong topology added to crate `prio` in [2], which in turn conforms to the specification added after VDAF-06 and further tweaked in [3] (we expect this to be published soon as VDAF-07).

This commit makes some changes to what intermediate values are stored by aggregators. In the case where an aggregator is continuing, it will have computed a prepare state, a prepare message for the current round and a
prepare share for the next round. The existing implementation would store all three objects in the database, significantly increasing the per-report storage requirements. In particular, this makes things worse for the Helper, which previously never needed to store a prepare share because the Leader always took responsibility for combining prepare
shares.

To mitigate this, we instead have aggregators store a `prio::ping_pong::topology::Transition`, which will contain a prepare
state and a prepare message (both of which are generally much smaller than prepare shares), from which the next prepare state and importantly prepare share can be recomputed.

The main benefit of this change is to reduce how many round trips between aggregators are needed to prepare reports. Quite a few tests used Prio3 but depended on having the leader or helper in the `Waiting` state after running aggregation initialization. Accordingly, those tests are changed to run Poplar1, which now takes 2 rounds.

[1]: https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/494
[2]: https://github.com/divviup/libprio-rs/pull/683
[3]: https://github.com/cfrg/draft-irtf-cfrg-vdaf/pull/281

Part of https://github.com/divviup/janus/issues/1669