### PR TITLE
Interop binaries: wait for database to be up, 0.5 backport

### DIFF
--- a/interop_binaries/setup.sh
+++ b/interop_binaries/setup.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+set -e
+
+timeout 5m bash -c 'until pg_isready -U postgres; do sleep 1; done'
 /usr/bin/supervisorctl -c /etc/janus/supervisord.conf start janus_interop_aggregator
 /usr/bin/supervisorctl -c /etc/janus/supervisord.conf start aggregation_job_creator
 /usr/bin/supervisorctl -c /etc/janus/supervisord.conf start aggregation_job_driver


### PR DESCRIPTION
This backports #2006 to the release/0.5 branch.