### PR TITLE
Tasks have only one aggregator, collector token

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/aggregation_job_continue.rs
@@ -302,11 +302,12 @@ pub mod test_util {
         request: &AggregationJobContinueReq,
         handler: &impl Handler,
     ) -> TestConn {
+        let (header, value) = task
+            .aggregator_auth_token()
+            .unwrap()
+            .request_authentication();
         post(task.aggregation_job_uri(aggregation_job_id).unwrap().path())
-            .with_request_header(
-                "DAP-Auth-Token",
-                task.primary_aggregator_auth_token().as_ref().to_owned(),
-            )
+            .with_request_header(header, value)
             .with_request_header(
                 KnownHeaderName::ContentType,
                 AggregationJobContinueReq::MEDIA_TYPE,

--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -91,7 +91,7 @@ impl CollectionJobTestCase {
         self.put_collection_job_with_auth_token(
             collection_job_id,
             request,
-            Some(self.task.primary_collector_auth_token()),
+            self.task.collector_auth_token(),
         )
         .await
     }
@@ -120,7 +120,7 @@ impl CollectionJobTestCase {
     ) -> TestConn {
         self.post_collection_job_with_auth_token(
             collection_job_id,
-            Some(self.task.primary_collector_auth_token()),
+            self.task.collector_auth_token(),
         )
         .await
     }

--- a/aggregator/src/bin/janus_cli.rs
+++ b/aggregator/src/bin/janus_cli.rs
@@ -718,7 +718,7 @@ mod tests {
   vdaf: !Prio3Sum
     bits: 2
   role: Leader
-  vdaf_verify_keys:
+  vdaf_verify_key:
   max_batch_query_count: 1
   task_expiration: 9000000000
   min_batch_size: 10
@@ -731,8 +731,8 @@ mod tests {
     kdf_id: HkdfSha256
     aead_id: Aes128Gcm
     public_key: 8lAqZ7OfNV2Gi_9cNE6J9WRmPbO-k1UPtu2Bztd0-yc
-  aggregator_auth_tokens: []
-  collector_auth_tokens: []
+  aggregator_auth_token:
+  collector_auth_token:
   hpke_keys: []
 - leader_aggregator_endpoint: https://leader
   helper_aggregator_endpoint: https://helper
@@ -740,7 +740,7 @@ mod tests {
   vdaf: !Prio3Sum
     bits: 2
   role: Helper
-  vdaf_verify_keys:
+  vdaf_verify_key:
   max_batch_query_count: 1
   task_expiration: 9000000000
   min_batch_size: 10
@@ -753,8 +753,8 @@ mod tests {
     kdf_id: HkdfSha256
     aead_id: Aes128Gcm
     public_key: 8lAqZ7OfNV2Gi_9cNE6J9WRmPbO-k1UPtu2Bztd0-yc
-  aggregator_auth_tokens: []
-  collector_auth_tokens: []
+  aggregator_auth_token:
+  collector_auth_token:
   hpke_keys: []
 "#;
 
@@ -800,8 +800,8 @@ mod tests {
 
         for task in &got_tasks {
             match task.role() {
-                Role::Leader => assert_eq!(task.collector_auth_tokens().len(), 1),
-                Role::Helper => assert!(task.collector_auth_tokens().is_empty()),
+                Role::Leader => assert!(task.collector_auth_token().is_some()),
+                Role::Helper => assert!(task.collector_auth_token().is_none()),
                 role => panic!("unexpected role {role}"),
             }
         }

--- a/aggregator_api/src/models.rs
+++ b/aggregator_api/src/models.rs
@@ -108,13 +108,12 @@ pub(crate) struct TaskResp {
     /// How much clock skew to allow between client and aggregator. Reports from
     /// farther than this duration into the future will be rejected.
     pub(crate) tolerable_clock_skew: Duration,
-    /// The authentication token for inter-aggregator communication in this task.
-    /// If `role` is Leader, this token is used by the aggregator to authenticate requests to
-    /// the Helper. If `role` is Helper, this token is used by the aggregator to authenticate
-    /// requests from the Leader.
+    /// The authentication token for inter-aggregator communication in this task. If `role` is
+    /// Helper, this token is used by the aggregator to authenticate requests from the Leader. Not
+    /// set if `role` is Leader..
     // TODO(#1509): This field will have to change as Janus helpers will only store a salted
     // hash of aggregator auth tokens.
-    pub(crate) aggregator_auth_token: AuthenticationToken,
+    pub(crate) aggregator_auth_token: Option<AuthenticationToken>,
     /// The authentication token used by the task's Collector to authenticate to the Leader.
     /// `Some` if `role` is Leader, `None` otherwise.
     // TODO(#1509) This field will have to change as Janus leaders will only store a salted hash
@@ -143,21 +142,6 @@ impl TryFrom<&Task> for TaskResp {
         }
         .clone();
 
-        if task.aggregator_auth_tokens().len() != 1 {
-            return Err("illegal number of aggregator auth tokens in task");
-        }
-
-        let collector_auth_token = match task.role() {
-            Role::Leader => {
-                if task.collector_auth_tokens().len() != 1 {
-                    return Err("illegal number of collector auth tokens in task");
-                }
-                Some(task.primary_collector_auth_token().clone())
-            }
-            Role::Helper => None,
-            _ => return Err("illegal aggregator role in task"),
-        };
-
         let mut aggregator_hpke_configs: Vec<_> = task
             .hpke_keys()
             .values()
@@ -178,8 +162,8 @@ impl TryFrom<&Task> for TaskResp {
             min_batch_size: task.min_batch_size(),
             time_precision: *task.time_precision(),
             tolerable_clock_skew: *task.tolerable_clock_skew(),
-            aggregator_auth_token: task.primary_aggregator_auth_token().clone(),
-            collector_auth_token,
+            aggregator_auth_token: task.aggregator_auth_token().cloned(),
+            collector_auth_token: task.collector_auth_token().cloned(),
             collector_hpke_config: task
                 .collector_hpke_config()
                 .ok_or("collector_hpke_config is required")?

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -205,6 +205,76 @@ async fn roundtrip_task(ephemeral_datastore: EphemeralDatastore) {
 
 #[rstest_reuse::apply(schema_versions_template)]
 #[tokio::test]
+async fn put_task_invalid_aggregator_auth_tokens(ephemeral_datastore: EphemeralDatastore) {
+    install_test_trace_subscriber();
+    let ds = ephemeral_datastore.datastore(MockClock::default()).await;
+
+    let task = TaskBuilder::new(
+        task::QueryType::TimeInterval,
+        VdafInstance::Prio3Count,
+        Role::Leader,
+    )
+    .build();
+
+    ds.put_task(&task).await.unwrap();
+
+    for (auth_token, auth_token_type) in [("NULL", "'BEARER'"), ("\\xDEADBEEF::bytea", "NULL")] {
+        ds.run_tx(|tx| {
+            Box::pin(async move {
+                tx.query_one(
+                    &format!(
+                        "UPDATE tasks SET aggregator_auth_token = {auth_token},
+                            aggregator_auth_token_type = {auth_token_type}"
+                    ),
+                    &[],
+                )
+                .await
+                .unwrap_err();
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
+    }
+}
+
+#[rstest_reuse::apply(schema_versions_template)]
+#[tokio::test]
+async fn put_task_invalid_collector_auth_tokens(ephemeral_datastore: EphemeralDatastore) {
+    install_test_trace_subscriber();
+    let ds = ephemeral_datastore.datastore(MockClock::default()).await;
+
+    let task = TaskBuilder::new(
+        task::QueryType::TimeInterval,
+        VdafInstance::Prio3Count,
+        Role::Leader,
+    )
+    .build();
+
+    ds.put_task(&task).await.unwrap();
+
+    for (auth_token, auth_token_type) in [("NULL", "'BEARER'"), ("\\xDEADBEEF::bytea", "NULL")] {
+        ds.run_tx(|tx| {
+            Box::pin(async move {
+                tx.query_one(
+                    &format!(
+                        "UPDATE tasks SET collector_auth_token = {auth_token},
+                            collector_auth_token_type = {auth_token_type}"
+                    ),
+                    &[],
+                )
+                .await
+                .unwrap_err();
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
+    }
+}
+
+#[rstest_reuse::apply(schema_versions_template)]
+#[tokio::test]
 async fn get_task_metrics(ephemeral_datastore: EphemeralDatastore) {
     install_test_trace_subscriber();
 

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -218,18 +218,24 @@ async fn put_task_invalid_aggregator_auth_tokens(ephemeral_datastore: EphemeralD
 
     ds.put_task(&task).await.unwrap();
 
-    for (auth_token, auth_token_type) in [("NULL", "'BEARER'"), ("\\xDEADBEEF::bytea", "NULL")] {
+    for (auth_token, auth_token_type) in [("NULL", "'BEARER'"), ("'\\xDEADBEEF'::bytea", "NULL")] {
         ds.run_tx(|tx| {
             Box::pin(async move {
-                tx.query_one(
-                    &format!(
-                        "UPDATE tasks SET aggregator_auth_token = {auth_token},
+                let err = tx
+                    .query_one(
+                        &format!(
+                            "UPDATE tasks SET aggregator_auth_token = {auth_token},
                             aggregator_auth_token_type = {auth_token_type}"
-                    ),
-                    &[],
-                )
-                .await
-                .unwrap_err();
+                        ),
+                        &[],
+                    )
+                    .await
+                    .unwrap_err();
+
+                assert_eq!(
+                    err.as_db_error().unwrap().constraint().unwrap(),
+                    "aggregator_auth_token_null"
+                );
                 Ok(())
             })
         })
@@ -253,18 +259,24 @@ async fn put_task_invalid_collector_auth_tokens(ephemeral_datastore: EphemeralDa
 
     ds.put_task(&task).await.unwrap();
 
-    for (auth_token, auth_token_type) in [("NULL", "'BEARER'"), ("\\xDEADBEEF::bytea", "NULL")] {
+    for (auth_token, auth_token_type) in [("NULL", "'BEARER'"), ("'\\xDEADBEEF'::bytea", "NULL")] {
         ds.run_tx(|tx| {
             Box::pin(async move {
-                tx.query_one(
-                    &format!(
-                        "UPDATE tasks SET collector_auth_token = {auth_token},
+                let err = tx
+                    .query_one(
+                        &format!(
+                            "UPDATE tasks SET collector_auth_token = {auth_token},
                             collector_auth_token_type = {auth_token_type}"
-                    ),
-                    &[],
-                )
-                .await
-                .unwrap_err();
+                        ),
+                        &[],
+                    )
+                    .await
+                    .unwrap_err();
+
+                assert_eq!(
+                    err.as_db_error().unwrap().constraint().unwrap(),
+                    "collector_auth_token_null"
+                );
                 Ok(())
             })
         })

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -132,7 +132,7 @@ pub struct Task {
     /// Token used to authenticate messages sent to or received from the other aggregator. Only set
     /// if the task was not created via taskprov.
     aggregator_auth_token: Option<AuthenticationToken>,
-    /// Token used to authenticate messages sent to received from the collector. Only set if this
+    /// Token used to authenticate messages sent to or received from the collector. Only set if this
     /// aggregator is the leader.
     collector_auth_token: Option<AuthenticationToken>,
     /// HPKE configurations & private keys used by this aggregator to decrypt client reports.

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -129,10 +129,12 @@ pub struct Task {
     tolerable_clock_skew: Duration,
     /// HPKE configuration for the collector.
     collector_hpke_config: Option<HpkeConfig>,
-    /// Tokens used to authenticate messages sent to or received from the other aggregator.
-    aggregator_auth_tokens: Vec<AuthenticationToken>,
-    /// Tokens used to authenticate messages sent to or received from the collector.
-    collector_auth_tokens: Vec<AuthenticationToken>,
+    /// Token used to authenticate messages sent to or received from the other aggregator. Only set
+    /// if the task was not created via taskprov.
+    aggregator_auth_token: Option<AuthenticationToken>,
+    /// Token used to authenticate messages sent to received from the collector. Only set if this
+    /// aggregator is the leader.
+    collector_auth_token: Option<AuthenticationToken>,
     /// HPKE configurations & private keys used by this aggregator to decrypt client reports.
     hpke_keys: HashMap<HpkeConfigId, HpkeKeypair>,
 }
@@ -155,8 +157,8 @@ impl Task {
         time_precision: Duration,
         tolerable_clock_skew: Duration,
         collector_hpke_config: HpkeConfig,
-        aggregator_auth_tokens: Vec<AuthenticationToken>,
-        collector_auth_tokens: Vec<AuthenticationToken>,
+        aggregator_auth_token: Option<AuthenticationToken>,
+        collector_auth_token: Option<AuthenticationToken>,
         hpke_keys: I,
     ) -> Result<Self, Error> {
         let task = Self::new_without_validation(
@@ -174,8 +176,8 @@ impl Task {
             time_precision,
             tolerable_clock_skew,
             Some(collector_hpke_config),
-            aggregator_auth_tokens,
-            collector_auth_tokens,
+            aggregator_auth_token,
+            collector_auth_token,
             hpke_keys,
         );
         task.validate()?;
@@ -200,8 +202,8 @@ impl Task {
         time_precision: Duration,
         tolerable_clock_skew: Duration,
         collector_hpke_config: Option<HpkeConfig>,
-        aggregator_auth_tokens: Vec<AuthenticationToken>,
-        collector_auth_tokens: Vec<AuthenticationToken>,
+        aggregator_auth_token: Option<AuthenticationToken>,
+        collector_auth_token: Option<AuthenticationToken>,
         hpke_keys: I,
     ) -> Self {
         // Compute hpke_configs mapping cfg.id -> (cfg, key).
@@ -228,8 +230,8 @@ impl Task {
             time_precision,
             tolerable_clock_skew,
             collector_hpke_config,
-            aggregator_auth_tokens,
-            collector_auth_tokens,
+            aggregator_auth_token,
+            collector_auth_token,
             hpke_keys,
         }
     }
@@ -264,13 +266,13 @@ impl Task {
 
     pub(crate) fn validate(&self) -> Result<(), Error> {
         self.validate_common()?;
-        if self.aggregator_auth_tokens.is_empty() {
-            return Err(Error::InvalidParameter("aggregator_auth_tokens"));
+        if self.aggregator_auth_token.is_none() {
+            return Err(Error::InvalidParameter("aggregator_auth_token"));
         }
-        if (self.role == Role::Leader) == (self.collector_auth_tokens.is_empty()) {
+        if (self.role == Role::Leader) == (self.collector_auth_token.is_none()) {
             // Collector auth tokens are allowed & required if and only if this task is in the
             // leader role.
-            return Err(Error::InvalidParameter("collector_auth_tokens"));
+            return Err(Error::InvalidParameter("collector_auth_token"));
         }
         if self.hpke_keys.is_empty() {
             return Err(Error::InvalidParameter("hpke_keys"));
@@ -357,14 +359,14 @@ impl Task {
         self.collector_hpke_config.as_ref()
     }
 
-    /// Retrieves the aggregator authentication tokens associated with this task.
-    pub fn aggregator_auth_tokens(&self) -> &[AuthenticationToken] {
-        &self.aggregator_auth_tokens
+    /// Retrieves the aggregator authentication token associated with this task.
+    pub fn aggregator_auth_token(&self) -> Option<&AuthenticationToken> {
+        self.aggregator_auth_token.as_ref()
     }
 
-    /// Retrieves the collector authentication tokens associated with this task.
-    pub fn collector_auth_tokens(&self) -> &[AuthenticationToken] {
-        &self.collector_auth_tokens
+    /// Retrieves the collector authentication token associated with this task.
+    pub fn collector_auth_token(&self) -> Option<&AuthenticationToken> {
+        self.collector_auth_token.as_ref()
     }
 
     /// Retrieves the HPKE keys in use associated with this task.
@@ -397,35 +399,22 @@ impl Task {
         }
     }
 
-    /// Returns the [`AuthenticationToken`] currently used by this aggregator to authenticate itself
-    /// to other aggregators.
-    pub fn primary_aggregator_auth_token(&self) -> &AuthenticationToken {
-        self.aggregator_auth_tokens.iter().next_back().unwrap()
-    }
-
     /// Checks if the given aggregator authentication token is valid (i.e. matches with an
     /// authentication token recognized by this task).
     pub fn check_aggregator_auth_token(&self, auth_token: &AuthenticationToken) -> bool {
-        self.aggregator_auth_tokens
-            .iter()
-            .rev()
-            .any(|t| t == auth_token)
-    }
-
-    /// Returns the [`AuthenticationToken`] currently used by the collector to authenticate itself
-    /// to the aggregators.
-    pub fn primary_collector_auth_token(&self) -> &AuthenticationToken {
-        // Unwrap safety: self.collector_auth_tokens is never empty
-        self.collector_auth_tokens.iter().next_back().unwrap()
+        match self.aggregator_auth_token {
+            Some(ref t) => t == auth_token,
+            None => false,
+        }
     }
 
     /// Checks if the given collector authentication token is valid (i.e. matches with an
     /// authentication token recognized by this task).
     pub fn check_collector_auth_token(&self, auth_token: &AuthenticationToken) -> bool {
-        self.collector_auth_tokens
-            .iter()
-            .rev()
-            .any(|t| t == auth_token)
+        match self.collector_auth_token {
+            Some(ref t) => t == auth_token,
+            None => false,
+        }
     }
 
     /// Returns the [`VerifyKey`] used by this aggregator to prepare report shares with other
@@ -495,8 +484,8 @@ pub struct SerializedTask {
     time_precision: Duration,
     tolerable_clock_skew: Duration,
     collector_hpke_config: HpkeConfig,
-    aggregator_auth_tokens: Vec<AuthenticationToken>,
-    collector_auth_tokens: Vec<AuthenticationToken>,
+    aggregator_auth_token: Option<AuthenticationToken>,
+    collector_auth_token: Option<AuthenticationToken>,
     hpke_keys: Vec<HpkeKeypair>, // uses unpadded base64url
 }
 
@@ -532,12 +521,12 @@ impl SerializedTask {
             self.vdaf_verify_key = Some(URL_SAFE_NO_PAD.encode(vdaf_verify_key.as_ref()));
         }
 
-        if self.aggregator_auth_tokens.is_empty() {
-            self.aggregator_auth_tokens = Vec::from([random()]);
+        if self.aggregator_auth_token.is_none() {
+            self.aggregator_auth_token = Some(random());
         }
 
-        if self.collector_auth_tokens.is_empty() && self.role == Role::Leader {
-            self.collector_auth_tokens = Vec::from([random()]);
+        if self.collector_auth_token.is_none() && self.role == Role::Leader {
+            self.collector_auth_token = Some(random());
         }
 
         if self.hpke_keys.is_empty() {
@@ -577,8 +566,8 @@ impl Serialize for Task {
                 .collector_hpke_config()
                 .expect("serializable tasks must have collector_hpke_config")
                 .clone(),
-            aggregator_auth_tokens: self.aggregator_auth_tokens.clone(),
-            collector_auth_tokens: self.collector_auth_tokens.clone(),
+            aggregator_auth_token: self.aggregator_auth_token.clone(),
+            collector_auth_token: self.collector_auth_token.clone(),
             hpke_keys,
         }
         .serialize(serializer)
@@ -614,8 +603,8 @@ impl TryFrom<SerializedTask> for Task {
             serialized_task.time_precision,
             serialized_task.tolerable_clock_skew,
             serialized_task.collector_hpke_config,
-            serialized_task.aggregator_auth_tokens,
-            serialized_task.collector_auth_tokens,
+            serialized_task.aggregator_auth_token,
+            serialized_task.collector_auth_token,
             serialized_task.hpke_keys,
         )
     }
@@ -689,10 +678,10 @@ pub mod test_util {
                     .collect(),
             );
 
-            let collector_auth_tokens = if role == Role::Leader {
-                Vec::from([random(), AuthenticationToken::DapAuth(random())])
+            let collector_auth_token = if role == Role::Leader {
+                Some(random()) // Create an AuthenticationToken::Bearer by default
             } else {
-                Vec::new()
+                None
             };
 
             Self(
@@ -711,8 +700,8 @@ pub mod test_util {
                     Duration::from_hours(8).unwrap(),
                     Duration::from_minutes(10).unwrap(),
                     generate_test_hpke_config_and_private_key().config().clone(),
-                    Vec::from([random(), AuthenticationToken::DapAuth(random())]),
-                    collector_auth_tokens,
+                    Some(random()), // Create an AuthenticationToken::Bearer by default
+                    collector_auth_token,
                     Vec::from([aggregator_keypair_0, aggregator_keypair_1]),
                 )
                 .unwrap(),
@@ -795,24 +784,42 @@ pub mod test_util {
             })
         }
 
-        /// Associates the eventual task with the given aggregator authentication tokens.
-        pub fn with_aggregator_auth_tokens(
+        /// Associates the eventual task with the given aggregator authentication token.
+        pub fn with_aggregator_auth_token(
             self,
-            aggregator_auth_tokens: Vec<AuthenticationToken>,
+            aggregator_auth_token: Option<AuthenticationToken>,
         ) -> Self {
             Self(Task {
-                aggregator_auth_tokens,
+                aggregator_auth_token,
                 ..self.0
             })
         }
 
-        /// Sets the collector authentication tokens for the task.
-        pub fn with_collector_auth_tokens(
+        /// Associates the eventual task with a random [`AuthenticationToken::DapAuth`] aggregator
+        /// auth token.
+        pub fn with_dap_auth_aggregator_token(self) -> Self {
+            Self(Task {
+                aggregator_auth_token: Some(AuthenticationToken::DapAuth(random())),
+                ..self.0
+            })
+        }
+
+        /// Associates the eventual task with the given collector authentication token.
+        pub fn with_collector_auth_token(
             self,
-            collector_auth_tokens: Vec<AuthenticationToken>,
+            collector_auth_token: Option<AuthenticationToken>,
         ) -> Self {
             Self(Task {
-                collector_auth_tokens,
+                collector_auth_token,
+                ..self.0
+            })
+        }
+
+        /// Associates the eventual task with a random [`AuthenticationToken::DapAuth`] collector
+        /// auth token.
+        pub fn with_dap_auth_collector_token(self) -> Self {
+            Self(Task {
+                collector_auth_token: Some(AuthenticationToken::DapAuth(random())),
                 ..self.0
             })
         }
@@ -915,8 +922,8 @@ mod tests {
             Duration::from_hours(8).unwrap(),
             Duration::from_minutes(10).unwrap(),
             generate_test_hpke_config_and_private_key().config().clone(),
-            Vec::from([random()]),
-            Vec::new(),
+            Some(random()),
+            None,
             Vec::from([generate_test_hpke_config_and_private_key()]),
         )
         .unwrap_err();
@@ -937,8 +944,8 @@ mod tests {
             Duration::from_hours(8).unwrap(),
             Duration::from_minutes(10).unwrap(),
             generate_test_hpke_config_and_private_key().config().clone(),
-            Vec::from([random()]),
-            Vec::from([random()]),
+            Some(random()),
+            Some(random()),
             Vec::from([generate_test_hpke_config_and_private_key()]),
         )
         .unwrap();
@@ -959,8 +966,8 @@ mod tests {
             Duration::from_hours(8).unwrap(),
             Duration::from_minutes(10).unwrap(),
             generate_test_hpke_config_and_private_key().config().clone(),
-            Vec::from([random()]),
-            Vec::new(),
+            Some(random()),
+            None,
             Vec::from([generate_test_hpke_config_and_private_key()]),
         )
         .unwrap();
@@ -981,8 +988,8 @@ mod tests {
             Duration::from_hours(8).unwrap(),
             Duration::from_minutes(10).unwrap(),
             generate_test_hpke_config_and_private_key().config().clone(),
-            Vec::from([random()]),
-            Vec::from([random()]),
+            Some(random()),
+            Some(random()),
             Vec::from([generate_test_hpke_config_and_private_key()]),
         )
         .unwrap_err();
@@ -1005,8 +1012,8 @@ mod tests {
             Duration::from_hours(8).unwrap(),
             Duration::from_minutes(10).unwrap(),
             generate_test_hpke_config_and_private_key().config().clone(),
-            Vec::from([random()]),
-            Vec::from([random()]),
+            Some(random()),
+            Some(random()),
             Vec::from([generate_test_hpke_config_and_private_key()]),
         )
         .unwrap();
@@ -1088,14 +1095,14 @@ mod tests {
                     HpkeAeadId::Aes128Gcm,
                     HpkePublicKey::from(b"collector hpke public key".to_vec()),
                 ),
-                Vec::from([AuthenticationToken::new_dap_auth_token_from_string(
-                    "YWdncmVnYXRvciB0b2tlbg",
-                )
-                .unwrap()]),
-                Vec::from([AuthenticationToken::new_bearer_token_from_string(
-                    "Y29sbGVjdG9yIHRva2Vu",
-                )
-                .unwrap()]),
+                Some(
+                    AuthenticationToken::new_dap_auth_token_from_string("YWdncmVnYXRvciB0b2tlbg")
+                        .unwrap(),
+                ),
+                Some(
+                    AuthenticationToken::new_bearer_token_from_string("Y29sbGVjdG9yIHRva2Vu")
+                        .unwrap(),
+                ),
                 [HpkeKeypair::new(
                     HpkeConfig::new(
                         HpkeConfigId::from(255),
@@ -1180,8 +1187,8 @@ mod tests {
                 Token::Str("public_key"),
                 Token::Str("Y29sbGVjdG9yIGhwa2UgcHVibGljIGtleQ"),
                 Token::StructEnd,
-                Token::Str("aggregator_auth_tokens"),
-                Token::Seq { len: Some(1) },
+                Token::Str("aggregator_auth_token"),
+                Token::Some,
                 Token::Struct {
                     name: "AuthenticationToken",
                     len: 2,
@@ -1194,9 +1201,8 @@ mod tests {
                 Token::Str("token"),
                 Token::Str("YWdncmVnYXRvciB0b2tlbg"),
                 Token::StructEnd,
-                Token::SeqEnd,
-                Token::Str("collector_auth_tokens"),
-                Token::Seq { len: Some(1) },
+                Token::Str("collector_auth_token"),
+                Token::Some,
                 Token::Struct {
                     name: "AuthenticationToken",
                     len: 2,
@@ -1209,7 +1215,6 @@ mod tests {
                 Token::Str("token"),
                 Token::Str("Y29sbGVjdG9yIHRva2Vu"),
                 Token::StructEnd,
-                Token::SeqEnd,
                 Token::Str("hpke_keys"),
                 Token::Seq { len: Some(1) },
                 Token::Struct {
@@ -1277,11 +1282,11 @@ mod tests {
                     HpkeAeadId::Aes128Gcm,
                     HpkePublicKey::from(b"collector hpke public key".to_vec()),
                 ),
-                Vec::from([AuthenticationToken::new_bearer_token_from_string(
-                    "YWdncmVnYXRvciB0b2tlbg",
-                )
-                .unwrap()]),
-                Vec::new(),
+                Some(
+                    AuthenticationToken::new_bearer_token_from_string("YWdncmVnYXRvciB0b2tlbg")
+                        .unwrap(),
+                ),
+                None,
                 [HpkeKeypair::new(
                     HpkeConfig::new(
                         HpkeConfigId::from(255),
@@ -1378,8 +1383,8 @@ mod tests {
                 Token::Str("public_key"),
                 Token::Str("Y29sbGVjdG9yIGhwa2UgcHVibGljIGtleQ"),
                 Token::StructEnd,
-                Token::Str("aggregator_auth_tokens"),
-                Token::Seq { len: Some(1) },
+                Token::Str("aggregator_auth_token"),
+                Token::Some,
                 Token::Struct {
                     name: "AuthenticationToken",
                     len: 2,
@@ -1392,10 +1397,8 @@ mod tests {
                 Token::Str("token"),
                 Token::Str("YWdncmVnYXRvciB0b2tlbg"),
                 Token::StructEnd,
-                Token::SeqEnd,
-                Token::Str("collector_auth_tokens"),
-                Token::Seq { len: Some(0) },
-                Token::SeqEnd,
+                Token::Str("collector_auth_token"),
+                Token::None,
                 Token::Str("hpke_keys"),
                 Token::Seq { len: Some(1) },
                 Token::Struct {

--- a/aggregator_core/src/taskprov.rs
+++ b/aggregator_core/src/taskprov.rs
@@ -302,8 +302,8 @@ impl Task {
             time_precision,
             tolerable_clock_skew,
             None,
-            Vec::new(),
-            Vec::new(),
+            None,
+            None,
             Vec::new(),
         ));
         task.validate()?;

--- a/db/00000000000001_initial_schema.down.sql
+++ b/db/00000000000001_initial_schema.down.sql
@@ -24,8 +24,6 @@ DROP INDEX client_reports_task_and_timestamp_index CASCADE;
 DROP INDEX client_reports_task_and_timestamp_unaggregated_index CASCADE;
 DROP TABLE client_reports CASCADE;
 DROP TABLE task_hpke_keys CASCADE;
-DROP TABLE task_collector_auth_tokens CASCADE;
-DROP TABLE task_aggregator_auth_tokens CASCADE;
 DROP INDEX task_id_index CASCADE;
 DROP TABLE tasks CASCADE;
 DROP TABLE taskprov_aggregator_auth_tokens;

--- a/db/00000000000001_initial_schema.up.sql
+++ b/db/00000000000001_initial_schema.up.sql
@@ -89,31 +89,23 @@ CREATE TABLE tasks(
     time_precision              BIGINT NOT NULL,           -- the duration to which clients are expected to round their report timestamps, in seconds
     tolerable_clock_skew        BIGINT NOT NULL,           -- the maximum acceptable clock skew to allow between client and aggregator, in seconds
     collector_hpke_config       BYTEA,                     -- the HPKE config of the collector (encoded HpkeConfig message)
-    vdaf_verify_key             BYTEA NOT NULL             -- the VDAF verification key (encrypted)
+    vdaf_verify_key             BYTEA NOT NULL,            -- the VDAF verification key (encrypted)
+
+    -- Authentication token used to authenticate messages to/from the other aggregator.
+    -- These columns are NULL if the task was provisioned by taskprov.
+    aggregator_auth_token_type  AUTH_TOKEN_TYPE,    -- the type of the authentication token
+    aggregator_auth_token       BYTEA,              -- encrypted bearer token
+    -- The aggregator_auth_token columns must either both be NULL or both be non-NULL
+    CONSTRAINT aggregator_auth_token_null CHECK ((aggregator_auth_token_type IS NULL) = (aggregator_auth_token IS NULL)),
+
+    -- Authentication token used to authenticate messages to the leader from the collector. These
+    -- columns are NULL if the task was provisioned by taskprov or if the task's role is helper.
+    collector_auth_token_type   AUTH_TOKEN_TYPE,    -- the type of the authentication token
+    collector_auth_token        BYTEA,              -- encrypted bearer token
+    -- The collector_auth_token columns must either both be NULL or both be non-NULL
+    CONSTRAINT collector_auth_token_null CHECK ((collector_auth_token_type IS NULL) = (collector_auth_token IS NULL))
 );
 CREATE INDEX task_id_index ON tasks(task_id);
-
--- The aggregator authentication tokens used by a given task.
-CREATE TABLE task_aggregator_auth_tokens(
-    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,  -- artificial ID, internal-only
-    task_id BIGINT NOT NULL,                           -- task ID the token is associated with
-    type AUTH_TOKEN_TYPE NOT NULL DEFAULT 'BEARER',    -- the type of the authentication token
-    token BYTEA NOT NULL,                              -- bearer token used to authenticate messages to/from the other aggregator (encrypted)
-
-    CONSTRAINT task_aggregator_auth_tokens_unique_task_id UNIQUE(task_id),
-    CONSTRAINT fk_task_id FOREIGN KEY(task_id) REFERENCES tasks(id) ON DELETE CASCADE
-);
-
--- The collector authentication tokens used by a given task.
-CREATE TABLE task_collector_auth_tokens(
-    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,  -- artificial ID, internal-only
-    task_id BIGINT NOT NULL,                           -- task ID the token is associated with
-    type AUTH_TOKEN_TYPE NOT NULL DEFAULT 'BEARER',    -- the type of the authentication token
-    token BYTEA NOT NULL,                              -- bearer token used to authenticate messages from the collector (encrypted)
-
-    CONSTRAINT task_collector_auth_tokens_unique_task_id UNIQUE(task_id),
-    CONSTRAINT fk_task_id FOREIGN KEY(task_id) REFERENCES tasks(id) ON DELETE CASCADE
-);
 
 -- The HPKE public keys (aka configs) and private keys used by a given task.
 CREATE TABLE task_hpke_keys(

--- a/db/00000000000001_initial_schema.up.sql
+++ b/db/00000000000001_initial_schema.up.sql
@@ -97,11 +97,10 @@ CREATE INDEX task_id_index ON tasks(task_id);
 CREATE TABLE task_aggregator_auth_tokens(
     id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,  -- artificial ID, internal-only
     task_id BIGINT NOT NULL,                           -- task ID the token is associated with
-    ord BIGINT NOT NULL,                               -- a value used to specify the ordering of the authentication tokens
     type AUTH_TOKEN_TYPE NOT NULL DEFAULT 'BEARER',    -- the type of the authentication token
     token BYTEA NOT NULL,                              -- bearer token used to authenticate messages to/from the other aggregator (encrypted)
 
-    CONSTRAINT task_aggregator_auth_tokens_unique_task_id_and_ord UNIQUE(task_id, ord),
+    CONSTRAINT task_aggregator_auth_tokens_unique_task_id UNIQUE(task_id),
     CONSTRAINT fk_task_id FOREIGN KEY(task_id) REFERENCES tasks(id) ON DELETE CASCADE
 );
 
@@ -109,11 +108,10 @@ CREATE TABLE task_aggregator_auth_tokens(
 CREATE TABLE task_collector_auth_tokens(
     id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,  -- artificial ID, internal-only
     task_id BIGINT NOT NULL,                           -- task ID the token is associated with
-    ord BIGINT NOT NULL,                               -- a value used to specify the ordering of the authentication tokens
     type AUTH_TOKEN_TYPE NOT NULL DEFAULT 'BEARER',    -- the type of the authentication token
     token BYTEA NOT NULL,                              -- bearer token used to authenticate messages from the collector (encrypted)
 
-    CONSTRAINT task_collector_auth_tokens_unique_task_id_and_ord UNIQUE(task_id, ord),
+    CONSTRAINT task_collector_auth_tokens_unique_task_id UNIQUE(task_id),
     CONSTRAINT fk_task_id FOREIGN KEY(task_id) REFERENCES tasks(id) ON DELETE CASCADE
 );
 

--- a/docs/samples/tasks.yaml
+++ b/docs/samples/tasks.yaml
@@ -59,31 +59,29 @@
     aead_id: Aes128Gcm
     public_key: 4qiv6IY5jrjCV3xbaQXULmPIpvoIml1oJmeXm-yOuAo
 
-  # Authentication tokens shared beteween the aggregators, and used to
+  # Authentication token shared beteween the aggregators, and used to
   # authenticate leader-to-helper requests. In the case of a leader-role task,
-  # the leader will include the first token in a header when making requests to
-  # the helper. In the case of a helper-role task, the helper will accept
-  # requests with any of the listed authentication tokens.
+  # the leader will include the token in a header when making requests to the
+  # helper. In the case of a helper-role task, the helper will accept requests
+  # requests with  authentication tokens.
   #
   # Each token's `type` governs how it is inserted into HTTP requests if used by
   # the leader to authenticate a request to the helper.
-  aggregator_auth_tokens:
+  aggregator_auth_token:
     # DAP-Auth-Token values are encoded in unpadded base64url, and the decoded
     # value is sent in an HTTP header. For example, this token's value decodes
     # to "aggregator-235242f99406c4fd28b820c32eab0f68".
-  - type: "DapAuth"
+    type: "DapAuth"
     token: "YWdncmVnYXRvci0yMzUyNDJmOTk0MDZjNGZkMjhiODIwYzMyZWFiMGY2OA"
-    # Bearer token values are encoded in unpadded base64url.
-  - type: "Bearer"
-    token: "YWdncmVnYXRvci04NDc1NjkwZjJmYzQzMDBmYjE0NmJiMjk1NDIzNDk1NA"
 
-  # Authentication tokens shared between the leader and the collector, and used
+  # Authentication token shared between the leader and the collector, and used
   # to authenticate collector-to-leader requests. For leader tasks, this has the
   # same format as `aggregator_auth_tokens` above. For helper tasks, this will
   # be an empty list instead.
+  # Bearer token values are encoded in unpadded base64url.
   # This example decodes to "collector-abf5408e2b1601831625af3959106458".
-  collector_auth_tokens:
-  - type: "Bearer"
+  collector_auth_token:
+    type: "Bearer"
     token: "Y29sbGVjdG9yLWFiZjU0MDhlMmIxNjAxODMxNjI1YWYzOTU5MTA2NDU4"
 
   # This aggregator's HPKE keypairs. The first keypair's HPKE configuration will
@@ -122,12 +120,12 @@
     kdf_id: HkdfSha256
     aead_id: Aes128Gcm
     public_key: KHRLcWgfWxli8cdOLPsgsZPttHXh0ho3vLVLrW-63lE
-  aggregator_auth_tokens:
-  - type: "Bearer"
+  aggregator_auth_token:
+    type: "Bearer"
     token: "YWdncmVnYXRvci1jZmE4NDMyZjdkMzllMjZiYjU3OGUzMzY5Mzk1MWQzNQ"
-  # Note that this task does not have any collector authentication tokens, since
+  # Note that this task does not have a collector authentication token, since
   # it is a helper role task.
-  collector_auth_tokens: []
+  collector_auth_token:
   hpke_keys:
   - config:
       id: 37

--- a/integration_tests/tests/common/mod.rs
+++ b/integration_tests/tests/common/mod.rs
@@ -45,11 +45,14 @@ pub fn test_task_builders(
             Url::parse(&format!("http://helper-{endpoint_random_value}:8080/")).unwrap(),
         )
         .with_min_batch_size(46)
+        // Force use of DAP-Auth-Tokens, as required by interop testing standard.
+        .with_dap_auth_aggregator_token()
+        .with_dap_auth_collector_token()
         .with_collector_hpke_config(collector_keypair.config().clone());
     let helper_task = leader_task
         .clone()
         .with_role(Role::Helper)
-        .with_collector_auth_tokens(Vec::new());
+        .with_collector_auth_token(None);
     let temporary_task = leader_task.clone().build();
     let task_parameters = TaskParameters {
         task_id: *temporary_task.id(),
@@ -60,7 +63,7 @@ pub fn test_task_builders(
         time_precision: *temporary_task.time_precision(),
         collector_hpke_config: collector_keypair.config().clone(),
         collector_private_key: collector_keypair.private_key().clone(),
-        collector_auth_token: temporary_task.primary_collector_auth_token().clone(),
+        collector_auth_token: temporary_task.collector_auth_token().unwrap().clone(),
     };
 
     (task_parameters, leader_task, helper_task)

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -291,12 +291,12 @@ impl From<Task> for AggregatorAddTaskRequest {
             helper: task.helper_aggregator_endpoint().clone(),
             vdaf: task.vdaf().clone().into(),
             leader_authentication_token: String::from_utf8(
-                task.primary_aggregator_auth_token().as_ref().to_vec(),
+                task.aggregator_auth_token().unwrap().as_ref().to_vec(),
             )
             .unwrap(),
             collector_authentication_token: if task.role() == &Role::Leader {
                 Some(
-                    String::from_utf8(task.primary_collector_auth_token().as_ref().to_vec())
+                    String::from_utf8(task.collector_auth_token().unwrap().as_ref().to_vec())
                         .unwrap(),
                 )
             } else {


### PR DESCRIPTION
We've decided that each task has exactly one aggregator and collector auth token, and rotating those means rotating the task. This commit updates the representations of auth tokens in the database and in memory (`aggregator_core::task::Task`) accordingly.

Several tests relied upon tasks constructed in tests having two aggregator auth tokens, one of each supported type. Those tests are fixed to explicitly construct tasks using `DAP-Auth-Token` tokens where necessary.

Given that there is now a single aggregator or collector auth token per task, we could remove the `task_aggregator_auth_tokens` and `task_collector_auth_tokens` tables and instead add columns `aggregator_auth_token`, `aggregator_auth_token_type`, `collector_auth_token` and `collector_auth_token_type` to `tasks`.

I chose not to do this because validating the correctness of those columns would be tricky. We couldn't make them all `NOT NULL`, because a helper task doesn't have a collector auth token and a task provisioned via taskprov won't have either token (instead it'll use tokens from the `taskprov_*_auth_tokens` tables). So we would have to write constraints on the `tasks` table to ensure pairs of columns are either `NULL` or `NOT NULL` in tandem, which I think are expressed more clearly in the independent `task_*_auth_tokens` tables. Plus, if we ever _do_ decide to support auth token rotation, it'll be easier to do with these tables in place.

Part of #1524, #1521