### PR TITLE
Scrub report data once it is no longer required.

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -3300,13 +3300,12 @@ mod tests {
     async fn upload() {
         install_test_trace_subscriber();
 
-        let (vdaf, aggregator, clock, task, datastore, _ephemeral_datastore) =
-            setup_upload_test(Config {
-                max_upload_batch_size: 1000,
-                max_upload_batch_write_delay: StdDuration::from_millis(500),
-                ..Default::default()
-            })
-            .await;
+        let (vdaf, aggregator, clock, task, ds, _ephemeral_datastore) = setup_upload_test(Config {
+            max_upload_batch_size: 1000,
+            max_upload_batch_write_delay: StdDuration::from_millis(500),
+            ..Default::default()
+        })
+        .await;
         let leader_task = task.leader_view().unwrap();
         let report = create_report(&leader_task, clock.now());
 
@@ -3315,17 +3314,17 @@ mod tests {
             .await
             .unwrap();
 
-        let got_report = datastore
+        let got_report = ds
             .run_unnamed_tx(|tx| {
-                let (vdaf, task_id, report_id) =
-                    (vdaf.clone(), *task.id(), *report.metadata().id());
+                let vdaf = vdaf.clone();
+                let task_id = *task.id();
+                let report_id = *report.metadata().id();
                 Box::pin(async move { tx.get_client_report(&vdaf, &task_id, &report_id).await })
             })
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(task.id(), got_report.task_id());
-        assert_eq!(report.metadata(), got_report.metadata());
+        assert!(got_report.eq_report(&vdaf, leader_task.current_hpke_key(), &report));
 
         // Report uploads are idempotent.
         aggregator
@@ -3333,7 +3332,8 @@ mod tests {
             .await
             .unwrap();
 
-        // Even if the report is modified, it is still reported as a duplicate.
+        // Even if the report is modified, it is still reported as a duplicate. The original report
+        // is stored.
         let mutated_report = create_report_custom(
             &leader_task,
             clock.now(),
@@ -3344,6 +3344,19 @@ mod tests {
             .handle_upload(task.id(), &mutated_report.get_encoded())
             .await
             .unwrap();
+
+        // Verify that the original report, rather than the modified report, is stored.
+        let got_report = ds
+            .run_unnamed_tx(|tx| {
+                let vdaf = vdaf.clone();
+                let task_id = *task.id();
+                let report_id = *report.metadata().id();
+                Box::pin(async move { tx.get_client_report(&vdaf, &task_id, &report_id).await })
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(got_report.eq_report(&vdaf, leader_task.current_hpke_key(), &report));
     }
 
     #[tokio::test]

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -314,6 +314,13 @@ impl AggregationJobDriver {
         A::InputShare: PartialEq + Send + Sync,
         A::PublicShare: PartialEq + Send + Sync,
     {
+        // We currently scrub all reports included in an aggregation job as part of completing the
+        // first step. Once we support VDAFs which accept use an aggregation parameter &
+        // permit/require multiple aggregations per report, we will need a more complicated strategy
+        // where we only scrub a report as part of the _final_ aggregation over the report.
+        let report_ids_to_scrub = client_reports.keys().copied().collect();
+
+        // Only process non-failed report aggregations.
         let report_aggregations: Vec<_> = report_aggregations
             .into_iter()
             .filter(|report_aggregation| {
@@ -435,6 +442,7 @@ impl AggregationJobDriver {
             aggregation_job,
             &stepped_aggregations,
             report_aggregations_to_write,
+            report_ids_to_scrub,
             resp.prepare_resps(),
         )
         .await
@@ -493,8 +501,8 @@ impl AggregationJobDriver {
                     message,
                 ));
                 stepped_aggregations.push(SteppedAggregation {
-                    report_aggregation: report_aggregation.clone(),
-                    leader_state: prep_state.clone(),
+                    report_aggregation,
+                    leader_state: prep_state,
                 });
             }
         }
@@ -529,6 +537,7 @@ impl AggregationJobDriver {
             aggregation_job,
             &stepped_aggregations,
             report_aggregations_to_write,
+            Vec::new(), /* reports are only scrubbed on the initial step */
             resp.prepare_resps(),
         )
         .await
@@ -549,6 +558,7 @@ impl AggregationJobDriver {
         aggregation_job: AggregationJob<SEED_SIZE, Q, A>,
         stepped_aggregations: &[SteppedAggregation<SEED_SIZE, A>],
         mut report_aggregations_to_write: Vec<ReportAggregation<SEED_SIZE, A>>,
+        report_ids_to_scrub: Vec<ReportId>,
         helper_prep_resps: &[PrepareResp],
     ) -> Result<()>
     where
@@ -702,18 +712,26 @@ impl AggregationJobDriver {
         )?;
         let aggregation_job_writer = Arc::new(aggregation_job_writer);
 
+        let report_ids_to_scrub = Arc::new(report_ids_to_scrub);
         let accumulator = Arc::new(accumulator);
         datastore
             .run_tx("step_aggregation_job_2", |tx| {
+                let task_id = *task.id();
                 let vdaf = Arc::clone(&vdaf);
                 let aggregation_job_writer = Arc::clone(&aggregation_job_writer);
                 let accumulator = Arc::clone(&accumulator);
+                let report_ids_to_scrub = Arc::clone(&report_ids_to_scrub);
                 let lease = Arc::clone(&lease);
 
                 Box::pin(async move {
-                    let (unwritable_ra_report_ids, unwritable_ba_report_ids, _) = try_join!(
+                    let (unwritable_ra_report_ids, unwritable_ba_report_ids, _, _) = try_join!(
                         aggregation_job_writer.write(tx, Arc::clone(&vdaf)),
                         accumulator.flush_to_datastore(tx, &vdaf),
+                        try_join_all(
+                            report_ids_to_scrub
+                                .iter()
+                                .map(|report_id| tx.scrub_client_report(&task_id, report_id))
+                        ),
                         tx.release_aggregation_job(&lease),
                     )?;
 

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -1114,7 +1114,7 @@ mod tests {
 
         let accepted_report_id = report.metadata().id();
 
-        // Verify that new reports using an existing report ID are rejected with reportRejected
+        // Verify that new reports using an existing report ID are also accepted as a duplicate.
         let duplicate_id_report = create_report_custom(
             &leader_task,
             clock.now(),
@@ -1126,14 +1126,8 @@ mod tests {
             .with_request_body(duplicate_id_report.get_encoded())
             .run_async(&handler)
             .await;
-        check_response(
-            &mut test_conn,
-            Status::BadRequest,
-            "reportRejected",
-            "Report could not be processed.",
-            task.id(),
-        )
-        .await;
+        assert_eq!(test_conn.status(), Some(Status::Ok));
+        assert!(test_conn.take_response_body().is_none());
 
         // Verify that reports older than the report expiry age are rejected with the reportRejected
         // error type.

--- a/aggregator/src/aggregator/report_writer.rs
+++ b/aggregator/src/aggregator/report_writer.rs
@@ -218,18 +218,9 @@ where
             .put_client_report::<SEED_SIZE, A>(&self.vdaf, &self.report)
             .await
         {
-            Ok(()) => Ok(()),
-
-            // Reject reports whose report IDs have been seen before.
-            // https://datatracker.ietf.org/doc/html/draft-ietf-ppm-dap-03#section-4.3.2-16
-            Err(datastore::Error::MutationTargetAlreadyExists) => Err(datastore::Error::User(
-                Error::ReportRejected(
-                    *self.report.task_id(),
-                    *self.report.metadata().id(),
-                    *self.report.metadata().time(),
-                )
-                .into(),
-            )),
+            // If the report already existed in the datastore, assume it is a duplicate and return
+            // OK.
+            Ok(()) | Err(datastore::Error::MutationTargetAlreadyExists) => Ok(()),
 
             err => err,
         }

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -1441,12 +1441,12 @@ impl<C: Clock> Transaction<'_, C> {
         }
 
         if let Some(row) = rows.into_iter().next() {
-            // Fast path: one row was affected, meaning there was no conflict and we wrote a new
-            // report. We check that the report wasn't expired per the task's report_expiry_age,
-            // but otherwise we are done. (If the report was expired, we need to delete it; we do
-            // this in a separate query rather than the initial insert because the initial insert
-            // cannot discriminate between a row that was skipped due to expiry & a row that was
-            // skipped due to a write conflict.)
+            // One row was affected, meaning there was no conflict and we wrote a new report. We
+            // check that the report wasn't expired per the task's report_expiry_age, but otherwise
+            // we are done. (If the report was expired, we need to delete it; we do this in a
+            // separate query rather than the initial insert because the initial insert cannot
+            // discriminate between a row that was skipped due to expiry & a row that was skipped
+            // due to a write conflict.)
             if row.get("is_expired") {
                 let stmt = self
                     .prepare_cached(
@@ -1470,81 +1470,48 @@ impl<C: Clock> Transaction<'_, C> {
             return Ok(());
         }
 
-        // Slow path: no rows were affected, meaning a row with the new report ID already existed
-        // and we hit the query's ON CONFLICT DO NOTHING clause. We need to check whether the new
-        // report matches the existing one.
-        let existing_report = {
-            // We intentionally don't use `get_client_report` because it omits expired reports. It
-            // is possible that we have conflicted with an expired report that hasn't been fully
-            // GC'd yet.
-            let stmt = self
-                .prepare_cached(
-                    "SELECT
-                        client_reports.client_timestamp,
-                        client_reports.extensions,
-                        client_reports.public_share,
-                        client_reports.leader_input_share,
-                        client_reports.helper_encrypted_input_share
-                    FROM client_reports
-                    JOIN tasks ON tasks.id = client_reports.task_id
-                    WHERE tasks.task_id = $1
-                      AND client_reports.report_id = $2",
-                )
-                .await?;
+        // No rows were affected, meaning a row with the report ID already existed and we hit the
+        // query's ON CONFLICT DO NOTHING clause.
+        Err(Error::MutationTargetAlreadyExists)
+    }
 
-            self.query_opt(
+    // scrub_client_report removes the client report itself from the datastore, retaining only a
+    // small amount of metadata required to perform duplicate-report detection & garbage collection.
+    //
+    // This method is intended for use by aggregators acting in the Leader role. Scrubbed reports
+    // can no longer be read, so this method should only be called once all aggregations over the
+    // report have stepped past their START state.
+    pub async fn scrub_client_report(
+        &self,
+        task_id: &TaskId,
+        report_id: &ReportId,
+    ) -> Result<(), Error> {
+        let stmt = self
+            .prepare_cached(
+                "UPDATE client_reports SET
+                extensions = NULL,
+                public_share = NULL,
+                leader_input_share = NULL,
+                helper_encrypted_input_share = NULL,
+                updated_at = $1,
+                updated_by = $2
+            FROM tasks
+            WHERE tasks.id = client_reports.task_id
+              AND tasks.task_id = $3 AND client_reports.report_id = $4",
+            )
+            .await?;
+        check_single_row_mutation(
+            self.execute(
                 &stmt,
                 &[
-                    /* task_id */ &new_report.task_id().as_ref(),
-                    /* report_id */ &new_report.metadata().id().as_ref(),
+                    /* updated_at */ &self.clock.now().as_naive_date_time()?,
+                    /* updated_by */ &self.name,
+                    /* task_id */ &task_id.as_ref(),
+                    /* report_id */ &report_id.as_ref(),
                 ],
             )
-            .await?
-            .map(|row| {
-                Self::client_report_from_row(
-                    vdaf,
-                    *new_report.task_id(),
-                    *new_report.metadata().id(),
-                    row,
-                )
-            })
-            .transpose()?
-            .ok_or_else(|| {
-                // This codepath can be taken due to a quirk of how the Repeatable Read isolation
-                // level works. It cannot occur at the Serializable isolation level.
-                //
-                // For this codepath to be taken, two writers must concurrently choose to write the
-                // same client report (by task & report ID), and this report must not already exist
-                // in the datastore.
-                //
-                // One writer will succeed. The other will receive a unique constraint violation on
-                // (task_id, report_id), since unique constraints are still enforced even in the
-                // presence of snapshot isolation. They will then receive `None` from the
-                // `get_client_report` call, since their snapshot is from before the successful
-                // writer's write, and fall into this codepath.
-                //
-                // The failing writer can't do anything about this problem while in its current
-                // transaction: further attempts to read the client report will continue to return
-                // `None` (since all reads in the same transaction are from the same snapshot), so
-                // so it can't evaluate idempotency. All it can do is give up on this transaction
-                // and try again, by calling `retry` and returning an error; once it retries, it
-                // will be able to read the report written by the successful writer.
-                self.retry();
-                Error::Concurrency(
-                    "retrying transaction because another writer has concurrently inserted this report",
-                )
-            })?
-        };
-
-        // If the existing report does not match the new report, then someone is trying to mutate an
-        // existing report, which is forbidden.
-        if !existing_report.eq(new_report) {
-            return Err(Error::MutationTargetAlreadyExists);
-        }
-
-        // If the existing report does match the new one, then there is no error (PUTting a report
-        // is idempotent).
-        Ok(())
+            .await?,
+        )
     }
 
     /// put_report_share stores a report share, given its associated task ID.

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -196,7 +196,7 @@ where
             PlaintextInputShare::get_decoded(&encoded_leader_plaintext_input_share)
                 .expect("couldn't decode Leader's PlaintextInputShare");
         let leader_input_share = A::InputShare::get_decoded_with_param(
-            &(&vdaf, Role::Leader.index().unwrap()),
+            &(vdaf, Role::Leader.index().unwrap()),
             leader_plaintext_input_share.payload(),
         )
         .expect("couldn't decode Leader's InputShare");

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -692,7 +692,10 @@ async fn roundtrip_report(ephemeral_datastore: EphemeralDatastore) {
             assert_eq!(row.get::<_, Option<Vec<u8>>>("extensions"), None);
             assert_eq!(row.get::<_, Option<Vec<u8>>>("public_share"), None);
             assert_eq!(row.get::<_, Option<Vec<u8>>>("leader_input_share"), None);
-            assert_eq!(row.get::<_, Option<Vec<u8>>>("helper_encrypted_input_share"), None);
+            assert_eq!(
+                row.get::<_, Option<Vec<u8>>>("helper_encrypted_input_share"),
+                None
+            );
 
             Ok(())
         })


### PR DESCRIPTION
Specifically, we scrub report data once aggregation has been started, at the end of the first aggregation step. This will considerably reduce the amount of data we store, at the cost of additional writes to the datastore. We also change the semantics of report-upload idempotency; see below.

Implementing this required changing the semantics of report-upload idempotency. Specifically, we can no longer detect when an uploaded report matches an already-stored report if the already-stored report has been scrubbed, since the data required to perform this check has been deleted. The new semantics are to do idempotency-checking on (task_id, report_id) only; any task that sees a duplicate report ID will treat it as a duplicated upload & return OK. I think these semantics are acceptable: in real deployments, a repeated report ID will most commonly mean a client is retrying an upload that actually succeeded the first time, and returning OK is fine here. There are some scenarios (e.g. bad client RNG) where the old duplicate-detection semantics would be better than the new semantics, but I think these are marginal enough that we can ignore them. The new semantics would also help with implementing the object-store design, which also doesn't store reports longer than necessary to perform aggregation.

(We could maintain the existing duplicate-checking logic by e.g. keeping a hash of the report around rather than the full report. If folks think it's worthwhile to maintain the existing semantics, let's chat about it in review.)

The current logic around scrubbing reports works for VDAFs which permit only a single aggregation per report. We will need to expand it once we support VDAFs permitting more than one aggregation per report by scrubbing each report at the beginning of the final aggregation for that report.

Closes #1278.