### PR TITLE
Collector API redesign

### DIFF
--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -171,13 +171,19 @@ impl<P, Q: QueryType> CollectionJob<P, Q> {
         }
     }
 
-    /// Destructure a collection job into its fields.
-    pub fn into_fields(self) -> (CollectionJobId, Query<Q>, P) {
-        (
-            self.collection_job_id,
-            self.query,
-            self.aggregation_parameter,
-        )
+    /// Gets this collection job's identifier.
+    pub fn collection_job_id(&self) -> &CollectionJobId {
+        &self.collection_job_id
+    }
+
+    /// Gets the query used to create this collection job.
+    pub fn query(&self) -> &Query<Q> {
+        &self.query
+    }
+
+    /// Gets the aggregation parameter used to create this collection job.
+    pub fn aggregation_parameter(&self) -> &P {
+        &self.aggregation_parameter
     }
 }
 

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -421,6 +421,17 @@ impl<V: vdaf::Collector> Collector<V> {
         ))?)
     }
 
+    /// Send a collection request to the leader aggregator, wait for it to complete, and return the
+    /// result of the aggregation.
+    pub async fn collect<Q: QueryType>(
+        &self,
+        query: Query<Q>,
+        aggregation_parameter: &V::AggregationParam,
+    ) -> Result<Collection<V::AggregateResult, Q>, Error> {
+        let job = self.start_collection(query, aggregation_parameter).await?;
+        self.poll_until_complete(&job).await
+    }
+
     /// Send a collection request to the leader aggregator.
     ///
     /// This returns a [`CollectionJob`] that must be polled separately using [`Self::poll_once`] or
@@ -644,17 +655,6 @@ impl<V: vdaf::Collector> Collector<V> {
             };
             sleep(sleep_duration).await;
         }
