### PR TITLE
Add missing non_exhaustive to enums

### DIFF
--- a/aggregator_api/src/routes.rs
+++ b/aggregator_api/src/routes.rs
@@ -146,12 +146,14 @@ pub(super) async fn post_task<C: Clock>(
         _ => unreachable!(),
     };
 
+    // Unwrap safety: we always use a supported KEM.
     let hpke_keys = Vec::from([generate_hpke_config_and_private_key(
         random(),
         HpkeKemId::X25519HkdfSha256,
         HpkeKdfId::HkdfSha256,
         HpkeAeadId::Aes128Gcm,
-    )]);
+    )
+    .unwrap()]);
 
     let task = Arc::new(
         Task::new(
@@ -321,7 +323,8 @@ pub(super) async fn put_global_hpke_config<C: Clock>(
         req.kem_id.unwrap_or(HpkeKemId::X25519HkdfSha256),
         req.kdf_id.unwrap_or(HpkeKdfId::HkdfSha256),
         req.aead_id.unwrap_or(HpkeAeadId::Aes128Gcm),
-    );
+    )
+    .unwrap();
 
     let inserted_keypair = ds
         .run_tx_with_name("put_global_hpke_config", |tx| {

--- a/aggregator_api/src/routes.rs
+++ b/aggregator_api/src/routes.rs
@@ -323,8 +323,7 @@ pub(super) async fn put_global_hpke_config<C: Clock>(
         req.kem_id.unwrap_or(HpkeKemId::X25519HkdfSha256),
         req.kdf_id.unwrap_or(HpkeKdfId::HkdfSha256),
         req.aead_id.unwrap_or(HpkeAeadId::Aes128Gcm),
-    )
-    .unwrap();
+    )?;
 
     let inserted_keypair = ds
         .run_tx_with_name("put_global_hpke_config", |tx| {

--- a/aggregator_api/src/tests.rs
+++ b/aggregator_api/src/tests.rs
@@ -206,6 +206,7 @@ async fn post_task_bad_role() {
             HpkeKdfId::HkdfSha256,
             HpkeAeadId::Aes128Gcm,
         )
+        .unwrap()
         .config()
         .clone(),
         aggregator_auth_token: Some(aggregator_auth_token),
@@ -246,6 +247,7 @@ async fn post_task_unauthorized() {
             HpkeKdfId::HkdfSha256,
             HpkeAeadId::Aes128Gcm,
         )
+        .unwrap()
         .config()
         .clone(),
         aggregator_auth_token: Some(aggregator_auth_token),
@@ -287,6 +289,7 @@ async fn post_task_helper_no_optional_fields() {
             HpkeKdfId::HkdfSha256,
             HpkeAeadId::Aes128Gcm,
         )
+        .unwrap()
         .config()
         .clone(),
         aggregator_auth_token: None,
@@ -366,6 +369,7 @@ async fn post_task_helper_with_aggregator_auth_token() {
             HpkeKdfId::HkdfSha256,
             HpkeAeadId::Aes128Gcm,
         )
+        .unwrap()
         .config()
         .clone(),
         aggregator_auth_token: Some(aggregator_auth_token),
@@ -408,6 +412,7 @@ async fn post_task_idempotence() {
             HpkeKdfId::HkdfSha256,
             HpkeAeadId::Aes128Gcm,
         )
+        .unwrap()
         .config()
         .clone(),
         aggregator_auth_token: Some(aggregator_auth_token.clone()),
@@ -488,6 +493,7 @@ async fn post_task_leader_all_optional_fields() {
             HpkeKdfId::HkdfSha256,
             HpkeAeadId::Aes128Gcm,
         )
+        .unwrap()
         .config()
         .clone(),
         aggregator_auth_token: Some(aggregator_auth_token.clone()),
@@ -577,6 +583,7 @@ async fn post_task_leader_no_aggregator_auth_token() {
             HpkeKdfId::HkdfSha256,
             HpkeAeadId::Aes128Gcm,
         )
+        .unwrap()
         .config()
         .clone(),
         aggregator_auth_token: None,
@@ -861,7 +868,8 @@ async fn get_global_hpke_configs() {
         HpkeKemId::P256HkdfSha256,
         HpkeKdfId::HkdfSha384,
         HpkeAeadId::Aes128Gcm,
-    );
+    )
+    .unwrap();
     ds.run_tx(|tx| {
         let keypair1 = keypair1.clone();
         let keypair2 = keypair2.clone();
@@ -962,7 +970,8 @@ async fn get_global_hpke_config() {
         HpkeKemId::P256HkdfSha256,
         HpkeKdfId::HkdfSha384,
         HpkeAeadId::Aes128Gcm,
-    );
+    )
+    .unwrap();
     ds.run_tx(|tx| {
         let keypair1 = keypair1.clone();
         let keypair2 = keypair2.clone();

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -550,12 +550,14 @@ impl SerializedTask {
         }
 
         if self.hpke_keys.is_empty() {
+            // Unwrap safety: we always use a supported KEM.
             let hpke_keypair = generate_hpke_config_and_private_key(
                 random(),
                 HpkeKemId::X25519HkdfSha256,
                 HpkeKdfId::HkdfSha256,
                 HpkeAeadId::Aes128Gcm,
-            );
+            )
+            .unwrap();
 
             self.hpke_keys = Vec::from([hpke_keypair]);
         }

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -25,7 +25,7 @@
 //!     HpkeKemId::X25519HkdfSha256,
 //!     HpkeKdfId::HkdfSha256,
 //!     HpkeAeadId::Aes128Gcm,
-//! );
+//! ).unwrap();
 //! let parameters = CollectorParameters::new(
 //!     task_id,
 //!     "https://example.com/dap/".parse().unwrap(),

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -352,6 +352,7 @@ impl HpkeConfigRegistry {
         self.keypairs
             .entry(id)
             .or_insert_with(|| {
+                // Unwrap safety: we always use a supported KEM.
                 generate_hpke_config_and_private_key(
                     id,
                     // These algorithms should be broadly compatible with other DAP implementations, since they
@@ -360,6 +361,7 @@ impl HpkeConfigRegistry {
                     HpkeKdfId::HkdfSha256,
                     HpkeAeadId::Aes128Gcm,
                 )
+                .unwrap()
             })
             .clone()
     }

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -2022,6 +2022,7 @@ pub mod query_type {
     /// DAP protocol message representing the type of a query.
     #[derive(Copy, Clone, Debug, PartialEq, Eq, TryFromPrimitive, Serialize, Deserialize)]
     #[repr(u8)]
+    #[non_exhaustive]
     pub enum Code {
         Reserved = 0,
         TimeInterval = 1,

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -886,6 +886,7 @@ impl Decode for Extension {
 /// DAP protocol message representing the type of an extension included in a client report.
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, TryFromPrimitive)]
 #[repr(u16)]
+#[non_exhaustive]
 pub enum ExtensionType {
     Tbd = 0,
 }

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -744,6 +744,7 @@ impl<'de> Deserialize<'de> for TaskId {
 /// DAP protocol message representing an HPKE key encapsulation mechanism.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, TryFromPrimitive, Serialize, Deserialize)]
 #[repr(u16)]
+#[non_exhaustive]
 pub enum HpkeKemId {
     /// NIST P-256 keys and HKDF-SHA256.
     P256HkdfSha256 = 0x0010,
@@ -773,6 +774,7 @@ impl Decode for HpkeKemId {
 /// DAP protocol message representing an HPKE key derivation function.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, TryFromPrimitive, Serialize, Deserialize)]
 #[repr(u16)]
+#[non_exhaustive]
 pub enum HpkeKdfId {
     /// HMAC Key Derivation Function SHA256.
     HkdfSha256 = 0x0001,
@@ -804,6 +806,7 @@ impl Decode for HpkeKdfId {
 /// DAP protocol message representing an HPKE AEAD.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, TryFromPrimitive, Serialize, Deserialize)]
 #[repr(u16)]
+#[non_exhaustive]
 pub enum HpkeAeadId {
     /// AES-128-GCM.
     Aes128Gcm = 0x0001,

--- a/tools/src/bin/hpke_keygen.rs
+++ b/tools/src/bin/hpke_keygen.rs
@@ -19,7 +19,7 @@ fn main() -> Result<()> {
         options.kem.into(),
         options.kdf.into(),
         options.aead.into(),
-    );
+    )?;
 
     let mut writer = stdout().lock();
 


### PR DESCRIPTION
Mainly targeting the ExtensionType, but I noticed other enums that could expand in the future in this crate are missing it.

Adding it to the HPKE types comes with unfortunate propagation of an error and unwraps. I'm open to whether this change is worth it. We could also alternatively have a panic here https://github.com/divviup/janus/pull/1957/files#diff-9c7b948f33912f9d1847860795daa701030c35ed114ba5d7e1fcd9674f234ba2R219.