### PR TITLE
Dependabot tweaks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       interval: "weekly"
     target-branch: "main"
     open-pull-requests-limit: 20
+    ignore:
+      - dependency-name: prio
+        update-types:
+          - version-update:semver-minor
     groups:
       serde:
         patterns:
@@ -63,6 +67,10 @@ updates:
       interval: "weekly"
     target-branch: "release/0.subscriber-01"
     open-pull-requests-limit: 20
+    ignore:
+      - dependency-name: prio
+        update-types:
+          - version-update:semver-minor
     groups:
       serde:
         patterns:
@@ -118,6 +126,10 @@ updates:
       interval: "weekly"
     target-branch: "release/0.5"
     open-pull-requests-limit: 20
+    ignore:
+      - dependency-name: prio
+        update-types:
+          - version-update:semver-minor
     groups:
       serde:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,11 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "main"
+    groups:
+      docker:
+        patterns:
+          - docker/*
+          - crazymax/ghaction-github-runtime
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
@@ -93,6 +98,11 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "release/0.subscriber-01"
+    groups:
+      docker:
+        patterns:
+          - docker/*
+          - crazymax/ghaction-github-runtime
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
@@ -143,6 +153,11 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "release/0.5"
+    groups:
+      docker:
+        patterns:
+          - docker/*
+          - crazymax/ghaction-github-runtime
   - package-ecosystem: "docker"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,8 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "main"
+    ignore:
+      - dependency-name: "postgres"
 
   # Manage dependencies on the `release/0.subscriber-01` branch
   - package-ecosystem: "cargo"
@@ -96,6 +98,8 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "release/0.subscriber-01"
+    ignore:
+      - dependency-name: "postgres"
 
   # Manage dependencies on the `release/0.5` branch
   - package-ecosystem: "cargo"
@@ -144,3 +148,5 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "release/0.5"
+    ignore:
+      - dependency-name: "postgres"


### PR DESCRIPTION
This makes three changes to our Dependabot configuration:

- Ignore all updates to the library "postgres" container image. Putting this in the configuration will avoid some back-and-forth with each new release branch.
- Group all GHA reusable actions related to Docker together.
- Ignore all semver-minor updates to libprio-rs. Since these are often wire-breaking changes, these tend to be just noise. We can handle updates in other cases manually.