### PR TITLE
Differential Privacy Cleanups

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -16,8 +16,8 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use bytes::Bytes;
 #[cfg(feature = "fpvec_bounded_l2")]
 use fixed::{
-    types::extra::{U15, U31, U63},
-    FixedI16, FixedI32, FixedI64,
+    types::extra::{U15, U31},
+    FixedI16, FixedI32,
 };
 use futures::future::try_join_all;
 use http::{header::CONTENT_TYPE, Method};
@@ -856,12 +856,6 @@ impl<C: Clock> TaskAggregator<C> {
                         let verify_key = task.vdaf_verify_key()?;
                         VdafOps::Prio3FixedPoint32BitBoundedL2VecSum(Arc::new(vdaf), verify_key, vdaf_ops_strategies::Prio3FixedPointBoundedL2VecSum::from_vdaf_dp_strategy(dp_strategy.clone()))
                     }
-                    Prio3FixedPointBoundedL2VecSumBitSize::BitSize64 => {
-                        let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>> =
-                            Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, *length)?;
-                        let verify_key = task.vdaf_verify_key()?;
-                        VdafOps::Prio3FixedPoint64BitBoundedL2VecSum(Arc::new(vdaf), verify_key, vdaf_ops_strategies::Prio3FixedPointBoundedL2VecSum::from_vdaf_dp_strategy(dp_strategy.clone()))
-                    }
                 }
             }
 
@@ -1088,12 +1082,6 @@ enum VdafOps {
         VerifyKey<VERIFY_KEY_LENGTH>,
         vdaf_ops_strategies::Prio3FixedPointBoundedL2VecSum,
     ),
-    #[cfg(feature = "fpvec_bounded_l2")]
-    Prio3FixedPoint64BitBoundedL2VecSum(
-        Arc<Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>>>,
-        VerifyKey<VERIFY_KEY_LENGTH>,
-        vdaf_ops_strategies::Prio3FixedPointBoundedL2VecSum,
-    ),
     Poplar1(Arc<Poplar1<XofShake128, 16>>, VerifyKey<VERIFY_KEY_LENGTH>),
     #[cfg(feature = "test-util")]
     Fake(Arc<dummy_vdaf::Vdaf>),
