### PR TITLE
Use regex for bearer token validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2044,6 +2044,7 @@ dependencies = [
  "mockito",
  "prio 0.15.2",
  "rand",
+ "regex",
  "reqwest",
  "ring",
  "rstest",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -47,6 +47,7 @@ kube = { workspace = true, optional = true, features = ["rustls-tls"] }
 k8s-openapi = { workspace = true, optional = true }
 prio.workspace = true
 rand = "0.8"
+regex = "1.9.5"
 reqwest = { version = "0.11.20", default-features = false, features = ["rustls-tls", "json"] }
 ring = "0.16.20"
 serde.workspace = true


### PR DESCRIPTION
This implements the suggestion in https://github.com/divviup/janus/pull/1985/files#r1336411760.