### PR TITLE
collect: Accept the newest divviup-api credentials file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2232,6 +2232,7 @@ dependencies = [
  "prio 0.15.3",
  "rand",
  "reqwest",
+ "serde",
  "serde_json",
  "serde_yaml",
  "tempfile",

--- a/core/src/hpke.rs
+++ b/core/src/hpke.rs
@@ -261,7 +261,7 @@ impl HpkeKeypair {
     }
 }
 
-/// HPKE configuration compatible with the output of `divviup hpke-config generate`.
+/// HPKE configuration compatible with the output of `divviup collector-credential generate`.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct DivviUpHpkeConfig {
     id: HpkeConfigId,

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -22,6 +22,7 @@ janus_core.workspace = true
 janus_messages.workspace = true
 prio.workspace = true
 reqwest = { version = "0.11.22", default-features = false, features = ["rustls-tls", "json"] }
+serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
 tokio.workspace = true

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -369,9 +369,7 @@ impl Options {
                 // Iterate over each one and return the first one that is valid.
                 match Deserializer::from_reader(reader)
                     .into_iter::<Value>()
-                    .collect::<Result<Vec<_>, _>>()?
-                    .into_iter()
-                    .find_map(|partial| DivviUpHpkeConfig::deserialize(partial).ok())
+                    .find_map(|partial| DivviUpHpkeConfig::deserialize(partial.ok()?).ok())
                 {
                     Some(divviup_hpke_config) => HpkeKeypair::try_from(divviup_hpke_config)
                         .context("could not convert HPKE config"),

--- a/tools/tests/cmd/collect.trycmd
+++ b/tools/tests/cmd/collect.trycmd
@@ -27,7 +27,7 @@ DAP Task Parameters:
           [env: HPKE_PRIVATE_KEY]
 
       --hpke-config-json <HPKE_CONFIG_JSON>
-          Path to a JSON document containing the collector's HPKE configuration and private key, in the format output by `divviup hpke-config generate`
+          Path to a JSON document containing the collector's HPKE configuration and private key, in the format output by `divviup collector-credential generate`
 
 Authorization:
       --dap-auth-token <DAP_AUTH_TOKEN>

--- a/tools/tests/cmd/collect_fpvec_bounded_l2.trycmd
+++ b/tools/tests/cmd/collect_fpvec_bounded_l2.trycmd
@@ -27,7 +27,7 @@ DAP Task Parameters:
           [env: HPKE_PRIVATE_KEY]
 
       --hpke-config-json <HPKE_CONFIG_JSON>
-          Path to a JSON document containing the collector's HPKE configuration and private key, in the format output by `divviup hpke-config generate`
+          Path to a JSON document containing the collector's HPKE configuration and private key, in the format output by `divviup collector-credential generate`
 
 Authorization:
       --dap-auth-token <DAP_AUTH_TOKEN>


### PR DESCRIPTION
Since we've adopted https://github.com/divviup/divviup-api/pull/565/files#diff-5e36eb06fc0c6a6dab5d267db1ed4c554858a2a3419a200f21153b689dfcc837, the collector credentials yielded by `divviup collector-credential generate` is like so:

```json
{
  "id": "b17f6ef9-2696-4793-8af2-377b77668c59",
  "hpke_config": {
    "id": 241,
    "kem_id": "X25519HkdfSha256",
    "kdf_id": "HkdfSha256",
    "aead_id": "Aes128Gcm",
    "public_key": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
  },
  "created_at": "2023-11-03T20:28:39.796684Z",
  "deleted_at": null,
  "updated_at": "2023-11-03T20:28:39.796685Z",
  "name": "inahga",
  "token_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
  "token": "aaaaaaaaaaaaaaaaaaaaaa"
}
{
  "aead": "AesGcm128",
  "id": 241,
  "kdf": "Sha256",
  "kem": "X25519HkdfSha256",
  "private_key": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
  "public_key": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
  "token": "aaaaaaaaaaaaaaaaaaaaaa"
}
```

The additional top level object chokes `collect.rs`, if we're supplying the verbatim output of `divviup`. IMO we shouldn't expect users to have to mangle the output of divviup, in realistic usage I think people will want to do `divviup collector-credential generate >credential.json`.

Change `collect.rs`'s JSON parsing logic so that it searches all top level objects for the one it wants.

Also change references of `divviup hpke-config` to `divviup collector-credential`, since that's what that subcommand is called now.