### PR TITLE
Fix infinite retry bug

### DIFF
--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -1473,12 +1473,43 @@ impl<C: Clock> Transaction<'_, C> {
         // Slow path: no rows were affected, meaning a row with the new report ID already existed
         // and we hit the query's ON CONFLICT DO NOTHING clause. We need to check whether the new
         // report matches the existing one.
-        let existing_report = match self
-            .get_client_report(vdaf, new_report.task_id(), new_report.metadata().id())
+        let existing_report = {
+            // We intentionally don't use `get_client_report` because it omits expired reports. It
+            // is possible that we have conflicted with an expired report that hasn't been fully
+            // GC'd yet.
+            let stmt = self
+                .prepare_cached(
+                    "SELECT
+                        client_reports.client_timestamp,
+                        client_reports.extensions,
+                        client_reports.public_share,
+                        client_reports.leader_input_share,
+                        client_reports.helper_encrypted_input_share
+                    FROM client_reports
+                    JOIN tasks ON tasks.id = client_reports.task_id
+                    WHERE tasks.task_id = $1
+                      AND client_reports.report_id = $2",
+                )
+                .await?;
+
+            self.query_opt(
+                &stmt,
+                &[
+                    /* task_id */ &new_report.task_id().as_ref(),
+                    /* report_id */ &new_report.metadata().id().as_ref(),
+                ],
+            )
             .await?
-        {
-            Some(e) => e,
-            None => {
+            .map(|row| {
+                Self::client_report_from_row(
+                    vdaf,
+                    *new_report.task_id(),
+                    *new_report.metadata().id(),
+                    row,
+                )
+            })
+            .transpose()?
+            .ok_or_else(|| {
                 // This codepath can be taken due to a quirk of how the Repeatable Read isolation
                 // level works. It cannot occur at the Serializable isolation level.
                 //
@@ -1500,8 +1531,8 @@ impl<C: Clock> Transaction<'_, C> {
                 // will be able to read the report written by the successful writer. (It doesn't
                 // matter what error we return here, as the transaction will be retried.)
                 self.retry();
-                return Err(Error::MutationTargetAlreadyExists);
-            }
+                Error::MutationTargetAlreadyExists
+            })?
         };
 
         // If the existing report does not match the new report, then someone is trying to mutate an

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -1528,10 +1528,12 @@ impl<C: Clock> Transaction<'_, C> {
                 // `None` (since all reads in the same transaction are from the same snapshot), so
                 // so it can't evaluate idempotency. All it can do is give up on this transaction
                 // and try again, by calling `retry` and returning an error; once it retries, it
-                // will be able to read the report written by the successful writer. (It doesn't
-                // matter what error we return here, as the transaction will be retried.)
+                // will be able to read the report written by the successful writer.
                 self.retry();
-                Error::MutationTargetAlreadyExists
+                Error::DbState(
+                    "retrying transaction because another writer has concurrently inserted this report"
+                        .to_string(),
+                )
             })?
         };
 

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -1530,9 +1530,8 @@ impl<C: Clock> Transaction<'_, C> {
                 // and try again, by calling `retry` and returning an error; once it retries, it
                 // will be able to read the report written by the successful writer.
                 self.retry();
-                Error::DbState(
-                    "retrying transaction because another writer has concurrently inserted this report"
-                        .to_string(),
+                Error::Concurrency(
+                    "retrying transaction because another writer has concurrently inserted this report",
                 )
             })?
         };
@@ -5003,6 +5002,9 @@ pub enum Error {
     TimeOverflow(&'static str),
     #[error("batch already collected")]
     AlreadyCollected,
+    /// An error that occurred due to concurrency problems with another Janus replica.
+    #[error("{0}")]
+    Concurrency(&'static str),
 }
 
 impl From<ring::error::Unspecified> for Error {


### PR DESCRIPTION
An infinite retry could be triggered if a report with the same ID as an expired report was submitted.

Supports https://github.com/divviup/janus/issues/2124.

I didn't add a separate method for `get_client_reports_including_expired_ones` because naming things is hard, and I think this is the only situation where we care about expired reports.

I altered the error message to provide more detail as to what's happening in this branch of code. The error here does matter because it is logged by `tracing`.