### PR TITLE
upgrade trillium

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
 dependencies = [
  "concurrent-queue",
- "event-listener",
+ "event-listener 2.5.3",
  "futures-core",
 ]
 
@@ -1083,6 +1083,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "event-listener"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29e56284f00d94c1bc7fd3c77027b4623c88c1f53d8d2394c6199f2921dea325"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1286,6 +1297,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
 dependencies = [
  "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-lite"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c1155db57329dca6d018b61e76b1488ce9a2e5e44028cac420a5898f4fcef63"
+dependencies = [
+ "fastrand 2.0.0",
  "futures-core",
  "futures-io",
  "memchr",
@@ -2422,9 +2448,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.6.3"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memmem"
@@ -2900,9 +2926,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -3428,9 +3454,9 @@ dependencies = [
 
 [[package]]
 name = "rlimit"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a29d87a652dc4d43c586328706bb5cdff211f3f39a530f240b53f7221dab8e"
+checksum = "3560f70f30a0f16d11d01ed078a07740fe6b489667abc7c7b029155d9f21c3d8"
 dependencies = [
  "libc",
 ]
@@ -3901,7 +3927,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38aabbeafa6f6dead8cebf246fe9fae1f9215c8d29b3a69f93bd62a9e4a3dcd6"
 dependencies = [
- "event-listener",
+ "event-listener 2.5.3",
 ]
 
 [[package]]
@@ -4065,7 +4091,7 @@ dependencies = [
  "crossbeam-queue",
  "dotenvy",
  "either",
- "event-listener",
+ "event-listener 2.5.3",
  "futures-channel",
  "futures-core",
  "futures-intrusive",
@@ -4244,13 +4270,13 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stopper"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4573bf2456e356934de15c7151d1c9fc8873e8866a7c2b5e0bb20f8244bd0073"
+checksum = "c3cbaa496909aa4ff7ff606b9d7fe90bc8b619a1ece49c25bd5fb4c93bb466fb"
 dependencies = [
- "futures-lite",
- "pin-project",
- "waker-set",
+ "event-listener 3.0.0",
+ "futures-lite 2.0.0",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -4818,12 +4844,12 @@ dependencies = [
 
 [[package]]
 name = "trillium"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f06392b9c819adcd9416b88d26244603e73ca84d40b191e7a751524b30bb3a9"
+checksum = "6c3e64edfefacd15e5a3acd4437459d1d8a0cdc9f70e6cfe4eece37fb252c301"
 dependencies = [
  "async-trait",
- "futures-lite",
+ "futures-lite 2.0.0",
  "log",
  "trillium-http",
 ]
@@ -4863,7 +4889,7 @@ dependencies = [
  "crossbeam-queue",
  "dashmap",
  "encoding_rs",
- "futures-lite",
+ "futures-lite 1.13.0",
  "httparse",
  "log",
  "memmem",
@@ -4888,17 +4914,17 @@ dependencies = [
 
 [[package]]
 name = "trillium-http"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb554db15b8b056d593ba768948d87cff0a819ea9823a1aa228344b4abed37ce"
+checksum = "191b0bbc9a1b9daaae5edc8e6faacdbfcf5fed8da8a85700de428bc1de0828ee"
 dependencies = [
  "encoding_rs",
- "futures-lite",
+ "futures-lite 2.0.0",
  "hashbrown 0.14.0",
  "httparse",
  "httpdate",
  "log",
- "memmem",
+ "memchr",
  "mime",
  "smallvec",
  "smartcow",
@@ -4954,19 +4980,20 @@ dependencies = [
 
 [[package]]
 name = "trillium-server-common"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "004466f0e82f7467463d15b42f3f4c7a576895f3dadb828a858e838e7ae68237"
+checksum = "72bc41ffb1eb97c76f95b9684ce10fce6ba710d0322bd826b0480f00f3ddc98d"
 dependencies = [
  "async-trait",
  "async_cell",
- "futures-lite",
+ "event-listener 3.0.0",
+ "futures-lite 2.0.0",
  "log",
+ "pin-project-lite",
  "rlimit",
  "trillium",
  "trillium-http",
  "url",
- "waker-set",
 ]
 
 [[package]]
@@ -4978,7 +5005,7 @@ dependencies = [
  "async-channel",
  "async-dup",
  "cfg-if",
- "futures-lite",
+ "futures-lite 1.13.0",
  "portpicker",
  "trillium",
  "trillium-http",
@@ -5187,16 +5214,6 @@ name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
-
-[[package]]
-name = "waker-set"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e958152c46345e1af5c61812030ac85200573a0b384c137e83ce2c01ac4bc07"
-dependencies = [
- "crossbeam-utils",
- "slab",
-]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ rstest = "0.17.0"
 testcontainers = "0.15.0"
 thiserror = "1.0"
 tokio = { version = "1.33", features = ["full", "tracing"] }
-trillium = "0.2.9"
+trillium = "0.2.10"
 trillium-api = { version = "0.2.0-rc.4", default-features = false }
 trillium-caching-headers = "0.2.1"
 trillium-head = "0.2.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -54,7 +54,7 @@ ring = "0.17.5"
 serde.workspace = true
 serde_json = { workspace = true, optional = true }
 serde_yaml.workspace = true
-stopper = { version = "0.2.0", optional = true }
+stopper = { version = "0.2.2", optional = true }
 tempfile = { version = "3", optional = true }
 testcontainers = { workspace = true, optional = true }
 thiserror.workspace = true


### PR DESCRIPTION
see:

* [trillium-http@0.3.4](https://github.com/trillium-rs/trillium/releases/tag/trillium-http-v0.3.4)
* [trillium@0.2.10](https://github.com/trillium-rs/trillium/releases/tag/trillium-v0.2.10)
* [trillium-server-common@0.4.5](https://github.com/trillium-rs/trillium/releases/tag/trillium-server-common-v0.4.5)