### PR TITLE
Task rewrite: aggregation job handling

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1595,7 +1595,7 @@ impl VdafOps {
         let agg_param = A::AggregationParam::get_decoded(req.aggregation_parameter())?;
 
         let mut accumulator = Accumulator::<SEED_SIZE, Q, A>::new(
-            Arc::clone(&task),
+            Arc::new(task.view_for_role()?),
             batch_aggregation_shard_count,
             agg_param.clone(),
         );
@@ -2064,6 +2064,8 @@ impl VdafOps {
                 "aggregation job cannot be advanced to step 0",
             ));
         }
+
+        let task = Arc::new(task.view_for_role()?);
 
         // TODO(#224): don't hold DB transaction open while computing VDAF updates?
         // TODO(#224): don't do O(n) network round-trips (where n is the number of prepare steps)

--- a/aggregator/src/aggregator/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/aggregation_job_continue.rs
@@ -10,7 +10,7 @@ use janus_aggregator_core::{
         Transaction,
     },
     query_type::AccumulableQueryType,
-    task::Task,
+    task::AggregatorTask,
 };
 use janus_core::time::Clock;
 use janus_messages::{
@@ -32,7 +32,7 @@ impl VdafOps {
     /// `report_aggregations` with the step `n+1` ping pong messages in `leader_aggregation_job`.
     pub(super) async fn step_aggregation_job<const SEED_SIZE: usize, C, Q, A>(
         tx: &Transaction<'_, C>,
-        task: Arc<Task>,
+        task: Arc<AggregatorTask>,
         vdaf: Arc<A>,
         batch_aggregation_shard_count: u64,
         helper_aggregation_job: AggregationJob<SEED_SIZE, Q, A>,


### PR DESCRIPTION
# Stacked on #2025

Adopts `AggregatorTask` and `NewTaskBuilder` across the aggregation job handling components.

Part of #1524