### PR TITLE
Add single process integration tests

### DIFF
--- a/aggregator/src/bin/janus_cli.rs
+++ b/aggregator/src/bin/janus_cli.rs
@@ -504,8 +504,10 @@ mod tests {
             Vec::from(["datastore-key-1".to_string(), "datastore-key-2".to_string()]);
 
         // Keys provided at command line, not present in k8s
-        let mut common_options = CommonBinaryOptions::default();
-        common_options.datastore_keys = expected_datastore_keys.clone();
+        let common_options = CommonBinaryOptions {
+            datastore_keys: expected_datastore_keys.clone(),
+            ..Default::default()
+        };
 
         let kubernetes_secret_options = KubernetesSecretOptions {
             datastore_keys_secret_name: "secret-name".to_string(),

--- a/aggregator/src/binaries/aggregation_job_creator.rs
+++ b/aggregator/src/binaries/aggregation_job_creator.rs
@@ -34,7 +34,7 @@ pub async fn main_callback(ctx: BinaryContext<RealClock, Options, Config>) -> Re
 )]
 pub struct Options {
     #[clap(flatten)]
-    common: CommonBinaryOptions,
+    pub common: CommonBinaryOptions,
 }
 
 impl BinaryOptions for Options {

--- a/aggregator/src/binaries/aggregation_job_driver.rs
+++ b/aggregator/src/binaries/aggregation_job_driver.rs
@@ -64,7 +64,7 @@ pub async fn main_callback(ctx: BinaryContext<RealClock, Options, Config>) -> Re
 )]
 pub struct Options {
     #[clap(flatten)]
-    common: CommonBinaryOptions,
+    pub common: CommonBinaryOptions,
 }
 
 impl BinaryOptions for Options {

--- a/aggregator/src/binaries/aggregator.rs
+++ b/aggregator/src/binaries/aggregator.rs
@@ -33,7 +33,7 @@ pub async fn main_callback(ctx: BinaryContext<RealClock, Options, Config>) -> Re
 pub fn make_callback_ephemeral_address(
     ctx: BinaryContext<RealClock, Options, Config>,
 ) -> (
-    impl Future<Output = Result<()>>,
+    impl Future<Output = Result<()>> + Send,
     watch::Receiver<Option<SocketAddr>>,
 ) {
     let (sender, receiver) = watch::channel(None);
@@ -91,7 +91,7 @@ async fn run_aggregator(
         }
     };
 
-    let aggregator_api_future: Pin<Box<dyn Future<Output = ()> + 'static>> =
+    let aggregator_api_future: Pin<Box<dyn Future<Output = ()> + Send + 'static>> =
         match build_aggregator_api_handler(&options, &config, &datastore)? {
             Some((handler, config)) => {
                 if let Some(listen_address) = config.listen_address {
@@ -188,7 +188,7 @@ fn build_aggregator_api_handler<'a>(
 )]
 pub struct Options {
     #[clap(flatten)]
-    common: CommonBinaryOptions,
+    pub common: CommonBinaryOptions,
 
     /// Aggregator API authentication tokens.
     #[clap(
@@ -199,7 +199,7 @@ pub struct Options {
         use_value_delimiter = true,
         help = "aggregator API auth tokens, encoded in base64 then comma-separated"
     )]
-    aggregator_api_auth_tokens: Vec<String>,
+    pub aggregator_api_auth_tokens: Vec<String>,
 }
 
 impl BinaryOptions for Options {

--- a/aggregator/src/binaries/collection_job_driver.rs
+++ b/aggregator/src/binaries/collection_job_driver.rs
@@ -64,7 +64,7 @@ pub async fn main_callback(ctx: BinaryContext<RealClock, Options, Config>) -> Re
 )]
 pub struct Options {
     #[clap(flatten)]
-    common: CommonBinaryOptions,
+    pub common: CommonBinaryOptions,
 }
 
 impl BinaryOptions for Options {

--- a/aggregator/src/binary_utils.rs
+++ b/aggregator/src/binary_utils.rs
@@ -177,7 +177,7 @@ pub trait BinaryOptions: Parser + Debug {
 }
 
 #[cfg_attr(doc, doc = "Common options that are used by all Janus binaries.")]
-#[derive(Default, Parser)]
+#[derive(Default, Clone, Parser)]
 pub struct CommonBinaryOptions {
     /// Path to configuration YAML.
     #[clap(
@@ -187,7 +187,7 @@ pub struct CommonBinaryOptions {
         required(true),
         help = "path to configuration file"
     )]
-    config_file: PathBuf,
+    pub config_file: PathBuf,
 
     /// Password for the PostgreSQL database connection. If specified, must not be specified in the
     /// connection string.
@@ -220,7 +220,7 @@ pub struct CommonBinaryOptions {
         value_name = "KEY=value",
         use_value_delimiter = true
     )]
