### PR TITLE
Datastore keys should be unpadded url-safe base64

### DIFF
--- a/aggregator/src/bin/janus_cli.rs
+++ b/aggregator/src/bin/janus_cli.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Context, Result};
-use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use clap::Parser;
 use janus_aggregator::{
     binary_utils::{database_pool, datastore, read_config, CommonBinaryOptions},
@@ -265,7 +265,7 @@ async fn create_datastore_key(
         .sample_iter(Standard)
         .take(AES_128_GCM.key_len())
         .collect();
-    let secret_content = STANDARD_NO_PAD.encode(key_bytes);
+    let secret_content = URL_SAFE_NO_PAD.encode(key_bytes);
 
     // Write the secret.
     secrets_api
@@ -454,7 +454,7 @@ impl From<kube::Client> for LazyKubeClient {
 #[cfg(test)]
 mod tests {
     use super::{fetch_datastore_keys, CommandLineOptions, ConfigFile, KubernetesSecretOptions};
-    use crate::{LazyKubeClient, STANDARD_NO_PAD};
+    use crate::{LazyKubeClient, URL_SAFE_NO_PAD};
     use base64::Engine;
     use clap::CommandFactory;
     use janus_aggregator::{
@@ -840,7 +840,7 @@ mod tests {
 
         // Verify that the written secret data can be parsed as a comma-separated list of datastore
         // keys.
-        let datastore_key_bytes = STANDARD_NO_PAD.decode(&secret_data[0]).unwrap();
+        let datastore_key_bytes = URL_SAFE_NO_PAD.decode(&secret_data[0]).unwrap();
         UnboundKey::new(&AES_128_GCM, &datastore_key_bytes).unwrap();
     }
 

--- a/aggregator/src/binary_utils.rs
+++ b/aggregator/src/binary_utils.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use anyhow::{anyhow, Context as _, Result};
 use backoff::{future::retry, ExponentialBackoff};
-use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use clap::Parser;
 use deadpool::managed::TimeoutType;
 use deadpool_postgres::{Manager, Pool, PoolError, Runtime, Timeouts};
@@ -140,7 +140,7 @@ pub async fn datastore<C: Clock>(
         .iter()
         .filter(|k| !k.is_empty())
         .map(|k| {
-            STANDARD_NO_PAD
+            URL_SAFE_NO_PAD
                 .decode(k)
                 .context("couldn't base64-decode datastore keys")
                 .and_then(|k| {
@@ -206,7 +206,7 @@ pub struct CommonBinaryOptions {
         hide_env_values = true,
         num_args = 1,
         use_value_delimiter = true,
-        help = "datastore encryption keys, encoded in base64 then comma-separated"
+        help = "datastore encryption keys, encoded in url-safe unpadded base64 then comma-separated"
     )]
     pub datastore_keys: Vec<String>,
 

--- a/aggregator/tests/cmd/aggregation_job_creator.trycmd
+++ b/aggregator/tests/cmd/aggregation_job_creator.trycmd
@@ -10,7 +10,7 @@ Options:
       --database-password <DATABASE_PASSWORD>
           PostgreSQL password [env: PGPASSWORD]
       --datastore-keys <DATASTORE_KEYS>
-          datastore encryption keys, encoded in base64 then comma-separated [env: DATASTORE_KEYS]
+          datastore encryption keys, encoded in url-safe unpadded base64 then comma-separated [env: DATASTORE_KEYS]
       --otlp-tracing-metadata <KEY=value>
           additional OTLP/gRPC metadata key/value pairs for the tracing exporter [env: OTLP_TRACING_METADATA=]
       --otlp-metrics-metadata <KEY=value>

--- a/aggregator/tests/cmd/aggregation_job_driver.trycmd
+++ b/aggregator/tests/cmd/aggregation_job_driver.trycmd
@@ -10,7 +10,7 @@ Options:
       --database-password <DATABASE_PASSWORD>
           PostgreSQL password [env: PGPASSWORD]
       --datastore-keys <DATASTORE_KEYS>
-          datastore encryption keys, encoded in base64 then comma-separated [env: DATASTORE_KEYS]
+          datastore encryption keys, encoded in url-safe unpadded base64 then comma-separated [env: DATASTORE_KEYS]
       --otlp-tracing-metadata <KEY=value>
           additional OTLP/gRPC metadata key/value pairs for the tracing exporter [env: OTLP_TRACING_METADATA=]
       --otlp-metrics-metadata <KEY=value>

--- a/aggregator/tests/cmd/aggregator.trycmd
+++ b/aggregator/tests/cmd/aggregator.trycmd
@@ -10,7 +10,7 @@ Options:
       --database-password <DATABASE_PASSWORD>
           PostgreSQL password [env: PGPASSWORD]
       --datastore-keys <DATASTORE_KEYS>
-          datastore encryption keys, encoded in base64 then comma-separated [env: DATASTORE_KEYS]
+          datastore encryption keys, encoded in url-safe unpadded base64 then comma-separated [env: DATASTORE_KEYS]
       --otlp-tracing-metadata <KEY=value>
           additional OTLP/gRPC metadata key/value pairs for the tracing exporter [env: OTLP_TRACING_METADATA=]
       --otlp-metrics-metadata <KEY=value>

--- a/aggregator/tests/graceful_shutdown.rs
+++ b/aggregator/tests/graceful_shutdown.rs
@@ -3,7 +3,7 @@
 //! process. The process should promptly shut down, and this test will fail if
 //! it times out waiting for the process to do so.
 
-use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use janus_aggregator_core::{
     datastore::test_util::ephemeral_datastore,
     task::{test_util::TaskBuilder, QueryType},
@@ -157,7 +157,7 @@ async fn graceful_shutdown(binary: &Path, mut config: Mapping) {
         .env("RUSTLOG", "trace")
         .env(
             "DATASTORE_KEYS",
-            STANDARD_NO_PAD.encode(ephemeral_datastore.datastore_key_bytes()),
+            URL_SAFE_NO_PAD.encode(ephemeral_datastore.datastore_key_bytes()),
         )
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())


### PR DESCRIPTION
Closes https://github.com/divviup/janus/issues/1997.

This eliminates all usage of non-URL_SAFE_NO_PAD in Janus :tada: