### PR TITLE
Only store aggregator auth token hash in helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1891,6 +1891,7 @@ name = "janus_aggregator_api"
 version = "0.6.0-prerelease-2"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "async-trait",
  "base64 0.21.4",
  "futures",
@@ -1901,6 +1902,7 @@ dependencies = [
  "querystring",
  "rand",
  "ring 0.17.0",
+ "rstest",
  "serde",
  "serde_json",
  "serde_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ version = "0.6.0-prerelease-2"
 
 [workspace.dependencies]
 anyhow = "1"
+assert_matches = "1"
 base64 = "0.21.3"
 # Disable default features to disable compatibility with the old `time` crate, and we also don't
 # (yet) need other default features.

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -100,7 +100,7 @@ url = { version = "2.4.1", features = ["serde"] }
 uuid = { version = "1.4.1", features = ["v4"] }
 
 [dev-dependencies]
-assert_matches = "1"
+assert_matches.workspace = true
 hyper = "0.14.27"
 janus_aggregator = { path = ".", features = ["fpvec_bounded_l2", "test-util"] }
 janus_aggregator_core = { workspace = true, features = ["test-util"] }

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -354,14 +354,14 @@ impl<C: Clock> Aggregator<C> {
     ) -> Result<AggregationJobResp, Error> {
         let task_aggregator = match self.task_aggregator_for(task_id).await? {
             Some(task_aggregator) => {
+                if task_aggregator.task.role() != &Role::Helper {
+                    return Err(Error::UnrecognizedTask(*task_id));
+                }
                 if !task_aggregator
                     .task
                     .check_aggregator_auth_token(auth_token.as_ref())
                 {
                     return Err(Error::UnauthorizedRequest(*task_id));
-                }
-                if task_aggregator.task.role() != &Role::Helper {
-                    return Err(Error::UnrecognizedTask(*task_id));
                 }
                 task_aggregator
             }

--- a/aggregator/src/bin/janus_cli.rs
+++ b/aggregator/src/bin/janus_cli.rs
@@ -728,7 +728,11 @@ mod tests {
     aead_id: Aes128Gcm
     public_key: 8lAqZ7OfNV2Gi_9cNE6J9WRmPbO-k1UPtu2Bztd0-yc
   aggregator_auth_token:
+    type: Bearer
+    token: Y29sbGVjdG9yLWFiZjU0MDhlMmIxNjAxODMxNjI1YWYzOTU5MTA2NDU4
   collector_auth_token:
+    type: Bearer
+    token: Y29sbGVjdG9yLWFiZjU0MDhlMmIxNjAxODMxNjI1YWYzOTU5MTA2NDU4
   hpke_keys: []
 - peer_aggregator_endpoint: https://leader
   query_type: TimeInterval
@@ -748,7 +752,9 @@ mod tests {
     kdf_id: HkdfSha256
     aead_id: Aes128Gcm
     public_key: 8lAqZ7OfNV2Gi_9cNE6J9WRmPbO-k1UPtu2Bztd0-yc
-  aggregator_auth_token:
+  aggregator_auth_token_hash:
+    type: Bearer
+    hash: MJOoBO_ysLEuG_lv2C37eEOf1Ngetsr-Ers0ZYj4vdQ
   collector_auth_token:
   hpke_keys: []
 "#;

--- a/aggregator_api/Cargo.toml
+++ b/aggregator_api/Cargo.toml
@@ -31,7 +31,9 @@ trillium-router.workspace = true
 url = { version = "2.4.1", features = ["serde"] }
 
 [dev-dependencies]
+assert_matches.workspace = true
 futures = "0.3.28"
 janus_aggregator_core = { workspace = true, features = ["test-util"] }
+rstest.workspace = true
 tokio.workspace = true
 trillium-testing = { workspace = true, features = ["tokio"] }

--- a/aggregator_api/src/models.rs
+++ b/aggregator_api/src/models.rs
@@ -108,11 +108,9 @@ pub(crate) struct TaskResp {
     /// How much clock skew to allow between client and aggregator. Reports from
     /// farther than this duration into the future will be rejected.
     pub(crate) tolerable_clock_skew: Duration,
-    /// The authentication token for inter-aggregator communication in this task. If `role` is
-    /// Helper, this token is used by the aggregator to authenticate requests from the Leader. Not
-    /// set if `role` is Leader..
-    // TODO(#1509): This field will have to change as Janus helpers will only store a salted
-    // hash of aggregator auth tokens.
+    /// The authentication token for inter-aggregator communication in this task. Only set in the
+    /// initial response to a task creation request and only when the role is helper. Subsequent
+    /// `TaskResp`s obtained from `GET /tasks/:task_id` will not contain the authentication token.
     pub(crate) aggregator_auth_token: Option<AuthenticationToken>,
     /// The authentication token used by the task's Collector to authenticate to the Leader.
     /// `Some` if `role` is Leader, `None` otherwise.
@@ -149,7 +147,7 @@ impl TryFrom<&AggregatorTask> for TaskResp {
             min_batch_size: task.min_batch_size(),
             time_precision: *task.time_precision(),
             tolerable_clock_skew: *task.tolerable_clock_skew(),
-            aggregator_auth_token: task.aggregator_auth_token().cloned(),
+            aggregator_auth_token: None,
             collector_auth_token: task.collector_auth_token().cloned(),
             collector_hpke_config: task
                 .collector_hpke_config()

--- a/aggregator_core/Cargo.toml
+++ b/aggregator_core/Cargo.toml
@@ -56,7 +56,7 @@ url = { version = "2.4.1", features = ["serde"] }
 uuid = { version = "1.4.1", features = ["v4"] }
 
 [dev-dependencies]
-assert_matches = "1"
+assert_matches.workspace = true
 hyper = "0.14.27"
 janus_aggregator_core = { path = ".", features = ["test-util"] }
 janus_core = { workspace = true, features = ["test-util"] }

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -5,7 +5,7 @@ use base64::{display::Base64Display, engine::general_purpose::URL_SAFE_NO_PAD};
 use chrono::NaiveDateTime;
 use derivative::Derivative;
 use janus_core::{
-    auth_tokens::AuthenticationToken,
+    auth_tokens::{AuthenticationToken, AuthenticationTokenHash},
     hpke::HpkeKeypair,
     report_id::ReportIdChecksumExt,
     time::{DurationExt, IntervalExt, TimeExt},
@@ -59,6 +59,19 @@ impl AuthenticationTokenType {
         }
         .map_err(|e| Error::DbState(format!("invalid DAP auth token in database: {e:?}")))
     }
+
+    pub fn as_authentication_token_hash(
+        &self,
+        hash_bytes: &[u8],
+    ) -> Result<AuthenticationTokenHash, Error> {
+        let hash_array = hash_bytes
+            .try_into()
+            .map_err(|e| Error::DbState(format!("invalid auth token hash in database: {e:?}")))?;
+        Ok(match self {
+            Self::DapAuthToken => AuthenticationTokenHash::DapAuth(hash_array),
+            Self::AuthorizationBearerToken => AuthenticationTokenHash::Bearer(hash_array),
+        })
+    }
 }
 
 impl From<&AuthenticationToken> for AuthenticationTokenType {
@@ -66,6 +79,16 @@ impl From<&AuthenticationToken> for AuthenticationTokenType {
         match value {
             AuthenticationToken::DapAuth(_) => Self::DapAuthToken,
             AuthenticationToken::Bearer(_) => Self::AuthorizationBearerToken,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl From<&AuthenticationTokenHash> for AuthenticationTokenType {
+    fn from(value: &AuthenticationTokenHash) -> Self {
+        match value {
+            AuthenticationTokenHash::DapAuth(_) => Self::DapAuthToken,
+            AuthenticationTokenHash::Bearer(_) => Self::AuthorizationBearerToken,
             _ => unreachable!(),
         }
     }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -25,7 +25,7 @@ tracing = "0.1.37"
 url = "2.4.1"
 
 [dev-dependencies]
-assert_matches = "1"
+assert_matches.workspace = true
 hex-literal = "0.4.1"
 janus_core = { workspace = true, features = ["test-util"]}
 mockito = "1.2.0"

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -35,7 +35,7 @@ tracing = "0.1.37"
 url = "2.4.1"
 
 [dev-dependencies]
-assert_matches = "1"
+assert_matches.workspace = true
 janus_collector = { path = ".", features = ["fpvec_bounded_l2", "test-util"] }
 janus_core = { workspace = true, features = ["fpvec_bounded_l2", "test-util"] }
 mockito = "1.2.0"

--- a/db/00000000000001_initial_schema.up.sql
+++ b/db/00000000000001_initial_schema.up.sql
@@ -93,9 +93,16 @@ CREATE TABLE tasks(
     -- Authentication token used to authenticate messages to/from the other aggregator.
     -- These columns are NULL if the task was provisioned by taskprov.
     aggregator_auth_token_type  AUTH_TOKEN_TYPE,    -- the type of the authentication token
-    aggregator_auth_token       BYTEA,              -- encrypted bearer token
-    -- The aggregator_auth_token columns must either both be NULL or both be non-NULL
-    CONSTRAINT aggregator_auth_token_null CHECK ((aggregator_auth_token_type IS NULL) = (aggregator_auth_token IS NULL)),
+    aggregator_auth_token       BYTEA,              -- encrypted bearer token (only set for leader)
+    aggregator_auth_token_hash  BYTEA,              -- hash of the token (only set for helper)
+    CONSTRAINT aggregator_auth_token_null CHECK (
+        -- If aggregator_auth_token_type is not NULL, then exactly one of aggregator_auth_token or
+        -- aggregator_auth_token_hash must be not NULL.
+        ((aggregator_auth_token_type IS NOT NULL) AND (aggregator_auth_token IS NULL) != (aggregator_auth_token_hash IS NULL))
+        -- If aggregator_auth_token_type is NULL, then both aggregator_auth_token and
+        -- aggregator_auth_token_hash must be NULL
+        OR ((aggregator_auth_token_type IS NULL) AND (aggregator_auth_token IS NULL) AND (aggregator_auth_token_hash IS NULL))
+    ),
 
     -- Authentication token used to authenticate messages to the leader from the collector. These
     -- columns are NULL if the task was provisioned by taskprov or if the task's role is helper.

--- a/docs/samples/tasks.yaml
+++ b/docs/samples/tasks.yaml
@@ -58,11 +58,8 @@
     aead_id: Aes128Gcm
     public_key: 4qiv6IY5jrjCV3xbaQXULmPIpvoIml1oJmeXm-yOuAo
 
-  # Authentication token shared beteween the aggregators, and used to
-  # authenticate leader-to-helper requests. In the case of a leader-role task,
-  # the leader will include the token in a header when making requests to the
-  # helper. In the case of a helper-role task, the helper will accept requests
-  # requests with  authentication tokens.
+  # Authentication token hash used by the leader to authenticate requests made
+  # to the helper. This value should only be included in leader-role tasks.
   #
   # Each token's `type` governs how it is inserted into HTTP requests if used by
   # the leader to authenticate a request to the helper.
@@ -118,9 +115,18 @@
     kdf_id: HkdfSha256
     aead_id: Aes128Gcm
     public_key: KHRLcWgfWxli8cdOLPsgsZPttHXh0ho3vLVLrW-63lE
-  aggregator_auth_token:
+  # Authentication token hash used by the helper to authenticate requests
+  # received from the leader. This value should only be included in helper-role
+  # tasks.
+  #
+  # The `type` corresponds to the `type` of an `aggregator_auth_token` stanza,
+  # and the helper will only accept the auth token if it is presented in a
+  # request in the indicated manner.
+  #
+  # `hash` is the SHA-256 hash of the token value, encoded in unpadded base64url.
+  aggregator_auth_token_hash:
     type: "Bearer"
-    token: "YWdncmVnYXRvci1jZmE4NDMyZjdkMzllMjZiYjU3OGUzMzY5Mzk1MWQzNQ"
+    hash: "MJOoBO_ysLEuG_lv2C37eEOf1Ngetsr-Ers0ZYj4vdQ"
   # Note that this task does not have a collector authentication token, since
   # it is a helper role task.
   collector_auth_token:

--- a/interop_binaries/src/bin/janus_interop_aggregator.rs
+++ b/interop_binaries/src/bin/janus_interop_aggregator.rs
@@ -11,7 +11,10 @@ use janus_aggregator_core::{
     task::{self, AggregatorTask, AggregatorTaskParameters},
     SecretBytes,
 };
-use janus_core::{auth_tokens::AuthenticationToken, time::RealClock};
+use janus_core::{
+    auth_tokens::{AuthenticationToken, AuthenticationTokenHash},
+    time::RealClock,
+};
 use janus_interop_binaries::{
     status::{ERROR, SUCCESS},
     AddTaskResponse, AggregatorAddTaskRequest, AggregatorRole, HpkeConfigRegistry, Keyring,
@@ -73,7 +76,7 @@ async fn handle_add_task(
             }
         }
         (AggregatorRole::Helper, _) => AggregatorTaskParameters::Helper {
-            aggregator_auth_token: leader_authentication_token,
+            aggregator_auth_token_hash: AuthenticationTokenHash::from(&leader_authentication_token),
             collector_hpke_config,
         },
     };

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -27,5 +27,5 @@ thiserror.workspace = true
 url = "2.4.1"
 
 [dev-dependencies]
-assert_matches = "1"
+assert_matches.workspace = true
 serde_test.workspace = true

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -31,7 +31,7 @@ tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt"] 
 url = "2.4.1"
 
 [dev-dependencies]
-assert_matches = "1"
+assert_matches.workspace = true
 cfg-if = "1.0.0"
 janus_core = { workspace = true, features = ["test-util"] }
 rand = "0.8"


### PR DESCRIPTION
When acting as the helper, Janus only needs the aggregator auth token hash to validate requests. It never makes aggregation sub-protocol requests and thus doesn't need the actual token.

In this commit we change the schema of the `tasks` table so that helpers may store an auth token hash instead of an auth token. These changes are reflected in `janus_aggregator_core::task::AggregatorTask`. Finally we make changes to the aggregator API to accommodate this: the helper reports the aggregator auth token it generates during task provisioning, but doesn't store that token and cannot subsequently provide it when responding to `GET /tasks/:task_id` requests. Fortunately that field in `TaskResp` was already optional, and divviup-api already ignored it except in the creation case.

Part of #1509, 1524