### PR TITLE
Use HpkeKeypair instead of config and private key

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1396,8 +1396,7 @@ impl VdafOps {
 
         let try_hpke_open = |hpke_keypair: &HpkeKeypair| {
             hpke::open(
-                hpke_keypair.config(),
-                hpke_keypair.private_key(),
+                hpke_keypair,
                 &HpkeApplicationInfo::new(&Label::InputShare, &Role::Client, task.role()),
                 report.leader_encrypted_input_share(),
                 &InputShareAad::new(
@@ -1623,8 +1622,7 @@ impl VdafOps {
             // If decryption fails, then the aggregator MUST fail with error `hpke-decrypt-error`. (§4.4.2.2)
             let try_hpke_open = |hpke_keypair: &HpkeKeypair| {
                 hpke::open(
-                    hpke_keypair.config(),
-                    hpke_keypair.private_key(),
+                    hpke_keypair,
                     &HpkeApplicationInfo::new(&Label::InputShare, &Role::Client, &Role::Helper),
                     prepare_init.report_share().encrypted_input_share(),
                     &InputShareAad::new(

--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -367,8 +367,7 @@ async fn collection_job_success_fixed_size() {
         );
 
         let decrypted_leader_aggregate_share = hpke::open(
-            test_case.task.collector_hpke_keypair().config(),
-            test_case.task.collector_hpke_keypair().private_key(),
+            test_case.task.collector_hpke_keypair(),
             &HpkeApplicationInfo::new(&Label::AggregateShare, &Role::Leader, &Role::Collector),
             collect_resp.leader_encrypted_aggregate_share(),
             &AggregateShareAad::new(
@@ -386,8 +385,7 @@ async fn collection_job_success_fixed_size() {
         );
 
         let decrypted_helper_aggregate_share = hpke::open(
-            test_case.task.collector_hpke_keypair().config(),
-            test_case.task.collector_hpke_keypair().private_key(),
+            test_case.task.collector_hpke_keypair(),
             &HpkeApplicationInfo::new(&Label::AggregateShare, &Role::Helper, &Role::Collector),
             collect_resp.helper_encrypted_aggregate_share(),
             &AggregateShareAad::new(

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -1017,8 +1017,7 @@ mod tests {
         )
         .unwrap();
         let plaintext = hpke::open(
-            hpke_keypair.config(),
-            hpke_keypair.private_key(),
+            hpke_keypair,
             &application_info,
             &ciphertext,
             associated_data,
@@ -4433,8 +4432,7 @@ mod tests {
         assert_eq!(collect_resp.interval(), &batch_interval);
 
         let decrypted_leader_aggregate_share = hpke::open(
-            test_case.task.collector_hpke_keypair().config(),
-            test_case.task.collector_hpke_keypair().private_key(),
+            test_case.task.collector_hpke_keypair(),
             &HpkeApplicationInfo::new(&Label::AggregateShare, &Role::Leader, &Role::Collector),
             collect_resp.leader_encrypted_aggregate_share(),
             &AggregateShareAad::new(
@@ -4452,8 +4450,7 @@ mod tests {
         );
 
         let decrypted_helper_aggregate_share = hpke::open(
-            test_case.task.collector_hpke_keypair().config(),
-            test_case.task.collector_hpke_keypair().private_key(),
+            test_case.task.collector_hpke_keypair(),
             &HpkeApplicationInfo::new(&Label::AggregateShare, &Role::Helper, &Role::Collector),
             collect_resp.helper_encrypted_aggregate_share(),
             &AggregateShareAad::new(
@@ -5152,8 +5149,7 @@ mod tests {
                     decode_response_body(&mut test_conn).await;
 
                 let aggregate_share = hpke::open(
-                    task.collector_hpke_keypair().config(),
-                    task.collector_hpke_keypair().private_key(),
+                    task.collector_hpke_keypair(),
                     &HpkeApplicationInfo::new(
                         &Label::AggregateShare,
                         &Role::Helper,

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -979,8 +979,7 @@ async fn taskprov_aggregate_share() {
     let aggregate_share_resp: AggregateShareMessage = decode_response_body(&mut test_conn).await;
 
     hpke::open(
-        test.collector_hpke_keypair.config(),
-        test.collector_hpke_keypair.private_key(),
+        &test.collector_hpke_keypair,
         &HpkeApplicationInfo::new(&Label::AggregateShare, &Role::Helper, &Role::Collector),
         aggregate_share_resp.encrypted_aggregate_share(),
         &AggregateShareAad::new(
@@ -1116,8 +1115,7 @@ async fn end_to_end() {
     let aggregate_share_resp: AggregateShareMessage = decode_response_body(&mut test_conn).await;
 
     let plaintext = hpke::open(
-        test.collector_hpke_keypair.config(),
-        test.collector_hpke_keypair.private_key(),
+        &test.collector_hpke_keypair,
         &HpkeApplicationInfo::new(&Label::AggregateShare, &Role::Helper, &Role::Collector),
         aggregate_share_resp.encrypted_aggregate_share(),
         &AggregateShareAad::new(

--- a/integration_tests/tests/common/mod.rs
+++ b/integration_tests/tests/common/mod.rs
@@ -135,8 +135,7 @@ pub async fn submit_measurements_and_verify_aggregate_generic<V>(
         task_parameters.task_id,
         leader_endpoint,
         task_parameters.collector_auth_token.clone(),
-        task_parameters.collector_hpke_keypair.config().clone(),
-        task_parameters.collector_hpke_keypair.private_key().clone(),
+        task_parameters.collector_hpke_keypair.clone(),
     )
     .with_http_request_backoff(test_http_request_exponential_backoff())
     .with_collect_poll_backoff(

--- a/interop_binaries/src/bin/janus_interop_collector.rs
+++ b/interop_binaries/src/bin/janus_interop_collector.rs
@@ -235,8 +235,7 @@ async fn handle_collection_start(
         task_id,
         task_state.leader_url.clone(),
         task_state.auth_token.clone(),
-        task_state.keypair.config().clone(),
-        task_state.keypair.private_key().clone(),
+        task_state.keypair.clone(),
     )
     .with_http_request_backoff(
         ExponentialBackoffBuilder::new()

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -439,8 +439,7 @@ where
         options.task_id,
         options.leader,
         authentication.clone(),
-        hpke_keypair.config().clone(),
-        hpke_keypair.private_key().clone(),
+        hpke_keypair,
     );
     let http_client = default_http_client().map_err(|err| Error::Anyhow(err.into()))?;
     match (options.vdaf, options.length, options.bits) {


### PR DESCRIPTION
This changes `janus_core::hpke::open()` and `janus_collector::CollectorParameters::new()` to take a single `HpkeKeypair` instead of separate `HpkeConfig` and `HpkePrivateKey` arguments. This addresses part of #230.