### PR TITLE
Don't use rustls if no trust store is provided

### DIFF
--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -29,6 +29,13 @@ Each component must be provided a connection string/URL. Note that the database
 password may be separately passed on the command line or through an environment
 variable, to override (or fill in) the password set in the configuration file.
 
+##### TLS
+
+By default, TLS is never used for database connections. Opportunistic TLS
+connections can be enabled by providing a file with PEM-format CA certificates
+to trust. Furthermore, TLS connections can be required by setting
+`sslmode=require` in the database connection string.
+
 #### Health Check
 
 Each binary starts an HTTP server to service health check requests from

--- a/docs/samples/advanced_config/aggregation_job_creator.yaml
+++ b/docs/samples/advanced_config/aggregation_job_creator.yaml
@@ -12,7 +12,9 @@ database:
   check_schema_version: true
 
   # Path to a PEM file with root certificates to trust for TLS database
-  # connections. (optional)
+  # connections. If present, TLS may be used depending on the "sslmode"
+  # connection string parameter, and the server's support for TLS. If absent,
+  # TLS will never be used. (optional)
   tls_trust_store_path: /path/to/file.pem
 
 # Socket address for /healthz and /traceconfigz HTTP requests. Defaults to 127.0.0.1:9001.

--- a/docs/samples/advanced_config/aggregation_job_driver.yaml
+++ b/docs/samples/advanced_config/aggregation_job_driver.yaml
@@ -12,7 +12,9 @@ database:
   check_schema_version: true
 
   # Path to a PEM file with root certificates to trust for TLS database
-  # connections. (optional)
+  # connections. If present, TLS may be used depending on the "sslmode"
+  # connection string parameter, and the server's support for TLS. If absent,
+  # TLS will never be used. (optional)
   tls_trust_store_path: /path/to/file.pem
 
 # Socket address for /healthz and /traceconfigz HTTP requests. Defaults to 127.0.0.1:9001.

--- a/docs/samples/advanced_config/aggregator.yaml
+++ b/docs/samples/advanced_config/aggregator.yaml
@@ -12,7 +12,9 @@ database:
   check_schema_version: true
 
   # Path to a PEM file with root certificates to trust for TLS database
-  # connections. (optional)
+  # connections. If present, TLS may be used depending on the "sslmode"
+  # connection string parameter, and the server's support for TLS. If absent,
+  # TLS will never be used. (optional)
   tls_trust_store_path: /path/to/file.pem
 
 # Socket address for /healthz and /traceconfigz HTTP requests. Defaults to 127.0.0.1:9001.

--- a/docs/samples/advanced_config/collection_job_driver.yaml
+++ b/docs/samples/advanced_config/collection_job_driver.yaml
@@ -12,7 +12,9 @@ database:
   check_schema_version: true
 
   # Path to a PEM file with root certificates to trust for TLS database
-  # connections. (optional)
+  # connections. If present, TLS may be used depending on the "sslmode"
+  # connection string parameter, and the server's support for TLS. If absent,
+  # TLS will never be used. (optional)
   tls_trust_store_path: /path/to/file.pem
 
 # Socket address for /healthz and /traceconfigz HTTP requests. Defaults to 127.0.0.1:9001.

--- a/docs/samples/advanced_config/janus_cli.yaml
+++ b/docs/samples/advanced_config/janus_cli.yaml
@@ -12,7 +12,9 @@ database:
   check_schema_version: true
 
   # Path to a PEM file with root certificates to trust for TLS database
-  # connections. (optional)
+  # connections. If present, TLS may be used depending on the "sslmode"
+  # connection string parameter, and the server's support for TLS. If absent,
+  # TLS will never be used. (optional)
   tls_trust_store_path: /path/to/file.pem
 
 # Socket address for /healthz HTTP requests. Defaults to 127.0.0.1:9001.


### PR DESCRIPTION
This closes #2226. #2179 introduced optional support for TLS in database connections. For database servers that don't support TLS, this resulted in no change to default behavior, but for database servers that do support TLS, our client would always try to use TLS, which fails without having a trust store. This PR fixes the default behavior without a trust store by conditionally using `tokio_postgres::NoTls` in that situation. This struct has a special implementation of a trait, with an override of a `#[doc(hidden)]` method that can't be overridden from third-party crates, that changes the client's default behavior to skip attempting TLS connections.