### PR TITLE
Do not compare preparation states in non-test code.

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/aggregation_job_continue.rs
@@ -245,7 +245,7 @@ impl VdafOps {
                     ))
                 }
             })
-            .with_last_continue_request_hash(request_hash);
+            .with_last_request_hash(request_hash);
 
         try_join!(
             tx.update_aggregation_job(&helper_aggregation_job),

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -187,7 +187,8 @@ impl AggregationJobDriver {
                     // operation to avoid needing to join many futures?
                     let client_reports: HashMap<_, _> =
                         try_join_all(report_aggregations.iter().filter_map(|report_aggregation| {
-                            if report_aggregation.state() == &ReportAggregationState::Start {
+                            if matches!(report_aggregation.state(), &ReportAggregationState::Start)
+                            {
                                 Some(
                                     tx.get_client_report(
                                         vdaf.as_ref(),
@@ -308,7 +309,7 @@ impl AggregationJobDriver {
         let report_aggregations: Vec<_> = report_aggregations
             .into_iter()
             .filter(|report_aggregation| {
-                report_aggregation.state() == &ReportAggregationState::Start
+                matches!(report_aggregation.state(), &ReportAggregationState::Start)
             })
             .collect();
 

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -2710,7 +2710,7 @@ mod tests {
                 AggregationJobState::Finished,
                 AggregationJobRound::from(1),
             )
-            .with_last_continue_request_hash(aggregation_job.last_continue_request_hash().unwrap())
+            .with_last_request_hash(aggregation_job.last_request_hash().unwrap())
         );
         assert_eq!(
             report_aggregations,
@@ -3633,7 +3633,7 @@ mod tests {
                 AggregationJobState::Finished,
                 AggregationJobRound::from(1),
             )
-            .with_last_continue_request_hash(aggregation_job.last_continue_request_hash().unwrap())
+            .with_last_request_hash(aggregation_job.last_request_hash().unwrap())
         );
         assert_eq!(
             report_aggregation,

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -237,7 +237,7 @@ pub struct AggregationJob<const SEED_SIZE: usize, Q: QueryType, A: vdaf::Aggrega
     /// The SHA-256 hash of the most recent [`janus_messages::AggregationJobContinueReq`]
     /// received for this aggregation job. Will only be set for helpers, and only after the
     /// first round of the job.
-    last_continue_request_hash: Option<[u8; 32]>,
+    last_request_hash: Option<[u8; 32]>,
 }
 
 impl<const SEED_SIZE: usize, Q: QueryType, A: vdaf::Aggregator<SEED_SIZE, 16>>
@@ -261,7 +261,7 @@ impl<const SEED_SIZE: usize, Q: QueryType, A: vdaf::Aggregator<SEED_SIZE, 16>>
             client_timestamp_interval,
             state,
             round,
-            last_continue_request_hash: None,
+            last_request_hash: None,
         }
     }
 
@@ -317,16 +317,17 @@ impl<const SEED_SIZE: usize, Q: QueryType, A: vdaf::Aggregator<SEED_SIZE, 16>>
     }
 
     /// Returns the SHA-256 digest of the most recent
+    /// [`janus_messages::AggregationJobInitializeReq`] or
     /// [`janus_messages::AggregationJobContinueReq`] for the job, if any.
-    pub fn last_continue_request_hash(&self) -> Option<[u8; 32]> {
-        self.last_continue_request_hash
+    pub fn last_request_hash(&self) -> Option<[u8; 32]> {
+        self.last_request_hash
     }
 
-    /// Returns a new [`AggregationJob`] corresponding to this aggregation job updated to have
-    /// the given last continue request hash.
-    pub fn with_last_continue_request_hash(self, hash: [u8; 32]) -> Self {
+    /// Returns a new [`AggregationJob`] corresponding to this aggregation job updated to have the
+    /// given last request hash.
+    pub fn with_last_request_hash(self, hash: [u8; 32]) -> Self {
         Self {
-            last_continue_request_hash: Some(hash),
+            last_request_hash: Some(hash),
             ..self
         }
     }
@@ -354,7 +355,7 @@ where
             && self.client_timestamp_interval == other.client_timestamp_interval
             && self.state == other.state
             && self.round == other.round
-            && self.last_continue_request_hash == other.last_continue_request_hash
+            && self.last_request_hash == other.last_request_hash
     }
 }
 
@@ -669,6 +670,10 @@ impl<const SEED_SIZE: usize, A: vdaf::Aggregator<SEED_SIZE, 16>> ReportAggregati
     }
 }
 
+// This trait implementation is gated on the `test-util` feature as we do not wish to compare
+// preparation states in non-test code, since doing so would require a constant-time comparison to
+// avoid risking leaking information about the preparation state.
+#[cfg(feature = "test-util")]
 impl<const SEED_SIZE: usize, A: vdaf::Aggregator<SEED_SIZE, 16>> PartialEq
     for ReportAggregation<SEED_SIZE, A>
 where
@@ -688,6 +693,10 @@ where
     }
 }
 
+// This trait implementation is gated on the `test-util` feature as we do not wish to compare
+// preparation states in non-test code, since doing so would require a constant-time comparison to
+// avoid risking leaking information about the preparation state.
+#[cfg(feature = "test-util")]
 impl<const SEED_SIZE: usize, A: vdaf::Aggregator<SEED_SIZE, 16>> Eq
     for ReportAggregation<SEED_SIZE, A>
 where
@@ -775,6 +784,10 @@ pub enum ReportAggregationStateCode {
     Failed,
 }
 
+// This trait implementation is gated on the `test-util` feature as we do not wish to compare
+// preparation states in non-test code, since doing so would require a constant-time comparison to
+// avoid risking leaking information about the preparation state.
+#[cfg(feature = "test-util")]
 impl<const SEED_SIZE: usize, A: vdaf::Aggregator<SEED_SIZE, 16>> PartialEq
     for ReportAggregationState<SEED_SIZE, A>
 where
@@ -797,6 +810,10 @@ where
     }
 }
 