@@ -1189,30 +1177,6 @@ macro_rules! vdaf_ops_dispatch {
                 let $vdaf = vdaf;
                 let $verify_key = verify_key;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>>;
-                const $VERIFY_KEY_LENGTH: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
-
-                match _dp_strategy {
-                    vdaf_ops_strategies::Prio3FixedPointBoundedL2VecSum::ZCdpDiscreteGaussian(_strategy) => {
-                        type $DpStrategy = ::prio::dp::distributions::ZCdpDiscreteGaussian;
-                        let $dp_strategy = &_strategy;
-                        $body
-                    },
-                    vdaf_ops_strategies::Prio3FixedPointBoundedL2VecSum::NoDifferentialPrivacy => {
-                        type $DpStrategy = janus_core::dp::NoDifferentialPrivacy;
-                        let $dp_strategy = &Arc::new(janus_core::dp::NoDifferentialPrivacy);
-                        $body
-                    }
-                }
-            }
-
-            #[cfg(feature = "fpvec_bounded_l2")]
-            // Note that the variable `_dp_strategy` is used if `$dp_strategy`
-            // and `$DpStrategy` are given. The underscore suppresses warnings
-            // which occur when `vdaf_ops!` is called without these parameters.
-            crate::aggregator::VdafOps::Prio3FixedPoint64BitBoundedL2VecSum(vdaf, verify_key, _dp_strategy) => {
-                let $vdaf = vdaf;
-                let $verify_key = verify_key;
-                type $Vdaf = ::prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>>;
                 const $VERIFY_KEY_LENGTH: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
 
                 match _dp_strategy {

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -2957,7 +2957,7 @@ impl VdafOps {
                             );
 
                             let (mut helper_aggregate_share, report_count, checksum) =
-                                compute_aggregate_share::<SEED_SIZE, Q, S, A>(
+                                compute_aggregate_share::<SEED_SIZE, Q, A>(
                                     &task,
                                     &batch_aggregations,
                                 )

--- a/aggregator/src/aggregator/aggregate_share.rs
+++ b/aggregator/src/aggregator/aggregate_share.rs
@@ -4,10 +4,7 @@ use super::Error;
 use janus_aggregator_core::{datastore::models::BatchAggregation, task::AggregatorTask};
 use janus_core::report_id::ReportIdChecksumExt;
 use janus_messages::{query_type::QueryType, ReportIdChecksum};
-use prio::{
-    dp::DifferentialPrivacyStrategy,
-    vdaf::{self, Aggregatable},
-};
+use prio::vdaf::{self, Aggregatable};
 
 /// Computes the aggregate share over the provided batch aggregations.
 /// The assumption is that all aggregation jobs contributing to those batch aggregations have
@@ -17,8 +14,7 @@ use prio::{
 pub(crate) async fn compute_aggregate_share<
     const SEED_SIZE: usize,
     Q: QueryType,
-    S: DifferentialPrivacyStrategy,
-    A: vdaf::AggregatorWithNoise<SEED_SIZE, 16, S>,
+    A: vdaf::Aggregator<SEED_SIZE, 16>,
 >(
     task: &AggregatorTask,
     batch_aggregations: &[BatchAggregation<SEED_SIZE, Q, A>],

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -1,8 +1,8 @@
 use crate::aggregator::aggregation_job_writer::AggregationJobWriter;
 #[cfg(feature = "fpvec_bounded_l2")]
 use fixed::{
-    types::extra::{U15, U31, U63},
-    FixedI16, FixedI32, FixedI64,
+    types::extra::{U15, U31},
+    FixedI16, FixedI32,
 };
 use janus_aggregator_core::{
     datastore::models::{
@@ -350,14 +350,6 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                     self.create_aggregation_jobs_for_time_interval_task_no_param::<VERIFY_KEY_LENGTH, Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>>>(task, vdaf)
                             .await
                 }
-                Prio3FixedPointBoundedL2VecSumBitSize::BitSize64 => {
-                    let vdaf: Arc<Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>>> =
-                        Arc::new(Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
-                            2, *length,
-                        )?);
-                    self.create_aggregation_jobs_for_time_interval_task_no_param::<VERIFY_KEY_LENGTH, Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>>>(task, vdaf)
-                            .await
-                }
             },
 
             (
@@ -494,16 +486,6 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                         self.create_aggregation_jobs_for_fixed_size_task_no_param::<
                                 VERIFY_KEY_LENGTH,
                             Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>>,
-                            >(task, vdaf, max_batch_size, batch_time_window_size).await
-                    }
-                    janus_core::vdaf::Prio3FixedPointBoundedL2VecSumBitSize::BitSize64 => {
-                        let vdaf: Arc<Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>>> =
-                            Arc::new(Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
-                                2, *length,
-                            )?);
-                        self.create_aggregation_jobs_for_fixed_size_task_no_param::<
-                                VERIFY_KEY_LENGTH,
-                            Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>>,
                             >(task, vdaf, max_batch_size, batch_time_window_size).await
                     }
                 }

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -214,7 +214,7 @@ impl CollectionJobDriver {
         }
 
         let (mut leader_aggregate_share, report_count, checksum) =
-            compute_aggregate_share::<SEED_SIZE, Q, S, A>(&task, &batch_aggregations)
+            compute_aggregate_share::<SEED_SIZE, Q, A>(&task, &batch_aggregations)
                 .await
                 .map_err(|e| datastore::Error::User(e.into()))?;
 

--- a/core/src/vdaf.rs
+++ b/core/src/vdaf.rs
@@ -12,7 +12,6 @@ pub const VERIFY_KEY_LENGTH: usize = 16;
 pub enum Prio3FixedPointBoundedL2VecSumBitSize {
     BitSize16,
     BitSize32,
-    BitSize64,
 }
 
 /// Contains dedicated enums which describe the differential privacy strategies
@@ -324,16 +323,6 @@ macro_rules! vdaf_dispatch_impl_fpvec_bounded_l2 {
                     )?;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded<
                     ::fixed::FixedI32<::fixed::types::extra::U31>,
-                >;
-                $body
-            },
-            janus_core::vdaf::Prio3FixedPointBoundedL2VecSumBitSize::BitSize64 => {
-                let $vdaf =
-                    ::prio::vdaf::prio3::Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
-                        2, *$length,
-                    )?;
-                type $Vdaf = ::prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded<
-                    ::fixed::FixedI64<::fixed::types::extra::U63>,
                 >;
                 $body
             },

