### PR TITLE
Task rewrite: `janus_cli`

### DIFF
--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -2257,7 +2257,8 @@ mod tests {
 
     #[test]
     fn deserialize_docs_sample_tasks() {
-        serde_yaml::from_str::<Vec<Task>>(include_str!("../../docs/samples/tasks.yaml")).unwrap();
+        serde_yaml::from_str::<Vec<AggregatorTask>>(include_str!("../../docs/samples/tasks.yaml"))
+            .unwrap();
     }
 
     #[test]

--- a/docs/samples/tasks.yaml
+++ b/docs/samples/tasks.yaml
@@ -6,9 +6,8 @@
   # DAP's recommendation.
   task_id: "G9YKXjoEjfoU7M_fi_o2H0wmzavRb2sBFHeykeRhDMk"
 
-  # HTTPS endpoints of the leader and helper aggregators.
-  leader_aggregator_endpoint: "https://example.com/"
-  helper_aggregator_endpoint: "https://example.net/"
+  # HTTPS endpoints of the peer aggregator.
+  peer_aggregator_endpoint: "https://example.com/"
 
   # The DAP query type. See below for an example of a fixed-size task
   query_type: TimeInterval
@@ -98,8 +97,7 @@
     private_key: wFRYwiypcHC-mkGP1u3XQgIvtnlkQlUfZjgtM_zRsnI
 
 - task_id: "D-hCKPuqL2oTf7ZVRVyMP5VGt43EAEA8q34mDf6p1JE"
-  leader_aggregator_endpoint: "https://example.org/"
-  helper_aggregator_endpoint: "https://example.com/"
+  peer_aggregator_endpoint: "https://example.org/"
   # For tasks using the fixed size query type, an additional `max_batch_size`
   # parameter must be provided.
   query_type: !FixedSize

--- a/docs/samples/tasks.yaml
+++ b/docs/samples/tasks.yaml
@@ -6,7 +6,7 @@
   # DAP's recommendation.
   task_id: "G9YKXjoEjfoU7M_fi_o2H0wmzavRb2sBFHeykeRhDMk"
 
-  # HTTPS endpoints of the peer aggregator.
+  # HTTPS endpoint of the peer aggregator.
   peer_aggregator_endpoint: "https://example.com/"
 
   # The DAP query type. See below for an example of a fixed-size task


### PR DESCRIPTION
# Stacked on #2027

Adopts `AggregatorTask` in `janus_cli`. There's a functional change here: the YAML task accepted by `janus_cli` is now an `AggregatorTask` (via `SerializedAggregatorTask`), containing an aggregator's specific view of a task, meaning it contains just the peer aggregator's endpoint URL. In the near future, there will be more changes to the task YAML format so that for instance leader tasks only get the collector auth token _hash_ and helper tasks only get the aggregator auth token _hash_.

Part of #1524