### PR TITLE
Migration filenames containing numbers are valid

### DIFF
--- a/.github/actions/validate-migrations/action.yml
+++ b/.github/actions/validate-migrations/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Ensure all migrations have the proper filename
       shell: bash
       run: |
-        REGEX='^(README.md)|([0-9]{14}_[a-z_]+\.(down|up)\.sql$)'
+        REGEX='^(README.md)|([0-9]{14}_[a-z0-9_]+\.(down|up)\.sql$)'
         INVALID_FILES=$(find db/ -mindepth 1 -printf "%f\n" | grep -Pv "$REGEX" || true)
 
         if [ -n "$INVALID_FILES" ]; then


### PR DESCRIPTION
e.g. `00000000000001_taskprov_sub01.up.sql` should pass.