### PR TITLE
Release Janus `0.6.0-prerelease-1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1804,7 +1804,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "janus_aggregator"
-version = "0.6.0"
+version = "0.6.0-prerelease-1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1830,7 +1830,7 @@ dependencies = [
  "janus_aggregator_api",
  "janus_aggregator_core",
  "janus_core",
- "janus_messages 0.6.0",
+ "janus_messages 0.6.0-prerelease-1",
  "k8s-openapi",
  "kube",
  "mockito",
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "janus_aggregator_api"
-version = "0.6.0"
+version = "0.6.0-prerelease-1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1892,7 +1892,7 @@ dependencies = [
  "futures",
  "janus_aggregator_core",
  "janus_core",
- "janus_messages 0.6.0",
+ "janus_messages 0.6.0-prerelease-1",
  "opentelemetry",
  "querystring",
  "rand",
@@ -1913,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "janus_aggregator_core"
-version = "0.6.0"
+version = "0.6.0-prerelease-1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1932,7 +1932,7 @@ dependencies = [
  "hyper",
  "janus_aggregator_core",
  "janus_core",
- "janus_messages 0.6.0",
+ "janus_messages 0.6.0-prerelease-1",
  "k8s-openapi",
  "kube",
  "opentelemetry",
@@ -1967,14 +1967,14 @@ dependencies = [
 
 [[package]]
 name = "janus_build_script_utils"
-version = "0.6.0"
+version = "0.6.0-prerelease-1"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "janus_client"
-version = "0.6.0"
+version = "0.6.0-prerelease-1"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -1983,7 +1983,7 @@ dependencies = [
  "http-api-problem",
  "itertools",
  "janus_core",
- "janus_messages 0.6.0",
+ "janus_messages 0.6.0-prerelease-1",
  "mockito",
  "prio 0.15.1",
  "rand",
@@ -1998,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "janus_collector"
-version = "0.6.0"
+version = "0.6.0-prerelease-1"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -2009,7 +2009,7 @@ dependencies = [
  "http-api-problem",
  "janus_collector",
  "janus_core",
- "janus_messages 0.6.0",
+ "janus_messages 0.6.0-prerelease-1",
  "mockito",
  "prio 0.15.1",
  "rand",
@@ -2023,7 +2023,7 @@ dependencies = [
 
 [[package]]
 name = "janus_core"
-version = "0.6.0"
+version = "0.6.0-prerelease-1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2038,7 +2038,7 @@ dependencies = [
  "http",
  "http-api-problem",
  "janus_core",
- "janus_messages 0.6.0",
+ "janus_messages 0.6.0-prerelease-1",
  "k8s-openapi",
  "kube",
  "mockito",
@@ -2066,7 +2066,7 @@ dependencies = [
 
 [[package]]
 name = "janus_integration_tests"
-version = "0.6.0"
+version = "0.6.0-prerelease-1"
 dependencies = [
  "anyhow",
  "backoff",
@@ -2082,7 +2082,7 @@ dependencies = [
  "janus_collector",
  "janus_core",
  "janus_interop_binaries",
- "janus_messages 0.6.0",
+ "janus_messages 0.6.0-prerelease-1",
  "k8s-openapi",
  "kube",
  "prio 0.15.1",
@@ -2099,7 +2099,7 @@ dependencies = [
 
 [[package]]
 name = "janus_interop_binaries"
-version = "0.6.0"
+version = "0.6.0-prerelease-1"
 dependencies = [
  "anyhow",
  "backoff",
@@ -2116,7 +2116,7 @@ dependencies = [
  "janus_collector",
  "janus_core",
  "janus_interop_binaries",
- "janus_messages 0.6.0",
+ "janus_messages 0.6.0-prerelease-1",
  "opentelemetry",
  "prio 0.15.1",
  "rand",
@@ -2159,7 +2159,7 @@ dependencies = [
 
 [[package]]
 name = "janus_messages"
-version = "0.6.0"
+version = "0.6.0-prerelease-1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2177,7 +2177,7 @@ dependencies = [
 
 [[package]]
 name = "janus_tools"
-version = "0.6.0"
+version = "0.6.0-prerelease-1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2188,7 +2188,7 @@ dependencies = [
  "fixed",
  "janus_collector",
  "janus_core",
- "janus_messages 0.6.0",
+ "janus_messages 0.6.0-prerelease-1",
  "prio 0.15.1",
  "rand",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://divviup.org"
 license = "MPL-2.0"
 repository = "https://github.com/divviup/janus"
 rust-version = "1.70.0"
-version = "0.6.0"
+version = "0.6.0-prerelease-1"
 
 [workspace.dependencies]
 anyhow = "1"
@@ -30,16 +30,16 @@ base64 = "0.21.3"
 # https://docs.rs/chrono/latest/chrono/#duration
 chrono = { version = "0.4", default-features = false }
 itertools = "0.10"
-janus_aggregator = { version = "0.6", path = "aggregator" }
-janus_aggregator_api = { version = "0.6", path = "aggregator_api" }
-janus_aggregator_core = { version = "0.6", path = "aggregator_core" }
-janus_build_script_utils = { version = "0.6", path = "build_script_utils" }
-janus_client = { version = "0.6", path = "client" }
-janus_collector = { version = "0.6", path = "collector" }
-janus_core = { version = "0.6", path = "core" }
-janus_integration_tests = { version = "0.6", path = "integration_tests" }
-janus_interop_binaries = { version = "0.6", path = "interop_binaries" }
-janus_messages = { version = "0.6", path = "messages" }
+janus_aggregator = { version = "0.6.0-prerelease-1", path = "aggregator" }
+janus_aggregator_api = { version = "0.6.0-prerelease-1", path = "aggregator_api" }
+janus_aggregator_core = { version = "0.6.0-prerelease-1", path = "aggregator_core" }
+janus_build_script_utils = { version = "0.6.0-prerelease-1", path = "build_script_utils" }
+janus_client = { version = "0.6.0-prerelease-1", path = "client" }
+janus_collector = { version = "0.6.0-prerelease-1", path = "collector" }
+janus_core = { version = "0.6.0-prerelease-1", path = "core" }
+janus_integration_tests = { version = "0.6.0-prerelease-1", path = "integration_tests" }
+janus_interop_binaries = { version = "0.6.0-prerelease-1", path = "interop_binaries" }
+janus_messages = { version = "0.6.0-prerelease-1", path = "messages" }
 k8s-openapi = { version = "0.18.0", features = ["v1_24"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
 kube = { version = "0.82.2", default-features = false, features = ["client", "rustls-tls"] }
 opentelemetry = { version = "0.20", features = ["metrics"] }


### PR DESCRIPTION
This release is being cut for integration testing, but tagged as a pre-release because we anticipate making more disruptive changes (especially SQL schema changes) before deploying it anywhere.

The Janus maintainers DO NOT recommend deploying this version as it will be incompatible with eventual 0.6.x releases and no migration path will be provided.