### PR TITLE
Add `AuthenticationTokenHash`

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -355,9 +355,9 @@ impl<C: Clock> Aggregator<C> {
     ) -> Result<AggregationJobResp, Error> {
         let task_aggregator = match self.task_aggregator_for(task_id).await? {
             Some(task_aggregator) => {
-                if !auth_token
-                    .map(|t| task_aggregator.task.check_aggregator_auth_token(&t))
-                    .unwrap_or(false)
+                if !task_aggregator
+                    .task
+                    .check_aggregator_auth_token(auth_token.as_ref())
                 {
                     return Err(Error::UnauthorizedRequest(*task_id));
                 }
@@ -426,9 +426,9 @@ impl<C: Clock> Aggregator<C> {
                 auth_token.as_ref(),
             )
             .await?;
-        } else if !auth_token
-            .map(|t| task_aggregator.task.check_aggregator_auth_token(&t))
-            .unwrap_or(false)
+        } else if !task_aggregator
+            .task
+            .check_aggregator_auth_token(auth_token.as_ref())
         {
             return Err(Error::UnauthorizedRequest(*task_id));
         }
@@ -465,9 +465,9 @@ impl<C: Clock> Aggregator<C> {
         if task_aggregator.task.role() != &Role::Leader {
             return Err(Error::UnrecognizedTask(*task_id));
         }
-        if !auth_token
-            .map(|t| task_aggregator.task.check_collector_auth_token(&t))
-            .unwrap_or(false)
+        if !task_aggregator
+            .task
+            .check_collector_auth_token(auth_token.as_ref())
         {
             return Err(Error::UnauthorizedRequest(*task_id));
         }
@@ -494,9 +494,9 @@ impl<C: Clock> Aggregator<C> {
         if task_aggregator.task.role() != &Role::Leader {
             return Err(Error::UnrecognizedTask(*task_id));
         }
-        if !auth_token
-            .map(|t| task_aggregator.task.check_collector_auth_token(&t))
-            .unwrap_or(false)
+        if !task_aggregator
+            .task
+            .check_collector_auth_token(auth_token.as_ref())
         {
             return Err(Error::UnauthorizedRequest(*task_id));
         }
@@ -520,9 +520,9 @@ impl<C: Clock> Aggregator<C> {
         if task_aggregator.task.role() != &Role::Leader {
             return Err(Error::UnrecognizedTask(*task_id));
         }
-        if !auth_token
-            .map(|t| task_aggregator.task.check_collector_auth_token(&t))
-            .unwrap_or(false)
+        if !task_aggregator
+            .task
+            .check_collector_auth_token(auth_token.as_ref())
         {
             return Err(Error::UnauthorizedRequest(*task_id));
         }
@@ -566,9 +566,9 @@ impl<C: Clock> Aggregator<C> {
 
                 peer_aggregator.collector_hpke_config()
             } else {
-                if !auth_token
-                    .map(|t| task_aggregator.task.check_aggregator_auth_token(&t))
-                    .unwrap_or(false)
+                if !task_aggregator
+                    .task
+                    .check_aggregator_auth_token(auth_token.as_ref())
                 {
                     return Err(Error::UnauthorizedRequest(*task_id));
                 }


### PR DESCRIPTION
When acting as an HTTP server, Janus only needs a hash of the aggregator authentication token to validate incoming requests, and can avoid storing the actual token. This commit adds
`janus_core::auth_tokens::AuthenticationTokenHash` which will be used to implement that.

Part of #1509