### PR TITLE
`collect` tool: accept HPKE keypair from `divviup`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,6 +1570,7 @@ dependencies = [
  "hpke",
  "num_enum",
  "rand",
+ "serde",
  "wasm-bindgen",
  "zeroize",
 ]
@@ -2177,7 +2178,9 @@ dependencies = [
  "prio",
  "rand",
  "reqwest",
+ "serde_json",
  "serde_yaml",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-log",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -40,7 +40,7 @@ chrono = { workspace = true, features = ["clock"] }
 derivative = "2.2.0"
 futures = "0.3.28"
 hex = "0.4"
-hpke-dispatch = "0.5.1"
+hpke-dispatch = { version = "0.5.1", features = ["serde"] }
 http = "0.2.9"
 http-api-problem = "0.57.0"
 janus_messages.workspace = true

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -912,7 +912,7 @@ impl Decode for ExtensionType {
 pub struct HpkeCiphertext {
     /// An identifier of the HPKE configuration used to seal the message.
     config_id: HpkeConfigId,
-    /// An encasulated HPKE key.
+    /// An encapsulated HPKE key.
     #[derivative(Debug = "ignore")]
     encapsulated_key: Vec<u8>,
     /// An HPKE ciphertext.

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -22,6 +22,7 @@ janus_core.workspace = true
 janus_messages.workspace = true
 prio.workspace = true
 reqwest = { version = "0.11.20", default-features = false, features = ["rustls-tls", "json"] }
+serde_json.workspace = true
 serde_yaml = "0.9.25"
 tokio.workspace = true
 tracing = "0.1.37"
@@ -34,4 +35,5 @@ assert_matches = "1"
 cfg-if = "1.0.0"
 janus_core = { workspace = true, features = ["test-util"] }
 rand = "0.8"
+tempfile = "3.8.0"
 trycmd = "0.14.17"

--- a/tools/tests/cmd/collect.trycmd
+++ b/tools/tests/cmd/collect.trycmd
@@ -2,7 +2,7 @@
 $ collect --help
 Command-line DAP-PPM collector from ISRG's Divvi Up
 
-Usage: collect [OPTIONS] --task-id <TASK_ID> --leader <LEADER> --hpke-config <HPKE_CONFIG> --hpke-private-key <HPKE_PRIVATE_KEY> --vdaf <VDAF> <--dap-auth-token <DAP_AUTH_TOKEN>|--authorization-bearer-token <AUTHORIZATION_BEARER_TOKEN>> <--batch-interval-start <BATCH_INTERVAL_START>|--batch-interval-duration <BATCH_INTERVAL_DURATION>|--batch-id <BATCH_ID>|--current-batch>
+Usage: collect [OPTIONS] --task-id <TASK_ID> --leader <LEADER> --vdaf <VDAF> <--dap-auth-token <DAP_AUTH_TOKEN>|--authorization-bearer-token <AUTHORIZATION_BEARER_TOKEN>> <--batch-interval-start <BATCH_INTERVAL_START>|--batch-interval-duration <BATCH_INTERVAL_DURATION>|--batch-id <BATCH_ID>|--current-batch>
 
 Options:
   -h, --help
@@ -25,6 +25,9 @@ DAP Task Parameters:
           The collector's HPKE private key, encoded with base64url
           
           [env: HPKE_PRIVATE_KEY=]
+
+      --hpke-config-json <HPKE_CONFIG_JSON>
+          Path to a JSON document containing the collector's HPKE configuration and private key, in the format output by `divviup hpke-config generate`
 
 Authorization:
       --dap-auth-token <DAP_AUTH_TOKEN>


### PR DESCRIPTION
Adds a new option to `collect` so that an HPKE keypair encoded in JSON by `divviup hpke-config generate` may be used instead of providing the Base64URL unpadded private key plus the RFC 8446 encoding of the HPKE config.

Backport of #1844