### PR TITLE
Check collection job equivalence by query, not batch ID.

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -898,9 +898,10 @@ mod tests {
     use janus_messages::{
         query_type::{FixedSize, TimeInterval},
         AggregationJobContinueReq, AggregationJobInitializeReq, AggregationJobResp,
-        AggregationJobRound, Duration, Extension, ExtensionType, HpkeConfig, InputShareAad,
-        Interval, PartialBatchSelector, PlaintextInputShare, PrepareStep, PrepareStepResult,
-        ReportIdChecksum, ReportMetadata, ReportShare, ReportShareError, Role, TaskId, Time,
+        AggregationJobRound, Duration, Extension, ExtensionType, FixedSizeQuery, HpkeConfig,
+        InputShareAad, Interval, PartialBatchSelector, PlaintextInputShare, PrepareStep,
+        PrepareStepResult, Query, ReportIdChecksum, ReportMetadata, ReportShare, ReportShareError,
+        Role, TaskId, Time,
     };
     use prio::{
         codec::Encode,
@@ -1019,8 +1020,9 @@ mod tests {
                         CollectionJob::<VERIFY_KEY_LENGTH, TimeInterval, Prio3Count>::new(
                             *task.id(),
                             random(),
-                            batch_identifier,
+                            Query::new_time_interval(batch_identifier),
                             (),
+                            batch_identifier,
                             CollectionJobState::Start,
                         );
                     tx.put_collection_job(&collection_job).await?;
@@ -1180,7 +1182,7 @@ mod tests {
                         .await?
                         .unwrap();
                     let collection_job = tx
-                        .get_collection_job(vdaf.as_ref(), &collection_job_id)
+                        .get_collection_job(vdaf.as_ref(), task.id(), &collection_job_id)
                         .await?
                         .unwrap();
                     Ok((aggregation_job, report_aggregation, batch, collection_job))
@@ -1930,8 +1932,9 @@ mod tests {
                         CollectionJob::<VERIFY_KEY_LENGTH, TimeInterval, Prio3Count>::new(
                             *task.id(),
                             random(),
-                            collection_identifier,
+                            Query::new_time_interval(collection_identifier),
                             (),
+                            collection_identifier,
                             CollectionJobState::Start,
                         );
                     tx.put_collection_job(&collection_job).await?;
@@ -2140,7 +2143,7 @@ mod tests {
                         .await?
                         .unwrap();
                     let got_collection_job = tx
-                        .get_collection_job(vdaf.as_ref(), &collection_job_id)
+                        .get_collection_job(vdaf.as_ref(), task.id(), &collection_job_id)
                         .await?
                         .unwrap();
 
@@ -2294,8 +2297,9 @@ mod tests {
                         CollectionJob::<VERIFY_KEY_LENGTH, FixedSize, Prio3Count>::new(
                             *task.id(),
                             random(),
-                            batch_id,
+                            Query::new_fixed_size(FixedSizeQuery::CurrentBatch),
                             (),
+                            batch_id,
                             CollectionJobState::Start,
                         );
                     tx.put_collection_job(&collection_job).await?;
@@ -2467,7 +2471,7 @@ mod tests {
                         .await?;
                     let batch = tx.get_batch(task.id(), &batch_id, &()).await?.unwrap();
                     let collection_job = tx
-                        .get_collection_job(vdaf.as_ref(), &collection_job_id)
+                        .get_collection_job(vdaf.as_ref(), task.id(), &collection_job_id)
                         .await?
                         .unwrap();
                     Ok((

--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -305,6 +305,7 @@ async fn collection_job_success_fixed_size() {
                     let collection_job = tx
                         .get_collection_job::<0, FixedSize, dummy_vdaf::Vdaf>(
                             &vdaf,
+                            task.id(),
                             &collection_job_id,
                         )
                         .await

--- a/aggregator/src/aggregator/garbage_collector.rs
+++ b/aggregator/src/aggregator/garbage_collector.rs
@@ -99,8 +99,8 @@ mod tests {
     };
     use janus_messages::{
         query_type::{FixedSize, TimeInterval},
-        AggregationJobRound, Duration, HpkeCiphertext, HpkeConfigId, Interval, ReportIdChecksum,
-        ReportMetadata, ReportShare, Role, Time,
+        AggregationJobRound, Duration, FixedSizeQuery, HpkeCiphertext, HpkeConfigId, Interval,
+        Query, ReportIdChecksum, ReportMetadata, ReportShare, Role, Time,
     };
     use rand::random;
     use std::sync::Arc;
@@ -203,8 +203,9 @@ mod tests {
                         &CollectionJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
                             *task.id(),
                             random(),
-                            batch_identifier,
+                            Query::new_time_interval(batch_identifier),
                             AggregationParam(0),
+                            batch_identifier,
                             CollectionJobState::Start,
                         ),
                     )
@@ -575,8 +576,9 @@ mod tests {
                     tx.put_collection_job(&CollectionJob::<0, FixedSize, dummy_vdaf::Vdaf>::new(
                         *task.id(),
                         random(),
-                        batch_id,
+                        Query::new_fixed_size(FixedSizeQuery::CurrentBatch),
                         AggregationParam(0),
+                        batch_id,
                         CollectionJobState::Start,
                     ))
                     .await

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -4291,8 +4291,9 @@ mod tests {
         let want_collection_job = CollectionJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
             *test_case.task.id(),
             collection_job_id,
-            batch_interval,
+            Query::new_time_interval(batch_interval),
             aggregation_param,
+            batch_interval,
             CollectionJobState::Start,
         );
         let want_batches = Vec::from([Batch::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
@@ -4311,7 +4312,7 @@ mod tests {
 
                 Box::pin(async move {
                     let got_collection_job = tx
-                        .get_collection_job(&dummy_vdaf::Vdaf::new(), &collection_job_id)
+                        .get_collection_job(&dummy_vdaf::Vdaf::new(), &task_id, &collection_job_id)
                         .await?
                         .unwrap();
                     let got_batches = tx.get_batches_for_task(&task_id).await?;
@@ -4356,6 +4357,7 @@ mod tests {
                     let collection_job = tx
                         .get_collection_job::<0, TimeInterval, dummy_vdaf::Vdaf>(
                             &dummy_vdaf::Vdaf::new(),
+                            task.id(),
                             &collection_job_id,
                         )
                         .await

--- a/db/00000000000001_initial_schema.up.sql
+++ b/db/00000000000001_initial_schema.up.sql
@@ -281,9 +281,10 @@ CREATE TABLE collection_jobs(
     id                      BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,  -- artificial ID, internal-only
     collection_job_id       BYTEA NOT NULL,              -- 16 byte identifier used by collector to refer to this job
     task_id                 BIGINT NOT NULL,             -- the task ID being collected
+    query                   BYTEA NOT NULL,              -- encoded query-type-specific query (corresponds to Query)
+    aggregation_param       BYTEA NOT NULL,              -- the aggregation parameter (opaque VDAF message)
     batch_identifier        BYTEA NOT NULL,              -- encoded query-type-specific batch identifier (corresponds to identifier in BatchSelector)
     batch_interval          TSRANGE,                     -- batch interval, as a TSRANGE, populated only for time-interval tasks. (will always match batch_identifier)
-    aggregation_param       BYTEA NOT NULL,              -- the aggregation parameter (opaque VDAF message)
     state                   COLLECTION_JOB_STATE NOT NULL,  -- the current state of this collection job
     report_count            BIGINT,                      -- the number of reports included in this collection job (only if in state FINISHED)
     helper_aggregate_share  BYTEA,                       -- the helper's encrypted aggregate share (HpkeCiphertext, only if in state FINISHED)


### PR DESCRIPTION
This allows current-batch requests to be reissued in fixed-size tasks, simplifying implementation of a Collector & avoiding the potential for loss of a collection job due to an inopportunely-timed task failure.

While I'm at it, I also update `get_collection_job` to take a task ID in addition to a collection job ID. This provides isolation between different tasks, which is especially imporant now that the Collector generates the collection job IDs -- otherwise, it would be trivial for Collectors to generate the same collection job ID for two tasks, which would cause some very strange behavior in Janus.

Resolves #1877. Part of #1860.