### PR TITLE
`collect` tool: accept HPKE keypair from `divviup`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1571,6 +1571,7 @@ dependencies = [
  "hpke",
  "num_enum 0.5.11",
  "rand",
+ "serde",
  "wasm-bindgen",
  "zeroize",
 ]
@@ -2179,7 +2180,9 @@ dependencies = [
  "prio",
  "rand",
  "reqwest",
+ "serde_json",
  "serde_yaml",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-log",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -40,7 +40,7 @@ chrono = { workspace = true, features = ["clock"] }
 derivative = "2.2.0"
 futures = "0.3.28"
 hex = "0.4"
-hpke-dispatch = "0.5.0"
+hpke-dispatch = { version = "0.5.0", features = ["serde"] }
 http = "0.2.9"
 http-api-problem = "0.57.0"
 janus_messages.workspace = true

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -912,7 +912,7 @@ impl Decode for ExtensionType {
 pub struct HpkeCiphertext {
     /// An identifier of the HPKE configuration used to seal the message.
     config_id: HpkeConfigId,
-    /// An encasulated HPKE key.
+    /// An encapsulated HPKE key.
     #[derivative(Debug = "ignore")]
     encapsulated_key: Vec<u8>,
     /// An HPKE ciphertext.

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -22,7 +22,8 @@ janus_core.workspace = true
 janus_messages.workspace = true
 prio.workspace = true
 reqwest = { version = "0.11.19", default-features = false, features = ["rustls-tls", "json"] }
-serde_yaml = "0.9.25"
+serde_json.workspace = true
+serde_yaml.workspace = true
 tokio.workspace = true
 tracing = "0.1.37"
 tracing-log = "0.1.3"
@@ -34,4 +35,5 @@ assert_matches = "1"
 cfg-if = "1.0.0"
 janus_core = { workspace = true, features = ["test-util"] }
 rand = "0.8"
+tempfile = "3.8.0"
 trycmd = "0.14.16"

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -297,7 +297,8 @@ struct Options {
         value_parser = HpkeConfigValueParser::new(),
         help_heading = "DAP Task Parameters",
         display_order = 2,
-        conflicts_with = "hpke_config_json"
+        requires = "hpke_private_key",
+        conflicts_with = "hpke_config_json",
     )]
     hpke_config: Option<HpkeConfig>,
     /// The collector's HPKE private key, encoded with base64url
@@ -307,7 +308,8 @@ struct Options {
         env,
         help_heading = "DAP Task Parameters",
         display_order = 3,
-        conflicts_with = "hpke_config_json"
+        requires = "hpke_config",
+        conflicts_with = "hpke_config_json",
     )]
     #[derivative(Debug = "ignore")]
     hpke_private_key: Option<HpkePrivateKey>,

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use clap::{
     builder::{NonEmptyStringValueParser, StringValueParser, TypedValueParser},
@@ -10,7 +11,7 @@ use fixed::types::extra::{U15, U31, U63};
 #[cfg(feature = "fpvec_bounded_l2")]
 use fixed::{FixedI16, FixedI32, FixedI64};
 use janus_collector::{default_http_client, AuthenticationToken, Collector, CollectorParameters};
-use janus_core::hpke::HpkePrivateKey;
+use janus_core::hpke::{DivviUpHpkeConfig, HpkeKeypair, HpkePrivateKey};
 use janus_messages::{
     query_type::{FixedSize, QueryType, TimeInterval},
     BatchId, Duration, FixedSizeQuery, HpkeConfig, Interval, PartialBatchSelector, Query, TaskId,
@@ -22,7 +23,7 @@ use prio::{
     codec::Decode,
     vdaf::{self, prio3::Prio3},
 };
-use std::fmt::Debug;
+use std::{fmt::Debug, fs::File, path::PathBuf};
 use tracing_log::LogTracer;
 use tracing_subscriber::{prelude::*, EnvFilter, Registry};
 use url::Url;
@@ -295,19 +296,30 @@ struct Options {
         long,
         value_parser = HpkeConfigValueParser::new(),
         help_heading = "DAP Task Parameters",
-        display_order = 2
+        display_order = 2,
+        conflicts_with = "hpke_config_json"
     )]
-    hpke_config: HpkeConfig,
+    hpke_config: Option<HpkeConfig>,
     /// The collector's HPKE private key, encoded with base64url
     #[clap(
         long,
         value_parser = PrivateKeyValueParser::new(),
         env,
         help_heading = "DAP Task Parameters",
-        display_order = 3
+        display_order = 3,
+        conflicts_with = "hpke_config_json"
     )]
     #[derivative(Debug = "ignore")]
