### PR TITLE
collect: hide sensitive environment variable values

### DIFF
--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -214,6 +214,7 @@ struct AuthenticationOptions {
         required = false,
         value_parser = StringValueParser::new().try_map(AuthenticationToken::new_dap_auth_token_from_string),
         env,
+        hide_env_values = true,
         help_heading = "Authorization",
         display_order = 0,
         conflicts_with = "authorization_bearer_token"
@@ -227,6 +228,7 @@ struct AuthenticationOptions {
         required = false,
         value_parser = StringValueParser::new().try_map(AuthenticationToken::new_bearer_token_from_string),
         env,
+        hide_env_values = true,
         help_heading = "Authorization",
         display_order = 1,
         conflicts_with = "dap_auth_token"
@@ -306,6 +308,7 @@ struct Options {
         long,
         value_parser = PrivateKeyValueParser::new(),
         env,
+        hide_env_values = true,
         help_heading = "DAP Task Parameters",
         display_order = 3,
         requires = "hpke_config",

--- a/tools/tests/cmd/collect.trycmd
+++ b/tools/tests/cmd/collect.trycmd
@@ -24,7 +24,7 @@ DAP Task Parameters:
       --hpke-private-key <HPKE_PRIVATE_KEY>
           The collector's HPKE private key, encoded with base64url
           
-          [env: HPKE_PRIVATE_KEY=]
+          [env: HPKE_PRIVATE_KEY]
 
       --hpke-config-json <HPKE_CONFIG_JSON>
           Path to a JSON document containing the collector's HPKE configuration and private key, in the format output by `divviup hpke-config generate`
@@ -33,12 +33,12 @@ Authorization:
       --dap-auth-token <DAP_AUTH_TOKEN>
           Authentication token for the DAP-Auth-Token HTTP header
           
-          [env: DAP_AUTH_TOKEN=]
+          [env: DAP_AUTH_TOKEN]
 
       --authorization-bearer-token <AUTHORIZATION_BEARER_TOKEN>
           Authentication token for the "Authorization: Bearer ..." HTTP header
           
-          [env: AUTHORIZATION_BEARER_TOKEN=]
+          [env: AUTHORIZATION_BEARER_TOKEN]
 
 VDAF Algorithm and Parameters:
       --vdaf <VDAF>

--- a/tools/tests/cmd/collect_fpvec_bounded_l2.trycmd
+++ b/tools/tests/cmd/collect_fpvec_bounded_l2.trycmd
@@ -24,7 +24,7 @@ DAP Task Parameters:
       --hpke-private-key <HPKE_PRIVATE_KEY>
           The collector's HPKE private key, encoded with base64url
           
-          [env: HPKE_PRIVATE_KEY=]
+          [env: HPKE_PRIVATE_KEY]
 
       --hpke-config-json <HPKE_CONFIG_JSON>
           Path to a JSON document containing the collector's HPKE configuration and private key, in the format output by `divviup hpke-config generate`
@@ -33,12 +33,12 @@ Authorization:
       --dap-auth-token <DAP_AUTH_TOKEN>
           Authentication token for the DAP-Auth-Token HTTP header
           
-          [env: DAP_AUTH_TOKEN=]
+          [env: DAP_AUTH_TOKEN]
 
       --authorization-bearer-token <AUTHORIZATION_BEARER_TOKEN>
           Authentication token for the "Authorization: Bearer ..." HTTP header
           
-          [env: AUTHORIZATION_BEARER_TOKEN=]
+          [env: AUTHORIZATION_BEARER_TOKEN]
 
 VDAF Algorithm and Parameters:
       --vdaf <VDAF>


### PR DESCRIPTION
Don't print the values of these variables when using `--help`, to avoid exposing secrets.