### PR TITLE
Eagerly delete aggregation jobs.

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -666,7 +666,7 @@ mod tests {
     use futures::future::try_join_all;
     use janus_aggregator_core::{
         datastore::{
-            models::{AggregationJob, AggregationJobState, Batch, BatchState, LeaderStoredReport},
+            models::{AggregationJob, Batch, BatchState, LeaderStoredReport},
             test_util::ephemeral_datastore,
             Transaction,
         },
@@ -1077,33 +1077,30 @@ mod tests {
             iter::repeat_with(|| LeaderStoredReport::new_dummy(*task.id(), report_time))
                 .take(2 * MAX_AGGREGATION_JOB_SIZE + MIN_AGGREGATION_JOB_SIZE + 1)
                 .collect();
-        let all_report_ids: HashSet<ReportId> = reports
-            .iter()
-            .map(|report| *report.metadata().id())
-            .collect();
 
-        ds.run_unnamed_tx(|tx| {
-            let (task, reports) = (Arc::clone(&task), reports.clone());
-            Box::pin(async move {
-                tx.put_aggregator_task(&task).await?;
-                for report in reports.iter() {
-                    tx.put_client_report(&dummy_vdaf::Vdaf::new(), report)
-                        .await?;
-                }
-                tx.put_batch(&Batch::<VERIFY_KEY_LENGTH, TimeInterval, Prio3Count>::new(
-                    *task.id(),
-                    batch_identifier,
-                    (),
-                    BatchState::Closed,
-                    0,
-                    Interval::from_time(&report_time).unwrap(),
-                ))
-                .await?;
-                Ok(())
+        let want_batch = ds
+            .run_unnamed_tx(|tx| {
+                let (task, reports) = (Arc::clone(&task), reports.clone());
+                Box::pin(async move {
+                    tx.put_aggregator_task(&task).await?;
+                    for report in reports.iter() {
+                        tx.put_client_report(&dummy_vdaf::Vdaf::new(), report)
+                            .await?;
+                    }
+                    let batch = Batch::<VERIFY_KEY_LENGTH, TimeInterval, Prio3Count>::new(
+                        *task.id(),
+                        batch_identifier,
+                        (),
+                        BatchState::Closed,
+                        0,
+                        Interval::from_time(&report_time).unwrap(),
+                    );
+                    tx.put_batch(&batch).await?;
+                    Ok(batch)
+                })
             })
-        })
-        .await
-        .unwrap();
+            .await
+            .unwrap();
 
         // Run.
         let job_creator = Arc::new(AggregationJobCreator::new(
@@ -1138,42 +1135,13 @@ mod tests {
             })
             .await
             .unwrap();
-        let mut seen_report_ids = HashSet::new();
-        for (agg_job, report_ids) in &agg_jobs {
-            // Job immediately finished since all reports are in a closed batch.
-            assert_eq!(agg_job.state(), &AggregationJobState::Finished);
 
-            // Jobs are created in step 0.
-            assert_eq!(agg_job.step(), AggregationJobStep::from(0));
+        // Every client report was dropped because they are all associated with a closed batch, so
+        // we don't write any aggregation jobs at all.
+        assert!(agg_jobs.is_empty());
 
-            // The batch is at most MAX_AGGREGATION_JOB_SIZE in size.
-            assert!(report_ids.len() <= MAX_AGGREGATION_JOB_SIZE);
-
-            // The batch is at least MIN_AGGREGATION_JOB_SIZE in size.
-            assert!(report_ids.len() >= MIN_AGGREGATION_JOB_SIZE);
-
-            // Report IDs are not repeated across or inside aggregation jobs.
-            for report_id in report_ids {
-                assert!(!seen_report_ids.contains(report_id));
-                seen_report_ids.insert(*report_id);
-            }
-        }
-
-        // Every client report was added to some aggregation job.
-        assert_eq!(all_report_ids, seen_report_ids);
-
-        // Batches are created appropriately.
-        assert_eq!(
-            batches,
-            Vec::from([Batch::new(
-                *task.id(),
-                batch_identifier,
-                (),
-                BatchState::Closed,
-                0,
-                Interval::from_time(&report_time).unwrap(),
-            )])
-        );
+        // The existing batch was left untouched, and no new batches were created.
+        assert_eq!(batches, Vec::from([want_batch]));
     }
 
     #[tokio::test]
@@ -1273,15 +1241,14 @@ mod tests {
         let mut min_size_batch_id = None;
         let mut max_size_batch_id = None;
         for outstanding_batch in &outstanding_batches {
-            assert_eq!(outstanding_batch.size().start(), &0);
-            assert!(&MIN_BATCH_SIZE <= outstanding_batch.size().end());
-            assert!(outstanding_batch.size().end() <= &MAX_BATCH_SIZE);
-            total_max_size += *outstanding_batch.size().end();
+            assert!(MIN_BATCH_SIZE <= outstanding_batch.max_size());
+            assert!(outstanding_batch.max_size() <= MAX_BATCH_SIZE);
+            total_max_size += outstanding_batch.max_size();
 
-            if outstanding_batch.size().end() == &MIN_BATCH_SIZE {
+            if outstanding_batch.max_size() == MIN_BATCH_SIZE {
                 min_size_batch_id = Some(*outstanding_batch.id());
             }
-            if outstanding_batch.size().end() == &MAX_BATCH_SIZE {
+            if outstanding_batch.max_size() == MAX_BATCH_SIZE {
                 max_size_batch_id = Some(*outstanding_batch.id());
             }
         }
@@ -1554,7 +1521,7 @@ mod tests {
         // Verify sizes of batches and aggregation jobs.
         let mut outstanding_batch_sizes = outstanding_batches
             .iter()
-            .map(|outstanding_batch| *outstanding_batch.size().end())
+            .map(|outstanding_batch| outstanding_batch.max_size())
             .collect::<Vec<_>>();
         outstanding_batch_sizes.sort();
         assert_eq!(outstanding_batch_sizes, [180, MAX_BATCH_SIZE]);
@@ -1617,7 +1584,7 @@ mod tests {
         // Verify sizes of batches and aggregation jobs.
         let mut outstanding_batch_sizes = outstanding_batches
             .iter()
-            .map(|outstanding_batch| *outstanding_batch.size().end())
+            .map(|outstanding_batch| outstanding_batch.max_size())
             .collect::<Vec<_>>();
         outstanding_batch_sizes.sort();
         assert_eq!(outstanding_batch_sizes, [MIN_BATCH_SIZE, MAX_BATCH_SIZE]);
@@ -1740,7 +1707,7 @@ mod tests {
         // Verify sizes of batches and aggregation jobs.
         let mut outstanding_batch_sizes = outstanding_batches
             .iter()
-            .map(|outstanding_batch| *outstanding_batch.size().end())
+            .map(|outstanding_batch| outstanding_batch.max_size())
             .collect::<Vec<_>>();
         outstanding_batch_sizes.sort();
         assert_eq!(outstanding_batch_sizes, [55, MAX_BATCH_SIZE]);
@@ -1810,7 +1777,7 @@ mod tests {
         // Verify sizes of batches and aggregation jobs.
         let mut outstanding_batch_sizes = outstanding_batches
             .iter()
-            .map(|outstanding_batch| *outstanding_batch.size().end())
+            .map(|outstanding_batch| outstanding_batch.max_size())
             .collect::<Vec<_>>();
         outstanding_batch_sizes.sort();
         assert_eq!(outstanding_batch_sizes, [110, MAX_BATCH_SIZE]);
@@ -1949,27 +1916,26 @@ mod tests {
         for outstanding_batches in [&outstanding_batches_bucket_1, &outstanding_batches_bucket_2] {
             assert_eq!(outstanding_batches.len(), 2);
             for outstanding_batch in outstanding_batches {
-                assert_eq!(outstanding_batch.size().start(), &0);
-                assert!(outstanding_batch.size().end() >= &MIN_BATCH_SIZE);
-                assert!(outstanding_batch.size().end() <= &MAX_BATCH_SIZE);
+                assert!(outstanding_batch.max_size() >= MIN_BATCH_SIZE);
+                assert!(outstanding_batch.max_size() <= MAX_BATCH_SIZE);
             }
             let total_max_size: usize = outstanding_batches
                 .iter()
-                .map(|outstanding_batch| outstanding_batch.size().end())
+                .map(|outstanding_batch| outstanding_batch.max_size())
                 .sum();
             assert_eq!(total_max_size, report_ids.len() / 2);
             let smallest_batch_size = outstanding_batches
                 .iter()
-                .map(|outstanding_batch| outstanding_batch.size().end())
+                .map(|outstanding_batch| outstanding_batch.max_size())
                 .min()
                 .unwrap();
-            assert_eq!(smallest_batch_size, &MIN_BATCH_SIZE);
+            assert_eq!(smallest_batch_size, MIN_BATCH_SIZE);
             let largest_batch_size = outstanding_batches
                 .iter()
-                .map(|outstanding_batch| outstanding_batch.size().end())
+                .map(|outstanding_batch| outstanding_batch.max_size())
                 .max()
                 .unwrap();
-            assert_eq!(largest_batch_size, &MAX_BATCH_SIZE);
+            assert_eq!(largest_batch_size, MAX_BATCH_SIZE);
         }
         let batch_ids: HashSet<_> = [&outstanding_batches_bucket_1, &outstanding_batches_bucket_2]
             .into_iter()
@@ -2004,22 +1970,22 @@ mod tests {
 
         let bucket_1_small_batch_id = *outstanding_batches_bucket_1
             .iter()
-            .find(|outstanding_batch| outstanding_batch.size().end() == &MIN_BATCH_SIZE)
+            .find(|outstanding_batch| outstanding_batch.max_size() == MIN_BATCH_SIZE)
             .unwrap()
             .id();
         let bucket_1_large_batch_id = *outstanding_batches_bucket_1
             .iter()
-            .find(|outstanding_batch| outstanding_batch.size().end() == &MAX_BATCH_SIZE)
+            .find(|outstanding_batch| outstanding_batch.max_size() == MAX_BATCH_SIZE)
             .unwrap()
             .id();
         let bucket_2_small_batch_id = *outstanding_batches_bucket_2
             .iter()
-            .find(|outstanding_batch| outstanding_batch.size().end() == &MIN_BATCH_SIZE)
+            .find(|outstanding_batch| outstanding_batch.max_size() == MIN_BATCH_SIZE)
             .unwrap()
             .id();
         let bucket_2_large_batch_id = *outstanding_batches_bucket_2
             .iter()
-            .find(|outstanding_batch| outstanding_batch.size().end() == &MAX_BATCH_SIZE)
+            .find(|outstanding_batch| outstanding_batch.max_size() == MAX_BATCH_SIZE)
             .unwrap()
             .id();
 

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -962,8 +962,8 @@ mod tests {
         AggregationJobContinueReq, AggregationJobInitializeReq, AggregationJobResp,
         AggregationJobStep, Duration, Extension, ExtensionType, FixedSizeQuery, HpkeConfig,
         InputShareAad, Interval, PartialBatchSelector, PlaintextInputShare, PrepareContinue,
-        PrepareError, PrepareInit, PrepareResp, PrepareStepResult, Query, ReportIdChecksum,
-        ReportMetadata, ReportShare, Role, TaskId, Time,
+        PrepareInit, PrepareResp, PrepareStepResult, Query, ReportIdChecksum, ReportMetadata,
+        ReportShare, Role, TaskId, Time,
     };
     use prio::{
         codec::Encode,
@@ -1201,27 +1201,6 @@ mod tests {
             mocked_aggregate.assert_async().await;
         }
 
-        let want_aggregation_job =
-            AggregationJob::<VERIFY_KEY_LENGTH, TimeInterval, Poplar1<XofShake128, 16>>::new(
-                *task.id(),
-                aggregation_job_id,
-                aggregation_param.clone(),
-                (),
-                Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
-                    .unwrap(),
-                AggregationJobState::Finished,
-                AggregationJobStep::from(2),
-            );
-        let want_report_aggregation =
-            ReportAggregation::<VERIFY_KEY_LENGTH, Poplar1<XofShake128, 16>>::new(
-                *task.id(),
-                aggregation_job_id,
-                *report.metadata().id(),
-                *report.metadata().time(),
-                0,
-                None,
-                ReportAggregationState::Finished,
-            );
         let want_batch = Batch::<VERIFY_KEY_LENGTH, TimeInterval, Poplar1<XofShake128, 16>>::new(
             *task.id(),
             batch_identifier,
@@ -1236,6 +1215,7 @@ mod tests {
             .run_unnamed_tx(|tx| {
                 let vdaf = Arc::clone(&vdaf);
                 let task = task.clone();
+                let aggregation_param = aggregation_param.clone();
                 let report_id = *report.metadata().id();
                 let collection_job_id = *want_collection_job.id();
 
@@ -1245,24 +1225,22 @@ mod tests {
                             task.id(),
                             &aggregation_job_id,
                         )
-                        .await?
-                        .unwrap();
+                        .await?;
                     let report_aggregation = tx
                         .get_report_aggregation(
                             vdaf.as_ref(),
                             &Role::Leader,
                             task.id(),
                             &aggregation_job_id,
-                            aggregation_job.aggregation_parameter(),
+                            &aggregation_param,
                             &report_id,
                         )
-                        .await?
-                        .unwrap();
+                        .await?;
                     let batch = tx
                         .get_batch(
                             task.id(),
                             &batch_identifier,
-                            aggregation_job.aggregation_parameter(),
+                            &aggregation_param,
                         )
                         .await?
                         .unwrap();
@@ -1276,8 +1254,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(want_aggregation_job, got_aggregation_job);
-        assert_eq!(want_report_aggregation, got_report_aggregation);
+        assert!(got_aggregation_job.is_none());
+        assert!(got_report_aggregation.is_none());
         assert_eq!(want_batch, got_batch);
         assert_eq!(want_collection_job, got_collection_job);
     }
@@ -1507,46 +1485,6 @@ mod tests {
         mocked_aggregate_failure.assert_async().await;
         mocked_aggregate_success.assert_async().await;
 
-        let want_aggregation_job =
-            AggregationJob::<VERIFY_KEY_LENGTH, TimeInterval, Prio3Count>::new(
-                *task.id(),
-                aggregation_job_id,
-                (),
-                (),
-                Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
-                    .unwrap(),
-                AggregationJobState::Finished,
-                AggregationJobStep::from(1),
-            );
-        let want_report_aggregation = ReportAggregation::<VERIFY_KEY_LENGTH, Prio3Count>::new(
-            *task.id(),
-            aggregation_job_id,
-            *report.metadata().id(),
-            *report.metadata().time(),
-            0,
-            None,
-            ReportAggregationState::Finished,
-        );
-        let want_repeated_extension_report_aggregation =
-            ReportAggregation::<VERIFY_KEY_LENGTH, Prio3Count>::new(
-                *task.id(),
-                aggregation_job_id,
-                *repeated_extension_report.metadata().id(),
-                *repeated_extension_report.metadata().time(),
-                1,
-                None,
-                ReportAggregationState::Failed(PrepareError::InvalidMessage),
-            );
-        let want_missing_report_report_aggregation =
-            ReportAggregation::<VERIFY_KEY_LENGTH, Prio3Count>::new(
-                *task.id(),
-                aggregation_job_id,
-                missing_report_id,
-                time,
-                2,
-                None,
-                ReportAggregationState::Failed(PrepareError::ReportDropped),
-            );
         let want_batch = Batch::<VERIFY_KEY_LENGTH, TimeInterval, Prio3Count>::new(
             *task.id(),
             batch_identifier,
@@ -1576,41 +1514,37 @@ mod tests {
                             task.id(),
                             &aggregation_job_id,
                         )
-                        .await?
-                        .unwrap();
+                        .await?;
                     let report_aggregation = tx
                         .get_report_aggregation(
                             vdaf.as_ref(),
                             &Role::Leader,
                             task.id(),
                             &aggregation_job_id,
-                            aggregation_job.aggregation_parameter(),
+                            &(),
                             &report_id,
                         )
-                        .await?
-                        .unwrap();
+                        .await?;
                     let repeated_extension_report_aggregation = tx
                         .get_report_aggregation(
                             vdaf.as_ref(),
                             &Role::Leader,
                             task.id(),
                             &aggregation_job_id,
-                            aggregation_job.aggregation_parameter(),
+                            &(),
                             &repeated_extension_report_id,
                         )
-                        .await?
-                        .unwrap();
+                        .await?;
                     let missing_report_report_aggregation = tx
                         .get_report_aggregation(
                             vdaf.as_ref(),
                             &Role::Leader,
                             task.id(),
                             &aggregation_job_id,
-                            aggregation_job.aggregation_parameter(),
+                            &(),
                             &missing_report_id,
                         )
-                        .await?
-                        .unwrap();
+                        .await?;
                     let batch = tx
                         .get_batch(task.id(), &batch_identifier, &())
                         .await?
@@ -1627,16 +1561,10 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(want_aggregation_job, got_aggregation_job);
-        assert_eq!(want_report_aggregation, got_report_aggregation);
-        assert_eq!(
-            want_repeated_extension_report_aggregation,
-            got_repeated_extension_report_aggregation
-        );
-        assert_eq!(
-            want_missing_report_report_aggregation,
-            got_missing_report_report_aggregation
-        );
+        assert!(got_aggregation_job.is_none());
+        assert!(got_report_aggregation.is_none());
+        assert!(got_repeated_extension_report_aggregation.is_none());
+        assert!(got_missing_report_report_aggregation.is_none());
         assert_eq!(want_batch, got_batch);
     }
 
@@ -2079,24 +2007,6 @@ mod tests {
         mocked_aggregate_failure.assert_async().await;
         mocked_aggregate_success.assert_async().await;
 
-        let want_aggregation_job = AggregationJob::<VERIFY_KEY_LENGTH, FixedSize, Prio3Count>::new(
-            *task.id(),
-            aggregation_job_id,
-            (),
-            batch_id,
-            Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1)).unwrap(),
-            AggregationJobState::Finished,
-            AggregationJobStep::from(1),
-        );
-        let want_report_aggregation = ReportAggregation::<VERIFY_KEY_LENGTH, Prio3Count>::new(
-            *task.id(),
-            aggregation_job_id,
-            *report.metadata().id(),
-            *report.metadata().time(),
-            0,
-            None,
-            ReportAggregationState::Finished,
-        );
         let want_batch = Batch::<VERIFY_KEY_LENGTH, FixedSize, Prio3Count>::new(
             *task.id(),
             batch_id,
@@ -2116,19 +2026,17 @@ mod tests {
                             task.id(),
                             &aggregation_job_id,
                         )
-                        .await?
-                        .unwrap();
+                        .await?;
                     let report_aggregation = tx
                         .get_report_aggregation(
                             vdaf.as_ref(),
                             &Role::Leader,
                             task.id(),
                             &aggregation_job_id,
-                            aggregation_job.aggregation_parameter(),
+                            &(),
                             &report_id,
                         )
-                        .await?
-                        .unwrap();
+                        .await?;
                     let batch = tx.get_batch(task.id(), &batch_id, &()).await?.unwrap();
                     Ok((aggregation_job, report_aggregation, batch))
                 })
@@ -2136,8 +2044,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(want_aggregation_job, got_aggregation_job);
-        assert_eq!(want_report_aggregation, got_report_aggregation);
+        assert!(got_aggregation_job.is_none());
+        assert!(got_report_aggregation.is_none());
         assert_eq!(want_batch, got_batch);
     }
 
@@ -2638,28 +2546,6 @@ mod tests {
         mocked_aggregate_failure.assert_async().await;
         mocked_aggregate_success.assert_async().await;
 
-        let want_aggregation_job =
-            AggregationJob::<VERIFY_KEY_LENGTH, TimeInterval, Poplar1<XofShake128, 16>>::new(
-                *task.id(),
-                aggregation_job_id,
-                aggregation_param.clone(),
-                (),
-                Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
-                    .unwrap(),
-                AggregationJobState::Finished,
-                AggregationJobStep::from(2),
-            );
-        let want_report_aggregation =
-            ReportAggregation::<VERIFY_KEY_LENGTH, Poplar1<XofShake128, 16>>::new(
-                *task.id(),
-                aggregation_job_id,
-                *report.metadata().id(),
-                *report.metadata().time(),
-                0,
-                None,
-                ReportAggregationState::Finished,
-            );
-
         let batch_interval_start = report
             .metadata()
             .time()
@@ -2721,19 +2607,17 @@ mod tests {
                             task.id(),
                             &aggregation_job_id,
                         )
-                        .await?
-                        .unwrap();
+                        .await?;
                     let report_aggregation = tx
                         .get_report_aggregation(
                             vdaf.as_ref(),
                             &Role::Leader,
                             task.id(),
                             &aggregation_job_id,
-                            aggregation_job.aggregation_parameter(),
+                            &aggregation_param,
                             report_metadata.id(),
                         )
-                        .await?
-                        .unwrap();
+                        .await?;
                     let batch_aggregations =
                         TimeInterval::get_batch_aggregations_for_collection_identifier::<
                             VERIFY_KEY_LENGTH,
@@ -2799,8 +2683,8 @@ mod tests {
             })
             .collect();
 
-        assert_eq!(want_aggregation_job, got_aggregation_job);
-        assert_eq!(want_report_aggregation, got_report_aggregation);
+        assert!(got_aggregation_job.is_none());
+        assert!(got_report_aggregation.is_none());
         assert_eq!(want_batch_aggregations, got_batch_aggregations);
         assert_eq!(want_active_batch, got_active_batch);
         assert_eq!(want_other_batch, got_other_batch);
@@ -3026,27 +2910,6 @@ mod tests {
         mocked_aggregate_failure.assert_async().await;
         mocked_aggregate_success.assert_async().await;
 
-        let want_aggregation_job =
-            AggregationJob::<VERIFY_KEY_LENGTH, FixedSize, Poplar1<XofShake128, 16>>::new(
-                *task.id(),
-                aggregation_job_id,
-                aggregation_param.clone(),
-                batch_id,
-                Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
-                    .unwrap(),
-                AggregationJobState::Finished,
-                AggregationJobStep::from(2),
-            );
-        let want_report_aggregation =
-            ReportAggregation::<VERIFY_KEY_LENGTH, Poplar1<XofShake128, 16>>::new(
-                *task.id(),
-                aggregation_job_id,
-                *report.metadata().id(),
-                *report.metadata().time(),
-                0,
-                None,
-                ReportAggregationState::Finished,
-            );
         let want_batch_aggregations = Vec::from([BatchAggregation::<
             VERIFY_KEY_LENGTH,
             FixedSize,
@@ -3093,19 +2956,17 @@ mod tests {
                             task.id(),
                             &aggregation_job_id,
                         )
-                        .await?
-                        .unwrap();
+                        .await?;
                     let report_aggregation = tx
                         .get_report_aggregation(
                             vdaf.as_ref(),
                             &Role::Leader,
                             task.id(),
                             &aggregation_job_id,
-                            aggregation_job.aggregation_parameter(),
+                            &aggregation_param,
                             report_metadata.id(),
                         )
-                        .await?
-                        .unwrap();
+                        .await?;
                     let batch_aggregations =
                         FixedSize::get_batch_aggregations_for_collection_identifier::<
                             VERIFY_KEY_LENGTH,
@@ -3151,8 +3012,8 @@ mod tests {
             })
             .collect();
 
-        assert_eq!(want_aggregation_job, got_aggregation_job);
-        assert_eq!(want_report_aggregation, got_report_aggregation);
+        assert!(got_aggregation_job.is_none());
+        assert!(got_report_aggregation.is_none());
         assert_eq!(want_batch_aggregations, got_batch_aggregations);
         assert_eq!(want_batch, got_batch);
         assert_eq!(want_collection_job, got_collection_job);
@@ -3266,10 +3127,7 @@ mod tests {
             .unwrap();
 
         // Verify: check that the datastore state is updated as expected (the aggregation job is
-        // abandoned, the report aggregation is untouched) and sanity-check that the job can no
-        // longer be acquired.
-        let want_aggregation_job = aggregation_job.with_state(AggregationJobState::Abandoned);
-        let want_report_aggregation = report_aggregation;
+        // deleted) and sanity-check that the job can no longer be acquired.
         let want_batch = Batch::<VERIFY_KEY_LENGTH, TimeInterval, Prio3Count>::new(
             *task.id(),
             batch_identifier,
@@ -3289,7 +3147,7 @@ mod tests {
                             task.id(),
                             &aggregation_job_id,
                         )
-                        .await?
+                        .await
                         .unwrap();
                     let report_aggregation = tx
                         .get_report_aggregation(
@@ -3297,25 +3155,27 @@ mod tests {
                             &Role::Leader,
                             task.id(),
                             &aggregation_job_id,
-                            aggregation_job.aggregation_parameter(),
+                            &(),
                             &report_id,
                         )
-                        .await?
+                        .await
                         .unwrap();
                     let batch = tx
                         .get_batch(task.id(), &batch_identifier, &())
-                        .await?
+                        .await
+                        .unwrap()
                         .unwrap();
                     let leases = tx
                         .acquire_incomplete_aggregation_jobs(&StdDuration::from_secs(60), 1)
-                        .await?;
+                        .await
+                        .unwrap();
                     Ok((aggregation_job, report_aggregation, batch, leases))
                 })
             })
             .await
             .unwrap();
-        assert_eq!(want_aggregation_job, got_aggregation_job);
-        assert_eq!(want_report_aggregation, got_report_aggregation);
+        assert!(got_aggregation_job.is_none());
+        assert!(got_report_aggregation.is_none());
         assert_eq!(want_batch, got_batch);
         assert!(got_leases.is_empty());
     }
@@ -3535,37 +3395,30 @@ mod tests {
         failure_mock.assert_async().await;
         assert!(!no_more_requests_mock.matched_async().await);
 
-        // Confirm in the database that the job was abandoned.
+        // Confirm in the database that the job was abandoned, i.e. it has been deleted & the batch
+        // state has been updated appropriately.
         let (got_aggregation_job, got_batch) = ds
             .run_unnamed_tx(|tx| {
                 let task = task.clone();
                 Box::pin(async move {
                     let got_aggregation_job = tx
-                        .get_aggregation_job(task.id(), &aggregation_job_id)
-                        .await?
+                        .get_aggregation_job::<VERIFY_KEY_LENGTH, TimeInterval, Prio3Count>(
+                            task.id(),
+                            &aggregation_job_id,
+                        )
+                        .await
                         .unwrap();
                     let got_batch = tx
                         .get_batch(task.id(), &batch_identifier, &())
-                        .await?
+                        .await
+                        .unwrap()
                         .unwrap();
                     Ok((got_aggregation_job, got_batch))
                 })
             })
             .await
             .unwrap();
-        assert_eq!(
-            got_aggregation_job,
-            AggregationJob::<VERIFY_KEY_LENGTH, TimeInterval, Prio3Count>::new(
-                *task.id(),
-                aggregation_job_id,
-                (),
-                (),
-                Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1))
-                    .unwrap(),
-                AggregationJobState::Abandoned,
-                AggregationJobStep::from(0),
-            ),
-        );
+        assert!(got_aggregation_job.is_none());
         assert_eq!(
             got_batch,
             Batch::<VERIFY_KEY_LENGTH, TimeInterval, Prio3Count>::new(

--- a/aggregator/src/aggregator/batch_creator.rs
+++ b/aggregator/src/aggregator/batch_creator.rs
@@ -17,7 +17,6 @@ use rand::random;
 use std::{
     cmp::{max, min, Ordering},
     collections::{binary_heap::PeekMut, hash_map, BinaryHeap, HashMap, VecDeque},
-    ops::RangeInclusive,
     sync::Arc,
 };
 use tokio::try_join;
@@ -241,7 +240,7 @@ where
                 let outstanding_batch = OutstandingBatch::new(
                     properties.task_id,
                     batch_id,
-                    RangeInclusive::new(0, desired_aggregation_job_size),
+                    desired_aggregation_job_size,
                 );
                 bucket
                     .outstanding_batches
@@ -408,7 +407,7 @@ struct UpdatedOutstandingBatch {
 impl UpdatedOutstandingBatch {
     fn new(outstanding_batch: OutstandingBatch) -> Self {
         Self {
-            new_max_size: *outstanding_batch.size().end(),
+            new_max_size: outstanding_batch.max_size(),
             inner: outstanding_batch,
         }
     }

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -31,7 +31,6 @@ use serde::{Deserialize, Serialize};
 use std::{
     fmt::{Debug, Display, Formatter},
     hash::{Hash, Hasher},
-    ops::RangeInclusive,
 };
 
 // We have to manually implement [Partial]Eq for a number of types because the derived
@@ -1486,20 +1485,18 @@ pub struct OutstandingBatch {
     task_id: TaskId,
     /// The batch ID for this outstanding batch.
     batch_id: BatchId,
-    /// The range of possible sizes of this batch. The minimum size is the count of reports
-    /// which have successfully completed the aggregation process, while the maximum size is the
-    /// count of reports which are currently being aggregated or have successfully completed the
-    /// aggregation process.
-    size: RangeInclusive<usize>,
+    /// The maximum possible size of this batch. The maximum size is the count of reports which are
+    /// currently being aggregated or which have successfully completed the aggregatino process.
+    max_size: usize,
 }
 
 impl OutstandingBatch {
     /// Creates a new [`OutstandingBatch`].
-    pub fn new(task_id: TaskId, batch_id: BatchId, size: RangeInclusive<usize>) -> Self {
+    pub fn new(task_id: TaskId, batch_id: BatchId, max_size: usize) -> Self {
         Self {
             task_id,
             batch_id,
-            size,
+            max_size,
         }
     }
 
@@ -1513,12 +1510,10 @@ impl OutstandingBatch {
         &self.batch_id
     }
 
-    /// Gets the range of possible sizes of this batch. The minimum size is the count of reports
-    /// which have successfully completed the aggregation process, while the maximum size is the
-    /// count of reports which are currently being aggregated or have successfully completed the
-    /// aggregation process.
-    pub fn size(&self) -> &RangeInclusive<usize> {
-        &self.size
+    /// Gets ths maximum possible size of this batch. The maximum size is the count of reports which
+    /// are currently being aggregated or which have successfully completed the aggregatino process.
+    pub fn max_size(&self) -> usize {
+        self.max_size
     }
 }
 

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -1486,7 +1486,7 @@ pub struct OutstandingBatch {
     /// The batch ID for this outstanding batch.
     batch_id: BatchId,
     /// The maximum possible size of this batch. The maximum size is the count of reports which are
-    /// currently being aggregated or which have successfully completed the aggregatino process.
+    /// currently being aggregated or which have successfully completed the aggregation process.
     max_size: usize,
 }
 


### PR DESCRIPTION
We can only eagerly delete Leader aggregation jobs: Helper aggregation jobs need to stick around to allow the possibility of a replayed request.  (I think we could delete them too once an aggregate share request arrives, but I leave that for later improvement.)

I had to update a few other places that were reading this data:
 * Report count per batch used report_aggregations. Now, it reads the number of reports that have successfully completed aggregation -- this is a stronger requirement than before, but I think it's more correct. Notably this is the same condition used to determine which batches can be selected for a current-batch request; I don't see a good reason to let folks collect a batch by ID that would not be selected for current-batch.
 * Outstanding batch size used report_aggregations. Now, it gets a count of reports which have completed aggregation from batch_aggregations, instead.

There were a few places that used this data that didn't need to change:
 * check_other_report_aggregation_exists is Helper-only.
 * Task metrics read report_aggregations, but only to determine how many reports have been aggregated. Since the only information we need from these metrics is now how many reports have been uploaded, this doesn't matter.