### PR TITLE
Include `task_id` in effective primary keys for all tables.

### DIFF
--- a/db/00000000000001_initial_schema.up.sql
+++ b/db/00000000000001_initial_schema.up.sql
@@ -167,7 +167,7 @@ CREATE TABLE aggregation_jobs(
     lease_token              BYTEA,                                             -- a value identifying the current leaseholder; NULL implies no current lease
     lease_attempts           BIGINT NOT NULL DEFAULT 0,                         -- the number of lease acquiries since the last successful lease release
 
-    CONSTRAINT aggregation_jobs_unique_id UNIQUE(aggregation_job_id),
+    CONSTRAINT aggregation_jobs_unique_id UNIQUE(task_id, aggregation_job_id),
     CONSTRAINT fk_task_id FOREIGN KEY(task_id) REFERENCES tasks(id) ON DELETE CASCADE
 );
 CREATE INDEX aggregation_jobs_state_and_lease_expiry ON aggregation_jobs(state, lease_expiry) WHERE state = 'IN_PROGRESS';
@@ -278,7 +278,7 @@ CREATE TABLE collection_jobs(
     lease_token             BYTEA,                                             -- a value identifying the current leaseholder; NULL implies no current lease
     lease_attempts          BIGINT NOT NULL DEFAULT 0,                         -- the number of lease acquiries since the last successful lease release
 
-    CONSTRAINT collection_jobs_unique_id UNIQUE(collection_job_id),
+    CONSTRAINT collection_jobs_unique_id UNIQUE(task_id, collection_job_id),
     CONSTRAINT fk_task_id FOREIGN KEY(task_id) REFERENCES tasks(id) ON DELETE CASCADE
 );
 CREATE INDEX collection_jobs_task_id_batch_id ON collection_jobs(task_id, batch_identifier);


### PR DESCRIPTION
This updates the `aggregation_jobs` & `collection_jobs` tables; previously, only the direct ID (`aggregation_job_id` or `collection_job_id`) was treated as the effective primary key. For both tables, this will allow an indexed lookup where previously a scan was required (in `get_aggregation_job`/`get_collection_job`, respectively).

Closes #1550.