### PR TITLE
adopt new `divviup-client`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,7 +951,7 @@ dependencies = [
 [[package]]
 name = "divviup-client"
 version = "0.0.1"
-source = "git+https://github.com/divviup/divviup-api?rev=81fe8753bb1b9bc7d3abb3aa7a2ce96d1e0623e8#81fe8753bb1b9bc7d3abb3aa7a2ce96d1e0623e8"
+source = "git+https://github.com/divviup/divviup-api?tag=0.0.30#073f7700ea02748739a24d80b019a9a95a8d96e4"
 dependencies = [
  "base64 0.21.4",
  "email_address",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,11 +950,11 @@ dependencies = [
 [[package]]
 name = "divviup-client"
 version = "0.0.1"
-source = "git+https://github.com/divviup/divviup-api?rev=06667dbeb93d4870bb257b7ddf9a19b37a7e5da5#06667dbeb93d4870bb257b7ddf9a19b37a7e5da5"
+source = "git+https://github.com/divviup/divviup-api?rev=804f7fe856478d3791f50ff4f4659ecc9a6d91fe#804f7fe856478d3791f50ff4f4659ecc9a6d91fe"
 dependencies = [
  "base64 0.21.4",
  "email_address",
- "janus_messages 0.5.20",
+ "janus_messages 0.5.24",
  "log",
  "pad-adapter",
  "serde",
@@ -2158,16 +2158,16 @@ dependencies = [
 
 [[package]]
 name = "janus_messages"
-version = "0.5.20"
+version = "0.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7269662cdac52cea2a98cf10cb35028d1d673951e4ff1bcf8c653b5d3b8577"
+checksum = "7189ed015947d1da772e0d376f43d2a334383a1174443ef46142f230af369a9b"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
  "derivative",
  "hex",
  "num_enum",
- "prio 0.12.3",
+ "prio 0.12.4",
  "rand",
  "serde",
  "thiserror",
@@ -3022,9 +3022,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prio"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d6fbe33c4d999c3ba5e5f2673cfeadffd2c8e1ffd58ab67a3cf06cd576d834"
+checksum = "e3d13d814fa9a577a07b129e27745f67477679e6750673c8617d034cdf899a5b"
 dependencies = [
  "base64 0.21.4",
  "byteorder",
@@ -3678,9 +3678,9 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
 dependencies = [
  "serde_derive",
 ]
@@ -3697,9 +3697,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4390,9 +4390,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
+checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
 dependencies = [
  "deranged",
  "itoa",
@@ -4403,15 +4403,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572"
+checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
 dependencies = [
  "time-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,10 +887,11 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
 dependencies = [
+ "powerfmt",
  "serde",
 ]
 
@@ -950,7 +951,7 @@ dependencies = [
 [[package]]
 name = "divviup-client"
 version = "0.0.1"
-source = "git+https://github.com/divviup/divviup-api?rev=804f7fe856478d3791f50ff4f4659ecc9a6d91fe#804f7fe856478d3791f50ff4f4659ecc9a6d91fe"
+source = "git+https://github.com/divviup/divviup-api?rev=81fe8753bb1b9bc7d3abb3aa7a2ce96d1e0623e8#81fe8753bb1b9bc7d3abb3aa7a2ce96d1e0623e8"
 dependencies = [
  "base64 0.21.4",
  "email_address",
@@ -3015,6 +3016,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4390,12 +4397,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
+checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
 dependencies = [
  "deranged",
  "itoa",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -5138,9 +5146,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
 dependencies = [
  "getrandom",
  "rand",

--- a/aggregator_api/src/routes.rs
+++ b/aggregator_api/src/routes.rs
@@ -117,7 +117,7 @@ pub(super) async fn post_task<C: Clock>(
             })?;
             let collector_auth_token_hash = req.collector_auth_token_hash.ok_or_else(|| {
                 Error::BadRequest(
-                    "aggregator acting in leader role must be provided a collector auth token"
+                    "aggregator acting in leader role must be provided a collector auth token hash"
                         .to_string(),
                 )
             })?;

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -15,8 +15,7 @@ in-cluster = ["dep:k8s-openapi", "dep:kube"]
 anyhow.workspace = true
 backoff = { version = "0.4", features = ["tokio"] }
 base64.workspace = true
-# TOOD(timg): change pinned commit or tag once https://github.com/divviup/divviup-api/pull/583 lands
-divviup-client = { git = "https://github.com/divviup/divviup-api", features = ["admin"], rev = "804f7fe856478d3791f50ff4f4659ecc9a6d91fe" }
+divviup-client = { git = "https://github.com/divviup/divviup-api", features = ["admin"], rev = "81fe8753bb1b9bc7d3abb3aa7a2ce96d1e0623e8" }
 futures = "0.3.28"
 hex = "0.4"
 http = "0.2"

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -15,7 +15,7 @@ in-cluster = ["dep:k8s-openapi", "dep:kube"]
 anyhow.workspace = true
 backoff = { version = "0.4", features = ["tokio"] }
 base64.workspace = true
-divviup-client = { git = "https://github.com/divviup/divviup-api", features = ["admin"], rev = "81fe8753bb1b9bc7d3abb3aa7a2ce96d1e0623e8" }
+divviup-client = { git = "https://github.com/divviup/divviup-api", features = ["admin"], tag = "0.0.30" }
 futures = "0.3.28"
 hex = "0.4"
 http = "0.2"

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -15,7 +15,8 @@ in-cluster = ["dep:k8s-openapi", "dep:kube"]
 anyhow.workspace = true
 backoff = { version = "0.4", features = ["tokio"] }
 base64.workspace = true
-divviup-client = { git = "https://github.com/divviup/divviup-api", features = ["admin"], rev = "06667dbeb93d4870bb257b7ddf9a19b37a7e5da5" }
+# TOOD(timg): change pinned commit or tag once https://github.com/divviup/divviup-api/pull/583 lands
+divviup-client = { git = "https://github.com/divviup/divviup-api", features = ["admin"], rev = "804f7fe856478d3791f50ff4f4659ecc9a6d91fe" }
 futures = "0.3.28"
 hex = "0.4"
 http = "0.2"


### PR DESCRIPTION
The PRs related to https://github.com/divviup/divviup-api/issues/542 implement the new concept of "collector credential". This entails changes to the API for provisioning tasks via divviup-api that we use in e2e integration tests. In this commit we adopt the new `divviup-client` and fix up its usage.

Part of #2071