### PR TITLE
Update cache configuration for sqlx container

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -180,11 +180,12 @@ target "janus_db_migrator" {
   }
   dockerfile = "Dockerfile.sqlx"
   cache-from = [
-    "type=gha,scope=main-janus",
-    "type=gha,scope=${GITHUB_BASE_REF}-janus",
-    "type=gha,scope=${GITHUB_REF_NAME}-janus",
+    "type=gha,scope=main-sqlx",
+    "type=gha,scope=${GITHUB_BASE_REF}-sqlx",
+    "type=gha,scope=${GITHUB_REF_NAME}-sqlx",
   ]
-  tags = ["janus_db_migrator:${VERSION}"]
+  cache-to = ["type=gha,scope=${GITHUB_REF_NAME}-sqlx,mode=max"]
+  tags     = ["janus_db_migrator:${VERSION}"]
 }
 
 target "janus_db_migrator_release" {


### PR DESCRIPTION
This is a follow-up to #2177 to tweak the docker buildx cache configuration. Currently, the layers aren't being cached, and sqlx is rebuilt (with the release profile) on each commit. This PR changes the `cache-from` lines to read from a different cache key (distinct from that used for Janus) and adds a `cache-to` line that writes back layers under that new cache key.