### PR TITLE
Handle chunk_length VDAF parameter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,7 +951,7 @@ dependencies = [
 [[package]]
 name = "divviup-client"
 version = "0.0.1"
-source = "git+https://github.com/divviup/divviup-api?tag=0.0.25#8eda807aff7a6ed20d7ea8873b4d36b2421cdb95"
+source = "git+https://github.com/divviup/divviup-api?rev=06667dbeb93d4870bb257b7ddf9a19b37a7e5da5#06667dbeb93d4870bb257b7ddf9a19b37a7e5da5"
 dependencies = [
  "base64 0.21.4",
  "email_address",

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -801,13 +801,11 @@ impl<C: Clock> TaskAggregator<C> {
                 VdafOps::Prio3Count(Arc::new(vdaf), verify_key)
             }
 
-            VdafInstance::Prio3CountVec { length } => {
-                let vdaf = Prio3::new_sum_vec_multithreaded(
-                    2,
-                    1,
-                    *length,
-                    VdafInstance::chunk_size(*length),
-                )?;
+            VdafInstance::Prio3CountVec {
+                length,
+                chunk_length,
+            } => {
+                let vdaf = Prio3::new_sum_vec_multithreaded(2, 1, *length, *chunk_length)?;
                 let verify_key = task.vdaf_verify_key()?;
                 VdafOps::Prio3CountVec(Arc::new(vdaf), verify_key)
             }
@@ -818,19 +816,21 @@ impl<C: Clock> TaskAggregator<C> {
                 VdafOps::Prio3Sum(Arc::new(vdaf), verify_key)
             }
 
-            VdafInstance::Prio3SumVec { bits, length } => {
-                let vdaf = Prio3::new_sum_vec_multithreaded(
-                    2,
-                    *bits,
-                    *length,
-                    VdafInstance::chunk_size(*bits * *length),
-                )?;
+            VdafInstance::Prio3SumVec {
+                bits,
+                length,
+                chunk_length,
+            } => {
+                let vdaf = Prio3::new_sum_vec_multithreaded(2, *bits, *length, *chunk_length)?;
                 let verify_key = task.vdaf_verify_key()?;
                 VdafOps::Prio3SumVec(Arc::new(vdaf), verify_key)
             }
 
-            VdafInstance::Prio3Histogram { length } => {
-                let vdaf = Prio3::new_histogram(2, *length, VdafInstance::chunk_size(*length))?;
+            VdafInstance::Prio3Histogram {
+                length,
+                chunk_length,
+            } => {
+                let vdaf = Prio3::new_histogram(2, *length, *chunk_length)?;
                 let verify_key = task.vdaf_verify_key()?;
                 VdafOps::Prio3Histogram(Arc::new(vdaf), verify_key)
             }

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -268,12 +268,18 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                     .await
             }
 
-            (task::QueryType::TimeInterval, VdafInstance::Prio3CountVec { length }) => {
+            (
+                task::QueryType::TimeInterval,
+                VdafInstance::Prio3CountVec {
+                    length,
+                    chunk_length,
+                },
+            ) => {
                 let vdaf = Arc::new(Prio3::new_sum_vec_multithreaded(
                     2,
                     1,
                     *length,
-                    VdafInstance::chunk_size(*length),
+                    *chunk_length,
                 )?);
                 self.create_aggregation_jobs_for_time_interval_task_no_param::<
                     VERIFY_KEY_LENGTH,
@@ -287,23 +293,32 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                     .await
             }
 
-            (task::QueryType::TimeInterval, VdafInstance::Prio3SumVec { bits, length }) => {
+            (
+                task::QueryType::TimeInterval,
+                VdafInstance::Prio3SumVec {
+                    bits,
+                    length,
+                    chunk_length,
+                },
+            ) => {
                 let vdaf = Arc::new(Prio3::new_sum_vec_multithreaded(
                     2,
                     *bits,
                     *length,
-                    VdafInstance::chunk_size(*bits * *length),
+                    *chunk_length,
                 )?);
                 self.create_aggregation_jobs_for_time_interval_task_no_param::<VERIFY_KEY_LENGTH, Prio3SumVecMultithreaded>(task, vdaf)
                     .await
             }
 
-            (task::QueryType::TimeInterval, VdafInstance::Prio3Histogram { length }) => {
-                let vdaf = Arc::new(Prio3::new_histogram(
-                    2,
-                    *length,
-                    VdafInstance::chunk_size(*length),
-                )?);
+            (
+                task::QueryType::TimeInterval,
+                VdafInstance::Prio3Histogram {
+                    length,
+                    chunk_length,
+                },
+            ) => {
+                let vdaf = Arc::new(Prio3::new_histogram(2, *length, *chunk_length)?);
                 self.create_aggregation_jobs_for_time_interval_task_no_param::<VERIFY_KEY_LENGTH, Prio3Histogram>(task, vdaf)
                     .await
             }
@@ -368,13 +383,16 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                     max_batch_size,
                     batch_time_window_size,
                 },
-                VdafInstance::Prio3CountVec { length },
+                VdafInstance::Prio3CountVec {
+                    length,
+                    chunk_length,
+                },
             ) => {
                 let vdaf = Arc::new(Prio3::new_sum_vec_multithreaded(
                     2,
                     1,
                     *length,
-                    VdafInstance::chunk_size(*length),
+                    *chunk_length,
                 )?);
                 let max_batch_size = *max_batch_size;
                 let batch_time_window_size = *batch_time_window_size;
@@ -405,13 +423,17 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                     max_batch_size,
                     batch_time_window_size,
                 },
-                VdafInstance::Prio3SumVec { bits, length },
+                VdafInstance::Prio3SumVec {
+                    bits,
+                    length,
+                    chunk_length,
+                },
             ) => {
                 let vdaf = Arc::new(Prio3::new_sum_vec_multithreaded(
                     2,
                     *bits,
                     *length,
-                    VdafInstance::chunk_size(*bits * *length),
+                    *chunk_length,
                 )?);
                 let max_batch_size = *max_batch_size;
                 let batch_time_window_size = *batch_time_window_size;
@@ -426,13 +448,12 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                     max_batch_size,
                     batch_time_window_size,
                 },
-                VdafInstance::Prio3Histogram { length },
+                VdafInstance::Prio3Histogram {
+                    length,
+                    chunk_length,
+                },
             ) => {
-                let vdaf = Arc::new(Prio3::new_histogram(
-                    2,
-                    *length,
-                    VdafInstance::chunk_size(*length),
-                )?);
+                let vdaf = Arc::new(Prio3::new_histogram(2, *length, *chunk_length)?);
                 let max_batch_size = *max_batch_size;
                 let batch_time_window_size = *batch_time_window_size;
                 self.create_aggregation_jobs_for_fixed_size_task_no_param::<

--- a/aggregator/src/bin/janus_cli.rs
+++ b/aggregator/src/bin/janus_cli.rs
@@ -671,7 +671,10 @@ mod tests {
                 max_batch_size: 100,
                 batch_time_window_size: None,
             },
-            VdafInstance::Prio3CountVec { length: 4 },
+            VdafInstance::Prio3CountVec {
+                length: 4,
+                chunk_length: 2,
+            },
             Role::Leader,
         )
         .with_id(*tasks[0].id())

--- a/aggregator_api/src/tests.rs
+++ b/aggregator_api/src/tests.rs
@@ -1518,7 +1518,10 @@ fn post_task_req_serialization() {
                 max_batch_size: 999,
                 batch_time_window_size: None,
             },
-            vdaf: VdafInstance::Prio3CountVec { length: 5 },
+            vdaf: VdafInstance::Prio3CountVec {
+                length: 5,
+                chunk_length: 2,
+            },
             role: Role::Helper,
             vdaf_verify_key: "encoded".to_owned(),
             max_batch_query_count: 1,
@@ -1556,10 +1559,12 @@ fn post_task_req_serialization() {
             Token::StructVariant {
                 name: "VdafInstance",
                 variant: "Prio3CountVec",
-                len: 1,
+                len: 2,
             },
             Token::Str("length"),
             Token::U64(5),
+            Token::Str("chunk_length"),
+            Token::U64(2),
             Token::StructVariantEnd,
             Token::Str("role"),
             Token::UnitVariant {
@@ -1619,7 +1624,10 @@ fn post_task_req_serialization() {
                 max_batch_size: 999,
                 batch_time_window_size: None,
             },
-            vdaf: VdafInstance::Prio3CountVec { length: 5 },
+            vdaf: VdafInstance::Prio3CountVec {
+                length: 5,
+                chunk_length: 2,
+            },
             role: Role::Leader,
             vdaf_verify_key: "encoded".to_owned(),
             max_batch_query_count: 1,
@@ -1659,10 +1667,12 @@ fn post_task_req_serialization() {
             Token::StructVariant {
                 name: "VdafInstance",
                 variant: "Prio3CountVec",
-                len: 1,
+                len: 2,
             },
             Token::Str("length"),
             Token::U64(5),
+            Token::Str("chunk_length"),
+            Token::U64(2),
             Token::StructVariantEnd,
             Token::Str("role"),
             Token::UnitVariant {
@@ -1739,7 +1749,10 @@ fn task_resp_serialization() {
             max_batch_size: 999,
             batch_time_window_size: None,
         },
-        VdafInstance::Prio3CountVec { length: 5 },
+        VdafInstance::Prio3CountVec {
+            length: 5,
+            chunk_length: 2,
+        },
         Role::Leader,
         SecretBytes::new(b"vdaf verify key!".to_vec()),
         1,
@@ -1801,10 +1814,12 @@ fn task_resp_serialization() {
             Token::StructVariant {
                 name: "VdafInstance",
                 variant: "Prio3CountVec",
-                len: 1,
+                len: 2,
             },
             Token::Str("length"),
             Token::U64(5),
+            Token::Str("chunk_length"),
+            Token::U64(2),
             Token::StructVariantEnd,
             Token::Str("role"),
             Token::UnitVariant {

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -110,12 +110,36 @@ async fn roundtrip_task(ephemeral_datastore: EphemeralDatastore) {
     let mut want_tasks = HashMap::new();
     for (vdaf, role) in [
         (VdafInstance::Prio3Count, Role::Leader),
-        (VdafInstance::Prio3CountVec { length: 8 }, Role::Leader),
-        (VdafInstance::Prio3CountVec { length: 64 }, Role::Helper),
+        (
+            VdafInstance::Prio3CountVec {
+                length: 8,
+                chunk_length: 3,
+            },
+            Role::Leader,
+        ),
+        (
+            VdafInstance::Prio3CountVec {
+                length: 64,
+                chunk_length: 10,
+            },
+            Role::Helper,
+        ),
         (VdafInstance::Prio3Sum { bits: 64 }, Role::Helper),
         (VdafInstance::Prio3Sum { bits: 32 }, Role::Helper),
-        (VdafInstance::Prio3Histogram { length: 4 }, Role::Leader),
-        (VdafInstance::Prio3Histogram { length: 5 }, Role::Leader),
+        (
+            VdafInstance::Prio3Histogram {
+                length: 4,
+                chunk_length: 2,
+            },
+            Role::Leader,
+        ),
+        (
+            VdafInstance::Prio3Histogram {
+                length: 5,
+                chunk_length: 2,
+            },
+            Role::Leader,
+        ),
         (VdafInstance::Poplar1 { bits: 8 }, Role::Helper),
         (VdafInstance::Poplar1 { bits: 64 }, Role::Helper),
     ] {

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -1266,7 +1266,10 @@ mod tests {
                     max_batch_size: 10,
                     batch_time_window_size: None,
                 },
-                VdafInstance::Prio3CountVec { length: 8 },
+                VdafInstance::Prio3CountVec {
+                    length: 8,
+                    chunk_length: 3,
+                },
                 Role::Helper,
                 SecretBytes::new(b"1234567812345678".to_vec()),
                 1,
@@ -1326,10 +1329,12 @@ mod tests {
                 Token::StructVariant {
                     name: "VdafInstance",
                     variant: "Prio3CountVec",
-                    len: 1,
+                    len: 2,
                 },
                 Token::Str("length"),
                 Token::U64(8),
+                Token::Str("chunk_length"),
+                Token::U64(3),
                 Token::StructVariantEnd,
                 Token::Str("role"),
                 Token::UnitVariant {

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -15,7 +15,7 @@ in-cluster = ["dep:k8s-openapi", "dep:kube"]
 anyhow.workspace = true
 backoff = { version = "0.4", features = ["tokio"] }
 base64.workspace = true
-divviup-client = { git = "https://github.com/divviup/divviup-api", features = ["admin"], tag = "0.0.25" }
+divviup-client = { git = "https://github.com/divviup/divviup-api", features = ["admin"], rev = "06667dbeb93d4870bb257b7ddf9a19b37a7e5da5" }
 futures = "0.3.28"
 hex = "0.4"
 http = "0.2"

--- a/integration_tests/src/client.rs
+++ b/integration_tests/src/client.rs
@@ -58,23 +58,28 @@ fn json_encode_vdaf(vdaf: &VdafInstance) -> Value {
         VdafInstance::Prio3Count => json!({
             "type": "Prio3Count"
         }),
-        VdafInstance::Prio3CountVec { length } => json!({
-            "type": "Prio3CountVec",
-            "length": format!("{length}"),
-        }),
         VdafInstance::Prio3Sum { bits } => json!({
             "type": "Prio3Sum",
             "bits": format!("{bits}"),
         }),
-        VdafInstance::Prio3SumVec { bits, length } => json!({
+        VdafInstance::Prio3SumVec {
+            bits,
+            length,
+            chunk_length,
+        } => json!({
             "type": "Prio3SumVec",
             "bits": format!("{bits}"),
             "length": format!("{length}"),
+            "chunk_length": format!("{chunk_length}"),
         }),
-        VdafInstance::Prio3Histogram { length } => {
+        VdafInstance::Prio3Histogram {
+            length,
+            chunk_length,
+        } => {
             json!({
                 "type": "Prio3Histogram",
                 "length": format!("{length}"),
+                "chunk_length": format!("{chunk_length}"),
             })
         }
         _ => panic!("VDAF {vdaf:?} is not yet supported"),

--- a/integration_tests/tests/common/mod.rs
+++ b/integration_tests/tests/common/mod.rs
@@ -282,14 +282,12 @@ pub async fn submit_measurements_and_verify_aggregate(
             )
             .await;
         }
-        VdafInstance::Prio3SumVec { bits, length } => {
-            let vdaf = Prio3::new_sum_vec_multithreaded(
-                2,
-                *bits,
-                *length,
-                VdafInstance::chunk_size(*bits * *length),
-            )
-            .unwrap();
+        VdafInstance::Prio3SumVec {
+            bits,
+            length,
+            chunk_length,
+        } => {
+            let vdaf = Prio3::new_sum_vec_multithreaded(2, *bits, *length, *chunk_length).unwrap();
 
             let measurements = iter::repeat_with(|| {
                 iter::repeat_with(|| (random::<u128>()) >> (128 - bits))
@@ -327,8 +325,11 @@ pub async fn submit_measurements_and_verify_aggregate(
             )
             .await;
         }
-        VdafInstance::Prio3Histogram { length } => {
-            let vdaf = Prio3::new_histogram(2, *length, VdafInstance::chunk_size(*length)).unwrap();
+        VdafInstance::Prio3Histogram {
+            length,
+            chunk_length,
+        } => {
+            let vdaf = Prio3::new_histogram(2, *length, *chunk_length).unwrap();
 
             let mut aggregate_result = vec![0; *length];
             let measurements = iter::repeat_with(|| {
@@ -358,10 +359,11 @@ pub async fn submit_measurements_and_verify_aggregate(
             )
             .await;
         }
-        VdafInstance::Prio3CountVec { length } => {
-            let vdaf =
-                Prio3::new_sum_vec_multithreaded(2, 1, *length, VdafInstance::chunk_size(*length))
-                    .unwrap();
+        VdafInstance::Prio3CountVec {
+            length,
+            chunk_length,
+        } => {
+            let vdaf = Prio3::new_sum_vec_multithreaded(2, 1, *length, *chunk_length).unwrap();
 
             let measurements = iter::repeat_with(|| {
                 iter::repeat_with(|| random::<bool>() as u128)

--- a/integration_tests/tests/divviup_ts.rs
+++ b/integration_tests/tests/divviup_ts.rs
@@ -58,7 +58,10 @@ async fn janus_divviup_ts_histogram() {
 
     run_divviup_ts_integration_test(
         &container_client(),
-        VdafInstance::Prio3Histogram { length: 4 },
+        VdafInstance::Prio3Histogram {
+            length: 4,
+            chunk_length: 2,
+        },
     )
     .await;
 }

--- a/integration_tests/tests/in_cluster.rs
+++ b/integration_tests/tests/in_cluster.rs
@@ -169,15 +169,28 @@ impl InClusterJanusPair {
                 VdafInstance::Prio3Sum { bits } => Vdaf::Sum {
                     bits: bits.try_into().unwrap(),
                 },
-                VdafInstance::Prio3SumVec { bits, length } => Vdaf::SumVec {
+                VdafInstance::Prio3SumVec {
+                    bits,
+                    length,
+                    chunk_length,
+                } => Vdaf::SumVec {
                     bits: bits.try_into().unwrap(),
                     length: length.try_into().unwrap(),
+                    chunk_length: Some(chunk_length.try_into().unwrap()),
                 },
-                VdafInstance::Prio3Histogram { length } => Vdaf::Histogram(Histogram::Length {
+                VdafInstance::Prio3Histogram {
+                    length,
+                    chunk_length,
+                } => Vdaf::Histogram(Histogram::Length {
                     length: length.try_into().unwrap(),
+                    chunk_length: Some(chunk_length.try_into().unwrap()),
                 }),
-                VdafInstance::Prio3CountVec { length } => Vdaf::CountVec {
+                VdafInstance::Prio3CountVec {
+                    length,
+                    chunk_length,
+                } => Vdaf::CountVec {
                     length: length.try_into().unwrap(),
+                    chunk_length: Some(chunk_length.try_into().unwrap()),
                 },
                 other => panic!("unsupported vdaf {other:?}"),
             },
@@ -285,7 +298,10 @@ async fn in_cluster_histogram() {
 
     // Start port forwards and set up task.
     let janus_pair = InClusterJanusPair::new(
-        VdafInstance::Prio3Histogram { length: 4 },
+        VdafInstance::Prio3Histogram {
+            length: 4,
+            chunk_length: 2,
+        },
         QueryType::TimeInterval,
     )
     .await;

--- a/integration_tests/tests/janus.rs
+++ b/integration_tests/tests/janus.rs
@@ -99,30 +99,10 @@ async fn janus_janus_histogram_4_buckets() {
     let container_client = container_client();
     let janus_pair = JanusPair::new(
         &container_client,
-        VdafInstance::Prio3Histogram { length: 4 },
-        QueryType::TimeInterval,
-    )
-    .await;
-
-    // Run the behavioral test.
-    submit_measurements_and_verify_aggregate(
-        &janus_pair.task_parameters,
-        (janus_pair.leader.port(), janus_pair.helper.port()),
-        &ClientBackend::InProcess,
-    )
-    .await;
-}
-
-/// This test exercises Prio3CountVec with Janus as both the leader and the helper.
-#[tokio::test(flavor = "multi_thread")]
-async fn janus_janus_count_vec_15() {
-    install_test_trace_subscriber();
-
-    // Start servers.
-    let container_client = container_client();
-    let janus_pair = JanusPair::new(
-        &container_client,
-        VdafInstance::Prio3CountVec { length: 15 },
+        VdafInstance::Prio3Histogram {
+            length: 4,
+            chunk_length: 2,
+        },
         QueryType::TimeInterval,
     )
     .await;
@@ -173,6 +153,7 @@ async fn janus_janus_sum_vec() {
         VdafInstance::Prio3SumVec {
             bits: 16,
             length: 15,
+            chunk_length: 16,
         },
         QueryType::TimeInterval,
     )

--- a/interop_binaries/src/bin/janus_interop_client.rs
+++ b/interop_binaries/src/bin/janus_interop_client.rs
@@ -144,14 +144,6 @@ async fn handle_upload(
             handle_upload_generic(http_client, vdaf_client, request, measurement).await?;
         }
 
-        VdafInstance::Prio3CountVec { length } => {
-            let measurement = parse_vector_measurement::<u128>(request.measurement.clone())?;
-            let vdaf_client =
-                Prio3::new_sum_vec_multithreaded(2, 1, length, VdafInstance::chunk_size(length))
-                    .context("failed to construct Prio3CountVec VDAF")?;
-            handle_upload_generic(http_client, vdaf_client, request, measurement).await?;
-        }
-
         VdafInstance::Prio3Sum { bits } => {
             let measurement = parse_primitive_measurement::<u128>(request.measurement.clone())?;
             let vdaf_client =
@@ -159,21 +151,23 @@ async fn handle_upload(
             handle_upload_generic(http_client, vdaf_client, request, measurement).await?;
         }
 
-        VdafInstance::Prio3SumVec { bits, length } => {
+        VdafInstance::Prio3SumVec {
+            bits,
+            length,
+            chunk_length,
+        } => {
             let measurement = parse_vector_measurement::<u128>(request.measurement.clone())?;
-            let vdaf_client = Prio3::new_sum_vec_multithreaded(
-                2,
-                bits,
-                length,
-                VdafInstance::chunk_size(bits * length),
-            )
-            .context("failed to construct Prio3SumVec VDAF")?;
+            let vdaf_client = Prio3::new_sum_vec_multithreaded(2, bits, length, chunk_length)
+                .context("failed to construct Prio3SumVec VDAF")?;
             handle_upload_generic(http_client, vdaf_client, request, measurement).await?;
         }
 
-        VdafInstance::Prio3Histogram { length } => {
+        VdafInstance::Prio3Histogram {
+            length,
+            chunk_length,
+        } => {
             let measurement = parse_primitive_measurement::<usize>(request.measurement.clone())?;
-            let vdaf_client = Prio3::new_histogram(2, length, VdafInstance::chunk_size(length))
+            let vdaf_client = Prio3::new_histogram(2, length, chunk_length)
                 .context("failed to construct Prio3Histogram VDAF")?;
             handle_upload_generic(http_client, vdaf_client, request, measurement).await?;
         }

--- a/interop_binaries/src/bin/janus_interop_collector.rs
+++ b/interop_binaries/src/bin/janus_interop_collector.rs
@@ -311,25 +311,6 @@ async fn handle_collection_start(
             .await?
         }
 
-        (ParsedQuery::TimeInterval(batch_interval), VdafInstance::Prio3CountVec { length }) => {
-            let vdaf =
-                Prio3::new_sum_vec_multithreaded(2, 1, length, VdafInstance::chunk_size(length))
-                    .context("failed to construct Prio3CountVec VDAF")?;
-            handle_collect_generic(
-                http_client,
-                collector_params,
-                Query::new_time_interval(batch_interval),
-                vdaf,
-                &agg_param,
-                |_| None,
-                |result| {
-                    let converted = result.iter().cloned().map(NumberAsString).collect();
-                    AggregationResult::NumberVec(converted)
-                },
-            )
-            .await?
-        }
-
         (ParsedQuery::TimeInterval(batch_interval), VdafInstance::Prio3Sum { bits }) => {
             let vdaf = Prio3::new_sum(2, bits).context("failed to construct Prio3Sum VDAF")?;
             handle_collect_generic(
@@ -344,14 +325,16 @@ async fn handle_collection_start(
             .await?
         }
 
-        (ParsedQuery::TimeInterval(batch_interval), VdafInstance::Prio3SumVec { bits, length }) => {
-            let vdaf = Prio3::new_sum_vec_multithreaded(
-                2,
+        (
+            ParsedQuery::TimeInterval(batch_interval),
+            VdafInstance::Prio3SumVec {
                 bits,
                 length,
-                VdafInstance::chunk_size(bits * length),
-            )
-            .context("failed to construct Prio3SumVec VDAF")?;
+                chunk_length,
+            },
+        ) => {
+            let vdaf = Prio3::new_sum_vec_multithreaded(2, bits, length, chunk_length)
+                .context("failed to construct Prio3SumVec VDAF")?;
             handle_collect_generic(
                 http_client,
                 collector_params,
@@ -367,8 +350,14 @@ async fn handle_collection_start(
             .await?
         }
 
-        (ParsedQuery::TimeInterval(batch_interval), VdafInstance::Prio3Histogram { length }) => {
-            let vdaf = Prio3::new_histogram(2, length, VdafInstance::chunk_size(length))
+        (
+            ParsedQuery::TimeInterval(batch_interval),
+            VdafInstance::Prio3Histogram {
+                length,
+                chunk_length,
+            },
+        ) => {
+            let vdaf = Prio3::new_histogram(2, length, chunk_length)
                 .context("failed to construct Prio3Histogram VDAF")?;
             handle_collect_generic(
                 http_client,
@@ -468,10 +457,15 @@ async fn handle_collection_start(
             .await?
         }
 
-        (ParsedQuery::FixedSize(fixed_size_query), VdafInstance::Prio3CountVec { length }) => {
-            let vdaf =
-                Prio3::new_sum_vec_multithreaded(2, 1, length, VdafInstance::chunk_size(length))
-                    .context("failed to construct Prio3CountVec VDAF")?;
+        (
+            ParsedQuery::FixedSize(fixed_size_query),
+            VdafInstance::Prio3CountVec {
+                length,
+                chunk_length,
+            },
+        ) => {
+            let vdaf = Prio3::new_sum_vec_multithreaded(2, 1, length, chunk_length)
+                .context("failed to construct Prio3CountVec VDAF")?;
             handle_collect_generic(
                 http_client,
                 collector_params,
@@ -570,14 +564,16 @@ async fn handle_collection_start(
             .await?
         }
 
-        (ParsedQuery::FixedSize(fixed_size_query), VdafInstance::Prio3SumVec { bits, length }) => {
-            let vdaf = Prio3::new_sum_vec_multithreaded(
-                2,
+        (
+            ParsedQuery::FixedSize(fixed_size_query),
+            VdafInstance::Prio3SumVec {
                 bits,
                 length,
-                VdafInstance::chunk_size(bits * length),
-            )
-            .context("failed to construct Prio3SumVec VDAF")?;
+                chunk_length,
+            },
+        ) => {
+            let vdaf = Prio3::new_sum_vec_multithreaded(2, bits, length, chunk_length)
+                .context("failed to construct Prio3SumVec VDAF")?;
             handle_collect_generic(
                 http_client,
                 collector_params,
@@ -593,8 +589,14 @@ async fn handle_collection_start(
             .await?
         }
 
-        (ParsedQuery::FixedSize(fixed_size_query), VdafInstance::Prio3Histogram { length }) => {
-            let vdaf = Prio3::new_histogram(2, length, VdafInstance::chunk_size(length))
+        (
+            ParsedQuery::FixedSize(fixed_size_query),
+            VdafInstance::Prio3Histogram {
+                length,
+                chunk_length,
+            },
+        ) => {
+            let vdaf = Prio3::new_histogram(2, length, chunk_length)
                 .context("failed to construct Prio3Histogram VDAF")?;
             handle_collect_generic(
                 http_client,

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -106,18 +106,17 @@ where
 #[serde(tag = "type")]
 pub enum VdafObject {
     Prio3Count,
-    Prio3CountVec {
-        length: NumberAsString<usize>,
-    },
     Prio3Sum {
         bits: NumberAsString<usize>,
     },
     Prio3SumVec {
         bits: NumberAsString<usize>,
         length: NumberAsString<usize>,
+        chunk_length: NumberAsString<usize>,
     },
     Prio3Histogram {
         length: NumberAsString<usize>,
+        chunk_length: NumberAsString<usize>,
     },
     #[cfg(feature = "fpvec_bounded_l2")]
     Prio3FixedPoint16BitBoundedL2VecSum {
@@ -138,21 +137,26 @@ impl From<VdafInstance> for VdafObject {
         match vdaf {
             VdafInstance::Prio3Count => VdafObject::Prio3Count,
 
-            VdafInstance::Prio3CountVec { length } => VdafObject::Prio3CountVec {
-                length: NumberAsString(length),
-            },
-
             VdafInstance::Prio3Sum { bits } => VdafObject::Prio3Sum {
                 bits: NumberAsString(bits),
             },
 
-            VdafInstance::Prio3SumVec { bits, length } => VdafObject::Prio3SumVec {
+            VdafInstance::Prio3SumVec {
+                bits,
+                length,
+                chunk_length,
+            } => VdafObject::Prio3SumVec {
                 bits: NumberAsString(bits),
                 length: NumberAsString(length),
+                chunk_length: NumberAsString(chunk_length),
             },
 
-            VdafInstance::Prio3Histogram { length } => VdafObject::Prio3Histogram {
+            VdafInstance::Prio3Histogram {
+                length,
+                chunk_length,
+            } => VdafObject::Prio3Histogram {
                 length: NumberAsString(length),
+                chunk_length: NumberAsString(chunk_length),
             },
 
             #[cfg(feature = "fpvec_bounded_l2")]
@@ -185,20 +189,25 @@ impl From<VdafObject> for VdafInstance {
         match vdaf {
             VdafObject::Prio3Count => VdafInstance::Prio3Count,
 
-            VdafObject::Prio3CountVec { length } => {
-                VdafInstance::Prio3CountVec { length: length.0 }
-            }
-
             VdafObject::Prio3Sum { bits } => VdafInstance::Prio3Sum { bits: bits.0 },
 
-            VdafObject::Prio3SumVec { bits, length } => VdafInstance::Prio3SumVec {
+            VdafObject::Prio3SumVec {
+                bits,
+                length,
+                chunk_length,
+            } => VdafInstance::Prio3SumVec {
                 bits: bits.0,
                 length: length.0,
+                chunk_length: chunk_length.0,
             },
 
-            VdafObject::Prio3Histogram { length } => {
-                VdafInstance::Prio3Histogram { length: length.0 }
-            }
+            VdafObject::Prio3Histogram {
+                length,
+                chunk_length,
+            } => VdafInstance::Prio3Histogram {
+                length: length.0,
+                chunk_length: chunk_length.0,
+            },
 
             #[cfg(feature = "fpvec_bounded_l2")]
             VdafObject::Prio3FixedPoint16BitBoundedL2VecSum { length } => {

--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -621,7 +621,12 @@ async fn e2e_prio3_sum() {
 async fn e2e_prio3_sum_vec() {
     let result = run(
         QueryKind::TimeInterval,
-        json!({"type": "Prio3SumVec", "bits": "64", "length": "4"}),
+        json!({
+            "type": "Prio3SumVec",
+            "bits": "64",
+            "length": "4",
+            "chunk_length": "18",
+        }),
         &[
             json!(["0", "0", "0", "10"]),
             json!(["0", "0", "10", "0"]),
@@ -643,6 +648,7 @@ async fn e2e_prio3_histogram() {
         json!({
             "type": "Prio3Histogram",
             "length": "6",
+            "chunk_length": "2",
         }),
         &[
             json!("0"),
@@ -658,28 +664,6 @@ async fn e2e_prio3_histogram() {
     for element in result
         .as_array()
         .expect("Histogram result should be an array")
-    {
-        assert!(element.is_string());
-    }
-}
-
-#[tokio::test]
-async fn e2e_prio3_count_vec() {
-    let result = run(
-        QueryKind::TimeInterval,
-        json!({"type": "Prio3CountVec", "length": "4"}),
-        &[
-            json!(["0", "0", "0", "1"]),
-            json!(["0", "0", "1", "0"]),
-            json!(["0", "1", "0", "0"]),
-            json!(["1", "0", "0", "0"]),
-        ],
-        b"",
-    )
-    .await;
-    for element in result
-        .as_array()
-        .expect("CountVec result should be an array")
     {
         assert!(element.is_string());
     }


### PR DESCRIPTION
This adds chunk_length parameters to `VdafInstance` and updates to the latest editor's copy of draft-wang-ppm-dap-taskprov. This will require some additional changes in divviup-api to handle aggregator API changes.

Closes #1900.