### PR TITLE
Set a default log level in Dockerfile.interop_aggregator

### DIFF
--- a/Dockerfile.interop_aggregator
+++ b/Dockerfile.interop_aggregator
@@ -82,5 +82,6 @@ COPY --from=builder-aggregator \
     /src/target/$PROFILE/aggregation_job_driver \
     /src/target/$PROFILE/collection_job_driver \
     /usr/local/bin/
+ENV RUST_LOG=info
 EXPOSE 8080
 ENTRYPOINT ["/usr/bin/supervisord", "-c", "/etc/janus/supervisord.conf"]


### PR DESCRIPTION
This is a follow-up to #2011 to set the default `RUST_LOG` level in a Dockerfile environment variable. Docker allows environment variables declared in a container image to be overridden when creating a container, so the new code in #2011 will still be able to pass through `RUST_LOG` from integration test processes. This change just affects other use cases of the images (such as in the divviup-ts test suite), so that they still get a good default amount of logging.