### PR TITLE
Account max_batch_query_count against distinct requests. [0.5 backport]

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -76,6 +76,7 @@ use std::{
     borrow::Borrow,
     collections::{hash_map::Entry, HashMap, HashSet},
     fmt::Debug,
+    hash::Hash,
     panic,
     sync::Arc,
     time::{Duration as StdDuration, Instant},
@@ -2151,7 +2152,7 @@ impl VdafOps {
         req_bytes: &[u8],
     ) -> Result<(), Error>
     where
-        A::AggregationParam: 'static + Send + Sync + PartialEq + Eq,
+        A::AggregationParam: 'static + Send + Sync + PartialEq + Eq + Hash,
         A::AggregateShare: Send + Sync,
     {
         let req = Arc::new(CollectionReq::<Q>::get_decoded(req_bytes)?);
@@ -2222,7 +2223,8 @@ impl VdafOps {
                             tx,
                             &vdaf,
                             &task,
-                            &collection_identifier
+                            &collection_identifier,
+                            &aggregation_param,
                         ),
                         Q::count_client_reports(tx, &task, &collection_identifier),
                         try_join_all(
@@ -2712,7 +2714,7 @@ impl VdafOps {
         collector_hpke_config: &HpkeConfig,
     ) -> Result<AggregateShare, Error>
     where
-        A::AggregationParam: Send + Sync,
+        A::AggregationParam: Send + Sync + Eq + Hash,
         A::AggregateShare: Send + Sync,
     {
         // Decode request, and verify that it is for the current task. We use an assert to check
@@ -2799,6 +2801,7 @@ impl VdafOps {
                                     vdaf.as_ref(),
                                     &task,
                                     aggregate_share_req.batch_selector().batch_identifier(),
+                                    &aggregation_param,
                                 )
                             )?;
 

--- a/aggregator/src/aggregator/query_type.rs
+++ b/aggregator/src/aggregator/query_type.rs
@@ -11,6 +11,7 @@ use janus_messages::{
     Role,
 };
 use prio::vdaf;
+use std::{collections::HashSet, hash::Hash};
 
 #[async_trait]
 pub trait UploadableQueryType: QueryType {
@@ -100,7 +101,10 @@ pub trait CollectableQueryType: CoreCollectableQueryType + AccumulableQueryType 
         vdaf: &A,
         task: &Task,
         batch_identifier: &Self::BatchIdentifier,
-    ) -> Result<(), datastore::Error>;
+        aggregation_param: &A::AggregationParam,
+    ) -> Result<(), datastore::Error>
+    where
+        A::AggregationParam: Send + Sync + Eq + Hash;
 }
 
 #[async_trait]
@@ -114,11 +118,18 @@ impl CollectableQueryType for TimeInterval {
         vdaf: &A,
         task: &Task,
         collect_interval: &Self::BatchIdentifier,
-    ) -> Result<(), datastore::Error> {
-        // Check how many rows in the relevant table have an intersecting batch interval.
-        // Each such row consumes one unit of query count.
-        // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-02.html#section-4.5.6
-        let intersecting_intervals: Vec<_> = match task.role() {
+        aggregation_param: &A::AggregationParam,
+    ) -> Result<(), datastore::Error>
+    where
+        A::AggregationParam: Send + Sync + Eq + Hash,
+    {
+        // Check how distinct aggregation parameters appear in rows in the relevant table with an
+        // intersecting batch interval. Each distinct aggregation parameter consumes one unit of
+        // query count.
+        //
+        // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-05.html#section-4.6.6
+        let mut found_overlapping_nonequal_interval = false;
+        let agg_params = match task.role() {
             Role::Leader => tx
                 .get_collection_jobs_intersecting_interval::<SEED_SIZE, A>(
                     vdaf,
@@ -127,8 +138,13 @@ impl CollectableQueryType for TimeInterval {
                 )
                 .await?
                 .into_iter()
-                .map(|job| *job.batch_interval())
-                .collect(),
+                .map(|job| {
+                    if job.batch_interval() != collect_interval {
+                        found_overlapping_nonequal_interval = true;
+                    }
+                    job.take_aggregation_parameter()
+                })
+                .collect::<HashSet<_>>(),
 
             Role::Helper => tx
                 .get_aggregate_share_jobs_intersecting_interval::<SEED_SIZE, A>(
@@ -138,30 +154,35 @@ impl CollectableQueryType for TimeInterval {
                 )
                 .await?
                 .into_iter()
-                .map(|job| *job.batch_interval())
-                .collect(),
+                .map(|job| {
+                    if job.batch_interval() != collect_interval {
+                        found_overlapping_nonequal_interval = true;
+                    };
+                    job.take_aggregation_parameter()
+                })
+                .collect::<HashSet<_>>(),
 
             _ => panic!("Unexpected task role {:?}", task.role()),
         };
 
         // Check that all intersecting collect intervals are equal to this collect interval.
-        // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-02.html#section-4.5.6-5
-        if intersecting_intervals
-            .iter()
-            .any(|interval| interval != collect_interval)
-        {
+        if found_overlapping_nonequal_interval {
             return Err(datastore::Error::User(
                 Error::BatchOverlap(*task.id(), *collect_interval).into(),
             ));
         }
 
         // Check that the batch query count is being consumed appropriately.
-        // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-02.html#section-4.5.6
         let max_batch_query_count: usize = task.max_batch_query_count().try_into()?;
-        if intersecting_intervals.len() >= max_batch_query_count {
+        let query_count = agg_params.len()
+            + if agg_params.contains(aggregation_param) {
+                0
+            } else {
+                1
+            };
+        if query_count > max_batch_query_count {
             return Err(datastore::Error::User(
-                Error::BatchQueriedTooManyTimes(*task.id(), intersecting_intervals.len() as u64)
-                    .into(),
+                Error::BatchQueriedTooManyTimes(*task.id(), query_count as u64).into(),
             ));
         }
         Ok(())
@@ -179,25 +200,42 @@ impl CollectableQueryType for FixedSize {
         vdaf: &A,
         task: &Task,
         batch_id: &Self::BatchIdentifier,
-    ) -> Result<(), datastore::Error> {
-        let query_count = match task.role() {
+        aggregation_param: &A::AggregationParam,
+    ) -> Result<(), datastore::Error>
+    where
+        A::AggregationParam: Send + Sync + Eq + Hash,
+    {
+        // Check how distinct aggregation parameters appear in rows in the relevant table with an
+        // intersecting batch interval. Each distinct aggregation parameter consumes one unit of
+        // query count.
+        //
+        // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-05.html#section-4.6.6
+        let agg_params = match task.role() {
             Role::Leader => tx
                 .get_collection_jobs_by_batch_id::<SEED_SIZE, A>(vdaf, task.id(), batch_id)
                 .await?
-                .len(),
+                .into_iter()
+                .map(|job| job.take_aggregation_parameter())
+                .collect::<HashSet<_>>(),
 
             Role::Helper => tx
                 .get_aggregate_share_jobs_by_batch_id::<SEED_SIZE, A>(vdaf, task.id(), batch_id)
                 .await?
-                .len(),
+                .into_iter()
+                .map(|job| job.take_aggregation_parameter())
+                .collect::<HashSet<_>>(),
 
             _ => panic!("Unexpected task role {:?}", task.role()),
         };
 
-        // Check that the batch query count is being consumed appropriately.
-        // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-02.html#section-4.5.6
         let max_batch_query_count: usize = task.max_batch_query_count().try_into()?;
-        if query_count >= max_batch_query_count {
+        let query_count = agg_params.len()
+            + if agg_params.contains(aggregation_param) {
+                0
+            } else {
+                1
+            };
+        if query_count > max_batch_query_count {
             return Err(datastore::Error::User(
                 Error::BatchQueriedTooManyTimes(*task.id(), query_count as u64).into(),
             ));

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -100,7 +100,7 @@ macro_rules! supported_schema_versions {
 // version is seen, [`Datastore::new`] fails.
 //
 // Note that the latest supported version must be first in the list.
-supported_schema_versions!(17, 16, 15);
+supported_schema_versions!(18, 17, 16, 15);
 
 /// Datastore represents a datastore for Janus, with support for transactional reads and writes.
 /// In practice, Datastore instances are currently backed by a PostgreSQL database.

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -1084,6 +1084,11 @@ impl<const SEED_SIZE: usize, Q: QueryType, A: vdaf::Aggregator<SEED_SIZE, 16>>
         &self.aggregation_parameter
     }
 
+    /// Takes the aggregation parameter associated with this collection job, consuming the job.
+    pub fn take_aggregation_parameter(self) -> A::AggregationParam {
+        self.aggregation_parameter
+    }
+
     /// Returns the state associated with this collection job.
     pub fn state(&self) -> &CollectionJobState<SEED_SIZE, A> {
         &self.state
@@ -1301,6 +1306,11 @@ impl<const SEED_SIZE: usize, Q: QueryType, A: vdaf::Aggregator<SEED_SIZE, 16>>
     /// Gets the aggregation parameter associated with this aggregate share job.
     pub fn aggregation_parameter(&self) -> &A::AggregationParam {
         &self.aggregation_parameter
+    }
+
+    /// Takes the aggregation parameter associated with this aggregate share job, consuming the job.
+    pub fn take_aggregation_parameter(self) -> A::AggregationParam {
+        self.aggregation_parameter
     }
 
     /// Gets the helper aggregate share associated with this aggregate share job.

--- a/db/00000000000018_nonunique_collection_jobs.down.sql
+++ b/db/00000000000018_nonunique_collection_jobs.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE collection_jobs ADD CONSTRAINT collection_jobs_unique_task_id_batch_id_aggregation_param UNIQUE(task_id, batch_identifier, aggregation_param);
+DROP INDEX collection_jobs_task_id_batch_id CASCADE;

--- a/db/00000000000018_nonunique_collection_jobs.up.sql
+++ b/db/00000000000018_nonunique_collection_jobs.up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX collection_jobs_task_id_batch_id ON collection_jobs(task_id, batch_identifier);
+ALTER TABLE collection_jobs DROP CONSTRAINT collection_jobs_unique_task_id_batch_id_aggregation_param;


### PR DESCRIPTION
Before, the Leader would account for max_batch_query_count over all requests, so multiple identical requests would count as multiple queries.