### PR TITLE
Replace "round" with "step"

### DIFF
--- a/aggregator/src/aggregator/aggregate_init_tests.rs
+++ b/aggregator/src/aggregator/aggregate_init_tests.rs
@@ -448,7 +448,7 @@ async fn aggregation_job_mutation_report_aggregations() {
 }
 
 #[tokio::test]
-async fn aggregation_job_init_two_round_vdaf_idempotence() {
+async fn aggregation_job_init_two_step_vdaf_idempotence() {
     // We must run Poplar1 in this test so that the aggregation job won't finish on the first step
     let test_case = setup_poplar1_aggregate_init_test().await;
 

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -17,7 +17,7 @@ use janus_core::{
 };
 use janus_messages::{
     query_type::{FixedSize, TimeInterval},
-    AggregationJobRound, Duration as DurationMsg, Interval, Role, TaskId,
+    AggregationJobStep, Duration as DurationMsg, Interval, Role, TaskId,
 };
 use opentelemetry::{
     metrics::{Histogram, Meter, Unit},
@@ -579,7 +579,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                             (),
                             client_timestamp_interval,
                             AggregationJobState::InProgress,
-                            AggregationJobRound::from(0),
+                            AggregationJobStep::from(0),
                         );
 
                         let report_aggregations = agg_job_reports
@@ -692,7 +692,7 @@ mod tests {
     use janus_messages::{
         codec::ParameterizedDecode,
         query_type::{FixedSize, TimeInterval},
-        AggregationJobRound, Interval, ReportId, Role, TaskId, Time,
+        AggregationJobStep, Interval, ReportId, Role, TaskId, Time,
     };
     use prio::vdaf::{self, prio3::Prio3Count};
     use std::{collections::HashSet, iter, sync::Arc, time::Duration};
@@ -807,7 +807,7 @@ mod tests {
         assert_eq!(leader_aggregations.len(), 1);
         let leader_aggregation = leader_aggregations.into_iter().next().unwrap();
         assert_eq!(leader_aggregation.0.partial_batch_identifier(), &());
-        assert_eq!(leader_aggregation.0.round(), AggregationJobRound::from(0));
+        assert_eq!(leader_aggregation.0.step(), AggregationJobStep::from(0));
         assert_eq!(
             leader_aggregation.1,
             Vec::from([*leader_report.metadata().id()])
@@ -910,8 +910,8 @@ mod tests {
             .unwrap();
         let mut seen_report_ids = HashSet::new();
         for (agg_job, report_ids) in &agg_jobs {
-            // Jobs are created in round 0
-            assert_eq!(agg_job.round(), AggregationJobRound::from(0));
+            // Jobs are created in step 0
+            assert_eq!(agg_job.step(), AggregationJobStep::from(0));
 
             // The batch is at most MAX_AGGREGATION_JOB_SIZE in size.
             assert!(report_ids.len() <= MAX_AGGREGATION_JOB_SIZE);
@@ -1163,8 +1163,8 @@ mod tests {
             // Job immediately finished since all reports are in a closed batch.
             assert_eq!(agg_job.state(), &AggregationJobState::Finished);
 
-            // Jobs are created in round 0.
-            assert_eq!(agg_job.round(), AggregationJobRound::from(0));
+            // Jobs are created in step 0.
+            assert_eq!(agg_job.step(), AggregationJobStep::from(0));
 
             // The batch is at most MAX_AGGREGATION_JOB_SIZE in size.
             assert!(report_ids.len() <= MAX_AGGREGATION_JOB_SIZE);
@@ -1314,8 +1314,8 @@ mod tests {
         let mut seen_report_ids = HashSet::new();
         let mut batches_with_small_agg_jobs = HashSet::new();
         for (agg_job, report_ids) in agg_jobs {
-            // Aggregation jobs are created in round 0.
-            assert_eq!(agg_job.round(), AggregationJobRound::from(0));
+            // Aggregation jobs are created in step 0.
+            assert_eq!(agg_job.step(), AggregationJobStep::from(0));
 
             // Every batch corresponds to one of the outstanding batches.
             assert!(batch_ids.contains(agg_job.batch_id()));
@@ -1648,7 +1648,7 @@ mod tests {
         // Verify consistency of batches and aggregation jobs.
         let mut seen_report_ids = HashSet::new();
         for (agg_job, report_ids) in agg_jobs {
-            assert_eq!(agg_job.round(), AggregationJobRound::from(0));
+            assert_eq!(agg_job.step(), AggregationJobStep::from(0));
             assert!(batch_ids.contains(agg_job.batch_id()));
             assert!(report_ids.len() <= MAX_AGGREGATION_JOB_SIZE);
 
@@ -1840,7 +1840,7 @@ mod tests {
         // Verify consistency of batches and aggregation jobs.
         let mut seen_report_ids = HashSet::new();
         for (agg_job, report_ids) in agg_jobs {
-            assert_eq!(agg_job.round(), AggregationJobRound::from(0));
+            assert_eq!(agg_job.step(), AggregationJobStep::from(0));
             assert!(batch_ids.contains(agg_job.batch_id()));
             assert!(report_ids.len() <= MAX_AGGREGATION_JOB_SIZE);
 
@@ -1996,7 +1996,7 @@ mod tests {
         let mut seen_report_ids = HashSet::new();
         let mut batches_with_small_agg_jobs = HashSet::new();
         for (agg_job, report_ids) in agg_jobs {
-            assert_eq!(agg_job.round(), AggregationJobRound::from(0));
+            assert_eq!(agg_job.step(), AggregationJobStep::from(0));
             assert!(batch_ids.contains(agg_job.batch_id()));
             assert!(report_ids.len() <= MAX_AGGREGATION_JOB_SIZE);
 

--- a/aggregator/src/aggregator/batch_creator.rs
+++ b/aggregator/src/aggregator/batch_creator.rs
@@ -10,7 +10,7 @@ use janus_aggregator_core::datastore::{
 };
 use janus_core::time::{Clock, DurationExt, TimeExt};
 use janus_messages::{
-    query_type::FixedSize, AggregationJobRound, BatchId, Duration, Interval, ReportId, TaskId, Time,
+    query_type::FixedSize, AggregationJobStep, BatchId, Duration, Interval, ReportId, TaskId, Time,
 };
 use prio::{codec::Encode, vdaf::Aggregator};
 use rand::random;
@@ -318,7 +318,7 @@ where
             batch_id,
             client_timestamp_interval,
             AggregationJobState::InProgress,
-            AggregationJobRound::from(0),
+            AggregationJobStep::from(0),
         );
         aggregation_job_writer.put(aggregation_job, report_aggregations)?;
 

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -552,7 +552,7 @@ mod tests {
         Runtime,
     };
     use janus_messages::{
-        query_type::TimeInterval, AggregateShare, AggregateShareReq, AggregationJobRound,
+        query_type::TimeInterval, AggregateShare, AggregateShareReq, AggregationJobStep,
         BatchSelector, Duration, HpkeCiphertext, HpkeConfigId, Interval, Query, ReportIdChecksum,
         Role,
     };
@@ -612,7 +612,7 @@ mod tests {
                             (),
                             Interval::from_time(&report_timestamp).unwrap(),
                             AggregationJobState::Finished,
-                            AggregationJobRound::from(1),
+                            AggregationJobStep::from(1),
                         ),
                     )
                     .await?;
@@ -770,7 +770,7 @@ mod tests {
                             (),
                             Interval::from_time(&report_timestamp).unwrap(),
                             AggregationJobState::Finished,
-                            AggregationJobRound::from(1),
+                            AggregationJobStep::from(1),
                         ),
                     )
                     .await?;

--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -33,7 +33,7 @@ use janus_core::{
 };
 use janus_messages::{
     query_type::{FixedSize, QueryType as QueryTypeTrait, TimeInterval},
-    AggregateShareAad, AggregationJobRound, BatchId, BatchSelector, Collection, CollectionJobId,
+    AggregateShareAad, AggregationJobStep, BatchId, BatchSelector, Collection, CollectionJobId,
     CollectionReq, Duration, FixedSizeQuery, Interval, Query, ReportIdChecksum, Role, Time,
 };
 use prio::codec::{Decode, Encode};
@@ -200,7 +200,7 @@ async fn setup_fixed_size_current_batch_collection_job_test_case(
                         batch_id,
                         interval,
                         AggregationJobState::Finished,
-                        AggregationJobRound::from(1),
+                        AggregationJobStep::from(1),
                     ))
                     .await
                     .unwrap();

--- a/aggregator/src/aggregator/error.rs
+++ b/aggregator/src/aggregator/error.rs
@@ -1,7 +1,7 @@
 use http_api_problem::HttpApiProblem;
 use janus_aggregator_core::{datastore, task};
 use janus_messages::{
-    problem_type::DapProblemType, AggregationJobId, AggregationJobRound, CollectionJobId,
+    problem_type::DapProblemType, AggregationJobId, AggregationJobStep, CollectionJobId,
     HpkeConfigId, Interval, PrepareError, ReportId, ReportIdChecksum, Role, TaskId, Time,
 };
 use opentelemetry::{metrics::Counter, KeyValue};
@@ -42,8 +42,8 @@ pub enum Error {
     StepMismatch {
         task_id: TaskId,
         aggregation_job_id: AggregationJobId,
-        expected_step: AggregationJobRound,
-        got_step: AggregationJobRound,
+        expected_step: AggregationJobStep,
+        got_step: AggregationJobStep,
     },
     /// Corresponds to `unrecognizedTask`, §3.2
     #[error("task {0}: unrecognized task")]

--- a/aggregator/src/aggregator/garbage_collector.rs
+++ b/aggregator/src/aggregator/garbage_collector.rs
@@ -99,7 +99,7 @@ mod tests {
     };
     use janus_messages::{
         query_type::{FixedSize, TimeInterval},
-        AggregationJobRound, Duration, FixedSizeQuery, HpkeCiphertext, HpkeConfigId, Interval,
+        AggregationJobStep, Duration, FixedSizeQuery, HpkeCiphertext, HpkeConfigId, Interval,
         Query, ReportIdChecksum, ReportMetadata, ReportShare, Role, Time,
     };
     use rand::random;
@@ -153,7 +153,7 @@ mod tests {
                             (),
                             Interval::from_time(&client_timestamp).unwrap(),
                             AggregationJobState::InProgress,
-                            AggregationJobRound::from(0),
+                            AggregationJobStep::from(0),
                         ),
                     )
                     .await
@@ -343,7 +343,7 @@ mod tests {
                             (),
                             Interval::from_time(&client_timestamp).unwrap(),
                             AggregationJobState::InProgress,
-                            AggregationJobRound::from(0),
+                            AggregationJobStep::from(0),
                         ),
                     )
                     .await
@@ -524,7 +524,7 @@ mod tests {
                         batch_id,
                         Interval::from_time(&client_timestamp).unwrap(),
                         AggregationJobState::InProgress,
-                        AggregationJobRound::from(0),
+                        AggregationJobStep::from(0),
                     );
                     tx.put_aggregation_job(&aggregation_job).await.unwrap();
 
@@ -717,7 +717,7 @@ mod tests {
                         batch_id,
                         Interval::from_time(&client_timestamp).unwrap(),
                         AggregationJobState::InProgress,
-                        AggregationJobRound::from(0),
+                        AggregationJobStep::from(0),
                     );
                     tx.put_aggregation_job(&aggregation_job).await.unwrap();
 

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -695,7 +695,7 @@ mod tests {
     use janus_messages::{
         query_type::TimeInterval, AggregateShare as AggregateShareMessage, AggregateShareAad,
         AggregateShareReq, AggregationJobContinueReq, AggregationJobId,
-        AggregationJobInitializeReq, AggregationJobResp, AggregationJobRound, BatchSelector,
+        AggregationJobInitializeReq, AggregationJobResp, AggregationJobStep, BatchSelector,
         Collection, CollectionJobId, CollectionReq, Duration, Extension, ExtensionType,
         HpkeCiphertext, HpkeConfigId, HpkeConfigList, InputShareAad, Interval,
         PartialBatchSelector, PrepareContinue, PrepareError, PrepareInit, PrepareResp,
@@ -1711,7 +1711,7 @@ mod tests {
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,
-                        AggregationJobRound::from(0),
+                        AggregationJobStep::from(0),
                     );
                     tx.put_aggregation_job::<0, TimeInterval, dummy_vdaf::Vdaf>(
                         &conflicting_aggregation_job,
@@ -1742,7 +1742,7 @@ mod tests {
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,
-                        AggregationJobRound::from(0),
+                        AggregationJobStep::from(0),
                     );
                     tx.put_aggregation_job::<0, TimeInterval, dummy_vdaf::Vdaf>(
                         &non_conflicting_aggregation_job,
@@ -2530,7 +2530,7 @@ mod tests {
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,
-                        AggregationJobRound::from(0),
+                        AggregationJobStep::from(0),
                     ))
                     .await?;
 
@@ -2592,7 +2592,7 @@ mod tests {
             .unwrap();
 
         let request = AggregationJobContinueReq::new(
-            AggregationJobRound::from(1),
+            AggregationJobStep::from(1),
             Vec::from([
                 PrepareContinue::new(*report_metadata_0.id(), leader_prep_message_0.clone()),
                 PrepareContinue::new(*report_metadata_2.id(), leader_prep_message_2.clone()),
@@ -2653,7 +2653,7 @@ mod tests {
                 Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                     .unwrap(),
                 AggregationJobState::Finished,
-                AggregationJobRound::from(1),
+                AggregationJobStep::from(1),
             )
             .with_last_request_hash(aggregation_job.last_request_hash().unwrap())
         );
@@ -2870,7 +2870,7 @@ mod tests {
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,
-                        AggregationJobRound::from(0),
+                        AggregationJobStep::from(0),
                     ))
                     .await?;
 
@@ -2946,7 +2946,7 @@ mod tests {
             .unwrap();
 
         let request = AggregationJobContinueReq::new(
-            AggregationJobRound::from(1),
+            AggregationJobStep::from(1),
             Vec::from([
                 PrepareContinue::new(*report_metadata_0.id(), ping_pong_leader_message_0.clone()),
                 PrepareContinue::new(*report_metadata_1.id(), ping_pong_leader_message_1.clone()),
@@ -3197,7 +3197,7 @@ mod tests {
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,
-                        AggregationJobRound::from(0),
+                        AggregationJobStep::from(0),
                     ))
                     .await?;
 
@@ -3248,7 +3248,7 @@ mod tests {
             .unwrap();
 
         let request = AggregationJobContinueReq::new(
-            AggregationJobRound::from(1),
+            AggregationJobStep::from(1),
             Vec::from([
                 PrepareContinue::new(*report_metadata_3.id(), ping_pong_leader_message_3.clone()),
                 PrepareContinue::new(*report_metadata_4.id(), ping_pong_leader_message_4.clone()),
@@ -3453,7 +3453,7 @@ mod tests {
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,
-                        AggregationJobRound::from(0),
+                        AggregationJobStep::from(0),
                     ))
                     .await?;
                     tx.put_report_aggregation(
@@ -3479,7 +3479,7 @@ mod tests {
 
         // Make request.
         let request = AggregationJobContinueReq::new(
-            AggregationJobRound::from(1),
+            AggregationJobStep::from(1),
             Vec::from([PrepareContinue::new(
                 *report_metadata.id(),
                 // An AggregationJobContinueReq should only ever contain Continue or Finished
@@ -3562,7 +3562,7 @@ mod tests {
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,
-                        AggregationJobRound::from(0),
+                        AggregationJobStep::from(0),
                     ))
                     .await?;
                     tx.put_report_aggregation(
@@ -3588,7 +3588,7 @@ mod tests {
 
         // Make request.
         let request = AggregationJobContinueReq::new(
-            AggregationJobRound::from(1),
+            AggregationJobStep::from(1),
             Vec::from([PrepareContinue::new(
                 *report_metadata.id(),
                 PingPongMessage::Continue {
@@ -3650,7 +3650,7 @@ mod tests {
                 Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                     .unwrap(),
                 AggregationJobState::Finished,
-                AggregationJobRound::from(1),
+                AggregationJobStep::from(1),
             )
             .with_last_request_hash(aggregation_job.last_request_hash().unwrap())
         );
@@ -3734,7 +3734,7 @@ mod tests {
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,
-                        AggregationJobRound::from(0),
+                        AggregationJobStep::from(0),
                     ))
                     .await?;
                     tx.put_report_aggregation(
@@ -3760,7 +3760,7 @@ mod tests {
 
         // Make request.
         let request = AggregationJobContinueReq::new(
-            AggregationJobRound::from(1),
+            AggregationJobStep::from(1),
             Vec::from([PrepareContinue::new(
                 ReportId::from(
                     [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1], // not the same as above
@@ -3882,7 +3882,7 @@ mod tests {
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,
-                        AggregationJobRound::from(0),
+                        AggregationJobStep::from(0),
                     ))
                     .await?;
 
@@ -3925,7 +3925,7 @@ mod tests {
 
         // Make request.
         let request = AggregationJobContinueReq::new(
-            AggregationJobRound::from(1),
+            AggregationJobStep::from(1),
             Vec::from([
                 // Report IDs are in opposite order to what was stored in the datastore.
                 PrepareContinue::new(
@@ -4000,7 +4000,7 @@ mod tests {
                             )
                             .unwrap(),
                             AggregationJobState::InProgress,
-                            AggregationJobRound::from(0),
+                            AggregationJobStep::from(0),
                         ),
                     )
                     .await?;
@@ -4021,7 +4021,7 @@ mod tests {
 
         // Make request.
         let request = AggregationJobContinueReq::new(
-            AggregationJobRound::from(1),
+            AggregationJobStep::from(1),
             Vec::from([PrepareContinue::new(
                 ReportId::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
                 PingPongMessage::Continue {

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -44,7 +44,7 @@ use janus_messages::{
     },
     AggregateShare as AggregateShareMessage, AggregateShareAad, AggregateShareReq,
     AggregationJobContinueReq, AggregationJobId, AggregationJobInitializeReq, AggregationJobResp,
-    AggregationJobRound, BatchSelector, Duration, Interval, PartialBatchSelector, PrepareContinue,
+    AggregationJobStep, BatchSelector, Duration, Interval, PartialBatchSelector, PrepareContinue,
     PrepareInit, PrepareResp, PrepareStepResult, ReportIdChecksum, ReportMetadata, ReportShare,
     Role, TaskId, Time,
 };
@@ -155,7 +155,7 @@ async fn setup_taskprov_test() -> TaskprovTestCase {
     task_config.encode(&mut task_config_encoded);
 
     // We use a real VDAF since taskprov doesn't have any allowance for a test VDAF, and we use
-    // Poplar1 so that the VDAF wil take more than one round, so we can exercise aggregation
+    // Poplar1 so that the VDAF wil take more than one step, so we can exercise aggregation
     // continuation.
     let vdaf = Poplar1::new(1);
 
@@ -755,7 +755,7 @@ async fn taskprov_aggregate_continue() {
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,
-                        AggregationJobRound::from(0),
+                        AggregationJobStep::from(0),
                     ),
                 )
                 .await?;
@@ -792,7 +792,7 @@ async fn taskprov_aggregate_continue() {
         .unwrap();
 
     let request = AggregationJobContinueReq::new(
-        AggregationJobRound::from(1),
+        AggregationJobStep::from(1),
         Vec::from([PrepareContinue::new(
             *test.report_metadata.id(),
             test.transcript.leader_prepare_transitions[1]
@@ -1044,7 +1044,7 @@ async fn end_to_end() {
     );
 
     let aggregation_job_continue_request = AggregationJobContinueReq::new(
-        AggregationJobRound::from(1),
+        AggregationJobStep::from(1),
         Vec::from([PrepareContinue::new(
             *test.report_metadata.id(),
             test.transcript.leader_prepare_transitions[1]

--- a/aggregator_api/src/tests.rs
+++ b/aggregator_api/src/tests.rs
@@ -39,7 +39,7 @@ use janus_core::{
     time::MockClock,
 };
 use janus_messages::{
-    query_type::TimeInterval, AggregationJobRound, Duration, HpkeAeadId, HpkeConfig, HpkeConfigId,
+    query_type::TimeInterval, AggregationJobStep, Duration, HpkeAeadId, HpkeConfig, HpkeConfigId,
     HpkeKdfId, HpkeKemId, HpkePublicKey, Interval, Role, TaskId, Time,
 };
 use rand::{distributions::Standard, random, thread_rng, Rng};
@@ -763,7 +763,7 @@ async fn get_task_metrics() {
                     Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                         .unwrap(),
                     AggregationJobState::InProgress,
-                    AggregationJobRound::from(0),
+                    AggregationJobStep::from(0),
                 ))
                 .await?;
 

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -12,7 +12,7 @@ use janus_core::{
 };
 use janus_messages::{
     query_type::{FixedSize, QueryType, TimeInterval},
-    AggregationJobId, AggregationJobRound, BatchId, CollectionJobId, Duration, Extension,
+    AggregationJobId, AggregationJobStep, BatchId, CollectionJobId, Duration, Extension,
     HpkeCiphertext, Interval, PrepareError, PrepareResp, Query, ReportId, ReportIdChecksum,
     ReportMetadata, Role, TaskId, Time,
 };
@@ -233,11 +233,11 @@ pub struct AggregationJob<const SEED_SIZE: usize, Q: QueryType, A: vdaf::Aggrega
     client_timestamp_interval: Interval,
     /// The overall state of this aggregation job.
     state: AggregationJobState,
-    /// The round of VDAF preparation that this aggregation job is currently on.
-    round: AggregationJobRound,
+    /// The step of VDAF preparation that this aggregation job is currently on.
+    step: AggregationJobStep,
     /// The SHA-256 hash of the most recent [`janus_messages::AggregationJobContinueReq`]
     /// received for this aggregation job. Will only be set for helpers, and only after the
-    /// first round of the job.
+    /// first step of the job.
     last_request_hash: Option<[u8; 32]>,
 }
 
@@ -252,7 +252,7 @@ impl<const SEED_SIZE: usize, Q: QueryType, A: vdaf::Aggregator<SEED_SIZE, 16>>
         batch_id: Q::PartialBatchIdentifier,
         client_timestamp_interval: Interval,
         state: AggregationJobState,
-        round: AggregationJobRound,
+        step: AggregationJobStep,
     ) -> Self {
         Self {
             task_id,
@@ -261,7 +261,7 @@ impl<const SEED_SIZE: usize, Q: QueryType, A: vdaf::Aggregator<SEED_SIZE, 16>>
             batch_id,
             client_timestamp_interval,
             state,
-            round,
+            step,
             last_request_hash: None,
         }
     }
@@ -306,15 +306,15 @@ impl<const SEED_SIZE: usize, Q: QueryType, A: vdaf::Aggregator<SEED_SIZE, 16>>
         AggregationJob { state, ..self }
     }
 
-    /// Returns the round of the VDAF preparation protocol the aggregation job is on.
-    pub fn round(&self) -> AggregationJobRound {
-        self.round
+    /// Returns the step of the VDAF preparation protocol the aggregation job is on.
+    pub fn step(&self) -> AggregationJobStep {
+        self.step
     }
 
     /// Returns a new [`AggregationJob`] corresponding to this aggregation job updated to be on
-    /// the given VDAF preparation round.
-    pub fn with_round(self, round: AggregationJobRound) -> Self {
-        Self { round, ..self }
+    /// the given VDAF preparation step.
+    pub fn with_step(self, step: AggregationJobStep) -> Self {
+        Self { step, ..self }
     }
 
     /// Returns the SHA-256 digest of the most recent
@@ -355,7 +355,7 @@ where
             && self.batch_id == other.batch_id
             && self.client_timestamp_interval == other.client_timestamp_interval
             && self.state == other.state
-            && self.round == other.round
+            && self.step == other.step
             && self.last_request_hash == other.last_request_hash
     }
 }

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -32,7 +32,7 @@ use janus_core::{
 };
 use janus_messages::{
     query_type::{FixedSize, QueryType, TimeInterval},
-    AggregateShareAad, AggregationJobId, AggregationJobRound, BatchId, BatchSelector,
+    AggregateShareAad, AggregationJobId, AggregationJobStep, BatchId, BatchSelector,
     CollectionJobId, Duration, Extension, ExtensionType, FixedSizeQuery, HpkeCiphertext,
     HpkeConfigId, Interval, PrepareError, PrepareResp, PrepareStepResult, Query, ReportId,
     ReportIdChecksum, ReportMetadata, ReportShare, Role, TaskId, Time,
@@ -268,7 +268,7 @@ async fn get_task_metrics(ephemeral_datastore: EphemeralDatastore) {
                     )
                     .unwrap(),
                     AggregationJobState::InProgress,
-                    AggregationJobRound::from(0),
+                    AggregationJobStep::from(0),
                 );
                 let expired_aggregation_job =
                     AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
@@ -284,7 +284,7 @@ async fn get_task_metrics(ephemeral_datastore: EphemeralDatastore) {
                         )
                         .unwrap(),
                         AggregationJobState::InProgress,
-                        AggregationJobRound::from(0),
+                        AggregationJobStep::from(0),
                     );
                 let other_aggregation_job =
                     AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
@@ -300,7 +300,7 @@ async fn get_task_metrics(ephemeral_datastore: EphemeralDatastore) {
                         )
                         .unwrap(),
                         AggregationJobState::InProgress,
-                        AggregationJobRound::from(0),
+                        AggregationJobStep::from(0),
                     );
 
                 let report_aggregations: Vec<_> = reports
@@ -959,7 +959,7 @@ async fn count_client_reports_for_batch_id(ephemeral_datastore: EphemeralDatasto
                     )
                     .unwrap(),
                     AggregationJobState::InProgress,
-                    AggregationJobRound::from(0),
+                    AggregationJobStep::from(0),
                 );
                 let expired_report_aggregation = ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
                     *task.id(),
@@ -979,7 +979,7 @@ async fn count_client_reports_for_batch_id(ephemeral_datastore: EphemeralDatasto
                     Interval::new(OLDEST_ALLOWED_REPORT_TIMESTAMP, Duration::from_seconds(2))
                         .unwrap(),
                     AggregationJobState::InProgress,
-                    AggregationJobRound::from(0),
+                    AggregationJobStep::from(0),
                 );
                 let aggregation_job_0_report_aggregation_0 =
                     ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
@@ -1010,7 +1010,7 @@ async fn count_client_reports_for_batch_id(ephemeral_datastore: EphemeralDatasto
                     Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                         .unwrap(),
                     AggregationJobState::InProgress,
-                    AggregationJobRound::from(0),
+                    AggregationJobStep::from(0),
                 );
                 let aggregation_job_1_report_aggregation_0 =
                     ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
@@ -1202,7 +1202,7 @@ async fn roundtrip_aggregation_job(ephemeral_datastore: EphemeralDatastore) {
         batch_id,
         Interval::new(OLDEST_ALLOWED_REPORT_TIMESTAMP, Duration::from_seconds(1)).unwrap(),
         AggregationJobState::InProgress,
-        AggregationJobRound::from(0),
+        AggregationJobStep::from(0),
     );
     let helper_aggregation_job = AggregationJob::<0, FixedSize, dummy_vdaf::Vdaf>::new(
         *task.id(),
@@ -1211,7 +1211,7 @@ async fn roundtrip_aggregation_job(ephemeral_datastore: EphemeralDatastore) {
         random(),
         Interval::new(OLDEST_ALLOWED_REPORT_TIMESTAMP, Duration::from_seconds(1)).unwrap(),
         AggregationJobState::InProgress,
-        AggregationJobRound::from(0),
+        AggregationJobStep::from(0),
     );
 
     ds.run_tx(|tx| {
@@ -1341,7 +1341,7 @@ async fn roundtrip_aggregation_job(ephemeral_datastore: EphemeralDatastore) {
         )
         .unwrap(),
         AggregationJobState::InProgress,
-        AggregationJobRound::from(0),
+        AggregationJobStep::from(0),
     );
     ds.run_tx(|tx| {
         let new_leader_aggregation_job = new_leader_aggregation_job.clone();
@@ -1442,7 +1442,7 @@ async fn aggregation_job_acquire_release(ephemeral_datastore: EphemeralDatastore
                         )
                         .unwrap(),
                         AggregationJobState::InProgress,
-                        AggregationJobRound::from(0),
+                        AggregationJobStep::from(0),
                     ))
                     .await
                 }
@@ -1459,7 +1459,7 @@ async fn aggregation_job_acquire_release(ephemeral_datastore: EphemeralDatastore
                     Interval::new(OLDEST_ALLOWED_REPORT_TIMESTAMP, Duration::from_seconds(1))
                         .unwrap(),
                     AggregationJobState::Finished,
-                    AggregationJobRound::from(1),
+                    AggregationJobStep::from(1),
                 ),
             )
             .await?;
@@ -1474,7 +1474,7 @@ async fn aggregation_job_acquire_release(ephemeral_datastore: EphemeralDatastore
                     Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                         .unwrap(),
                     AggregationJobState::InProgress,
-                    AggregationJobRound::from(0),
+                    AggregationJobStep::from(0),
                 ),
             )
             .await?;
@@ -1497,7 +1497,7 @@ async fn aggregation_job_acquire_release(ephemeral_datastore: EphemeralDatastore
                     Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                         .unwrap(),
                     AggregationJobState::InProgress,
-                    AggregationJobRound::from(0),
+                    AggregationJobStep::from(0),
                 ),
             )
             .await
@@ -1761,7 +1761,7 @@ async fn aggregation_job_not_found(ephemeral_datastore: EphemeralDatastore) {
                         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,
-                        AggregationJobRound::from(0),
+                        AggregationJobStep::from(0),
                     ),
                 )
                 .await
@@ -1796,7 +1796,7 @@ async fn get_aggregation_jobs_for_task(ephemeral_datastore: EphemeralDatastore) 
         random(),
         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1)).unwrap(),
         AggregationJobState::InProgress,
-        AggregationJobRound::from(0),
+        AggregationJobStep::from(0),
     );
     let second_aggregation_job = AggregationJob::<0, FixedSize, dummy_vdaf::Vdaf>::new(
         *task.id(),
@@ -1805,7 +1805,7 @@ async fn get_aggregation_jobs_for_task(ephemeral_datastore: EphemeralDatastore) 
         random(),
         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1)).unwrap(),
         AggregationJobState::InProgress,
-        AggregationJobRound::from(0),
+        AggregationJobStep::from(0),
     );
     let aggregation_job_with_request_hash = AggregationJob::<0, FixedSize, dummy_vdaf::Vdaf>::new(
         *task.id(),
@@ -1814,7 +1814,7 @@ async fn get_aggregation_jobs_for_task(ephemeral_datastore: EphemeralDatastore) 
         random(),
         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1)).unwrap(),
         AggregationJobState::InProgress,
-        AggregationJobRound::from(0),
+        AggregationJobStep::from(0),
     )
     .with_last_request_hash([3; 32]);
 
@@ -1853,7 +1853,7 @@ async fn get_aggregation_jobs_for_task(ephemeral_datastore: EphemeralDatastore) 
                 Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                     .unwrap(),
                 AggregationJobState::InProgress,
-                AggregationJobRound::from(0),
+                AggregationJobStep::from(0),
             ))
             .await
         })
@@ -1960,7 +1960,7 @@ async fn roundtrip_report_aggregation(ephemeral_datastore: EphemeralDatastore) {
                         Interval::new(OLDEST_ALLOWED_REPORT_TIMESTAMP, Duration::from_seconds(1))
                             .unwrap(),
                         AggregationJobState::InProgress,
-                        AggregationJobRound::from(0),
+                        AggregationJobStep::from(0),
                     ))
                     .await?;
                     tx.put_report_share(
@@ -2127,7 +2127,7 @@ async fn check_other_report_aggregation_exists(ephemeral_datastore: EphemeralDat
                 (),
                 Interval::new(OLDEST_ALLOWED_REPORT_TIMESTAMP, Duration::from_seconds(1)).unwrap(),
                 AggregationJobState::InProgress,
-                AggregationJobRound::from(0),
+                AggregationJobStep::from(0),
             ))
             .await?;
             tx.put_report_share(
@@ -2349,7 +2349,7 @@ async fn get_report_aggregations_for_aggregation_job(ephemeral_datastore: Epheme
                     Interval::new(OLDEST_ALLOWED_REPORT_TIMESTAMP, Duration::from_seconds(1))
                         .unwrap(),
                     AggregationJobState::InProgress,
-                    AggregationJobRound::from(0),
+                    AggregationJobStep::from(0),
                 ))
                 .await
                 .unwrap();
@@ -3037,7 +3037,7 @@ async fn time_interval_collection_job_acquire_release_happy_path(
         (),
         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1)).unwrap(),
         AggregationJobState::Finished,
-        AggregationJobRound::from(1),
+        AggregationJobStep::from(1),
     )]);
     let report_aggregations = Vec::from([ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
         task_id,
@@ -3162,7 +3162,7 @@ async fn fixed_size_collection_job_acquire_release_happy_path(
         batch_id,
         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1)).unwrap(),
         AggregationJobState::Finished,
-        AggregationJobRound::from(1),
+        AggregationJobStep::from(1),
     )]);
     let report_aggregations = Vec::from([ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
         task_id,
@@ -3294,7 +3294,7 @@ async fn collection_job_acquire_no_aggregation_job_with_task_id(
         (),
         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1)).unwrap(),
         AggregationJobState::Finished,
-        AggregationJobRound::from(1),
+        AggregationJobStep::from(1),
     )]);
 
     let collection_job_test_cases = Vec::from([CollectionJobTestCase::<TimeInterval> {
@@ -3349,7 +3349,7 @@ async fn collection_job_acquire_no_aggregation_job_with_agg_param(
         (),
         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1)).unwrap(),
         AggregationJobState::Finished,
-        AggregationJobRound::from(1),
+        AggregationJobStep::from(1),
     )]);
 
     let collection_job_test_cases = Vec::from([CollectionJobTestCase::<TimeInterval> {
@@ -3404,7 +3404,7 @@ async fn collection_job_acquire_report_shares_outside_interval(
         )
         .unwrap(),
         AggregationJobState::Finished,
-        AggregationJobRound::from(1),
+        AggregationJobStep::from(1),
     )]);
     let report_aggregations = Vec::from([ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
         task_id,
@@ -3467,7 +3467,7 @@ async fn collection_job_acquire_release_job_finished(ephemeral_datastore: Epheme
         (),
         Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1)).unwrap(),
         AggregationJobState::Finished,
-        AggregationJobRound::from(1),
+        AggregationJobStep::from(1),
     )]);
 
     let report_aggregations = Vec::from([ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
@@ -3534,7 +3534,7 @@ async fn collection_job_acquire_release_aggregation_job_in_progress(
             (),
             Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1)).unwrap(),
             AggregationJobState::Finished,
-            AggregationJobRound::from(1),
+            AggregationJobStep::from(1),
         ),
         AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
             task_id,
@@ -3544,7 +3544,7 @@ async fn collection_job_acquire_release_aggregation_job_in_progress(
             Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1)).unwrap(),
             // Aggregation job included in collect request is in progress
             AggregationJobState::InProgress,
-            AggregationJobRound::from(0),
+            AggregationJobStep::from(0),
         ),
     ]);
 
@@ -3619,7 +3619,7 @@ async fn collection_job_acquire_job_max(ephemeral_datastore: EphemeralDatastore)
             (),
             Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1)).unwrap(),
             AggregationJobState::Finished,
-            AggregationJobRound::from(1),
+            AggregationJobStep::from(1),
         ),
         AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
             task_id,
@@ -3628,7 +3628,7 @@ async fn collection_job_acquire_job_max(ephemeral_datastore: EphemeralDatastore)
             (),
             Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1)).unwrap(),
             AggregationJobState::Finished,
-            AggregationJobRound::from(1),
+            AggregationJobStep::from(1),
         ),
     ]);
     let report_aggregations = Vec::from([
@@ -3763,7 +3763,7 @@ async fn collection_job_acquire_state_filtering(ephemeral_datastore: EphemeralDa
             (),
             Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1)).unwrap(),
             AggregationJobState::Finished,
-            AggregationJobRound::from(1),
+            AggregationJobStep::from(1),
         ),
         AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
             task_id,
@@ -3772,7 +3772,7 @@ async fn collection_job_acquire_state_filtering(ephemeral_datastore: EphemeralDa
             (),
             Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1)).unwrap(),
             AggregationJobState::Finished,
-            AggregationJobRound::from(1),
+            AggregationJobStep::from(1),
         ),
         AggregationJob::<0, TimeInterval, dummy_vdaf::Vdaf>::new(
             task_id,
@@ -3781,7 +3781,7 @@ async fn collection_job_acquire_state_filtering(ephemeral_datastore: EphemeralDa
             (),
             Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1)).unwrap(),
             AggregationJobState::Finished,
-            AggregationJobRound::from(1),
+            AggregationJobStep::from(1),
         ),
     ]);
     let report_aggregations = Vec::from([
@@ -4826,7 +4826,7 @@ async fn roundtrip_outstanding_batch(ephemeral_datastore: EphemeralDatastore) {
                     Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                         .unwrap(),
                     AggregationJobState::Finished,
-                    AggregationJobRound::from(1),
+                    AggregationJobStep::from(1),
                 );
                 let report_aggregation_0_0 = ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
                     *task_1.id(),
@@ -4877,7 +4877,7 @@ async fn roundtrip_outstanding_batch(ephemeral_datastore: EphemeralDatastore) {
                     Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                         .unwrap(),
                     AggregationJobState::Finished,
-                    AggregationJobRound::from(1),
+                    AggregationJobStep::from(1),
                 );
                 let report_aggregation_1_0 = ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
                     *task_1.id(),
@@ -4915,7 +4915,7 @@ async fn roundtrip_outstanding_batch(ephemeral_datastore: EphemeralDatastore) {
                     Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
                         .unwrap(),
                     AggregationJobState::Finished,
-                    AggregationJobRound::from(1),
+                    AggregationJobStep::from(1),
                 );
                 let report_aggregation_2_0 = ReportAggregation::<0, dummy_vdaf::Vdaf>::new(
                     *task_2.id(),
@@ -5364,7 +5364,7 @@ async fn delete_expired_aggregation_artifacts(ephemeral_datastore: EphemeralData
             Q::partial_batch_identifier(&batch_identifier).clone(),
             client_timestamp_interval,
             AggregationJobState::InProgress,
-            AggregationJobRound::from(0),
+            AggregationJobStep::from(0),
         );
         tx.put_aggregation_job(&aggregation_job).await.unwrap();
 

--- a/core/src/test_util/mod.rs
+++ b/core/src/test_util/mod.rs
@@ -60,12 +60,12 @@ pub struct VdafTranscript<
     pub helper_input_share: V::InputShare,
 
     /// The leader's states and messages computed throughout the protocol run. Indexed by the
-    /// aggregation job round.
+    /// aggregation job step.
     #[allow(clippy::type_complexity)]
     pub leader_prepare_transitions: Vec<LeaderPrepareTransition<VERIFY_KEY_LENGTH, V>>,
 
     /// The helper's states and messages computed throughout the protocol run. Indexed by the
-    /// aggregation job round.
+    /// aggregation job step.
     #[allow(clippy::type_complexity)]
     pub helper_prepare_transitions: Vec<HelperPrepareTransition<VERIFY_KEY_LENGTH, V>>,
 

--- a/db/00000000000001_initial_schema.up.sql
+++ b/db/00000000000001_initial_schema.up.sql
@@ -173,7 +173,7 @@ CREATE TABLE aggregation_jobs(
     batch_id                   BYTEA NOT NULL,                  -- batch ID (fixed-size only; corresponds to identifier in BatchSelector)
     client_timestamp_interval  TSRANGE NOT NULL,                -- the minimal interval containing all of client timestamps included in this aggregation job
     state                      AGGREGATION_JOB_STATE NOT NULL,  -- current state of the aggregation job
-    round                      INTEGER NOT NULL,                -- current round of the VDAF preparation protocol
+    step                       INTEGER NOT NULL,                -- current step of the VDAF preparation protocol
     last_request_hash          BYTEA,                           -- SHA-256 hash of the most recently received AggregationJobContinueReq (helper only)
     trace_context              JSONB,                           -- distributed tracing metadata
 

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -4562,7 +4562,7 @@ mod tests {
                 ]),
             },
             concat!(
-                "A5A5", // round
+                "A5A5", // step
                 concat!(
                     // prepare_steps
                     "00000036", // length


### PR DESCRIPTION
When DAP-05 introduced the ping-pong topology, it also started talking about aggregation protocol "steps" instead of "rounds". This commit corrects the word usage across Janus to line up with the specification.

This change is pretty pedantic, but I think it's worth it for readers trying to resolve Janus against the DAP specification.

Relevant to #1669