### PR TITLE
Updates for Rust 1.73.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2021"
 homepage = "https://divviup.org"
 license = "MPL-2.0"
 repository = "https://github.com/divviup/janus"
-rust-version = "1.70.0"
+rust-version = "1.71.0"
 version = "0.6.0-prerelease-3"
 
 [workspace.dependencies]

--- a/aggregator/src/aggregator/batch_creator.rs
+++ b/aggregator/src/aggregator/batch_creator.rs
@@ -436,7 +436,7 @@ impl Eq for UpdatedOutstandingBatch {}
 
 impl PartialOrd for UpdatedOutstandingBatch {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.new_max_size.partial_cmp(&other.new_max_size)
+        Some(self.new_max_size.cmp(&other.new_max_size))
     }
 }
 

--- a/aggregator_api/src/routes.rs
+++ b/aggregator_api/src/routes.rs
@@ -356,7 +356,6 @@ pub(super) async fn patch_global_hpke_config<C: Clock>(
     let config_id = conn.hpke_config_id_param()?;
 
     ds.run_tx_with_name("patch_hpke_global_keypair", |tx| {
-        let config_id = config_id;
         Box::pin(async move {
             tx.set_global_hpke_keypair_state(&config_id, &req.state)
                 .await


### PR DESCRIPTION
This fixes two Clippy lints (`clippy::redundant_locals` and `clippy::incorrect_partial_ord_impl_on_ord_type`) and bumps the MSRV following our stable-plus-two-releases policy.