### PR TITLE
Taskprov: fix authorization bug in aggregate init call

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -357,7 +357,15 @@ impl<C: Clock> Aggregator<C> {
                 if task_aggregator.task.role() != &Role::Helper {
                     return Err(Error::UnrecognizedTask(*task_id));
                 }
-                if !task_aggregator
+                if self.cfg.taskprov_config.enabled && taskprov_task_config.is_some() {
+                    self.taskprov_authorize_request(
+                        &Role::Leader,
+                        task_id,
+                        taskprov_task_config.unwrap(),
+                        auth_token.as_ref(),
+                    )
+                    .await?;
+                } else if !task_aggregator
                     .task
                     .check_aggregator_auth_token(auth_token.as_ref())
                 {

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -78,238 +78,250 @@ pub struct TaskprovTestCase {
     datastore: Arc<Datastore<MockClock>>,
     handler: Box<dyn Handler>,
     peer_aggregator: PeerAggregator,
-    report_metadata: ReportMetadata,
-    transcript: VdafTranscript<16, TestVdaf>,
-    report_share: ReportShare,
     task: Task,
     task_config: TaskConfig,
     task_id: TaskId,
-    aggregation_param: Poplar1AggregationParam,
+    vdaf: TestVdaf,
+    global_hpke_key: HpkeKeypair,
 }
 
-async fn setup_taskprov_test() -> TaskprovTestCase {
-    install_test_trace_subscriber();
+impl TaskprovTestCase {
+    async fn new() -> Self {
+        install_test_trace_subscriber();
 
-    let clock = MockClock::default();
-    let ephemeral_datastore = ephemeral_datastore().await;
-    let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
+        let clock = MockClock::default();
+        let ephemeral_datastore = ephemeral_datastore().await;
+        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
 
-    let global_hpke_key = generate_test_hpke_config_and_private_key();
-    let collector_hpke_keypair = generate_test_hpke_config_and_private_key();
-    let peer_aggregator = PeerAggregatorBuilder::new()
-        .with_endpoint(url::Url::parse("https://leader.example.com/").unwrap())
-        .with_role(Role::Leader)
-        .with_collector_hpke_config(collector_hpke_keypair.config().clone())
-        .build();
+        let global_hpke_key = generate_test_hpke_config_and_private_key();
+        let collector_hpke_keypair = generate_test_hpke_config_and_private_key();
+        let peer_aggregator = PeerAggregatorBuilder::new()
+            .with_endpoint(url::Url::parse("https://leader.example.com/").unwrap())
+            .with_role(Role::Leader)
+            .with_collector_hpke_config(collector_hpke_keypair.config().clone())
+            .build();
 
-    datastore
-        .run_tx(|tx| {
-            let global_hpke_key = global_hpke_key.clone();
-            let peer_aggregator = peer_aggregator.clone();
-            Box::pin(async move {
-                tx.put_global_hpke_keypair(&global_hpke_key).await.unwrap();
-                tx.put_taskprov_peer_aggregator(&peer_aggregator)
-                    .await
-                    .unwrap();
-                Ok(())
+        datastore
+            .run_tx(|tx| {
+                let global_hpke_key = global_hpke_key.clone();
+                let peer_aggregator = peer_aggregator.clone();
+                Box::pin(async move {
+                    tx.put_global_hpke_keypair(&global_hpke_key).await.unwrap();
+                    tx.put_taskprov_peer_aggregator(&peer_aggregator)
+                        .await
+                        .unwrap();
+                    Ok(())
+                })
             })
-        })
+            .await
+            .unwrap();
+
+        let handler = aggregator_handler(
+            Arc::clone(&datastore),
+            clock.clone(),
+            &noop_meter(),
+            Config {
+                taskprov_config: TaskprovConfig { enabled: true },
+                ..Default::default()
+            },
+        )
         .await
         .unwrap();
 
-    let handler = aggregator_handler(
-        Arc::clone(&datastore),
-        clock.clone(),
-        &noop_meter(),
-        Config {
-            taskprov_config: TaskprovConfig { enabled: true },
-            ..Default::default()
-        },
-    )
-    .await
-    .unwrap();
-
-    let time_precision = Duration::from_seconds(1);
-    let max_batch_query_count = 1;
-    let min_batch_size = 1;
-    let max_batch_size = 1;
-    let task_expiration = clock.now().add(&Duration::from_hours(24).unwrap()).unwrap();
-    let task_config = TaskConfig::new(
-        Vec::from("foobar".as_bytes()),
-        Vec::from([
-            "https://leader.example.com/".as_bytes().try_into().unwrap(),
-            "https://helper.example.com/".as_bytes().try_into().unwrap(),
-        ]),
-        QueryConfig::new(
-            time_precision,
-            max_batch_query_count,
-            min_batch_size,
-            TaskprovQuery::FixedSize { max_batch_size },
-        ),
-        task_expiration,
-        VdafConfig::new(
-            DpConfig::new(DpMechanism::None),
-            VdafType::Poplar1 { bits: 1 },
-        )
-        .unwrap(),
-    )
-    .unwrap();
-
-    let mut task_config_encoded = vec![];
-    task_config.encode(&mut task_config_encoded);
-
-    // We use a real VDAF since taskprov doesn't have any allowance for a test VDAF, and we use
-    // Poplar1 so that the VDAF wil take more than one step, so we can exercise aggregation
-    // continuation.
-    let vdaf = Poplar1::new(1);
-
-    let task_id = TaskId::try_from(digest(&SHA256, &task_config_encoded).as_ref()).unwrap();
-    let vdaf_instance = task_config.vdaf_config().vdaf_type().try_into().unwrap();
-    let vdaf_verify_key = peer_aggregator.derive_vdaf_verify_key(&task_id, &vdaf_instance);
-    let aggregation_param =
-        Poplar1AggregationParam::try_from_prefixes(Vec::from([IdpfInput::from_bools(&[true])]))
-            .unwrap();
-    let measurement = IdpfInput::from_bools(&[true]);
-
-    let task = TaskBuilder::new(
-        QueryType::FixedSize {
-            max_batch_size: max_batch_size as u64,
-            batch_time_window_size: None,
-        },
-        vdaf_instance,
-    )
-    .with_id(task_id)
-    .with_leader_aggregator_endpoint(Url::parse("https://leader.example.com/").unwrap())
-    .with_helper_aggregator_endpoint(Url::parse("https://helper.example.com/").unwrap())
-    .with_vdaf_verify_key(vdaf_verify_key.clone())
-    .with_max_batch_query_count(max_batch_query_count as u64)
-    .with_task_expiration(Some(task_expiration))
-    .with_report_expiry_age(peer_aggregator.report_expiry_age().copied())
-    .with_min_batch_size(min_batch_size as u64)
-    .with_time_precision(Duration::from_seconds(1))
-    .with_tolerable_clock_skew(Duration::from_seconds(1))
-    .build();
-
-    let report_metadata = ReportMetadata::new(
-        random(),
-        clock
-            .now()
-            .to_batch_interval_start(task.time_precision())
+        let time_precision = Duration::from_seconds(1);
+        let max_batch_query_count = 1;
+        let min_batch_size = 1;
+        let max_batch_size = 1;
+        let task_expiration = clock.now().add(&Duration::from_hours(24).unwrap()).unwrap();
+        let task_config = TaskConfig::new(
+            Vec::from("foobar".as_bytes()),
+            Vec::from([
+                "https://leader.example.com/".as_bytes().try_into().unwrap(),
+                "https://helper.example.com/".as_bytes().try_into().unwrap(),
+            ]),
+            QueryConfig::new(
+                time_precision,
+                max_batch_query_count,
+                min_batch_size,
+                TaskprovQuery::FixedSize { max_batch_size },
+            ),
+            task_expiration,
+            VdafConfig::new(
+                DpConfig::new(DpMechanism::None),
+                VdafType::Poplar1 { bits: 1 },
+            )
             .unwrap(),
-    );
-    let transcript = run_vdaf(
-        &vdaf,
-        vdaf_verify_key.as_ref().try_into().unwrap(),
-        &aggregation_param,
-        report_metadata.id(),
-        &measurement,
-    );
-    let report_share = generate_helper_report_share::<TestVdaf>(
-        task_id,
-        report_metadata.clone(),
-        global_hpke_key.config(),
-        &transcript.public_share,
-        Vec::new(),
-        &transcript.helper_input_share,
-    );
+        )
+        .unwrap();
 
-    TaskprovTestCase {
-        _ephemeral_datastore: ephemeral_datastore,
-        clock,
-        collector_hpke_keypair,
-        datastore,
-        handler: Box::new(handler),
-        peer_aggregator,
-        task,
-        task_config,
-        task_id,
-        report_metadata,
-        transcript,
-        report_share,
-        aggregation_param,
+        let task_config_encoded = task_config.get_encoded();
+
+        // We use a real VDAF since taskprov doesn't have any allowance for a test VDAF, and we use
+        // Poplar1 so that the VDAF wil take more than one step, so we can exercise aggregation
+        // continuation.
+        let vdaf = Poplar1::new(1);
+
+        let task_id = TaskId::try_from(digest(&SHA256, &task_config_encoded).as_ref()).unwrap();
+        let vdaf_instance = task_config.vdaf_config().vdaf_type().try_into().unwrap();
+        let vdaf_verify_key = peer_aggregator.derive_vdaf_verify_key(&task_id, &vdaf_instance);
+
+        let task = TaskBuilder::new(
+            QueryType::FixedSize {
+                max_batch_size: max_batch_size as u64,
+                batch_time_window_size: None,
+            },
+            vdaf_instance,
+        )
+        .with_id(task_id)
+        .with_leader_aggregator_endpoint(Url::parse("https://leader.example.com/").unwrap())
+        .with_helper_aggregator_endpoint(Url::parse("https://helper.example.com/").unwrap())
+        .with_vdaf_verify_key(vdaf_verify_key.clone())
+        .with_max_batch_query_count(max_batch_query_count as u64)
+        .with_task_expiration(Some(task_expiration))
+        .with_report_expiry_age(peer_aggregator.report_expiry_age().copied())
+        .with_min_batch_size(min_batch_size as u64)
+        .with_time_precision(Duration::from_seconds(1))
+        .with_tolerable_clock_skew(Duration::from_seconds(1))
+        .build();
+
+        Self {
+            _ephemeral_datastore: ephemeral_datastore,
+            clock,
+            collector_hpke_keypair,
+            datastore,
+            handler: Box::new(handler),
+            peer_aggregator,
+            task: task.into(),
+            task_config,
+            task_id,
+            vdaf,
+            global_hpke_key,
+        }
+    }
+
+    fn generate_helper_report_share(
+        &self,
+    ) -> (
+        ReportMetadata,
+        VdafTranscript<16, TestVdaf>,
+        ReportShare,
+        Poplar1AggregationParam,
+    ) {
+        let aggregation_param =
+            Poplar1AggregationParam::try_from_prefixes(Vec::from([IdpfInput::from_bools(&[true])]))
+                .unwrap();
+        let measurement = IdpfInput::from_bools(&[true]);
+        let report_metadata = ReportMetadata::new(
+            random(),
+            self.clock
+                .now()
+                .to_batch_interval_start(self.task.time_precision())
+                .unwrap(),
+        );
+        let transcript = run_vdaf(
+            &self.vdaf,
+            self.task.vdaf_verify_key().unwrap().as_bytes(),
+            &aggregation_param,
+            report_metadata.id(),
+            &measurement,
+        );
+        let report_share = generate_helper_report_share::<TestVdaf>(
+            *self.task.id(),
+            report_metadata.clone(),
+            self.global_hpke_key.config(),
+            &transcript.public_share,
+            Vec::new(),
+            &transcript.helper_input_share,
+        );
+        (report_metadata, transcript, report_share, aggregation_param)
     }
 }
 
 #[tokio::test]
 async fn taskprov_aggregate_init() {
-    let test = setup_taskprov_test().await;
+    let test = TaskprovTestCase::new().await;
 
-    let batch_id = random();
-    let request = AggregationJobInitializeReq::new(
-        test.aggregation_param.get_encoded(),
-        PartialBatchSelector::new_fixed_size(batch_id),
+    // Use two requests with the same task config. The second request will ensure that a previously
+    // provisioned task is usable.
+    let (_, transcript_1, report_share_1, aggregation_param_1) =
+        test.generate_helper_report_share();
+    let batch_id_1 = random();
+    let request_1 = AggregationJobInitializeReq::new(
+        aggregation_param_1.get_encoded(),
+        PartialBatchSelector::new_fixed_size(batch_id_1),
         Vec::from([PrepareInit::new(
-            test.report_share.clone(),
-            test.transcript.leader_prepare_transitions[0]
-                .message
-                .clone(),
+            report_share_1.clone(),
+            transcript_1.leader_prepare_transitions[0].message.clone(),
         )]),
     );
+    let aggregation_job_id_1: AggregationJobId = random();
 
-    let aggregation_job_id: AggregationJobId = random();
+    for (request, aggregation_job_id, report_share) in
+        [(request_1, aggregation_job_id_1, report_share_1)]
+    {
+        let auth = test
+            .peer_aggregator
+            .primary_aggregator_auth_token()
+            .request_authentication();
 
-    let auth = test
-        .peer_aggregator
-        .primary_aggregator_auth_token()
-        .request_authentication();
+        let mut test_conn = put(test
+            .task
+            .aggregation_job_uri(&aggregation_job_id)
+            .unwrap()
+            .path())
+        .with_request_header(auth.0, "Bearer invalid_token")
+        .with_request_header(
+            KnownHeaderName::ContentType,
+            AggregationJobInitializeReq::<FixedSize>::MEDIA_TYPE,
+        )
+        .with_request_header(
+            TASKPROV_HEADER,
+            URL_SAFE_NO_PAD.encode(test.task_config.get_encoded()),
+        )
+        .with_request_body(request.get_encoded())
+        .run_async(&test.handler)
+        .await;
+        assert_eq!(test_conn.status(), Some(Status::BadRequest));
+        assert_eq!(
+            take_problem_details(&mut test_conn).await,
+            json!({
+                "status": Status::BadRequest as u16,
+                "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
+                "title": "The request's authorization is not valid.",
+                "taskid": format!("{}", test.task_id),
+            })
+        );
 
-    let mut test_conn = put(test
-        .task
-        .aggregation_job_uri(&aggregation_job_id)
-        .unwrap()
-        .path())
-    .with_request_header(auth.0, "Bearer invalid_token")
-    .with_request_header(
-        KnownHeaderName::ContentType,
-        AggregationJobInitializeReq::<FixedSize>::MEDIA_TYPE,
-    )
-    .with_request_header(
-        TASKPROV_HEADER,
-        URL_SAFE_NO_PAD.encode(test.task_config.get_encoded()),
-    )
-    .with_request_body(request.get_encoded())
-    .run_async(&test.handler)
-    .await;
-    assert_eq!(test_conn.status(), Some(Status::BadRequest));
-    assert_eq!(
-        take_problem_details(&mut test_conn).await,
-        json!({
-            "status": Status::BadRequest as u16,
-            "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
-            "title": "The request's authorization is not valid.",
-            "taskid": format!("{}", test.task_id),
-        })
-    );
+        let mut test_conn = put(test
+            .task
+            .aggregation_job_uri(&aggregation_job_id_1)
+            .unwrap()
+            .path())
+        .with_request_header(auth.0, auth.1)
+        .with_request_header(
+            KnownHeaderName::ContentType,
+            AggregationJobInitializeReq::<FixedSize>::MEDIA_TYPE,
+        )
+        .with_request_header(
+            TASKPROV_HEADER,
+            URL_SAFE_NO_PAD.encode(test.task_config.get_encoded()),
+        )
+        .with_request_body(request.get_encoded())
+        .run_async(&test.handler)
+        .await;
 
-    let mut test_conn = put(test
-        .task
-        .aggregation_job_uri(&aggregation_job_id)
-        .unwrap()
-        .path())
-    .with_request_header(auth.0, auth.1)
-    .with_request_header(
-        KnownHeaderName::ContentType,
-        AggregationJobInitializeReq::<FixedSize>::MEDIA_TYPE,
-    )
-    .with_request_header(
-        TASKPROV_HEADER,
-        URL_SAFE_NO_PAD.encode(test.task_config.get_encoded()),
-    )
-    .with_request_body(request.get_encoded())
-    .run_async(&test.handler)
-    .await;
+        assert_eq!(test_conn.status(), Some(Status::Ok));
+        assert_headers!(
+            &test_conn,
+            "content-type" => (AggregationJobResp::MEDIA_TYPE)
+        );
+        let aggregate_resp: AggregationJobResp = decode_response_body(&mut test_conn).await;
 
-    assert_eq!(test_conn.status(), Some(Status::Ok));
-    assert_headers!(
-        &test_conn,
-        "content-type" => (AggregationJobResp::MEDIA_TYPE)
-    );
-    let aggregate_resp: AggregationJobResp = decode_response_body(&mut test_conn).await;
-
-    assert_eq!(aggregate_resp.prepare_resps().len(), 1);
-    let prepare_step = aggregate_resp.prepare_resps().get(0).unwrap();
-    assert_eq!(prepare_step.report_id(), test.report_share.metadata().id());
-    assert_matches!(prepare_step.result(), &PrepareStepResult::Continue { .. });
+        assert_eq!(aggregate_resp.prepare_resps().len(), 1);
+        let prepare_step = aggregate_resp.prepare_resps().get(0).unwrap();
+        assert_eq!(prepare_step.report_id(), report_share.metadata().id());
+        assert_matches!(prepare_step.result(), &PrepareStepResult::Continue { .. });
+    }
 
     let (aggregation_jobs, got_task) = test
         .datastore
@@ -330,8 +342,10 @@ async fn taskprov_aggregate_init() {
     assert_eq!(aggregation_jobs.len(), 1);
     assert!(
         aggregation_jobs[0].task_id().eq(&test.task_id)
-            && aggregation_jobs[0].id().eq(&aggregation_job_id)
-            && aggregation_jobs[0].partial_batch_identifier().eq(&batch_id)
+            && aggregation_jobs[0].id().eq(&aggregation_job_id_1)
+            && aggregation_jobs[0]
+                .partial_batch_identifier()
+                .eq(&batch_id_1)
             && aggregation_jobs[0]
                 .state()
                 .eq(&AggregationJobState::InProgress)
@@ -341,17 +355,16 @@ async fn taskprov_aggregate_init() {
 
 #[tokio::test]
 async fn taskprov_opt_out_task_expired() {
-    let test = setup_taskprov_test().await;
+    let test = TaskprovTestCase::new().await;
 
+    let (_, transcript, report_share, _) = test.generate_helper_report_share();
     let batch_id = random();
     let request = AggregationJobInitializeReq::new(
         ().get_encoded(),
         PartialBatchSelector::new_fixed_size(batch_id),
         Vec::from([PrepareInit::new(
-            test.report_share.clone(),
-            test.transcript.leader_prepare_transitions[0]
-                .message
-                .clone(),
+            report_share.clone(),
+            transcript.leader_prepare_transitions[0].message.clone(),
         )]),
     );
 
@@ -396,17 +409,16 @@ async fn taskprov_opt_out_task_expired() {
 
 #[tokio::test]
 async fn taskprov_opt_out_mismatched_task_id() {
-    let test = setup_taskprov_test().await;
+    let test = TaskprovTestCase::new().await;
 
+    let (_, transcript, report_share, _) = test.generate_helper_report_share();
     let batch_id = random();
     let request = AggregationJobInitializeReq::new(
         ().get_encoded(),
         PartialBatchSelector::new_fixed_size(batch_id),
         Vec::from([PrepareInit::new(
-            test.report_share.clone(),
-            test.transcript.leader_prepare_transitions[0]
-                .message
-                .clone(),
+            report_share.clone(),
+            transcript.leader_prepare_transitions[0].message.clone(),
         )]),
     );
 
@@ -479,17 +491,16 @@ async fn taskprov_opt_out_mismatched_task_id() {
 
 #[tokio::test]
 async fn taskprov_opt_out_missing_aggregator() {
-    let test = setup_taskprov_test().await;
+    let test = TaskprovTestCase::new().await;
 
+    let (_, transcript, report_share, _) = test.generate_helper_report_share();
     let batch_id = random();
     let request = AggregationJobInitializeReq::new(
         ().get_encoded(),
         PartialBatchSelector::new_fixed_size(batch_id),
         Vec::from([PrepareInit::new(
-            test.report_share.clone(),
-            test.transcript.leader_prepare_transitions[0]
-                .message
-                .clone(),
+            report_share.clone(),
+            transcript.leader_prepare_transitions[0].message.clone(),
         )]),
     );
 
@@ -560,17 +571,16 @@ async fn taskprov_opt_out_missing_aggregator() {
 
 #[tokio::test]
 async fn taskprov_opt_out_peer_aggregator_wrong_role() {
-    let test = setup_taskprov_test().await;
+    let test = TaskprovTestCase::new().await;
 
+    let (_, transcript, report_share, _) = test.generate_helper_report_share();
     let batch_id = random();
     let request = AggregationJobInitializeReq::new(
         ().get_encoded(),
         PartialBatchSelector::new_fixed_size(batch_id),
         Vec::from([PrepareInit::new(
-            test.report_share.clone(),
-            test.transcript.leader_prepare_transitions[0]
-                .message
-                .clone(),
+            report_share.clone(),
+            transcript.leader_prepare_transitions[0].message.clone(),
         )]),
     );
 
@@ -644,17 +654,16 @@ async fn taskprov_opt_out_peer_aggregator_wrong_role() {
 
 #[tokio::test]
 async fn taskprov_opt_out_peer_aggregator_does_not_exist() {
-    let test = setup_taskprov_test().await;
+    let test = TaskprovTestCase::new().await;
 
+    let (_, transcript, report_share, _) = test.generate_helper_report_share();
     let batch_id = random();
     let request = AggregationJobInitializeReq::new(
         ().get_encoded(),
         PartialBatchSelector::new_fixed_size(batch_id),
         Vec::from([PrepareInit::new(
-            test.report_share.clone(),
-            test.transcript.leader_prepare_transitions[0]
-                .message
-                .clone(),
+            report_share.clone(),
+            transcript.leader_prepare_transitions[0].message.clone(),
         )]),
     );
 
@@ -728,18 +737,20 @@ async fn taskprov_opt_out_peer_aggregator_does_not_exist() {
 
 #[tokio::test]
 async fn taskprov_aggregate_continue() {
-    let test = setup_taskprov_test().await;
+    let test = TaskprovTestCase::new().await;
 
     let aggregation_job_id = random();
     let batch_id = random();
 
+    let (report_metadata, transcript, report_share, aggregation_param) =
+        test.generate_helper_report_share();
     test.datastore
         .run_tx(|tx| {
             let task = test.task.clone();
-            let report_share = test.report_share.clone();
-            let report_metadata = test.report_metadata.clone();
-            let transcript = test.transcript.clone();
-            let aggregation_param = test.aggregation_param.clone();
+            let report_share = report_share.clone();
+            let report_metadata = report_metadata.clone();
+            let transcript = transcript.clone();
+            let aggregation_param = aggregation_param.clone();
 
             Box::pin(async move {
                 // Aggregate continue is only possible if the task has already been inserted.
@@ -796,10 +807,8 @@ async fn taskprov_aggregate_continue() {
     let request = AggregationJobContinueReq::new(
         AggregationJobStep::from(1),
         Vec::from([PrepareContinue::new(
-            *test.report_metadata.id(),
-            test.transcript.leader_prepare_transitions[1]
-                .message
-                .clone(),
+            *report_metadata.id(),
+            transcript.leader_prepare_transitions[1].message.clone(),
         )]),
     );
 
@@ -866,7 +875,7 @@ async fn taskprov_aggregate_continue() {
     assert_eq!(
         aggregate_resp,
         AggregationJobResp::new(Vec::from([PrepareResp::new(
-            *test.report_metadata.id(),
+            *report_metadata.id(),
             PrepareStepResult::Finished
         )]))
     );
@@ -874,8 +883,9 @@ async fn taskprov_aggregate_continue() {
 
 #[tokio::test]
 async fn taskprov_aggregate_share() {
-    let test = setup_taskprov_test().await;
+    let test = TaskprovTestCase::new().await;
 
+    let (_, transcript, _, aggregation_param) = test.generate_helper_report_share();
     let batch_id = random();
     test.datastore
         .run_tx(|tx| {
@@ -883,8 +893,8 @@ async fn taskprov_aggregate_share() {
             let interval =
                 Interval::new(Time::from_seconds_since_epoch(6000), *task.time_precision())
                     .unwrap();
-            let aggregation_param = test.aggregation_param.clone();
-            let transcript = test.transcript.clone();
+            let aggregation_param = aggregation_param.clone();
+            let transcript = transcript.clone();
 
             Box::pin(async move {
                 tx.put_aggregator_task(&task.taskprov_helper_view().unwrap())
@@ -922,7 +932,7 @@ async fn taskprov_aggregate_share() {
 
     let request = AggregateShareReq::new(
         BatchSelector::new_fixed_size(batch_id),
-        test.aggregation_param.get_encoded(),
+        aggregation_param.get_encoded(),
         1,
         ReportIdChecksum::get_decoded(&[3; 32]).unwrap(),
     );
@@ -984,7 +994,7 @@ async fn taskprov_aggregate_share() {
         aggregate_share_resp.encrypted_aggregate_share(),
         &AggregateShareAad::new(
             test.task_id,
-            test.aggregation_param.get_encoded(),
+            aggregation_param.get_encoded(),
             request.batch_selector().clone(),
         )
         .get_encoded(),
@@ -996,7 +1006,7 @@ async fn taskprov_aggregate_share() {
 /// taskprov-enabled helper, and confirms that correct results are returned.
 #[tokio::test]
 async fn end_to_end() {
-    let test = setup_taskprov_test().await;
+    let test = TaskprovTestCase::new().await;
     let (auth_header_name, auth_header_value) = test
         .peer_aggregator
         .primary_aggregator_auth_token()
@@ -1005,14 +1015,14 @@ async fn end_to_end() {
     let batch_id = random();
     let aggregation_job_id = random();
 
+    let (report_metadata, transcript, report_share, aggregation_param) =
+        test.generate_helper_report_share();
     let aggregation_job_init_request = AggregationJobInitializeReq::new(
-        test.aggregation_param.get_encoded(),
+        aggregation_param.get_encoded(),
         PartialBatchSelector::new_fixed_size(batch_id),
         Vec::from([PrepareInit::new(
-            test.report_share.clone(),
-            test.transcript.leader_prepare_transitions[0]
-                .message
-                .clone(),
+            report_share.clone(),
+            transcript.leader_prepare_transitions[0].message.clone(),
         )]),
     );
 
@@ -1040,23 +1050,18 @@ async fn end_to_end() {
 
     assert_eq!(aggregation_job_resp.prepare_resps().len(), 1);
     let prepare_resp = &aggregation_job_resp.prepare_resps()[0];
-    assert_eq!(prepare_resp.report_id(), test.report_metadata.id());
+    assert_eq!(prepare_resp.report_id(), report_metadata.id());
     let message = assert_matches!(
         prepare_resp.result(),
         PrepareStepResult::Continue { message } => message.clone()
     );
-    assert_eq!(
-        message,
-        test.transcript.helper_prepare_transitions[0].message,
-    );
+    assert_eq!(message, transcript.helper_prepare_transitions[0].message,);
 
     let aggregation_job_continue_request = AggregationJobContinueReq::new(
         AggregationJobStep::from(1),
         Vec::from([PrepareContinue::new(
-            *test.report_metadata.id(),
-            test.transcript.leader_prepare_transitions[1]
-                .message
-                .clone(),
+            *report_metadata.id(),
+            transcript.leader_prepare_transitions[1].message.clone(),
         )]),
     );
 
@@ -1085,13 +1090,13 @@ async fn end_to_end() {
 
     assert_eq!(aggregation_job_resp.prepare_resps().len(), 1);
     let prepare_resp = &aggregation_job_resp.prepare_resps()[0];
-    assert_eq!(prepare_resp.report_id(), test.report_metadata.id());
+    assert_eq!(prepare_resp.report_id(), report_metadata.id());
     assert_matches!(prepare_resp.result(), PrepareStepResult::Finished);
 
-    let checksum = ReportIdChecksum::for_report_id(test.report_metadata.id());
+    let checksum = ReportIdChecksum::for_report_id(report_metadata.id());
     let aggregate_share_request = AggregateShareReq::new(
         BatchSelector::new_fixed_size(batch_id),
-        test.aggregation_param.get_encoded(),
+        aggregation_param.get_encoded(),
         1,
         checksum,
     );
@@ -1120,14 +1125,11 @@ async fn end_to_end() {
         aggregate_share_resp.encrypted_aggregate_share(),
         &AggregateShareAad::new(
             test.task_id,
-            test.aggregation_param.get_encoded(),
+            aggregation_param.get_encoded(),
             aggregate_share_request.batch_selector().clone(),
         )
         .get_encoded(),
     )
     .unwrap();
-    assert_eq!(
-        plaintext,
-        test.transcript.helper_aggregate_share.get_encoded()
-    );
+    assert_eq!(plaintext, transcript.helper_aggregate_share.get_encoded());
 }

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -175,7 +175,7 @@ impl TaskprovTestCase {
         .with_id(task_id)
         .with_leader_aggregator_endpoint(Url::parse("https://leader.example.com/").unwrap())
         .with_helper_aggregator_endpoint(Url::parse("https://helper.example.com/").unwrap())
-        .with_vdaf_verify_key(vdaf_verify_key.clone())
+        .with_vdaf_verify_key(vdaf_verify_key)
         .with_max_batch_query_count(max_batch_query_count as u64)
         .with_task_expiration(Some(task_expiration))
         .with_report_expiry_age(peer_aggregator.report_expiry_age().copied())

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -286,8 +286,7 @@ async fn taskprov_aggregate_init() {
                 "title": "The request's authorization is not valid.",
                 "taskid": format!("{}", test.task_id),
             }),
-            "{}",
-            name
+            "{name}",
         );
 
         let mut test_conn = put(test
@@ -308,7 +307,7 @@ async fn taskprov_aggregate_init() {
         .run_async(&test.handler)
         .await;
 
-        assert_eq!(test_conn.status(), Some(Status::Ok), "{}", name);
+        assert_eq!(test_conn.status(), Some(Status::Ok), "{name}");
         assert_headers!(
             &test_conn,
             "content-type" => (AggregationJobResp::MEDIA_TYPE)
@@ -320,14 +319,12 @@ async fn taskprov_aggregate_init() {
         assert_eq!(
             prepare_step.report_id(),
             report_share.metadata().id(),
-            "{}",
-            name
+            "{name}",
         );
         assert_matches!(
             prepare_step.result(),
             &PrepareStepResult::Continue { .. },
-            "{}",
-            name
+            "{name}",
         );
     }
 


### PR DESCRIPTION
Calls to /aggregate subsequent to taskprov task provisioning would fail for the same task, because /aggregate was not using the right authorization tokens (that is, it was attempting to use non-existent authorization tokens and failing).

The first commit is just a refactoring PR to make the test implementation cleaner. The second commit is the operative one.