-    otlp_tracing_metadata: Vec<(String, String)>,
+    pub otlp_tracing_metadata: Vec<(String, String)>,
 
     /// Additional OTLP/gRPC metadata key/value pairs. (concatenated with those in the metrics
     /// configuration sections)
@@ -232,7 +232,7 @@ pub struct CommonBinaryOptions {
         value_name = "KEY=value",
         use_value_delimiter = true
     )]
-    otlp_metrics_metadata: Vec<(String, String)>,
+    pub otlp_metrics_metadata: Vec<(String, String)>,
 }
 
 impl Debug for CommonBinaryOptions {

--- a/integration_tests/src/client.rs
+++ b/integration_tests/src/client.rs
@@ -225,7 +225,7 @@ where
     ) -> Result<ClientImplementation<'static, V>, janus_client::Error> {
         let (leader_aggregator_endpoint, helper_aggregator_endpoint) = task_parameters
             .endpoint_fragments
-            .port_forwarded_endpoints(leader_port, helper_port);
+            .endpoints_for_host_client(leader_port, helper_port);
         let client = Client::new(
             task_parameters.task_id,
             leader_aggregator_endpoint,
@@ -260,7 +260,7 @@ where
         let http_client = reqwest::Client::new();
         let (leader_aggregator_endpoint, helper_aggregator_endpoint) = task_parameters
             .endpoint_fragments
-            .container_network_endpoints();
+            .endpoints_for_virtual_network_client();
         ClientImplementation::Container(Box::new(ContainerClientImplementation {
             _container: container,
             leader: leader_aggregator_endpoint,

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -1,13 +1,39 @@
 //! Functionality for tests interacting with Janus (<https://github.com/divviup/janus>).
 
 use crate::interop_api;
-use janus_aggregator_core::task::test_util::Task;
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use janus_aggregator::{
+    binaries::{
+        aggregation_job_creator::{
+            self, Config as AggregationJobCreatorConfig, Options as AggregationJobCreatorOptions,
+        },
+        aggregation_job_driver::{
+            self, Config as AggregationJobDriverConfig, Options as AggregationJobDriverOptions,
+        },
+        aggregator::{self, Config as AggregatorConfig, Options as AggregatorOptions},
+        collection_job_driver::{
+            self, Config as CollectionJobDriverConfig, Options as CollectionJobDriverOptions,
+        },
+    },
+    binary_utils::{BinaryContext, CommonBinaryOptions},
+    config::{CommonConfig, DbConfig, JobDriverConfig, TaskprovConfig},
+    metrics::MetricsConfiguration,
+    trace::{TokioConsoleConfiguration, TraceConfiguration},
+};
+use janus_aggregator_core::{
+    datastore::test_util::{ephemeral_datastore, EphemeralDatastore},
+    task::test_util::Task,
+    test_util::noop_meter,
+};
+use janus_core::time::RealClock;
 use janus_interop_binaries::{
     get_rust_log_level, test_util::await_http_server, testcontainer::Aggregator,
     ContainerLogsDropGuard,
 };
 use janus_messages::Role;
+use std::net::{Ipv4Addr, SocketAddr};
 use testcontainers::{clients::Cli, RunnableImage};
+use trillium_tokio::Stopper;
 
 /// Represents a running Janus test instance in a container.
 pub struct JanusContainer<'a> {
@@ -54,5 +80,190 @@ impl<'a> JanusContainer<'a> {
     pub fn port(&self) -> u16 {
         self.container
             .get_host_port_ipv4(Aggregator::INTERNAL_SERVING_PORT)
+    }
+}
+
+/// Represents a running Janus test instance in this process.
+pub struct JanusInProcess {
+    socket_address: SocketAddr,
+    stopper: Stopper,
+    _ephemeral_datastore: EphemeralDatastore,
+}
+
+impl JanusInProcess {
+    /// Start a new Janus instance in the current process, using a separate ephemeral database,
+    /// configured to service the given task.
+    pub async fn new(task: &Task, role: Role) -> Self {
+        // Set up common utilities.
+        let stopper = Stopper::new();
+        let clock = RealClock::default();
+        let ephemeral_datastore = ephemeral_datastore().await;
+        let datastore = ephemeral_datastore.datastore(clock).await;
+        let encoded_datastore_key =
+            URL_SAFE_NO_PAD.encode(ephemeral_datastore.datastore_key_bytes());
+        let datastore_keys = Vec::from([encoded_datastore_key]);
+        let database_url = ephemeral_datastore
+            .connection_string()
+            .parse()
+            .expect("error parsing database URL");
+
+        // Provision the task.
+        datastore
+            .put_aggregator_task(&task.view_for_role(role).expect("invalid role"))
+            .await
+            .expect("task provisioning failed");
+
+        // Construct configuration and options for each component.
+        let common_binary_options = CommonBinaryOptions {
+            datastore_keys,
+            ..Default::default()
+        };
+        let logging_config = TraceConfiguration {
+            use_test_writer: false,
+            force_json_output: true,
+            stackdriver_json_output: false,
+            tokio_console_config: TokioConsoleConfiguration {
+                enabled: false,
+                listen_address: None,
+            },
+            open_telemetry_config: None,
+            chrome: false,
+        };
+        let common_config = CommonConfig {
+            database: DbConfig {
+                url: database_url,
+                connection_pool_timeouts_secs: 60,
+                check_schema_version: false,
+            },
+            logging_config,
+            metrics_config: MetricsConfiguration { exporter: None },
+            health_check_listen_address: (Ipv4Addr::LOCALHOST, 0).into(),
+        };
+        let aggregator_options = AggregatorOptions {
+            common: common_binary_options.clone(),
+            aggregator_api_auth_tokens: Vec::new(),
+        };
+        let aggregator_config = AggregatorConfig {
+            common_config: common_config.clone(),
+            taskprov_config: TaskprovConfig::default(),
+            garbage_collection: None,
+            listen_address: (Ipv4Addr::LOCALHOST, 0).into(),
+            aggregator_api: None,
+            response_headers: Vec::new(),
+            max_upload_batch_size: 100,
+            max_upload_batch_write_delay_ms: 100,
+            batch_aggregation_shard_count: 32,
+            global_hpke_configs_refresh_interval: None,
+        };
+        let aggregation_job_creator_options = AggregationJobCreatorOptions {
+            common: common_binary_options.clone(),
+        };
+        let aggregation_job_creator_config = AggregationJobCreatorConfig {
+            common_config: common_config.clone(),
+            tasks_update_frequency_secs: 2,
+            aggregation_job_creation_interval_secs: 1,
+            min_aggregation_job_size: 1,
+            max_aggregation_job_size: 100,
+        };
+        let aggregation_job_driver_options = AggregationJobDriverOptions {
+            common: common_binary_options.clone(),
+        };
+        let aggregation_job_driver_config = AggregationJobDriverConfig {
+            common_config: common_config.clone(),
+            job_driver_config: JobDriverConfig {
+                min_job_discovery_delay_secs: 1,
+                max_job_discovery_delay_secs: 2,
+                max_concurrent_job_workers: 10,
+                worker_lease_duration_secs: 10,
+                worker_lease_clock_skew_allowance_secs: 1,
+                maximum_attempts_before_failure: 3,
+            },
+            taskprov_config: TaskprovConfig::default(),
+            batch_aggregation_shard_count: 32,
+        };
+        let collection_job_driver_options = CollectionJobDriverOptions {
+            common: common_binary_options.clone(),
+        };
+        let collection_job_driver_config = CollectionJobDriverConfig {
+            common_config,
+            job_driver_config: JobDriverConfig {
+                min_job_discovery_delay_secs: 1,
+                max_job_discovery_delay_secs: 2,
+                max_concurrent_job_workers: 10,
+                worker_lease_duration_secs: 10,
+                worker_lease_clock_skew_allowance_secs: 1,
+                maximum_attempts_before_failure: 3,
+            },
+            batch_aggregation_shard_count: 32,
+        };
+
+        // Spawn each component.
+        let (aggregator_future, mut socket_address_receiver) =
+            aggregator::make_callback_ephemeral_address(BinaryContext {
+                clock,
+                options: aggregator_options,
+                config: aggregator_config,
+                datastore: ephemeral_datastore.datastore(clock).await,
+                meter: noop_meter(),
+                stopper: stopper.clone(),
+            });
+        tokio::spawn(aggregator_future);
+        tokio::spawn(aggregation_job_creator::main_callback(BinaryContext {
+            clock,
+            options: aggregation_job_creator_options,
+            config: aggregation_job_creator_config,
+            datastore: ephemeral_datastore.datastore(clock).await,
+            meter: noop_meter(),
+            stopper: stopper.clone(),
+        }));
+        tokio::spawn(aggregation_job_driver::main_callback(BinaryContext {
+            clock,
+            options: aggregation_job_driver_options,
+            config: aggregation_job_driver_config,
+            datastore: ephemeral_datastore.datastore(clock).await,
+            meter: noop_meter(),
+            stopper: stopper.clone(),
+        }));
+        tokio::spawn(collection_job_driver::main_callback(BinaryContext {
+            clock,
+            options: collection_job_driver_options,
+            config: collection_job_driver_config,
+            datastore: ephemeral_datastore.datastore(clock).await,
+            meter: noop_meter(),
+            stopper: stopper.clone(),
+        }));
+
+        // Wait for the aggregator's socket address.
+        let socket_address = loop {
+            if let Some(socket_address) = *socket_address_receiver.borrow_and_update() {
+                break socket_address;
+            }
+            socket_address_receiver
+                .changed()
+                .await
+                .expect("aggregator task shut down before sending socket address");
+        };
+
+        Self {
+            socket_address,
+            stopper,
+            _ephemeral_datastore: ephemeral_datastore,
+        }
+    }
+
+    /// Returns the aggregator's port.
+    pub fn port(&self) -> u16 {
+        self.socket_address.port()
+    }
+}
+
+impl Drop for JanusInProcess {
+    fn drop(&mut self) {
+        // Request that all components shut down.
+        //
+        // Note that the EphemeralDatastore will be terminated when it is dropped, right after the
+        // Stopper's flag is set. This means there may be some log noise about broken connections,
+        // due to in-flight work on tasks that haven't read the Stopper yet.
+        self.stopper.stop();
     }
 }

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -10,11 +10,11 @@ use janus_messages::Role;
 use testcontainers::{clients::Cli, RunnableImage};
 
 /// Represents a running Janus test instance in a container.
-pub struct Janus<'a> {
+pub struct JanusContainer<'a> {
     container: ContainerLogsDropGuard<'a, Aggregator>,
 }
 
-impl<'a> Janus<'a> {
+impl<'a> JanusContainer<'a> {
     /// Create and start a new hermetic Janus test instance in the given Docker network, configured
     /// to service the given task. The aggregator port is also exposed to the host.
     pub async fn new(
@@ -23,7 +23,7 @@ impl<'a> Janus<'a> {
         network: &str,
         task: &Task,
         role: Role,
-    ) -> Janus<'a> {
+    ) -> JanusContainer<'a> {
         // Start the Janus interop aggregator container running.
         let endpoint = match role {
             Role::Leader => task.leader_aggregator_endpoint(),

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -24,47 +24,89 @@ pub struct TaskParameters {
     pub collector_auth_token: AuthenticationToken,
 }
 
-/// Components of DAP endpoints for a leader and helper aggregator. By default, the scheme is
-/// assumed to be `http:`, and the port number is assumed to be 8080.
+/// Components of one aggregator's DAP endpoint. The scheme is assumed to always be `http:`.
+#[derive(Debug)]
+pub enum AggregatorEndpointFragments {
+    /// The aggregator is in a virtual network, (a Docker network or a Kind cluster) so different
+    /// URLs must be used depending on whether it is accessed from within the same virtual network
+    /// or via a port forward on localhost. It is assumed that the port will always be 8080 within
+    /// the virtual network. The port number of forwarded ports will be supplied later.
+    VirtualNetwork { host: String, path: String },
+    /// The aggregator is running on localhost. No port forwarding is involved, so the same URL is
+    /// used in all circumstances. The port number will be supplied later.
+    Localhost { path: String },
+}
+
+impl AggregatorEndpointFragments {
+    /// Provides the URL for the aggregator's endpoint from the perspective of the host. If the
+    /// aggregator is in a virtual network, this will use a port forward, with the provided port
+    /// number. If the aggregator itself is running on the host, it will use the provided port
+    /// number as well.
+    pub fn endpoint_for_host(&self, port: u16) -> Url {
+        let path = match self {
+            AggregatorEndpointFragments::VirtualNetwork { path, .. } => path,
+            AggregatorEndpointFragments::Localhost { path } => path,
+        };
+        Url::parse(&format!("http://127.0.0.1:{port}{path}")).unwrap()
+    }
+
+    /// Provides the URL for the aggregator's endpoint from the perspective of another protocol
+    /// participant on the virtual network. If the aggregator is in a virtual network, this will use
+    /// the configured hostname and port 8080. If the aggregator is running on the host, it will
+    /// panic.
+    pub fn endpoint_for_virtual_network(&self) -> Url {
+        match self {
+            AggregatorEndpointFragments::VirtualNetwork { host, path } => {
+                Url::parse(&format!("http://{host}:8080{path}")).unwrap()
+            }
+            AggregatorEndpointFragments::Localhost { .. } => panic!(
+                "cannot combine an aggregator running on localhost with a client or leader running \
+                 in a virtual network"
+            ),
+        }
+    }
+
+    /// Set the path component.
+    pub fn set_path(&mut self, path: String) {
+        match self {
+            AggregatorEndpointFragments::VirtualNetwork {
+                path: self_path, ..
+            }
+            | AggregatorEndpointFragments::Localhost { path: self_path } => *self_path = path,
+        }
+    }
+}
+
+/// Components of DAP endpoints for a leader and helper aggregator.
 pub struct EndpointFragments {
-    pub leader_endpoint_host: String,
-    pub leader_endpoint_path: String,
-    pub helper_endpoint_host: String,
-    pub helper_endpoint_path: String,
+    pub leader: AggregatorEndpointFragments,
+    pub helper: AggregatorEndpointFragments,
 }
 
 impl EndpointFragments {
-    pub fn port_forwarded_leader_endpoint(&self, leader_port: u16) -> Url {
-        Url::parse(&format!(
-            "http://127.0.0.1:{leader_port}{}",
-            self.leader_endpoint_path
-        ))
-        .unwrap()
+    /// Provides the DAP endpoint URL for the leader aggregator to be used from the host. This
+    /// requires an ephemeral port number, from either the aggregator itself or a port forward for
+    /// the aggregator.
+    pub fn leader_endpoint_for_host(&self, leader_port: u16) -> Url {
+        self.leader.endpoint_for_host(leader_port)
     }
 
-    pub fn port_forwarded_endpoints(&self, leader_port: u16, helper_port: u16) -> (Url, Url) {
+    /// Provides the DAP endpoint URL for both aggregators to be used from the host. This requires
+    /// ephemeral port numbers for each.
+    pub fn endpoints_for_host_client(&self, leader_port: u16, helper_port: u16) -> (Url, Url) {
         (
-            self.port_forwarded_leader_endpoint(leader_port),
-            Url::parse(&format!(
-                "http://127.0.0.1:{helper_port}{}",
-                self.helper_endpoint_path
-            ))
-            .unwrap(),
+            self.leader.endpoint_for_host(leader_port),
+            self.helper.endpoint_for_host(helper_port),
         )
     }
 
-    pub fn container_network_endpoints(&self) -> (Url, Url) {
+    /// Provides the DAP endpoint URL for both aggregators to be used from within the virtual
+    /// network. This will panic if either aggregator is on localhost instead of in the virtual
+    /// network.
+    pub fn endpoints_for_virtual_network_client(&self) -> (Url, Url) {
         (
-            Url::parse(&format!(
-                "http://{}:8080{}",
-                self.leader_endpoint_host, self.leader_endpoint_path
-            ))
-            .unwrap(),
-            Url::parse(&format!(
-                "http://{}:8080{}",
-                self.helper_endpoint_host, self.helper_endpoint_path
-            ))
-            .unwrap(),
+            self.leader.endpoint_for_virtual_network(),
+            self.helper.endpoint_for_virtual_network(),
         )
     }
 }

--- a/integration_tests/tests/daphne.rs
+++ b/integration_tests/tests/daphne.rs
@@ -23,7 +23,10 @@ async fn daphne_janus() {
         test_task_builder(VdafInstance::Prio3Count, QueryType::TimeInterval);
 
     // Daphne is hardcoded to serve from a path starting with /v04/.
-    task_parameters.endpoint_fragments.leader_endpoint_path = "/v04/".to_string();
+    task_parameters
+        .endpoint_fragments
+        .leader
+        .set_path("/v04/".to_string());
     let mut leader_aggregator_endpoint = task_builder.leader_aggregator_endpoint().clone();
     leader_aggregator_endpoint.set_path("/v04/");
     let task = task_builder
@@ -58,7 +61,10 @@ async fn janus_daphne() {
         test_task_builder(VdafInstance::Prio3Count, QueryType::TimeInterval);
 
     // Daphne is hardcoded to serve from a path starting with /v04/.
-    task_parameters.endpoint_fragments.leader_endpoint_path = "/v04/".to_string();
+    task_parameters
+        .endpoint_fragments
+        .helper
+        .set_path("/v04/".to_string());
     let mut helper_aggregator_endpoint = task_builder.helper_aggregator_endpoint().clone();
     helper_aggregator_endpoint.set_path("/v04/");
     let task = task_builder

--- a/integration_tests/tests/daphne.rs
+++ b/integration_tests/tests/daphne.rs
@@ -4,7 +4,7 @@ use janus_core::{
     test_util::{install_test_trace_subscriber, testcontainers::container_client},
     vdaf::VdafInstance,
 };
-use janus_integration_tests::{client::ClientBackend, daphne::Daphne, janus::Janus};
+use janus_integration_tests::{client::ClientBackend, daphne::Daphne, janus::JanusContainer};
 use janus_interop_binaries::test_util::generate_network_name;
 use janus_messages::Role;
 
@@ -32,7 +32,8 @@ async fn daphne_janus() {
 
     let container_client = container_client();
     let leader = Daphne::new(TEST_NAME, &container_client, &network, &task, Role::Leader).await;
-    let helper = Janus::new(TEST_NAME, &container_client, &network, &task, Role::Helper).await;
+    let helper =
+        JanusContainer::new(TEST_NAME, &container_client, &network, &task, Role::Helper).await;
 
     // Run the behavioral test.
     submit_measurements_and_verify_aggregate(
@@ -65,7 +66,8 @@ async fn janus_daphne() {
         .build();
 
     let container_client = container_client();
-    let leader = Janus::new(TEST_NAME, &container_client, &network, &task, Role::Leader).await;
+    let leader =
+        JanusContainer::new(TEST_NAME, &container_client, &network, &task, Role::Leader).await;
     let helper = Daphne::new(TEST_NAME, &container_client, &network, &task, Role::Helper).await;
 
     // Run the behavioral test.

--- a/integration_tests/tests/daphne.rs
+++ b/integration_tests/tests/daphne.rs
@@ -4,7 +4,12 @@ use janus_core::{
     test_util::{install_test_trace_subscriber, testcontainers::container_client},
     vdaf::VdafInstance,
 };
-use janus_integration_tests::{client::ClientBackend, daphne::Daphne, janus::JanusContainer};
+use janus_integration_tests::{
+    client::ClientBackend,
+    daphne::Daphne,
+    janus::{JanusContainer, JanusInProcess},
+    AggregatorEndpointFragments,
+};
 use janus_interop_binaries::test_util::generate_network_name;
 use janus_messages::Role;
 
@@ -52,7 +57,7 @@ async fn daphne_janus() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "Daphne does not currently support DAP-07 (issue #1669)"]
 async fn janus_daphne() {
-    static TEST_NAME: &str = "daphne_janus";
+    static TEST_NAME: &str = "janus_daphne";
     install_test_trace_subscriber();
 
     // Start servers.
@@ -75,6 +80,52 @@ async fn janus_daphne() {
     let leader =
         JanusContainer::new(TEST_NAME, &container_client, &network, &task, Role::Leader).await;
     let helper = Daphne::new(TEST_NAME, &container_client, &network, &task, Role::Helper).await;
+
+    // Run the behavioral test.
+    submit_measurements_and_verify_aggregate(
+        TEST_NAME,
+        &task_parameters,
+        (leader.port(), helper.port()),
+        &ClientBackend::InProcess,
+    )
+    .await;
+}
+
+/// This test places Janus in the leader role and Daphne in the helper role. Janus is run
+/// in-process, while Daphne is run in Docker.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "Daphne does not currently support DAP-07 (issue #1669)"]
+async fn janus_in_process_daphne() {
+    static TEST_NAME: &str = "janus_in_process_daphne";
+    install_test_trace_subscriber();
+
+    // Start servers.
+    let network = generate_network_name();
+    let container_client = container_client();
+    let (mut task_parameters, mut task_builder) =
+        test_task_builder(VdafInstance::Prio3Count, QueryType::TimeInterval);
+    task_parameters.endpoint_fragments.leader = AggregatorEndpointFragments::Localhost {
+        path: "/".to_owned(),
+    };
+    task_parameters
+        .endpoint_fragments
+        .helper
+        .set_path("/v04/".to_owned());
+    let helper = Daphne::new(
+        TEST_NAME,
+        &container_client,
+        &network,
+        &task_builder.clone().build(),
+        Role::Helper,
+    )
+    .await;
+    task_builder = task_builder.with_helper_aggregator_endpoint(
+        task_parameters
+            .endpoint_fragments
+            .helper
+            .endpoint_for_host(helper.port()),
+    );
+    let leader = JanusInProcess::new(&task_builder.build(), Role::Leader).await;
 
     // Run the behavioral test.
     submit_measurements_and_verify_aggregate(

--- a/integration_tests/tests/divviup_ts.rs
+++ b/integration_tests/tests/divviup_ts.rs
@@ -8,7 +8,7 @@ use janus_core::{
 };
 use janus_integration_tests::{
     client::{ClientBackend, InteropClient},
-    janus::Janus,
+    janus::JanusContainer,
 };
 use janus_interop_binaries::test_util::generate_network_name;
 use janus_messages::Role;
@@ -24,8 +24,10 @@ async fn run_divviup_ts_integration_test(
     let (task_parameters, task_builder) = test_task_builder(vdaf, QueryType::TimeInterval);
     let task = task_builder.build();
     let network = generate_network_name();
-    let leader = Janus::new(test_name, container_client, &network, &task, Role::Leader).await;
-    let helper = Janus::new(test_name, container_client, &network, &task, Role::Helper).await;
+    let leader =
+        JanusContainer::new(test_name, container_client, &network, &task, Role::Leader).await;
+    let helper =
+        JanusContainer::new(test_name, container_client, &network, &task, Role::Helper).await;
 
     let client_backend = ClientBackend::Container {
         container_client,


### PR DESCRIPTION
This is part of #2081. This PR adds new integration tests that run both Janus aggregator instances in-process, relying on the existing ephemeral database support for Postgres. This also includes one test with an in-process Janus leader and a Daphne helper running in a container.

Note that the divviup-ts integration tests, or tests with Daphne as the leader, are not supported with in-process aggregators yet. That will require making connections from inside a container to TCP servers on the host, which may be doable using `host.docker.internal` on Windows/Mac and `--add-host` with `host-gateway` on Linux, FWIW.