### PR TITLE
Do not use exponential backoff when acquiring jobs

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -1172,7 +1172,6 @@ mod tests {
                 noop_meter(),
                 stopper.clone(),
                 StdDuration::from_secs(1),
-                StdDuration::from_secs(1),
                 10,
                 StdDuration::from_secs(60),
                 aggregation_job_driver.make_incomplete_job_acquirer_callback(
@@ -3463,7 +3462,6 @@ mod tests {
                 runtime_manager.with_label("stepper"),
                 noop_meter(),
                 stopper.clone(),
-                StdDuration::from_secs(1),
                 StdDuration::from_secs(1),
                 10,
                 StdDuration::from_secs(60),

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -1092,7 +1092,6 @@ mod tests {
                 noop_meter(),
                 stopper.clone(),
                 StdDuration::from_secs(1),
-                StdDuration::from_secs(1),
                 10,
                 StdDuration::from_secs(60),
                 collection_job_driver.make_incomplete_job_acquirer_callback(

--- a/aggregator/src/binaries/aggregation_job_driver.rs
+++ b/aggregator/src/binaries/aggregation_job_driver.rs
@@ -35,8 +35,7 @@ pub async fn main_callback(ctx: BinaryContext<RealClock, Options, Config>) -> Re
         TokioRuntime,
         ctx.meter,
         ctx.stopper,
-        Duration::from_secs(ctx.config.job_driver_config.min_job_discovery_delay_secs),
-        Duration::from_secs(ctx.config.job_driver_config.max_job_discovery_delay_secs),
+        Duration::from_secs(ctx.config.job_driver_config.job_discovery_interval_secs),
         ctx.config.job_driver_config.max_concurrent_job_workers,
         Duration::from_secs(
             ctx.config
@@ -85,9 +84,8 @@ impl BinaryOptions for Options {
 ///   url: "postgres://postgres:postgres@localhost:5432/postgres"
 /// logging_config: # logging_config is optional
 ///   force_json_output: true
-/// min_job_discovery_delay_secs: 10
-/// max_job_discovery_delay_secs: 60
 /// max_concurrent_job_workers: 10
+/// job_discovery_interval_secs: 10
 /// worker_lease_duration_secs: 600
 /// worker_lease_clock_skew_allowance_secs: 60
 /// maximum_attempts_before_failure: 5
@@ -149,8 +147,7 @@ mod tests {
                 health_check_listen_address: SocketAddr::from((Ipv4Addr::UNSPECIFIED, 8080)),
             },
             job_driver_config: JobDriverConfig {
-                min_job_discovery_delay_secs: 10,
-                max_job_discovery_delay_secs: 60,
+                job_discovery_interval_secs: 10,
                 max_concurrent_job_workers: 10,
                 worker_lease_duration_secs: 600,
                 worker_lease_clock_skew_allowance_secs: 60,

--- a/aggregator/src/binaries/collection_job_driver.rs
+++ b/aggregator/src/binaries/collection_job_driver.rs
@@ -35,8 +35,7 @@ pub async fn main_callback(ctx: BinaryContext<RealClock, Options, Config>) -> Re
         TokioRuntime,
         ctx.meter,
         ctx.stopper,
-        Duration::from_secs(ctx.config.job_driver_config.min_job_discovery_delay_secs),
-        Duration::from_secs(ctx.config.job_driver_config.max_job_discovery_delay_secs),
+        Duration::from_secs(ctx.config.job_driver_config.job_discovery_interval_secs),
         ctx.config.job_driver_config.max_concurrent_job_workers,
         Duration::from_secs(
             ctx.config
@@ -85,8 +84,7 @@ impl BinaryOptions for Options {
 ///   url: "postgres://postgres:postgres@localhost:5432/postgres"
 /// logging_config: # logging_config is optional
 ///   force_json_output: true
-/// min_job_discovery_delay_secs: 10
-/// max_job_discovery_delay_secs: 60
+/// job_discovery_interval_secs: 10
 /// max_concurrent_job_workers: 10
 /// worker_lease_duration_secs: 600
 /// worker_lease_clock_skew_allowance_secs: 60
@@ -145,8 +143,7 @@ mod tests {
                 health_check_listen_address: SocketAddr::from((Ipv4Addr::UNSPECIFIED, 8080)),
             },
             job_driver_config: JobDriverConfig {
-                min_job_discovery_delay_secs: 10,
-                max_job_discovery_delay_secs: 60,
+                job_discovery_interval_secs: 10,
                 max_concurrent_job_workers: 10,
                 worker_lease_duration_secs: 600,
                 worker_lease_clock_skew_allowance_secs: 60,

--- a/aggregator/src/binary_utils/job_driver.rs
+++ b/aggregator/src/binary_utils/job_driver.rs
@@ -157,7 +157,7 @@ where
             // concurrently with us acquiring jobs; but that's OK, since this can only make us
             // underestimate the number of jobs we can acquire, and underestimation is acceptable
             // (we'll pick up any additional jobs on the next iteration of this loop). We can't
-            // overestimate since this task is the only place that permits are acquired.
+            // overestimate since this task is the only place that leases are acquired.
             let max_acquire_count = sem.available_permits();
             let start = Instant::now();
             debug!(%max_acquire_count, "Acquiring jobs");

--- a/aggregator/src/config.rs
+++ b/aggregator/src/config.rs
@@ -2,12 +2,16 @@
 
 use crate::{metrics::MetricsConfiguration, trace::TraceConfiguration};
 use derivative::Derivative;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{
+    de::{DeserializeOwned, Error as _},
+    Deserialize, Deserializer, Serialize,
+};
 use std::{
     fmt::Debug,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::PathBuf,
 };
+use tracing::warn;
 use url::Url;
 
 /// Configuration options common to all Janus binaries.
@@ -113,8 +117,7 @@ pub struct TaskprovConfig {
 ///
 /// let yaml_config = r#"
 /// ---
-/// min_job_discovery_delay_secs: 10
-/// max_job_discovery_delay_secs: 60
+/// job_discovery_interval_secs: 10
 /// max_concurrent_job_workers: 10
 /// worker_lease_duration_secs: 600
 /// worker_lease_clock_skew_allowance_secs: 60
@@ -123,14 +126,12 @@ pub struct TaskprovConfig {
 ///
 /// let _decoded: JobDriverConfig = serde_yaml::from_str(yaml_config).unwrap();
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct JobDriverConfig {
-    /// The minimum delay between checking for jobs ready to be stepped, in seconds. Applies only
-    /// when there are no jobs to be stepped.
-    pub min_job_discovery_delay_secs: u64,
     /// The maximum delay between checking for jobs ready to be stepped, in seconds. Applies only
-    /// when there are no jobs to be stepped.
-    pub max_job_discovery_delay_secs: u64,
+    /// when there are no jobs to be stepped. The actual wait time is randomly chosen in the interval
+    /// `[0, job_discovery_interval)`.
+    pub job_discovery_interval_secs: u64,
     /// The maximum number of jobs being stepped at once. This parameter determines the amount of
     /// per-process concurrency.
     pub max_concurrent_job_workers: usize,
@@ -145,6 +146,38 @@ pub struct JobDriverConfig {
     /// The number of attempts to drive a work item before it is placed in a permanent failure
     /// state.
     pub maximum_attempts_before_failure: usize,
+}
+
+// TODO(#2252): This custom deserializer is for backwards-compatibility with Janus 0.6.3 and below.
+// Remove it for the next major version of Janus.
+impl<'de> Deserialize<'de> for JobDriverConfig {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        struct JobDriverConfigInner {
+            max_job_discovery_delay_secs: Option<u64>,
+            job_discovery_interval_secs: Option<u64>,
+            max_concurrent_job_workers: usize,
+            worker_lease_duration_secs: u64,
+            worker_lease_clock_skew_allowance_secs: u64,
+            maximum_attempts_before_failure: usize,
+        }
+        let inner = JobDriverConfigInner::deserialize(deserializer)?;
+        let job_discovery_interval_secs = inner
+            .job_discovery_interval_secs
+            .or_else(||{
+                warn!("job_discovery_interval_secs is missing, falling back to deprecated field max_job_discovery_delay_secs");
+                inner.max_job_discovery_delay_secs
+            })
+            .ok_or(D::Error::custom("required field job_discovery_interval_secs is missing"))?;
+
+        Ok(Self {
+            job_discovery_interval_secs,
+            max_concurrent_job_workers: inner.max_concurrent_job_workers,
+            worker_lease_duration_secs: inner.worker_lease_duration_secs,
+            worker_lease_clock_skew_allowance_secs: inner.worker_lease_clock_skew_allowance_secs,
+            maximum_attempts_before_failure: inner.maximum_attempts_before_failure,
+        })
+    }
 }
 
 #[cfg(feature = "test-util")]
@@ -242,13 +275,26 @@ mod tests {
     #[test]
     fn roundtrip_job_driver_config() {
         roundtrip_encoding(JobDriverConfig {
-            min_job_discovery_delay_secs: 10,
-            max_job_discovery_delay_secs: 60,
+            job_discovery_interval_secs: 10,
             max_concurrent_job_workers: 10,
             worker_lease_duration_secs: 600,
             worker_lease_clock_skew_allowance_secs: 60,
             maximum_attempts_before_failure: 5,
         })
+    }
+
+    #[test]
+    fn job_driver_config_backcompat() {
+        let input = concat!(
+            "min_job_discovery_delay_secs: 10\n",
+            "max_job_discovery_delay_secs: 60\n",
+            "max_concurrent_job_workers: 10\n",
+            "worker_lease_duration_secs: 600\n",
+            "worker_lease_clock_skew_allowance_secs: 60\n",
+            "maximum_attempts_before_failure: 5\n",
+        );
+        let config: JobDriverConfig = serde_yaml::from_str(input).unwrap();
+        assert_eq!(config.job_discovery_interval_secs, 60);
     }
 
     #[test]

--- a/aggregator/src/config.rs
+++ b/aggregator/src/config.rs
@@ -128,9 +128,8 @@ pub struct TaskprovConfig {
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct JobDriverConfig {
-    /// The maximum delay between checking for jobs ready to be stepped, in seconds. Applies only
-    /// when there are no jobs to be stepped. The actual wait time is randomly chosen in the interval
-    /// `[0, job_discovery_interval)`.
+    /// The delay between checking for jobs ready to be stepped, in seconds. Applies only when
+    /// there are no jobs to be stepped.
     pub job_discovery_interval_secs: u64,
     /// The maximum number of jobs being stepped at once. This parameter determines the amount of
     /// per-process concurrency.

--- a/aggregator/tests/integration/graceful_shutdown.rs
+++ b/aggregator/tests/integration/graceful_shutdown.rs
@@ -311,8 +311,7 @@ async fn aggregation_job_driver_shutdown() {
             health_check_listen_address: "127.0.0.1:9001".parse().unwrap(),
         },
         job_driver_config: JobDriverConfig {
-            min_job_discovery_delay_secs: 10,
-            max_job_discovery_delay_secs: 60,
+            job_discovery_interval_secs: 10,
             max_concurrent_job_workers: 10,
             worker_lease_duration_secs: 600,
             worker_lease_clock_skew_allowance_secs: 60,
@@ -341,8 +340,7 @@ async fn collection_job_driver_shutdown() {
             health_check_listen_address: "127.0.0.1:9001".parse().unwrap(),
         },
         job_driver_config: JobDriverConfig {
-            min_job_discovery_delay_secs: 10,
-            max_job_discovery_delay_secs: 60,
+            job_discovery_interval_secs: 10,
             max_concurrent_job_workers: 10,
             worker_lease_duration_secs: 600,
             worker_lease_clock_skew_allowance_secs: 60,

--- a/docs/samples/advanced_config/aggregation_job_driver.yaml
+++ b/docs/samples/advanced_config/aggregation_job_driver.yaml
@@ -70,11 +70,8 @@ metrics_config:
 
 # Aggregation job driver-related parameters:
 
-# Minimum interval on which to acquire incomplete aggregation jobs. (required)
-min_job_discovery_delay_secs: 10
-
 # Maximum interval on which to acquire incomplete aggregation jobs. (required)
-max_job_discovery_delay_secs: 60
+job_discovery_interval_secs: 10
 
 # Maximum number of aggregation jobs to step concurrently. (required)
 max_concurrent_job_workers: 10

--- a/docs/samples/advanced_config/collection_job_driver.yaml
+++ b/docs/samples/advanced_config/collection_job_driver.yaml
@@ -70,11 +70,8 @@ metrics_config:
 
 # Collection job driver-related parameters:
 
-# Minimum interval on which to acquire incomplete collection jobs. (required)
-min_job_discovery_delay_secs: 10
-
 # Maximum interval on which to acquire incomplete collection jobs. (required)
-max_job_discovery_delay_secs: 60
+job_discovery_interval_secs: 10
 
 # Maximum number of collection jobs to step concurrently. (required)
 max_concurrent_job_workers: 10

--- a/docs/samples/basic_config/aggregation_job_driver.yaml
+++ b/docs/samples/basic_config/aggregation_job_driver.yaml
@@ -9,11 +9,8 @@ health_check_listen_address: "0.0.0.0:8000"
 
 # Aggregation job driver-related parameters:
 
-# Minimum interval on which to acquire incomplete aggregation jobs. (required)
-min_job_discovery_delay_secs: 10
-
 # Maximum interval on which to acquire incomplete aggregation jobs. (required)
-max_job_discovery_delay_secs: 60
+job_discovery_interval_secs: 10
 
 # Maximum number of aggregation jobs to step concurrently. (required)
 max_concurrent_job_workers: 10

--- a/docs/samples/basic_config/collection_job_driver.yaml
+++ b/docs/samples/basic_config/collection_job_driver.yaml
@@ -9,11 +9,8 @@ health_check_listen_address: "0.0.0.0:8000"
 
 # Collection job driver-related parameters:
 
-# Minimum interval on which to acquire incomplete collection jobs. (required)
-min_job_discovery_delay_secs: 10
-
 # Maximum interval on which to acquire incomplete collection jobs. (required)
-max_job_discovery_delay_secs: 60
+job_discovery_interval_secs: 10
 
 # Maximum number of collection jobs to step concurrently. (required)
 max_concurrent_job_workers: 10

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -177,8 +177,7 @@ impl JanusInProcess {
         let aggregation_job_driver_config = AggregationJobDriverConfig {
             common_config: common_config.clone(),
             job_driver_config: JobDriverConfig {
-                min_job_discovery_delay_secs: 1,
-                max_job_discovery_delay_secs: 2,
+                job_discovery_interval_secs: 1,
                 max_concurrent_job_workers: 10,
                 worker_lease_duration_secs: 10,
                 worker_lease_clock_skew_allowance_secs: 1,
@@ -193,8 +192,7 @@ impl JanusInProcess {
         let collection_job_driver_config = CollectionJobDriverConfig {
             common_config,
             job_driver_config: JobDriverConfig {
-                min_job_discovery_delay_secs: 1,
-                max_job_discovery_delay_secs: 2,
+                job_discovery_interval_secs: 1,
                 max_concurrent_job_workers: 10,
                 worker_lease_duration_secs: 10,
                 worker_lease_clock_skew_allowance_secs: 1,

--- a/interop_binaries/config/aggregation_job_driver.yaml
+++ b/interop_binaries/config/aggregation_job_driver.yaml
@@ -7,8 +7,7 @@ database:
 health_check_listen_address: 0.0.0.0:8002
 logging_config:
   force_json_output: true
-min_job_discovery_delay_secs: 1
-max_job_discovery_delay_secs: 2
+job_discovery_interval_secs: 2
 max_concurrent_job_workers: 10
 worker_lease_clock_skew_allowance_secs: 1
 worker_lease_duration_secs: 10

--- a/interop_binaries/config/collection_job_driver.yaml
+++ b/interop_binaries/config/collection_job_driver.yaml
@@ -7,8 +7,7 @@ database:
 health_check_listen_address: 0.0.0.0:8003
 logging_config:
   force_json_output: true
-min_job_discovery_delay_secs: 1
-max_job_discovery_delay_secs: 2
+job_discovery_interval_secs: 2
 max_concurrent_job_workers: 10
 worker_lease_clock_skew_allowance_secs: 1
 worker_lease_duration_secs: 10


### PR DESCRIPTION
Replaces the exponential backoff strategy used in job drivers with the fixed interval with random jitter strategy used by the job creator.

The configuration parameters min_job_discovery_delay_secs and max_job_discovery_delay_secs are deprecated and replaced with the parameter job_discovery_interval_secs. The configuration changes are backwards compatible--if job_discovery_interval_secs is not present we use the value max_job_discovery_delay_secs in its place.

Closes https://github.com/divviup/janus/issues/2252