### PR TITLE
Move version information to OTel resource

### DIFF
--- a/aggregator/src/bin/janus_cli.rs
+++ b/aggregator/src/bin/janus_cli.rs
@@ -2,9 +2,7 @@ use anyhow::{anyhow, Context, Result};
 use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine};
 use clap::Parser;
 use janus_aggregator::{
-    binary_utils::{
-        database_pool, datastore, read_config, record_build_info_gauge, CommonBinaryOptions,
-    },
+    binary_utils::{database_pool, datastore, read_config, CommonBinaryOptions},
     config::{BinaryConfig, CommonConfig},
     metrics::{install_metrics_exporter, MetricsExporterHandle},
     trace::{install_trace_subscriber, TraceGuards},
@@ -36,8 +34,6 @@ async fn main() -> Result<()> {
     let config_file: ConfigFile = read_config(&command_line_options.common_options)?;
 
     let _guards = install_tracing_and_metrics_handlers(config_file.common_config()).await?;
-
-    record_build_info_gauge(&meter("janus_aggregator"));
 
     info!(
         common_options = ?&command_line_options.common_options,


### PR DESCRIPTION
This implements #1842, moving build-time version information from a custom `janus_build_info` gauge into `target_info`, which is produced by the `opentelemetry-prometheus` exporter. I tried to follow the spirit of the semantic conventions for resource attributes, relating to [`service.version`](https://opentelemetry.io/docs/specs/otel/resource/semantic_conventions/#service-experimental) and [`process.runtime.name` and `process.runtime.version`](https://opentelemetry.io/docs/specs/otel/resource/semantic_conventions/process/#process-runtimes).

Note that there's only one `service.version` attribute defined, while we previously recorded both a semantic version and a git hash separately. The conventions for [version attributes](https://opentelemetry.io/docs/specs/otel/resource/semantic_conventions/#version-attributes) say that the value may be an arbitrary identifier, so I decided to interpolate both the crate's semantic version and the git commit hash, rather than come up with a different attribute name for one or both values.

I ran this with the environment variable `OTEL_SERVICE_NAME=aggregator` set, and I get the following in the response. It sticks around after waiting and re-scraping.
```
# HELP target_info Target metadata
# TYPE target_info gauge
target_info{process_runtime_name="Rust",process_runtime_version="1.72.0",service_name="aggregator",service_version="0.5.14-c529b01f"} 1
```