### PR TITLE
Change default auth token type to `BEARER`

### DIFF
--- a/db/00000000000001_initial_schema.up.sql
+++ b/db/00000000000001_initial_schema.up.sql
@@ -97,7 +97,7 @@ CREATE TABLE task_aggregator_auth_tokens(
     id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,  -- artificial ID, internal-only
     task_id BIGINT NOT NULL,                           -- task ID the token is associated with
     ord BIGINT NOT NULL,                               -- a value used to specify the ordering of the authentication tokens
-    type AUTH_TOKEN_TYPE NOT NULL DEFAULT 'DAP_AUTH',  -- the type of the authentication token
+    type AUTH_TOKEN_TYPE NOT NULL DEFAULT 'BEARER',    -- the type of the authentication token
     token BYTEA NOT NULL,                              -- bearer token used to authenticate messages to/from the other aggregator (encrypted)
 
     CONSTRAINT task_aggregator_auth_tokens_unique_task_id_and_ord UNIQUE(task_id, ord),
@@ -109,7 +109,7 @@ CREATE TABLE task_collector_auth_tokens(
     id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,  -- artificial ID, internal-only
     task_id BIGINT NOT NULL,                           -- task ID the token is associated with
     ord BIGINT NOT NULL,                               -- a value used to specify the ordering of the authentication tokens
-    type AUTH_TOKEN_TYPE NOT NULL DEFAULT 'DAP_AUTH',  -- the type of the authentication token
+    type AUTH_TOKEN_TYPE NOT NULL DEFAULT 'BEARER',    -- the type of the authentication token
     token BYTEA NOT NULL,                              -- bearer token used to authenticate messages from the collector (encrypted)
 
     CONSTRAINT task_collector_auth_tokens_unique_task_id_and_ord UNIQUE(task_id, ord),


### PR DESCRIPTION
I don't think this makes a real difference, because all the code paths that write auth tokens into the database should be setting the token type explicitly anyway, and we switched the default type in the aggregator API to `BEARER` a while ago. But this at least is consistent with the other token tables and will be less confusing to readers.