-    }
-
-    /// Send a collection request to the leader aggregator, wait for it to complete, and return the
-    /// result of the aggregation.
-    pub async fn collect<Q: QueryType>(
-        &self,
-        query: Query<Q>,
-        aggregation_parameter: &V::AggregationParam,
-    ) -> Result<Collection<V::AggregateResult, Q>, Error> {
-        let job = self.start_collection(query, aggregation_parameter).await?;
-        self.poll_until_complete(&job).await
     }
 }
 

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -205,7 +205,6 @@ impl CollectorParameters {
 /// Construct a [`reqwest::Client`] suitable for use in a DAP [`Collector`].
 pub fn default_http_client() -> Result<reqwest::Client, Error> {
     Ok(reqwest::Client::builder()
-        .redirect(reqwest::redirect::Policy::none())
         .user_agent(COLLECTOR_USER_AGENT)
         .build()?)
 }
@@ -346,8 +345,8 @@ pub struct Collector<V: vdaf::Collector> {
 
 impl<V: vdaf::Collector> Collector<V> {
     /// Construct a new collector. This requires certain DAP task parameters, an implementation of
-    /// the task's VDAF, and a [`reqwest::Client`], configured to never follow redirects, that will
-    /// be used to communicate with the leader aggregator.
+    /// the task's VDAF, and a [`reqwest::Client`] that will be used to communicate with the leader
+    /// aggregator.
     pub fn new(
         parameters: CollectorParameters,
         vdaf_collector: V,
@@ -395,7 +394,7 @@ impl<V: vdaf::Collector> Collector<V> {
                 if status.is_client_error() || status.is_server_error() {
                     return Err(Error::from_http_response(response).await);
                 } else if status != StatusCode::CREATED {
-                    // Incorrect success/redirect status code:
+                    // Incorrect success status code:
                     return Err(Error::Http(Box::new(status.into())));
                 }
             }

--- a/core/src/test_util/dummy_vdaf.rs
+++ b/core/src/test_util/dummy_vdaf.rs
@@ -150,6 +150,17 @@ impl vdaf::Client<16> for Vdaf {
     }
 }
 
+impl vdaf::Collector for Vdaf {
+    fn unshard<M: IntoIterator<Item = Self::AggregateShare>>(
+        &self,
+        _agg_param: &Self::AggregationParam,
+        _agg_shares: M,
+        _num_measurements: usize,
+    ) -> Result<Self::AggregateResult, VdafError> {
+        Ok(())
+    }
+}
+
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct InputShare(pub u8);
 

--- a/integration_tests/tests/common/mod.rs
+++ b/integration_tests/tests/common/mod.rs
@@ -145,11 +145,7 @@ pub async fn submit_measurements_and_verify_aggregate_generic<V>(
             .with_max_elapsed_time(Some(time::Duration::from_secs(60)))
             .build(),
     );
-    let collector = Collector::new(
-        collector_params,
-        vdaf,
-        janus_collector::default_http_client().unwrap(),
-    );
+    let collector = Collector::new(collector_params, vdaf).unwrap();
 
     // Send a collect request and verify that we got the correct result.
     match &task_parameters.query_type {

--- a/integration_tests/tests/common/mod.rs
+++ b/integration_tests/tests/common/mod.rs
@@ -1,7 +1,7 @@
 use backoff::{future::retry, ExponentialBackoffBuilder};
 use itertools::Itertools;
 use janus_aggregator_core::task::{test_util::TaskBuilder, QueryType};
-use janus_collector::{Collection, Collector, CollectorParameters};
+use janus_collector::{Collection, Collector};
 use janus_core::{
     retries::test_http_request_exponential_backoff,
     time::{Clock, RealClock, TimeExt},
@@ -131,11 +131,12 @@ pub async fn submit_measurements_and_verify_aggregate_generic<V>(
     let leader_endpoint = task_parameters
         .endpoint_fragments
         .port_forwarded_leader_endpoint(leader_port);
-    let collector_params = CollectorParameters::new(
+    let collector = Collector::builder(
         task_parameters.task_id,
         leader_endpoint,
         task_parameters.collector_auth_token.clone(),
         task_parameters.collector_hpke_keypair.clone(),
+        vdaf,
     )
     .with_http_request_backoff(test_http_request_exponential_backoff())
     .with_collect_poll_backoff(
@@ -144,8 +145,9 @@ pub async fn submit_measurements_and_verify_aggregate_generic<V>(
             .with_max_interval(time::Duration::from_millis(500))
             .with_max_elapsed_time(Some(time::Duration::from_secs(60)))
             .build(),
-    );
-    let collector = Collector::new(collector_params, vdaf).unwrap();
+    )
+    .build()
+    .unwrap();
 
     // Send a collect request and verify that we got the correct result.
     match &task_parameters.query_type {

--- a/interop_binaries/src/bin/janus_interop_collector.rs
+++ b/interop_binaries/src/bin/janus_interop_collector.rs
@@ -6,7 +6,7 @@ use clap::{value_parser, Arg, Command};
 use fixed::types::extra::{U15, U31, U63};
 #[cfg(feature = "fpvec_bounded_l2")]
 use fixed::{FixedI16, FixedI32, FixedI64};
-use janus_collector::{Collector, CollectorParameters};
+use janus_collector::Collector;
 use janus_core::{auth_tokens::AuthenticationToken, hpke::HpkeKeypair, vdaf::VdafInstance};
 use janus_interop_binaries::Keyring;
 use janus_interop_binaries::{
@@ -122,6 +122,7 @@ struct CollectPollResponse {
 }
 
 struct TaskState {
+    task_id: TaskId,
     keypair: HpkeKeypair,
     leader_url: Url,
     vdaf: VdafObject,
@@ -168,6 +169,7 @@ async fn handle_add_task(
             .context("invalid header value in \"collector_authentication_token\"")?;
 
     entry.or_insert(TaskState {
+        task_id,
         keypair,
         leader_url: request.leader,
         vdaf: request.vdaf,
@@ -179,7 +181,7 @@ async fn handle_add_task(
 
 async fn handle_collect_generic<V, Q>(
     http_client: &reqwest::Client,
-    collector_params: CollectorParameters,
+    task_state: &TaskState,
     query: Query<Q>,
     vdaf: V,
     agg_param_encoded: &[u8],
@@ -191,9 +193,30 @@ where
     V::AggregationParam: Send + Sync + 'static,
     Q: QueryType,
 {
-    let collector = Collector::builder(collector_params, vdaf)
-        .with_http_client(http_client.clone())
-        .build()?;
+    let collector = Collector::builder(
+        task_state.task_id,
+        task_state.leader_url.clone(),
+        task_state.auth_token.clone(),
+        task_state.keypair.clone(),
+        vdaf,
+    )
+    .with_http_client(http_client.clone())
+    .with_http_request_backoff(
+        ExponentialBackoffBuilder::new()
+            .with_initial_interval(StdDuration::from_secs(1))
+            .with_max_interval(StdDuration::from_secs(1))
+            .with_max_elapsed_time(Some(StdDuration::from_secs(60)))
+            .build(),
+    )
+    .with_collect_poll_backoff(
+        ExponentialBackoffBuilder::new()
+            .with_initial_interval(StdDuration::from_millis(200))
+            .with_max_interval(StdDuration::from_secs(1))
+            .with_multiplier(1.2)
+            .with_max_elapsed_time(Some(StdDuration::from_secs(60)))
+            .build(),
+    )
+    .build()?;
     let agg_param = V::AggregationParam::get_decoded(agg_param_encoded)?;
     let handle = tokio::spawn(async move {
         let collect_result = collector.collect(query, &agg_param).await?;
@@ -232,28 +255,6 @@ async fn handle_collection_start(
     let task_state = tasks_guard
         .get(&task_id)
         .context("task was not added before being used in a collect request")?;
-
-    let collector_params = CollectorParameters::new(
-        task_id,
-        task_state.leader_url.clone(),
-        task_state.auth_token.clone(),
-        task_state.keypair.clone(),
-    )
-    .with_http_request_backoff(
-        ExponentialBackoffBuilder::new()
-            .with_initial_interval(StdDuration::from_secs(1))
-            .with_max_interval(StdDuration::from_secs(1))
-            .with_max_elapsed_time(Some(StdDuration::from_secs(60)))
-            .build(),
-    )
-    .with_collect_poll_backoff(
-        ExponentialBackoffBuilder::new()
-            .with_initial_interval(StdDuration::from_millis(200))
-            .with_max_interval(StdDuration::from_secs(1))
-            .with_multiplier(1.2)
-            .with_max_elapsed_time(Some(StdDuration::from_secs(60)))
-            .build(),
-    );
 
     let query = match request.query.query_type {
         1 => {
@@ -299,7 +300,7 @@ async fn handle_collection_start(
             let vdaf = Prio3::new_count(2).context("failed to construct Prio3Count VDAF")?;
             handle_collect_generic(
                 http_client,
-                collector_params,
+                task_state,
                 Query::new_time_interval(batch_interval),
                 vdaf,
                 &agg_param,
@@ -313,7 +314,7 @@ async fn handle_collection_start(
             let vdaf = Prio3::new_sum(2, bits).context("failed to construct Prio3Sum VDAF")?;
             handle_collect_generic(
                 http_client,
-                collector_params,
+                task_state,
                 Query::new_time_interval(batch_interval),
                 vdaf,
                 &agg_param,
@@ -335,7 +336,7 @@ async fn handle_collection_start(
                 .context("failed to construct Prio3SumVec VDAF")?;
             handle_collect_generic(
                 http_client,
-                collector_params,
+                task_state,
                 Query::new_time_interval(batch_interval),
                 vdaf,
                 &agg_param,
@@ -359,7 +360,7 @@ async fn handle_collection_start(
                 .context("failed to construct Prio3Histogram VDAF")?;
             handle_collect_generic(
                 http_client,
-                collector_params,
+                task_state,
                 Query::new_time_interval(batch_interval),
                 vdaf,
                 &agg_param,
@@ -382,7 +383,7 @@ async fn handle_collection_start(
                     .context("failed to construct Prio3FixedPoint16BitBoundedL2VecSum VDAF")?;
             handle_collect_generic(
                 http_client,
-                collector_params,
+                task_state,
                 Query::new_time_interval(batch_interval),
                 vdaf,
                 &agg_param,
@@ -405,7 +406,7 @@ async fn handle_collection_start(
                     .context("failed to construct Prio3FixedPoint32BitBoundedL2VecSum VDAF")?;
             handle_collect_generic(
                 http_client,
-                collector_params,
+                task_state,
                 Query::new_time_interval(batch_interval),
                 vdaf,
                 &agg_param,
@@ -428,7 +429,7 @@ async fn handle_collection_start(
                     .context("failed to construct Prio3FixedPoint64BitBoundedL2VecSum VDAF")?;
             handle_collect_generic(
                 http_client,
-                collector_params,
+                task_state,
                 Query::new_time_interval(batch_interval),
                 vdaf,
                 &agg_param,
@@ -445,7 +446,7 @@ async fn handle_collection_start(
             let vdaf = Prio3::new_count(2).context("failed to construct Prio3Count VDAF")?;
             handle_collect_generic(
                 http_client,
-                collector_params,
+                task_state,
                 Query::new_fixed_size(fixed_size_query),
                 vdaf,
                 &agg_param,
@@ -466,7 +467,7 @@ async fn handle_collection_start(
                 .context("failed to construct Prio3CountVec VDAF")?;
             handle_collect_generic(
                 http_client,
-                collector_params,
+                task_state,
                 Query::new_fixed_size(fixed_size_query),
                 vdaf,
                 &agg_param,
@@ -489,7 +490,7 @@ async fn handle_collection_start(
                     .context("failed to construct Prio3FixedPoint16BitBoundedL2VecSum VDAF")?;
             handle_collect_generic(
                 http_client,
-                collector_params,
+                task_state,
                 Query::new_fixed_size(fixed_size_query),
                 vdaf,
                 &agg_param,
@@ -512,7 +513,7 @@ async fn handle_collection_start(
                     .context("failed to construct Prio3FixedPoint32BitBoundedL2VecSum VDAF")?;
             handle_collect_generic(
                 http_client,
-                collector_params,
+                task_state,
                 Query::new_fixed_size(fixed_size_query),
                 vdaf,
                 &agg_param,
@@ -535,7 +536,7 @@ async fn handle_collection_start(
                     .context("failed to construct Prio3FixedPoint64BitBoundedL2VecSum VDAF")?;
             handle_collect_generic(
                 http_client,
-                collector_params,
+                task_state,
                 Query::new_fixed_size(fixed_size_query),
                 vdaf,
                 &agg_param,
@@ -552,7 +553,7 @@ async fn handle_collection_start(
             let vdaf = Prio3::new_sum(2, bits).context("failed to construct Prio3Sum VDAF")?;
             handle_collect_generic(
                 http_client,
-                collector_params,
+                task_state,
                 Query::new_fixed_size(fixed_size_query),
                 vdaf,
                 &agg_param,
@@ -574,7 +575,7 @@ async fn handle_collection_start(
                 .context("failed to construct Prio3SumVec VDAF")?;
             handle_collect_generic(
                 http_client,
-                collector_params,
+                task_state,
                 Query::new_fixed_size(fixed_size_query),
                 vdaf,
                 &agg_param,
@@ -598,7 +599,7 @@ async fn handle_collection_start(
                 .context("failed to construct Prio3Histogram VDAF")?;
             handle_collect_generic(
                 http_client,
-                collector_params,
+                task_state,
                 Query::new_fixed_size(fixed_size_query),
                 vdaf,
                 &agg_param,

--- a/interop_binaries/src/bin/janus_interop_collector.rs
+++ b/interop_binaries/src/bin/janus_interop_collector.rs
@@ -191,7 +191,9 @@ where
     V::AggregationParam: Send + Sync + 'static,
     Q: QueryType,
 {
-    let collector = Collector::new(collector_params, vdaf, http_client.clone());
+    let collector = Collector::builder(collector_params, vdaf)
+        .with_http_client(http_client.clone())
+        .build()?;
     let agg_param = V::AggregationParam::get_decoded(agg_param_encoded)?;
     let handle = tokio::spawn(async move {
         let collect_result = collector.collect(query, &agg_param).await?;

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -10,7 +10,7 @@ use derivative::Derivative;
 use fixed::types::extra::{U15, U31, U63};
 #[cfg(feature = "fpvec_bounded_l2")]
 use fixed::{FixedI16, FixedI32, FixedI64};
-use janus_collector::{default_http_client, AuthenticationToken, Collector, CollectorParameters};
+use janus_collector::{default_http_client, AuthenticationToken, Collector};
 use janus_core::hpke::{DivviUpHpkeConfig, HpkeKeypair, HpkePrivateKey};
 use janus_messages::{
     query_type::{FixedSize, QueryType, TimeInterval},
@@ -424,90 +424,57 @@ async fn run_with_query<Q: QueryType>(options: Options, query: Query<Q>) -> Resu
 where
     Q: QueryTypeExt,
 {
-    let authentication = match (
-        &options.authentication.dap_auth_token,
-        &options.authentication.authorization_bearer_token,
-    ) {
-        (None, Some(token)) => token,
-        (Some(token), None) => token,
-        (None, None) | (Some(_), Some(_)) => unreachable!(),
-    };
-
-    let hpke_keypair = options.hpke_keypair()?;
-
-    let parameters = CollectorParameters::new(
-        options.task_id,
-        options.leader,
-        authentication.clone(),
-        hpke_keypair,
-    );
     let http_client = default_http_client().map_err(|err| Error::Anyhow(err.into()))?;
     match (options.vdaf, options.length, options.bits) {
         (VdafType::Count, None, None) => {
             let vdaf = Prio3::new_count(2).map_err(|err| Error::Anyhow(err.into()))?;
-            run_collection_generic(parameters, vdaf, http_client, query, &())
-                .await
-                .map_err(|err| Error::Anyhow(err.into()))
+            run_collection_generic(options, vdaf, http_client, query, &()).await
         }
         (VdafType::CountVec, Some(length), None) => {
             // We can take advantage of the fact that Prio3SumVec unsharding does not use the
             // chunk_length parameter and avoid asking the user for it.
             let vdaf =
                 Prio3::new_sum_vec(2, 1, length, 1).map_err(|err| Error::Anyhow(err.into()))?;
-            run_collection_generic(parameters, vdaf, http_client, query, &())
-                .await
-                .map_err(|err| Error::Anyhow(err.into()))
+            run_collection_generic(options, vdaf, http_client, query, &()).await
         }
         (VdafType::Sum, None, Some(bits)) => {
             let vdaf = Prio3::new_sum(2, bits).map_err(|err| Error::Anyhow(err.into()))?;
-            run_collection_generic(parameters, vdaf, http_client, query, &())
-                .await
-                .map_err(|err| Error::Anyhow(err.into()))
+            run_collection_generic(options, vdaf, http_client, query, &()).await
         }
         (VdafType::SumVec, Some(length), Some(bits)) => {
             // We can take advantage of the fact that Prio3SumVec unsharding does not use the
             // chunk_length parameter and avoid asking the user for it.
             let vdaf =
                 Prio3::new_sum_vec(2, bits, length, 1).map_err(|err| Error::Anyhow(err.into()))?;
-            run_collection_generic(parameters, vdaf, http_client, query, &())
-                .await
-                .map_err(|err| Error::Anyhow(err.into()))
+            run_collection_generic(options, vdaf, http_client, query, &()).await
         }
         (VdafType::Histogram, Some(length), None) => {
             // We can take advantage of the fact that Prio3Histogram unsharding does not use the
             // chunk_length parameter and avoid asking the user for it.
             let vdaf =
                 Prio3::new_histogram(2, length, 1).map_err(|err| Error::Anyhow(err.into()))?;
-            run_collection_generic(parameters, vdaf, http_client, query, &())
-                .await
-                .map_err(|err| Error::Anyhow(err.into()))
+            run_collection_generic(options, vdaf, http_client, query, &()).await
         }
         #[cfg(feature = "fpvec_bounded_l2")]
         (VdafType::FixedPoint16BitBoundedL2VecSum, Some(length), None) => {
             let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>> =
                 Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length)
                     .map_err(|err| Error::Anyhow(err.into()))?;
-            run_collection_generic(parameters, vdaf, http_client, query, &())
-                .await
-                .map_err(|err| Error::Anyhow(err.into()))
+            run_collection_generic(options, vdaf, http_client, query, &()).await
         }
         #[cfg(feature = "fpvec_bounded_l2")]
         (VdafType::FixedPoint32BitBoundedL2VecSum, Some(length), None) => {
             let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>> =
                 Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length)
                     .map_err(|err| Error::Anyhow(err.into()))?;
-            run_collection_generic(parameters, vdaf, http_client, query, &())
-                .await
-                .map_err(|err| Error::Anyhow(err.into()))
+            run_collection_generic(options, vdaf, http_client, query, &()).await
         }
         #[cfg(feature = "fpvec_bounded_l2")]
         (VdafType::FixedPoint64BitBoundedL2VecSum, Some(length), None) => {
             let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>> =
                 Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length)
                     .map_err(|err| Error::Anyhow(err.into()))?;
-            run_collection_generic(parameters, vdaf, http_client, query, &())
-                .await
-                .map_err(|err| Error::Anyhow(err.into()))
+            run_collection_generic(options, vdaf, http_client, query, &()).await
         }
         _ => Err(clap::Error::raw(
             ErrorKind::ArgumentConflict,
@@ -526,19 +493,36 @@ where
 }
 
 async fn run_collection_generic<V: vdaf::Collector, Q: QueryTypeExt>(
-    parameters: CollectorParameters,
+    options: Options,
     vdaf: V,
     http_client: reqwest::Client,
     query: Query<Q>,
     agg_param: &V::AggregationParam,
-) -> Result<(), janus_collector::Error>
+) -> Result<(), Error>
 where
     V::AggregateResult: Debug,
 {
-    let collector = Collector::builder(parameters, vdaf)
-        .with_http_client(http_client)
-        .build()?;
-    let collection = collector.collect(query, agg_param).await?;
+    let hpke_keypair = options.hpke_keypair().map_err(Error::Anyhow)?;
+    let task_id = options.task_id;
+    let leader_endpoint = options.leader;
+    let authentication = match (
+        options.authentication.dap_auth_token,
+        options.authentication.authorization_bearer_token,
+    ) {
+        (None, Some(token)) => token,
+        (Some(token), None) => token,
+        (None, None) | (Some(_), Some(_)) => unreachable!(),
+    };
+
+    let collector =
+        Collector::builder(task_id, leader_endpoint, authentication, hpke_keypair, vdaf)
+            .with_http_client(http_client)
+            .build()
+            .map_err(|err| Error::Anyhow(err.into()))?;
+    let collection = collector
+        .collect(query, agg_param)
+        .await
+        .map_err(|err| Error::Anyhow(err.into()))?;
     if !Q::IS_PARTIAL_BATCH_SELECTOR_TRIVIAL {
         println!(
             "Batch: {}",

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -535,7 +535,9 @@ async fn run_collection_generic<V: vdaf::Collector, Q: QueryTypeExt>(
 where
     V::AggregateResult: Debug,
 {
-    let collector = Collector::new(parameters, vdaf, http_client);
+    let collector = Collector::builder(parameters, vdaf)
+        .with_http_client(http_client)
+        .build()?;
     let collection = collector.collect(query, agg_param).await?;
     if !Q::IS_PARTIAL_BATCH_SELECTOR_TRIVIAL {
         println!(


### PR DESCRIPTION
This overhauls the public API of janus_collector. `CollectorParameters` is removed, and functionally replaced with the new `CollectorBuilder`. `CollectionJob` and `PollResult` are made public, along with methods for starting and polling a job. A new method is added to delete a job.

`CollectionJob` has a public constructor and `into_fields()` method, so that it can be serialized and reconstructed in stateful collectors, but I chose not to define serde implementations (or `prio::codec` implementations) in this PR, since the struct has two generic parameters, mixing VDAF-level and DAP-level concepts. Implementing serialization in an opinionated way may require additional trait bounds. The constructor and access to fields at least makes it possible for applications to do their own serialization that suits their needs.

Closes #1796 and closes #762.