--- a/interop_binaries/src/bin/janus_interop_client.rs
+++ b/interop_binaries/src/bin/janus_interop_client.rs
@@ -4,8 +4,8 @@ use clap::{value_parser, Arg, Command};
 use derivative::Derivative;
 #[cfg(feature = "fpvec_bounded_l2")]
 use fixed::{
-    types::extra::{U15, U31, U63},
-    FixedI16, FixedI32, FixedI64,
+    types::extra::{U15, U31},
+    FixedI16, FixedI32,
 };
 #[cfg(feature = "fpvec_bounded_l2")]
 use janus_core::vdaf::Prio3FixedPointBoundedL2VecSumBitSize;
@@ -166,15 +166,6 @@ async fn handle_upload(
                 let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>> =
                     Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length).context(
                         "failed to construct Prio3FixedPoint32BitBoundedL2VecSumZCdp VDAF",
-                    )?;
-                handle_upload_generic(http_client, vdaf, request, measurement).await?;
-            }
-            Prio3FixedPointBoundedL2VecSumBitSize::BitSize64 => {
-                let measurement =
-                    parse_vector_measurement::<FixedI64<U63>>(request.measurement.clone())?;
-                let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>> =
-                    Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length).context(
-                        "failed to construct Prio3FixedPoint64BitBoundedL2VecSumZCdp VDAF",
                     )?;
                 handle_upload_generic(http_client, vdaf, request, measurement).await?;
             }

--- a/interop_binaries/src/bin/janus_interop_collector.rs
+++ b/interop_binaries/src/bin/janus_interop_collector.rs
@@ -4,9 +4,9 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use clap::{value_parser, Arg, Command};
 use derivative::Derivative;
 #[cfg(feature = "fpvec_bounded_l2")]
-use fixed::types::extra::{U15, U31, U63};
+use fixed::types::extra::{U15, U31};
 #[cfg(feature = "fpvec_bounded_l2")]
-use fixed::{FixedI16, FixedI32, FixedI64};
+use fixed::{FixedI16, FixedI32};
 use janus_collector::Collector;
 #[cfg(feature = "fpvec_bounded_l2")]
 use janus_core::vdaf::Prio3FixedPointBoundedL2VecSumBitSize;
@@ -424,24 +424,6 @@ async fn handle_collection_start(
                 )
                 .await?
             }
