### PR TITLE
Use correct batch-collected check for aggregation job continuation.

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/aggregation_job_continue.rs
@@ -82,12 +82,14 @@ impl VdafOps {
                 break report_agg;
             };
 
-            // Make sure this report isn't in an interval that has already started collection.
-            let conflicting_aggregate_share_jobs = tx
-                .get_aggregate_share_jobs_including_time::<SEED_SIZE, A>(
+            // Make sure this report is not part of a batch that has started collection.
+            let conflicting_aggregate_share_jobs =
+                Q::get_conflicting_aggregate_share_jobs::<SEED_SIZE, C, A>(
+                    tx,
                     &vdaf,
                     task.id(),
-                    report_aggregation.time(),
+                    helper_aggregation_job.partial_batch_identifier(),
+                    &report_aggregation.report_metadata(),
                 )
                 .await?;
 


### PR DESCRIPTION
The time-interval check was correct. The fixed-size check was effectively a no-op since `aggregate_share_jobs.batch_interval` is not populated for fixed-size tasks. Instead, we replace it with a check that the relevant batch has not yet started collection by ID.

Closes #2174.