### PR TITLE
Update comments

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/aggregation_job_continue.rs
@@ -28,9 +28,8 @@ use tokio::try_join;
 use tracing::trace_span;
 
 impl VdafOps {
-    /// Step the helper's aggregation job to the next step of VDAF preparation using the step `n`
-    /// prepare state in `report_aggregations` with the step `n+1` broadcast prepare messages in
-    /// `leader_aggregation_job`.
+    /// Step the helper's aggregation job to the next step using the step `n` ping pong state in
+    /// `report_aggregations` with the step `n+1` ping pong messages in `leader_aggregation_job`.
     pub(super) async fn step_aggregation_job<const SEED_SIZE: usize, C, Q, A>(
         tx: &Transaction<'_, C>,
         task: Arc<Task>,

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -306,13 +306,13 @@ impl<const SEED_SIZE: usize, Q: QueryType, A: vdaf::Aggregator<SEED_SIZE, 16>>
         AggregationJob { state, ..self }
     }
 
-    /// Returns the step of the VDAF preparation protocol the aggregation job is on.
+    /// Returns the step the aggregation job is on.
     pub fn step(&self) -> AggregationJobStep {
         self.step
     }
 
     /// Returns a new [`AggregationJob`] corresponding to this aggregation job updated to be on
-    /// the given VDAF preparation step.
+    /// the given step.
     pub fn with_step(self, step: AggregationJobStep) -> Self {
         Self { step, ..self }
     }

--- a/db/00000000000001_initial_schema.up.sql
+++ b/db/00000000000001_initial_schema.up.sql
@@ -174,7 +174,7 @@ CREATE TABLE aggregation_jobs(
     client_timestamp_interval  TSRANGE NOT NULL,                -- the minimal interval containing all of client timestamps included in this aggregation job
     state                      AGGREGATION_JOB_STATE NOT NULL,  -- current state of the aggregation job
     step                       INTEGER NOT NULL,                -- current step of the aggregation job
-    last_request_hash          BYTEA,                           -- SHA-256 hash of the most recently received AggregationJobContinueReq (helper only)
+    last_request_hash          BYTEA,                           -- SHA-256 hash of the most recently received AggregationJobInitReq or AggregationJobContinueReq (helper only)
     trace_context              JSONB,                           -- distributed tracing metadata
 
     lease_expiry             TIMESTAMP NOT NULL DEFAULT TIMESTAMP '-infinity',  -- when lease on this aggregation job expires; -infinity implies no current lease
@@ -209,7 +209,7 @@ CREATE TABLE report_aggregations(
     helper_prep_state   BYTEA,                              -- the current VDAF prepare state (opaque VDAF message, only if in state WAITING, only populated for helper)
     leader_prep_transition BYTEA,                           -- the current VDAF prepare transition (opaque VDAF message, only if in state WAITING, only populated for leader)
     error_code          SMALLINT,                           -- error code corresponding to a DAP ReportShareError value; null if in a state other than FAILED
-    last_prep_resp      BYTEA,                              -- the last PrepareResp message sent to the Leader, to assist in replay (opaque VDAF message, populated for Helper only)
+    last_prep_resp      BYTEA,                              -- the last PrepareResp message sent to the Leader, to assist in replay (opaque DAP message, populated for Helper only)
 
     CONSTRAINT report_aggregations_unique_ord UNIQUE(aggregation_job_id, ord),
     CONSTRAINT fk_aggregation_job_id FOREIGN KEY(aggregation_job_id) REFERENCES aggregation_jobs(id) ON DELETE CASCADE

--- a/db/00000000000001_initial_schema.up.sql
+++ b/db/00000000000001_initial_schema.up.sql
@@ -173,7 +173,7 @@ CREATE TABLE aggregation_jobs(
     batch_id                   BYTEA NOT NULL,                  -- batch ID (fixed-size only; corresponds to identifier in BatchSelector)
     client_timestamp_interval  TSRANGE NOT NULL,                -- the minimal interval containing all of client timestamps included in this aggregation job
     state                      AGGREGATION_JOB_STATE NOT NULL,  -- current state of the aggregation job
-    step                       INTEGER NOT NULL,                -- current step of the VDAF preparation protocol
+    step                       INTEGER NOT NULL,                -- current step of the aggregation job
     last_request_hash          BYTEA,                           -- SHA-256 hash of the most recently received AggregationJobContinueReq (helper only)
     trace_context              JSONB,                           -- distributed tracing metadata
 

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -2559,7 +2559,7 @@ impl AggregationJobContinueReq {
         }
     }
 
-    /// Gets the step of VDAF preparation this aggregation job is on.
+    /// Gets the step this aggregation job is on.
     pub fn step(&self) -> AggregationJobStep {
         self.step
     }


### PR DESCRIPTION
This makes a few small changes to comments.

* Language around "steps" is changed slightly. Since the term is introduced in the DAP spec, and the steps are assigned numbers there, I think we shouldn't refer to them as "VDAF preparation steps". Moreover, one aggregation job step could encompass two VDAF preparation rounds.
* Noted that the `last_prep_resp` column could also contain an encoded `AggregationJobInitReq`.
* Since `PrepareResp` is a DAP message type, call it an "opaque DAP message" instead of an "opaque VDAF message".