### PR TITLE
Integration/E2E test logging improvements 

### DIFF
--- a/integration_tests/tests/common/mod.rs
+++ b/integration_tests/tests/common/mod.rs
@@ -216,6 +216,7 @@ pub async fn submit_measurements_and_verify_aggregate_generic<V>(
 }
 
 pub async fn submit_measurements_and_verify_aggregate(
+    test_name: &str,
     task_parameters: &TaskParameters,
     (leader_port, helper_port): (u16, u16),
     client_backend: &ClientBackend<'_>,
@@ -242,7 +243,12 @@ pub async fn submit_measurements_and_verify_aggregate(
             };
 
             let client_implementation = client_backend
-                .build(task_parameters, (leader_port, helper_port), vdaf.clone())
+                .build(
+                    test_name,
+                    task_parameters,
+                    (leader_port, helper_port),
+                    vdaf.clone(),
+                )
                 .await
                 .unwrap();
 
@@ -269,7 +275,12 @@ pub async fn submit_measurements_and_verify_aggregate(
             };
 
             let client_implementation = client_backend
-                .build(task_parameters, (leader_port, helper_port), vdaf.clone())
+                .build(
+                    test_name,
+                    task_parameters,
+                    (leader_port, helper_port),
+                    vdaf.clone(),
+                )
                 .await
                 .unwrap();
 
@@ -312,7 +323,12 @@ pub async fn submit_measurements_and_verify_aggregate(
             };
 
             let client_implementation = client_backend
-                .build(task_parameters, (leader_port, helper_port), vdaf.clone())
+                .build(
+                    test_name,
+                    task_parameters,
+                    (leader_port, helper_port),
+                    vdaf.clone(),
+                )
                 .await
                 .unwrap();
 
@@ -346,7 +362,12 @@ pub async fn submit_measurements_and_verify_aggregate(
             };
 
             let client_implementation = client_backend
-                .build(task_parameters, (leader_port, helper_port), vdaf.clone())
+                .build(
+                    test_name,
+                    task_parameters,
+                    (leader_port, helper_port),
+                    vdaf.clone(),
+                )
                 .await
                 .unwrap();
 
@@ -388,7 +409,12 @@ pub async fn submit_measurements_and_verify_aggregate(
             };
 
             let client_implementation = client_backend
-                .build(task_parameters, (leader_port, helper_port), vdaf.clone())
+                .build(
+                    test_name,
+                    task_parameters,
+                    (leader_port, helper_port),
+                    vdaf.clone(),
+                )
                 .await
                 .unwrap();
 

--- a/integration_tests/tests/daphne.rs
+++ b/integration_tests/tests/daphne.rs
@@ -13,6 +13,7 @@ mod common;
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "Daphne does not yet publish a leader container image"]
 async fn daphne_janus() {
+    static TEST_NAME: &'static str = "daphne_janus";
     install_test_trace_subscriber();
 
     // Start servers.
@@ -35,11 +36,12 @@ async fn daphne_janus() {
         .unwrap();
 
     let container_client = container_client();
-    let leader = Daphne::new(&container_client, &network, &leader_task).await;
-    let helper = Janus::new(&container_client, &network, &helper_task).await;
+    let leader = Daphne::new(TEST_NAME, &container_client, &network, &leader_task).await;
+    let helper = Janus::new(TEST_NAME, &container_client, &network, &helper_task).await;
 
     // Run the behavioral test.
     submit_measurements_and_verify_aggregate(
+        TEST_NAME,
         &task_parameters,
         (leader.port(), helper.port()),
         &ClientBackend::InProcess,
@@ -51,6 +53,7 @@ async fn daphne_janus() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "Daphne does not currently support DAP-07 (issue #1669)"]
 async fn janus_daphne() {
+    static TEST_NAME: &'static str = "daphne_janus";
     install_test_trace_subscriber();
 
     // Start servers.
@@ -73,11 +76,12 @@ async fn janus_daphne() {
         .unwrap();
 
     let container_client = container_client();
-    let leader = Janus::new(&container_client, &network, &leader_task).await;
-    let helper = Daphne::new(&container_client, &network, &helper_task).await;
+    let leader = Janus::new(TEST_NAME, &container_client, &network, &leader_task).await;
+    let helper = Daphne::new(TEST_NAME, &container_client, &network, &helper_task).await;
 
     // Run the behavioral test.
     submit_measurements_and_verify_aggregate(
+        TEST_NAME,
         &task_parameters,
         (leader.port(), helper.port()),
         &ClientBackend::InProcess,

--- a/integration_tests/tests/daphne.rs
+++ b/integration_tests/tests/daphne.rs
@@ -13,7 +13,7 @@ mod common;
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "Daphne does not yet publish a leader container image"]
 async fn daphne_janus() {
-    static TEST_NAME: &'static str = "daphne_janus";
+    static TEST_NAME: &str = "daphne_janus";
     install_test_trace_subscriber();
 
     // Start servers.
@@ -53,7 +53,7 @@ async fn daphne_janus() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "Daphne does not currently support DAP-07 (issue #1669)"]
 async fn janus_daphne() {
-    static TEST_NAME: &'static str = "daphne_janus";
+    static TEST_NAME: &str = "daphne_janus";
     install_test_trace_subscriber();
 
     // Start servers.

--- a/integration_tests/tests/divviup_ts.rs
+++ b/integration_tests/tests/divviup_ts.rs
@@ -15,12 +15,16 @@ use testcontainers::clients::Cli;
 
 mod common;
 
-async fn run_divviup_ts_integration_test(container_client: &Cli, vdaf: VdafInstance) {
+async fn run_divviup_ts_integration_test(
+    test_name: &str,
+    container_client: &Cli,
+    vdaf: VdafInstance,
+) {
     let (task_parameters, leader_task, helper_task) =
         test_task_builders(vdaf, QueryType::TimeInterval);
     let network = generate_network_name();
-    let leader = Janus::new(container_client, &network, &leader_task.build()).await;
-    let helper = Janus::new(container_client, &network, &helper_task.build()).await;
+    let leader = Janus::new(test_name, container_client, &network, &leader_task.build()).await;
+    let helper = Janus::new(test_name, container_client, &network, &helper_task.build()).await;
 
     let client_backend = ClientBackend::Container {
         container_client,
@@ -28,6 +32,7 @@ async fn run_divviup_ts_integration_test(container_client: &Cli, vdaf: VdafInsta
         network: &network,
     };
     submit_measurements_and_verify_aggregate(
+        test_name,
         &task_parameters,
         (leader.port(), helper.port()),
         &client_backend,
@@ -40,7 +45,12 @@ async fn run_divviup_ts_integration_test(container_client: &Cli, vdaf: VdafInsta
 async fn janus_divviup_ts_count() {
     install_test_trace_subscriber();
 
-    run_divviup_ts_integration_test(&container_client(), VdafInstance::Prio3Count).await;
+    run_divviup_ts_integration_test(
+        "janus_divviup_ts_count",
+        &container_client(),
+        VdafInstance::Prio3Count,
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -48,7 +58,12 @@ async fn janus_divviup_ts_count() {
 async fn janus_divviup_ts_sum() {
     install_test_trace_subscriber();
 
-    run_divviup_ts_integration_test(&container_client(), VdafInstance::Prio3Sum { bits: 8 }).await;
+    run_divviup_ts_integration_test(
+        "janus_divviup_ts_sum",
+        &container_client(),
+        VdafInstance::Prio3Sum { bits: 8 },
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -57,6 +72,7 @@ async fn janus_divviup_ts_histogram() {
     install_test_trace_subscriber();
 
     run_divviup_ts_integration_test(
+        "janus_divviup_ts_histogram",
         &container_client(),
         VdafInstance::Prio3Histogram {
             length: 4,

--- a/integration_tests/tests/in_cluster.rs
+++ b/integration_tests/tests/in_cluster.rs
@@ -268,6 +268,7 @@ async fn in_cluster_count() {
 
     // Run the behavioral test.
     submit_measurements_and_verify_aggregate(
+        "in_cluster_count",
         &janus_pair.task_parameters,
         (janus_pair.leader.port(), janus_pair.helper.port()),
         &ClientBackend::InProcess,
@@ -285,6 +286,7 @@ async fn in_cluster_sum() {
 
     // Run the behavioral test.
     submit_measurements_and_verify_aggregate(
+        "in_cluster_sum",
         &janus_pair.task_parameters,
         (janus_pair.leader.port(), janus_pair.helper.port()),
         &ClientBackend::InProcess,
@@ -308,6 +310,7 @@ async fn in_cluster_histogram() {
 
     // Run the behavioral test.
     submit_measurements_and_verify_aggregate(
+        "in_cluster_histogram",
         &janus_pair.task_parameters,
         (janus_pair.leader.port(), janus_pair.helper.port()),
         &ClientBackend::InProcess,
@@ -331,6 +334,7 @@ async fn in_cluster_fixed_size() {
 
     // Run the behavioral test.
     submit_measurements_and_verify_aggregate(
+        "in_cluster_fixed_size",
         &janus_pair.task_parameters,
         (janus_pair.leader.port(), janus_pair.helper.port()),
         &ClientBackend::InProcess,

--- a/integration_tests/tests/janus.rs
+++ b/integration_tests/tests/janus.rs
@@ -26,6 +26,7 @@ impl<'a> JanusPair<'a> {
     /// Set up a new pair of containerized Janus test instances, and set up a new task in each using
     /// the given VDAF and query type.
     pub async fn new(
+        test_name: &str,
         container_client: &'a Cli,
         vdaf: VdafInstance,
         query_type: QueryType,
@@ -33,8 +34,8 @@ impl<'a> JanusPair<'a> {
         let (task_parameters, leader_task, helper_task) = test_task_builders(vdaf, query_type);
 
         let network = generate_network_name();
-        let leader = Janus::new(container_client, &network, &leader_task.build()).await;
-        let helper = Janus::new(container_client, &network, &helper_task.build()).await;
+        let leader = Janus::new(test_name, container_client, &network, &leader_task.build()).await;
+        let helper = Janus::new(test_name, container_client, &network, &helper_task.build()).await;
 
         Self {
             task_parameters,
@@ -47,11 +48,13 @@ impl<'a> JanusPair<'a> {
 /// This test exercises Prio3Count with Janus as both the leader and the helper.
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_janus_count() {
+    static TEST_NAME: &'static str = "janus_janus_count";
     install_test_trace_subscriber();
 
     // Start servers.
     let container_client = container_client();
     let janus_pair = JanusPair::new(
+        TEST_NAME,
         &container_client,
         VdafInstance::Prio3Count,
         QueryType::TimeInterval,
@@ -60,6 +63,7 @@ async fn janus_janus_count() {
 
     // Run the behavioral test.
     submit_measurements_and_verify_aggregate(
+        TEST_NAME,
         &janus_pair.task_parameters,
         (janus_pair.leader.port(), janus_pair.helper.port()),
         &ClientBackend::InProcess,
@@ -70,11 +74,13 @@ async fn janus_janus_count() {
 /// This test exercises Prio3Sum with Janus as both the leader and the helper.
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_janus_sum_16() {
+    static TEST_NAME: &'static str = "janus_janus_sum_16";
     install_test_trace_subscriber();
 
     // Start servers.
     let container_client = container_client();
     let janus_pair = JanusPair::new(
+        TEST_NAME,
         &container_client,
         VdafInstance::Prio3Sum { bits: 16 },
         QueryType::TimeInterval,
@@ -83,6 +89,7 @@ async fn janus_janus_sum_16() {
 
     // Run the behavioral test.
     submit_measurements_and_verify_aggregate(
+        TEST_NAME,
         &janus_pair.task_parameters,
         (janus_pair.leader.port(), janus_pair.helper.port()),
         &ClientBackend::InProcess,
@@ -93,11 +100,13 @@ async fn janus_janus_sum_16() {
 /// This test exercises Prio3Histogram with Janus as both the leader and the helper.
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_janus_histogram_4_buckets() {
+    static TEST_NAME: &'static str = "janus_janus_histogram_4_buckets";
     install_test_trace_subscriber();
 
     // Start servers.
     let container_client = container_client();
     let janus_pair = JanusPair::new(
+        TEST_NAME,
         &container_client,
         VdafInstance::Prio3Histogram {
             length: 4,
@@ -109,6 +118,7 @@ async fn janus_janus_histogram_4_buckets() {
 
     // Run the behavioral test.
     submit_measurements_and_verify_aggregate(
+        TEST_NAME,
         &janus_pair.task_parameters,
         (janus_pair.leader.port(), janus_pair.helper.port()),
         &ClientBackend::InProcess,
@@ -119,11 +129,13 @@ async fn janus_janus_histogram_4_buckets() {
 /// This test exercises the fixed-size query type with Janus as both the leader and the helper.
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_janus_fixed_size() {
+    static TEST_NAME: &'static str = "janus_janus_fixed_size";
     install_test_trace_subscriber();
 
     // Start servers.
     let container_client = container_client();
     let janus_pair = JanusPair::new(
+        TEST_NAME,
         &container_client,
         VdafInstance::Prio3Count,
         QueryType::FixedSize {
@@ -135,6 +147,7 @@ async fn janus_janus_fixed_size() {
 
     // Run the behavioral test.
     submit_measurements_and_verify_aggregate(
+        TEST_NAME,
         &janus_pair.task_parameters,
         (janus_pair.leader.port(), janus_pair.helper.port()),
         &ClientBackend::InProcess,
@@ -145,10 +158,12 @@ async fn janus_janus_fixed_size() {
 // This test exercises Prio3SumVec with Janus as both the leader and the helper.
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_janus_sum_vec() {
+    static TEST_NAME: &'static str = "janus_janus_sum_vec";
     install_test_trace_subscriber();
 
     let container_client = container_client();
     let janus_pair = JanusPair::new(
+        TEST_NAME,
         &container_client,
         VdafInstance::Prio3SumVec {
             bits: 16,
@@ -160,6 +175,7 @@ async fn janus_janus_sum_vec() {
     .await;
 
     submit_measurements_and_verify_aggregate(
+        TEST_NAME,
         &janus_pair.task_parameters,
         (janus_pair.leader.port(), janus_pair.helper.port()),
         &ClientBackend::InProcess,

--- a/integration_tests/tests/janus.rs
+++ b/integration_tests/tests/janus.rs
@@ -48,7 +48,7 @@ impl<'a> JanusPair<'a> {
 /// This test exercises Prio3Count with Janus as both the leader and the helper.
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_janus_count() {
-    static TEST_NAME: &'static str = "janus_janus_count";
+    static TEST_NAME: &str = "janus_janus_count";
     install_test_trace_subscriber();
 
     // Start servers.
@@ -74,7 +74,7 @@ async fn janus_janus_count() {
 /// This test exercises Prio3Sum with Janus as both the leader and the helper.
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_janus_sum_16() {
-    static TEST_NAME: &'static str = "janus_janus_sum_16";
+    static TEST_NAME: &str = "janus_janus_sum_16";
     install_test_trace_subscriber();
 
     // Start servers.
@@ -100,7 +100,7 @@ async fn janus_janus_sum_16() {
 /// This test exercises Prio3Histogram with Janus as both the leader and the helper.
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_janus_histogram_4_buckets() {
-    static TEST_NAME: &'static str = "janus_janus_histogram_4_buckets";
+    static TEST_NAME: &str = "janus_janus_histogram_4_buckets";
     install_test_trace_subscriber();
 
     // Start servers.
@@ -129,7 +129,7 @@ async fn janus_janus_histogram_4_buckets() {
 /// This test exercises the fixed-size query type with Janus as both the leader and the helper.
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_janus_fixed_size() {
-    static TEST_NAME: &'static str = "janus_janus_fixed_size";
+    static TEST_NAME: &str = "janus_janus_fixed_size";
     install_test_trace_subscriber();
 
     // Start servers.
@@ -158,7 +158,7 @@ async fn janus_janus_fixed_size() {
 // This test exercises Prio3SumVec with Janus as both the leader and the helper.
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_janus_sum_vec() {
-    static TEST_NAME: &'static str = "janus_janus_sum_vec";
+    static TEST_NAME: &str = "janus_janus_sum_vec";
     install_test_trace_subscriber();
 
     let container_client = container_client();

--- a/interop_binaries/config/supervisord.conf
+++ b/interop_binaries/config/supervisord.conf
@@ -14,28 +14,28 @@ serverurl=unix:///tmp/janus-supervisor.sock
 [program:janus_interop_aggregator]
 command=/usr/local/bin/janus_interop_aggregator --config-file /etc/janus/janus_interop_aggregator.yaml
 autostart=false
-environment=RUST_LOG=info,DATASTORE_KEYS=OSjfC8QVPATwO3uVJcAnTA
+environment=DATASTORE_KEYS=OSjfC8QVPATwO3uVJcAnTA
 stdout_logfile=/logs/aggregator_stdout.log
 stderr_logfile=/logs/aggregator_stderr.log
 
 [program:aggregation_job_creator]
 command=/usr/local/bin/aggregation_job_creator --config-file /etc/janus/aggregation_job_creator.yaml
 autostart=false
-environment=RUST_LOG=info,DATASTORE_KEYS=OSjfC8QVPATwO3uVJcAnTA
+environment=DATASTORE_KEYS=OSjfC8QVPATwO3uVJcAnTA
 stdout_logfile=/logs/aggregation_job_creator_stdout.log
 stderr_logfile=/logs/aggregation_job_creator_stderr.log
 
 [program:aggregation_job_driver]
 command=/usr/local/bin/aggregation_job_driver --config-file /etc/janus/aggregation_job_driver.yaml
 autostart=false
-environment=RUST_LOG=info,DATASTORE_KEYS=OSjfC8QVPATwO3uVJcAnTA
+environment=DATASTORE_KEYS=OSjfC8QVPATwO3uVJcAnTA
 stdout_logfile=/logs/aggregation_job_driver_stdout.log
 stderr_logfile=/logs/aggregation_job_driver_stderr.log
 
 [program:collection_job_driver]
 command=/usr/local/bin/collection_job_driver --config-file /etc/janus/collection_job_driver.yaml
 autostart=false
-environment=RUST_LOG=info,DATASTORE_KEYS=OSjfC8QVPATwO3uVJcAnTA
+environment=DATASTORE_KEYS=OSjfC8QVPATwO3uVJcAnTA
 stdout_logfile=/logs/collection_job_driver_stdout.log
 stderr_logfile=/logs/collection_job_driver_stderr.log
 
@@ -50,6 +50,5 @@ stderr_logfile=/logs/postgres_stderr.log
 command=/usr/local/bin/setup.sh
 autostart=true
 autorestart=false
-environment=RUST_LOG=info
 stdout_logfile=/logs/setup_stdout.log
 stderr_logfile=/logs/setup_stderr.log

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -23,7 +23,6 @@ use std::{
     process::{Command, Stdio},
     str::FromStr,
     sync::Arc,
-    thread::panicking,
 };
 use testcontainers::{Container, Image};
 use tokio::sync::Mutex;
@@ -438,12 +437,6 @@ impl<'d, I: Image> ContainerLogsDropGuard<'d, I> {
 
 impl<'d, I: Image> Drop for ContainerLogsDropGuard<'d, I> {
     fn drop(&mut self) {
-        if !panicking() {
-            return;
-        }
-        // If we're panicking then we're probably in the middle of test failure. In this case,
-        // export logs if log_export_path() suggests doing so.
-        //
         // The unwraps in this code block would induce a double panic, but we accept this risk
         // since it happens only in test code. This is also our main method of debugging
         // integration tests, so if it's broken we should be alerted and have it fixed ASAP.

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -539,7 +539,7 @@ impl Default for Keyring {
 }
 
 /// Returns the environment variable RUST_LOG. If it's unset or otherwise invalid, return the
-/// default value of "debug".
+/// default value of "info".
 pub fn get_rust_log_level() -> (&'static str, String) {
     (
         "RUST_LOG",


### PR DESCRIPTION
Some improvements that came out of me debugging https://github.com/divviup/janus/issues/1977.

- Pass through the RUST_LOG environment variable to test containers, so we can directly control log level at the CLI. We still default to `info` logging level.
- Have each test deposit logs to a folder whose name is the test name, so that logs from a run that invoked multiple tests can be differentiated.
- Always output logs if JANUS_E2E_LOGS_PATH is set, in case we need help debugging a test that should fail, but doesn't.