### PR TITLE
subscriber-01: Bump supported schema version

### DIFF
--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -97,7 +97,7 @@ macro_rules! supported_schema_versions {
 // version is seen, [`Datastore::new`] fails.
 //
 // Note that the latest supported version must be first in the list.
-supported_schema_versions!(2);
+supported_schema_versions!(3);
 
 /// Datastore represents a datastore for Janus, with support for transactional reads and writes.
 /// In practice, Datastore instances are currently backed by a PostgreSQL database.


### PR DESCRIPTION
Should have been bumped in https://github.com/divviup/janus/pull/1976.

Integration tests in janus-ops would have kept this from moving to a live system. Arguable whether a check for this should be made earlier in the CI/CD process, to prevent from cutting a faulty release.