-            Prio3FixedPointBoundedL2VecSumBitSize::BitSize64 => {
-                let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>> =
-                    Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length)
-                        .context("failed to construct Prio3FixedPoint64BitBoundedL2VecSum VDAF")?;
-                handle_collect_generic(
-                    http_client,
-                    task_state,
-                    Query::new_time_interval(batch_interval),
-                    vdaf,
-                    &agg_param,
-                    |_| None,
-                    |result| {
-                        let converted = result.iter().cloned().map(NumberAsString).collect();
-                        AggregationResult::FloatVec(converted)
-                    },
-                )
-                .await?
-            }
         },
 
         (ParsedQuery::FixedSize(fixed_size_query), VdafInstance::Prio3Count {}) => {
@@ -513,24 +495,6 @@ async fn handle_collection_start(
                 let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>> =
                     Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length)
                         .context("failed to construct Prio3FixedPoint32BitBoundedL2VecSum VDAF")?;
-                handle_collect_generic(
-                    http_client,
-                    task_state,
-                    Query::new_fixed_size(fixed_size_query),
-                    vdaf,
-                    &agg_param,
-                    |selector| Some(*selector.batch_id()),
-                    |result| {
-                        let converted = result.iter().cloned().map(NumberAsString).collect();
-                        AggregationResult::FloatVec(converted)
-                    },
-                )
-                .await?
-            }
-            Prio3FixedPointBoundedL2VecSumBitSize::BitSize64 => {
-                let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>> =
-                    Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length)
-                        .context("failed to construct Prio3FixedPoint64BitBoundedL2VecSum VDAF")?;
                 handle_collect_generic(
                     http_client,
                     task_state,

--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -762,45 +762,6 @@ async fn e2e_prio3_fixed32vec() {
 }
 
 #[tokio::test]
-async fn e2e_prio3_fixed64vec() {
-    let fp64_4_inv = fixed!(0.25: I1F63);
-    let fp64_8_inv = fixed!(0.125: I1F63);
-    let fp64_16_inv = fixed!(0.0625: I1F63);
-    let result = run(
-        "e2e_prio3_fixed64vec",
-        QueryKind::TimeInterval,
-        json!({"type": "Prio3FixedPointBoundedL2VecSum",
-               "bitsize": "BitSize64",
-               "length": "3"}),
-        &[
-            json!([
-                fp64_4_inv.to_string(),
-                fp64_8_inv.to_string(),
-                fp64_8_inv.to_string()
-            ]),
-            json!([
-                fp64_16_inv.to_string(),
-                fp64_8_inv.to_string(),
-                fp64_16_inv.to_string()
-            ]),
-            json!([
-                fp64_8_inv.to_string(),
-                fp64_8_inv.to_string(),
-                fp64_4_inv.to_string()
-            ]),
-            json!([
-                fp64_16_inv.to_string(),
-                fp64_8_inv.to_string(),
-                fp64_4_inv.to_string()
-            ]),
-        ],
-        b"",
-    )
-    .await;
-    assert_eq!(result, json!(["0.5", "0.5", "0.6875"]));
-}
-
-#[tokio::test]
 async fn e2e_prio3_fixed16vec_fixed_size() {
     let fp16_4_inv = fixed!(0.25: I1F15);
     let fp16_8_inv = fixed!(0.125: I1F15);
@@ -870,45 +831,6 @@ async fn e2e_prio3_fixed32vec_fixed_size() {
                 fp32_16_inv.to_string(),
                 fp32_8_inv.to_string(),
                 fp32_4_inv.to_string()
-            ]),
-        ],
-        b"",
-    )
-    .await;
-    assert_eq!(result, json!(["0.5", "0.5", "0.6875"]));
-}
-
-#[tokio::test]
-async fn e2e_prio3_fixed64vec_fixed_size() {
-    let fp64_4_inv = fixed!(0.25: I1F63);
-    let fp64_8_inv = fixed!(0.125: I1F63);
-    let fp64_16_inv = fixed!(0.0625: I1F63);
-    let result = run(
-        "e2e_prio3_fixed64vec_fixed_size",
-        QueryKind::FixedSize,
-        json!({"type": "Prio3FixedPointBoundedL2VecSum",
-               "bitsize": "BitSize64",
-               "length": "3"}),
-        &[
-            json!([
-                fp64_4_inv.to_string(),
-                fp64_8_inv.to_string(),
-                fp64_8_inv.to_string()
-            ]),
-            json!([
-                fp64_16_inv.to_string(),
-                fp64_8_inv.to_string(),
-                fp64_16_inv.to_string()
-            ]),
-            json!([
-                fp64_8_inv.to_string(),
-                fp64_8_inv.to_string(),
-                fp64_4_inv.to_string()
-            ]),
-            json!([
-                fp64_16_inv.to_string(),
-                fp64_8_inv.to_string(),
-                fp64_4_inv.to_string()
             ]),
         ],
         b"",

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -7,9 +7,9 @@ use clap::{
 };
 use derivative::Derivative;
 #[cfg(feature = "fpvec_bounded_l2")]
-use fixed::types::extra::{U15, U31, U63};
+use fixed::types::extra::{U15, U31};
 #[cfg(feature = "fpvec_bounded_l2")]
-use fixed::{FixedI16, FixedI32, FixedI64};
+use fixed::{FixedI16, FixedI32};
 use janus_collector::{default_http_client, AuthenticationToken, Collector};
 use janus_core::hpke::{DivviUpHpkeConfig, HpkeKeypair, HpkePrivateKey};
 use janus_messages::{
@@ -465,13 +465,6 @@ where
         #[cfg(feature = "fpvec_bounded_l2")]
         (VdafType::FixedPoint32BitBoundedL2VecSum, Some(length), None) => {
             let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>> =
-                Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length)
-                    .map_err(|err| Error::Anyhow(err.into()))?;
-            run_collection_generic(options, vdaf, http_client, query, &()).await
-        }
-        #[cfg(feature = "fpvec_bounded_l2")]
-        (VdafType::FixedPoint64BitBoundedL2VecSum, Some(length), None) => {
-            let vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI64<U63>> =
                 Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length)
                     .map_err(|err| Error::Anyhow(err.into()))?;
             run_collection_generic(options, vdaf, http_client, query, &()).await


### PR DESCRIPTION
This cleans up a couple items as a follow-up to #1892. First, we close #1658 by removing the 64-bit variant of Prio3FixedPointBoundedL2VecSum. Due to length constraints, this could only be used on vectors with maximum dimension of three. Lower-precision variants will be more practically useful. Second, I removed the DP strategy generic type parameter from `compute_aggregate_share()`, and relaxed the bound on the VDAF type parameter from `AggregatorWithNoise` to `Aggregator`. This simplifies callsites and gets rid of some extra monomorphizations.