+// This trait implementation is gated on the `test-util` feature as we do not wish to compare
+// preparation states in non-test code, since doing so would require a constant-time comparison to
+// avoid risking leaking information about the preparation state.
+#[cfg(feature = "test-util")]
 impl<const SEED_SIZE: usize, A: vdaf::Aggregator<SEED_SIZE, 16>> Eq
     for ReportAggregationState<SEED_SIZE, A>
 where

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -1270,8 +1270,7 @@ async fn roundtrip_aggregation_job(ephemeral_datastore: EphemeralDatastore) {
     let new_leader_aggregation_job = leader_aggregation_job
         .clone()
         .with_state(AggregationJobState::Finished);
-    let new_helper_aggregation_job =
-        helper_aggregation_job.with_last_continue_request_hash([3; 32]);
+    let new_helper_aggregation_job = helper_aggregation_job.with_last_request_hash([3; 32]);
     ds.run_tx(|tx| {
         let (new_leader_aggregation_job, new_helper_aggregation_job) = (
             new_leader_aggregation_job.clone(),
@@ -1812,7 +1811,7 @@ async fn get_aggregation_jobs_for_task(ephemeral_datastore: EphemeralDatastore) 
         AggregationJobState::InProgress,
         AggregationJobRound::from(0),
     )
-    .with_last_continue_request_hash([3; 32]);
+    .with_last_request_hash([3; 32]);
 
     let mut want_agg_jobs = Vec::from([
         first_aggregation_job,

--- a/db/00000000000001_initial_schema.up.sql
+++ b/db/00000000000001_initial_schema.up.sql
@@ -174,8 +174,7 @@ CREATE TABLE aggregation_jobs(
     client_timestamp_interval  TSRANGE NOT NULL,                -- the minimal interval containing all of client timestamps included in this aggregation job
     state                      AGGREGATION_JOB_STATE NOT NULL,  -- current state of the aggregation job
     round                      INTEGER NOT NULL,                -- current round of the VDAF preparation protocol
-    last_continue_request_hash BYTEA,                           -- SHA-256 hash of the most recently received AggregationJobContinueReq
-                                                                -- (helper only and only after the first round of the job)
+    last_request_hash          BYTEA,                           -- SHA-256 hash of the most recently received AggregationJobContinueReq (helper only)
     trace_context              JSONB,                           -- distributed tracing metadata
 
     lease_expiry             TIMESTAMP NOT NULL DEFAULT TIMESTAMP '-infinity',  -- when lease on this aggregation job expires; -infinity implies no current lease


### PR DESCRIPTION
This required a few updates to non-test code:

* The aggregation job creator used equality checks to determine if a given report aggregation was in state `START`. These are easily replaced by a call to `matches!`, which does not require `PartialEq + Eq`.

* Checking if a repeated aggregation job `PUT` matched the preexisting aggregation job checked if the report aggregations were equal. This is replaced by populating the last request hash for initialization requests (as well as continuation requests) and checking if the aggregation job is equal; since the aggregation job carries both the round number as well as the request hash, this should suffice to check that the requests are equal. As a bonus, we no longer need to read the preexisting report aggregations.