### PR TITLE
collect: More user-friendly description of a collection's interval

### DIFF
--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -533,11 +533,15 @@ where
             Q::format_partial_batch_selector(collection.partial_batch_selector())
         );
     }
+    let (start, duration) = collection.interval();
+
     println!("Number of reports: {}", collection.report_count());
+    println!("Interval start: {}", start);
+    println!("Interval end: {}", *start + *duration);
     println!(
-        "Spanned interval: start: {} length: {}",
-        collection.interval().0,
-        collection.interval().1
+        "Interval length: {:?}",
+        // `std::time::Duration` has the most human-readable debug print for a Duration.
+        duration.to_std().map_err(|err| Error::Anyhow(err.into()))?
     );
     println!("Aggregation result: {:?}", collection.aggregate_result());
     Ok(())


### PR DESCRIPTION
Closes #1861--incorporates all suggestions present.

Example output:
```
Batch: Z38FaJX_134j3alqLvuhWH7BkafhyGYNzQlQs2_CLYc
Number of reports: 100
Interval start: 2023-11-13 21:46:00 UTC
Interval end: 2023-11-13 21:47:00 UTC
Interval length: 60s
Aggregation result: 100
```