### PR TITLE
Garbage collector observability improvements

### DIFF
--- a/aggregator/src/aggregator/garbage_collector.rs
+++ b/aggregator/src/aggregator/garbage_collector.rs
@@ -55,6 +55,7 @@ impl<C: Clock> GarbageCollector<C> {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self, task), fields(task_id = ?task.id()), err)]
     async fn gc_task(&self, task: Arc<AggregatorTask>) -> Result<()> {
         self.datastore
             .run_tx("garbage_collector", |tx| {

--- a/aggregator/src/aggregator/garbage_collector.rs
+++ b/aggregator/src/aggregator/garbage_collector.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use futures::future::join_all;
 use janus_aggregator_core::{datastore::Datastore, task::AggregatorTask};
 use janus_core::time::Clock;
+use opentelemetry::metrics::{Counter, Meter, Unit};
 use std::sync::Arc;
 use tokio::try_join;
 use tracing::error;
@@ -14,20 +15,49 @@ pub struct GarbageCollector<C: Clock> {
     report_limit: u64,
     aggregation_limit: u64,
     collection_limit: u64,
+
+    // Metrics.
+    deleted_report_counter: Counter<u64>,
+    deleted_aggregation_job_counter: Counter<u64>,
+    deleted_batch_counter: Counter<u64>,
 }
 
 impl<C: Clock> GarbageCollector<C> {
     pub fn new(
         datastore: Arc<Datastore<C>>,
+        meter: &Meter,
         report_limit: u64,
         aggregation_limit: u64,
         collection_limit: u64,
     ) -> Self {
+        let deleted_report_counter = meter
+            .u64_counter("janus_gc_deleted_reports")
+            .with_description("Count of client reports deleted by the garbage collector.")
+            .with_unit(Unit::new("{report}"))
+            .init();
+        let deleted_aggregation_job_counter = meter
+            .u64_counter("janus_gc_deleted_aggregation_jobs")
+            .with_description("Count of aggregation jobs deleted by the garbage collector.")
+            .with_unit(Unit::new("{job}"))
+            .init();
+        let deleted_batch_counter = meter
+            .u64_counter("janus_gc_deleted_batches")
+            .with_description("Count of batches deleted by the garbage collector.")
+            .with_unit(Unit::new("{batch}"))
+            .init();
+
+        deleted_report_counter.add(0, &[]);
+        deleted_aggregation_job_counter.add(0, &[]);
+        deleted_batch_counter.add(0, &[]);
+
         Self {
             datastore,
             report_limit,
             aggregation_limit,
             collection_limit,
+            deleted_report_counter,
+            deleted_aggregation_job_counter,
+            deleted_batch_counter,
         }
     }
 
@@ -57,7 +87,8 @@ impl<C: Clock> GarbageCollector<C> {
 
     #[tracing::instrument(skip(self, task), fields(task_id = ?task.id()), err)]
     async fn gc_task(&self, task: Arc<AggregatorTask>) -> Result<()> {
-        self.datastore
+        let (client_reports_deleted, aggregation_jobs_deleted, batches_deleted) = self
+            .datastore
             .run_tx("garbage_collector", |tx| {
                 let task = Arc::clone(&task);
                 let report_limit = self.report_limit;
@@ -69,11 +100,14 @@ impl<C: Clock> GarbageCollector<C> {
                         tx.delete_expired_client_reports(task.id(), report_limit),
                         tx.delete_expired_aggregation_artifacts(task.id(), aggregation_limit),
                         tx.delete_expired_collection_artifacts(task.id(), collection_limit),
-                    )?;
-                    Ok(())
+                    )
                 })
             })
             .await?;
+        self.deleted_report_counter.add(client_reports_deleted, &[]);
+        self.deleted_aggregation_job_counter
+            .add(aggregation_jobs_deleted, &[]);
+        self.deleted_batch_counter.add(batches_deleted, &[]);
         Ok(())
     }
 }
@@ -91,6 +125,7 @@ mod tests {
             test_util::ephemeral_datastore,
         },
         task::{self, test_util::TaskBuilder},
+        test_util::noop_meter,
     };
     use janus_core::{
         test_util::{
@@ -226,6 +261,7 @@ mod tests {
         let task = Arc::new(task);
         GarbageCollector::new(
             Arc::clone(&ds),
+            &noop_meter(),
             u64::try_from(i64::MAX).unwrap(),
             u64::try_from(i64::MAX).unwrap(),
             u64::try_from(i64::MAX).unwrap(),
@@ -416,6 +452,7 @@ mod tests {
         let task = Arc::new(task);
         GarbageCollector::new(
             Arc::clone(&ds),
+            &noop_meter(),
             u64::try_from(i64::MAX).unwrap(),
             u64::try_from(i64::MAX).unwrap(),
             u64::try_from(i64::MAX).unwrap(),
@@ -597,6 +634,7 @@ mod tests {
         let task = Arc::new(task);
         GarbageCollector::new(
             Arc::clone(&ds),
+            &noop_meter(),
             u64::try_from(i64::MAX).unwrap(),
             u64::try_from(i64::MAX).unwrap(),
             u64::try_from(i64::MAX).unwrap(),
@@ -793,6 +831,7 @@ mod tests {
         let task = Arc::new(task);
         GarbageCollector::new(
             Arc::clone(&ds),
+            &noop_meter(),
             u64::try_from(i64::MAX).unwrap(),
             u64::try_from(i64::MAX).unwrap(),
             u64::try_from(i64::MAX).unwrap(),

--- a/aggregator/src/binaries/aggregator.rs
+++ b/aggregator/src/binaries/aggregator.rs
@@ -76,6 +76,7 @@ async fn run_aggregator(
             if let Some(gc_config) = gc_config {
                 let gc = GarbageCollector::new(
                     datastore,
+                    &meter,
                     gc_config.report_limit,
                     gc_config.aggregation_limit,
                     gc_config.collection_limit,

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -4086,12 +4086,13 @@ impl<C: Clock> Transaction<'_, C> {
 
     /// Deletes old client reports for a given task, that is, client reports whose timestamp is
     /// older than the task's report expiry age. Up to `limit` client reports will be deleted.
+    /// Returns the number of client reports deleted.
     #[tracing::instrument(skip(self), err)]
     pub async fn delete_expired_client_reports(
         &self,
         task_id: &TaskId,
         limit: u64,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         let stmt = self
             .prepare_cached(
                 "WITH client_reports_to_delete AS (
@@ -4114,20 +4115,21 @@ impl<C: Clock> Transaction<'_, C> {
                 /* limit */ &i64::try_from(limit)?,
             ],
         )
-        .await?;
-        Ok(())
+        .await
+        .map_err(Into::into)
     }
 
     /// Deletes old aggregation artifacts (aggregation jobs/report aggregations) for a given task,
     /// that is, aggregation artifacts for which the aggregation job's maximum client timestamp is
     /// older than the task's report expiry age. Up to `limit` aggregation jobs will be deleted,
-    /// along with all related aggregation artifacts.
+    /// along with all related aggregation artifacts. Returns the number of aggregation jobs
+    /// deleted.
     #[tracing::instrument(skip(self), err)]
     pub async fn delete_expired_aggregation_artifacts(
         &self,
         task_id: &TaskId,
         limit: u64,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         let stmt = self
             .prepare_cached(
                 "WITH task_id AS (SELECT id FROM tasks WHERE task_id = $1),
@@ -4155,8 +4157,8 @@ impl<C: Clock> Transaction<'_, C> {
                 /* limit */ &i64::try_from(limit)?,
             ],
         )
-        .await?;
-        Ok(())
+        .await
+        .map_err(Into::into)
     }
 
     /// Deletes old collection artifacts (batches/outstanding batches/batch aggregations/collection
@@ -4177,12 +4179,14 @@ impl<C: Clock> Transaction<'_, C> {
     ///     for GC if the related batch is eligible for GC.
     ///
     /// Up to `limit` batches will be deleted, along with all related collection artifacts.
+    ///
+    /// Returns the number of batches deleted.
     #[tracing::instrument(skip(self), err)]
     pub async fn delete_expired_collection_artifacts(
         &self,
         task_id: &TaskId,
         limit: u64,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         let stmt = self
             .prepare_cached(
                 "WITH batches_to_delete AS (
@@ -4237,8 +4241,8 @@ impl<C: Clock> Transaction<'_, C> {
                 /* limit */ &i64::try_from(limit)?,
             ],
         )
-        .await?;
-        Ok(())
+        .await
+        .map_err(Into::into)
     }
 
     /// Retrieve all global HPKE keypairs.


### PR DESCRIPTION
This adds a tracing span around the `gc_task()` method (which will be helpful in the event we see events fired from the datastore methods) and counter metrics that add up the total number of deleted rows from three of the tables.