### PR TITLE
Use simpler body for trace config endpoint

### DIFF
--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -56,10 +56,10 @@ an example using this with `curl`:
 $ HEALTH_CHECK_LISTEN_ADDRESS=http://localhost:8000
 
 $ curl $HEALTH_CHECK_LISTEN_ADDRESS/traceconfigz
-{"filter":"info"}
+info
 
-$ curl $HEALTH_CHECK_LISTEN_ADDRESS/traceconfigz -X PUT -d '{"filter":"debug"}'
-{"filter":"debug"}
+$ curl $HEALTH_CHECK_LISTEN_ADDRESS/traceconfigz -X PUT -d 'debug'
+debug
 ```
 
 The `filter` field corresponds exactly to the [EnvFilter] format.


### PR DESCRIPTION
From brief discussion in https://github.com/divviup/divviup-api/pull/607#discussion_r1378180279, the trace config endpoint can be made simpler.

(From discussion in https://isrg.slack.com/archives/C0167LT4C73/p1698787638814279, the previous code is subtly wrong or otherwise cumbersome to properly use, because of how trillium intends to do content negotiation).