### PR TITLE
subscriber-01: Implement draft-wang-ppm-dap-taskprov-02

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -2655,7 +2655,7 @@ fn decode_taskprov_task_config<Q: QueryType>(
         ));
     } else if !taskprov_extensions
         .windows(2)
-        .all(|report_shares| report_shares[0] == report_shares[1])
+        .all(|extensions| extensions[0] == extensions[1])
     {
         return Err(Error::UnrecognizedMessage(
             Some(*task_id),

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -666,6 +666,7 @@ impl<C: Clock> Aggregator<C> {
 
     /// subscriber-01 only: We ignore task-specific authorization tokens and just use the global
     /// auth token for every helper request.
+    #[tracing::instrument(skip(self, auth_token), err)]
     async fn authorize_helper_request(
         &self,
         task_id: &TaskId,

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -1,4 +1,5 @@
 use crate::aggregator::{
+    aggregate_init_tests::setup_aggregate_init_test_without_sending_request,
     http_handlers::{
         aggregator_handler,
         test_util::{take_problem_details, take_response_body},
@@ -7,117 +8,105 @@ use crate::aggregator::{
     Config,
 };
 use assert_matches::assert_matches;
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use janus_aggregator_core::{
-    datastore::{
-        models::{
-            AggregateShareJob, AggregationJob, AggregationJobState, Batch, BatchAggregation,
-            BatchAggregationState, BatchState, ReportAggregation, ReportAggregationState,
-        },
-        test_util::{ephemeral_datastore, EphemeralDatastore},
-        Datastore,
-    },
-    task::{QueryType, Task},
+    datastore::test_util::ephemeral_datastore, task::QueryType, taskprov::VerifyKeyInit,
     test_util::noop_meter,
 };
 use janus_core::{
     hpke::{
         self, aggregate_share_aad, test_util::generate_test_hpke_config_and_private_key,
-        HpkeApplicationInfo, HpkeKeypair, Label,
+        HpkeApplicationInfo, Label,
     },
     report_id::ReportIdChecksumExt,
-    task::{AuthenticationToken, PRIO3_VERIFY_KEY_LENGTH},
-    test_util::{install_test_trace_subscriber, run_vdaf, VdafTranscript},
+    task::AuthenticationToken,
+    test_util::{install_test_trace_subscriber, run_vdaf},
     time::{Clock, DurationExt, MockClock, TimeExt},
 };
 use janus_messages::{
     codec::{Decode, Encode},
-    query_type::FixedSize,
+    query_type::{FixedSize, TimeInterval},
     taskprov::{
         DpConfig, DpMechanism, Query as TaskprovQuery, QueryConfig, TaskConfig, VdafConfig,
         VdafType,
     },
     AggregateContinueReq, AggregateContinueResp, AggregateInitializeReq, AggregateInitializeResp,
-    AggregateShareReq, AggregateShareResp, AggregationJobId, BatchSelector, Duration, Interval,
-    PartialBatchSelector, PrepareStep, PrepareStepResult, ReportIdChecksum, ReportMetadata,
-    ReportShare, Role, TaskId, Time,
+    AggregateShareReq, AggregateShareResp, AggregationJobId, BatchSelector, Duration, Extension,
+    ExtensionType, PartialBatchSelector, PrepareStep, PrepareStepResult, ReportIdChecksum,
+    ReportMetadata, Role, TaskId,
 };
-use prio::{
-    field::Field64,
-    vdaf::{
-        prio3::{Prio3, Prio3Aes128Count},
-        AggregateShare, OutputShare,
-    },
-};
+use prio::vdaf::prio3::Prio3Aes128Count;
 use rand::random;
 use ring::digest::{digest, SHA256};
 use serde_json::json;
 use std::sync::Arc;
-use trillium::{Handler, KnownHeaderName, Status};
+use trillium::{KnownHeaderName, Status};
 use trillium_testing::{assert_headers, prelude::post};
 
-type TestVdaf = Prio3Aes128Count;
+#[tokio::test]
+async fn taskprov_opt_in_time_interval() {
+    let test = setup_aggregate_init_test_without_sending_request().await;
 
-pub struct TaskprovTestCase {
-    _ephemeral_datastore: EphemeralDatastore,
-    clock: MockClock,
-    collector_hpke_keypair: HpkeKeypair,
-    datastore: Arc<Datastore<MockClock>>,
-    handler: Box<dyn Handler>,
-    report_metadata: ReportMetadata,
-    transcript: VdafTranscript<16, TestVdaf>,
-    report_share: ReportShare,
-    task: Task,
-    task_config: TaskConfig,
-    task_id: TaskId,
-    aggregator_auth_token: AuthenticationToken,
-}
+    let auth = test.auth_token.request_authentication();
 
-async fn setup_taskprov_test() -> TaskprovTestCase {
-    install_test_trace_subscriber();
+    let mut test_conn = post(test.task.aggregation_job_uri().unwrap().path())
+        .with_request_header(auth.0, "Bearer invalid_token")
+        .with_request_header(
+            KnownHeaderName::ContentType,
+            AggregateInitializeReq::<TimeInterval>::MEDIA_TYPE,
+        )
+        .with_request_body(test.aggregation_job_init_req.get_encoded())
+        .run_async(&test.handler)
+        .await;
+    assert_eq!(test_conn.status(), Some(Status::BadRequest));
+    assert_eq!(
+        take_problem_details(&mut test_conn).await,
+        json!({
+            "status": Status::BadRequest as u16,
+            "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
+            "title": "The request's authorization is not valid.",
+            "taskid": format!("{}", test.task.id()),
+        })
+    );
 
-    let clock = MockClock::default();
-    let ephemeral_datastore = ephemeral_datastore().await;
-    let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
+    let test_conn = post(test.task.aggregation_job_uri().unwrap().path())
+        .with_request_header(auth.0, auth.1)
+        .with_request_header(
+            KnownHeaderName::ContentType,
+            AggregateInitializeReq::<TimeInterval>::MEDIA_TYPE,
+        )
+        .with_request_body(test.aggregation_job_init_req.get_encoded())
+        .run_async(&test.handler)
+        .await;
+    assert_eq!(test_conn.status(), Some(Status::Ok));
 
-    let global_hpke_key = generate_test_hpke_config_and_private_key();
-    let collector_hpke_keypair = generate_test_hpke_config_and_private_key();
-    let aggregator_auth_token: AuthenticationToken = random();
-
-    datastore
+    let got_task = test
+        .datastore
         .run_tx(|tx| {
-            let global_hpke_key = global_hpke_key.clone();
-            Box::pin(async move {
-                tx.put_global_hpke_keypair(&global_hpke_key).await.unwrap();
-                Ok(())
-            })
+            let task_id = *test.task.id();
+            Box::pin(async move { tx.get_task(&task_id).await })
         })
         .await
         .unwrap();
 
-    let tolerable_clock_skew = Duration::from_seconds(60);
-    let config = Config {
-        collector_hpke_config: collector_hpke_keypair.config().clone(),
-        verify_key_init: random(),
-        auth_tokens: vec![aggregator_auth_token.clone()],
-        tolerable_clock_skew,
-        ..Default::default()
-    };
+    assert_eq!(test.task, got_task.unwrap());
+}
 
-    let handler = aggregator_handler(
-        Arc::clone(&datastore),
-        clock.clone(),
-        &noop_meter(),
-        config.clone(),
-    )
-    .await
-    .unwrap();
+#[tokio::test]
+async fn taskprov_opt_in_fixed_size() {
+    let test = setup_aggregate_init_test_without_sending_request().await;
 
-    let time_precision = Duration::from_seconds(1);
-    let max_batch_query_count = 1;
-    let min_batch_size = 1;
-    let max_batch_size = 1;
-    let task_expiration = clock.now().add(&Duration::from_hours(24).unwrap()).unwrap();
+    let batch_id = random();
+    let aggregation_job_id: AggregationJobId = random();
+
+    let vdaf = Prio3Aes128Count::new_aes128_count(2).unwrap();
+    let task_expiration = test
+        .clock
+        .now()
+        .add(&Duration::from_hours(24).unwrap())
+        .unwrap();
+
+    let max_batch_query_count = 100;
+    let min_batch_size = 100;
     let task_config = TaskConfig::new(
         Vec::from("foobar".as_bytes()),
         Vec::from([
@@ -125,25 +114,24 @@ async fn setup_taskprov_test() -> TaskprovTestCase {
             "https://helper.example.com/".as_bytes().try_into().unwrap(),
         ]),
         QueryConfig::new(
-            time_precision,
-            max_batch_query_count,
+            Duration::from_seconds(1),
             min_batch_size,
-            TaskprovQuery::FixedSize { max_batch_size },
+            max_batch_query_count,
+            TaskprovQuery::FixedSize {
+                max_batch_size: min_batch_size as u32,
+            },
         ),
         task_expiration,
         VdafConfig::new(DpConfig::new(DpMechanism::None), VdafType::Prio3Aes128Count).unwrap(),
     )
     .unwrap();
-
-    let mut task_config_encoded = vec![];
-    task_config.encode(&mut task_config_encoded);
-
-    // We use a real VDAF since taskprov doesn't have any allowance for a test VDAF.
-    let vdaf = Prio3::new_aes128_count(2).unwrap();
-
-    let task_id = TaskId::try_from(digest(&SHA256, &task_config_encoded).as_ref()).unwrap();
+    let task_config_encoded = task_config.get_encoded();
+    let task_id: TaskId = digest(&SHA256, &task_config_encoded)
+        .as_ref()
+        .try_into()
+        .unwrap();
     let vdaf_instance = task_config.vdaf_config().vdaf_type().try_into().unwrap();
-    let vdaf_verify_key = config
+    let vdaf_verify_key = test
         .verify_key_init
         .derive_vdaf_verify_key(&task_id, &vdaf_instance);
 
@@ -154,7 +142,7 @@ async fn setup_taskprov_test() -> TaskprovTestCase {
             url::Url::parse("https://helper.example.com/").unwrap(),
         ]),
         QueryType::FixedSize {
-            max_batch_size: max_batch_size as u64,
+            max_batch_size: min_batch_size as u64,
             batch_time_window_size: None,
         },
         vdaf_instance,
@@ -162,90 +150,49 @@ async fn setup_taskprov_test() -> TaskprovTestCase {
         Vec::from([vdaf_verify_key.clone()]),
         max_batch_query_count as u64,
         Some(task_expiration),
-        config.report_expiry_age,
+        test.config.report_expiry_age,
         min_batch_size as u64,
         Duration::from_seconds(1),
-        tolerable_clock_skew,
+        test.config.tolerable_clock_skew,
     )
     .unwrap();
 
     let report_metadata = ReportMetadata::new(
         random(),
-        clock
+        test.clock
             .now()
-            .to_batch_interval_start(task.task().time_precision())
+            .to_batch_interval_start(test.task.time_precision())
             .unwrap(),
-        Vec::new(),
+        Vec::from([Extension::new(
+            ExtensionType::Taskprov,
+            task_config_encoded.clone(),
+        )]),
     );
     let transcript = run_vdaf(
         &vdaf,
         vdaf_verify_key.as_ref().try_into().unwrap(),
         &(),
         report_metadata.id(),
-        &1,
+        &1u64,
     );
-    let report_share = generate_helper_report_share::<TestVdaf>(
+    let report_share = generate_helper_report_share::<Prio3Aes128Count>(
         task_id,
-        report_metadata.clone(),
-        global_hpke_key.config(),
+        report_metadata,
+        test.hpke_key.config(),
         &transcript.public_share,
         &transcript.input_shares[1],
     );
-
-    TaskprovTestCase {
-        _ephemeral_datastore: ephemeral_datastore,
-        clock,
-        collector_hpke_keypair,
-        datastore,
-        handler: Box::new(handler),
-        task: task.into(),
-        task_config,
-        task_id,
-        report_metadata,
-        transcript,
-        report_share,
-        aggregator_auth_token,
-    }
-}
-
-#[tokio::test]
-async fn taskprov_aggregate_init() {
-    let test = setup_taskprov_test().await;
-
-    let batch_id = random();
-    let aggregation_job_id: AggregationJobId = random();
-
     let request = AggregateInitializeReq::new(
-        *test.task.id(),
+        task_id,
         aggregation_job_id,
         ().get_encoded(),
         PartialBatchSelector::new_fixed_size(batch_id),
-        Vec::from([test.report_share.clone()]),
+        Vec::from([report_share.clone()]),
     );
 
-    let auth = test.aggregator_auth_token.request_authentication();
+    let auth = test.auth_token.request_authentication();
 
-    let mut test_conn = post(test.task.aggregation_job_uri().unwrap().path())
-        .with_request_header(auth.0, "Bearer invalid_token")
-        .with_request_header(
-            KnownHeaderName::ContentType,
-            AggregateInitializeReq::<FixedSize>::MEDIA_TYPE,
-        )
-        .with_request_body(request.get_encoded())
-        .run_async(&test.handler)
-        .await;
-    assert_eq!(test_conn.status(), Some(Status::BadRequest));
-    assert_eq!(
-        take_problem_details(&mut test_conn).await,
-        json!({
-            "status": Status::BadRequest as u16,
-            "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
-            "title": "The request's authorization is not valid.",
-            "taskid": format!("{}", test.task_id),
-        })
-    );
-
-    let mut test_conn = post(test.task.aggregation_job_uri().unwrap().path())
+    let test_conn = post(task.task().aggregation_job_uri().unwrap().path())
         .with_request_header(auth.0, auth.1)
         .with_request_header(
             KnownHeaderName::ContentType,
@@ -254,64 +201,25 @@ async fn taskprov_aggregate_init() {
         .with_request_body(request.get_encoded())
         .run_async(&test.handler)
         .await;
-
     assert_eq!(test_conn.status(), Some(Status::Ok));
-    assert_headers!(
-        &test_conn,
-        "content-type" => (AggregateInitializeResp::MEDIA_TYPE)
-    );
-    let body_bytes = take_response_body(&mut test_conn).await;
-    let aggregate_resp = AggregateInitializeResp::get_decoded(&body_bytes).unwrap();
 
-    assert_eq!(aggregate_resp.prepare_steps().len(), 1);
-    let prepare_step = aggregate_resp.prepare_steps().get(0).unwrap();
-    assert_eq!(prepare_step.report_id(), test.report_share.metadata().id());
-    assert_matches!(prepare_step.result(), &PrepareStepResult::Continued(..));
-
-    let (aggregation_jobs, got_task) = test
+    let got_task = test
         .datastore
         .run_tx(|tx| {
-            let task_id = test.task_id;
-            Box::pin(async move {
-                Ok((
-                    tx.get_aggregation_jobs_for_task::<16, FixedSize, TestVdaf>(&task_id)
-                        .await
-                        .unwrap(),
-                    tx.get_task(&task_id).await.unwrap(),
-                ))
-            })
+            let task_id = *task.task().id();
+            Box::pin(async move { tx.get_task(&task_id).await })
         })
         .await
         .unwrap();
 
-    assert_eq!(aggregation_jobs.len(), 1);
-    assert!(
-        aggregation_jobs[0].task_id().eq(&test.task_id)
-            && aggregation_jobs[0].id().eq(&aggregation_job_id)
-            && aggregation_jobs[0].partial_batch_identifier().eq(&batch_id)
-            && aggregation_jobs[0]
-                .state()
-                .eq(&AggregationJobState::InProgress)
-    );
-    assert_eq!(test.task, got_task.unwrap());
+    assert_eq!(task.task(), &got_task.unwrap());
 }
 
 #[tokio::test]
 async fn taskprov_opt_out_task_expired() {
-    let test = setup_taskprov_test().await;
+    let test = setup_aggregate_init_test_without_sending_request().await;
 
-    let batch_id = random();
-    let aggregation_job_id: AggregationJobId = random();
-
-    let request = AggregateInitializeReq::new(
-        *test.task.id(),
-        aggregation_job_id,
-        ().get_encoded(),
-        PartialBatchSelector::new_fixed_size(batch_id),
-        Vec::from([test.report_share.clone()]),
-    );
-
-    let auth = test.aggregator_auth_token.request_authentication();
+    let auth = test.auth_token.request_authentication();
 
     // Advance clock past task expiry.
     test.clock.advance(&Duration::from_hours(48).unwrap());
@@ -320,9 +228,9 @@ async fn taskprov_opt_out_task_expired() {
         .with_request_header(auth.0, auth.1)
         .with_request_header(
             KnownHeaderName::ContentType,
-            AggregateInitializeReq::<FixedSize>::MEDIA_TYPE,
+            AggregateInitializeReq::<TimeInterval>::MEDIA_TYPE,
         )
-        .with_request_body(request.get_encoded())
+        .with_request_body(test.aggregation_job_init_req.get_encoded())
         .run_async(&test.handler)
         .await;
     assert_eq!(test_conn.status(), Some(Status::BadRequest));
@@ -332,25 +240,112 @@ async fn taskprov_opt_out_task_expired() {
             "status": Status::BadRequest as u16,
             "type": "urn:ietf:params:ppm:dap:error:invalidTask",
             "title": "Aggregator has opted out of the indicated task.",
-            "taskid": format!("{}", test.task_id),
+            "taskid": format!("{}", test.task.id()),
         })
     );
 }
 
 #[tokio::test]
+async fn taskprov_reject_aggregate_init_with_bad_extension_payloads() {
+    let test = setup_aggregate_init_test_without_sending_request().await;
+
+    let another_task_config = TaskConfig::new(
+        Vec::from("foobar".as_bytes()),
+        Vec::from([
+            "https://leader.example.com/".as_bytes().try_into().unwrap(),
+            "https://helper.example.com/".as_bytes().try_into().unwrap(),
+        ]),
+        QueryConfig::new(
+            Duration::from_seconds(1),
+            1,
+            1,
+            TaskprovQuery::FixedSize {
+                max_batch_size: 100,
+            },
+        ),
+        *test.task.task_expiration().unwrap(),
+        VdafConfig::new(DpConfig::new(DpMechanism::None), VdafType::Prio3Aes128Count).unwrap(),
+    )
+    .unwrap();
+    let another_task_config_encoded = another_task_config.get_encoded();
+
+    let (report_share_no_extension, _) =
+        test.report_share_generator
+            .next_with_metadata(ReportMetadata::new(
+                random(),
+                test.clock
+                    .now()
+                    .to_batch_interval_start(test.task.time_precision())
+                    .unwrap(),
+                Vec::new(),
+            ));
+
+    let (report_share_mismatched_extension, _) =
+        test.report_share_generator
+            .next_with_metadata(ReportMetadata::new(
+                random(),
+                test.clock
+                    .now()
+                    .to_batch_interval_start(test.task.time_precision())
+                    .unwrap(),
+                Vec::from([Extension::new(
+                    ExtensionType::Taskprov,
+                    another_task_config_encoded.clone(),
+                )]),
+            ));
+
+    let auth = test.auth_token.request_authentication();
+
+    for (name, report_shares) in [
+        (
+            "missing_report_share_extensions",
+            vec![test.report_shares[0].clone(), report_share_no_extension],
+        ),
+        (
+            "mismatched_report_share_extensions",
+            vec![
+                test.report_shares[0].clone(),
+                report_share_mismatched_extension,
+            ],
+        ),
+        ("no_report_shares", vec![]),
+    ] {
+        let batch_id = random();
+        let aggregation_job_id = random();
+        let request = AggregateInitializeReq::new(
+            *test.task.id(),
+            aggregation_job_id,
+            ().get_encoded(),
+            PartialBatchSelector::new_fixed_size(batch_id),
+            report_shares,
+        );
+
+        let mut test_conn = post(test.task.aggregation_job_uri().unwrap().path())
+            .with_request_header(auth.0, auth.1.clone())
+            .with_request_header(
+                KnownHeaderName::ContentType,
+                AggregateInitializeReq::<FixedSize>::MEDIA_TYPE,
+            )
+            .with_request_body(request.get_encoded())
+            .run_async(&test.handler)
+            .await;
+        assert_eq!(test_conn.status(), Some(Status::BadRequest), "{name}");
+        assert_eq!(
+            take_problem_details(&mut test_conn).await,
+            json!({
+                "status": Status::BadRequest as u16,
+                "type": "urn:ietf:params:ppm:dap:error:unrecognizedMessage",
+                "title": "The message type for a response was incorrect or the payload was malformed.",
+                "taskid": format!("{}", test.task.id()),
+            }),
+            "{name}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn taskprov_opt_out_mismatched_task_id() {
-    let test = setup_taskprov_test().await;
-
-    let batch_id = random();
-    let aggregation_job_id: AggregationJobId = random();
-
-    let request = AggregateInitializeReq::new(
-        *test.task.id(),
-        aggregation_job_id,
-        ().get_encoded(),
-        PartialBatchSelector::new_fixed_size(batch_id),
-        Vec::from([test.report_share.clone()]),
-    );
+    let test = setup_aggregate_init_test_without_sending_request().await;
 
     let task_expiration = test
         .clock
@@ -363,21 +358,42 @@ async fn taskprov_opt_out_mismatched_task_id() {
             "https://leader.example.com/".as_bytes().try_into().unwrap(),
             "https://helper.example.com/".as_bytes().try_into().unwrap(),
         ]),
-        // Query configuration is different from the normal test case.
         QueryConfig::new(
             Duration::from_seconds(1),
             100,
             100,
-            TaskprovQuery::FixedSize {
-                max_batch_size: 100,
-            },
+            TaskprovQuery::TimeInterval,
         ),
         task_expiration,
         VdafConfig::new(DpConfig::new(DpMechanism::None), VdafType::Prio3Aes128Count).unwrap(),
     )
     .unwrap();
 
-    let auth = test.aggregator_auth_token.request_authentication();
+    let aggregation_job_id: AggregationJobId = random();
+
+    let (report_share, _) = test
+        .report_share_generator
+        .next_with_metadata(ReportMetadata::new(
+            random(),
+            test.clock
+                .now()
+                .to_batch_interval_start(test.task.time_precision())
+                .unwrap(),
+            Vec::from([Extension::new(
+                ExtensionType::Taskprov,
+                another_task_config.get_encoded(),
+            )]),
+        ));
+
+    let request = AggregateInitializeReq::new(
+        *test.task.id(),
+        aggregation_job_id,
+        ().get_encoded(),
+        PartialBatchSelector::new_time_interval(),
+        Vec::from([report_share.clone()]),
+    );
+
+    let auth = test.auth_token.request_authentication();
 
     let mut test_conn = post(
         test
@@ -402,24 +418,25 @@ async fn taskprov_opt_out_mismatched_task_id() {
             "status": Status::BadRequest as u16,
             "type": "urn:ietf:params:ppm:dap:error:unrecognizedMessage",
             "title": "The message type for a response was incorrect or the payload was malformed.",
-            "taskid": format!("{}", test.task_id),
+            "taskid": format!("{}", test.task.id()),
         })
     );
 }
 
 #[tokio::test]
 async fn taskprov_opt_out_missing_aggregator() {
-    let test = setup_taskprov_test().await;
+    let test = setup_aggregate_init_test_without_sending_request().await;
 
     let batch_id = random();
     let aggregation_job_id: AggregationJobId = random();
 
+    let vdaf = Prio3Aes128Count::new_aes128_count(2).unwrap();
     let task_expiration = test
         .clock
         .now()
         .add(&Duration::from_hours(24).unwrap())
         .unwrap();
-    let another_task_config = TaskConfig::new(
+    let task_config = TaskConfig::new(
         Vec::from("foobar".as_bytes()),
         // Only one aggregator!
         Vec::from(["https://leader.example.com/".as_bytes().try_into().unwrap()]),
@@ -435,21 +452,50 @@ async fn taskprov_opt_out_missing_aggregator() {
         VdafConfig::new(DpConfig::new(DpMechanism::None), VdafType::Prio3Aes128Count).unwrap(),
     )
     .unwrap();
-    let another_task_config_encoded = another_task_config.get_encoded();
-    let another_task_id: TaskId = digest(&SHA256, &another_task_config_encoded)
+    let task_config_encoded = task_config.get_encoded();
+    let task_id: TaskId = digest(&SHA256, &task_config_encoded)
         .as_ref()
         .try_into()
         .unwrap();
+    let vdaf_instance = task_config.vdaf_config().vdaf_type().try_into().unwrap();
+    let vdaf_verify_key = test
+        .verify_key_init
+        .derive_vdaf_verify_key(&task_id, &vdaf_instance);
 
+    let report_metadata = ReportMetadata::new(
+        random(),
+        test.clock
+            .now()
+            .to_batch_interval_start(test.task.time_precision())
+            .unwrap(),
+        Vec::from([Extension::new(
+            ExtensionType::Taskprov,
+            task_config_encoded.clone(),
+        )]),
+    );
+    let transcript = run_vdaf(
+        &vdaf,
+        vdaf_verify_key.as_ref().try_into().unwrap(),
+        &(),
+        report_metadata.id(),
+        &1u64,
+    );
+    let report_share = generate_helper_report_share::<Prio3Aes128Count>(
+        task_id,
+        report_metadata,
+        test.hpke_key.config(),
+        &transcript.public_share,
+        &transcript.input_shares[1],
+    );
     let request = AggregateInitializeReq::new(
-        another_task_id,
+        task_id,
         aggregation_job_id,
         ().get_encoded(),
         PartialBatchSelector::new_fixed_size(batch_id),
-        Vec::from([test.report_share.clone()]),
+        Vec::from([report_share.clone()]),
     );
 
-    let auth = test.aggregator_auth_token.request_authentication();
+    let auth = test.auth_token.request_authentication();
 
     let mut test_conn = post(
         test
@@ -474,275 +520,155 @@ async fn taskprov_opt_out_missing_aggregator() {
             "status": Status::BadRequest as u16,
             "type": "urn:ietf:params:ppm:dap:error:unrecognizedMessage",
             "title": "The message type for a response was incorrect or the payload was malformed.",
-            "taskid": format!("{}", another_task_id),
+            "taskid": format!("{}", task_id),
         })
     );
-}
-
-#[tokio::test]
-async fn taskprov_aggregate_continue() {
-    let test = setup_taskprov_test().await;
-
-    let aggregation_job_id = random();
-    let batch_id = random();
-
-    let (prep_state, _) = test.transcript.helper_prep_state(0);
-    let prep_msg = test.transcript.prepare_messages[0].clone();
-
-    test.datastore
-        .run_tx(|tx| {
-            let task = test.task.clone();
-            let report_share = test.report_share.clone();
-            let prep_state = prep_state.clone();
-            let report_metadata = test.report_metadata.clone();
-
-            Box::pin(async move {
-                // Aggregate continue is only possible if the task has already been inserted.
-                tx.put_task(&task).await?;
-
-                tx.put_report_share(task.id(), &report_share).await?;
-
-                tx.put_aggregation_job(&AggregationJob::<
-                    PRIO3_VERIFY_KEY_LENGTH,
-                    FixedSize,
-                    TestVdaf,
-                >::new(
-                    *task.id(),
-                    aggregation_job_id,
-                    (),
-                    batch_id,
-                    Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
-                        .unwrap(),
-                    AggregationJobState::InProgress,
-                ))
-                .await?;
-
-                tx.put_report_aggregation::<PRIO3_VERIFY_KEY_LENGTH, TestVdaf>(
-                    &ReportAggregation::new(
-                        *task.id(),
-                        aggregation_job_id,
-                        *report_metadata.id(),
-                        *report_metadata.time(),
-                        0,
-                        ReportAggregationState::Waiting(prep_state, None),
-                    ),
-                )
-                .await?;
-
-                tx.put_aggregate_share_job::<PRIO3_VERIFY_KEY_LENGTH, FixedSize, TestVdaf>(
-                    &AggregateShareJob::new(
-                        *task.id(),
-                        batch_id,
-                        (),
-                        AggregateShare::from(OutputShare::from(Vec::from([Field64::from(7)]))),
-                        0,
-                        ReportIdChecksum::default(),
-                    ),
-                )
-                .await
-            })
-        })
-        .await
-        .unwrap();
-
-    let request = AggregateContinueReq::new(
-        *test.task.id(),
-        aggregation_job_id,
-        Vec::from([PrepareStep::new(
-            *test.report_metadata.id(),
-            PrepareStepResult::Continued(prep_msg.get_encoded()),
-        )]),
-    );
-
-    let auth = test.aggregator_auth_token.request_authentication();
-
-    // Attempt using the wrong credentials, should reject.
-    let mut test_conn = post(test.task.aggregation_job_uri().unwrap().path())
-        .with_request_header(auth.0, "Bearer invalid_token")
-        .with_request_header(
-            KnownHeaderName::ContentType,
-            AggregateContinueReq::MEDIA_TYPE,
-        )
-        .with_request_body(request.get_encoded())
-        .run_async(&test.handler)
-        .await;
-    assert_eq!(test_conn.status(), Some(Status::BadRequest));
-    assert_eq!(
-        take_problem_details(&mut test_conn).await,
-        json!({
-            "status": Status::BadRequest as u16,
-            "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
-            "title": "The request's authorization is not valid.",
-            "taskid": format!("{}", test.task_id),
-        })
-    );
-
-    let mut test_conn = post(test.task.aggregation_job_uri().unwrap().path())
-        .with_request_header(auth.0, auth.1)
-        .with_request_header(
-            KnownHeaderName::ContentType,
-            AggregateContinueReq::MEDIA_TYPE,
-        )
-        .with_request_body(request.get_encoded())
-        .run_async(&test.handler)
-        .await;
-
-    assert_eq!(test_conn.status(), Some(Status::Ok));
-    assert_eq!(
-        test_conn
-            .response_headers()
-            .get(KnownHeaderName::ContentType)
-            .unwrap(),
-        AggregateContinueResp::MEDIA_TYPE
-    );
-    let body_bytes = take_response_body(&mut test_conn).await;
-    let aggregate_resp = AggregateContinueResp::get_decoded(&body_bytes).unwrap();
-
-    // We'll only validate the response. Taskprov doesn't touch functionality beyond the authorization
-    // of the request.
-    assert_eq!(
-        aggregate_resp,
-        AggregateContinueResp::new(Vec::from([PrepareStep::new(
-            *test.report_metadata.id(),
-            PrepareStepResult::Finished
-        )]))
-    );
-}
-
-#[tokio::test]
-async fn taskprov_aggregate_share() {
-    let test = setup_taskprov_test().await;
-
-    let batch_id = random();
-    test.datastore
-        .run_tx(|tx| {
-            let task = test.task.clone();
-            let interval =
-                Interval::new(Time::from_seconds_since_epoch(6000), *task.time_precision())
-                    .unwrap();
-
-            Box::pin(async move {
-                tx.put_task(&task).await?;
-
-                tx.put_batch(&Batch::<16, FixedSize, TestVdaf>::new(
-                    *task.id(),
-                    batch_id,
-                    (),
-                    BatchState::Closed,
-                    0,
-                    interval,
-                ))
-                .await
-                .unwrap();
-
-                tx.put_batch_aggregation(&BatchAggregation::<16, FixedSize, TestVdaf>::new(
-                    *task.id(),
-                    batch_id,
-                    (),
-                    0,
-                    BatchAggregationState::Aggregating,
-                    Some(AggregateShare::from(OutputShare::from(Vec::from([
-                        Field64::from(7),
-                    ])))),
-                    1,
-                    interval,
-                    ReportIdChecksum::get_decoded(&[3; 32]).unwrap(),
-                ))
-                .await
-                .unwrap();
-                Ok(())
-            })
-        })
-        .await
-        .unwrap();
-
-    let request = AggregateShareReq::new(
-        *test.task.id(),
-        BatchSelector::new_fixed_size(batch_id),
-        ().get_encoded(),
-        1,
-        ReportIdChecksum::get_decoded(&[3; 32]).unwrap(),
-    );
-
-    let auth = test.aggregator_auth_token.request_authentication();
-
-    // Attempt using the wrong credentials, should reject.
-    let mut test_conn = post(test.task.aggregate_shares_uri().unwrap().path())
-        .with_request_header(auth.0, "Bearer invalid_token")
-        .with_request_header(
-            KnownHeaderName::ContentType,
-            AggregateShareReq::<FixedSize>::MEDIA_TYPE,
-        )
-        .with_request_body(request.get_encoded())
-        .run_async(&test.handler)
-        .await;
-    assert_eq!(test_conn.status(), Some(Status::BadRequest));
-    assert_eq!(
-        take_problem_details(&mut test_conn).await,
-        json!({
-            "status": Status::BadRequest as u16,
-            "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
-            "title": "The request's authorization is not valid.",
-            "taskid": format!("{}", test.task_id),
-        })
-    );
-
-    let mut test_conn = post(test.task.aggregate_shares_uri().unwrap().path())
-        .with_request_header(auth.0, auth.1)
-        .with_request_header(
-            KnownHeaderName::ContentType,
-            AggregateShareReq::<FixedSize>::MEDIA_TYPE,
-        )
-        .with_request_body(request.get_encoded())
-        .run_async(&test.handler)
-        .await;
-
-    println!("{:?}", test_conn);
-
-    assert_eq!(test_conn.status(), Some(Status::Ok));
-    assert_headers!(
-        &test_conn,
-        "content-type" => (AggregateShareResp::MEDIA_TYPE)
-    );
-    let body_bytes = take_response_body(&mut test_conn).await;
-    let aggregate_share_resp = AggregateShareResp::get_decoded(&body_bytes).unwrap();
-
-    hpke::open(
-        test.collector_hpke_keypair.config(),
-        test.collector_hpke_keypair.private_key(),
-        &HpkeApplicationInfo::new(&Label::AggregateShare, &Role::Helper, &Role::Collector),
-        aggregate_share_resp.encrypted_aggregate_share(),
-        &aggregate_share_aad(&test.task_id, request.batch_selector()),
-    )
-    .unwrap();
 }
 
 /// This runs aggregate init, aggregate continue, and aggregate share requests against a
 /// taskprov-enabled helper, and confirms that correct results are returned.
 #[tokio::test]
 async fn end_to_end() {
-    let test = setup_taskprov_test().await;
-    let (auth_header_name, auth_header_value) = test.aggregator_auth_token.request_authentication();
+    install_test_trace_subscriber();
+
+    let clock = MockClock::default();
+    let ephemeral_datastore = ephemeral_datastore().await;
+    let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
+
+    let global_hpke_key = generate_test_hpke_config_and_private_key();
+    datastore
+        .run_tx(|tx| {
+            let global_hpke_key = global_hpke_key.clone();
+            Box::pin(async move {
+                tx.put_global_hpke_keypair(&global_hpke_key).await.unwrap();
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
+
+    let auth_token: AuthenticationToken = random();
+    let verify_key_init: VerifyKeyInit = random();
+    let collector_hpke_key = generate_test_hpke_config_and_private_key();
+
+    let tolerable_clock_skew = Duration::from_seconds(60);
+    let config = Config {
+        auth_tokens: vec![auth_token.clone()],
+        verify_key_init,
+        collector_hpke_config: collector_hpke_key.config().clone(),
+        tolerable_clock_skew,
+        ..Default::default()
+    };
+
+    let handler = aggregator_handler(
+        Arc::clone(&datastore),
+        clock.clone(),
+        &noop_meter(),
+        config.clone(),
+    )
+    .await
+    .unwrap();
 
     let batch_id = random();
-    let aggregation_job_id = random();
+    let aggregation_job_id: AggregationJobId = random();
+
+    let vdaf = Prio3Aes128Count::new_aes128_count(2).unwrap();
+    let task_expiration = clock.now().add(&Duration::from_hours(24).unwrap()).unwrap();
+
+    let max_batch_query_count = 1;
+    let min_batch_size = 1;
+    let task_config = TaskConfig::new(
+        Vec::from("foobar".as_bytes()),
+        Vec::from([
+            "https://leader.example.com/".as_bytes().try_into().unwrap(),
+            "https://helper.example.com/".as_bytes().try_into().unwrap(),
+        ]),
+        QueryConfig::new(
+            Duration::from_seconds(1),
+            min_batch_size,
+            max_batch_query_count,
+            TaskprovQuery::FixedSize {
+                max_batch_size: min_batch_size as u32,
+            },
+        ),
+        task_expiration,
+        VdafConfig::new(DpConfig::new(DpMechanism::None), VdafType::Prio3Aes128Count).unwrap(),
+    )
+    .unwrap();
+    let task_config_encoded = task_config.get_encoded();
+    let task_id: TaskId = digest(&SHA256, &task_config_encoded)
+        .as_ref()
+        .try_into()
+        .unwrap();
+    let vdaf_instance = task_config.vdaf_config().vdaf_type().try_into().unwrap();
+    let vdaf_verify_key = verify_key_init.derive_vdaf_verify_key(&task_id, &vdaf_instance);
+
+    let task = janus_aggregator_core::taskprov::Task::new(
+        task_id,
+        Vec::from([
+            url::Url::parse("https://leader.example.com/").unwrap(),
+            url::Url::parse("https://helper.example.com/").unwrap(),
+        ]),
+        QueryType::FixedSize {
+            max_batch_size: min_batch_size as u64,
+            batch_time_window_size: None,
+        },
+        vdaf_instance,
+        Role::Helper,
+        Vec::from([vdaf_verify_key.clone()]),
+        max_batch_query_count as u64,
+        Some(task_expiration),
+        config.report_expiry_age,
+        min_batch_size as u64,
+        Duration::from_seconds(1),
+        config.tolerable_clock_skew,
+    )
+    .unwrap();
+
+    let report_metadata = ReportMetadata::new(
+        random(),
+        clock
+            .now()
+            .to_batch_interval_start(task.task().time_precision())
+            .unwrap(),
+        Vec::from([Extension::new(
+            ExtensionType::Taskprov,
+            task_config_encoded.clone(),
+        )]),
+    );
+    let transcript = run_vdaf(
+        &vdaf,
+        vdaf_verify_key.as_ref().try_into().unwrap(),
+        &(),
+        report_metadata.id(),
+        &1u64,
+    );
+    let report_share = generate_helper_report_share::<Prio3Aes128Count>(
+        task_id,
+        report_metadata.clone(),
+        global_hpke_key.config(),
+        &transcript.public_share,
+        &transcript.input_shares[1],
+    );
 
     let aggregate_init_request = AggregateInitializeReq::new(
-        *test.task.id(),
+        task_id,
         aggregation_job_id,
         ().get_encoded(),
         PartialBatchSelector::new_fixed_size(batch_id),
-        Vec::from([test.report_share.clone()]),
+        Vec::from([report_share.clone()]),
     );
 
-    let mut test_conn = post(test.task.aggregation_job_uri().unwrap().path())
-        .with_request_header(auth_header_name, auth_header_value.clone())
+    let auth = auth_token.request_authentication();
+
+    let mut test_conn = post(task.task().aggregation_job_uri().unwrap().path())
+        .with_request_header(auth.0, auth.1.clone())
         .with_request_header(
             KnownHeaderName::ContentType,
             AggregateInitializeReq::<FixedSize>::MEDIA_TYPE,
         )
         .with_request_body(aggregate_init_request.get_encoded())
-        .run_async(&test.handler)
+        .run_async(&handler)
         .await;
 
     assert_eq!(test_conn.status(), Some(Status::Ok));
@@ -752,33 +678,33 @@ async fn end_to_end() {
 
     assert_eq!(aggregate_resp.prepare_steps().len(), 1);
     let prepare_step = &aggregate_resp.prepare_steps()[0];
-    assert_eq!(prepare_step.report_id(), test.report_metadata.id());
+    assert_eq!(prepare_step.report_id(), report_metadata.id());
     let encoded_prep_share = assert_matches!(
         prepare_step.result(),
         PrepareStepResult::Continued(payload) => payload.clone()
     );
     assert_eq!(
         encoded_prep_share,
-        test.transcript.helper_prep_state(0).1.get_encoded()
+        transcript.helper_prep_state(0).1.get_encoded()
     );
 
     let aggregate_continue_request = AggregateContinueReq::new(
-        *test.task.id(),
+        *task.task().id(),
         aggregation_job_id,
         Vec::from([PrepareStep::new(
-            *test.report_metadata.id(),
-            PrepareStepResult::Continued(test.transcript.prepare_messages[0].get_encoded()),
+            *report_metadata.id(),
+            PrepareStepResult::Continued(transcript.prepare_messages[0].get_encoded()),
         )]),
     );
 
-    let mut test_conn = post(test.task.aggregation_job_uri().unwrap().path())
-        .with_request_header(auth_header_name, auth_header_value.clone())
+    let mut test_conn = post(task.task().aggregation_job_uri().unwrap().path())
+        .with_request_header(auth.0, auth.1.clone())
         .with_request_header(
             KnownHeaderName::ContentType,
             AggregateContinueReq::MEDIA_TYPE,
         )
         .with_request_body(aggregate_continue_request.get_encoded())
-        .run_async(&test.handler)
+        .run_async(&handler)
         .await;
 
     assert_eq!(test_conn.status(), Some(Status::Ok));
@@ -788,26 +714,26 @@ async fn end_to_end() {
 
     assert_eq!(aggregate_resp.prepare_steps().len(), 1);
     let prepare_step = &aggregate_resp.prepare_steps()[0];
-    assert_eq!(prepare_step.report_id(), test.report_metadata.id());
+    assert_eq!(prepare_step.report_id(), report_metadata.id());
     assert_matches!(prepare_step.result(), PrepareStepResult::Finished);
 
-    let checksum = ReportIdChecksum::for_report_id(test.report_metadata.id());
+    let checksum = ReportIdChecksum::for_report_id(report_metadata.id());
     let aggregate_share_request = AggregateShareReq::new(
-        *test.task.id(),
+        *task.task().id(),
         BatchSelector::new_fixed_size(batch_id),
         ().get_encoded(),
         1,
         checksum,
     );
 
-    let mut test_conn = post(test.task.aggregate_shares_uri().unwrap().path())
-        .with_request_header(auth_header_name, auth_header_value.clone())
+    let mut test_conn = post(task.task().aggregate_shares_uri().unwrap().path())
+        .with_request_header(auth.0, auth.1.clone())
         .with_request_header(
             KnownHeaderName::ContentType,
             AggregateShareReq::<FixedSize>::MEDIA_TYPE,
         )
         .with_request_body(aggregate_share_request.get_encoded())
-        .run_async(&test.handler)
+        .run_async(&handler)
         .await;
 
     assert_eq!(test_conn.status(), Some(Status::Ok));
@@ -816,15 +742,12 @@ async fn end_to_end() {
     let aggregate_share_resp = AggregateShareResp::get_decoded(&body_bytes).unwrap();
 
     let plaintext = hpke::open(
-        test.collector_hpke_keypair.config(),
-        test.collector_hpke_keypair.private_key(),
+        collector_hpke_key.config(),
+        collector_hpke_key.private_key(),
         &HpkeApplicationInfo::new(&Label::AggregateShare, &Role::Helper, &Role::Collector),
         aggregate_share_resp.encrypted_aggregate_share(),
-        &aggregate_share_aad(&test.task_id, aggregate_share_request.batch_selector()),
+        &aggregate_share_aad(&task_id, aggregate_share_request.batch_selector()),
     )
     .unwrap();
-    assert_eq!(
-        plaintext,
-        Vec::<u8>::from(&test.transcript.aggregate_shares[1])
-    );
+    assert_eq!(plaintext, Vec::<u8>::from(&transcript.aggregate_shares[1]));
 }

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -27,7 +27,6 @@ use janus_core::{
     },
     report_id::ReportIdChecksumExt,
     task::{AuthenticationToken, PRIO3_VERIFY_KEY_LENGTH},
-    taskprov::TASKPROV_HEADER,
     test_util::{install_test_trace_subscriber, run_vdaf, VdafTranscript},
     time::{Clock, DurationExt, MockClock, TimeExt},
 };
@@ -232,10 +231,6 @@ async fn taskprov_aggregate_init() {
             KnownHeaderName::ContentType,
             AggregateInitializeReq::<FixedSize>::MEDIA_TYPE,
         )
-        .with_request_header(
-            TASKPROV_HEADER,
-            URL_SAFE_NO_PAD.encode(test.task_config.get_encoded()),
-        )
         .with_request_body(request.get_encoded())
         .run_async(&test.handler)
         .await;
@@ -255,10 +250,6 @@ async fn taskprov_aggregate_init() {
         .with_request_header(
             KnownHeaderName::ContentType,
             AggregateInitializeReq::<FixedSize>::MEDIA_TYPE,
-        )
-        .with_request_header(
-            TASKPROV_HEADER,
-            URL_SAFE_NO_PAD.encode(test.task_config.get_encoded()),
         )
         .with_request_body(request.get_encoded())
         .run_async(&test.handler)
@@ -331,10 +322,6 @@ async fn taskprov_opt_out_task_expired() {
             KnownHeaderName::ContentType,
             AggregateInitializeReq::<FixedSize>::MEDIA_TYPE,
         )
-        .with_request_header(
-            TASKPROV_HEADER,
-            URL_SAFE_NO_PAD.encode(test.task_config.get_encoded()),
-        )
         .with_request_body(request.get_encoded())
         .run_async(&test.handler)
         .await;
@@ -404,11 +391,6 @@ async fn taskprov_opt_out_mismatched_task_id() {
     .with_request_header(
         KnownHeaderName::ContentType,
         AggregateInitializeReq::<FixedSize>::MEDIA_TYPE,
-    )
-    .with_request_header(
-        TASKPROV_HEADER,
-        // Use a different task than the URL's.
-        URL_SAFE_NO_PAD.encode(another_task_config.get_encoded()),
     )
     .with_request_body(request.get_encoded())
     .run_async(&test.handler)
@@ -481,10 +463,6 @@ async fn taskprov_opt_out_missing_aggregator() {
     .with_request_header(
         KnownHeaderName::ContentType,
         AggregateInitializeReq::<FixedSize>::MEDIA_TYPE,
-    )
-    .with_request_header(
-        TASKPROV_HEADER,
-        URL_SAFE_NO_PAD.encode(another_task_config_encoded),
     )
     .with_request_body(request.get_encoded())
     .run_async(&test.handler)
@@ -585,10 +563,6 @@ async fn taskprov_aggregate_continue() {
             KnownHeaderName::ContentType,
             AggregateContinueReq::MEDIA_TYPE,
         )
-        .with_request_header(
-            TASKPROV_HEADER,
-            URL_SAFE_NO_PAD.encode(test.task_config.get_encoded()),
-        )
         .with_request_body(request.get_encoded())
         .run_async(&test.handler)
         .await;
@@ -610,10 +584,6 @@ async fn taskprov_aggregate_continue() {
             AggregateContinueReq::MEDIA_TYPE,
         )
         .with_request_body(request.get_encoded())
-        .with_request_header(
-            TASKPROV_HEADER,
-            URL_SAFE_NO_PAD.encode(test.task_config.get_encoded()),
-        )
         .run_async(&test.handler)
         .await;
 
@@ -703,10 +673,6 @@ async fn taskprov_aggregate_share() {
             KnownHeaderName::ContentType,
             AggregateShareReq::<FixedSize>::MEDIA_TYPE,
         )
-        .with_request_header(
-            TASKPROV_HEADER,
-            URL_SAFE_NO_PAD.encode(test.task_config.get_encoded()),
-        )
         .with_request_body(request.get_encoded())
         .run_async(&test.handler)
         .await;
@@ -728,10 +694,6 @@ async fn taskprov_aggregate_share() {
             AggregateShareReq::<FixedSize>::MEDIA_TYPE,
         )
         .with_request_body(request.get_encoded())
-        .with_request_header(
-            TASKPROV_HEADER,
-            URL_SAFE_NO_PAD.encode(test.task_config.get_encoded()),
-        )
         .run_async(&test.handler)
         .await;
 
@@ -779,10 +741,6 @@ async fn end_to_end() {
             KnownHeaderName::ContentType,
             AggregateInitializeReq::<FixedSize>::MEDIA_TYPE,
         )
-        .with_request_header(
-            TASKPROV_HEADER,
-            URL_SAFE_NO_PAD.encode(test.task_config.get_encoded()),
-        )
         .with_request_body(aggregate_init_request.get_encoded())
         .run_async(&test.handler)
         .await;
@@ -819,10 +777,6 @@ async fn end_to_end() {
             KnownHeaderName::ContentType,
             AggregateContinueReq::MEDIA_TYPE,
         )
-        .with_request_header(
-            TASKPROV_HEADER,
-            URL_SAFE_NO_PAD.encode(test.task_config.get_encoded()),
-        )
         .with_request_body(aggregate_continue_request.get_encoded())
         .run_async(&test.handler)
         .await;
@@ -851,10 +805,6 @@ async fn end_to_end() {
         .with_request_header(
             KnownHeaderName::ContentType,
             AggregateShareReq::<FixedSize>::MEDIA_TYPE,
-        )
-        .with_request_header(
-            TASKPROV_HEADER,
-            URL_SAFE_NO_PAD.encode(test.task_config.get_encoded()),
         )
         .with_request_body(aggregate_share_request.get_encoded())
         .run_async(&test.handler)

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -35,7 +35,3 @@ impl Runtime for TokioRuntime {
         tokio::task::spawn(future)
     }
 }
-
-pub mod taskprov {
-    pub const TASKPROV_HEADER: &str = "dap-taskprov";
-}

--- a/integration_tests/tests/divviup_ts.rs
+++ b/integration_tests/tests/divviup_ts.rs
@@ -36,6 +36,7 @@ async fn run_divviup_ts_integration_test(container_client: &Cli, vdaf: VdafInsta
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "subscriber-01 does not operate as a leader, therefore will not service client requests"]
 async fn janus_divviup_ts_count() {
     install_test_trace_subscriber();
 
@@ -43,6 +44,7 @@ async fn janus_divviup_ts_count() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "subscriber-01 does not operate as a leader, therefore will not service client requests"]
 async fn janus_divviup_ts_sum() {
     install_test_trace_subscriber();
 
@@ -54,6 +56,7 @@ async fn janus_divviup_ts_sum() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "subscriber-01 does not operate as a leader, therefore will not service client requests"]
 async fn janus_divviup_ts_histogram() {
     install_test_trace_subscriber();
 

--- a/integration_tests/tests/in_cluster.rs
+++ b/integration_tests/tests/in_cluster.rs
@@ -218,6 +218,7 @@ impl InClusterJanus {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "subscriber-01 cannot operate as a leader"]
 async fn in_cluster_count() {
     install_test_trace_subscriber();
 
@@ -235,6 +236,7 @@ async fn in_cluster_count() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "subscriber-01 cannot operate as a leader"]
 async fn in_cluster_sum() {
     install_test_trace_subscriber();
 
@@ -255,6 +257,7 @@ async fn in_cluster_sum() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "subscriber-01 cannot operate as a leader"]
 async fn in_cluster_histogram() {
     install_test_trace_subscriber();
 
@@ -276,6 +279,7 @@ async fn in_cluster_histogram() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "subscriber-01 cannot operate as a leader"]
 async fn in_cluster_fixed_size() {
     install_test_trace_subscriber();
 

--- a/integration_tests/tests/janus.rs
+++ b/integration_tests/tests/janus.rs
@@ -46,6 +46,7 @@ impl<'a> JanusPair<'a> {
 
 /// This test exercises Prio3Count with Janus as both the leader and the helper.
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "subscriber-01 cannot operate as a leader"]
 async fn janus_janus_count() {
     install_test_trace_subscriber();
 
@@ -69,6 +70,7 @@ async fn janus_janus_count() {
 
 /// This test exercises Prio3Sum with Janus as both the leader and the helper.
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "subscriber-01 cannot operate as a leader"]
 async fn janus_janus_sum_16() {
     install_test_trace_subscriber();
 
@@ -92,6 +94,7 @@ async fn janus_janus_sum_16() {
 
 /// This test exercises Prio3Histogram with Janus as both the leader and the helper.
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "subscriber-01 cannot operate as a leader"]
 async fn janus_janus_histogram_4_buckets() {
     install_test_trace_subscriber();
 
@@ -117,6 +120,7 @@ async fn janus_janus_histogram_4_buckets() {
 
 /// This test exercises Prio3CountVec with Janus as both the leader and the helper.
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "subscriber-01 cannot operate as a leader"]
 async fn janus_janus_count_vec_15() {
     install_test_trace_subscriber();
 
@@ -140,6 +144,7 @@ async fn janus_janus_count_vec_15() {
 
 /// This test exercises the fixed-size query type with Janus as both the leader and the helper.
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "subscriber-01 cannot operate as a leader"]
 async fn janus_janus_fixed_size() {
     install_test_trace_subscriber();
 

--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -600,6 +600,7 @@ async fn run(
 }
 
 #[tokio::test]
+#[ignore = "subscriber-01 cannot operate as a leader"]
 async fn e2e_prio3_count() {
     let result = run(
         QueryKind::TimeInterval,
@@ -631,6 +632,7 @@ async fn e2e_prio3_count() {
 }
 
 #[tokio::test]
+#[ignore = "subscriber-01 cannot operate as a leader"]
 async fn e2e_prio3_sum() {
     let result = run(
         QueryKind::TimeInterval,
@@ -651,6 +653,7 @@ async fn e2e_prio3_sum() {
 }
 
 #[tokio::test]
+#[ignore = "subscriber-01 cannot operate as a leader"]
 async fn e2e_prio3_histogram() {
     let result = run(
         QueryKind::TimeInterval,
@@ -682,6 +685,7 @@ async fn e2e_prio3_histogram() {
 }
 
 #[tokio::test]
+#[ignore = "subscriber-01 cannot operate as a leader"]
 async fn e2e_prio3_count_vec() {
     let result = run(
         QueryKind::TimeInterval,
@@ -704,6 +708,7 @@ async fn e2e_prio3_count_vec() {
 }
 
 #[tokio::test]
+#[ignore = "subscriber-01 cannot operate as a leader"]
 async fn e2e_prio3_count_fixed_size() {
     let result = run(
         QueryKind::FixedSize,

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -872,8 +872,10 @@ impl Decode for Extension {
 /// DAP protocol message representing the type of an extension included in a client report.
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, TryFromPrimitive)]
 #[repr(u16)]
+#[non_exhaustive]
 pub enum ExtensionType {
     Tbd = 0,
+    Taskprov = 0xFF00,
 }
 
 impl Encode for ExtensionType {


### PR DESCRIPTION
Adopts draft-wang-ppm-dap-taskprov-02 for the subscriber-01 branch.

The primary difference between this revision and the latest is that the taskprov configuration is expressed in the extension field of each report share. A helper must parse the extension in each AggregateInitRequest and use it to provision the task.

The implementation of this is unclean. Due to how AggregateInitRequest is structured, we need to know the query type ahead of time. We can't decode it unless we know the query type, but we won't know the query type until we decode it. To work around this, decode by trial.

To simplify implementation I made all helper requests use the main aggregator auth token established in https://github.com/divviup/janus/pull/1976. Leader requests are unmodified, but are effectively inert/useless now. We can consider removing leader endpoints in a future PR.

The first commit contains the operative logic, the remaining commits address tests.

Tests underwent considerable modification. The aggregate init harness needed to be adapted to provide the taskprov extension and aggregator authentication token. I accepted the large amount of change on the basis that we will likely just want to revert this PR to adopt taskprov-04+ again.

I disabled all integration tests as this branch can no longer service non-taskprov leader->helper requests.