### PR TITLE
Add task_id column to report_aggregations

### DIFF
--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -932,7 +932,7 @@ impl<C: Clock> Transaction<'_, C> {
                        AND client_reports.client_timestamp >= COALESCE($2::TIMESTAMP - tasks.report_expiry_age * '1 second'::INTERVAL, '-infinity'::TIMESTAMP)) AS report_count,
                     (SELECT COUNT(*) FROM aggregation_jobs
                      JOIN tasks ON tasks.id = aggregation_jobs.task_id
-                     RIGHT JOIN report_aggregations ON report_aggregations.aggregation_job_id = aggregation_jobs.id
+                     RIGHT JOIN report_aggregations ON report_aggregations.aggregation_job_id = aggregation_jobs.id AND report_aggregations.task_id = tasks.id
                      WHERE tasks.task_id = $1
                        AND UPPER(aggregation_jobs.client_timestamp_interval) >= COALESCE($2::TIMESTAMP - tasks.report_expiry_age * '1 second'::INTERVAL, '-infinity'::TIMESTAMP)) AS report_aggregation_count",
             )
@@ -1342,7 +1342,7 @@ impl<C: Clock> Transaction<'_, C> {
                 "SELECT COUNT(DISTINCT report_aggregations.client_report_id) AS count
                 FROM report_aggregations
                 JOIN aggregation_jobs ON aggregation_jobs.id = report_aggregations.aggregation_job_id
-                JOIN tasks ON tasks.id = aggregation_jobs.task_id
+                JOIN tasks ON tasks.id = aggregation_jobs.task_id AND tasks.id = report_aggregations.task_id
                 WHERE tasks.task_id = $1
                   AND aggregation_jobs.batch_id = $2
                   AND UPPER(aggregation_jobs.client_timestamp_interval) >= COALESCE($3::TIMESTAMP - tasks.report_expiry_age * '1 second'::INTERVAL, '-infinity'::TIMESTAMP)",
@@ -1888,6 +1888,7 @@ impl<C: Clock> Transaction<'_, C> {
                 JOIN aggregation_jobs ON aggregation_jobs.id = report_aggregations.aggregation_job_id
                 JOIN tasks ON tasks.id = aggregation_jobs.task_id
                 WHERE tasks.task_id = $1
+                  AND report_aggregations.task_id = tasks.id
                   AND report_aggregations.client_report_id = $2
                   AND aggregation_jobs.aggregation_param = $3
                   AND aggregation_jobs.aggregation_job_id != $4
@@ -1935,7 +1936,7 @@ impl<C: Clock> Transaction<'_, C> {
                     report_aggregations.last_prep_resp
                 FROM report_aggregations
                 JOIN aggregation_jobs ON aggregation_jobs.id = report_aggregations.aggregation_job_id
-                JOIN tasks ON tasks.id = aggregation_jobs.task_id
+                JOIN tasks ON tasks.id = aggregation_jobs.task_id AND tasks.id = report_aggregations.task_id
                 WHERE tasks.task_id = $1
                   AND aggregation_jobs.aggregation_job_id = $2
                   AND report_aggregations.client_report_id = $3
@@ -1990,7 +1991,7 @@ impl<C: Clock> Transaction<'_, C> {
                     report_aggregations.error_code, report_aggregations.last_prep_resp
                 FROM report_aggregations
                 JOIN aggregation_jobs ON aggregation_jobs.id = report_aggregations.aggregation_job_id
-                JOIN tasks ON tasks.id = aggregation_jobs.task_id
+                JOIN tasks ON tasks.id = aggregation_jobs.task_id AND tasks.id = report_aggregations.task_id
                 WHERE tasks.task_id = $1
                   AND aggregation_jobs.aggregation_job_id = $2
                   AND UPPER(aggregation_jobs.client_timestamp_interval) >= COALESCE($3::TIMESTAMP - tasks.report_expiry_age * '1 second'::INTERVAL, '-infinity'::TIMESTAMP)
@@ -2045,7 +2046,7 @@ impl<C: Clock> Transaction<'_, C> {
                     report_aggregations.last_prep_resp
                 FROM report_aggregations
                 JOIN aggregation_jobs ON aggregation_jobs.id = report_aggregations.aggregation_job_id
-                JOIN tasks ON tasks.id = aggregation_jobs.task_id
+                JOIN tasks ON tasks.id = aggregation_jobs.task_id AND tasks.id = report_aggregations.task_id
                 WHERE tasks.task_id = $1
                   AND UPPER(aggregation_jobs.client_timestamp_interval) >= COALESCE($2::TIMESTAMP - tasks.report_expiry_age * '1 second'::INTERVAL, '-infinity'::TIMESTAMP)",
             )
