### PR TITLE
Fix cli test for `fpvec_bounded_l2` feature flag.

### DIFF
--- a/tools/tests/cmd/collect_fpvec_bounded_l2.trycmd
+++ b/tools/tests/cmd/collect_fpvec_bounded_l2.trycmd
@@ -2,7 +2,7 @@
 $ collect --help
 Command-line DAP-PPM collector from ISRG's Divvi Up
 
-Usage: collect [OPTIONS] --task-id <TASK_ID> --leader <LEADER> --hpke-config <HPKE_CONFIG> --hpke-private-key <HPKE_PRIVATE_KEY> --vdaf <VDAF> <--dap-auth-token <DAP_AUTH_TOKEN>|--authorization-bearer-token <AUTHORIZATION_BEARER_TOKEN>> <--batch-interval-start <BATCH_INTERVAL_START>|--batch-interval-duration <BATCH_INTERVAL_DURATION>|--batch-id <BATCH_ID>|--current-batch>
+Usage: collect [OPTIONS] --task-id <TASK_ID> --leader <LEADER> --vdaf <VDAF> <--dap-auth-token <DAP_AUTH_TOKEN>|--authorization-bearer-token <AUTHORIZATION_BEARER_TOKEN>> <--batch-interval-start <BATCH_INTERVAL_START>|--batch-interval-duration <BATCH_INTERVAL_DURATION>|--batch-id <BATCH_ID>|--current-batch>
 
 Options:
   -h, --help
@@ -25,6 +25,9 @@ DAP Task Parameters:
           The collector's HPKE private key, encoded with base64url
           
           [env: HPKE_PRIVATE_KEY=]
+
+      --hpke-config-json <HPKE_CONFIG_JSON>
+          Path to a JSON document containing the collector's HPKE configuration and private key, in the format output by `divviup hpke-config generate`
 
 Authorization:
       --dap-auth-token <DAP_AUTH_TOKEN>


### PR DESCRIPTION
It seems that the `collect.trycmd` file was updated, while the `collect_fpvec_bounded_l2.trycmd` file was not. The result was that the relevant test didn't pass when running `cargo test --features fpvec_bounded_l2`. This commit fixes it.