### PR TITLE
Check existing collection jobs before resolving query

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -2189,28 +2189,6 @@ impl VdafOps {
                     Arc::clone(&aggregation_param),
                 );
                 Box::pin(async move {
-                    let collection_identifier =
-                        Q::collection_identifier_for_query(tx, &task, req.query())
-                            .await?
-                            .ok_or_else(|| {
-                                datastore::Error::User(
-                                    Error::BatchInvalid(
-                                        *task.id(),
-                                        "no batch ready for collection".to_string(),
-                                    )
-                                    .into(),
-                                )
-                            })?;
-
-                    // Check that the batch interval is valid for the task
-                    // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-02.html#section-4.5.6.1.1
-                    if !Q::validate_collection_identifier(&task, &collection_identifier) {
-                        return Err(datastore::Error::User(
-                            Error::BatchInvalid(*task.id(), format!("{collection_identifier}"))
-                                .into(),
-                        ));
-                    }
-
                     // Check if this collection job already exists, ensuring that all parameters match.
                     if let Some(collection_job) = tx
                         .get_collection_job::<SEED_SIZE, Q, A>(&vdaf, task.id(), &collection_job_id)
@@ -2234,6 +2212,28 @@ impl VdafOps {
                                 .into(),
                             ));
                         }
+                    }
+
+                    let collection_identifier =
+                        Q::collection_identifier_for_query(tx, &task, req.query())
+                            .await?
+                            .ok_or_else(|| {
+                                datastore::Error::User(
+                                    Error::BatchInvalid(
+                                        *task.id(),
+                                        "no batch ready for collection".to_string(),
+                                    )
+                                    .into(),
+                                )
+                            })?;
+
+                    // Check that the batch interval is valid for the task
+                    // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-02.html#section-4.5.6.1.1
+                    if !Q::validate_collection_identifier(&task, &collection_identifier) {
+                        return Err(datastore::Error::User(
+                            Error::BatchInvalid(*task.id(), format!("{collection_identifier}"))
+                                .into(),
+                        ));
                     }
 
                     debug!(collect_request = ?req, "Cache miss, creating new collection job");


### PR DESCRIPTION
Following #1878, we now perform idempotency checks for creation of a collection job based on the query in the request, not what batch we resolve that query to at different times. However, due to the order of checks, we still required that the query be able to be resolved to a batch, even if we would later discard it and return an already-existing collection job with a different batch. This could lead to the following problem: (which I have captured in a new test) if a forgetful collector creates a collection job using the current-batch query, polls it once, and then tries creating it with the same ID again, the response it gets to the final request would depend on the state of other outstanding batches, and it could either get a 201 or a 400. This PR fixes that by reordering the code in `handle_create_collection_job_generic()`.