### PR TITLE
only store collector auth token hash in leader

### DIFF
--- a/aggregator/src/bin/janus_cli.rs
+++ b/aggregator/src/bin/janus_cli.rs
@@ -730,9 +730,9 @@ mod tests {
   aggregator_auth_token:
     type: Bearer
     token: Y29sbGVjdG9yLWFiZjU0MDhlMmIxNjAxODMxNjI1YWYzOTU5MTA2NDU4
-  collector_auth_token:
+  collector_auth_token_hash:
     type: Bearer
-    token: Y29sbGVjdG9yLWFiZjU0MDhlMmIxNjAxODMxNjI1YWYzOTU5MTA2NDU4
+    hash: MJOoBO_ysLEuG_lv2C37eEOf1Ngetsr-Ers0ZYj4vdQ
   hpke_keys: []
 - peer_aggregator_endpoint: https://leader
   query_type: TimeInterval
@@ -801,8 +801,8 @@ mod tests {
 
         for task in &got_tasks {
             match task.role() {
-                Role::Leader => assert!(task.collector_auth_token().is_some()),
-                Role::Helper => assert!(task.collector_auth_token().is_none()),
+                Role::Leader => assert!(task.collector_auth_token_hash().is_some()),
+                Role::Helper => assert!(task.collector_auth_token_hash().is_none()),
                 role => panic!("unexpected role {role}"),
             }
         }

--- a/aggregator_api/src/routes.rs
+++ b/aggregator_api/src/routes.rs
@@ -49,7 +49,7 @@ pub(super) async fn get_config(
             SupportedQueryType::FixedSize,
         ],
         // Unconditionally indicate to divviup-api that we support collector auth token hashes
-        features: &["token-hash"],
+        features: &["TokenHash"],
     })
 }
 

--- a/aggregator_api/src/routes.rs
+++ b/aggregator_api/src/routes.rs
@@ -48,6 +48,8 @@ pub(super) async fn get_config(
             SupportedQueryType::TimeInterval,
             SupportedQueryType::FixedSize,
         ],
+        // Unconditionally indicate to divviup-api that we support collector auth token hashes
+        features: &["token-hash"],
     })
 }
 
@@ -113,11 +115,17 @@ pub(super) async fn post_task<C: Clock>(
                         .to_string(),
                 )
             })?;
+            let collector_auth_token_hash = req.collector_auth_token_hash.ok_or_else(|| {
+                Error::BadRequest(
+                    "aggregator acting in leader role must be provided a collector auth token"
+                        .to_string(),
+                )
+            })?;
             (
                 None,
                 AggregatorTaskParameters::Leader {
                     aggregator_auth_token,
-                    collector_auth_token: random(),
+                    collector_auth_token_hash,
                     collector_hpke_config: req.collector_hpke_config,
                 },
             )

