### PR TITLE
Differential privacy in janus

### DIFF
--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -43,8 +43,8 @@ console-subscriber = { version = "0.2.0", optional = true }
 deadpool = { version = "0.10.0", features = ["rt_tokio_1"] }
 deadpool-postgres = "0.11.0"
 derivative.workspace = true
-futures = "0.3.28"
 fixed = { version = "1.24", optional = true }
+futures = "0.3.28"
 git-version = "0.3.5"
 hex = { version = "0.4.3", features = ["serde"], optional = true }
 http = "0.2.9"

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -38,6 +38,8 @@ use janus_aggregator_core::{
 };
 #[cfg(feature = "test-util")]
 use janus_core::test_util::dummy_vdaf;
+#[cfg(feature = "fpvec_bounded_l2")]
+use janus_core::vdaf::Prio3FixedPointBoundedL2VecSumBitSize;
 use janus_core::{
     auth_tokens::AuthenticationToken,
     hpke::{self, HpkeApplicationInfo, HpkeKeypair, Label},
@@ -65,6 +67,7 @@ use prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded;
 use prio::vdaf::{PrepareTransition, VdafError};
 use prio::{
     codec::{Decode, Encode, ParameterizedDecode},
+    dp::DifferentialPrivacyStrategy,
     topology::ping_pong::{PingPongState, PingPongTopology},
     vdaf::{
         self,
@@ -835,27 +838,31 @@ impl<C: Clock> TaskAggregator<C> {
             }
 
             #[cfg(feature = "fpvec_bounded_l2")]
-            VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { length } => {
-                let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>> =
-                    Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, *length)?;
-                let verify_key = task.vdaf_verify_key()?;
-                VdafOps::Prio3FixedPoint16BitBoundedL2VecSum(Arc::new(vdaf), verify_key)
-            }
-
-            #[cfg(feature = "fpvec_bounded_l2")]
-            VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { length } => {
-                let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>> =
-                    Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, *length)?;
-                let verify_key = task.vdaf_verify_key()?;
-                VdafOps::Prio3FixedPoint32BitBoundedL2VecSum(Arc::new(vdaf), verify_key)
-            }
-
-            #[cfg(feature = "fpvec_bounded_l2")]
-            VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { length } => {
-                let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>> =
-                    Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, *length)?;
-                let verify_key = task.vdaf_verify_key()?;
-                VdafOps::Prio3FixedPoint64BitBoundedL2VecSum(Arc::new(vdaf), verify_key)
+            VdafInstance::Prio3FixedPointBoundedL2VecSum {
+                bitsize,
+                dp_strategy,
+                length,
+            } => {
+                match bitsize {
+                    Prio3FixedPointBoundedL2VecSumBitSize::BitSize16 => {
+                        let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>> =
+                            Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, *length)?;
+                        let verify_key = task.vdaf_verify_key()?;
+                        VdafOps::Prio3FixedPoint16BitBoundedL2VecSum(Arc::new(vdaf), verify_key, vdaf_ops_strategies::Prio3FixedPointBoundedL2VecSum::from_vdaf_dp_strategy(dp_strategy.clone()))
+                    }
+                    Prio3FixedPointBoundedL2VecSumBitSize::BitSize32 => {
+                        let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>> =
+                            Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, *length)?;
+                        let verify_key = task.vdaf_verify_key()?;
+                        VdafOps::Prio3FixedPoint32BitBoundedL2VecSum(Arc::new(vdaf), verify_key, vdaf_ops_strategies::Prio3FixedPointBoundedL2VecSum::from_vdaf_dp_strategy(dp_strategy.clone()))
+                    }
+                    Prio3FixedPointBoundedL2VecSumBitSize::BitSize64 => {
+                        let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>> =
+                            Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, *length)?;
+                        let verify_key = task.vdaf_verify_key()?;
+                        VdafOps::Prio3FixedPoint64BitBoundedL2VecSum(Arc::new(vdaf), verify_key, vdaf_ops_strategies::Prio3FixedPointBoundedL2VecSum::from_vdaf_dp_strategy(dp_strategy.clone()))
+                    }
+                }
             }
 
             VdafInstance::Poplar1 { bits } => {
@@ -1033,6 +1040,34 @@ impl<C: Clock> TaskAggregator<C> {
     }
 }
 
