### PR TITLE
Bump crate versions to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1785,7 +1785,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "janus_aggregator"
-version = "0.5.14"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1865,7 +1865,7 @@ dependencies = [
 
 [[package]]
 name = "janus_aggregator_api"
-version = "0.5.14"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1894,7 +1894,7 @@ dependencies = [
 
 [[package]]
 name = "janus_aggregator_core"
-version = "0.5.14"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1948,14 +1948,14 @@ dependencies = [
 
 [[package]]
 name = "janus_build_script_utils"
-version = "0.5.14"
+version = "0.6.0"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "janus_client"
-version = "0.5.14"
+version = "0.6.0"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -1979,7 +1979,7 @@ dependencies = [
 
 [[package]]
 name = "janus_collector"
-version = "0.5.14"
+version = "0.6.0"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -2004,7 +2004,7 @@ dependencies = [
 
 [[package]]
 name = "janus_core"
-version = "0.5.14"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2047,7 +2047,7 @@ dependencies = [
 
 [[package]]
 name = "janus_integration_tests"
-version = "0.5.14"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "backoff",
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "janus_interop_binaries"
-version = "0.5.14"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "backoff",
@@ -2120,7 +2120,7 @@ dependencies = [
 
 [[package]]
 name = "janus_messages"
-version = "0.5.14"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "janus_tools"
-version = "0.5.14"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://divviup.org"
 license = "MPL-2.0"
 repository = "https://github.com/divviup/janus"
 rust-version = "1.70.0"
-version = "0.5.14"
+version = "0.6.0"
 
 [workspace.dependencies]
 anyhow = "1"
@@ -29,16 +29,16 @@ anyhow = "1"
 # https://docs.rs/chrono/latest/chrono/#duration
 chrono = { version = "0.4", default-features = false }
 itertools = "0.10"
-janus_aggregator = { version = "0.5", path = "aggregator" }
-janus_aggregator_api = { version = "0.5", path = "aggregator_api" }
-janus_aggregator_core = { version = "0.5", path = "aggregator_core" }
-janus_build_script_utils = { version = "0.5", path = "build_script_utils" }
-janus_client = { version = "0.5", path = "client" }
-janus_collector = { version = "0.5", path = "collector" }
-janus_core = { version = "0.5", path = "core" }
-janus_integration_tests = { version = "0.5", path = "integration_tests" }
-janus_interop_binaries = { version = "0.5", path = "interop_binaries" }
-janus_messages = { version = "0.5", path = "messages" }
+janus_aggregator = { version = "0.6", path = "aggregator" }
+janus_aggregator_api = { version = "0.6", path = "aggregator_api" }
+janus_aggregator_core = { version = "0.6", path = "aggregator_core" }
+janus_build_script_utils = { version = "0.6", path = "build_script_utils" }
+janus_client = { version = "0.6", path = "client" }
+janus_collector = { version = "0.6", path = "collector" }
+janus_core = { version = "0.6", path = "core" }
+janus_integration_tests = { version = "0.6", path = "integration_tests" }
+janus_interop_binaries = { version = "0.6", path = "interop_binaries" }
+janus_messages = { version = "0.6", path = "messages" }
 k8s-openapi = { version = "0.18.0", features = ["v1_24"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
 kube = { version = "0.82.2", default-features = false, features = ["client", "rustls-tls"] }
 opentelemetry = { version = "0.20", features = ["metrics"] }


### PR DESCRIPTION
We don't imminently plan to release, but we don't want to suggest that the tip of `main` is equivalent to tag `0.5.14`.