### PR TITLE
Bump version to 0.6.0-prerelease-2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1803,7 +1803,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "janus_aggregator"
-version = "0.6.0-prerelease-1"
+version = "0.6.0-prerelease-2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1829,7 +1829,7 @@ dependencies = [
  "janus_aggregator_api",
  "janus_aggregator_core",
  "janus_core",
- "janus_messages 0.6.0-prerelease-1",
+ "janus_messages 0.6.0-prerelease-2",
  "k8s-openapi",
  "kube",
  "mockito",
@@ -1883,7 +1883,7 @@ dependencies = [
 
 [[package]]
 name = "janus_aggregator_api"
-version = "0.6.0-prerelease-1"
+version = "0.6.0-prerelease-2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1891,7 +1891,7 @@ dependencies = [
  "futures",
  "janus_aggregator_core",
  "janus_core",
- "janus_messages 0.6.0-prerelease-1",
+ "janus_messages 0.6.0-prerelease-2",
  "opentelemetry",
  "querystring",
  "rand",
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "janus_aggregator_core"
-version = "0.6.0-prerelease-1"
+version = "0.6.0-prerelease-2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1931,7 +1931,7 @@ dependencies = [
  "hyper",
  "janus_aggregator_core",
  "janus_core",
- "janus_messages 0.6.0-prerelease-1",
+ "janus_messages 0.6.0-prerelease-2",
  "k8s-openapi",
  "kube",
  "opentelemetry",
@@ -1966,14 +1966,14 @@ dependencies = [
 
 [[package]]
 name = "janus_build_script_utils"
-version = "0.6.0-prerelease-1"
+version = "0.6.0-prerelease-2"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "janus_client"
-version = "0.6.0-prerelease-1"
+version = "0.6.0-prerelease-2"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -1982,7 +1982,7 @@ dependencies = [
  "http-api-problem",
  "itertools",
  "janus_core",
- "janus_messages 0.6.0-prerelease-1",
+ "janus_messages 0.6.0-prerelease-2",
  "mockito",
  "prio 0.15.2",
  "rand",
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "janus_collector"
-version = "0.6.0-prerelease-1"
+version = "0.6.0-prerelease-2"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -2008,7 +2008,7 @@ dependencies = [
  "http-api-problem",
  "janus_collector",
  "janus_core",
- "janus_messages 0.6.0-prerelease-1",
+ "janus_messages 0.6.0-prerelease-2",
  "mockito",
  "prio 0.15.2",
  "rand",
@@ -2022,7 +2022,7 @@ dependencies = [
 
 [[package]]
 name = "janus_core"
-version = "0.6.0-prerelease-1"
+version = "0.6.0-prerelease-2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2037,7 +2037,7 @@ dependencies = [
  "http",
  "http-api-problem",
  "janus_core",
- "janus_messages 0.6.0-prerelease-1",
+ "janus_messages 0.6.0-prerelease-2",
  "k8s-openapi",
  "kube",
  "mockito",
@@ -2066,7 +2066,7 @@ dependencies = [
 
 [[package]]
 name = "janus_integration_tests"
-version = "0.6.0-prerelease-1"
+version = "0.6.0-prerelease-2"
 dependencies = [
  "anyhow",
  "backoff",
@@ -2082,7 +2082,7 @@ dependencies = [
  "janus_collector",
  "janus_core",
  "janus_interop_binaries",
- "janus_messages 0.6.0-prerelease-1",
+ "janus_messages 0.6.0-prerelease-2",
  "k8s-openapi",
  "kube",
  "prio 0.15.2",
@@ -2099,7 +2099,7 @@ dependencies = [
 
 [[package]]
 name = "janus_interop_binaries"
-version = "0.6.0-prerelease-1"
+version = "0.6.0-prerelease-2"
 dependencies = [
  "anyhow",
  "backoff",
@@ -2116,7 +2116,7 @@ dependencies = [
  "janus_collector",
  "janus_core",
  "janus_interop_binaries",
- "janus_messages 0.6.0-prerelease-1",
+ "janus_messages 0.6.0-prerelease-2",
  "opentelemetry",
  "prio 0.15.2",
  "rand",
@@ -2159,7 +2159,7 @@ dependencies = [
 
 [[package]]
 name = "janus_messages"
-version = "0.6.0-prerelease-1"
+version = "0.6.0-prerelease-2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2177,7 +2177,7 @@ dependencies = [
 
 [[package]]
 name = "janus_tools"
-version = "0.6.0-prerelease-1"
+version = "0.6.0-prerelease-2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2188,7 +2188,7 @@ dependencies = [
  "fixed",
  "janus_collector",
  "janus_core",
- "janus_messages 0.6.0-prerelease-1",
+ "janus_messages 0.6.0-prerelease-2",
  "prio 0.15.2",
  "rand",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://divviup.org"
 license = "MPL-2.0"
 repository = "https://github.com/divviup/janus"
 rust-version = "1.70.0"
-version = "0.6.0-prerelease-1"
+version = "0.6.0-prerelease-2"
 
 [workspace.dependencies]
 anyhow = "1"
@@ -30,16 +30,16 @@ base64 = "0.21.3"
 # https://docs.rs/chrono/latest/chrono/#duration
 chrono = { version = "0.4", default-features = false }
 itertools = "0.10"
-janus_aggregator = { version = "0.6.0-prerelease-1", path = "aggregator" }
-janus_aggregator_api = { version = "0.6.0-prerelease-1", path = "aggregator_api" }
-janus_aggregator_core = { version = "0.6.0-prerelease-1", path = "aggregator_core" }
-janus_build_script_utils = { version = "0.6.0-prerelease-1", path = "build_script_utils" }
-janus_client = { version = "0.6.0-prerelease-1", path = "client" }
-janus_collector = { version = "0.6.0-prerelease-1", path = "collector" }
-janus_core = { version = "0.6.0-prerelease-1", path = "core" }
-janus_integration_tests = { version = "0.6.0-prerelease-1", path = "integration_tests" }
-janus_interop_binaries = { version = "0.6.0-prerelease-1", path = "interop_binaries" }
-janus_messages = { version = "0.6.0-prerelease-1", path = "messages" }
+janus_aggregator = { version = "0.6.0-prerelease-2", path = "aggregator" }
+janus_aggregator_api = { version = "0.6.0-prerelease-2", path = "aggregator_api" }
+janus_aggregator_core = { version = "0.6.0-prerelease-2", path = "aggregator_core" }
+janus_build_script_utils = { version = "0.6.0-prerelease-2", path = "build_script_utils" }
+janus_client = { version = "0.6.0-prerelease-2", path = "client" }
+janus_collector = { version = "0.6.0-prerelease-2", path = "collector" }
+janus_core = { version = "0.6.0-prerelease-2", path = "core" }
+janus_integration_tests = { version = "0.6.0-prerelease-2", path = "integration_tests" }
+janus_interop_binaries = { version = "0.6.0-prerelease-2", path = "interop_binaries" }
+janus_messages = { version = "0.6.0-prerelease-2", path = "messages" }
 k8s-openapi = { version = "0.18.0", features = ["v1_24"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
 kube = { version = "0.82.2", default-features = false, features = ["client", "rustls-tls"] }
 opentelemetry = { version = "0.20", features = ["metrics"] }


### PR DESCRIPTION
This prepares us for cutting a new prerelease, in order to include full `chunk_length` support.