### PR TITLE
client: derive clone

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -278,7 +278,7 @@ impl<V: vdaf::Client<16>> ClientBuilder<V> {
 }
 
 /// A DAP client.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Client<V: vdaf::Client<16>> {
     parameters: ClientParameters,
     vdaf: V,


### PR DESCRIPTION
In case, e.g., a client needs to be used inside a `move` closure.