### PR TITLE
collect: improve polling feedback and timing; re-export ExponentialBackoff

### DIFF
--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -84,7 +84,7 @@ use std::{
     time::{Duration as StdDuration, SystemTime},
 };
 use tokio::time::{sleep, Instant};
-use tracing::info;
+use tracing::debug;
 use url::Url;
 
 /// Errors that may occur when performing collections.
@@ -623,7 +623,7 @@ impl<V: vdaf::Collector> Collector<V> {
             // received from it and return immediately.
             let retry_after = match self.poll_once(job).await? {
                 PollResult::CollectionResult(aggregate_result) => {
-                    info!(
+                    debug!(
                         job_id = %job.collection_job_id(),
                         elapsed = ?backoff.get_elapsed_time(),
                         "collection job complete"
@@ -669,7 +669,7 @@ impl<V: vdaf::Collector> Collector<V> {
                 backoff_duration
             };
 
-            info!(
+            debug!(
                 job_id = %job.collection_job_id(),
                 ?backoff_duration,
                 retry_after_header = ?retry_after,

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -10,7 +10,7 @@ use derivative::Derivative;
 use fixed::types::extra::{U15, U31};
 #[cfg(feature = "fpvec_bounded_l2")]
 use fixed::{FixedI16, FixedI32};
-use janus_collector::{default_http_client, AuthenticationToken, Collector};
+use janus_collector::{default_http_client, AuthenticationToken, Collector, ExponentialBackoff};
 use janus_core::hpke::{DivviUpHpkeConfig, HpkeKeypair, HpkePrivateKey};
 use janus_messages::{
     query_type::{FixedSize, QueryType, TimeInterval},
@@ -23,7 +23,7 @@ use prio::{
     codec::Decode,
     vdaf::{self, prio3::Prio3},
 };
-use std::{fmt::Debug, fs::File, path::PathBuf};
+use std::{fmt::Debug, fs::File, path::PathBuf, time::Duration as StdDuration};
 use tracing_log::LogTracer;
 use tracing_subscriber::{prelude::*, EnvFilter, Registry};
 use url::Url;
@@ -513,6 +513,14 @@ where
     let collector =
         Collector::builder(task_id, leader_endpoint, authentication, hpke_keypair, vdaf)
             .with_http_client(http_client)
+            .with_collect_poll_backoff(ExponentialBackoff {
+                initial_interval: StdDuration::from_secs(3),
+                max_interval: StdDuration::from_secs(300),
+                multiplier: 1.2,
+                max_elapsed_time: None,
+                randomization_factor: 0.0,
+                ..Default::default()
+            })
             .build()
             .map_err(|err| Error::Anyhow(err.into()))?;
     let collection = collector

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -518,7 +518,7 @@ where
                 max_interval: StdDuration::from_secs(300),
                 multiplier: 1.2,
                 max_elapsed_time: None,
-                randomization_factor: 0.0,
+                randomization_factor: 0.1,
                 ..Default::default()
             })
             .build()


### PR DESCRIPTION
A few things happening here, I can break this up if we want to evaluate them separately.

The main goal is to choose exponential backoff parameters that are better suited to my impatience. IMO at the CLI, more polling aggressiveness is justified since the tool is more likely being used interactively. The previous parameters yielded backoff timings of:
```
>>> [15*(1.2**t) for t in range(100) if 15*(1.2**t) < 300]
[15.0, 18.0, 21.599999999999998, 25.919999999999995, 31.104, 37.32479999999999, 44.78975999999999, 53.747711999999986, 64.49725439999997, 77.39670527999998, 92.87604633599996, 111.45125560319995, 133.74150672383993, 160.4898080686079, 192.58776968232948, 231.10532361879538, 277.3263883425545]
```

The new parameters yield: 
```
>>> [3*(1.2**t) for t in range(100) if 3*(1.2**t) < 300]
[3.0, 3.5999999999999996, 4.32, 5.183999999999999, 6.2208, 7.464959999999998, 8.957951999999999, 10.749542399999997, 12.899450879999996, 15.479341055999996, 18.57520926719999, 22.29025112063999, 26.748301344767988, 32.09796161372158, 38.5175539364659, 46.22106472375908, 55.46527766851089, 66.55833320221306, 79.86999984265569, 95.84399981118682, 115.01279977342418, 138.015359728109, 165.6184316737308, 198.74211800847692, 238.49054161017233, 286.1886499322068]
```

I also provided more `info` level logging to provide feedback to the user when polling. Finally, I reexport ExponentialBackoff as part of the collector API, so that users of the `janus_collector` library don't have to import `backoff` themselves.