### PR TITLE
Task rewrite: use `AggregatorTask` in `query_type`

### DIFF
--- a/aggregator/src/aggregator/accumulator.rs
+++ b/aggregator/src/aggregator/accumulator.rs
@@ -80,8 +80,11 @@ impl<const SEED_SIZE: usize, Q: AccumulableQueryType, A: vdaf::Aggregator<SEED_S
         client_timestamp: &Time,
         output_share: &A::OutputShare,
     ) -> Result<(), datastore::Error> {
-        let batch_identifier =
-            Q::to_batch_identifier(&self.task, partial_batch_identifier, client_timestamp)?;
+        let batch_identifier = Q::to_batch_identifier(
+            &self.task.view_for_role()?,
+            partial_batch_identifier,
+            client_timestamp,
+        )?;
         let client_timestamp_interval =
             Interval::from_time(client_timestamp).map_err(|e| datastore::Error::User(e.into()))?;
         let batch_aggregation_fn = || {

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -745,8 +745,12 @@ mod tests {
             Role::Leader,
         )
         .build();
-        let batch_identifier =
-            TimeInterval::to_batch_identifier(&leader_task, &(), &report_time).unwrap();
+        let batch_identifier = TimeInterval::to_batch_identifier(
+            &leader_task.view_for_role().unwrap(),
+            &(),
+            &report_time,
+        )
+        .unwrap();
         let leader_report = LeaderStoredReport::new_dummy(*leader_task.id(), report_time);
 
         let helper_task = TaskBuilder::new(
@@ -872,7 +876,9 @@ mod tests {
         // Create 2 max-size batches, a min-size batch, one extra report (which will be added to the
         // min-size batch).
         let report_time = clock.now();
-        let batch_identifier = TimeInterval::to_batch_identifier(&task, &(), &report_time).unwrap();
+        let batch_identifier =
+            TimeInterval::to_batch_identifier(&task.view_for_role().unwrap(), &(), &report_time)
+                .unwrap();
         let reports: Vec<_> =
             iter::repeat_with(|| LeaderStoredReport::new_dummy(*task.id(), report_time))
                 .take(2 * MAX_AGGREGATION_JOB_SIZE + MIN_AGGREGATION_JOB_SIZE + 1)
@@ -980,7 +986,9 @@ mod tests {
             .build(),
         );
         let report_time = clock.now();
-        let batch_identifier = TimeInterval::to_batch_identifier(&task, &(), &report_time).unwrap();
+        let batch_identifier =
+            TimeInterval::to_batch_identifier(&task.view_for_role().unwrap(), &(), &report_time)
+                .unwrap();
         let first_report = LeaderStoredReport::new_dummy(*task.id(), report_time);
         let second_report = LeaderStoredReport::new_dummy(*task.id(), report_time);
 
@@ -1113,7 +1121,9 @@ mod tests {
 
         // Create a min-size batch.
         let report_time = clock.now();
-        let batch_identifier = TimeInterval::to_batch_identifier(&task, &(), &report_time).unwrap();
+        let batch_identifier =
+            TimeInterval::to_batch_identifier(&task.view_for_role().unwrap(), &(), &report_time)
+                .unwrap();
         let reports: Vec<_> =
             iter::repeat_with(|| LeaderStoredReport::new_dummy(*task.id(), report_time))
                 .take(2 * MAX_AGGREGATION_JOB_SIZE + MIN_AGGREGATION_JOB_SIZE + 1)

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -988,7 +988,8 @@ mod tests {
             .now()
             .to_batch_interval_start(task.time_precision())
             .unwrap();
-        let batch_identifier = TimeInterval::to_batch_identifier(&task, &(), &time).unwrap();
+        let batch_identifier =
+            TimeInterval::to_batch_identifier(&task.view_for_role().unwrap(), &(), &time).unwrap();
         let report_metadata = ReportMetadata::new(random(), time);
         let verify_key: VerifyKey<VERIFY_KEY_LENGTH> = task.vdaf_verify_key().unwrap();
         let measurement = IdpfInput::from_bools(&[true]);
@@ -1286,7 +1287,8 @@ mod tests {
             .now()
             .to_batch_interval_start(task.time_precision())
             .unwrap();
-        let batch_identifier = TimeInterval::to_batch_identifier(&task, &(), &time).unwrap();
+        let batch_identifier =
+            TimeInterval::to_batch_identifier(&task.view_for_role().unwrap(), &(), &time).unwrap();
         let report_metadata = ReportMetadata::new(random(), time);
         let verify_key: VerifyKey<VERIFY_KEY_LENGTH> = task.vdaf_verify_key().unwrap();
 
@@ -1646,7 +1648,8 @@ mod tests {
             .now()
             .to_batch_interval_start(task.time_precision())
             .unwrap();
-        let batch_identifier = TimeInterval::to_batch_identifier(&task, &(), &time).unwrap();
+        let batch_identifier =
+            TimeInterval::to_batch_identifier(&task.view_for_role().unwrap(), &(), &time).unwrap();
         let report_metadata = ReportMetadata::new(random(), time);
         let verify_key: VerifyKey<VERIFY_KEY_LENGTH> = task.vdaf_verify_key().unwrap();
         let measurement = IdpfInput::from_bools(&[true]);
@@ -2404,7 +2407,8 @@ mod tests {
             .now()
             .to_batch_interval_start(task.time_precision())
             .unwrap();
-        let active_batch_identifier = TimeInterval::to_batch_identifier(&task, &(), &time).unwrap();
+        let active_batch_identifier =
+            TimeInterval::to_batch_identifier(&task.view_for_role().unwrap(), &(), &time).unwrap();
         let other_batch_identifier = Interval::new(
             active_batch_identifier
                 .start()
@@ -2727,7 +2731,7 @@ mod tests {
                             _,
                         >(
                             tx,
-                            &task,
+                            &task.view_for_role().unwrap(),
                             &vdaf,
                             &Interval::new(
                                 report_metadata
@@ -3096,7 +3100,7 @@ mod tests {
                             VERIFY_KEY_LENGTH,
                             Poplar1<XofShake128, 16>,
                             _,
-                        >(tx, &task, &vdaf, &batch_id, &aggregation_param)
+                        >(tx, &task.view_for_role().unwrap(), &vdaf, &batch_id, &aggregation_param)
                         .await?;
                     let batch = tx
                         .get_batch(task.id(), &batch_id, &aggregation_param)
@@ -3162,7 +3166,8 @@ mod tests {
             .now()
             .to_batch_interval_start(task.time_precision())
             .unwrap();
-        let batch_identifier = TimeInterval::to_batch_identifier(&task, &(), &time).unwrap();
+        let batch_identifier =
+            TimeInterval::to_batch_identifier(&task.view_for_role().unwrap(), &(), &time).unwrap();
         let report_metadata = ReportMetadata::new(random(), time);
         let verify_key: VerifyKey<VERIFY_KEY_LENGTH> = task.vdaf_verify_key().unwrap();
 
@@ -3370,7 +3375,8 @@ mod tests {
             .now()
             .to_batch_interval_start(task.time_precision())
             .unwrap();
-        let batch_identifier = TimeInterval::to_batch_identifier(&task, &(), &time).unwrap();
+        let batch_identifier =
+            TimeInterval::to_batch_identifier(&task.view_for_role().unwrap(), &(), &time).unwrap();
         let report_metadata = ReportMetadata::new(random(), time);
         let transcript = run_vdaf(&vdaf, verify_key.as_bytes(), &(), report_metadata.id(), &0);
         let report = generate_report::<VERIFY_KEY_LENGTH, Prio3Count>(

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -161,7 +161,7 @@ impl CollectionJobDriver {
                     let batch_aggregations: Vec<_> =
                         Q::get_batch_aggregations_for_collection_identifier(
                             tx,
-                            &task,
+                            &task.leader_view()?,
                             vdaf.as_ref(),
                             collection_job.batch_identifier(),
                             collection_job.aggregation_parameter(),
@@ -177,7 +177,7 @@ impl CollectionJobDriver {
                     // transactionally to avoid the possibility of overwriting other transactions'
                     // updates to batch aggregations.
                     let empty_batch_aggregations = empty_batch_aggregations(
-                        &task,
+                        &task.leader_view()?,
                         batch_aggregation_shard_count,
                         collection_job.batch_identifier(),
                         collection_job.aggregation_parameter(),

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -2817,7 +2817,7 @@ mod tests {
         .unwrap();
         let second_batch_want_batch_aggregations =
             empty_batch_aggregations::<VERIFY_KEY_LENGTH, TimeInterval, Poplar1<XofShake128, 16>>(
-                &task,
+                &task.view_for_role().unwrap(),
                 BATCH_AGGREGATION_SHARD_COUNT,
                 &second_batch_identifier,
                 &aggregation_param,
@@ -2969,7 +2969,7 @@ mod tests {
                         _,
                     >(
                         tx,
-                        &task,
+                        &task.view_for_role().unwrap(),
                         &vdaf,
                         &Interval::new(
                             report_metadata_0
@@ -3051,7 +3051,7 @@ mod tests {
                         _,
                     >(
                         tx,
-                        &task,
+                        &task.view_for_role().unwrap(),
                         &vdaf,
                         &Interval::new(
                             report_metadata_2
@@ -3272,7 +3272,7 @@ mod tests {
                         _,
                     >(
                         tx,
-                        &task,
+                        &task.view_for_role().unwrap(),
                         &vdaf,
                         &Interval::new(
                             report_metadata_0
@@ -3359,7 +3359,7 @@ mod tests {
                         _,
                     >(
                         tx,
-                        &task,
+                        &task.view_for_role().unwrap(),
                         &vdaf,
                         &Interval::new(
                             report_metadata_2
@@ -4338,7 +4338,7 @@ mod tests {
         let test_case = setup_collection_job_test_case(Role::Leader, QueryType::TimeInterval).await;
 
         let batch_interval = TimeInterval::to_batch_identifier(
-            &test_case.task,
+            &test_case.task.view_for_role().unwrap(),
             &(),
             &Time::from_seconds_since_epoch(0),
         )

--- a/aggregator/src/aggregator/query_type.rs
+++ b/aggregator/src/aggregator/query_type.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use janus_aggregator_core::{
     datastore::{self, models::LeaderStoredReport, Transaction},
     query_type::{AccumulableQueryType, CollectableQueryType as CoreCollectableQueryType},
-    task::Task,
+    task::AggregatorTask,
 };
 use janus_core::time::Clock;
 use janus_messages::{
@@ -99,7 +99,7 @@ pub trait CollectableQueryType: CoreCollectableQueryType + AccumulableQueryType 
     >(
         tx: &Transaction<'_, C>,
         vdaf: &A,
-        task: &Task,
+        task: &AggregatorTask,
         batch_identifier: &Self::BatchIdentifier,
         aggregation_param: &A::AggregationParam,
     ) -> Result<(), datastore::Error>
@@ -116,7 +116,7 @@ impl CollectableQueryType for TimeInterval {
     >(
         tx: &Transaction<'_, C>,
         vdaf: &A,
-        task: &Task,
+        task: &AggregatorTask,
         collect_interval: &Self::BatchIdentifier,
         aggregation_param: &A::AggregationParam,
     ) -> Result<(), datastore::Error>
@@ -198,7 +198,7 @@ impl CollectableQueryType for FixedSize {
     >(
         tx: &Transaction<'_, C>,
         vdaf: &A,
-        task: &Task,
+        task: &AggregatorTask,
         batch_id: &Self::BatchIdentifier,
         aggregation_param: &A::AggregationParam,
     ) -> Result<(), datastore::Error>

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -11,7 +11,7 @@ use crate::{
         Crypter, Datastore, Error, Transaction, SUPPORTED_SCHEMA_VERSIONS,
     },
     query_type::CollectableQueryType,
-    task::{self, test_util::NewTaskBuilder as TaskBuilder, AggregatorTask, Task},
+    task::{self, test_util::NewTaskBuilder as TaskBuilder, AggregatorTask},
     taskprov::test_util::PeerAggregatorBuilder,
     test_util::noop_meter,
 };
@@ -4178,7 +4178,7 @@ async fn roundtrip_batch_aggregation_time_interval(ephemeral_datastore: Ephemera
                     _,
                 >(
                     tx,
-                    &Task::from(task.clone()),
+                    &task,
                     &vdaf,
                     &Interval::new(
                         Time::from_seconds_since_epoch(1100),
@@ -4223,7 +4223,7 @@ async fn roundtrip_batch_aggregation_time_interval(ephemeral_datastore: Ephemera
                     _,
                 >(
                     tx,
-                    &Task::from(task),
+                    &task,
                     &vdaf,
                     &Interval::new(
                         Time::from_seconds_since_epoch(1100),
@@ -4267,7 +4267,7 @@ async fn roundtrip_batch_aggregation_time_interval(ephemeral_datastore: Ephemera
                     _,
                 >(
                     tx,
-                    &Task::from(task),
+                    &task,
                     &vdaf,
                     &Interval::new(
                         Time::from_seconds_since_epoch(1100),

--- a/aggregator_core/src/query_type.rs
+++ b/aggregator_core/src/query_type.rs
@@ -4,7 +4,7 @@ use crate::{
         models::{AggregateShareJob, Batch, BatchAggregation, CollectionJob},
         Transaction,
     },
-    task::Task,
+    task::AggregatorTask,
 };
 use async_trait::async_trait;
 use futures::future::try_join_all;
@@ -22,7 +22,7 @@ pub trait AccumulableQueryType: QueryType {
     /// arguments are somewhat arbitrary in the sense they are what "works out" to allow the
     /// necessary functionality to be implemented for all query types.
     fn to_batch_identifier(
-        _: &Task,
+        _: &AggregatorTask,
         _: &Self::PartialBatchIdentifier,
         client_timestamp: &Time,
     ) -> Result<Self::BatchIdentifier, datastore::Error>;
@@ -73,7 +73,7 @@ pub trait AccumulableQueryType: QueryType {
 #[async_trait]
 impl AccumulableQueryType for TimeInterval {
     fn to_batch_identifier(
-        task: &Task,
+        task: &AggregatorTask,
         _: &Self::PartialBatchIdentifier,
         client_timestamp: &Time,
     ) -> Result<Self::BatchIdentifier, datastore::Error> {
@@ -141,7 +141,7 @@ impl AccumulableQueryType for TimeInterval {
 #[async_trait]
 impl AccumulableQueryType for FixedSize {
     fn to_batch_identifier(
-        _: &Task,
+        _: &AggregatorTask,
         batch_id: &Self::PartialBatchIdentifier,
         _: &Time,
     ) -> Result<Self::BatchIdentifier, datastore::Error> {
@@ -207,7 +207,7 @@ pub trait CollectableQueryType: AccumulableQueryType {
     /// Retrieves the batch identifier for a given query.
     async fn collection_identifier_for_query<C: Clock>(
         tx: &Transaction<'_, C>,
-        task: &Task,
+        task: &AggregatorTask,
         query: &Query<Self>,
     ) -> Result<Option<Self::BatchIdentifier>, datastore::Error>;
 
@@ -215,14 +215,14 @@ pub trait CollectableQueryType: AccumulableQueryType {
     /// requests which refers to multiple batches. This method takes a batch identifier received in
     /// a collection request and provides an iterator over the individual batches' identifiers.
     fn batch_identifiers_for_collection_identifier(
-        _: &Task,
+        _: &AggregatorTask,
         collection_identifier: &Self::BatchIdentifier,
     ) -> Self::Iter;
 
     /// Validates a collection identifier, per the boundary checks in
     /// <https://www.ietf.org/archive/id/draft-ietf-ppm-dap-02.html#section-4.5.6>.
     fn validate_collection_identifier(
-        task: &Task,
+        task: &AggregatorTask,
         collection_identifier: &Self::BatchIdentifier,
     ) -> bool;
 
@@ -230,7 +230,7 @@ pub trait CollectableQueryType: AccumulableQueryType {
     /// they have been aggregated or not.
     async fn count_client_reports<C: Clock>(
         tx: &Transaction<'_, C>,
-        task: &Task,
+        task: &AggregatorTask,
         collection_identifier: &Self::BatchIdentifier,
     ) -> Result<u64, datastore::Error>;
 
@@ -242,7 +242,7 @@ pub trait CollectableQueryType: AccumulableQueryType {
         C: Clock,
     >(
         tx: &Transaction<C>,
-        task: &Task,
+        task: &AggregatorTask,
         vdaf: &A,
         collection_identifier: &Self::BatchIdentifier,
         aggregation_param: &A::AggregationParam,
@@ -280,7 +280,7 @@ pub trait CollectableQueryType: AccumulableQueryType {
         C: Clock,
     >(
         tx: &Transaction<C>,
-        task: &Task,
+        task: &AggregatorTask,
         collection_identifier: &Self::BatchIdentifier,
         aggregation_param: &A::AggregationParam,
     ) -> Result<Vec<Batch<SEED_SIZE, Self, A>>, datastore::Error>
@@ -322,21 +322,21 @@ impl CollectableQueryType for TimeInterval {
 
     async fn collection_identifier_for_query<C: Clock>(
         _: &Transaction<'_, C>,
-        _: &Task,
+        _: &AggregatorTask,
         query: &Query<Self>,
     ) -> Result<Option<Self::BatchIdentifier>, datastore::Error> {
         Ok(Some(*query.batch_interval()))
     }
 
     fn batch_identifiers_for_collection_identifier(
-        task: &Task,
+        task: &AggregatorTask,
         batch_interval: &Self::BatchIdentifier,
     ) -> Self::Iter {
         TimeIntervalBatchIdentifierIter::new(task, batch_interval)
     }
 
     fn validate_collection_identifier(
-        task: &Task,
+        task: &AggregatorTask,
         collection_identifier: &Self::BatchIdentifier,
     ) -> bool {
         // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-02.html#section-4.5.6.1.1
@@ -351,7 +351,7 @@ impl CollectableQueryType for TimeInterval {
 
     async fn count_client_reports<C: Clock>(
         tx: &Transaction<'_, C>,
-        task: &Task,
+        task: &AggregatorTask,
         batch_interval: &Self::BatchIdentifier,
     ) -> Result<u64, datastore::Error> {
         tx.count_client_reports_for_interval(task.id(), batch_interval)
@@ -379,7 +379,7 @@ pub struct TimeIntervalBatchIdentifierIter {
 }
 
 impl TimeIntervalBatchIdentifierIter {
-    fn new(task: &Task, batch_interval: &Interval) -> Self {
+    fn new(task: &AggregatorTask, batch_interval: &Interval) -> Self {
         // Sanity check that the given interval is of an appropriate length. We use an assert as
         // this is expected to be checked before this method is used.
         assert_eq!(
@@ -428,7 +428,7 @@ impl CollectableQueryType for FixedSize {
 
     async fn collection_identifier_for_query<C: Clock>(
         tx: &Transaction<'_, C>,
-        task: &Task,
+        task: &AggregatorTask,
         query: &Query<Self>,
     ) -> Result<Option<Self::BatchIdentifier>, datastore::Error> {
         match query.fixed_size_query() {
@@ -441,19 +441,19 @@ impl CollectableQueryType for FixedSize {
     }
 
     fn batch_identifiers_for_collection_identifier(
-        _: &Task,
+        _: &AggregatorTask,
         batch_id: &Self::BatchIdentifier,
     ) -> Self::Iter {
         iter::once(*batch_id)
     }
 
-    fn validate_collection_identifier(_: &Task, _: &Self::BatchIdentifier) -> bool {
+    fn validate_collection_identifier(_: &AggregatorTask, _: &Self::BatchIdentifier) -> bool {
         true
     }
 
     async fn count_client_reports<C: Clock>(
         tx: &Transaction<'_, C>,
-        task: &Task,
+        task: &AggregatorTask,
         batch_id: &Self::BatchIdentifier,
     ) -> Result<u64, datastore::Error> {
         tx.count_client_reports_for_batch_id(task.id(), batch_id)
@@ -473,17 +473,19 @@ impl CollectableQueryType for FixedSize {
 mod tests {
     use crate::{
         query_type::CollectableQueryType,
-        task::{test_util::TaskBuilder, QueryType},
+        task::{test_util::NewTaskBuilder as TaskBuilder, QueryType},
     };
     use janus_core::vdaf::VdafInstance;
-    use janus_messages::{query_type::TimeInterval, Duration, Interval, Role, Time};
+    use janus_messages::{query_type::TimeInterval, Duration, Interval, Time};
 
     #[test]
     fn validate_collect_identifier() {
         let time_precision_secs = 3600;
-        let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake, Role::Leader)
+        let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake)
             .with_time_precision(Duration::from_seconds(time_precision_secs))
-            .build();
+            .build()
+            .leader_view()
+            .unwrap();
 
         struct TestCase {
             name: &'static str,


### PR DESCRIPTION
# Stacked on #2017

Adopts `janus_aggregator_core::task::AggregatorTask` in the `janus_aggregator_core::query_type` and `janus_aggregator::query_type` modules, making use of the routines for converting between `janus_aggregator_core::Task` and
`janus_aggregator_core::AggregatorTask` to make this minimally intrusive.

Part of #1524