### PR TITLE
Update to testcontainers-rs 0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,11 +416,10 @@ dependencies = [
 
 [[package]]
 name = "bollard-stubs"
-version = "1.41.0"
+version = "1.42.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2f2e73fffe9455141e170fb9c1feb0ac521ec7e7dcd47a7cab72a658490fb8"
+checksum = "ed59b5c00048f48d7af971b71f800fdf23e858844a6f9e4d32ca72e9399e7864"
 dependencies = [
- "chrono",
  "serde",
  "serde_with",
 ]
@@ -4335,9 +4334,9 @@ dependencies = [
 
 [[package]]
 name = "testcontainers"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e2b1567ca8a2b819ea7b28c92be35d9f76fb9edb214321dcc86eb96023d1f87"
+checksum = "f83d2931d7f521af5bae989f716c3fa43a6af9af7ec7a5e21b59ae40878cec00"
 dependencies = [
  "bollard-stubs",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ serde_json = "1.0.106"
 serde_test = "1.0.175"
 serde_yaml = "0.9.25"
 rstest = "0.17.0"
+testcontainers = "0.15.0"
 thiserror = "1.0"
 tokio = { version = "1.32", features = ["full", "tracing"] }
 trillium = "0.2.9"

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -76,7 +76,7 @@ serde_urlencoded = "0.7.1"
 serde_yaml.workspace = true
 signal-hook = "0.3.17"
 signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
-testcontainers = { version = "0.14.0", optional = true }
+testcontainers = { workspace = true, optional = true }
 thiserror.workspace = true
 tokio.workspace = true
 tokio-postgres = { version = "0.7.10", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1", "array-impls"] }

--- a/aggregator_core/Cargo.toml
+++ b/aggregator_core/Cargo.toml
@@ -43,7 +43,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
 sqlx = { version = "0.7.2", optional = true, features = ["runtime-tokio-rustls", "migrate", "postgres"] }
-testcontainers = { version = "0.14.0", optional = true }
+testcontainers = { workspace = true, optional = true }
 thiserror.workspace = true
 tokio.workspace = true
 tokio-postgres = { version = "0.7.10", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1", "array-impls"] }

--- a/aggregator_core/src/datastore/test_util.rs
+++ b/aggregator_core/src/datastore/test_util.rs
@@ -3,7 +3,7 @@ use crate::{
     test_util::noop_meter,
 };
 use deadpool_postgres::{Manager, Pool};
-use janus_core::time::Clock;
+use janus_core::{test_util::testcontainers::Postgres, time::Clock};
 use rand::{distributions::Standard, random, thread_rng, Rng};
 use ring::aead::{LessSafeKey, UnboundKey, AES_128_GCM};
 use sqlx::{
@@ -16,7 +16,7 @@ use std::{
     sync::{Arc, Barrier, OnceLock, Weak},
     thread::{self, JoinHandle},
 };
-use testcontainers::{images::postgres::Postgres, RunnableImage};
+use testcontainers::RunnableImage;
 use tokio::sync::{oneshot, Mutex};
 use tokio_postgres::{connect, Config, NoTls};
 use tracing::trace;
@@ -55,8 +55,7 @@ impl EphemeralDatabase {
             move || {
                 // Start an instance of Postgres running in a container.
                 let container_client = testcontainers::clients::Cli::default();
-                let db_container = container_client
-                    .run(RunnableImage::from(Postgres::default()).with_tag("15-alpine"));
+                let db_container = container_client.run(RunnableImage::from(Postgres::default()));
                 const POSTGRES_DEFAULT_PORT: u16 = 5432;
                 let port_number = db_container.get_host_port_ipv4(POSTGRES_DEFAULT_PORT);
                 trace!("Postgres container is up with port {port_number}");

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -55,7 +55,7 @@ serde_json = { workspace = true, optional = true }
 serde_yaml.workspace = true
 stopper = { version = "0.2.0", optional = true }
 tempfile = { version = "3", optional = true }
-testcontainers = { version = "0.14", optional = true }
+testcontainers = { workspace = true, optional = true }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["macros", "net", "rt"] }
 tokio-stream = { version = "0.1.14", features = ["net"], optional = true }

--- a/core/src/test_util/testcontainers.rs
+++ b/core/src/test_util/testcontainers.rs
@@ -1,7 +1,10 @@
 //! Testing functionality that interacts with the testcontainers library.
 
-use std::sync::{Arc, Mutex, OnceLock, Weak};
-use testcontainers::clients::Cli;
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex, OnceLock, Weak},
+};
+use testcontainers::{clients::Cli, core::WaitFor, Image};
 
 /// Returns a container client, possibly shared with other callers to this function.
 pub fn container_client() -> Arc<Cli> {
@@ -18,4 +21,48 @@ pub fn container_client() -> Arc<Cli> {
         *container_client = Arc::downgrade(&client);
         client
     })
+}
+
+/// A [`testcontainers::Image`] that provides a Postgres server.
+#[derive(Debug)]
+pub struct Postgres {
+    env_vars: HashMap<String, String>,
+}
+
+impl Postgres {
+    const NAME: &str = "postgres";
+    const TAG: &str = "15-alpine";
+}
+
+impl Default for Postgres {
+    fn default() -> Self {
+        Self {
+            env_vars: HashMap::from([
+                ("POSTGRES_DB".to_owned(), "postgres".to_owned()),
+                ("POSTGRES_HOST_AUTH_METHOD".to_owned(), "trust".to_owned()),
+            ]),
+        }
+    }
+}
+
+impl Image for Postgres {
+    type Args = ();
+
+    fn name(&self) -> String {
+        Self::NAME.to_owned()
+    }
+
+    fn tag(&self) -> String {
+        Self::TAG.to_owned()
+    }
+
+    fn ready_conditions(&self) -> Vec<WaitFor> {
+        Vec::from([WaitFor::message_on_stderr(
+            "database system is ready to accept connections",
+        )])
+    }
+
+    fn env_vars(&self) -> Box<dyn Iterator<Item = (&String, &String)> + '_> {
+        Box::new(self.env_vars.iter())
+    }
 }

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -34,7 +34,7 @@ rand = "0.8"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
 serde.workspace = true
 serde_json = "1.0.106"
-testcontainers = "0.14.0"
+testcontainers.workspace = true
 tokio.workspace = true
 url = { version = "2.4.1", features = ["serde"] }
 trillium-tokio.workspace = true

--- a/integration_tests/src/daphne.rs
+++ b/integration_tests/src/daphne.rs
@@ -6,7 +6,7 @@ use janus_interop_binaries::{
     get_rust_log_level, test_util::await_http_server, ContainerLogsDropGuard, ContainerLogsSource,
 };
 use janus_messages::{Role, Time};
-use testcontainers::{clients::Cli, images::generic::GenericImage, RunnableImage};
+use testcontainers::{clients::Cli, GenericImage, RunnableImage};
 
 const DAPHNE_HELPER_IMAGE_NAME_AND_TAG: &str = "cloudflare/daphne-worker-helper:sha-f6b3ef1";
 

--- a/interop_binaries/Cargo.toml
+++ b/interop_binaries/Cargo.toml
@@ -45,7 +45,7 @@ ring = "0.17.0"
 serde.workspace = true
 serde_json = "1.0.106"
 sqlx = { version = "0.7.2", features = ["runtime-tokio-rustls", "migrate", "postgres"] }
-testcontainers = { version = "0.14" }
+testcontainers.workspace = true
 tokio.workspace = true
 tracing = "0.1.37"
 tracing-log = "0.1.3"


### PR DESCRIPTION
This updates to the just-released version 0.15.0 of testcontainers. This version removed all pre-defined container images to reduce maintenance burden, so I vendored the `Postgres` image into `janus_core` and simplified it.