### PR TITLE
Remove direct configuration of OTLP gRPC metadata

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,6 @@ updates:
           - opentelemetry
           - opentelemetry-*
           - opentelemetry_*
-          - tonic
       trillium:
         patterns:
           - trillium
@@ -89,7 +88,6 @@ updates:
         patterns:
           - opentelemetry
           - opentelemetry-*
-          - tonic
       trillium:
         patterns:
           - trillium

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1939,7 +1939,6 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tokio-postgres-rustls",
- "tonic 0.9.2",
  "tracing",
  "tracing-chrome",
  "tracing-log",
@@ -3628,7 +3627,7 @@ checksum = "446e14c5cda4f3f30fe71863c34ec70f5ac79d6087097ad0bb433e1be5edf04c"
 dependencies = [
  "log",
  "ring 0.17.5",
- "rustls-webpki 0.101.7",
+ "rustls-webpki",
  "sct",
 ]
 
@@ -3651,16 +3650,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.5",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.100.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e98ff011474fa39949b7e5c0428f9b4937eda7da7848bbb947786b7be0b27dab"
-dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -4694,7 +4683,6 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
- "async-stream",
  "async-trait",
  "axum",
  "base64 0.21.5",
@@ -4709,15 +4697,12 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost 0.11.9",
- "rustls-pemfile",
  "tokio",
- "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
- "webpki-roots 0.23.1",
 ]
 
 [[package]]