+#[cfg(feature = "fpvec_bounded_l2")]
+mod vdaf_ops_strategies {
+    use std::sync::Arc;
+
+    use janus_core::vdaf::vdaf_dp_strategies;
+    use prio::dp::distributions::ZCdpDiscreteGaussian;
+
+    pub enum Prio3FixedPointBoundedL2VecSum {
+        NoDifferentialPrivacy,
+        ZCdpDiscreteGaussian(Arc<ZCdpDiscreteGaussian>),
+    }
+
+    impl Prio3FixedPointBoundedL2VecSum {
+        pub fn from_vdaf_dp_strategy(
+            dp_strategy: vdaf_dp_strategies::Prio3FixedPointBoundedL2VecSum,
+        ) -> Self {
+            match dp_strategy {
+                vdaf_dp_strategies::Prio3FixedPointBoundedL2VecSum::NoDifferentialPrivacy => {
+                    Prio3FixedPointBoundedL2VecSum::NoDifferentialPrivacy
+                }
+                vdaf_dp_strategies::Prio3FixedPointBoundedL2VecSum::ZCdpDiscreteGaussian(s) => {
+                    Prio3FixedPointBoundedL2VecSum::ZCdpDiscreteGaussian(Arc::new(s))
+                }
+            }
+        }
+    }
+}
+
 /// VdafOps stores VDAF-specific operations for a TaskAggregator in a non-generic way.
 #[allow(clippy::enum_variant_names)]
 enum VdafOps {
@@ -1045,19 +1080,21 @@ enum VdafOps {
     Prio3FixedPoint16BitBoundedL2VecSum(
         Arc<Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>>>,
         VerifyKey<VERIFY_KEY_LENGTH>,
+        vdaf_ops_strategies::Prio3FixedPointBoundedL2VecSum,
     ),
     #[cfg(feature = "fpvec_bounded_l2")]
     Prio3FixedPoint32BitBoundedL2VecSum(
         Arc<Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>>>,
         VerifyKey<VERIFY_KEY_LENGTH>,
+        vdaf_ops_strategies::Prio3FixedPointBoundedL2VecSum,
     ),
     #[cfg(feature = "fpvec_bounded_l2")]
     Prio3FixedPoint64BitBoundedL2VecSum(
         Arc<Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>>>,
         VerifyKey<VERIFY_KEY_LENGTH>,
+        vdaf_ops_strategies::Prio3FixedPointBoundedL2VecSum,
     ),
     Poplar1(Arc<Poplar1<XofShake128, 16>>, VerifyKey<VERIFY_KEY_LENGTH>),
-
     #[cfg(feature = "test-util")]
     Fake(Arc<dummy_vdaf::Vdaf>),
 }
@@ -1068,13 +1105,15 @@ enum VdafOps {
 /// specify the VDAF's type, and the name of a const that will be set to the VDAF's verify key
 /// length, also for explicitly specifying type parameters.
 macro_rules! vdaf_ops_dispatch {
-    ($vdaf_ops:expr, ($vdaf:pat_param, $verify_key:pat_param, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident) => $body:tt) => {
+    ($vdaf_ops:expr, ($vdaf:pat_param, $verify_key:pat_param, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident, $dp_strategy:ident, $DpStrategy:ident) => $body:tt) => {
         match $vdaf_ops {
             crate::aggregator::VdafOps::Prio3Count(vdaf, verify_key) => {
                 let $vdaf = vdaf;
                 let $verify_key = verify_key;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Count;
                 const $VERIFY_KEY_LENGTH: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
+                type $DpStrategy = janus_core::dp::NoDifferentialPrivacy;
+                let $dp_strategy = &Arc::new(janus_core::dp::NoDifferentialPrivacy);
                 $body
             }
 
@@ -1083,6 +1122,8 @@ macro_rules! vdaf_ops_dispatch {
                 let $verify_key = verify_key;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3SumVecMultithreaded;
                 const $VERIFY_KEY_LENGTH: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
+                type $DpStrategy = janus_core::dp::NoDifferentialPrivacy;
+                let $dp_strategy = &Arc::new(janus_core::dp::NoDifferentialPrivacy);
                 $body
             }
 
@@ -1091,6 +1132,8 @@ macro_rules! vdaf_ops_dispatch {
                 let $verify_key = verify_key;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Sum;
                 const $VERIFY_KEY_LENGTH: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
+                type $DpStrategy = janus_core::dp::NoDifferentialPrivacy;
+                let $dp_strategy = &Arc::new(janus_core::dp::NoDifferentialPrivacy);
                 $body
             }
 
@@ -1099,6 +1142,8 @@ macro_rules! vdaf_ops_dispatch {
                 let $verify_key = verify_key;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3SumVecMultithreaded;
                 const $VERIFY_KEY_LENGTH: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
+                type $DpStrategy = janus_core::dp::NoDifferentialPrivacy;
+                let $dp_strategy = &Arc::new(janus_core::dp::NoDifferentialPrivacy);
                 $body
             }
 
@@ -1107,37 +1152,81 @@ macro_rules! vdaf_ops_dispatch {
                 let $verify_key = verify_key;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Histogram;
                 const $VERIFY_KEY_LENGTH: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
+                type $DpStrategy = janus_core::dp::NoDifferentialPrivacy;
+                let $dp_strategy = &Arc::new(janus_core::dp::NoDifferentialPrivacy);
                 $body
             }
 
             #[cfg(feature = "fpvec_bounded_l2")]
-            crate::aggregator::VdafOps::Prio3FixedPoint16BitBoundedL2VecSum(vdaf, verify_key) => {
+            // Note that the variable `_dp_strategy` is used if `$dp_strategy`
+            // and `$DpStrategy` are given. The underscore suppresses warnings
+            // which occur when `vdaf_ops!` is called without these parameters.
+            crate::aggregator::VdafOps::Prio3FixedPoint16BitBoundedL2VecSum(vdaf, verify_key, _dp_strategy) => {
                 let $vdaf = vdaf;
                 let $verify_key = verify_key;
-                type $Vdaf =
-                    ::prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>>;
+                type $Vdaf = ::prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>>;
                 const $VERIFY_KEY_LENGTH: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
-                $body
+
+                match _dp_strategy {
+                    vdaf_ops_strategies::Prio3FixedPointBoundedL2VecSum::ZCdpDiscreteGaussian(_strategy) => {
+                        type $DpStrategy = ::prio::dp::distributions::ZCdpDiscreteGaussian;
+                        let $dp_strategy = &_strategy;
+                        $body
+                    },
+                    vdaf_ops_strategies::Prio3FixedPointBoundedL2VecSum::NoDifferentialPrivacy => {
+                        type $DpStrategy = janus_core::dp::NoDifferentialPrivacy;
+                        let $dp_strategy = &Arc::new(janus_core::dp::NoDifferentialPrivacy);
+                        $body
+                    }
+                }
             }
 
             #[cfg(feature = "fpvec_bounded_l2")]
-            crate::aggregator::VdafOps::Prio3FixedPoint32BitBoundedL2VecSum(vdaf, verify_key) => {
+            // Note that the variable `_dp_strategy` is used if `$dp_strategy`
+            // and `$DpStrategy` are given. The underscore suppresses warnings
+            // which occur when `vdaf_ops!` is called without these parameters.
+            crate::aggregator::VdafOps::Prio3FixedPoint32BitBoundedL2VecSum(vdaf, verify_key, _dp_strategy) => {
                 let $vdaf = vdaf;
                 let $verify_key = verify_key;
-                type $Vdaf =
-                    ::prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>>;
+                type $Vdaf = ::prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>>;
                 const $VERIFY_KEY_LENGTH: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
-                $body
+
+                match _dp_strategy {
+                    vdaf_ops_strategies::Prio3FixedPointBoundedL2VecSum::ZCdpDiscreteGaussian(_strategy) => {
+                        type $DpStrategy = ::prio::dp::distributions::ZCdpDiscreteGaussian;
+                        let $dp_strategy = &_strategy;
+                        $body
+                    },
+                    vdaf_ops_strategies::Prio3FixedPointBoundedL2VecSum::NoDifferentialPrivacy => {
+                        type $DpStrategy = janus_core::dp::NoDifferentialPrivacy;
+                        let $dp_strategy = &Arc::new(janus_core::dp::NoDifferentialPrivacy);
+                        $body
+                    }
+                }
             }
 
             #[cfg(feature = "fpvec_bounded_l2")]
-            crate::aggregator::VdafOps::Prio3FixedPoint64BitBoundedL2VecSum(vdaf, verify_key) => {
+            // Note that the variable `_dp_strategy` is used if `$dp_strategy`
+            // and `$DpStrategy` are given. The underscore suppresses warnings
+            // which occur when `vdaf_ops!` is called without these parameters.
+            crate::aggregator::VdafOps::Prio3FixedPoint64BitBoundedL2VecSum(vdaf, verify_key, _dp_strategy) => {
                 let $vdaf = vdaf;
                 let $verify_key = verify_key;
-                type $Vdaf =
-                    ::prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>>;
+                type $Vdaf = ::prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>>;
                 const $VERIFY_KEY_LENGTH: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
-                $body
+
+                match _dp_strategy {
+                    vdaf_ops_strategies::Prio3FixedPointBoundedL2VecSum::ZCdpDiscreteGaussian(_strategy) => {
+                        type $DpStrategy = ::prio::dp::distributions::ZCdpDiscreteGaussian;
+                        let $dp_strategy = &_strategy;
+                        $body
+                    },
+                    vdaf_ops_strategies::Prio3FixedPointBoundedL2VecSum::NoDifferentialPrivacy => {
+                        type $DpStrategy = janus_core::dp::NoDifferentialPrivacy;
+                        let $dp_strategy = &Arc::new(janus_core::dp::NoDifferentialPrivacy);
+                        $body
+                    }
+                }
             }
 
             crate::aggregator::VdafOps::Poplar1(vdaf, verify_key) => {
@@ -1145,6 +1234,8 @@ macro_rules! vdaf_ops_dispatch {
                 let $verify_key = verify_key;
                 type $Vdaf = ::prio::vdaf::poplar1::Poplar1<::prio::vdaf::xof::XofShake128, 16>;
                 const $VERIFY_KEY_LENGTH: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
+                type $DpStrategy = janus_core::dp::NoDifferentialPrivacy;
+                let $dp_strategy = &Arc::new(janus_core::dp::NoDifferentialPrivacy);
                 $body
             }
 
@@ -1154,10 +1245,15 @@ macro_rules! vdaf_ops_dispatch {
                 let $verify_key = &VerifyKey::new([]);
                 type $Vdaf = ::janus_core::test_util::dummy_vdaf::Vdaf;
                 const $VERIFY_KEY_LENGTH: usize = 0;
+                type $DpStrategy = janus_core::dp::NoDifferentialPrivacy;
+                let $dp_strategy = &Arc::new(janus_core::dp::NoDifferentialPrivacy);
                 $body
             }
         }
     };
+
+    ($vdaf_ops:expr, ($vdaf:pat_param, $verify_key:pat_param, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident) => $body:tt) => {
+        vdaf_ops_dispatch!($vdaf_ops, ($vdaf, $verify_key, $Vdaf, $VERIFY_KEY_LENGTH, _unused, _Unused) => $body)};
 }
 
 impl VdafOps {
@@ -2751,25 +2847,25 @@ impl VdafOps {
     ) -> Result<AggregateShare, Error> {
         match task.query_type() {
             task::QueryType::TimeInterval => {
-                vdaf_ops_dispatch!(self, (vdaf, _, VdafType, VERIFY_KEY_LENGTH) => {
+                vdaf_ops_dispatch!(self, (vdaf, _, VdafType, VERIFY_KEY_LENGTH, dp_strategy, DpStrategyType) => {
                     Self::handle_aggregate_share_generic::<
                         VERIFY_KEY_LENGTH,
                         TimeInterval,
+                        DpStrategyType,
                         VdafType,
                         _,
-                    >(datastore, clock, task, Arc::clone(vdaf), req_bytes, batch_aggregation_shard_count, collector_hpke_config)
-                    .await
+                    >(datastore, clock, task, Arc::clone(vdaf), req_bytes, batch_aggregation_shard_count, collector_hpke_config, Arc::clone(dp_strategy)).await
                 })
             }
             task::QueryType::FixedSize { .. } => {
-                vdaf_ops_dispatch!(self, (vdaf, _, VdafType, VERIFY_KEY_LENGTH) => {
+                vdaf_ops_dispatch!(self, (vdaf, _, VdafType, VERIFY_KEY_LENGTH, dp_strategy, DpStrategyType) => {
                     Self::handle_aggregate_share_generic::<
                         VERIFY_KEY_LENGTH,
                         FixedSize,
+                        DpStrategyType,
                         VdafType,
                         _,
-                    >(datastore, clock, task, Arc::clone(vdaf), req_bytes, batch_aggregation_shard_count, collector_hpke_config)
-                    .await
+                    >(datastore, clock, task, Arc::clone(vdaf), req_bytes, batch_aggregation_shard_count, collector_hpke_config, Arc::clone(dp_strategy)).await
                 })
             }
         }
@@ -2778,7 +2874,8 @@ impl VdafOps {
     async fn handle_aggregate_share_generic<
         const SEED_SIZE: usize,
         Q: CollectableQueryType,
-        A: vdaf::Aggregator<SEED_SIZE, 16> + Send + Sync + 'static,
+        S: DifferentialPrivacyStrategy + Send + Clone + Sync + 'static,
+        A: vdaf::AggregatorWithNoise<SEED_SIZE, 16, S> + Send + Sync + 'static,
         C: Clock,
     >(
         datastore: &Datastore<C>,
@@ -2788,10 +2885,12 @@ impl VdafOps {
         req_bytes: &[u8],
         batch_aggregation_shard_count: u64,
         collector_hpke_config: &HpkeConfig,
+        dp_strategy: Arc<S>,
     ) -> Result<AggregateShare, Error>
     where
         A::AggregationParam: Send + Sync + Eq + Hash,
         A::AggregateShare: Send + Sync,
+        S: Send + Sync,
     {
         // Decode request, and verify that it is for the current task. We use an assert to check
         // that the task IDs match as this should be guaranteed by the caller.
@@ -2829,10 +2928,11 @@ impl VdafOps {
 
         let aggregate_share_job = datastore
             .run_tx("aggregate_share", |tx| {
-                let (task, vdaf, aggregate_share_req) = (
+                let (task, vdaf, aggregate_share_req, dp_strategy) = (
                     Arc::clone(&task),
                     Arc::clone(&vdaf),
                     Arc::clone(&aggregate_share_req),
+                    Arc::clone(&dp_strategy),
                 );
                 Box::pin(async move {
                     // Check if we have already serviced an aggregate share request with these
@@ -2892,13 +2992,21 @@ impl VdafOps {
                                 &batch_aggregations,
                             );
 
-                            let (helper_aggregate_share, report_count, checksum) =
-                                compute_aggregate_share::<SEED_SIZE, Q, A>(
+                            let (mut helper_aggregate_share, report_count, checksum) =
+                                compute_aggregate_share::<SEED_SIZE, Q, S, A>(
                                     &task,
                                     &batch_aggregations,
                                 )
                                 .await
                                 .map_err(|e| datastore::Error::User(e.into()))?;
+
+                            vdaf.add_noise_to_agg_share(
+                                &dp_strategy,
+                                &aggregation_param,
+                                &mut helper_aggregate_share,
+                                report_count.try_into()?,
+                            )
+                            .map_err(|e| datastore::Error::User(e.into()))?;
 
                             // Now that we are satisfied that the request is serviceable, we consume
                             // a query by recording the aggregate share request parameters and the

--- a/aggregator/src/aggregator/aggregate_share.rs
+++ b/aggregator/src/aggregator/aggregate_share.rs
@@ -4,7 +4,10 @@ use super::Error;
 use janus_aggregator_core::{datastore::models::BatchAggregation, task::AggregatorTask};
 use janus_core::report_id::ReportIdChecksumExt;
 use janus_messages::{query_type::QueryType, ReportIdChecksum};
-use prio::vdaf::{self, Aggregatable};
+use prio::{
+    dp::DifferentialPrivacyStrategy,
+    vdaf::{self, Aggregatable},
+};
 
 /// Computes the aggregate share over the provided batch aggregations.
 /// The assumption is that all aggregation jobs contributing to those batch aggregations have
@@ -14,7 +17,8 @@ use prio::vdaf::{self, Aggregatable};
 pub(crate) async fn compute_aggregate_share<
     const SEED_SIZE: usize,
     Q: QueryType,
-    A: vdaf::Aggregator<SEED_SIZE, 16>,
+    S: DifferentialPrivacyStrategy,
+    A: vdaf::AggregatorWithNoise<SEED_SIZE, 16, S>,
 >(
     task: &AggregatorTask,
     batch_aggregations: &[BatchAggregation<SEED_SIZE, Q, A>],

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -11,6 +11,8 @@ use janus_aggregator_core::{
     datastore::{self, Datastore},
     task::{self, AggregatorTask},
 };
+#[cfg(feature = "fpvec_bounded_l2")]
+use janus_core::vdaf::Prio3FixedPointBoundedL2VecSumBitSize;
 use janus_core::{
     time::{Clock, DurationExt as _, TimeExt as _},
     vdaf::{VdafInstance, VERIFY_KEY_LENGTH},
@@ -326,41 +328,37 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
             #[cfg(feature = "fpvec_bounded_l2")]
             (
                 task::QueryType::TimeInterval,
-                VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { length },
-            ) => {
-                let vdaf: Arc<Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>>> =
-                    Arc::new(Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
-                        2, *length,
-                    )?);
-                self.create_aggregation_jobs_for_time_interval_task_no_param::<VERIFY_KEY_LENGTH, Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>>>(task, vdaf)
-                    .await
-            }
-
-            #[cfg(feature = "fpvec_bounded_l2")]
-            (
-                task::QueryType::TimeInterval,
-                VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { length },
-            ) => {
-                let vdaf: Arc<Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>>> =
-                    Arc::new(Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
-                        2, *length,
-                    )?);
-                self.create_aggregation_jobs_for_time_interval_task_no_param::<VERIFY_KEY_LENGTH, Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>>>(task, vdaf)
-                    .await
-            }
-
-            #[cfg(feature = "fpvec_bounded_l2")]
-            (
-                task::QueryType::TimeInterval,
-                VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { length },
-            ) => {
-                let vdaf: Arc<Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>>> =
-                    Arc::new(Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
-                        2, *length,
-                    )?);
-                self.create_aggregation_jobs_for_time_interval_task_no_param::<VERIFY_KEY_LENGTH, Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>>>(task, vdaf)
-                    .await
-            }
+                VdafInstance::Prio3FixedPointBoundedL2VecSum {
+                    bitsize,
+                    dp_strategy: _,
+                    length,
+                },
+            ) => match bitsize {
+                Prio3FixedPointBoundedL2VecSumBitSize::BitSize16 => {
+                    let vdaf: Arc<Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>>> =
+                        Arc::new(Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
+                            2, *length,
+                        )?);
+                    self.create_aggregation_jobs_for_time_interval_task_no_param::<VERIFY_KEY_LENGTH, Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>>>(task, vdaf)
+                            .await
+                }
+                Prio3FixedPointBoundedL2VecSumBitSize::BitSize32 => {
+                    let vdaf: Arc<Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>>> =
+                        Arc::new(Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
+                            2, *length,
+                        )?);
+                    self.create_aggregation_jobs_for_time_interval_task_no_param::<VERIFY_KEY_LENGTH, Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>>>(task, vdaf)
+                            .await
+                }
+                Prio3FixedPointBoundedL2VecSumBitSize::BitSize64 => {
+                    let vdaf: Arc<Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>>> =
+                        Arc::new(Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
+                            2, *length,
+                        )?);
+                    self.create_aggregation_jobs_for_time_interval_task_no_param::<VERIFY_KEY_LENGTH, Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>>>(task, vdaf)
+                            .await
+                }
+            },
 
             (
                 task::QueryType::FixedSize {
@@ -468,58 +466,47 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                     max_batch_size,
                     batch_time_window_size,
                 },
-                VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { length },
-            ) => {
-                let vdaf: Arc<Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>>> =
-                    Arc::new(Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
-                        2, *length,
-                    )?);
-                let max_batch_size = *max_batch_size;
-                let batch_time_window_size = *batch_time_window_size;
-                self.create_aggregation_jobs_for_fixed_size_task_no_param::<
-                    VERIFY_KEY_LENGTH,
-                    Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>>,
-                >(task, vdaf, max_batch_size, batch_time_window_size).await
-            }
-
-            #[cfg(feature = "fpvec_bounded_l2")]
-            (
-                task::QueryType::FixedSize {
-                    max_batch_size,
-                    batch_time_window_size,
+                VdafInstance::Prio3FixedPointBoundedL2VecSum {
+                    bitsize,
+                    dp_strategy: _,
+                    length,
                 },
-                VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { length },
             ) => {
-                let vdaf: Arc<Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>>> =
-                    Arc::new(Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
-                        2, *length,
-                    )?);
                 let max_batch_size = *max_batch_size;
                 let batch_time_window_size = *batch_time_window_size;
-                self.create_aggregation_jobs_for_fixed_size_task_no_param::<
-                    VERIFY_KEY_LENGTH,
-                    Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>>,
-                >(task, vdaf, max_batch_size, batch_time_window_size).await
-            }
 
-            #[cfg(feature = "fpvec_bounded_l2")]
-            (
-                task::QueryType::FixedSize {
-                    max_batch_size,
-                    batch_time_window_size,
-                },
-                VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { length },
-            ) => {
-                let vdaf: Arc<Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>>> =
-                    Arc::new(Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
-                        2, *length,
-                    )?);
-                let max_batch_size = *max_batch_size;
-                let batch_time_window_size = *batch_time_window_size;
-                self.create_aggregation_jobs_for_fixed_size_task_no_param::<
-                    VERIFY_KEY_LENGTH,
-                    Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>>,
-                >(task, vdaf, max_batch_size, batch_time_window_size).await
+                match bitsize {
+                    janus_core::vdaf::Prio3FixedPointBoundedL2VecSumBitSize::BitSize16 => {
+                        let vdaf: Arc<Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>>> =
+                            Arc::new(Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
+                                2, *length,
+                            )?);
+                        self.create_aggregation_jobs_for_fixed_size_task_no_param::<
+                                VERIFY_KEY_LENGTH,
+                            Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>>,
+                            >(task, vdaf, max_batch_size, batch_time_window_size).await
+                    }
+                    janus_core::vdaf::Prio3FixedPointBoundedL2VecSumBitSize::BitSize32 => {
+                        let vdaf: Arc<Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>>> =
+                            Arc::new(Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
+                                2, *length,
+                            )?);
+                        self.create_aggregation_jobs_for_fixed_size_task_no_param::<
+                                VERIFY_KEY_LENGTH,
+                            Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>>,
+                            >(task, vdaf, max_batch_size, batch_time_window_size).await
+                    }
+                    janus_core::vdaf::Prio3FixedPointBoundedL2VecSumBitSize::BitSize64 => {
+                        let vdaf: Arc<Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>>> =
+                            Arc::new(Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
+                                2, *length,
+                            )?);
+                        self.create_aggregation_jobs_for_fixed_size_task_no_param::<
+                                VERIFY_KEY_LENGTH,
+                            Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>>,
+                            >(task, vdaf, max_batch_size, batch_time_window_size).await
+                    }
+                }
             }
 
             _ => {

--- a/aggregator/src/aggregator/error.rs
+++ b/aggregator/src/aggregator/error.rs
@@ -127,6 +127,9 @@ pub enum Error {
     /// Corresponds to taskprov invalidType (§2)
     #[error("aggregator has opted out of the indicated task: {1}")]
     InvalidTask(TaskId, OptOutReason),
+    /// An error occurred when trying to ensure differential privacy.
+    #[error("differential privacy error: {0}")]
+    DifferentialPrivacy(VdafError),
 }
 
 /// Errors that cause the aggregator to opt-out of a taskprov task.
@@ -181,6 +184,7 @@ impl Error {
             Error::ForbiddenMutation { .. } => "forbidden_mutation",
             Error::BadRequest(_) => "bad_request",
             Error::InvalidTask(_, _) => "invalid_task",
+            Error::DifferentialPrivacy(_) => "differential_privacy",
         }
     }
 }

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -106,6 +106,7 @@ impl Handler for Error {
             Error::InvalidTask(task_id, _) => {
                 conn.with_problem_details(DapProblemType::InvalidTask, Some(task_id))
             }
+            Error::DifferentialPrivacy(_) => conn.with_status(Status::InternalServerError),
         }
     }
 }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,7 +14,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-fpvec_bounded_l2 = ["prio/experimental"]
+fpvec_bounded_l2 = ["dep:fixed", "prio/experimental"]
 test-util = [
     "dep:assert_matches",
     "dep:k8s-openapi",
@@ -37,6 +37,7 @@ backoff = { version = "0.4.0", features = ["tokio"] }
 base64.workspace = true
 chrono = { workspace = true, features = ["clock"] }
 derivative.workspace = true
+fixed = { version = "1.24", optional = true }
 futures = "0.3.28"
 hex = "0.4"
 hpke-dispatch = { version = "0.5.1", features = ["serde"] }

--- a/core/src/dp.rs
+++ b/core/src/dp.rs
@@ -1,0 +1,144 @@
+#[cfg(feature = "test-util")]
+use crate::test_util::dummy_vdaf::Vdaf;
+use derivative::Derivative;
+#[cfg(feature = "fpvec_bounded_l2")]
+use fixed::traits::Fixed;
+#[cfg(feature = "fpvec_bounded_l2")]
+use prio::flp::{
+    gadgets::{ParallelSumGadget, PolyEval},
+    types::fixedpoint_l2::{compatible_float::CompatibleFloat, FixedPointBoundedL2VecSum},
+};
+use prio::{
+    dp::{
+        DifferentialPrivacyBudget, DifferentialPrivacyDistribution, DifferentialPrivacyStrategy,
+        DpError,
+    },
+    field::{Field128, Field64},
+    flp::{
+        gadgets::{Mul, ParallelSum, ParallelSumMultithreaded},
+        TypeWithNoise,
+    },
+    vdaf::{xof::XofShake128, AggregatorWithNoise},
+};
+use serde::{Deserialize, Serialize};
+
+/// An "empty" differential privacy budget type. Tasks which don't require differential privacy
+/// should use this type as their `DifferentialPrivacyBudget`.
+pub struct NoBudget;
+impl DifferentialPrivacyBudget for NoBudget {}
+
+/// An "empty" distribution. Tasks which don't require differential privacy should use this type
+/// as their `DifferentialPrivacyDistribution`.
+pub struct NoDistribution;
+impl DifferentialPrivacyDistribution for NoDistribution {}
+
+/// A "no-op" differential privacy strategy. Tasks which don't require differential privacy should
+/// use this type as their `DifferentialPrivacyStrategy`.
+#[derive(Debug, Derivative, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct NoDifferentialPrivacy;
+impl DifferentialPrivacyStrategy for NoDifferentialPrivacy {
+    type Budget = NoBudget;
+    type Distribution = NoDistribution;
+    type Sensitivity = ();
+    fn from_budget(_b: NoBudget) -> Self {
+        NoDifferentialPrivacy
+    }
+    fn create_distribution(&self, _s: Self::Sensitivity) -> Result<Self::Distribution, DpError> {
+        Ok(NoDistribution)
+    }
+}
+
+// identity strategy implementations for vdafs from janus
+#[cfg(feature = "test-util")]
+impl AggregatorWithNoise<0, 16, NoDifferentialPrivacy> for Vdaf {
+    fn add_noise_to_agg_share(
+        &self,
+        _dp_strategy: &NoDifferentialPrivacy,
+        _agg_param: &Self::AggregationParam,
+        _agg_share: &mut Self::AggregateShare,
+        _num_measurements: usize,
+    ) -> Result<(), prio::vdaf::VdafError> {
+        Ok(())
+    }
+}
+
+// identity strategy implementations for vdafs from libprio
+impl TypeWithNoise<NoDifferentialPrivacy> for prio::flp::types::Sum<Field128> {
+    fn add_noise_to_result(
+        &self,
+        _dp_strategy: &NoDifferentialPrivacy,
+        _agg_result: &mut [Self::Field],
+        _num_measurements: usize,
+    ) -> Result<(), prio::flp::FlpError> {
+        Ok(())
+    }
+}
+
+impl TypeWithNoise<NoDifferentialPrivacy> for prio::flp::types::Count<Field64> {
+    fn add_noise_to_result(
+        &self,
+        _dp_strategy: &NoDifferentialPrivacy,
+        _agg_result: &mut [Self::Field],
+        _num_measurements: usize,
+    ) -> Result<(), prio::flp::FlpError> {
+        Ok(())
+    }
+}
+
+impl TypeWithNoise<NoDifferentialPrivacy>
+    for prio::flp::types::Histogram<Field128, ParallelSum<Field128, Mul<Field128>>>
+{
+    fn add_noise_to_result(
+        &self,
+        _dp_strategy: &NoDifferentialPrivacy,
+        _agg_result: &mut [Self::Field],
+        _num_measurements: usize,
+    ) -> Result<(), prio::flp::FlpError> {
+        Ok(())
+    }
+}
+
+impl TypeWithNoise<NoDifferentialPrivacy>
+    for prio::flp::types::SumVec<Field128, ParallelSumMultithreaded<Field128, Mul<Field128>>>
+{
+    fn add_noise_to_result(
+        &self,
+        _dp_strategy: &NoDifferentialPrivacy,
+        _agg_result: &mut [Self::Field],
+        _num_measurements: usize,
+    ) -> Result<(), prio::flp::FlpError> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "fpvec_bounded_l2")]
+impl<T, SPoly, SBlindPoly> TypeWithNoise<NoDifferentialPrivacy>
+    for FixedPointBoundedL2VecSum<T, SPoly, SBlindPoly>
+where
+    T: Fixed + CompatibleFloat,
+    SPoly: ParallelSumGadget<Field128, PolyEval<Field128>> + Eq + Clone + 'static,
+    SBlindPoly: ParallelSumGadget<Field128, Mul<Field128>> + Eq + Clone + 'static,
+{
+    fn add_noise_to_result(
+        &self,
+        _dp_strategy: &NoDifferentialPrivacy,
+        _agg_result: &mut [Self::Field],
+        _num_measurements: usize,
+    ) -> Result<(), prio::flp::FlpError> {
+        Ok(())
+    }
+}
+
+impl AggregatorWithNoise<16, 16, NoDifferentialPrivacy>
+    for prio::vdaf::poplar1::Poplar1<XofShake128, 16>
+{
+    fn add_noise_to_agg_share(
+        &self,
+        _dp_strategy: &NoDifferentialPrivacy,
+        _agg_param: &Self::AggregationParam,
+        _agg_share: &mut Self::AggregateShare,
+        _num_measurements: usize,
+    ) -> Result<(), prio::vdaf::VdafError> {
+        Ok(())
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -5,6 +5,7 @@ use tokio::task::JoinHandle;
 use url::Url;
 
 pub mod auth_tokens;
+pub mod dp;
 pub mod hpke;
 pub mod http;
 pub mod report_id;

--- a/core/src/test_util/dummy_vdaf.rs
+++ b/core/src/test_util/dummy_vdaf.rs
@@ -2,6 +2,7 @@
 
 use prio::{
     codec::{CodecError, Decode, Encode},
+    dp::distributions::ZCdpDiscreteGaussian,
     vdaf::{self, Aggregatable, PrepareTransition, VdafError},
 };
 use std::fmt::Debug;
@@ -90,6 +91,18 @@ impl vdaf::Vdaf for Vdaf {
 
     fn num_aggregators(&self) -> usize {
         2
+    }
+}
+
+impl vdaf::AggregatorWithNoise<0, 16, ZCdpDiscreteGaussian> for Vdaf {
+    fn add_noise_to_agg_share(
+        &self,
+        _dp_strategy: &ZCdpDiscreteGaussian,
+        _agg_param: &Self::AggregationParam,
+        _agg_share: &mut Self::AggregateShare,
+        _num_measurements: usize,
+    ) -> Result<(), VdafError> {
+        Ok(())
     }
 }
 

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -1,6 +1,8 @@
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use derivative::Derivative;
 use janus_aggregator_core::task::{test_util::Task, QueryType};
+#[cfg(feature = "fpvec_bounded_l2")]
+use janus_core::vdaf::{vdaf_dp_strategies, Prio3FixedPointBoundedL2VecSumBitSize};
 use janus_core::{
     hpke::{generate_hpke_config_and_private_key, HpkeKeypair},
     vdaf::VdafInstance,
@@ -119,15 +121,10 @@ pub enum VdafObject {
         chunk_length: NumberAsString<usize>,
     },
     #[cfg(feature = "fpvec_bounded_l2")]
-    Prio3FixedPoint16BitBoundedL2VecSum {
-        length: NumberAsString<usize>,
-    },
-    #[cfg(feature = "fpvec_bounded_l2")]
-    Prio3FixedPoint32BitBoundedL2VecSum {
-        length: NumberAsString<usize>,
-    },
-    #[cfg(feature = "fpvec_bounded_l2")]
-    Prio3FixedPoint64BitBoundedL2VecSum {
+    Prio3FixedPointBoundedL2VecSum {
+        bitsize: Prio3FixedPointBoundedL2VecSumBitSize,
+        #[serde(default)]
+        dp_strategy: vdaf_dp_strategies::Prio3FixedPointBoundedL2VecSum,
         length: NumberAsString<usize>,
     },
 }
@@ -160,25 +157,16 @@ impl From<VdafInstance> for VdafObject {
             },
 
             #[cfg(feature = "fpvec_bounded_l2")]
-            VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { length } => {
-                VdafObject::Prio3FixedPoint16BitBoundedL2VecSum {
-                    length: NumberAsString(length),
-                }
-            }
+            VdafInstance::Prio3FixedPointBoundedL2VecSum {
+                bitsize,
+                dp_strategy,
+                length,
+            } => VdafObject::Prio3FixedPointBoundedL2VecSum {
+                bitsize,
+                dp_strategy,
+                length: NumberAsString(length),
+            },
 
-            #[cfg(feature = "fpvec_bounded_l2")]
-            VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { length } => {
-                VdafObject::Prio3FixedPoint32BitBoundedL2VecSum {
-                    length: NumberAsString(length),
-                }
-            }
-
-            #[cfg(feature = "fpvec_bounded_l2")]
-            VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { length } => {
-                VdafObject::Prio3FixedPoint64BitBoundedL2VecSum {
-                    length: NumberAsString(length),
-                }
-            }
             _ => panic!("Unsupported VDAF: {vdaf:?}"),
         }
     }
@@ -210,19 +198,15 @@ impl From<VdafObject> for VdafInstance {
             },
 
             #[cfg(feature = "fpvec_bounded_l2")]
-            VdafObject::Prio3FixedPoint16BitBoundedL2VecSum { length } => {
-                VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { length: length.0 }
-            }
-
-            #[cfg(feature = "fpvec_bounded_l2")]
-            VdafObject::Prio3FixedPoint32BitBoundedL2VecSum { length } => {
-                VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { length: length.0 }
-            }
-
-            #[cfg(feature = "fpvec_bounded_l2")]
-            VdafObject::Prio3FixedPoint64BitBoundedL2VecSum { length } => {
-                VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { length: length.0 }
-            }
+            VdafObject::Prio3FixedPointBoundedL2VecSum {
+                bitsize,
+                dp_strategy,
+                length,
+            } => VdafInstance::Prio3FixedPointBoundedL2VecSum {
+                bitsize,
+                dp_strategy,
+                length: length.0,
+            },
         }
     }
 }

--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -691,7 +691,9 @@ async fn e2e_prio3_fixed16vec() {
     let result = run(
         "e2e_prio3_fixed16vec",
         QueryKind::TimeInterval,
-        json!({"type": "Prio3FixedPoint16BitBoundedL2VecSum", "length": "3"}),
+        json!({"type": "Prio3FixedPointBoundedL2VecSum",
+               "bitsize": "BitSize16",
+               "length": "3"}),
         &[
             json!([
                 fp16_4_inv.to_string(),
@@ -728,7 +730,9 @@ async fn e2e_prio3_fixed32vec() {
     let result = run(
         "e2e_prio3_fixed32vec",
         QueryKind::TimeInterval,
-        json!({"type": "Prio3FixedPoint32BitBoundedL2VecSum", "length": "3"}),
+        json!({"type": "Prio3FixedPointBoundedL2VecSum",
+               "bitsize": "BitSize32",
+               "length": "3"}),
         &[
             json!([
                 fp32_4_inv.to_string(),
@@ -765,7 +769,9 @@ async fn e2e_prio3_fixed64vec() {
     let result = run(
         "e2e_prio3_fixed64vec",
         QueryKind::TimeInterval,
-        json!({"type": "Prio3FixedPoint64BitBoundedL2VecSum", "length": "3"}),
+        json!({"type": "Prio3FixedPointBoundedL2VecSum",
+               "bitsize": "BitSize64",
+               "length": "3"}),
         &[
             json!([
                 fp64_4_inv.to_string(),
@@ -802,7 +808,9 @@ async fn e2e_prio3_fixed16vec_fixed_size() {
     let result = run(
         "e2e_prio3_fixed16vec_fixed_size",
         QueryKind::FixedSize,
-        json!({"type": "Prio3FixedPoint16BitBoundedL2VecSum", "length": "3"}),
+        json!({"type": "Prio3FixedPointBoundedL2VecSum",
+               "bitsize": "BitSize16",
+               "length": "3"}),
         &[
             json!([
                 fp16_4_inv.to_string(),
@@ -839,7 +847,9 @@ async fn e2e_prio3_fixed32vec_fixed_size() {
     let result = run(
         "e2e_prio3_fixed32vec_fixed_size",
         QueryKind::FixedSize,
-        json!({"type": "Prio3FixedPoint32BitBoundedL2VecSum", "length": "3"}),
+        json!({"type": "Prio3FixedPointBoundedL2VecSum",
+               "bitsize": "BitSize32",
+               "length": "3"}),
         &[
             json!([
                 fp32_4_inv.to_string(),
@@ -876,7 +886,9 @@ async fn e2e_prio3_fixed64vec_fixed_size() {
     let result = run(
         "e2e_prio3_fixed64vec_fixed_size",
         QueryKind::FixedSize,
-        json!({"type": "Prio3FixedPoint64BitBoundedL2VecSum", "length": "3"}),
+        json!({"type": "Prio3FixedPointBoundedL2VecSum",
+               "bitsize": "BitSize64",
+               "length": "3"}),
         &[
             json!([
                 fp64_4_inv.to_string(),


### PR DESCRIPTION
We have integrated differential privacy into janus as proposed here #1865.

Highlights:
 - The differential privacy strategy for a vdaf is carried directly in its enum variant in `VdafInstance` and `VdafOps`. This means that every vdaf is responsible to carry the data required for each of its supported strategies. No changes to database schema or task definition are required. For already existing types which do not need differential privacy the change is conservative - no updates to the enum variant have to occur. For a vdaf which supports multiple strategies, a dedicated enum containing *only* the supported dp strategies has to be created. An example for our type is [here](https://github.com/divviup/janus/blob/c22282e4777c01841350627662f3d51b2e62b050/core/src/task.rs#L25-L37).
 - We updated the `vdaf_dispatch!` and `vdaf_ops_dispatch!` macros to optionally generate the appropriate differential privacy strategy type and a value of that type from the data carried in `VdafInstance` and `VdafOps` respectively. For vdafs which don't support dp, the `NoDifferentialPrivacy` strategy is instantiated. For vdafs which support multiple strategies, multiple case-statements are generated - one for each possible strategy which it might be carrying.
 - We merged the three enum variants for the different bitsizes for our fixedvec type in `VdafInstance` into a single variant carrying the bitsize as data. For `VdafOps` this wasn't possible since it carries the already instantiated vdafs (as `Arc<A>`).

Note: We had to update prio a little bit, mostly deriving various traits for the new dp types. See this draft PR: https://github.com/divviup/libprio-rs/pull/751.