### PR TITLE
Release Janus 0.5.12-subscriber-01.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1741,7 +1741,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "janus_aggregator"
-version = "0.5.12-subscriber-01.9"
+version = "0.5.12-subscriber-01.10"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1823,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "janus_aggregator_api"
-version = "0.5.12-subscriber-01.9"
+version = "0.5.12-subscriber-01.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "janus_aggregator_core"
-version = "0.5.12-subscriber-01.9"
+version = "0.5.12-subscriber-01.10"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1907,14 +1907,14 @@ dependencies = [
 
 [[package]]
 name = "janus_build_script_utils"
-version = "0.5.12-subscriber-01.9"
+version = "0.5.12-subscriber-01.10"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "janus_client"
-version = "0.5.12-subscriber-01.9"
+version = "0.5.12-subscriber-01.10"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "janus_collector"
-version = "0.5.12-subscriber-01.9"
+version = "0.5.12-subscriber-01.10"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -1960,7 +1960,7 @@ dependencies = [
 
 [[package]]
 name = "janus_core"
-version = "0.5.12-subscriber-01.9"
+version = "0.5.12-subscriber-01.10"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2003,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "janus_integration_tests"
-version = "0.5.12-subscriber-01.9"
+version = "0.5.12-subscriber-01.10"
 dependencies = [
  "anyhow",
  "backoff",
@@ -2034,7 +2034,7 @@ dependencies = [
 
 [[package]]
 name = "janus_interop_binaries"
-version = "0.5.12-subscriber-01.9"
+version = "0.5.12-subscriber-01.10"
 dependencies = [
  "anyhow",
  "backoff",
@@ -2075,7 +2075,7 @@ dependencies = [
 
 [[package]]
 name = "janus_messages"
-version = "0.5.12-subscriber-01.9"
+version = "0.5.12-subscriber-01.10"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2093,7 +2093,7 @@ dependencies = [
 
 [[package]]
 name = "janus_tools"
-version = "0.5.12-subscriber-01.9"
+version = "0.5.12-subscriber-01.10"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ repository = "https://github.com/divviup/janus"
 rust-version = "1.70.0"
 # The format is [origin branch]-[purpose].[version]. Increment [version] to update the crate version.
 # See https://github.com/divviup/janus/pull/1732 for context.
-version = "0.5.12-subscriber-01.9"
+version = "0.5.12-subscriber-01.10"
 
 [workspace.dependencies]
 anyhow = "1"


### PR DESCRIPTION
Making the next release early since .9 was faulty due to missing https://github.com/divviup/janus/pull/2075, and so that https://github.com/divviup/janus-ops/pull/1083 can have passing CI on a new version.