@@ -5406,20 +5391,11 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
-dependencies = [
- "rustls-webpki 0.100.2",
-]
-
-[[package]]
-name = "webpki-roots"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b291546d5d9d1eab74f069c77749f2cb8504a12caa20f0f2de93ddbf6f411888"
 dependencies = [
- "rustls-webpki 0.101.7",
+ "rustls-webpki",
 ]
 
 [[package]]

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -20,7 +20,6 @@ otlp = [
     "dep:tracing-opentelemetry",
     "dep:opentelemetry-otlp",
     "dep:opentelemetry-semantic-conventions",
-    "dep:tonic",
 ]
 prometheus = ["dep:opentelemetry-prometheus", "dep:prometheus"]
 test-util = [
@@ -58,7 +57,7 @@ janus_messages.workspace = true
 k8s-openapi.workspace = true
 kube.workspace = true
 opentelemetry.workspace = true
-opentelemetry-otlp = { version = "0.14", optional = true, features = ["metrics"] }  # ensure that the version of tonic below matches what this uses
+opentelemetry-otlp = { version = "0.14", optional = true, features = ["metrics"] }
 opentelemetry-prometheus = { version = "0.14", optional = true }
 opentelemetry_sdk = { workspace = true, features = ["rt-tokio"] }
 opentelemetry-semantic-conventions = { version = "0.13", optional = true }
@@ -84,7 +83,6 @@ thiserror.workspace = true
 tokio.workspace = true
 tokio-postgres = { version = "0.7.10", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1", "array-impls"] }
 tokio-postgres-rustls = "0.10.0"
-tonic = { version = "0.9.2", optional = true, features = ["tls", "tls-webpki-roots"] }  # keep this version in sync with what opentelemetry-otlp uses
 tracing = "0.1.40"
 tracing-chrome = "0.7.1"
 tracing-log = "0.2.0"

--- a/aggregator/src/binaries/aggregator.rs
+++ b/aggregator/src/binaries/aggregator.rs
@@ -435,7 +435,6 @@ mod tests {
     use clap::CommandFactory;
     use janus_core::test_util::roundtrip_encoding;
     use std::{
-        collections::HashMap,
         net::{IpAddr, Ipv4Addr, SocketAddr},
         time::Duration,
     };
@@ -739,7 +738,6 @@ mod tests {
             Some(OpenTelemetryTraceConfiguration::Otlp(
                 OtlpTraceConfiguration {
                     endpoint: "http://localhost:4317".to_string(),
-                    metadata: HashMap::new()
                 }
             )),
         );
@@ -756,8 +754,6 @@ mod tests {
         open_telemetry_config:
             otlp:
                 endpoint: "https://api.honeycomb.io:443"
-                metadata:
-                    x-honeycomb-team: "YOUR_API_KEY"
     max_upload_batch_size: 100
     max_upload_batch_write_delay_ms: 250
     batch_aggregation_shard_count: 32
@@ -770,10 +766,6 @@ mod tests {
             Some(OpenTelemetryTraceConfiguration::Otlp(
                 OtlpTraceConfiguration {
                     endpoint: "https://api.honeycomb.io:443".to_string(),
-                    metadata: HashMap::from([(
-                        "x-honeycomb-team".to_string(),
-                        "YOUR_API_KEY".to_string(),
-                    )]),
                 },
             )),
         );
@@ -818,9 +810,6 @@ mod tests {
         exporter:
             otlp:
                 endpoint: "https://api.honeycomb.io:443"
-                metadata:
-                    x-honeycomb-team: "YOUR_API_KEY"
-                    x-honeycomb-dataset: "YOUR_METRICS_DATASET"
     max_upload_batch_size: 100
     max_upload_batch_write_delay_ms: 250
     batch_aggregation_shard_count: 32
@@ -833,13 +822,6 @@ mod tests {
             Some(MetricsExporterConfiguration::Otlp(
                 OtlpExporterConfiguration {
                     endpoint: "https://api.honeycomb.io:443".to_string(),
-                    metadata: HashMap::from([
-                        ("x-honeycomb-team".to_string(), "YOUR_API_KEY".to_string()),
-                        (
-                            "x-honeycomb-dataset".to_string(),
-                            "YOUR_METRICS_DATASET".to_string(),
-                        ),
-                    ]),
                 },
             )),
         );

--- a/aggregator/src/config.rs
+++ b/aggregator/src/config.rs
@@ -159,7 +159,6 @@ pub mod test_util {
         },
     };
     use reqwest::Url;
-    use std::collections::HashMap;
 
     pub fn generate_db_config() -> DbConfig {
         DbConfig {
@@ -182,10 +181,6 @@ pub mod test_util {
             open_telemetry_config: Some(OpenTelemetryTraceConfiguration::Otlp(
                 OtlpTraceConfiguration {
                     endpoint: "127.0.0.1:6668".to_string(),
-                    metadata: HashMap::from([
-                        ("metadata_key_0".to_string(), "metadata_value_0".to_string()),
-                        ("metadata_key_1".to_string(), "metadata_value_1".to_string()),
-                    ]),
                 },
             )),
             chrome: false,
@@ -260,30 +255,22 @@ mod tests {
             "  open_telemetry_config:\n",
             "    otlp:\n",
             "      endpoint: \"https://example.com/\"\n",
-            "      metadata:\n",
-            "        key: \"value\"\n",
             "metrics_config:\n",
             "  exporter:\n",
             "    otlp:\n",
             "      endpoint: \"https://example.com/\"\n",
-            "      metadata:\n",
-            "        key: \"value\"\n",
         );
         let config: CommonConfig = serde_yaml::from_str(input).unwrap();
         assert_matches!(
             config.logging_config.open_telemetry_config.unwrap(),
             OpenTelemetryTraceConfiguration::Otlp(otlp_config) => {
                 assert_eq!(otlp_config.endpoint, "https://example.com/");
-                assert_eq!(otlp_config.metadata.len(), 1);
-                assert_eq!(otlp_config.metadata.get("key").unwrap(), "value");
             }
         );
         assert_matches!(
             config.metrics_config.exporter.unwrap(),
             MetricsExporterConfiguration::Otlp(otlp_config) => {
                 assert_eq!(otlp_config.endpoint, "https://example.com/");
-                assert_eq!(otlp_config.metadata.len(), 1);
-                assert_eq!(otlp_config.metadata.get("key").unwrap(), "value");
             }
         )
     }

--- a/aggregator/tests/cmd/aggregation_job_creator.trycmd
+++ b/aggregator/tests/cmd/aggregation_job_creator.trycmd
@@ -11,10 +11,6 @@ Options:
           PostgreSQL password [env: PGPASSWORD]
       --datastore-keys <DATASTORE_KEYS>
           datastore encryption keys, encoded in url-safe unpadded base64 then comma-separated [env: DATASTORE_KEYS]
-      --otlp-tracing-metadata <KEY=value>
-          additional OTLP/gRPC metadata key/value pairs for the tracing exporter [env: OTLP_TRACING_METADATA=]
-      --otlp-metrics-metadata <KEY=value>
-          additional OTLP/gRPC metadata key/value pairs for the metrics exporter [env: OTLP_METRICS_METADATA=]
   -h, --help
           Print help
   -V, --version

--- a/aggregator/tests/cmd/aggregation_job_driver.trycmd
+++ b/aggregator/tests/cmd/aggregation_job_driver.trycmd
@@ -11,10 +11,6 @@ Options:
           PostgreSQL password [env: PGPASSWORD]
       --datastore-keys <DATASTORE_KEYS>
           datastore encryption keys, encoded in url-safe unpadded base64 then comma-separated [env: DATASTORE_KEYS]
-      --otlp-tracing-metadata <KEY=value>
-          additional OTLP/gRPC metadata key/value pairs for the tracing exporter [env: OTLP_TRACING_METADATA=]
-      --otlp-metrics-metadata <KEY=value>
-          additional OTLP/gRPC metadata key/value pairs for the metrics exporter [env: OTLP_METRICS_METADATA=]
   -h, --help
           Print help
   -V, --version

--- a/aggregator/tests/cmd/aggregator.trycmd
+++ b/aggregator/tests/cmd/aggregator.trycmd
@@ -11,10 +11,6 @@ Options:
           PostgreSQL password [env: PGPASSWORD]
       --datastore-keys <DATASTORE_KEYS>
           datastore encryption keys, encoded in url-safe unpadded base64 then comma-separated [env: DATASTORE_KEYS]
-      --otlp-tracing-metadata <KEY=value>
-          additional OTLP/gRPC metadata key/value pairs for the tracing exporter [env: OTLP_TRACING_METADATA=]
-      --otlp-metrics-metadata <KEY=value>
-          additional OTLP/gRPC metadata key/value pairs for the metrics exporter [env: OTLP_METRICS_METADATA=]
       --aggregator-api-auth-tokens [<AGGREGATOR_API_AUTH_TOKENS>]
           aggregator API auth tokens, encoded in base64 then comma-separated [env: AGGREGATOR_API_AUTH_TOKENS]
   -h, --help

--- a/docs/CONFIGURING_METRICS.md
+++ b/docs/CONFIGURING_METRICS.md
@@ -28,19 +28,14 @@ will fall back to the environment variables `OTEL_EXPORTER_PROMETHEUS_HOST` and
 
 Honeycomb also supports OpenTelemetry-formatted metrics, though only on the
 Enterprise and Pro plans. Compile `janus_aggregator` with the `otlp` feature
-enabled, and add the following section to the configuration file. Note that the
-OTLP/gRPC exporter will push metrics at regular intervals.
+enabled, add the following section to the configuration file, and provide your
+Honeycomb API key through an environment variable of the form
+`OTEL_EXPORTER_OTLP_HEADERS=x-honeycomb-team=YOUR_API_KEY,x-honeycomb-dataset=YOUR_METRICS_DATASET`.
+Note that the OTLP/gRPC exporter will push metrics at regular intervals.
 
 ```yaml
 metrics_config:
   exporter:
     otlp:
       endpoint: "https://api.honeycomb.io:443"
-      metadata:
-        x-honeycomb-team: "YOUR_API_KEY"
-        x-honeycomb-dataset: "YOUR_METRICS_DATASET"
 ```
-
-The command line flag `--otlp-metrics-metadata` or environment variable
-`OTLP_METRICS_METADATA` may alternately be used to supply gRPC metadata for the
-metrics exporter.

--- a/docs/CONFIGURING_TRACING.md
+++ b/docs/CONFIGURING_TRACING.md
@@ -34,18 +34,14 @@ logging_config:
 offers an integrated observability tool. To use it, sign up for an account,
 create a team and environment, and retrieve the corresponding API key. Compile
 `janus_aggregator` with the `otlp` feature enabled, to pull in the OTLP
-exporter. Add the following section to the configuration file, subtituting in
-the Honeycomb API key. Traces will be sent to Honeycomb via OTLP/gRPC.
+exporter. Add the following section to the configuration file, and provide your
+Honeycomb API key through an environment variable of the form
+`OTEL_EXPORTER_OTLP_HEADERS=x-honeycomb-team=YOUR_API_KEY`. Traces will be sent
+to Honeycomb via OTLP/gRPC.
 
 ```yaml
 logging_config:
   open_telemetry_config:
     otlp:
       endpoint: "https://api.honeycomb.io:443"
-      metadata:
-        x-honeycomb-team: "YOUR_API_KEY"
 ```
-
-The gRPC metadata can also be specified on the command line, with
-`--otlp-tracing-metadata x-honeycomb-team=YOUR_API_KEY`, or through the
-environment variable `OTLP_TRACING_METADATA`.


### PR DESCRIPTION
This takes advantage of support in the latest version of `opentelemetry-otlp` for reading additional metadata/headers from [standard environment variables](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.25.0/specification/protocol/exporter.md#specifying-headers-via-environment-variables). Support for setting these is removed from our configuration files and from our command-line interface, and documentation is updated with an example of how to pass them in via the environment. This is mainly relevant when using Honeycomb.