### PR TITLE
Fix bad formatting, remove unnecessary config

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -3485,7 +3485,6 @@ mod tests {
             setup_upload_test(Config {
                 max_upload_batch_size: 1000,
                 max_upload_batch_write_delay: StdDuration::from_millis(500),
-                global_hpke_configs_refresh_interval: StdDuration::from_millis(500),
                 ..Default::default()
             })
             .await;

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -714,7 +714,7 @@ mod tests {
     };
     use rand::random;
     use serde_json::json;
-    use std::{collections::HashMap, sync::Arc, time::Duration as StdDuration};
+    use std::{collections::HashMap, sync::Arc};
     use trillium::{Handler, KnownHeaderName, Status};
     use trillium_testing::{
         assert_headers,
@@ -831,17 +831,12 @@ mod tests {
             .await
             .unwrap();
 
-        let cfg = Config {
-            global_hpke_configs_refresh_interval: StdDuration::from_millis(500),
-            ..Default::default()
-        };
-
         let aggregator = Arc::new(
             crate::aggregator::Aggregator::new(
                 datastore.clone(),
                 clock.clone(),
                 &noop_meter(),
-                cfg,
+                Config::default(),
             )
             .await
             .unwrap(),

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -631,12 +631,11 @@ async fn taskprov_opt_out_peer_aggregator_wrong_role() {
     assert_eq!(
         take_problem_details(&mut test_conn).await,
         json!({
-                "status": Status::BadRequest as u16,
-                "type": "urn:ietf:params:ppm:dap:error:invalidTask",
-                "title": "Aggregator has opted out of the indicated task.",
-                "taskid": format!("{}", another_task_id
-        ),
-            })
+            "status": Status::BadRequest as u16,
+            "type": "urn:ietf:params:ppm:dap:error:invalidTask",
+            "title": "Aggregator has opted out of the indicated task.",
+            "taskid": format!("{}", another_task_id),
+        })
     );
 }
 
@@ -716,12 +715,11 @@ async fn taskprov_opt_out_peer_aggregator_does_not_exist() {
     assert_eq!(
         take_problem_details(&mut test_conn).await,
         json!({
-                "status": Status::BadRequest as u16,
-                "type": "urn:ietf:params:ppm:dap:error:invalidTask",
-                "title": "Aggregator has opted out of the indicated task.",
-                "taskid": format!("{}", another_task_id
-        ),
-            })
+            "status": Status::BadRequest as u16,
+            "type": "urn:ietf:params:ppm:dap:error:invalidTask",
+            "title": "Aggregator has opted out of the indicated task.",
+            "taskid": format!("{}", another_task_id),
+        })
     );
 }
 


### PR DESCRIPTION
Minor test cleanup.

Some bad formatting since rustfmt chokes on macros :sob:.

It's not necessary for us to tweak the global HPKE cache refresh interval in tests, since we manually `refresh()` them now.