### PR TITLE
break up `janus_core::task`

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -39,10 +39,11 @@ use janus_aggregator_core::{
 #[cfg(feature = "test-util")]
 use janus_core::test_util::dummy_vdaf;
 use janus_core::{
+    auth_tokens::AuthenticationToken,
     hpke::{self, HpkeApplicationInfo, HpkeKeypair, Label},
     http::response_to_problem_details,
-    task::{AuthenticationToken, VdafInstance, VERIFY_KEY_LENGTH},
     time::{Clock, DurationExt, IntervalExt, TimeExt},
+    vdaf::{VdafInstance, VERIFY_KEY_LENGTH},
 };
 use janus_messages::{
     problem_type::DapProblemType,
@@ -1075,7 +1076,7 @@ macro_rules! vdaf_ops_dispatch {
                 let $vdaf = vdaf;
                 let $verify_key = verify_key;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Count;
-                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 $body
             }
 
@@ -1083,7 +1084,7 @@ macro_rules! vdaf_ops_dispatch {
                 let $vdaf = vdaf;
                 let $verify_key = verify_key;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3SumVecMultithreaded;
-                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 $body
             }
 
@@ -1091,7 +1092,7 @@ macro_rules! vdaf_ops_dispatch {
                 let $vdaf = vdaf;
                 let $verify_key = verify_key;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Sum;
-                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 $body
             }
 
@@ -1099,7 +1100,7 @@ macro_rules! vdaf_ops_dispatch {
                 let $vdaf = vdaf;
                 let $verify_key = verify_key;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3SumVecMultithreaded;
-                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 $body
             }
 
@@ -1107,7 +1108,7 @@ macro_rules! vdaf_ops_dispatch {
                 let $vdaf = vdaf;
                 let $verify_key = verify_key;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Histogram;
-                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 $body
             }
 
@@ -1117,7 +1118,7 @@ macro_rules! vdaf_ops_dispatch {
                 let $verify_key = verify_key;
                 type $Vdaf =
                     ::prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>>;
-                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 $body
             }
 
@@ -1127,7 +1128,7 @@ macro_rules! vdaf_ops_dispatch {
                 let $verify_key = verify_key;
                 type $Vdaf =
                     ::prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>>;
-                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 $body
             }
 
@@ -1137,7 +1138,7 @@ macro_rules! vdaf_ops_dispatch {
                 let $verify_key = verify_key;
                 type $Vdaf =
                     ::prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>>;
-                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 $body
             }
 
@@ -1145,7 +1146,7 @@ macro_rules! vdaf_ops_dispatch {
                 let $vdaf = vdaf;
                 let $verify_key = verify_key;
                 type $Vdaf = ::prio::vdaf::poplar1::Poplar1<::prio::vdaf::xof::XofShake128, 16>;
-                const $VERIFY_KEY_LENGTH: usize = ::janus_core::task::VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LENGTH: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 $body
             }
 
@@ -3132,9 +3133,9 @@ mod tests {
             self, test_util::generate_test_hpke_config_and_private_key_with_id,
             HpkeApplicationInfo, HpkeKeypair, Label,
         },
-        task::{VdafInstance, VERIFY_KEY_LENGTH},
         test_util::install_test_trace_subscriber,
         time::{Clock, MockClock, TimeExt},
+        vdaf::{VdafInstance, VERIFY_KEY_LENGTH},
     };
     use janus_messages::{
         query_type::TimeInterval, Duration, Extension, HpkeCiphertext, HpkeConfig, HpkeConfigId,

--- a/aggregator/src/aggregator/aggregate_init_tests.rs
+++ b/aggregator/src/aggregator/aggregate_init_tests.rs
@@ -17,9 +17,10 @@ use janus_aggregator_core::{
     test_util::noop_meter,
 };
 use janus_core::{
-    task::{AuthenticationToken, VdafInstance, DAP_AUTH_HEADER},
+    auth_tokens::{AuthenticationToken, DAP_AUTH_HEADER},
     test_util::{dummy_vdaf, install_test_trace_subscriber, run_vdaf, VdafTranscript},
     time::{Clock, MockClock, TimeExt as _},
+    vdaf::VdafInstance,
 };
 use janus_messages::{
     query_type::TimeInterval, AggregationJobId, AggregationJobInitializeReq, AggregationJobResp,

--- a/aggregator/src/aggregator/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/aggregation_job_continue.rs
@@ -397,9 +397,9 @@ mod tests {
         test_util::noop_meter,
     };
     use janus_core::{
-        task::{VdafInstance, VERIFY_KEY_LENGTH},
         test_util::install_test_trace_subscriber,
         time::{IntervalExt, MockClock},
+        vdaf::{VdafInstance, VERIFY_KEY_LENGTH},
     };
     use janus_messages::{
         query_type::TimeInterval, AggregationJobContinueReq, AggregationJobId, AggregationJobResp,

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -12,8 +12,8 @@ use janus_aggregator_core::{
     task::{self, Task},
 };
 use janus_core::{
-    task::{VdafInstance, VERIFY_KEY_LENGTH},
     time::{Clock, DurationExt as _, TimeExt as _},
+    vdaf::{VdafInstance, VERIFY_KEY_LENGTH},
 };
 use janus_messages::{
     query_type::{FixedSize, TimeInterval},
@@ -706,9 +706,9 @@ mod tests {
         test_util::noop_meter,
     };
     use janus_core::{
-        task::{VdafInstance, VERIFY_KEY_LENGTH},
         test_util::{dummy_vdaf, install_test_trace_subscriber},
         time::{Clock, DurationExt, IntervalExt, MockClock, TimeExt},
+        vdaf::{VdafInstance, VERIFY_KEY_LENGTH},
     };
     use janus_messages::{
         codec::ParameterizedDecode,

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -931,9 +931,9 @@ mod tests {
             self, test_util::generate_test_hpke_config_and_private_key, HpkeApplicationInfo, Label,
         },
         report_id::ReportIdChecksumExt,
-        task::{VdafInstance, VERIFY_KEY_LENGTH},
         test_util::{install_test_trace_subscriber, run_vdaf, runtime::TestRuntimeManager},
         time::{Clock, IntervalExt, MockClock, TimeExt},
+        vdaf::{VdafInstance, VERIFY_KEY_LENGTH},
         Runtime,
     };
     use janus_messages::{

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -545,13 +545,13 @@ mod tests {
         test_util::noop_meter,
     };
     use janus_core::{
-        task::VdafInstance,
         test_util::{
             dummy_vdaf::{self, AggregationParam},
             install_test_trace_subscriber,
             runtime::TestRuntimeManager,
         },
         time::{Clock, IntervalExt, MockClock, TimeExt},
+        vdaf::VdafInstance,
         Runtime,
     };
     use janus_messages::{

--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -20,16 +20,17 @@ use janus_aggregator_core::{
     test_util::noop_meter,
 };
 use janus_core::{
+    auth_tokens::AuthenticationToken,
     hpke::{
         self, test_util::generate_test_hpke_config_and_private_key, HpkeApplicationInfo,
         HpkeKeypair, Label,
     },
-    task::{AuthenticationToken, VdafInstance},
     test_util::{
         dummy_vdaf::{self, AggregationParam},
         install_test_trace_subscriber,
     },
     time::{Clock, IntervalExt, MockClock},
+    vdaf::VdafInstance,
 };
 use janus_messages::{
     query_type::{FixedSize, QueryType as QueryTypeTrait, TimeInterval},

--- a/aggregator/src/aggregator/garbage_collector.rs
+++ b/aggregator/src/aggregator/garbage_collector.rs
@@ -90,12 +90,12 @@ mod tests {
         task::{self, test_util::TaskBuilder},
     };
     use janus_core::{
-        task::VdafInstance,
         test_util::{
             dummy_vdaf::{self, AggregateShare, AggregationParam},
             install_test_trace_subscriber,
         },
         time::{Clock, IntervalExt, MockClock, TimeExt},
+        vdaf::VdafInstance,
     };
     use janus_messages::{
         query_type::{FixedSize, TimeInterval},

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -4,8 +4,8 @@ use async_trait::async_trait;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use janus_aggregator_core::{datastore::Datastore, instrumented};
 use janus_core::{
+    auth_tokens::{AuthenticationToken, DAP_AUTH_HEADER},
     http::extract_bearer_token,
-    task::{AuthenticationToken, DAP_AUTH_HEADER},
     taskprov::TASKPROV_HEADER,
     time::Clock,
 };
@@ -679,6 +679,7 @@ mod tests {
         test_util::noop_meter,
     };
     use janus_core::{
+        auth_tokens::AuthenticationToken,
         hpke::{
             self,
             test_util::{
@@ -688,9 +689,9 @@ mod tests {
             HpkeApplicationInfo, HpkeKeypair, Label,
         },
         report_id::ReportIdChecksumExt,
-        task::{AuthenticationToken, VdafInstance, VERIFY_KEY_LENGTH},
         test_util::{dummy_vdaf, install_test_trace_subscriber, run_vdaf},
         time::{Clock, DurationExt, IntervalExt, MockClock, TimeExt},
+        vdaf::{VdafInstance, VERIFY_KEY_LENGTH},
     };
     use janus_messages::{
         query_type::TimeInterval, AggregateShare as AggregateShareMessage, AggregateShareAad,

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -30,10 +30,10 @@ use janus_core::{
         HpkeKeypair, Label,
     },
     report_id::ReportIdChecksumExt,
-    task::VERIFY_KEY_LENGTH,
     taskprov::TASKPROV_HEADER,
     test_util::{install_test_trace_subscriber, run_vdaf, VdafTranscript},
     time::{Clock, DurationExt, MockClock, TimeExt},
+    vdaf::VERIFY_KEY_LENGTH,
 };
 use janus_messages::{
     codec::{Decode, Encode},

--- a/aggregator/src/bin/aggregator.rs
+++ b/aggregator/src/bin/aggregator.rs
@@ -11,7 +11,7 @@ use janus_aggregator::{
 };
 use janus_aggregator_api::{self, aggregator_api_handler};
 use janus_aggregator_core::datastore::Datastore;
-use janus_core::{task::AuthenticationToken, time::RealClock};
+use janus_core::{auth_tokens::AuthenticationToken, time::RealClock};
 use serde::{de, Deserialize, Deserializer, Serialize};
 use std::{
     future::{ready, Future},

--- a/aggregator/src/bin/janus_cli.rs
+++ b/aggregator/src/bin/janus_cli.rs
@@ -467,9 +467,9 @@ mod tests {
         task::{test_util::TaskBuilder, QueryType, Task},
     };
     use janus_core::{
-        task::VdafInstance,
         test_util::{kubernetes, roundtrip_encoding},
         time::RealClock,
+        vdaf::VdafInstance,
     };
     use janus_messages::{Role, TaskId};
     use ring::aead::{UnboundKey, AES_128_GCM};

--- a/aggregator/src/binary_utils/job_driver.rs
+++ b/aggregator/src/binary_utils/job_driver.rs
@@ -300,9 +300,9 @@ mod tests {
         test_util::noop_meter,
     };
     use janus_core::{
-        task::VdafInstance,
         test_util::{install_test_trace_subscriber, runtime::TestRuntimeManager},
         time::MockClock,
+        vdaf::VdafInstance,
         Runtime,
     };
     use janus_messages::{AggregationJobId, TaskId};

--- a/aggregator/tests/graceful_shutdown.rs
+++ b/aggregator/tests/graceful_shutdown.rs
@@ -8,7 +8,7 @@ use janus_aggregator_core::{
     datastore::test_util::ephemeral_datastore,
     task::{test_util::TaskBuilder, QueryType},
 };
-use janus_core::{task::VdafInstance, test_util::install_test_trace_subscriber, time::RealClock};
+use janus_core::{test_util::install_test_trace_subscriber, time::RealClock, vdaf::VdafInstance};
 use janus_messages::Role;
 use reqwest::Url;
 use serde_yaml::{Mapping, Value};

--- a/aggregator_api/src/lib.rs
+++ b/aggregator_api/src/lib.rs
@@ -9,7 +9,7 @@ use janus_aggregator_core::{
     datastore::{self, Datastore},
     instrumented,
 };
-use janus_core::{hpke, http::extract_bearer_token, task::AuthenticationToken, time::Clock};
+use janus_core::{auth_tokens::AuthenticationToken, hpke, http::extract_bearer_token, time::Clock};
 use janus_messages::{HpkeConfigId, RoleParseError, TaskId};
 use routes::*;
 use std::{str::FromStr, sync::Arc};

--- a/aggregator_api/src/models.rs
+++ b/aggregator_api/src/models.rs
@@ -4,7 +4,7 @@ use janus_aggregator_core::{
     task::{QueryType, Task},
     taskprov::{PeerAggregator, VerifyKeyInit},
 };
-use janus_core::task::{AuthenticationToken, VdafInstance};
+use janus_core::{auth_tokens::AuthenticationToken, vdaf::VdafInstance};
 use janus_messages::{
     query_type::Code as SupportedQueryType, Duration, HpkeAeadId, HpkeConfig, HpkeKdfId, HpkeKemId,
     Role, TaskId, Time,

--- a/aggregator_api/src/tests.rs
+++ b/aggregator_api/src/tests.rs
@@ -23,6 +23,7 @@ use janus_aggregator_core::{
     SecretBytes,
 };
 use janus_core::{
+    auth_tokens::AuthenticationToken,
     hpke::{
         generate_hpke_config_and_private_key,
         test_util::{
@@ -31,12 +32,12 @@ use janus_core::{
         },
         HpkeKeypair, HpkePrivateKey,
     },
-    task::{AuthenticationToken, VdafInstance},
     test_util::{
         dummy_vdaf::{self, AggregationParam},
         install_test_trace_subscriber,
     },
     time::MockClock,
+    vdaf::VdafInstance,
 };
 use janus_messages::{
     query_type::TimeInterval, AggregationJobStep, Duration, HpkeAeadId, HpkeConfig, HpkeConfigId,

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -16,9 +16,10 @@ use crate::{
 use chrono::NaiveDateTime;
 use futures::future::try_join_all;
 use janus_core::{
+    auth_tokens::AuthenticationToken,
     hpke::{HpkeKeypair, HpkePrivateKey},
-    task::{AuthenticationToken, VdafInstance},
     time::{Clock, TimeExt},
+    vdaf::VdafInstance,
 };
 use janus_messages::{
     query_type::{FixedSize, QueryType, TimeInterval},

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -5,10 +5,11 @@ use base64::{display::Base64Display, engine::general_purpose::URL_SAFE_NO_PAD};
 use chrono::NaiveDateTime;
 use derivative::Derivative;
 use janus_core::{
+    auth_tokens::AuthenticationToken,
     hpke::HpkeKeypair,
     report_id::ReportIdChecksumExt,
-    task::{AuthenticationToken, VdafInstance},
     time::{DurationExt, IntervalExt, TimeExt},
+    vdaf::VdafInstance,
 };
 use janus_messages::{
     query_type::{FixedSize, QueryType, TimeInterval},

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -23,12 +23,12 @@ use janus_core::{
     hpke::{
         self, test_util::generate_test_hpke_config_and_private_key, HpkeApplicationInfo, Label,
     },
-    task::{VdafInstance, VERIFY_KEY_LENGTH},
     test_util::{
         dummy_vdaf::{self, AggregateShare, AggregationParam},
         install_test_trace_subscriber, run_vdaf,
     },
     time::{Clock, DurationExt, IntervalExt, MockClock, TimeExt},
+    vdaf::{VdafInstance, VERIFY_KEY_LENGTH},
 };
 use janus_messages::{
     query_type::{FixedSize, QueryType, TimeInterval},

--- a/aggregator_core/src/query_type.rs
+++ b/aggregator_core/src/query_type.rs
@@ -475,7 +475,7 @@ mod tests {
         query_type::CollectableQueryType,
         task::{test_util::TaskBuilder, QueryType},
     };
-    use janus_core::task::VdafInstance;
+    use janus_core::vdaf::VdafInstance;
     use janus_messages::{query_type::TimeInterval, Duration, Interval, Role, Time};
 
     #[test]

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -4,9 +4,11 @@ use crate::SecretBytes;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use derivative::Derivative;
 use janus_core::{
+    auth_tokens::AuthenticationToken,
     hpke::{generate_hpke_config_and_private_key, HpkeKeypair},
-    task::{url_ensure_trailing_slash, AuthenticationToken, VdafInstance},
     time::TimeExt,
+    url_ensure_trailing_slash,
+    vdaf::VdafInstance,
 };
 use janus_messages::{
     taskprov, AggregationJobId, CollectionJobId, Duration, HpkeAeadId, HpkeConfig, HpkeConfigId,
@@ -626,9 +628,10 @@ pub mod test_util {
         SecretBytes,
     };
     use janus_core::{
+        auth_tokens::AuthenticationToken,
         hpke::{test_util::generate_test_hpke_config_and_private_key, HpkeKeypair},
-        task::{AuthenticationToken, VdafInstance, VERIFY_KEY_LENGTH},
         time::DurationExt,
+        vdaf::{VdafInstance, VERIFY_KEY_LENGTH},
     };
     use janus_messages::{Duration, HpkeConfig, HpkeConfigId, Role, TaskId, Time};
     use rand::{distributions::Standard, random, thread_rng, Rng};
@@ -874,10 +877,11 @@ mod tests {
     };
     use assert_matches::assert_matches;
     use janus_core::{
+        auth_tokens::AuthenticationToken,
         hpke::{test_util::generate_test_hpke_config_and_private_key, HpkeKeypair, HpkePrivateKey},
-        task::{AuthenticationToken, VERIFY_KEY_LENGTH},
         test_util::roundtrip_encoding,
         time::DurationExt,
+        vdaf::VERIFY_KEY_LENGTH,
     };
     use janus_messages::{
         Duration, HpkeAeadId, HpkeConfig, HpkeConfigId, HpkeKdfId, HpkeKemId, HpkePublicKey, Role,

--- a/aggregator_core/src/taskprov.rs
+++ b/aggregator_core/src/taskprov.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use derivative::Derivative;
-use janus_core::task::{AuthenticationToken, VdafInstance};
+use janus_core::{auth_tokens::AuthenticationToken, vdaf::VdafInstance};
 use janus_messages::{Duration, HpkeConfig, Role, TaskId, Time};
 use rand::{distributions::Standard, prelude::Distribution};
 use ring::hkdf::{KeyType, Salt, HKDF_SHA256};
@@ -341,7 +341,8 @@ impl From<Task> for task::Task {
 #[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
 pub mod test_util {
     use janus_core::{
-        hpke::test_util::generate_test_hpke_config_and_private_key, task::AuthenticationToken,
+        auth_tokens::AuthenticationToken,
+        hpke::test_util::generate_test_hpke_config_and_private_key,
     };
     use janus_messages::{Duration, HpkeConfig, Role};
     use rand::random;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -9,8 +9,8 @@ use janus_core::{
     hpke::{self, HpkeApplicationInfo, Label},
     http::response_to_problem_details,
     retries::{http_request_exponential_backoff, retry_http_request},
-    task::url_ensure_trailing_slash,
     time::{Clock, TimeExt},
+    url_ensure_trailing_slash,
 };
 use janus_messages::{
     Duration, HpkeConfig, HpkeConfigList, InputShareAad, PlaintextInputShare, Report, ReportId,

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -57,13 +57,13 @@ use backoff::{backoff::Backoff, ExponentialBackoff};
 use chrono::{DateTime, Duration, TimeZone, Utc};
 use derivative::Derivative;
 use http_api_problem::HttpApiProblem;
-pub use janus_core::task::AuthenticationToken;
+pub use janus_core::auth_tokens::AuthenticationToken;
 use janus_core::{
     hpke::{self, HpkeApplicationInfo, HpkePrivateKey},
     http::response_to_problem_details,
     retries::{http_request_exponential_backoff, retry_http_request},
-    task::url_ensure_trailing_slash,
     time::{DurationExt, TimeExt},
+    url_ensure_trailing_slash,
 };
 use janus_messages::{
     problem_type::DapProblemType,
@@ -637,11 +637,11 @@ mod tests {
     #[cfg(feature = "fpvec_bounded_l2")]
     use fixed_macro::fixed;
     use janus_core::{
+        auth_tokens::AuthenticationToken,
         hpke::{
             self, test_util::generate_test_hpke_config_and_private_key, HpkeApplicationInfo, Label,
         },
         retries::test_http_request_exponential_backoff,
-        task::AuthenticationToken,
         test_util::{install_test_trace_subscriber, run_vdaf, VdafTranscript},
     };
     use janus_messages::{

--- a/core/src/auth_tokens.rs
+++ b/core/src/auth_tokens.rs
@@ -1,0 +1,333 @@
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use derivative::Derivative;
+use http::{header::AUTHORIZATION, HeaderValue};
+use rand::{distributions::Standard, prelude::Distribution};
+use ring::constant_time;
+use serde::{de::Error, Deserialize, Deserializer, Serialize};
+use std::str;
+
+/// HTTP header where auth tokens are provided in messages between participants.
+pub const DAP_AUTH_HEADER: &str = "DAP-Auth-Token";
+
+/// Different modes of authentication supported by Janus for either sending requests (e.g., leader
+/// to helper) or receiving them (e.g., collector to leader).
+#[derive(Clone, Derivative, Serialize, Deserialize, PartialEq, Eq)]
+#[derivative(Debug)]
+#[serde(tag = "type", content = "token")]
+#[non_exhaustive]
+pub enum AuthenticationToken {
+    /// A bearer token, presented as the value of the "Authorization" HTTP header as specified in
+    /// [RFC 6750 section 2.1][1].
+    ///
+    /// The token is not necessarily an OAuth token.
+    ///
+    /// [1]: https://datatracker.ietf.org/doc/html/rfc6750#section-2.1
+    Bearer(BearerToken),
+
+    /// Token presented as the value of the "DAP-Auth-Token" HTTP header. Conforms to
+    /// [draft-dcook-ppm-dap-interop-test-design-03][1], sections [4.3.3][2] and [4.4.2][3], and
+    /// [draft-ietf-dap-ppm-01 section 3.2][4].
+    ///
+    /// [1]: https://datatracker.ietf.org/doc/html/draft-dcook-ppm-dap-interop-test-design-03
+    /// [2]: https://datatracker.ietf.org/doc/html/draft-dcook-ppm-dap-interop-test-design-03#section-4.3.3
+    /// [3]: https://datatracker.ietf.org/doc/html/draft-dcook-ppm-dap-interop-test-design-03#section-4.4.2
+    /// [4]: https://datatracker.ietf.org/doc/html/draft-ietf-ppm-dap-01#name-https-sender-authentication
+    DapAuth(DapAuthToken),
+}
+
+impl AuthenticationToken {
+    /// Attempts to create a new bearer token from the provided bytes.
+    pub fn new_bearer_token_from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, anyhow::Error> {
+        BearerToken::try_from(bytes.as_ref().to_vec()).map(AuthenticationToken::Bearer)
+    }
+
+    /// Attempts to create a new bearer token from the provided string
+    pub fn new_bearer_token_from_string<T: Into<String>>(string: T) -> Result<Self, anyhow::Error> {
+        BearerToken::try_from(string.into()).map(AuthenticationToken::Bearer)
+    }
+
+    /// Attempts to create a new DAP auth token from the provided bytes.
+    pub fn new_dap_auth_token_from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, anyhow::Error> {
+        DapAuthToken::try_from(bytes.as_ref().to_vec()).map(AuthenticationToken::DapAuth)
+    }
+
+    /// Attempts to create a new DAP auth token from the provided string.
+    pub fn new_dap_auth_token_from_string<T: Into<String>>(
+        string: T,
+    ) -> Result<Self, anyhow::Error> {
+        DapAuthToken::try_from(string.into()).map(AuthenticationToken::DapAuth)
+    }
+
+    /// Returns an HTTP header and value that should be used to authenticate an HTTP request with
+    /// this credential.
+    pub fn request_authentication(&self) -> (&'static str, String) {
+        match self {
+            Self::Bearer(token) => (AUTHORIZATION.as_str(), format!("Bearer {}", token.as_str())),
+            // Cloning is unfortunate but necessary since other arms must allocate.
+            Self::DapAuth(token) => (DAP_AUTH_HEADER, token.as_str().to_string()),
+        }
+    }
+
+    /// Returns the token as a string.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::DapAuth(token) => token.as_str(),
+            Self::Bearer(token) => token.as_str(),
+        }
+    }
+}
+
+impl AsRef<[u8]> for AuthenticationToken {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            Self::DapAuth(token) => token.as_ref(),
+            Self::Bearer(token) => token.as_ref(),
+        }
+    }
+}
+
+impl Distribution<AuthenticationToken> for Standard {
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> AuthenticationToken {
+        AuthenticationToken::Bearer(Standard::sample(self, rng))
+    }
+}
+
+/// A token value used to authenticate HTTP requests. This token is used in the "DAP-Auth-Token"
+/// HTTP request header.
+///
+/// This token is used directly in HTTP request headers without further encoding and so must be a
+/// legal HTTP header value. The literal value is the canonical form of the token and is used
+/// directly, without any additional encoding or decoding, in configuration files, Janus aggregator
+/// API requests, and HTTP authentication headers.
+///
+/// This opaque type ensures it's impossible to construct an [`AuthenticationToken`] whose contents
+/// are invalid.
+#[derive(Clone, Derivative, Serialize)]
+#[derivative(Debug)]
+#[serde(transparent)]
+pub struct DapAuthToken(#[derivative(Debug = "ignore")] String);
+
+impl DapAuthToken {
+    /// Returns the token as a string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Validate that a DAP-Auth-Token value is a valid HTTP header value.
+    fn validate(value: &str) -> Result<(), anyhow::Error> {
+        HeaderValue::try_from(value)?;
+        Ok(())
+    }
+}
+
+impl AsRef<str> for DapAuthToken {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<[u8]> for DapAuthToken {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+impl TryFrom<String> for DapAuthToken {
+    type Error = anyhow::Error;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::validate(&value)?;
+        Ok(Self(value))
+    }
+}
+
+impl TryFrom<Vec<u8>> for DapAuthToken {
+    type Error = anyhow::Error;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        Self::try_from(String::from_utf8(value)?)
+    }
+}
+
+impl<'de> Deserialize<'de> for DapAuthToken {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        String::deserialize(deserializer)
+            .and_then(|string| Self::try_from(string).map_err(D::Error::custom))
+    }
+}
+
+impl PartialEq for DapAuthToken {
+    fn eq(&self, other: &Self) -> bool {
+        // We attempt constant-time comparisons of the token data to mitigate timing attacks. Note
+        // that this function still leaks whether the lengths of the tokens are equal -- this is
+        // acceptable because we expect the content of the tokens to provide enough randomness that
+        // needs to be guessed even if the length is known.
+        constant_time::verify_slices_are_equal(self.0.as_ref(), other.0.as_ref()).is_ok()
+    }
+}
+
+impl Eq for DapAuthToken {}
+
+impl Distribution<DapAuthToken> for Standard {
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> DapAuthToken {
+        DapAuthToken(URL_SAFE_NO_PAD.encode(rng.gen::<[u8; 16]>()))
+    }
+}
+
+/// A token value used to authenticate HTTP requests. This token is used in "Authorization: Bearer"
+/// HTTP request headers.
+///
+/// Token values must follow the syntax in
+/// <https://datatracker.ietf.org/doc/html/rfc6750#section-2.1>. Its literal value is the canonical
+/// form of the token and is used directly, without any additional encoding or decoding, in
+/// configuration files, Janus aggregator API requests, and HTTP authentication headers.
+///
+/// This opaque type ensures it's impossible to construct an [`AuthenticationToken`] whose contents
+/// are invalid.
+#[derive(Clone, Derivative, Serialize)]
+#[derivative(Debug)]
+#[serde(transparent)]
+pub struct BearerToken(#[derivative(Debug = "ignore")] String);
+
+impl BearerToken {
+    /// Returns the token as a string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Validate that a bearer token value matches the format in
+    /// https://datatracker.ietf.org/doc/html/rfc6750#section-2.1.
+    fn validate(value: &str) -> Result<(), anyhow::Error> {
+        let mut iter = value.chars();
+        let mut any_non_equals = false;
+        // First loop: consume "normal" characters, stop when we see an equals sign for padding or
+        // reach the end of the input.
+        for c in &mut iter {
+            match c {
+                'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '.' | '_' | '~' | '+' | '/' => {
+                    any_non_equals = true;
+                }
+                '=' => {
+                    if !any_non_equals {
+                        return Err(anyhow::anyhow!("bearer token may not start with '='"));
+                    }
+                    break;
+                }
+                _ => return Err(anyhow::anyhow!("bearer token may not contain '{c}'")),
+            }
+        }
+        // Second loop: consume any further padding characters, if present.
+        for c in &mut iter {
+            match c {
+                '=' => {}
+                _ => {
+                    return Err(anyhow::anyhow!(
+                        "bearer token may only contain '=' at the end"
+                    ))
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl AsRef<str> for BearerToken {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<[u8]> for BearerToken {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+impl TryFrom<String> for BearerToken {
+    type Error = anyhow::Error;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::validate(&value)?;
+        Ok(Self(value))
+    }
+}
+
+impl TryFrom<Vec<u8>> for BearerToken {
+    type Error = anyhow::Error;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        Self::try_from(String::from_utf8(value)?)
+    }
+}
+
+impl<'de> Deserialize<'de> for BearerToken {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        String::deserialize(deserializer)
+            .and_then(|string| Self::try_from(string).map_err(D::Error::custom))
+    }
+}
+
+impl PartialEq for BearerToken {
+    fn eq(&self, other: &Self) -> bool {
+        // We attempt constant-time comparisons of the token data to mitigate timing attacks. Note
+        // that this function still leaks whether the lengths of the tokens are equal -- this is
+        // acceptable because we expect the content of the tokens to provide enough randomness that
+        // needs to be guessed even if the length is known.
+        constant_time::verify_slices_are_equal(self.0.as_bytes(), other.0.as_bytes()).is_ok()
+    }
+}
+
+impl Eq for BearerToken {}
+
+impl Distribution<BearerToken> for Standard {
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> BearerToken {
+        BearerToken(URL_SAFE_NO_PAD.encode(rng.gen::<[u8; 16]>()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::auth_tokens::AuthenticationToken;
+
+    #[test]
+    fn valid_dap_auth_token() {
+        serde_yaml::from_str::<AuthenticationToken>(
+            "{type: \"DapAuth\", token: \"correct-horse-battery-staple-!@#$\"}",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn valid_bearer_token() {
+        serde_yaml::from_str::<AuthenticationToken>(
+            "{type: \"Bearer\", token: \"AAAAAAA~-_/A===\"}",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn reject_invalid_auth_token_dap_auth() {
+        serde_yaml::from_str::<AuthenticationToken>("{type: \"DapAuth\", token: \"\\x0b\"}")
+            .unwrap_err();
+        serde_yaml::from_str::<AuthenticationToken>("{type: \"DapAuth\", token: \"\\x00\"}")
+            .unwrap_err();
+    }
+
+    #[test]
+    fn reject_invalid_auth_token_bearer() {
+        serde_yaml::from_str::<AuthenticationToken>("{type: \"Bearer\", token: \"é\"}")
+            .unwrap_err();
+        serde_yaml::from_str::<AuthenticationToken>("{type: \"Bearer\", token: \"^\"}")
+            .unwrap_err();
+        serde_yaml::from_str::<AuthenticationToken>("{type: \"Bearer\", token: \"=\"}")
+            .unwrap_err();
+        serde_yaml::from_str::<AuthenticationToken>("{type: \"Bearer\", token: \"AAAA==AAA\"}")
+            .unwrap_err();
+    }
+}

--- a/core/src/http.rs
+++ b/core/src/http.rs
@@ -1,4 +1,4 @@
-use crate::task::AuthenticationToken;
+use crate::auth_tokens::AuthenticationToken;
 use anyhow::{anyhow, Context};
 use http_api_problem::{HttpApiProblem, PROBLEM_JSON_MEDIA_TYPE};
 use reqwest::{header::CONTENT_TYPE, Response};

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -2,16 +2,18 @@
 
 use std::future::Future;
 use tokio::task::JoinHandle;
+use url::Url;
 
+pub mod auth_tokens;
 pub mod hpke;
 pub mod http;
 pub mod report_id;
 pub mod retries;
-pub mod task;
 #[cfg(feature = "test-util")]
 #[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
 pub mod test_util;
 pub mod time;
+pub mod vdaf;
 
 /// This trait provides a mockable facade for [`tokio::task::spawn`].
 pub trait Runtime {
@@ -38,4 +40,16 @@ impl Runtime for TokioRuntime {
 
 pub mod taskprov {
     pub const TASKPROV_HEADER: &str = "dap-taskprov";
+}
+
+/// Returns the given [`Url`], possibly modified to end with a slash.
+///
+/// Aggregator endpoint URLs should end with a slash if they will be used with [`Url::join`],
+/// because that method will drop the last path component of the base URL if it does not end with a
+/// slash.
+pub fn url_ensure_trailing_slash(mut url: Url) -> Url {
+    if !url.as_str().ends_with('/') {
+        url.set_path(&format!("{}/", url.path()));
+    }
+    url
 }

--- a/core/src/vdaf.rs
+++ b/core/src/vdaf.rs
@@ -1,15 +1,7 @@
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use derivative::Derivative;
-use http::{header::AUTHORIZATION, HeaderValue};
 use janus_messages::taskprov;
-use rand::{distributions::Standard, prelude::Distribution};
-use ring::constant_time;
-use serde::{de::Error, Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use std::str;
-use url::Url;
-
-/// HTTP header where auth tokens are provided in messages between participants.
-pub const DAP_AUTH_HEADER: &str = "DAP-Auth-Token";
 
 /// The length of the verify key parameter for Prio3 & Poplar1 VDAF instantiations.
 pub const VERIFY_KEY_LENGTH: usize = 16;
@@ -107,39 +99,39 @@ macro_rules! vdaf_dispatch_impl_base {
     // Provide the dispatched type only, don't construct a VDAF instance.
     (impl match base $vdaf_instance:expr, (_, $Vdaf:ident, $VERIFY_KEY_LEN:ident) => $body:tt) => {
         match $vdaf_instance {
-            ::janus_core::task::VdafInstance::Prio3Count => {
+            ::janus_core::vdaf::VdafInstance::Prio3Count => {
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Count;
-                const $VERIFY_KEY_LEN: usize = ::janus_core::task::VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 $body
             }
 
-            ::janus_core::task::VdafInstance::Prio3CountVec { length } => {
+            ::janus_core::vdaf::VdafInstance::Prio3CountVec { length } => {
                 type $Vdaf = ::prio::vdaf::prio3::Prio3SumVecMultithreaded;
-                const $VERIFY_KEY_LEN: usize = ::janus_core::task::VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 $body
             }
 
-            ::janus_core::task::VdafInstance::Prio3Sum { bits } => {
+            ::janus_core::vdaf::VdafInstance::Prio3Sum { bits } => {
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Sum;
-                const $VERIFY_KEY_LEN: usize = ::janus_core::task::VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 $body
             }
 
-            ::janus_core::task::VdafInstance::Prio3SumVec { bits, length } => {
+            ::janus_core::vdaf::VdafInstance::Prio3SumVec { bits, length } => {
                 type $Vdaf = ::prio::vdaf::prio3::Prio3SumVecMultithreaded;
-                const $VERIFY_KEY_LEN: usize = ::janus_core::task::VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 $body
             }
 
-            ::janus_core::task::VdafInstance::Prio3Histogram { buckets } => {
+            ::janus_core::vdaf::VdafInstance::Prio3Histogram { buckets } => {
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Histogram;
-                const $VERIFY_KEY_LEN: usize = ::janus_core::task::VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 $body
             }
 
-            ::janus_core::task::VdafInstance::Poplar1 { bits } => {
+            ::janus_core::vdaf::VdafInstance::Poplar1 { bits } => {
                 type $Vdaf = ::prio::vdaf::poplar1::Poplar1<::prio::vdaf::prg::PrgSha3, 16>;
-                const $VERIFY_KEY_LEN: usize = ::janus_core::task::VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 $body
             }
 
@@ -150,14 +142,14 @@ macro_rules! vdaf_dispatch_impl_base {
     // Construct a VDAF instance, and provide that to the block as well.
     (impl match base $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LEN:ident) => $body:tt) => {
         match $vdaf_instance {
-            ::janus_core::task::VdafInstance::Prio3Count => {
+            ::janus_core::vdaf::VdafInstance::Prio3Count => {
                 let $vdaf = ::prio::vdaf::prio3::Prio3::new_count(2)?;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Count;
-                const $VERIFY_KEY_LEN: usize = ::janus_core::task::VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 $body
             }
 
-            ::janus_core::task::VdafInstance::Prio3CountVec {
+            ::janus_core::vdaf::VdafInstance::Prio3CountVec {
                 length,
                 chunk_length,
             } => {
@@ -169,18 +161,18 @@ macro_rules! vdaf_dispatch_impl_base {
                     *chunk_length,
                 )?;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3SumVecMultithreaded;
-                const $VERIFY_KEY_LEN: usize = ::janus_core::task::VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 $body
             }
 
-            ::janus_core::task::VdafInstance::Prio3Sum { bits } => {
+            ::janus_core::vdaf::VdafInstance::Prio3Sum { bits } => {
                 let $vdaf = ::prio::vdaf::prio3::Prio3::new_sum(2, *bits)?;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Sum;
-                const $VERIFY_KEY_LEN: usize = ::janus_core::task::VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 $body
             }
 
-            ::janus_core::task::VdafInstance::Prio3SumVec {
+            ::janus_core::vdaf::VdafInstance::Prio3SumVec {
                 bits,
                 length,
                 chunk_length,
@@ -192,24 +184,24 @@ macro_rules! vdaf_dispatch_impl_base {
                     *chunk_length,
                 )?;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3SumVecMultithreaded;
-                const $VERIFY_KEY_LEN: usize = ::janus_core::task::VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 $body
             }
 
-            ::janus_core::task::VdafInstance::Prio3Histogram {
+            ::janus_core::vdaf::VdafInstance::Prio3Histogram {
                 length,
                 chunk_length,
             } => {
                 let $vdaf = ::prio::vdaf::prio3::Prio3::new_histogram(2, *length, *chunk_length)?;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Histogram;
-                const $VERIFY_KEY_LEN: usize = ::janus_core::task::VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 $body
             }
 
-            ::janus_core::task::VdafInstance::Poplar1 { bits } => {
+            ::janus_core::vdaf::VdafInstance::Poplar1 { bits } => {
                 let $vdaf = ::prio::vdaf::poplar1::Poplar1::new_shake128(*bits);
                 type $Vdaf = ::prio::vdaf::poplar1::Poplar1<::prio::vdaf::xof::XofShake128, 16>;
-                const $VERIFY_KEY_LEN: usize = ::janus_core::task::VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 $body
             }
 
@@ -225,27 +217,27 @@ macro_rules! vdaf_dispatch_impl_fpvec_bounded_l2 {
     // Provide the dispatched type only, don't construct a VDAF instance.
     (impl match fpvec_bounded_l2 $vdaf_instance:expr, (_, $Vdaf:ident, $VERIFY_KEY_LEN:ident) => $body:tt) => {
         match $vdaf_instance {
-            ::janus_core::task::VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { length } => {
+            ::janus_core::vdaf::VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { length } => {
                 type $Vdaf = ::prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded<
                     ::fixed::FixedI16<::fixed::types::extra::U15>,
                 >;
-                const $VERIFY_KEY_LEN: usize = ::janus_core::task::VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 $body
             }
 
-            ::janus_core::task::VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { length } => {
+            ::janus_core::vdaf::VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { length } => {
                 type $Vdaf = ::prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded<
                     ::fixed::FixedI32<::fixed::types::extra::U31>,
                 >;
-                const $VERIFY_KEY_LEN: usize = ::janus_core::task::VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 $body
             }
 
-            ::janus_core::task::VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { length } => {
+            ::janus_core::vdaf::VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { length } => {
                 type $Vdaf = ::prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded<
                     ::fixed::FixedI64<::fixed::types::extra::U63>,
                 >;
-                const $VERIFY_KEY_LEN: usize = ::janus_core::task::VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 $body
             }
 
@@ -256,7 +248,7 @@ macro_rules! vdaf_dispatch_impl_fpvec_bounded_l2 {
     // Construct a VDAF instance, and provide that to the block as well.
     (impl match fpvec_bounded_l2 $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LEN:ident) => $body:tt) => {
         match $vdaf_instance {
-            ::janus_core::task::VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { length } => {
+            ::janus_core::vdaf::VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { length } => {
                 let $vdaf =
                     ::prio::vdaf::prio3::Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
                         2, *length,
@@ -264,11 +256,11 @@ macro_rules! vdaf_dispatch_impl_fpvec_bounded_l2 {
                 type $Vdaf = ::prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded<
                     ::fixed::FixedI16<::fixed::types::extra::U15>,
                 >;
-                const $VERIFY_KEY_LEN: usize = ::janus_core::task::VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 $body
             }
 
-            ::janus_core::task::VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { length } => {
+            ::janus_core::vdaf::VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { length } => {
                 let $vdaf =
                     ::prio::vdaf::prio3::Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
                         2, *length,
@@ -276,11 +268,11 @@ macro_rules! vdaf_dispatch_impl_fpvec_bounded_l2 {
                 type $Vdaf = ::prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded<
                     ::fixed::FixedI32<::fixed::types::extra::U31>,
                 >;
-                const $VERIFY_KEY_LEN: usize = ::janus_core::task::VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 $body
             }
 
-            ::janus_core::task::VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { length } => {
+            ::janus_core::vdaf::VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { length } => {
                 let $vdaf =
                     ::prio::vdaf::prio3::Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
                         2, *length,
@@ -288,7 +280,7 @@ macro_rules! vdaf_dispatch_impl_fpvec_bounded_l2 {
                 type $Vdaf = ::prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded<
                     ::fixed::FixedI64<::fixed::types::extra::U63>,
                 >;
-                const $VERIFY_KEY_LEN: usize = ::janus_core::task::VERIFY_KEY_LENGTH;
+                const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 $body
             }
 
@@ -304,19 +296,19 @@ macro_rules! vdaf_dispatch_impl_test_util {
     // Provide the dispatched type only, don't construct a VDAF instance.
     (impl match test_util $vdaf_instance:expr, (_, $Vdaf:ident, $VERIFY_KEY_LEN:ident) => $body:tt) => {
         match $vdaf_instance {
-            ::janus_core::task::VdafInstance::Fake => {
+            ::janus_core::vdaf::VdafInstance::Fake => {
                 type $Vdaf = ::janus_core::test_util::dummy_vdaf::Vdaf;
                 const $VERIFY_KEY_LEN: usize = 0;
                 $body
             }
 
-            ::janus_core::task::VdafInstance::FakeFailsPrepInit => {
+            ::janus_core::vdaf::VdafInstance::FakeFailsPrepInit => {
                 type $Vdaf = ::janus_core::test_util::dummy_vdaf::Vdaf;
                 const $VERIFY_KEY_LEN: usize = 0;
                 $body
             }
 
-            ::janus_core::task::VdafInstance::FakeFailsPrepStep => {
+            ::janus_core::vdaf::VdafInstance::FakeFailsPrepStep => {
                 type $Vdaf = ::janus_core::test_util::dummy_vdaf::Vdaf;
                 const $VERIFY_KEY_LEN: usize = 0;
                 $body
@@ -329,14 +321,14 @@ macro_rules! vdaf_dispatch_impl_test_util {
     // Construct a VDAF instance, and provide that to the block as well.
     (impl match test_util $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LEN:ident) => $body:tt) => {
         match $vdaf_instance {
-            ::janus_core::task::VdafInstance::Fake => {
+            ::janus_core::vdaf::VdafInstance::Fake => {
                 let $vdaf = ::janus_core::test_util::dummy_vdaf::Vdaf::new();
                 type $Vdaf = ::janus_core::test_util::dummy_vdaf::Vdaf;
                 const $VERIFY_KEY_LEN: usize = 0;
                 $body
             }
 
-            ::janus_core::task::VdafInstance::FakeFailsPrepInit => {
+            ::janus_core::vdaf::VdafInstance::FakeFailsPrepInit => {
                 let $vdaf = ::janus_core::test_util::dummy_vdaf::Vdaf::new().with_prep_init_fn(
                     |_| -> Result<(), ::prio::vdaf::VdafError> {
                         ::std::result::Result::Err(::prio::vdaf::VdafError::Uncategorized(
@@ -349,7 +341,7 @@ macro_rules! vdaf_dispatch_impl_test_util {
                 $body
             }
 
-            ::janus_core::task::VdafInstance::FakeFailsPrepStep => {
+            ::janus_core::vdaf::VdafInstance::FakeFailsPrepStep => {
                 let $vdaf = ::janus_core::test_util::dummy_vdaf::Vdaf::new().with_prep_step_fn(
                             || -> Result<
                                 ::prio::vdaf::PrepareTransition<
@@ -381,24 +373,24 @@ macro_rules! vdaf_dispatch_impl {
     // Provide the dispatched type only, don't construct a VDAF instance.
     (impl match all $vdaf_instance:expr, (_, $Vdaf:ident, $VERIFY_KEY_LEN:ident) => $body:tt) => {
         match $vdaf_instance {
-            ::janus_core::task::VdafInstance::Prio3Count
-            | ::janus_core::task::VdafInstance::Prio3CountVec { .. }
-            | ::janus_core::task::VdafInstance::Prio3Sum { .. }
-            | ::janus_core::task::VdafInstance::Prio3SumVec { .. }
-            | ::janus_core::task::VdafInstance::Prio3Histogram { .. }
-            | ::janus_core::task::VdafInstance::Poplar1 { .. } => {
+            ::janus_core::vdaf::VdafInstance::Prio3Count
+            | ::janus_core::vdaf::VdafInstance::Prio3CountVec { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3Sum { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3SumVec { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3Histogram { .. }
+            | ::janus_core::vdaf::VdafInstance::Poplar1 { .. } => {
                 ::janus_core::vdaf_dispatch_impl_base!(impl match base $vdaf_instance, (_, $Vdaf, $VERIFY_KEY_LEN) => $body)
             }
 
-            ::janus_core::task::VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { .. }
-            | ::janus_core::task::VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { .. }
-            | ::janus_core::task::VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { .. } => {
+            ::janus_core::vdaf::VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { .. } => {
                 ::janus_core::vdaf_dispatch_impl_fpvec_bounded_l2!(impl match fpvec_bounded_l2 $vdaf_instance, (_, $Vdaf, $VERIFY_KEY_LEN) => $body)
             }
 
-            ::janus_core::task::VdafInstance::Fake
-            | ::janus_core::task::VdafInstance::FakeFailsPrepInit
-            | ::janus_core::task::VdafInstance::FakeFailsPrepStep => {
+            ::janus_core::vdaf::VdafInstance::Fake
+            | ::janus_core::vdaf::VdafInstance::FakeFailsPrepInit
+            | ::janus_core::vdaf::VdafInstance::FakeFailsPrepStep => {
                 ::janus_core::vdaf_dispatch_impl_test_util!(impl match test_util $vdaf_instance, (_, $Vdaf, $VERIFY_KEY_LEN) => $body)
             }
 
@@ -409,24 +401,24 @@ macro_rules! vdaf_dispatch_impl {
     // Construct a VDAF instance, and provide that to the block as well.
     (impl match all $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LEN:ident) => $body:tt) => {
         match $vdaf_instance {
-            ::janus_core::task::VdafInstance::Prio3Count
-            | ::janus_core::task::VdafInstance::Prio3CountVec { .. }
-            | ::janus_core::task::VdafInstance::Prio3Sum { .. }
-            | ::janus_core::task::VdafInstance::Prio3SumVec { .. }
-            | ::janus_core::task::VdafInstance::Prio3Histogram { .. }
-            | ::janus_core::task::VdafInstance::Poplar1 { .. } => {
+            ::janus_core::vdaf::VdafInstance::Prio3Count
+            | ::janus_core::vdaf::VdafInstance::Prio3CountVec { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3Sum { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3SumVec { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3Histogram { .. }
+            | ::janus_core::vdaf::VdafInstance::Poplar1 { .. } => {
                 ::janus_core::vdaf_dispatch_impl_base!(impl match base $vdaf_instance, ($vdaf, $Vdaf, $VERIFY_KEY_LEN) => $body)
             }
 
-            ::janus_core::task::VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { .. }
-            | ::janus_core::task::VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { .. }
-            | ::janus_core::task::VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { .. } => {
+            ::janus_core::vdaf::VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { .. } => {
                 ::janus_core::vdaf_dispatch_impl_fpvec_bounded_l2!(impl match fpvec_bounded_l2 $vdaf_instance, ($vdaf, $Vdaf, $VERIFY_KEY_LEN) => $body)
             }
 
-            ::janus_core::task::VdafInstance::Fake
-            | ::janus_core::task::VdafInstance::FakeFailsPrepInit
-            | ::janus_core::task::VdafInstance::FakeFailsPrepStep => {
+            ::janus_core::vdaf::VdafInstance::Fake
+            | ::janus_core::vdaf::VdafInstance::FakeFailsPrepInit
+            | ::janus_core::vdaf::VdafInstance::FakeFailsPrepStep => {
                 ::janus_core::vdaf_dispatch_impl_test_util!(impl match test_util $vdaf_instance, ($vdaf, $Vdaf, $VERIFY_KEY_LEN) => $body)
             }
 
@@ -442,18 +434,18 @@ macro_rules! vdaf_dispatch_impl {
     // Provide the dispatched type only, don't construct a VDAF instance.
     (impl match all $vdaf_instance:expr, (_, $Vdaf:ident, $VERIFY_KEY_LEN:ident) => $body:tt) => {
         match $vdaf_instance {
-            ::janus_core::task::VdafInstance::Prio3Count
-            | ::janus_core::task::VdafInstance::Prio3CountVec { .. }
-            | ::janus_core::task::VdafInstance::Prio3Sum { .. }
-            | ::janus_core::task::VdafInstance::Prio3SumVec { .. }
-            | ::janus_core::task::VdafInstance::Prio3Histogram { .. }
-            | ::janus_core::task::VdafInstance::Poplar1 { .. } => {
+            ::janus_core::vdaf::VdafInstance::Prio3Count
+            | ::janus_core::vdaf::VdafInstance::Prio3CountVec { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3Sum { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3SumVec { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3Histogram { .. }
+            | ::janus_core::vdaf::VdafInstance::Poplar1 { .. } => {
                 ::janus_core::vdaf_dispatch_impl_base!(impl match base $vdaf_instance, (_, $Vdaf, $VERIFY_KEY_LEN) => $body)
             }
 
-            ::janus_core::task::VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { .. }
-            | ::janus_core::task::VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { .. }
-            | ::janus_core::task::VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { .. } => {
+            ::janus_core::vdaf::VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { .. } => {
                 ::janus_core::vdaf_dispatch_impl_fpvec_bounded_l2!(impl match fpvec_bounded_l2 $vdaf_instance, (_, $Vdaf, $VERIFY_KEY_LEN) => $body)
             }
 
@@ -464,18 +456,18 @@ macro_rules! vdaf_dispatch_impl {
     // Construct a VDAF instance, and provide that to the block as well.
     (impl match all $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LEN:ident) => $body:tt) => {
         match $vdaf_instance {
-            ::janus_core::task::VdafInstance::Prio3Count
-            | ::janus_core::task::VdafInstance::Prio3CountVec { .. }
-            | ::janus_core::task::VdafInstance::Prio3Sum { .. }
-            | ::janus_core::task::VdafInstance::Prio3SumVec { .. }
-            | ::janus_core::task::VdafInstance::Prio3Histogram { .. }
-            | ::janus_core::task::VdafInstance::Poplar1 { .. } => {
+            ::janus_core::vdaf::VdafInstance::Prio3Count
+            | ::janus_core::vdaf::VdafInstance::Prio3CountVec { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3Sum { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3SumVec { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3Histogram { .. }
+            | ::janus_core::vdaf::VdafInstance::Poplar1 { .. } => {
                 ::janus_core::vdaf_dispatch_impl_base!(impl match base $vdaf_instance, ($vdaf, $Vdaf, $VERIFY_KEY_LEN) => $body)
             }
 
-            ::janus_core::task::VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { .. }
-            | ::janus_core::task::VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { .. }
-            | ::janus_core::task::VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { .. } => {
+            ::janus_core::vdaf::VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { .. } => {
                 ::janus_core::vdaf_dispatch_impl_fpvec_bounded_l2!(impl match fpvec_bounded_l2 $vdaf_instance, ($vdaf, $Vdaf, $VERIFY_KEY_LEN) => $body)
             }
 
@@ -491,18 +483,18 @@ macro_rules! vdaf_dispatch_impl {
     // Provide the dispatched type only, don't construct a VDAF instance.
     (impl match all $vdaf_instance:expr, (_, $Vdaf:ident, $VERIFY_KEY_LEN:ident) => $body:tt) => {
         match $vdaf_instance {
-            ::janus_core::task::VdafInstance::Prio3Count
-            | ::janus_core::task::VdafInstance::Prio3CountVec { .. }
-            | ::janus_core::task::VdafInstance::Prio3Sum { .. }
-            | ::janus_core::task::VdafInstance::Prio3SumVec { .. }
-            | ::janus_core::task::VdafInstance::Prio3Histogram { .. }
-            | ::janus_core::task::VdafInstance::Poplar1 { .. } => {
+            ::janus_core::vdaf::VdafInstance::Prio3Count
+            | ::janus_core::vdaf::VdafInstance::Prio3CountVec { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3Sum { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3SumVec { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3Histogram { .. }
+            | ::janus_core::vdaf::VdafInstance::Poplar1 { .. } => {
                 ::janus_core::vdaf_dispatch_impl_base!(impl match base $vdaf_instance, (_, $Vdaf, $VERIFY_KEY_LEN) => $body)
             }
 
-            ::janus_core::task::VdafInstance::Fake
-            | ::janus_core::task::VdafInstance::FakeFailsPrepInit
-            | ::janus_core::task::VdafInstance::FakeFailsPrepStep => {
+            ::janus_core::vdaf::VdafInstance::Fake
+            | ::janus_core::vdaf::VdafInstance::FakeFailsPrepInit
+            | ::janus_core::vdaf::VdafInstance::FakeFailsPrepStep => {
                 ::janus_core::vdaf_dispatch_impl_test_util!(impl match test_util $vdaf_instance, (_, $Vdaf, $VERIFY_KEY_LEN) => $body)
             }
 
@@ -513,18 +505,18 @@ macro_rules! vdaf_dispatch_impl {
     // Construct a VDAF instance, and provide that to the block as well.
     (impl match all $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LEN:ident) => $body:tt) => {
         match $vdaf_instance {
-            ::janus_core::task::VdafInstance::Prio3Count
-            | ::janus_core::task::VdafInstance::Prio3CountVec { .. }
-            | ::janus_core::task::VdafInstance::Prio3Sum { .. }
-            | ::janus_core::task::VdafInstance::Prio3SumVec { .. }
-            | ::janus_core::task::VdafInstance::Prio3Histogram { .. }
-            | ::janus_core::task::VdafInstance::Poplar1 { .. } => {
+            ::janus_core::vdaf::VdafInstance::Prio3Count
+            | ::janus_core::vdaf::VdafInstance::Prio3CountVec { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3Sum { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3SumVec { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3Histogram { .. }
+            | ::janus_core::vdaf::VdafInstance::Poplar1 { .. } => {
                 ::janus_core::vdaf_dispatch_impl_base!(impl match base $vdaf_instance, ($vdaf, $Vdaf, $VERIFY_KEY_LEN) => $body)
             }
 
-            ::janus_core::task::VdafInstance::Fake
-            | ::janus_core::task::VdafInstance::FakeFailsPrepInit
-            | ::janus_core::task::VdafInstance::FakeFailsPrepStep => {
+            ::janus_core::vdaf::VdafInstance::Fake
+            | ::janus_core::vdaf::VdafInstance::FakeFailsPrepInit
+            | ::janus_core::vdaf::VdafInstance::FakeFailsPrepStep => {
                 ::janus_core::vdaf_dispatch_impl_test_util!(impl match test_util $vdaf_instance, ($vdaf, $Vdaf, $VERIFY_KEY_LEN) => $body)
             }
 
@@ -540,12 +532,12 @@ macro_rules! vdaf_dispatch_impl {
     // Provide the dispatched type only, don't construct a VDAF instance.
     (impl match all $vdaf_instance:expr, (_, $Vdaf:ident, $VERIFY_KEY_LEN:ident) => $body:tt) => {
         match $vdaf_instance {
-            ::janus_core::task::VdafInstance::Prio3Count
-            | ::janus_core::task::VdafInstance::Prio3CountVec { .. }
-            | ::janus_core::task::VdafInstance::Prio3Sum { .. }
-            | ::janus_core::task::VdafInstance::Prio3SumVec { .. }
-            | ::janus_core::task::VdafInstance::Prio3Histogram { .. }
-            | ::janus_core::task::VdafInstance::Poplar1 { .. } => {
+            ::janus_core::vdaf::VdafInstance::Prio3Count
+            | ::janus_core::vdaf::VdafInstance::Prio3CountVec { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3Sum { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3SumVec { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3Histogram { .. }
+            | ::janus_core::vdaf::VdafInstance::Poplar1 { .. } => {
                 ::janus_core::vdaf_dispatch_impl_base!(impl match base $vdaf_instance, (_, $Vdaf, $VERIFY_KEY_LEN) => $body)
             }
 
@@ -556,12 +548,12 @@ macro_rules! vdaf_dispatch_impl {
     // Construct a VDAF instance, and provide that to the block as well.
     (impl match all $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LEN:ident) => $body:tt) => {
         match $vdaf_instance {
-            ::janus_core::task::VdafInstance::Prio3Count
-            | ::janus_core::task::VdafInstance::Prio3CountVec { .. }
-            | ::janus_core::task::VdafInstance::Prio3Sum { .. }
-            | ::janus_core::task::VdafInstance::Prio3SumVec { .. }
-            | ::janus_core::task::VdafInstance::Prio3Histogram { .. }
-            | ::janus_core::task::VdafInstance::Poplar1 { .. } => {
+            ::janus_core::vdaf::VdafInstance::Prio3Count
+            | ::janus_core::vdaf::VdafInstance::Prio3CountVec { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3Sum { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3SumVec { .. }
+            | ::janus_core::vdaf::VdafInstance::Prio3Histogram { .. }
+            | ::janus_core::vdaf::VdafInstance::Poplar1 { .. } => {
                 ::janus_core::vdaf_dispatch_impl_base!(impl match base $vdaf_instance, ($vdaf, $Vdaf, $VERIFY_KEY_LEN) => $body)
             }
 
@@ -588,7 +580,7 @@ macro_rules! vdaf_dispatch_impl {
 /// #     Ok(())
 /// # }
 /// # fn test() -> Result<(), prio::vdaf::VdafError> {
-/// #     let vdaf = janus_core::task::VdafInstance::Prio3Count;
+/// #     let vdaf = janus_core::vdaf::VdafInstance::Prio3Count;
 /// vdaf_dispatch!(&vdaf, (vdaf, VdafType, VERIFY_KEY_LEN) => {
 ///     handle_request_generic::<VdafType, VERIFY_KEY_LEN>(&vdaf)
 /// })
@@ -607,303 +599,9 @@ macro_rules! vdaf_dispatch {
     };
 }
 
-/// Different modes of authentication supported by Janus for either sending requests (e.g., leader
-/// to helper) or receiving them (e.g., collector to leader).
-#[derive(Clone, Derivative, Serialize, Deserialize, PartialEq, Eq)]
-#[derivative(Debug)]
-#[serde(tag = "type", content = "token")]
-#[non_exhaustive]
-pub enum AuthenticationToken {
-    /// A bearer token, presented as the value of the "Authorization" HTTP header as specified in
-    /// [RFC 6750 section 2.1][1].
-    ///
-    /// The token is not necessarily an OAuth token.
-    ///
-    /// [1]: https://datatracker.ietf.org/doc/html/rfc6750#section-2.1
-    Bearer(BearerToken),
-
-    /// Token presented as the value of the "DAP-Auth-Token" HTTP header. Conforms to
-    /// [draft-dcook-ppm-dap-interop-test-design-03][1], sections [4.3.3][2] and [4.4.2][3], and
-    /// [draft-ietf-dap-ppm-01 section 3.2][4].
-    ///
-    /// [1]: https://datatracker.ietf.org/doc/html/draft-dcook-ppm-dap-interop-test-design-03
-    /// [2]: https://datatracker.ietf.org/doc/html/draft-dcook-ppm-dap-interop-test-design-03#section-4.3.3
-    /// [3]: https://datatracker.ietf.org/doc/html/draft-dcook-ppm-dap-interop-test-design-03#section-4.4.2
-    /// [4]: https://datatracker.ietf.org/doc/html/draft-ietf-ppm-dap-01#name-https-sender-authentication
-    DapAuth(DapAuthToken),
-}
-
-impl AuthenticationToken {
-    /// Attempts to create a new bearer token from the provided bytes.
-    pub fn new_bearer_token_from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, anyhow::Error> {
-        BearerToken::try_from(bytes.as_ref().to_vec()).map(AuthenticationToken::Bearer)
-    }
-
-    /// Attempts to create a new bearer token from the provided string
-    pub fn new_bearer_token_from_string<T: Into<String>>(string: T) -> Result<Self, anyhow::Error> {
-        BearerToken::try_from(string.into()).map(AuthenticationToken::Bearer)
-    }
-
-    /// Attempts to create a new DAP auth token from the provided bytes.
-    pub fn new_dap_auth_token_from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, anyhow::Error> {
-        DapAuthToken::try_from(bytes.as_ref().to_vec()).map(AuthenticationToken::DapAuth)
-    }
-
-    /// Attempts to create a new DAP auth token from the provided string.
-    pub fn new_dap_auth_token_from_string<T: Into<String>>(
-        string: T,
-    ) -> Result<Self, anyhow::Error> {
-        DapAuthToken::try_from(string.into()).map(AuthenticationToken::DapAuth)
-    }
-
-    /// Returns an HTTP header and value that should be used to authenticate an HTTP request with
-    /// this credential.
-    pub fn request_authentication(&self) -> (&'static str, String) {
-        match self {
-            Self::Bearer(token) => (AUTHORIZATION.as_str(), format!("Bearer {}", token.as_str())),
-            // Cloning is unfortunate but necessary since other arms must allocate.
-            Self::DapAuth(token) => (DAP_AUTH_HEADER, token.as_str().to_string()),
-        }
-    }
-
-    /// Returns the token as a string.
-    pub fn as_str(&self) -> &str {
-        match self {
-            Self::DapAuth(token) => token.as_str(),
-            Self::Bearer(token) => token.as_str(),
-        }
-    }
-}
-
-impl AsRef<[u8]> for AuthenticationToken {
-    fn as_ref(&self) -> &[u8] {
-        match self {
-            Self::DapAuth(token) => token.as_ref(),
-            Self::Bearer(token) => token.as_ref(),
-        }
-    }
-}
-
-impl Distribution<AuthenticationToken> for Standard {
-    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> AuthenticationToken {
-        AuthenticationToken::Bearer(Standard::sample(self, rng))
-    }
-}
-
-/// A token value used to authenticate HTTP requests. This token is used in the "DAP-Auth-Token"
-/// HTTP request header.
-///
-/// This token is used directly in HTTP request headers without further encoding and so must be a
-/// legal HTTP header value. The literal value is the canonical form of the token and is used
-/// directly, without any additional encoding or decoding, in configuration files, Janus aggregator
-/// API requests, and HTTP authentication headers.
-///
-/// This opaque type ensures it's impossible to construct an [`AuthenticationToken`] whose contents
-/// are invalid.
-#[derive(Clone, Derivative, Serialize)]
-#[derivative(Debug)]
-#[serde(transparent)]
-pub struct DapAuthToken(#[derivative(Debug = "ignore")] String);
-
-impl DapAuthToken {
-    /// Returns the token as a string.
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-
-    /// Validate that a DAP-Auth-Token value is a valid HTTP header value.
-    fn validate(value: &str) -> Result<(), anyhow::Error> {
-        HeaderValue::try_from(value)?;
-        Ok(())
-    }
-}
-
-impl AsRef<str> for DapAuthToken {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl AsRef<[u8]> for DapAuthToken {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-}
-
-impl TryFrom<String> for DapAuthToken {
-    type Error = anyhow::Error;
-
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        Self::validate(&value)?;
-        Ok(Self(value))
-    }
-}
-
-impl TryFrom<Vec<u8>> for DapAuthToken {
-    type Error = anyhow::Error;
-
-    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
-        Self::try_from(String::from_utf8(value)?)
-    }
-}
-
-impl<'de> Deserialize<'de> for DapAuthToken {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        String::deserialize(deserializer)
-            .and_then(|string| Self::try_from(string).map_err(D::Error::custom))
-    }
-}
-
-impl PartialEq for DapAuthToken {
-    fn eq(&self, other: &Self) -> bool {
-        // We attempt constant-time comparisons of the token data to mitigate timing attacks. Note
-        // that this function still leaks whether the lengths of the tokens are equal -- this is
-        // acceptable because we expect the content of the tokens to provide enough randomness that
-        // needs to be guessed even if the length is known.
-        constant_time::verify_slices_are_equal(self.0.as_ref(), other.0.as_ref()).is_ok()
-    }
-}
-
-impl Eq for DapAuthToken {}
-
-impl Distribution<DapAuthToken> for Standard {
-    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> DapAuthToken {
-        DapAuthToken(URL_SAFE_NO_PAD.encode(rng.gen::<[u8; 16]>()))
-    }
-}
-
-/// A token value used to authenticate HTTP requests. This token is used in "Authorization: Bearer"
-/// HTTP request headers.
-///
-/// Token values must follow the syntax in
-/// <https://datatracker.ietf.org/doc/html/rfc6750#section-2.1>. Its literal value is the canonical
-/// form of the token and is used directly, without any additional encoding or decoding, in
-/// configuration files, Janus aggregator API requests, and HTTP authentication headers.
-///
-/// This opaque type ensures it's impossible to construct an [`AuthenticationToken`] whose contents
-/// are invalid.
-#[derive(Clone, Derivative, Serialize)]
-#[derivative(Debug)]
-#[serde(transparent)]
-pub struct BearerToken(#[derivative(Debug = "ignore")] String);
-
-impl BearerToken {
-    /// Returns the token as a string.
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-
-    /// Validate that a bearer token value matches the format in
-    /// https://datatracker.ietf.org/doc/html/rfc6750#section-2.1.
-    fn validate(value: &str) -> Result<(), anyhow::Error> {
-        let mut iter = value.chars();
-        let mut any_non_equals = false;
-        // First loop: consume "normal" characters, stop when we see an equals sign for padding or
-        // reach the end of the input.
-        for c in &mut iter {
-            match c {
-                'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '.' | '_' | '~' | '+' | '/' => {
-                    any_non_equals = true;
-                }
-                '=' => {
-                    if !any_non_equals {
-                        return Err(anyhow::anyhow!("bearer token may not start with '='"));
-                    }
-                    break;
-                }
-                _ => return Err(anyhow::anyhow!("bearer token may not contain '{c}'")),
-            }
-        }
-        // Second loop: consume any further padding characters, if present.
-        for c in &mut iter {
-            match c {
-                '=' => {}
-                _ => {
-                    return Err(anyhow::anyhow!(
-                        "bearer token may only contain '=' at the end"
-                    ))
-                }
-            }
-        }
-        Ok(())
-    }
-}
-
-impl AsRef<str> for BearerToken {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl AsRef<[u8]> for BearerToken {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-}
-
-impl TryFrom<String> for BearerToken {
-    type Error = anyhow::Error;
-
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        Self::validate(&value)?;
-        Ok(Self(value))
-    }
-}
-
-impl TryFrom<Vec<u8>> for BearerToken {
-    type Error = anyhow::Error;
-
-    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
-        Self::try_from(String::from_utf8(value)?)
-    }
-}
-
-impl<'de> Deserialize<'de> for BearerToken {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        String::deserialize(deserializer)
-            .and_then(|string| Self::try_from(string).map_err(D::Error::custom))
-    }
-}
-
-impl PartialEq for BearerToken {
-    fn eq(&self, other: &Self) -> bool {
-        // We attempt constant-time comparisons of the token data to mitigate timing attacks. Note
-        // that this function still leaks whether the lengths of the tokens are equal -- this is
-        // acceptable because we expect the content of the tokens to provide enough randomness that
-        // needs to be guessed even if the length is known.
-        constant_time::verify_slices_are_equal(self.0.as_bytes(), other.0.as_bytes()).is_ok()
-    }
-}
-
-impl Eq for BearerToken {}
-
-impl Distribution<BearerToken> for Standard {
-    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> BearerToken {
-        BearerToken(URL_SAFE_NO_PAD.encode(rng.gen::<[u8; 16]>()))
-    }
-}
-
-/// Returns the given [`Url`], possibly modified to end with a slash.
-///
-/// Aggregator endpoint URLs should end with a slash if they will be used with [`Url::join`],
-/// because that method will drop the last path component of the base URL if it does not end with a
-/// slash.
-pub fn url_ensure_trailing_slash(mut url: Url) -> Url {
-    if !url.as_str().ends_with('/') {
-        url.set_path(&format!("{}/", url.path()));
-    }
-    url
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{AuthenticationToken, VdafInstance};
+    use super::VdafInstance;
     use serde_test::{assert_tokens, Token};
 
     #[test]
@@ -1000,41 +698,5 @@ mod tests {
                 variant: "FakeFailsPrepStep",
             }],
         );
-    }
-
-    #[test]
-    fn valid_dap_auth_token() {
-        serde_yaml::from_str::<AuthenticationToken>(
-            "{type: \"DapAuth\", token: \"correct-horse-battery-staple-!@#$\"}",
-        )
-        .unwrap();
-    }
-
-    #[test]
-    fn valid_bearer_token() {
-        serde_yaml::from_str::<AuthenticationToken>(
-            "{type: \"Bearer\", token: \"AAAAAAA~-_/A===\"}",
-        )
-        .unwrap();
-    }
-
-    #[test]
-    fn reject_invalid_auth_token_dap_auth() {
-        serde_yaml::from_str::<AuthenticationToken>("{type: \"DapAuth\", token: \"\\x0b\"}")
-            .unwrap_err();
-        serde_yaml::from_str::<AuthenticationToken>("{type: \"DapAuth\", token: \"\\x00\"}")
-            .unwrap_err();
-    }
-
-    #[test]
-    fn reject_invalid_auth_token_bearer() {
-        serde_yaml::from_str::<AuthenticationToken>("{type: \"Bearer\", token: \"é\"}")
-            .unwrap_err();
-        serde_yaml::from_str::<AuthenticationToken>("{type: \"Bearer\", token: \"^\"}")
-            .unwrap_err();
-        serde_yaml::from_str::<AuthenticationToken>("{type: \"Bearer\", token: \"=\"}")
-            .unwrap_err();
-        serde_yaml::from_str::<AuthenticationToken>("{type: \"Bearer\", token: \"AAAA==AAA\"}")
-            .unwrap_err();
     }
 }

--- a/integration_tests/src/client.rs
+++ b/integration_tests/src/client.rs
@@ -2,7 +2,7 @@ use crate::TaskParameters;
 use anyhow::anyhow;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use janus_client::{aggregator_hpke_config, default_http_client, Client, ClientParameters};
-use janus_core::{task::VdafInstance, time::RealClock};
+use janus_core::{time::RealClock, vdaf::VdafInstance};
 use janus_interop_binaries::ContainerLogsDropGuard;
 use janus_messages::{Duration, Role, TaskId};
 use prio::{

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -2,7 +2,7 @@
 
 use janus_aggregator_core::task::QueryType;
 use janus_collector::AuthenticationToken;
-use janus_core::{hpke::HpkePrivateKey, task::VdafInstance};
+use janus_core::{hpke::HpkePrivateKey, vdaf::VdafInstance};
 use janus_messages::{Duration, HpkeConfig, TaskId};
 use url::Url;
 

--- a/integration_tests/tests/common/mod.rs
+++ b/integration_tests/tests/common/mod.rs
@@ -5,8 +5,8 @@ use janus_collector::{Collection, Collector, CollectorParameters};
 use janus_core::{
     hpke::test_util::generate_test_hpke_config_and_private_key,
     retries::test_http_request_exponential_backoff,
-    task::VdafInstance,
     time::{Clock, RealClock, TimeExt},
+    vdaf::VdafInstance,
 };
 use janus_integration_tests::{
     client::{ClientBackend, ClientImplementation, InteropClientEncoding},

--- a/integration_tests/tests/daphne.rs
+++ b/integration_tests/tests/daphne.rs
@@ -1,8 +1,8 @@
 use common::{submit_measurements_and_verify_aggregate, test_task_builders};
 use janus_aggregator_core::task::{QueryType, Task};
 use janus_core::{
-    task::VdafInstance,
     test_util::{install_test_trace_subscriber, testcontainers::container_client},
+    vdaf::VdafInstance,
 };
 use janus_integration_tests::{client::ClientBackend, daphne::Daphne, janus::Janus};
 use janus_interop_binaries::test_util::generate_network_name;

--- a/integration_tests/tests/divviup_ts.rs
+++ b/integration_tests/tests/divviup_ts.rs
@@ -3,8 +3,8 @@
 use common::{submit_measurements_and_verify_aggregate, test_task_builders};
 use janus_aggregator_core::task::QueryType;
 use janus_core::{
-    task::VdafInstance,
     test_util::{install_test_trace_subscriber, testcontainers::container_client},
+    vdaf::VdafInstance,
 };
 use janus_integration_tests::{
     client::{ClientBackend, InteropClient},

--- a/integration_tests/tests/in_cluster.rs
+++ b/integration_tests/tests/in_cluster.rs
@@ -6,12 +6,12 @@ use divviup_client::{
 };
 use janus_aggregator_core::task::QueryType;
 use janus_core::{
-    task::AuthenticationToken,
-    task::VdafInstance,
+    auth_tokens::AuthenticationToken,
     test_util::{
         install_test_trace_subscriber,
         kubernetes::{Cluster, PortForward},
     },
+    vdaf::VdafInstance,
 };
 use janus_integration_tests::{client::ClientBackend, TaskParameters};
 use janus_messages::TaskId;

--- a/integration_tests/tests/janus.rs
+++ b/integration_tests/tests/janus.rs
@@ -1,8 +1,8 @@
 use common::{submit_measurements_and_verify_aggregate, test_task_builders};
 use janus_aggregator_core::task::QueryType;
 use janus_core::{
-    task::VdafInstance,
     test_util::{install_test_trace_subscriber, testcontainers::container_client},
+    vdaf::VdafInstance,
 };
 use janus_integration_tests::{client::ClientBackend, janus::Janus, TaskParameters};
 use janus_interop_binaries::test_util::generate_network_name;

--- a/interop_binaries/src/bin/janus_interop_aggregator.rs
+++ b/interop_binaries/src/bin/janus_interop_aggregator.rs
@@ -11,7 +11,7 @@ use janus_aggregator_core::{
     task::{self, Task},
     SecretBytes,
 };
-use janus_core::{task::AuthenticationToken, time::RealClock};
+use janus_core::{auth_tokens::AuthenticationToken, time::RealClock};
 use janus_interop_binaries::{
     status::{ERROR, SUCCESS},
     AddTaskResponse, AggregatorAddTaskRequest, AggregatorRole, HpkeConfigRegistry, Keyring,

--- a/interop_binaries/src/bin/janus_interop_client.rs
+++ b/interop_binaries/src/bin/janus_interop_client.rs
@@ -7,8 +7,8 @@ use fixed::types::extra::{U15, U31, U63};
 use fixed::{FixedI16, FixedI32, FixedI64};
 use janus_client::ClientParameters;
 use janus_core::{
-    task::VdafInstance,
     time::{MockClock, RealClock},
+    vdaf::VdafInstance,
 };
 use janus_interop_binaries::{
     install_tracing_subscriber,

--- a/interop_binaries/src/bin/janus_interop_collector.rs
+++ b/interop_binaries/src/bin/janus_interop_collector.rs
@@ -7,10 +7,7 @@ use fixed::types::extra::{U15, U31, U63};
 #[cfg(feature = "fpvec_bounded_l2")]
 use fixed::{FixedI16, FixedI32, FixedI64};
 use janus_collector::{Collector, CollectorParameters};
-use janus_core::{
-    hpke::HpkeKeypair,
-    task::{AuthenticationToken, VdafInstance},
-};
+use janus_core::{auth_tokens::AuthenticationToken, hpke::HpkeKeypair, vdaf::VdafInstance};
 use janus_interop_binaries::Keyring;
 use janus_interop_binaries::{
     install_tracing_subscriber,
@@ -377,7 +374,7 @@ async fn handle_collection_start(
         #[cfg(feature = "fpvec_bounded_l2")]
         (
             ParsedQuery::TimeInterval(batch_interval),
-            janus_core::task::VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { length },
+            janus_core::vdaf::VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { length },
         ) => {
             let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>> =
                 Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length)
@@ -400,7 +397,7 @@ async fn handle_collection_start(
         #[cfg(feature = "fpvec_bounded_l2")]
         (
             ParsedQuery::TimeInterval(batch_interval),
-            janus_core::task::VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { length },
+            janus_core::vdaf::VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { length },
         ) => {
             let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>> =
                 Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length)
@@ -423,7 +420,7 @@ async fn handle_collection_start(
         #[cfg(feature = "fpvec_bounded_l2")]
         (
             ParsedQuery::TimeInterval(batch_interval),
-            janus_core::task::VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { length },
+            janus_core::vdaf::VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { length },
         ) => {
             let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>> =
                 Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length)
@@ -484,7 +481,7 @@ async fn handle_collection_start(
         #[cfg(feature = "fpvec_bounded_l2")]
         (
             ParsedQuery::FixedSize(fixed_size_query),
-            janus_core::task::VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { length },
+            janus_core::vdaf::VdafInstance::Prio3FixedPoint16BitBoundedL2VecSum { length },
         ) => {
             let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>> =
                 Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length)
@@ -507,7 +504,7 @@ async fn handle_collection_start(
         #[cfg(feature = "fpvec_bounded_l2")]
         (
             ParsedQuery::FixedSize(fixed_size_query),
-            janus_core::task::VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { length },
+            janus_core::vdaf::VdafInstance::Prio3FixedPoint32BitBoundedL2VecSum { length },
         ) => {
             let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>> =
                 Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length)
@@ -530,7 +527,7 @@ async fn handle_collection_start(
         #[cfg(feature = "fpvec_bounded_l2")]
         (
             ParsedQuery::FixedSize(fixed_size_query),
-            janus_core::task::VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { length },
+            janus_core::vdaf::VdafInstance::Prio3FixedPoint64BitBoundedL2VecSum { length },
         ) => {
             let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>> =
                 Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length)

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -2,7 +2,7 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use janus_aggregator_core::task::{QueryType, Task};
 use janus_core::{
     hpke::{generate_hpke_config_and_private_key, HpkeKeypair},
-    task::VdafInstance,
+    vdaf::VdafInstance,
 };
 use janus_messages::{
     query_type::{FixedSize, QueryType as _, TimeInterval},

--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -2,9 +2,9 @@ use backoff::{backoff::Backoff, ExponentialBackoffBuilder};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use futures::future::join_all;
 use janus_core::{
-    task::VERIFY_KEY_LENGTH,
     test_util::{install_test_trace_subscriber, testcontainers::container_client},
     time::{Clock, RealClock, TimeExt},
+    vdaf::VERIFY_KEY_LENGTH,
 };
 use janus_interop_binaries::{
     test_util::{await_ready_ok, generate_network_name, generate_unique_name},

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -602,11 +602,11 @@ mod tests {
     use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
     use clap::{error::ErrorKind, CommandFactory, Parser};
     use janus_core::{
+        auth_tokens::{BearerToken, DapAuthToken},
         hpke::{
             test_util::{generate_test_hpke_config_and_private_key, SAMPLE_DIVVIUP_HPKE_CONFIG},
             DivviUpHpkeConfig, HpkeKeypair,
         },
-        task::{BearerToken, DapAuthToken},
     };
     use janus_messages::{BatchId, TaskId};
     use prio::codec::Encode;


### PR DESCRIPTION
Moves handling of authentication tokens to a new module `janus_core::auth_tokens`. Once that's gone, the only thing of substance left is `enum VdafInstance` and the macros for dispatching on VDAFs, so that module is renamed to `janus_core::vdaf` to better describe its purpose.