### PR TITLE
Fix dependabot automerge.

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -9,5 +9,5 @@ jobs:
       - name: Approve & enable auto-merge for Dependabot PRs
         run: gh pr review --approve -b "Auto-approving dependabot PR." "$PR_URL" && gh pr merge --auto --squash "$PR_URL"
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.DIVVIUP_GITHUB_AUTOMATION_DEPENDABOT_APPROVER_PAT}}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.DIVVIUP_GITHUB_AUTOMATION_DEPENDABOT_APPROVER_PAT }}


### PR DESCRIPTION
The important change is GITHUB_TOKEN -> GH_TOKEN. Despite the gh CLI allowing either, apparently in the context of Github Actions GITHUB_TOKEN is not allowed. (I couldn't find documentation to this effect, but the error I was receiving earlier suggested setting GH_TOKEN, and switching from GITHUB_TOKEN to GH_TOKEN does indeed cause the action to work as expected.)