@@ -2188,9 +2189,9 @@ impl<C: Clock> Transaction<'_, C> {
         let stmt = self
             .prepare_cached(
                 "INSERT INTO report_aggregations
-                    (aggregation_job_id, client_report_id, client_timestamp, ord, state,
+                    (task_id, aggregation_job_id, client_report_id, client_timestamp, ord, state,
                     helper_prep_state, leader_prep_transition, error_code, last_prep_resp)
-                SELECT aggregation_jobs.id, $3, $4, $5, $6, $7, $8, $9, $10
+                SELECT tasks.id, aggregation_jobs.id, $3, $4, $5, $6, $7, $8, $9, $10
                 FROM aggregation_jobs
                 JOIN tasks ON tasks.id = aggregation_jobs.task_id
                 WHERE tasks.task_id = $1
@@ -2241,6 +2242,7 @@ impl<C: Clock> Transaction<'_, C> {
                 SET state = $1, helper_prep_state = $2, leader_prep_transition = $3, error_code = $4, last_prep_resp = $5
                 FROM aggregation_jobs, tasks
                 WHERE report_aggregations.aggregation_job_id = aggregation_jobs.id
+                  AND report_aggregations.task_id = tasks.id
                   AND aggregation_jobs.task_id = tasks.id
                   AND aggregation_jobs.aggregation_job_id = $6
                   AND tasks.task_id = $7
@@ -3662,6 +3664,7 @@ impl<C: Clock> Transaction<'_, C> {
                      JOIN aggregation_jobs
                         ON report_aggregations.aggregation_job_id = aggregation_jobs.id
                      WHERE aggregation_jobs.task_id = (SELECT id FROM tasks WHERE task_id = $1)
+                     AND report_aggregations.task_id = aggregation_jobs.task_id
                      AND aggregation_jobs.batch_id = $2
                      GROUP BY report_aggregations.state)
                 SELECT
@@ -4025,7 +4028,8 @@ impl<C: Clock> Transaction<'_, C> {
     ) -> Result<(), Error> {
         let stmt = self
             .prepare_cached(
-                "WITH aggregation_jobs_to_delete AS (
+                "WITH task_id AS (SELECT id FROM tasks WHERE task_id = $1),
+                aggregation_jobs_to_delete AS (
                     SELECT aggregation_jobs.id FROM aggregation_jobs
                     JOIN tasks ON tasks.id = aggregation_jobs.task_id
                     WHERE tasks.task_id = $1
@@ -4035,6 +4039,7 @@ impl<C: Clock> Transaction<'_, C> {
                 deleted_report_aggregations AS (
                     DELETE FROM report_aggregations
                     WHERE aggregation_job_id IN (SELECT id FROM aggregation_jobs_to_delete)
+                    AND task_id IN (SELECT id FROM task_id)
                 )
                 DELETE FROM aggregation_jobs
                 WHERE id IN (SELECT id FROM aggregation_jobs_to_delete)",

--- a/db/00000000000001_initial_schema.up.sql
+++ b/db/00000000000001_initial_schema.up.sql
@@ -187,6 +187,7 @@ CREATE TYPE REPORT_AGGREGATION_STATE AS ENUM(
 -- therefore have multiple associated report aggregations.
 CREATE TABLE report_aggregations(
     id                  BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY, -- artificial ID, internal-only
+    task_id             BIGINT NOT NULL,                    -- ID of related task
     aggregation_job_id  BIGINT NOT NULL,                    -- the aggregation job ID this report aggregation is associated with
     client_report_id    BYTEA NOT NULL,                     -- the client report ID this report aggregation is associated with
     client_timestamp    TIMESTAMP NOT NULL,                 -- the client timestamp this report aggregation is associated with
@@ -197,7 +198,8 @@ CREATE TABLE report_aggregations(
     error_code          SMALLINT,                           -- error code corresponding to a DAP ReportShareError value; null if in a state other than FAILED
     last_prep_resp      BYTEA,                              -- the last PrepareResp message sent to the Leader, to assist in replay (opaque DAP message, populated for Helper only)
 
-    CONSTRAINT report_aggregations_unique_ord UNIQUE(aggregation_job_id, ord),
+    CONSTRAINT report_aggregations_unique_ord UNIQUE(task_id, aggregation_job_id, ord),
+    CONSTRAINT fk_task_id FOREIGN KEY (task_id) REFERENCES tasks (id) ON DELETE CASCADE,
     CONSTRAINT fk_aggregation_job_id FOREIGN KEY(aggregation_job_id) REFERENCES aggregation_jobs(id) ON DELETE CASCADE
 );
 CREATE INDEX report_aggregations_aggregation_job_id_index ON report_aggregations(aggregation_job_id);


### PR DESCRIPTION
This adds a task_id column to the report_aggregations table, adds it to the existing unique index over the table, and updates relevant queries to filter on it. This is intended to lay the groundwork for future partitioning (see #647), as this was the last table of per-task objects without a direct foreign key to the tasks table. While I haven't tested it, this may also help the performance of some of our more complex queries by improving the locality of index accesses when looking at multiple aggregation jobs in the same task, and giving the query planner another condition with good selectivity to move around.