### PR TITLE
subscriber-01: Remove taskprov feature flag, always behave as if taskprov is enabled

### DIFF
--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -1,13 +1,10 @@
-use crate::{
-    aggregator::{
-        http_handlers::{
-            aggregator_handler,
-            test_util::{take_problem_details, take_response_body},
-        },
-        tests::generate_helper_report_share,
-        Config,
+use crate::aggregator::{
+    http_handlers::{
+        aggregator_handler,
+        test_util::{take_problem_details, take_response_body},
     },
-    config::TaskprovConfig,
+    tests::generate_helper_report_share,
+    Config,
 };
 use assert_matches::assert_matches;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
@@ -112,10 +109,7 @@ async fn setup_taskprov_test() -> TaskprovTestCase {
         Arc::clone(&datastore),
         clock.clone(),
         &noop_meter(),
-        Config {
-            taskprov_config: TaskprovConfig { enabled: true },
-            ..Default::default()
-        },
+        Config::default(),
     )
     .await
     .unwrap();

--- a/aggregator/src/bin/aggregation_job_driver.rs
+++ b/aggregator/src/bin/aggregation_job_driver.rs
@@ -5,7 +5,7 @@ use janus_aggregator::{
     binary_utils::{
         janus_main, job_driver::JobDriver, setup_signal_handler, BinaryOptions, CommonBinaryOptions,
     },
-    config::{BinaryConfig, CommonConfig, JobDriverConfig, TaskprovConfig},
+    config::{BinaryConfig, CommonConfig, JobDriverConfig},
 };
 use janus_core::{time::RealClock, TokioRuntime};
 use serde::{Deserialize, Serialize};
@@ -113,8 +113,6 @@ struct Config {
     common_config: CommonConfig,
     #[serde(flatten)]
     job_driver_config: JobDriverConfig,
-    #[serde(default)]
-    taskprov_config: TaskprovConfig,
 
     /// Defines the number of shards to break each batch aggregation into. Increasing this value
     /// will reduce the amount of database contention during leader aggregation, while increasing
@@ -138,7 +136,7 @@ mod tests {
     use clap::CommandFactory;
     use janus_aggregator::config::{
         test_util::{generate_db_config, generate_metrics_config, generate_trace_config},
-        CommonConfig, JobDriverConfig, TaskprovConfig,
+        CommonConfig, JobDriverConfig,
     };
     use janus_core::test_util::roundtrip_encoding;
     use std::net::{Ipv4Addr, SocketAddr};
@@ -166,7 +164,6 @@ mod tests {
                 maximum_attempts_before_failure: 5,
             },
             batch_aggregation_shard_count: 32,
-            taskprov_config: TaskprovConfig::default(),
         })
     }
 

--- a/aggregator/src/config.rs
+++ b/aggregator/src/config.rs
@@ -84,20 +84,6 @@ impl DbConfig {
     }
 }
 
-/// Configuration options for the Taskprov extension. This extension is
-/// described in [draft-wang-ppm-dap-taskprov][spec], although its configuration
-/// options are implementation-specific.
-///
-/// [spec]: https://datatracker.ietf.org/doc/draft-wang-ppm-dap-taskprov/
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub struct TaskprovConfig {
-    /// Whether to enable the extension or not. Enabling this changes the behavior
-    /// of the aggregator consistent with the taskprov [specification][spec].
-    ///
-    /// [spec]: https://datatracker.ietf.org/doc/draft-wang-ppm-dap-taskprov/
-    pub enabled: bool,
-}
-
 /// Non-secret configuration options for Janus Job Driver jobs.
 ///
 /// # Examples

--- a/docs/samples/advanced_config/aggregator.yaml
+++ b/docs/samples/advanced_config/aggregator.yaml
@@ -88,12 +88,6 @@ max_upload_batch_write_delay_ms: 250
 # than the equivalent setting in the collection job driver. (required)
 batch_aggregation_shard_count: 32
 
-# Configuration for the taskprov extension. If enabled, this changes the behavior of the
-# aggregator as described in draft-wang-ppm-dap-taskprov. (optional)
-taskprov_config:
-  # Whether to enable the taskprov extension. Defaults to false.
-  enabled: false
-
 # Configuration for garbage collection. If omitted, old data is never deleted. (optional)
 garbage_collection:
   # How frequently to collect garbage, in seconds.


### PR DESCRIPTION
This environment will always operate with taskprov enabled. Make simplifications based on this assumption. We no longer have to consider cases where taskprov isn't enabled.

The main functionality change is that we always advertise a global HPKE key and not bother with the task key. Some tests are deleted based on this, the only operative test is `global_hpke_config()`.

Notice that a lot of our tests still work as-is--many of them insert a task specific HPKE key and use it directly without roundtripping through the advertisement endpoint. This works since we still trial decrypt global keys and task-specific keys. However, `taskprov_tests.rs` still exercises the roundtrip, so there is coverage.

This won't break janus-ops, since the extraneous config will be ignored (i.e. this doesn't block deployment).

In spirit of https://github.com/divviup/janus/issues/1728.