### PR TITLE
Add endpoint for configuring tracing filter at runtime

### DIFF
--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -618,7 +618,7 @@ pub mod test_util {
     use std::borrow::Cow;
     use trillium_testing::{assert_headers, TestConn};
 
-    async fn take_response_body(test_conn: &mut TestConn) -> Cow<'_, [u8]> {
+    pub async fn take_response_body(test_conn: &mut TestConn) -> Cow<'_, [u8]> {
         test_conn
             .take_response_body()
             .unwrap()

--- a/aggregator/src/bin/janus_cli.rs
+++ b/aggregator/src/bin/janus_cli.rs
@@ -142,8 +142,10 @@ impl Command {
 async fn install_tracing_and_metrics_handlers(
     config: &CommonConfig,
 ) -> Result<(TraceGuards, MetricsExporterHandle)> {
-    let trace_guard = install_trace_subscriber(&config.logging_config)
+    // Discard the trace reload handler, since this program is short-lived.
+    let (trace_guard, _) = install_trace_subscriber(&config.logging_config)
         .context("couldn't install tracing subscriber")?;
+
     let metrics_guard = install_metrics_exporter(&config.metrics_config)
         .await
         .context("failed to install metrics exporter")?;

--- a/aggregator/src/binary_utils.rs
+++ b/aggregator/src/binary_utils.rs
@@ -5,7 +5,7 @@ pub mod job_driver;
 use crate::{
     config::{BinaryConfig, DbConfig},
     metrics::{install_metrics_exporter, MetricsExporterConfiguration},
-    trace::{install_trace_subscriber, OpenTelemetryTraceConfiguration},
+    trace::{install_trace_subscriber, OpenTelemetryTraceConfiguration, TraceReloadHandle},
 };
 use anyhow::{anyhow, Context as _, Result};
 use backoff::{future::retry, ExponentialBackoff};
@@ -18,6 +18,7 @@ use janus_aggregator_core::datastore::{Crypter, Datastore};
 use janus_core::time::Clock;
 use opentelemetry::metrics::Meter;
 use ring::aead::{LessSafeKey, UnboundKey, AES_128_GCM};
+use serde::{Deserialize, Serialize};
 use std::{
     fmt::{self, Debug, Formatter},
     fs,
@@ -26,12 +27,15 @@ use std::{
     panic,
     path::PathBuf,
     str::FromStr,
+    sync::Arc,
     time::Duration,
 };
 use tokio::sync::oneshot;
 use tokio_postgres::NoTls;
 use tracing::{debug, info};
-use trillium::{Handler, Headers, Info, Init};
+use tracing_subscriber::EnvFilter;
+use trillium::{Handler, Headers, Info, Init, Status};
+use trillium_api::{api, Json, State};
 use trillium_head::Head;
 use trillium_router::Router;
 use trillium_tokio::Stopper;
@@ -279,8 +283,9 @@ where
     let config: Config = read_config(options.common_options())?;
 
     // Install tracing/metrics handlers.
-    let _guards = install_trace_subscriber(&config.common_config().logging_config)
-        .context("couldn't install tracing subscriber")?;
+    let (_guards, trace_reload_handle) =
+        install_trace_subscriber(&config.common_config().logging_config)
+            .context("couldn't install tracing subscriber")?;
     let _metrics_exporter = install_metrics_exporter(&config.common_config().metrics_config)
         .await
         .context("failed to install metrics exporter")?;
@@ -310,10 +315,9 @@ where
     .context("couldn't create datastore")?;
 
     let health_check_listen_address = config.common_config().health_check_listen_address;
-    let healthz_task_handle =
-        tokio::task::spawn(
-            async move { health_endpoint_server(health_check_listen_address).await },
-        );
+    let zpages_task_handle = tokio::task::spawn(async move {
+        zpages_server(health_check_listen_address, trace_reload_handle).await
+    });
 
     let result = f(BinaryContext {
         clock,
@@ -325,26 +329,92 @@ where
     })
     .await;
 
-    healthz_task_handle.abort();
+    zpages_task_handle.abort();
 
     result
 }
 
-/// Listen for HTTP requests on a given port, and respond to requests for "/healthz" with an empty
-/// body and status code 200. Each Janus component exposes this HTTP server to enable health
-/// checks, and to indicate when it has successfully started up.
-async fn health_endpoint_server(address: SocketAddr) {
-    let router = Router::new().get(
-        "/healthz",
-        |conn: trillium::Conn| async move { conn.ok("") },
-    );
-    let handler = (Head::new(), router);
+/// A trillium server which serves z-pages, which are utility endpoints for health checks and
+/// tracing configuration. It listens on the given address and port. It also takes the reload
+/// handle necessary for reloading the tracing_subscriber configuration.
+///
+/// `/healthz` responds with an empty body and status code 200, which serves as a healthcheck to
+/// indicate when Janus has started up.
+///
+/// `/traceconfigz` responds with the tracing_subscriber configuration, or allows configuring it
+/// with a PUT request.
+async fn zpages_server(address: SocketAddr, trace_reload_handle: TraceReloadHandle) {
+    let handler = zpages_handler(trace_reload_handle);
     trillium_tokio::config()
         .with_port(address.port())
         .with_host(&address.ip().to_string())
         .without_signals()
         .run_async(handler)
         .await;
+}
+
+fn zpages_handler(trace_reload_handle: TraceReloadHandle) -> impl Handler {
+    (
+        Head::new(),
+        State(Arc::new(trace_reload_handle)),
+        Router::new()
+            .get(
+                "/healthz",
+                |conn: trillium::Conn| async move { conn.ok("") },
+            )
+            .get("/traceconfigz", api(get_traceconfigz))
+            .put("/traceconfigz", api(put_traceconfigz)),
+    )
+}
+
+async fn get_traceconfigz(
+    conn: &mut trillium::Conn,
+    State(trace_filter_handler): State<Arc<TraceReloadHandle>>,
+) -> Result<Json<TraceconfigzBody>, Status> {
+    Ok(Json(TraceconfigzBody {
+        filter: trace_filter_handler
+            .with_current(|trace_filter| trace_filter.to_string())
+            .map_err(|err| {
+                conn.set_body(format!("failed to get current filter: {}", err));
+                Status::InternalServerError
+            })?,
+    }))
+}
+
+async fn put_traceconfigz(
+    conn: &mut trillium::Conn,
+    (State(trace_filter_handler), Json(req)): (
+        State<Arc<TraceReloadHandle>>,
+        Json<TraceconfigzBody>,
+    ),
+) -> Result<Json<TraceconfigzBody>, Status> {
+    trace_filter_handler
+        .reload(EnvFilter::new(req.filter))
+        .map_err(|err| {
+            conn.set_body(format!("failed to update filter: {}", err));
+            // Note: reload will accept malformed filter directives, and fall back to the `error`
+            // filter. An error indicating malformation is never propagated up, so we can't give
+            // a proper HTTP status code. The error state will be revealed to the operator in the
+            // response body, however, since it will show the fallback log filter rather than their
+            // desired one.
+            Status::InternalServerError
+        })?;
+    Ok(Json(TraceconfigzBody {
+        filter: trace_filter_handler
+            .with_current(|trace_filter| trace_filter.to_string())
+            .map_err(|err| {
+                conn.set_body(format!("failed to get current filter: {}", err));
+                Status::InternalServerError
+            })?,
+    }))
+}
+
+/// The response and request body used by /traceconfigz for reporting and updating its configuration.
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct TraceconfigzBody {
+    /// The directive that filters spans and events. This field follows the [`EnvFilter`][1] syntax.
+    /// [1]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives
+    filter: String,
 }
 
 /// Register a signal handler for SIGTERM, and stop the [`Stopper`] when a SIGTERM signal is
@@ -408,10 +478,60 @@ pub async fn setup_server(
 #[cfg(test)]
 mod tests {
     use super::CommonBinaryOptions;
+    use crate::{
+        aggregator::http_handlers::test_util::take_response_body,
+        binary_utils::{zpages_handler, TraceconfigzBody},
+    };
     use clap::CommandFactory;
+    use tracing_subscriber::{layer::SubscriberExt, reload, EnvFilter, Registry};
+    use trillium::Status;
+    use trillium_testing::prelude::*;
 
     #[test]
     fn verify_app() {
         CommonBinaryOptions::command().debug_assert()
+    }
+
+    #[tokio::test]
+    async fn healthz() {
+        let (_, filter_handle) = reload::Layer::new(EnvFilter::new("info"));
+        let handler = zpages_handler(filter_handle);
+
+        let test_conn = get("/healthz").run_async(&handler).await;
+        assert_eq!(test_conn.status(), Some(Status::Ok));
+    }
+
+    #[tokio::test]
+    async fn traceconfigz() {
+        let (filter, filter_handle) = reload::Layer::new(EnvFilter::new("info"));
+        let _subscriber = Registry::default().with(filter);
+
+        let handler = zpages_handler(filter_handle);
+
+        let mut test_conn = get("/traceconfigz").run_async(&handler).await;
+        assert_eq!(test_conn.status(), Some(Status::Ok));
+        assert_eq!(
+            serde_json::from_slice::<TraceconfigzBody>(&take_response_body(&mut test_conn).await)
+                .unwrap(),
+            TraceconfigzBody {
+                filter: "info".to_string()
+            }
+        );
+
+        let req = TraceconfigzBody {
+            filter: "debug".to_string(),
+        };
+        let mut test_conn = dbg!(
+            put("/traceconfigz")
+                .with_request_body(serde_json::to_vec(&req).unwrap())
+                .run_async(&handler)
+                .await
+        );
+        assert_eq!(test_conn.status(), Some(Status::Ok));
+        assert_eq!(
+            serde_json::from_slice::<TraceconfigzBody>(&take_response_body(&mut test_conn).await)
+                .unwrap(),
+            req,
+        );
     }
 }

--- a/aggregator/src/binary_utils.rs
+++ b/aggregator/src/binary_utils.rs
@@ -521,12 +521,10 @@ mod tests {
         let req = TraceconfigzBody {
             filter: "debug".to_string(),
         };
-        let mut test_conn = dbg!(
-            put("/traceconfigz")
-                .with_request_body(serde_json::to_vec(&req).unwrap())
-                .run_async(&handler)
-                .await
-        );
+        let mut test_conn = put("/traceconfigz")
+            .with_request_body(serde_json::to_vec(&req).unwrap())
+            .run_async(&handler)
+            .await;
         assert_eq!(test_conn.status(), Some(Status::Ok));
         assert_eq!(
             serde_json::from_slice::<TraceconfigzBody>(&take_response_body(&mut test_conn).await)

--- a/aggregator/src/trace.rs
+++ b/aggregator/src/trace.rs
@@ -9,7 +9,9 @@ use std::{
 use tracing::Level;
 use tracing_chrome::{ChromeLayerBuilder, TraceStyle};
 use tracing_log::LogTracer;
-use tracing_subscriber::{filter::FromEnvError, layer::SubscriberExt, EnvFilter, Layer, Registry};
+use tracing_subscriber::{
+    filter::FromEnvError, layer::SubscriberExt, reload, EnvFilter, Layer, Registry,
+};
 
 #[cfg(feature = "otlp")]
 use {
@@ -122,17 +124,23 @@ fn make_trace_filter() -> Result<EnvFilter, FromEnvError> {
         .from_env()
 }
 
-/// Configures and installs a tracing subscriber, to capture events logged with
-/// [`tracing::info`] and the like. Captured events are written to stdout, with
-/// formatting affected by the provided [`TraceConfiguration`].
-pub fn install_trace_subscriber(config: &TraceConfiguration) -> Result<TraceGuards, Error> {
+pub type TraceReloadHandle = reload::Handle<EnvFilter, Registry>;
+
+/// Configures and installs a tracing subscriber, to capture events logged with [`tracing::info`]
+/// and the like. Captured events are written to stdout, with formatting affected by the provided
+/// [`TraceConfiguration`]. A handle to the stdout [`Filter`] is provided, so that the filter
+/// configuration can be altered later on at runtime.
+pub fn install_trace_subscriber(
+    config: &TraceConfiguration,
+) -> Result<(TraceGuards, TraceReloadHandle), Error> {
     // If stdout is not a tty or if forced by config, output logs as JSON
     // structures
     let output_json = !stdout().is_terminal() || config.force_json_output;
 
     // Configure filters with RUST_LOG env var. Format discussed at
     // https://docs.rs/tracing-subscriber/latest/tracing_subscriber/struct.EnvFilter.html
-    let stdout_filter = EnvFilter::builder().from_env()?;
+    let (stdout_filter, stdout_filter_handle) =
+        reload::Layer::new(EnvFilter::builder().from_env()?);
 
     let mut layers = Vec::new();
     match (
@@ -237,10 +245,13 @@ pub fn install_trace_subscriber(config: &TraceConfiguration) -> Result<TraceGuar
     // Install a logger that converts logs into tracing events
     LogTracer::init()?;
 
-    Ok(TraceGuards {
-        uses_otel_tracer: config.open_telemetry_config.is_some(),
-        _chrome_guard: chrome_guard,
-    })
+    Ok((
+        TraceGuards {
+            uses_otel_tracer: config.open_telemetry_config.is_some(),
+            _chrome_guard: chrome_guard,
+        },
+        stdout_filter_handle,
+    ))
 }
 
 pub struct TraceGuards {

--- a/aggregator/src/trace.rs
+++ b/aggregator/src/trace.rs
@@ -128,7 +128,7 @@ pub type TraceReloadHandle = reload::Handle<EnvFilter, Registry>;
 
 /// Configures and installs a tracing subscriber, to capture events logged with [`tracing::info`]
 /// and the like. Captured events are written to stdout, with formatting affected by the provided
-/// [`TraceConfiguration`]. A handle to the stdout [`Filter`] is provided, so that the filter
+/// [`TraceConfiguration`]. A handle to the stdout [`EnvFilter`] is provided, so that the filter
 /// configuration can be altered later on at runtime.
 pub fn install_trace_subscriber(
     config: &TraceConfiguration,

--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -48,6 +48,22 @@ human-readable or structured JSON log format will be chosen automatically. This
 can be overridden with the `force_json_output` and `stackdriver_json_output`
 configuration parameters under `logging_config`.
 
+The environment variable can be overridden at runtime using the `/traceconfigz`
+path on the `health_check_listen_address` endpoint. Here's an example using this
+with `curl`:
+
+```bash
+$ HEALTH_CHECK_LISTEN_ADDRESS=http://localhost:8000
+
+$ curl $HEALTH_CHECK_LISTEN_ADDRESS/traceconfigz
+{"filter":"info"}
+
+$ curl $HEALTH_CHECK_LISTEN_ADDRESS/traceconfigz -X PUT -d '{"filter":"debug"}'
+{"filter":"debug"}
+```
+
+The `filter` field corresponds exactly to the [EnvFilter] format.
+
 [EnvFilter]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/struct.EnvFilter.html
 
 ##### Metrics

--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -48,9 +48,9 @@ human-readable or structured JSON log format will be chosen automatically. This
 can be overridden with the `force_json_output` and `stackdriver_json_output`
 configuration parameters under `logging_config`.
 
-The environment variable can be overridden at runtime using the `/traceconfigz`
-path on the `health_check_listen_address` endpoint. Here's an example using this
-with `curl`:
+The `RUST_LOG` environment variable can be overridden at runtime using the
+`/traceconfigz` path on the `health_check_listen_address` endpoint. Here's
+an example using this with `curl`:
 
 ```bash
 $ HEALTH_CHECK_LISTEN_ADDRESS=http://localhost:8000

--- a/docs/samples/advanced_config/aggregation_job_creator.yaml
+++ b/docs/samples/advanced_config/aggregation_job_creator.yaml
@@ -11,7 +11,7 @@ database:
   # (optional, defaults to true)
   check_schema_version: true
 
-# Socket address for /healthz HTTP requests. Defaults to 127.0.0.1:9001.
+# Socket address for /healthz and /traceconfigz HTTP requests. Defaults to 127.0.0.1:9001.
 health_check_listen_address: "0.0.0.0:8000"
 
 # Logging configuration. (optional)

--- a/docs/samples/advanced_config/aggregation_job_driver.yaml
+++ b/docs/samples/advanced_config/aggregation_job_driver.yaml
@@ -11,7 +11,7 @@ database:
   # (optional, defaults to true)
   check_schema_version: true
 
-# Socket address for /healthz HTTP requests. Defaults to 127.0.0.1:9001.
+# Socket address for /healthz and /traceconfigz HTTP requests. Defaults to 127.0.0.1:9001.
 health_check_listen_address: "0.0.0.0:8000"
 
 # Logging configuration. (optional)

--- a/docs/samples/advanced_config/aggregator.yaml
+++ b/docs/samples/advanced_config/aggregator.yaml
@@ -11,7 +11,7 @@ database:
   # (optional, defaults to true)
   check_schema_version: true
 
-# Socket address for /healthz HTTP requests. Defaults to 127.0.0.1:9001.
+# Socket address for /healthz and /traceconfigz HTTP requests. Defaults to 127.0.0.1:9001.
 health_check_listen_address: "0.0.0.0:8000"
 
 # Logging configuration. (optional)

--- a/docs/samples/advanced_config/collection_job_driver.yaml
+++ b/docs/samples/advanced_config/collection_job_driver.yaml
@@ -11,7 +11,7 @@ database:
   # (optional, defaults to true)
   check_schema_version: true
 
-# Socket address for /healthz HTTP requests. Defaults to 127.0.0.1:9001.
+# Socket address for /healthz and /traceconfigz HTTP requests. Defaults to 127.0.0.1:9001.
 health_check_listen_address: "0.0.0.0:8000"
 
 # Logging configuration. (optional)

--- a/docs/samples/basic_config/aggregation_job_creator.yaml
+++ b/docs/samples/basic_config/aggregation_job_creator.yaml
@@ -4,7 +4,7 @@ database:
   # Database URL. (required)
   url: "postgres://postgres:postgres@localhost:5432/postgres"
 
-# Socket address for /healthz HTTP requests. Defaults to 127.0.0.1:9001.
+# Socket address for /healthz and /traceconfigz HTTP requests. Defaults to 127.0.0.1:9001.
 health_check_listen_address: "0.0.0.0:8000"
 
 # Aggregation job creator-specific parameters:

--- a/docs/samples/basic_config/aggregation_job_driver.yaml
+++ b/docs/samples/basic_config/aggregation_job_driver.yaml
@@ -4,7 +4,7 @@ database:
   # Database URL. (required)
   url: "postgres://postgres:postgres@localhost:5432/postgres"
 
-# Socket address for /healthz HTTP requests. Defaults to 127.0.0.1:9001.
+# Socket address for /healthz and /traceconfigz HTTP requests. Defaults to 127.0.0.1:9001.
 health_check_listen_address: "0.0.0.0:8000"
 
 # Aggregation job driver-related parameters:

--- a/docs/samples/basic_config/aggregator.yaml
+++ b/docs/samples/basic_config/aggregator.yaml
@@ -4,7 +4,7 @@ database:
   # Database URL. (required)
   url: "postgres://postgres:postgres@localhost:5432/postgres"
 
-# Socket address for /healthz HTTP requests. Defaults to 127.0.0.1:9001.
+# Socket address for /healthz and /traceconfigz HTTP requests. Defaults to 127.0.0.1:9001.
 health_check_listen_address: "0.0.0.0:8000"
 
 # Aggregator-specific parameters:

--- a/docs/samples/basic_config/collection_job_driver.yaml
+++ b/docs/samples/basic_config/collection_job_driver.yaml
@@ -4,7 +4,7 @@ database:
   # Database URL. (required)
   url: "postgres://postgres:postgres@localhost:5432/postgres"
 
-# Socket address for /healthz HTTP requests. Defaults to 127.0.0.1:9001.
+# Socket address for /healthz and /traceconfigz HTTP requests. Defaults to 127.0.0.1:9001.
 health_check_listen_address: "0.0.0.0:8000"
 
 # Collection job driver-related parameters:


### PR DESCRIPTION
Supports https://github.com/divviup/janus/issues/2124, and may be necessary for helping us debug issues without blowing up our cloud logging bill.

I chose to add this endpoint to the same `/healthz` handler we use for k8s status checks. I didn't think it fit on the aggregator API since we support deployments where the aggregator API is disabled, and the control plane will never be able to make full use of it since it only operates on a single replica of Janus.