### PR TITLE
Add Dependabot group for deadpool

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,10 @@ updates:
         patterns:
           - tokio-postgres
           - postgres-*
+      deadpool:
+        patterns:
+          - deadpool
+          - deadpool-*
       error-handling:
         patterns:
           - thiserror
@@ -97,6 +101,10 @@ updates:
         patterns:
           - tokio-postgres
           - postgres-*
+      deadpool:
+        patterns:
+          - deadpool
+          - deadpool-*
       error-handling:
         patterns:
           - thiserror
@@ -156,6 +164,10 @@ updates:
         patterns:
           - tokio-postgres
           - postgres-*
+      deadpool:
+        patterns:
+          - deadpool
+          - deadpool-*
       error-handling:
         patterns:
           - thiserror


### PR DESCRIPTION
This adds a Dependabot group covering deadpool and deadpool-postgres. The new version of deadpool-postgres is now released, so this should create PRs updating the two in tandem.