-    hpke_private_key: HpkePrivateKey,
+    hpke_private_key: Option<HpkePrivateKey>,
+    /// Path to a JSON document containing the collector's HPKE configuration and private key, in
+    /// the format output by `divviup hpke-config generate`.
+    #[clap(
+        long,
+        help_heading = "DAP Task Parameters",
+        display_order = 4,
+        conflicts_with_all = ["hpke_config", "hpke_private_key"]
+    )]
+    hpke_config_json: Option<PathBuf>,
 
     #[clap(flatten)]
     authentication: AuthenticationOptions,
@@ -330,6 +342,28 @@ struct Options {
 
     #[clap(flatten)]
     query: QueryOptions,
+}
+
+impl Options {
+    fn hpke_keypair(&self) -> Result<HpkeKeypair, anyhow::Error> {
+        match (
+            &self.hpke_config,
+            &self.hpke_private_key,
+            &self.hpke_config_json,
+        ) {
+            (Some(config), Some(private), _) => {
+                Ok(HpkeKeypair::new(config.clone(), private.clone()))
+            }
+            (None, None, Some(hpke_config_json_path)) => {
+                let reader =
+                    File::open(hpke_config_json_path).context("could not open HPKE config file")?;
+                let divviup_hpke_config: DivviUpHpkeConfig =
+                    serde_json::from_reader(reader).context("could not parse HPKE config file")?;
+                HpkeKeypair::try_from(divviup_hpke_config).context("could not convert HPKE config")
+            }
+            _ => unreachable!(),
+        }
+    }
 }
 
 #[tokio::main]
