### PR TITLE
build(deps): Bump chrono from 0.4.26 to 0.4.30 and remove use of deprecated function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,18 +490,17 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "defd4e7873dbddba6c7c91e199c7fcb946abc4a6a4ac3195400bcfb01b5de877"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
- "time 0.1.45",
  "wasm-bindgen",
- "winapi",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1330,7 +1329,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -2409,7 +2408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys",
 ]
 
@@ -4224,17 +4223,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
@@ -4588,7 +4576,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "time 0.3.23",
+ "time",
  "tracing-core",
  "tracing-subscriber",
 ]
@@ -4983,12 +4971,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -54,7 +54,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 use backoff::{backoff::Backoff, ExponentialBackoff};
-use chrono::{DateTime, Duration, Utc};
+use chrono::{DateTime, Duration, TimeZone, Utc};
 use derivative::Derivative;
 use http_api_problem::HttpApiProblem;
 pub use janus_core::task::AuthenticationToken;
@@ -545,10 +545,7 @@ impl<V: vdaf::Collector> Collector<V> {
             partial_batch_selector: collect_response.partial_batch_selector().clone(),
             report_count: collect_response.report_count(),
             interval: (
-                DateTime::<Utc>::from_utc(
-                    collect_response.interval().start().as_naive_date_time()?,
-                    Utc,
-                ),
+                Utc.from_utc_datetime(&collect_response.interval().start().as_naive_date_time()?),
                 collect_response
                     .interval()
                     .duration()
@@ -635,7 +632,7 @@ mod tests {
         PollResult,
     };
     use assert_matches::assert_matches;
-    use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
+    use chrono::{NaiveDateTime, TimeZone, Utc};
     #[cfg(feature = "fpvec_bounded_l2")]
     use fixed_macro::fixed;
     use janus_core::{
@@ -870,9 +867,8 @@ mod tests {
                 PartialBatchSelector::new_time_interval(),
                 1,
                 (
-                    DateTime::<Utc>::from_utc(
-                        NaiveDateTime::from_timestamp_opt(1_000_000, 0).unwrap(),
-                        Utc
+                    Utc.from_utc_datetime(
+                        &NaiveDateTime::from_timestamp_opt(1_000_000, 0).unwrap(),
                     ),
                     chrono::Duration::seconds(3600),
                 ),
@@ -943,9 +939,8 @@ mod tests {
                 PartialBatchSelector::new_time_interval(),
                 1,
                 (
-                    DateTime::<Utc>::from_utc(
-                        NaiveDateTime::from_timestamp_opt(1_000_000, 0).unwrap(),
-                        Utc
+                    Utc.from_utc_datetime(
+                        &NaiveDateTime::from_timestamp_opt(1_000_000, 0).unwrap(),
                     ),
                     chrono::Duration::seconds(3600),
                 ),
@@ -1015,9 +1010,8 @@ mod tests {
                 PartialBatchSelector::new_time_interval(),
                 1,
                 (
-                    DateTime::<Utc>::from_utc(
-                        NaiveDateTime::from_timestamp_opt(1_000_000, 0).unwrap(),
-                        Utc
+                    Utc.from_utc_datetime(
+                        &NaiveDateTime::from_timestamp_opt(1_000_000, 0).unwrap(),
                     ),
                     chrono::Duration::seconds(3600),
                 ),
@@ -1096,9 +1090,8 @@ mod tests {
                 PartialBatchSelector::new_time_interval(),
                 1,
                 (
-                    DateTime::<Utc>::from_utc(
-                        NaiveDateTime::from_timestamp_opt(1_000_000, 0).unwrap(),
-                        Utc
+                    Utc.from_utc_datetime(
+                        &NaiveDateTime::from_timestamp_opt(1_000_000, 0).unwrap(),
                     ),
                     chrono::Duration::seconds(3600),
                 ),
@@ -1170,10 +1163,7 @@ mod tests {
                 PartialBatchSelector::new_fixed_size(batch_id),
                 1,
                 (
-                    DateTime::<Utc>::from_utc(
-                        NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
-                        Utc
-                    ),
+                    Utc.from_utc_datetime(&NaiveDateTime::from_timestamp_opt(0, 0).unwrap()),
                     chrono::Duration::seconds(1),
                 ),
                 1
@@ -1255,9 +1245,8 @@ mod tests {
                 PartialBatchSelector::new_time_interval(),
                 1,
                 (
-                    DateTime::<Utc>::from_utc(
-                        NaiveDateTime::from_timestamp_opt(1_000_000, 0).unwrap(),
-                        Utc
+                    Utc.from_utc_datetime(
+                        &NaiveDateTime::from_timestamp_opt(1_000_000, 0).unwrap(),
                     ),
                     chrono::Duration::seconds(3600),
                 ),


### PR DESCRIPTION
Same as https://github.com/divviup/janus/pull/1907, but with code changes to remove use of deprecated function `DateTime::from_utc`. Need peer review.