### PR TITLE
Do not use exponential backoff when acquiring jobs (#2253 release/0.5 backport)

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -1098,7 +1098,6 @@ mod tests {
                 noop_meter(),
                 stopper.clone(),
                 StdDuration::from_secs(1),
-                StdDuration::from_secs(1),
                 10,
                 StdDuration::from_secs(60),
                 aggregation_job_driver.make_incomplete_job_acquirer_callback(
@@ -2879,7 +2878,6 @@ mod tests {
                 runtime_manager.with_label("stepper"),
                 noop_meter(),
                 stopper.clone(),
-                StdDuration::from_secs(1),
                 StdDuration::from_secs(1),
                 10,
                 StdDuration::from_secs(60),

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -1068,7 +1068,6 @@ mod tests {
                 noop_meter(),
                 stopper.clone(),
                 StdDuration::from_secs(1),
-                StdDuration::from_secs(1),
                 10,
                 StdDuration::from_secs(60),
                 collection_job_driver.make_incomplete_job_acquirer_callback(

--- a/aggregator/src/bin/aggregation_job_driver.rs
+++ b/aggregator/src/bin/aggregation_job_driver.rs
@@ -43,8 +43,7 @@ async fn main() -> anyhow::Result<()> {
             TokioRuntime,
             ctx.meter,
             stopper,
-            Duration::from_secs(ctx.config.job_driver_config.min_job_discovery_delay_secs),
-            Duration::from_secs(ctx.config.job_driver_config.max_job_discovery_delay_secs),
+            Duration::from_secs(ctx.config.job_driver_config.job_discovery_interval_secs),
             ctx.config.job_driver_config.max_concurrent_job_workers,
             Duration::from_secs(
                 ctx.config
@@ -158,8 +157,7 @@ mod tests {
                 health_check_listen_address: SocketAddr::from((Ipv4Addr::UNSPECIFIED, 8080)),
             },
             job_driver_config: JobDriverConfig {
-                min_job_discovery_delay_secs: 10,
-                max_job_discovery_delay_secs: 60,
+                job_discovery_interval_secs: 10,
                 max_concurrent_job_workers: 10,
                 worker_lease_duration_secs: 600,
                 worker_lease_clock_skew_allowance_secs: 60,

--- a/aggregator/src/bin/collection_job_driver.rs
+++ b/aggregator/src/bin/collection_job_driver.rs
@@ -43,8 +43,7 @@ async fn main() -> anyhow::Result<()> {
             TokioRuntime,
             ctx.meter,
             stopper,
-            Duration::from_secs(ctx.config.job_driver_config.min_job_discovery_delay_secs),
-            Duration::from_secs(ctx.config.job_driver_config.max_job_discovery_delay_secs),
+            Duration::from_secs(ctx.config.job_driver_config.job_discovery_interval_secs),
             ctx.config.job_driver_config.max_concurrent_job_workers,
             Duration::from_secs(
                 ctx.config
@@ -154,8 +153,7 @@ mod tests {
                 health_check_listen_address: SocketAddr::from((Ipv4Addr::UNSPECIFIED, 8080)),
             },
             job_driver_config: JobDriverConfig {
-                min_job_discovery_delay_secs: 10,
-                max_job_discovery_delay_secs: 60,
+                job_discovery_interval_secs: 10,
                 max_concurrent_job_workers: 10,
                 worker_lease_duration_secs: 600,
                 worker_lease_clock_skew_allowance_secs: 60,

--- a/docs/samples/advanced_config/aggregation_job_driver.yaml
+++ b/docs/samples/advanced_config/aggregation_job_driver.yaml
@@ -64,11 +64,8 @@ metrics_config:
 
 # Aggregation job driver-related parameters:
 
-# Minimum interval on which to acquire incomplete aggregation jobs. (required)
-min_job_discovery_delay_secs: 10
-
 # Maximum interval on which to acquire incomplete aggregation jobs. (required)
-max_job_discovery_delay_secs: 60
+job_discovery_interval_secs: 10
 
 # Maximum number of aggregation jobs to step concurrently. (required)
 max_concurrent_job_workers: 10

--- a/docs/samples/advanced_config/collection_job_driver.yaml
+++ b/docs/samples/advanced_config/collection_job_driver.yaml
@@ -64,11 +64,8 @@ metrics_config:
 
 # Collection job driver-related parameters:
 
-# Minimum interval on which to acquire incomplete collection jobs. (required)
-min_job_discovery_delay_secs: 10
-
 # Maximum interval on which to acquire incomplete collection jobs. (required)
-max_job_discovery_delay_secs: 60
+job_discovery_interval_secs: 10
 
 # Maximum number of collection jobs to step concurrently. (required)
 max_concurrent_job_workers: 10

--- a/docs/samples/basic_config/aggregation_job_driver.yaml
+++ b/docs/samples/basic_config/aggregation_job_driver.yaml
@@ -9,11 +9,8 @@ health_check_listen_address: "0.0.0.0:8000"
 
 # Aggregation job driver-related parameters:
 
-# Minimum interval on which to acquire incomplete aggregation jobs. (required)
-min_job_discovery_delay_secs: 10
-
 # Maximum interval on which to acquire incomplete aggregation jobs. (required)
-max_job_discovery_delay_secs: 60
+job_discovery_interval_secs: 10
 
 # Maximum number of aggregation jobs to step concurrently. (required)
 max_concurrent_job_workers: 10

--- a/docs/samples/basic_config/collection_job_driver.yaml
+++ b/docs/samples/basic_config/collection_job_driver.yaml
@@ -9,11 +9,8 @@ health_check_listen_address: "0.0.0.0:8000"
 
 # Collection job driver-related parameters:
 
-# Minimum interval on which to acquire incomplete collection jobs. (required)
-min_job_discovery_delay_secs: 10
-
 # Maximum interval on which to acquire incomplete collection jobs. (required)
-max_job_discovery_delay_secs: 60
+job_discovery_interval_secs: 10
 
 # Maximum number of collection jobs to step concurrently. (required)
 max_concurrent_job_workers: 10

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -54,7 +54,6 @@ impl<'a> Drop for Janus<'a> {
     fn drop(&mut self) {
         // We assume that if a Janus value is dropped during a panic, we are in the middle of
         // test failure. In this case, export logs if log_export_path() suggests doing so.
-
         if !panicking() {
             return;
         }

--- a/interop_binaries/config/aggregation_job_driver.yaml
+++ b/interop_binaries/config/aggregation_job_driver.yaml
@@ -7,8 +7,7 @@ database:
 health_check_listen_address: 0.0.0.0:8002
 logging_config:
   force_json_output: true
-min_job_discovery_delay_secs: 1
-max_job_discovery_delay_secs: 2
+job_discovery_interval_secs: 2
 max_concurrent_job_workers: 10
 worker_lease_clock_skew_allowance_secs: 1
 worker_lease_duration_secs: 10

--- a/interop_binaries/config/collection_job_driver.yaml
+++ b/interop_binaries/config/collection_job_driver.yaml
@@ -7,8 +7,7 @@ database:
 health_check_listen_address: 0.0.0.0:8003
 logging_config:
   force_json_output: true
-min_job_discovery_delay_secs: 1
-max_job_discovery_delay_secs: 2
+job_discovery_interval_secs: 2
 max_concurrent_job_workers: 10
 worker_lease_clock_skew_allowance_secs: 1
 worker_lease_duration_secs: 10


### PR DESCRIPTION
Backports #2253.

Largely backporting this so we can phase out the old configuration from our infrastructure repo.