### PR TITLE
Adopt DAP-05 error types

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/aggregation_job_continue.rs
@@ -62,7 +62,7 @@ impl VdafOps {
             let report_aggregation = loop {
                 let report_agg = report_aggregations_iter.next().ok_or_else(|| {
                     datastore::Error::User(
-                        Error::UnrecognizedMessage(
+                        Error::InvalidMessage(
                             Some(*task.id()),
                             "leader sent unexpected, duplicate, or out-of-order prepare steps",
                         )
@@ -116,7 +116,7 @@ impl VdafOps {
                 }
                 _ => {
                     return Err(datastore::Error::User(
-                        Error::UnrecognizedMessage(
+                        Error::InvalidMessage(
                             Some(*task.id()),
                             "leader sent prepare step for non-WAITING report aggregation",
                         )
@@ -597,7 +597,7 @@ mod tests {
             &round_zero_request,
             &test_case.handler,
             Status::BadRequest,
-            "urn:ietf:params:ppm:dap:error:unrecognizedMessage",
+            "urn:ietf:params:ppm:dap:error:invalidMessage",
             "The message type for a response was incorrect or the payload was malformed.",
         )
         .await;
@@ -768,8 +768,8 @@ mod tests {
             &past_round_request,
             &test_case.handler,
             Status::BadRequest,
-            "urn:ietf:params:ppm:dap:error:roundMismatch",
-            "The leader and helper are not on the same round of VDAF preparation.",
+            "urn:ietf:params:ppm:dap:error:stepMismatch",
+            "The leader and helper are not on the same step of VDAF preparation.",
         )
         .await;
     }
@@ -791,8 +791,8 @@ mod tests {
             &future_round_request,
             &test_case.handler,
             Status::BadRequest,
-            "urn:ietf:params:ppm:dap:error:roundMismatch",
-            "The leader and helper are not on the same round of VDAF preparation.",
+            "urn:ietf:params:ppm:dap:error:stepMismatch",
+            "The leader and helper are not on the same step of VDAF preparation.",
         )
         .await;
     }

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -351,9 +351,10 @@ impl AggregationJobDriver {
                 info!(report_id = %report_aggregation.report_id(), "Received report with duplicate extensions");
                 self.aggregate_step_failure_counter
                     .add(1, &[KeyValue::new("type", "duplicate_extension")]);
-                report_aggregations_to_write.push(report_aggregation.with_state(
-                    ReportAggregationState::Failed(PrepareError::UnrecognizedMessage),
-                ));
+                report_aggregations_to_write.push(
+                    report_aggregation
+                        .with_state(ReportAggregationState::Failed(PrepareError::InvalidMessage)),
+                );
                 continue;
             }
 
@@ -1515,7 +1516,7 @@ mod tests {
                 *repeated_extension_report.metadata().time(),
                 1,
                 None,
-                ReportAggregationState::Failed(PrepareError::UnrecognizedMessage),
+                ReportAggregationState::Failed(PrepareError::InvalidMessage),
             );
         let want_missing_report_report_aggregation =
             ReportAggregation::<VERIFY_KEY_LENGTH, Prio3Count>::new(

--- a/aggregator/src/aggregator/error.rs
+++ b/aggregator/src/aggregator/error.rs
@@ -31,19 +31,19 @@ pub enum Error {
     /// far in the future, §4.3.2.
     #[error("task {0}: report {1} too early: {2}")]
     ReportTooEarly(TaskId, ReportId, Time),
-    /// Corresponds to `unrecognizedMessage`, §3.2
-    #[error("task {0:?}: unrecognized message: {1}")]
-    UnrecognizedMessage(Option<TaskId>, &'static str),
-    /// Corresponds to `roundMismatch`
+    /// Corresponds to `invalidMessage`, §3.2
+    #[error("task {0:?}: invalid message: {1}")]
+    InvalidMessage(Option<TaskId>, &'static str),
+    /// Corresponds to `stepMismatch`
     #[error(
-        "task {task_id}: unexpected round in aggregation job {aggregation_job_id} (expected \
-         {expected_round}, got {got_round})"
+        "task {task_id}: unexpected step in aggregation job {aggregation_job_id} (expected \
+         {expected_step}, got {got_step})"
     )]
-    RoundMismatch {
+    StepMismatch {
         task_id: TaskId,
         aggregation_job_id: AggregationJobId,
-        expected_round: AggregationJobRound,
-        got_round: AggregationJobRound,
+        expected_step: AggregationJobRound,
+        got_step: AggregationJobRound,
     },
     /// Corresponds to `unrecognizedTask`, §3.2
     #[error("task {0}: unrecognized task")]
@@ -157,8 +157,8 @@ impl Error {
             Error::Message(_) => "message",
             Error::ReportRejected(_, _, _) => "report_rejected",
             Error::ReportTooEarly(_, _, _) => "report_too_early",
-            Error::UnrecognizedMessage(_, _) => "unrecognized_message",
-            Error::RoundMismatch { .. } => "round_mismatch",
+            Error::InvalidMessage(_, _) => "unrecognized_message",
+            Error::StepMismatch { .. } => "step_mismatch",
             Error::UnrecognizedTask(_) => "unrecognized_task",
             Error::MissingTaskId => "missing_task_id",
             Error::UnrecognizedAggregationJob(_, _) => "unrecognized_aggregation_job",

--- a/aggregator/src/aggregator/problem_details.rs
+++ b/aggregator/src/aggregator/problem_details.rs
@@ -81,7 +81,7 @@ mod tests {
     #[test]
     fn dap_problem_type_round_trip() {
         for problem_type in [
-            DapProblemType::UnrecognizedMessage,
+            DapProblemType::InvalidMessage,
             DapProblemType::UnrecognizedTask,
             DapProblemType::MissingTaskId,
             DapProblemType::UnrecognizedAggregationJob,
@@ -135,8 +135,8 @@ mod tests {
                     Some(DapProblemType::ReportRejected),
                 ),
                 TestCase::new(
-                    Box::new(|| Error::UnrecognizedMessage(Some(random()), "test")),
-                    Some(DapProblemType::UnrecognizedMessage),
+                    Box::new(|| Error::InvalidMessage(Some(random()), "test")),
+                    Some(DapProblemType::InvalidMessage),
                 ),
                 TestCase::new(
                     Box::new(|| Error::UnrecognizedTask(random())),

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -467,7 +467,7 @@ async fn taskprov_opt_out_mismatched_task_id() {
         take_problem_details(&mut test_conn).await,
         json!({
             "status": Status::BadRequest as u16,
-            "type": "urn:ietf:params:ppm:dap:error:unrecognizedMessage",
+            "type": "urn:ietf:params:ppm:dap:error:invalidMessage",
             "title": "The message type for a response was incorrect or the payload was malformed.",
             "taskid": format!("{}", test.task_id),
         })
@@ -548,7 +548,7 @@ async fn taskprov_opt_out_missing_aggregator() {
         take_problem_details(&mut test_conn).await,
         json!({
             "status": Status::BadRequest as u16,
-            "type": "urn:ietf:params:ppm:dap:error:unrecognizedMessage",
+            "type": "urn:ietf:params:ppm:dap:error:invalidMessage",
             "title": "The message type for a response was incorrect or the payload was malformed.",
             "taskid": format!("{}", another_task_id),
         })

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -422,7 +422,7 @@ mod tests {
             .with_status(400)
             .with_header("Content-Type", "application/problem+json")
             .with_body(concat!(
-                "{\"type\": \"urn:ietf:params:ppm:dap:error:unrecognizedMessage\", ",
+                "{\"type\": \"urn:ietf:params:ppm:dap:error:invalidMessage\", ",
                 "\"detail\": \"The message type for a response was incorrect or the payload was \
                  malformed.\"}",
             ))
@@ -436,7 +436,7 @@ mod tests {
                 assert_eq!(problem.status.unwrap(), StatusCode::BAD_REQUEST);
                 assert_eq!(
                     problem.type_url.unwrap(),
-                    "urn:ietf:params:ppm:dap:error:unrecognizedMessage"
+                    "urn:ietf:params:ppm:dap:error:invalidMessage"
                 );
                 assert_eq!(
                     problem.detail.unwrap(),

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -1326,7 +1326,7 @@ mod tests {
             .with_status(400)
             .with_header("Content-Type", "application/problem+json")
             .with_body(concat!(
-                "{\"type\": \"urn:ietf:params:ppm:dap:error:unrecognizedMessage\", ",
+                "{\"type\": \"urn:ietf:params:ppm:dap:error:invalidMessage\", ",
                 "\"detail\": \"The message type for a response was incorrect or the payload was \
                  malformed.\"}"
             ))
@@ -1340,9 +1340,9 @@ mod tests {
             .unwrap_err();
         assert_matches!(error, Error::Http { problem_details, dap_problem_type } => {
             assert_eq!(problem_details.status.unwrap(), StatusCode::BAD_REQUEST);
-            assert_eq!(problem_details.type_url.unwrap(), "urn:ietf:params:ppm:dap:error:unrecognizedMessage");
+            assert_eq!(problem_details.type_url.unwrap(), "urn:ietf:params:ppm:dap:error:invalidMessage");
             assert_eq!(problem_details.detail.unwrap(), "The message type for a response was incorrect or the payload was malformed.");
-            assert_eq!(dap_problem_type, Some(DapProblemType::UnrecognizedMessage));
+            assert_eq!(dap_problem_type, Some(DapProblemType::InvalidMessage));
         });
 
         mock_bad_request.assert_async().await;
@@ -1420,7 +1420,7 @@ mod tests {
             .with_status(400)
             .with_header("Content-Type", "application/problem+json")
             .with_body(concat!(
-                "{\"type\": \"urn:ietf:params:ppm:dap:error:unrecognizedMessage\", ",
+                "{\"type\": \"urn:ietf:params:ppm:dap:error:invalidMessage\", ",
                 "\"detail\": \"The message type for a response was incorrect or the payload was \
                  malformed.\"}"
             ))
@@ -1431,9 +1431,9 @@ mod tests {
         let error = collector.poll_once(&job).await.unwrap_err();
         assert_matches!(error, Error::Http { problem_details, dap_problem_type } => {
             assert_eq!(problem_details.status.unwrap(), StatusCode::BAD_REQUEST);
-            assert_eq!(problem_details.type_url.unwrap(), "urn:ietf:params:ppm:dap:error:unrecognizedMessage");
+            assert_eq!(problem_details.type_url.unwrap(), "urn:ietf:params:ppm:dap:error:invalidMessage");
             assert_eq!(problem_details.detail.unwrap(), "The message type for a response was incorrect or the payload was malformed.");
-            assert_eq!(dap_problem_type, Some(DapProblemType::UnrecognizedMessage));
+            assert_eq!(dap_problem_type, Some(DapProblemType::InvalidMessage));
         });
 
         mock_collection_job_bad_request.assert_async().await;

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -2275,7 +2275,7 @@ pub enum PrepareError {
     VdafPrepError = 5,
     BatchSaturated = 6,
     TaskExpired = 7,
-    UnrecognizedMessage = 8,
+    InvalidMessage = 8,
 }
 
 impl Encode for PrepareError {

--- a/messages/src/problem_type.rs
+++ b/messages/src/problem_type.rs
@@ -3,9 +3,9 @@ use std::str::FromStr;
 /// Representation of the different problem types defined in Table 1 in §3.2.
 #[derive(Debug, PartialEq, Eq)]
 pub enum DapProblemType {
-    UnrecognizedMessage,
+    InvalidMessage,
     UnrecognizedTask,
-    RoundMismatch,
+    StepMismatch,
     MissingTaskId,
     UnrecognizedAggregationJob,
     OutdatedConfig,
@@ -24,11 +24,9 @@ impl DapProblemType {
     /// Returns the problem type URI for a particular kind of error.
     pub fn type_uri(&self) -> &'static str {
         match self {
-            DapProblemType::UnrecognizedMessage => {
-                "urn:ietf:params:ppm:dap:error:unrecognizedMessage"
-            }
+            DapProblemType::InvalidMessage => "urn:ietf:params:ppm:dap:error:invalidMessage",
             DapProblemType::UnrecognizedTask => "urn:ietf:params:ppm:dap:error:unrecognizedTask",
-            DapProblemType::RoundMismatch => "urn:ietf:params:ppm:dap:error:roundMismatch",
+            DapProblemType::StepMismatch => "urn:ietf:params:ppm:dap:error:stepMismatch",
             DapProblemType::MissingTaskId => "urn:ietf:params:ppm:dap:error:missingTaskID",
             DapProblemType::UnrecognizedAggregationJob => {
                 "urn:ietf:params:ppm:dap:error:unrecognizedAggregationJob"
@@ -53,14 +51,14 @@ impl DapProblemType {
     /// Returns a human-readable summary of a problem type.
     pub fn description(&self) -> &'static str {
         match self {
-            DapProblemType::UnrecognizedMessage => {
+            DapProblemType::InvalidMessage => {
                 "The message type for a response was incorrect or the payload was malformed."
             }
             DapProblemType::UnrecognizedTask => {
                 "An endpoint received a message with an unknown task ID."
             }
-            DapProblemType::RoundMismatch => {
-                "The leader and helper are not on the same round of VDAF preparation."
+            DapProblemType::StepMismatch => {
+                "The leader and helper are not on the same step of VDAF preparation."
             }
             DapProblemType::MissingTaskId => {
                 "HPKE configuration was requested without specifying a task ID."
@@ -103,13 +101,11 @@ impl FromStr for DapProblemType {
 
     fn from_str(value: &str) -> Result<DapProblemType, DapProblemTypeParseError> {
         match value {
-            "urn:ietf:params:ppm:dap:error:unrecognizedMessage" => {
-                Ok(DapProblemType::UnrecognizedMessage)
-            }
+            "urn:ietf:params:ppm:dap:error:invalidMessage" => Ok(DapProblemType::InvalidMessage),
             "urn:ietf:params:ppm:dap:error:unrecognizedTask" => {
                 Ok(DapProblemType::UnrecognizedTask)
             }
-            "urn:ietf:params:ppm:dap:error:roundMismatch" => Ok(DapProblemType::RoundMismatch),
+            "urn:ietf:params:ppm:dap:error:stepMismatch" => Ok(DapProblemType::StepMismatch),
             "urn:ietf:params:ppm:dap:error:missingTaskID" => Ok(DapProblemType::MissingTaskId),
             "urn:ietf:params:ppm:dap:error:unrecognizedAggregationJob" => {
                 Ok(DapProblemType::UnrecognizedAggregationJob)


### PR DESCRIPTION
DAP-05 changes a few error types.

- `unrecongizedMessage -> invalidMessage`
- `queryMismatch` is gone (now we use `invalidMessage` in that case)
- `roundMismatch -> stepMismatch`

We still use the word "round" in several places where "step" would be more appropriate given DAP-05 text. Renaming those variables, etc., will arrive in a later commit to avoid adding unnecessary noise here.

Part of #1669