### PR TITLE
Interop binaries: wait for database to be up

### DIFF
--- a/interop_binaries/setup.sh
+++ b/interop_binaries/setup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+until pg_isready -U postgres; do sleep 1; done
 /usr/bin/supervisorctl -c /etc/janus/supervisord.conf start janus_interop_aggregator
 /usr/bin/supervisorctl -c /etc/janus/supervisord.conf start aggregation_job_creator
 /usr/bin/supervisorctl -c /etc/janus/supervisord.conf start aggregation_job_driver

--- a/interop_binaries/setup.sh
+++ b/interop_binaries/setup.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+
 timeout 5m bash -c 'until pg_isready -U postgres; do sleep 1; done'
 /usr/bin/supervisorctl -c /etc/janus/supervisord.conf start janus_interop_aggregator
 /usr/bin/supervisorctl -c /etc/janus/supervisord.conf start aggregation_job_creator

--- a/interop_binaries/setup.sh
+++ b/interop_binaries/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-until pg_isready -U postgres; do sleep 1; done
+timeout 5m bash -c 'until pg_isready -U postgres; do sleep 1; done'
 /usr/bin/supervisorctl -c /etc/janus/supervisord.conf start janus_interop_aggregator
 /usr/bin/supervisorctl -c /etc/janus/supervisord.conf start aggregation_job_creator
 /usr/bin/supervisorctl -c /etc/janus/supervisord.conf start aggregation_job_driver


### PR DESCRIPTION
This waits for the Postgres database to come up before starting `janus_interop_aggregator` etc. This is for #1977. I tried this out locally, and saw the following on stdout from the `setup` job. (the first two lines are from `pg_isready`)

```
/var/run/postgresql:5432 - no response
/var/run/postgresql:5432 - accepting connections
janus_interop_aggregator: started
aggregation_job_creator: started
aggregation_job_driver: started
collection_job_driver: started
```