### PR TITLE
Replace most Row::try_get() calls with Row::get()

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -65,3 +65,11 @@ To create a new migration:
 * Follow documented best practices of the crates Janus depends on. For example,
   the `rand` crate suggests using `random()` to generate random data, falling
   back to `thread_rng()` to gain more control as-needed.
+
+* Prefer `tokio_postgres::Row::get()` over `tokio_postgres::Row::try_get()`.
+  The former panics if the column is not found in the row, or if the `FromSql`
+  conversion fails. In cases where a column is not present in a query, or when
+  it is not of the right Postgres data type, this represents a programmer error,
+  so a panic is appropriate. (Note that some `FromSql` implementations may
+  return errors for other reasons, such as out-of-range values or serde
+  deserialization falures)


### PR DESCRIPTION
This replaces most `try_get()` calls with `get()`, to follow our convention in this file. I left the ones of type `Json<T>` alone for now: in addition to mismatched column names and unsupported Postgres data types, those can also error/panic if the serde deserialization fails, which is a less clear signal of a source code-level mistake. We could leave them be, or do `row::get<_, serde_json::Value>("...")` and `serde_json::from_value(...).map_err(|e| Error::DbState(...))?`, at the expense of some allocations, in order to more tightly follow our conventions.