@@ -389,19 +423,22 @@ where
     Q: QueryTypeExt,
 {
     let authentication = match (
-        options.authentication.dap_auth_token,
-        options.authentication.authorization_bearer_token,
+        &options.authentication.dap_auth_token,
+        &options.authentication.authorization_bearer_token,
     ) {
         (None, Some(token)) => token,
         (Some(token), None) => token,
         (None, None) | (Some(_), Some(_)) => unreachable!(),
     };
+
+    let hpke_keypair = options.hpke_keypair()?;
+
     let parameters = CollectorParameters::new(
         options.task_id,
         options.leader,
-        authentication,
-        options.hpke_config.clone(),
-        options.hpke_private_key.clone(),
+        authentication.clone(),
+        hpke_keypair.config().clone(),
+        hpke_keypair.private_key().clone(),
     );
     let http_client = default_http_client().map_err(|err| Error::Anyhow(err.into()))?;
     match (options.vdaf, options.length, options.bits) {
@@ -555,12 +592,18 @@ mod tests {
     use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
     use clap::{error::ErrorKind, CommandFactory, Parser};
     use janus_core::{
-        hpke::test_util::generate_test_hpke_config_and_private_key, task::TokenInner,
+        hpke::{
+            test_util::{generate_test_hpke_config_and_private_key, SAMPLE_DIVVIUP_HPKE_CONFIG},
+            DivviUpHpkeConfig, HpkeKeypair,
+        },
+        task::TokenInner,
     };
     use janus_messages::{BatchId, TaskId};
     use prio::codec::Encode;
     use rand::random;
     use reqwest::Url;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
 
     #[test]
     fn verify_app() {
@@ -584,8 +627,9 @@ mod tests {
                 dap_auth_token: Some(auth_token.clone()),
                 authorization_bearer_token: None,
             },
-            hpke_config: hpke_keypair.config().clone(),
-            hpke_private_key: hpke_keypair.private_key().clone(),
+            hpke_config: Some(hpke_keypair.config().clone()),
+            hpke_private_key: Some(hpke_keypair.private_key().clone()),
+            hpke_config_json: None,
             vdaf: VdafType::Count,
             length: None,
             bits: None,
@@ -805,8 +849,9 @@ mod tests {
                 dap_auth_token: Some(auth_token.clone()),
                 authorization_bearer_token: None,
             },
-            hpke_config: hpke_keypair.config().clone(),
-            hpke_private_key: hpke_keypair.private_key().clone(),
+            hpke_config: Some(hpke_keypair.config().clone()),
+            hpke_private_key: Some(hpke_keypair.private_key().clone()),
+            hpke_config_json: None,
             vdaf: VdafType::Count,
             length: None,
             bits: None,
@@ -844,8 +889,9 @@ mod tests {
                 dap_auth_token: Some(auth_token.clone()),
                 authorization_bearer_token: None,
             },
-            hpke_config: hpke_keypair.config().clone(),
-            hpke_private_key: hpke_keypair.private_key().clone(),
+            hpke_config: Some(hpke_keypair.config().clone()),
+            hpke_private_key: Some(hpke_keypair.private_key().clone()),
+            hpke_config_json: None,
             vdaf: VdafType::Count,
             length: None,
             bits: None,
@@ -1055,5 +1101,42 @@ mod tests {
                 .kind(),
             ErrorKind::ValueValidation
         );
+    }
+
+    #[test]
+    fn hpke_config_json_file() {
+        let hpke_keypair = HpkeKeypair::try_from(
+            serde_json::from_str::<DivviUpHpkeConfig>(SAMPLE_DIVVIUP_HPKE_CONFIG).unwrap(),
+        )
+        .unwrap();
+
+        let mut hpke_config_file = NamedTempFile::new().unwrap();
+        hpke_config_file
+            .write_all(SAMPLE_DIVVIUP_HPKE_CONFIG.as_bytes())
+            .unwrap();
+        let hpke_config_file_path = hpke_config_file.into_temp_path();
+
+        let options = Options {
+            task_id: random(),
+            leader: Url::parse("https://example.com").unwrap(),
+            authentication: AuthenticationOptions {
+                dap_auth_token: Some(random()),
+                authorization_bearer_token: None,
+            },
+            hpke_config: None,
+            hpke_private_key: None,
+            hpke_config_json: Some(hpke_config_file_path.to_path_buf()),
+            vdaf: VdafType::Count,
+            length: None,
+            bits: None,
+            query: QueryOptions {
+                batch_interval_start: Some(1_000_000),
+                batch_interval_duration: Some(1_000),
+                batch_id: None,
+                current_batch: false,
+            },
+        };
+
+        assert_eq!(options.hpke_keypair().unwrap(), hpke_keypair);
     }
 }

--- a/tools/tests/cmd/collect.trycmd
+++ b/tools/tests/cmd/collect.trycmd
@@ -2,7 +2,7 @@
 $ collect --help
 Command-line DAP-PPM collector from ISRG's Divvi Up
 
-Usage: collect [OPTIONS] --task-id <TASK_ID> --leader <LEADER> --hpke-config <HPKE_CONFIG> --hpke-private-key <HPKE_PRIVATE_KEY> --vdaf <VDAF> <--dap-auth-token <DAP_AUTH_TOKEN>|--authorization-bearer-token <AUTHORIZATION_BEARER_TOKEN>> <--batch-interval-start <BATCH_INTERVAL_START>|--batch-interval-duration <BATCH_INTERVAL_DURATION>|--batch-id <BATCH_ID>|--current-batch>
+Usage: collect [OPTIONS] --task-id <TASK_ID> --leader <LEADER> --vdaf <VDAF> <--dap-auth-token <DAP_AUTH_TOKEN>|--authorization-bearer-token <AUTHORIZATION_BEARER_TOKEN>> <--batch-interval-start <BATCH_INTERVAL_START>|--batch-interval-duration <BATCH_INTERVAL_DURATION>|--batch-id <BATCH_ID>|--current-batch>
 
 Options:
   -h, --help
@@ -25,6 +25,9 @@ DAP Task Parameters:
           The collector's HPKE private key, encoded with base64url
           
           [env: HPKE_PRIVATE_KEY=]
+
+      --hpke-config-json <HPKE_CONFIG_JSON>
+          Path to a JSON document containing the collector's HPKE configuration and private key, in the format output by `divviup hpke-config generate`
 
 Authorization:
       --dap-auth-token <DAP_AUTH_TOKEN>


### PR DESCRIPTION
Adds a new option to `collect` so that an HPKE keypair encoded in JSON by `divviup hpke-config generate` may be used instead of providing the Base64URL unpadded private key plus the RFC 8446 encoding of the HPKE config.

Resolves #1810