### PR TITLE
Update MSRV and document MSRV policy, subscriber-01 backport

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       matrix:
         rust-toolchain: [
-          # MSRV from Cargo.toml
-          "1.65",
+          # MSRV policy
+          "stable minus 2 releases",
           "stable",
         ]
     runs-on: ubuntu-latest
@@ -100,8 +100,8 @@ jobs:
     strategy:
       matrix:
         rust-toolchain: [
-          # MSRV from Cargo.toml
-          "1.65",
+          # MSRV policy
+          "stable minus 2 releases",
           "stable",
         ]
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2021"
 homepage = "https://divviup.org"
 license = "MPL-2.0"
 repository = "https://github.com/divviup/janus"
-rust-version = "1.65.0"
+rust-version = "1.70.0"
 version = "0.5.12-subscriber-01.3"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ tagged `janus_aggregator`, `janus_aggregation_job_creator`,
 Pre-built container images are available at
 [us-west2-docker.pkg.dev/divviup-artifacts-public/janus](https://us-west2-docker.pkg.dev/divviup-artifacts-public/janus).
 
+## Minimum Supported Rust Version (MSRV)
+
+We support the latest stable version of Rust, at time of release, and the two
+preceding minor versions.
+
 ## Running tests
 
 Tests require that [`docker`](https://www.docker.com) and

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1982,14 +1982,11 @@ impl VdafOps {
                     // went to CLOSED, in which case the collection job will start at COLLECTABLE).
                     let mut initial_collection_job_state = CollectionJobState::Collectable;
 
-                    // Rust 1.65's clippy complains about needless collection, but we need to
-                    // process through the iterator in order to update
+                    // Note that we need to process through this iterator now in order to update
                     // `initial_collection_job_state` as a side-effect, since computing
                     // `initial_collection_job_state` is necessary to compute the collection job we
                     // are writing, and the collection job write occurs concurrently with the batch
-                    // writes. This appears to be fixed in Rust 1.69 -- we can likely remove this
-                    // annotation after the MSRV reaches that version.
-                    #[allow(clippy::needless_collect)]
+                    // writes.
                     let batches: Vec<_> = batches
                         .into_iter()
                         .flat_map(|(batch_identifier, batch)| {


### PR DESCRIPTION
This backports #1848 to the subscriber-01 release branch, implementing the new MSRV policy in #1730.