--- a/aggregator_api/src/tests.rs
+++ b/aggregator_api/src/tests.rs
@@ -87,7 +87,7 @@ async fn get_config() {
             r#"{"protocol":"DAP-07","dap_url":"https://dap.url/","role":"Either","vdafs":"#,
             r#"["Prio3Count","Prio3Sum","Prio3Histogram","Prio3CountVec","Prio3SumVec"],"#,
             r#""query_types":["TimeInterval","FixedSize"],"#,
-            r#""features":["token-hash"]}"#,
+            r#""features":["TokenHash"]}"#,
         )
     );
 }

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -287,7 +287,7 @@ async fn put_task_invalid_collector_auth_tokens(ephemeral_datastore: EphemeralDa
                 let err = tx
                     .query_one(
                         &format!(
-                            "UPDATE tasks SET collector_auth_token = {auth_token},
+                            "UPDATE tasks SET collector_auth_token_hash = {auth_token},
                             collector_auth_token_type = {auth_token_type}"
                         ),
                         &[],

--- a/db/00000000000001_initial_schema.up.sql
+++ b/db/00000000000001_initial_schema.up.sql
@@ -107,9 +107,9 @@ CREATE TABLE tasks(
     -- Authentication token used to authenticate messages to the leader from the collector. These
     -- columns are NULL if the task was provisioned by taskprov or if the task's role is helper.
     collector_auth_token_type   AUTH_TOKEN_TYPE,    -- the type of the authentication token
-    collector_auth_token        BYTEA,              -- encrypted bearer token
+    collector_auth_token_hash        BYTEA,         -- hash of the token
     -- The collector_auth_token columns must either both be NULL or both be non-NULL
-    CONSTRAINT collector_auth_token_null CHECK ((collector_auth_token_type IS NULL) = (collector_auth_token IS NULL))
+    CONSTRAINT collector_auth_token_null CHECK ((collector_auth_token_type IS NULL) = (collector_auth_token_hash IS NULL))
 );
 CREATE INDEX task_id_index ON tasks(task_id);
 

--- a/docs/samples/tasks.yaml
+++ b/docs/samples/tasks.yaml
@@ -70,15 +70,18 @@
     type: "DapAuth"
     token: "YWdncmVnYXRvci0yMzUyNDJmOTk0MDZjNGZkMjhiODIwYzMyZWFiMGY2OA"
 
-  # Authentication token shared between the leader and the collector, and used
-  # to authenticate collector-to-leader requests. For leader tasks, this has the
-  # same format as `aggregator_auth_tokens` above. For helper tasks, this will
-  # be an empty list instead.
-  # Bearer token values are encoded in unpadded base64url.
-  # This example decodes to "collector-abf5408e2b1601831625af3959106458".
-  collector_auth_token:
+  # Authentication token hash used by the leader to authenticate requests
+  # received from the collector. This value should only be included in
+  # leader-role tasks.
+  #
+  # The `type` corresponds to the `type` of an `aggregator_auth_token` stanza,
+  # and the leader will only accept the auth token if it is presented in a
+  # request in the indicated manner.
+  #
+  # `hash` is the SHA-256 hash of the token value, encoded in unpadded base64url.
+  collector_auth_token_hash:
     type: "Bearer"
-    token: "Y29sbGVjdG9yLWFiZjU0MDhlMmIxNjAxODMxNjI1YWYzOTU5MTA2NDU4"
+    hash: "MJOoBO_ysLEuG_lv2C37eEOf1Ngetsr-Ers0ZYj4vdQ"
 
   # This aggregator's HPKE keypairs. The first keypair's HPKE configuration will
   # be served via the `hpke_config` DAP endpoint. All keypairs will be tried

--- a/docs/samples/tasks.yaml
+++ b/docs/samples/tasks.yaml
@@ -74,9 +74,8 @@
   # received from the collector. This value should only be included in
   # leader-role tasks.
   #
-  # The `type` corresponds to the `type` of an `aggregator_auth_token` stanza,
-  # and the leader will only accept the auth token if it is presented in a
-  # request in the indicated manner.
+  # The `type` determines how tokens are parsed from HTTP requests, and it has
+  # the same set of allowable values as the `type` of an `aggregator_auth_token` stanza.
   #
   # `hash` is the SHA-256 hash of the token value, encoded in unpadded base64url.
   collector_auth_token_hash:

--- a/interop_binaries/src/bin/janus_interop_aggregator.rs
+++ b/interop_binaries/src/bin/janus_interop_aggregator.rs
@@ -68,10 +68,12 @@ async fn handle_add_task(
         (AggregatorRole::Leader, Some(collector_authentication_token)) => {
             AggregatorTaskParameters::Leader {
                 aggregator_auth_token: leader_authentication_token,
-                collector_auth_token: AuthenticationToken::new_dap_auth_token_from_string(
-                    collector_authentication_token,
-                )
-                .context("invalid header value in \"collector_authentication_token\"")?,
+                collector_auth_token_hash: AuthenticationTokenHash::from(
+                    &AuthenticationToken::new_dap_auth_token_from_string(
+                        collector_authentication_token,
+                    )
+                    .context("invalid header value in \"collector_authentication_token\"")?,
+                ),
                 collector_hpke_config,
             }
         }


### PR DESCRIPTION
# Stacked on #2062

The leader only needs the hash of the collector auth token in order to authenticate collection sub-protocol requests and thus we can avoid the risk of storing the unhashed token.

This commit changes the `tasks` table to store a hash instead of the token, and makes the corresponding change to
`janus_aggregator_core::task::AggregatorTask`. There are corresponding changes to the aggregator API: the leader must now be provided the collector auth token hash during task creation, and `TaskResp` now only contains a collector auth token hash.

Part of #1509, #1524