### PR TITLE
collect: allow specifying HPKE JSON config via environment variable

### DIFF
--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -5,7 +5,6 @@ use clap::{
     error::ErrorKind,
     ArgAction, Args, CommandFactory, FromArgMatches, Parser, ValueEnum,
 };
-use derivative::Derivative;
 #[cfg(feature = "fpvec_bounded_l2")]
 use fixed::types::extra::{U15, U31};
 #[cfg(feature = "fpvec_bounded_l2")]
@@ -208,8 +207,7 @@ fn divviup_hpke_config_parser(s: &str) -> Result<DivviUpHpkeConfig, serde_json::
     serde_json::from_str(s)
 }
 
-#[derive(Derivative, Args, PartialEq, Eq)]
-#[derivative(Debug)]
+#[derive(Debug, Args, PartialEq, Eq)]
 #[group(required = true)]
 struct AuthenticationOptions {
     /// Authentication token for the DAP-Auth-Token HTTP header
@@ -223,7 +221,6 @@ struct AuthenticationOptions {
         display_order = 0,
         conflicts_with = "authorization_bearer_token"
     )]
-    #[derivative(Debug = "ignore")]
     dap_auth_token: Option<AuthenticationToken>,
 
     /// Authentication token for the "Authorization: Bearer ..." HTTP header
@@ -237,7 +234,6 @@ struct AuthenticationOptions {
         display_order = 1,
         conflicts_with = "dap_auth_token"
     )]
-    #[derivative(Debug = "ignore")]
     authorization_bearer_token: Option<AuthenticationToken>,
 }
 

--- a/tools/tests/cmd/collect.trycmd
+++ b/tools/tests/cmd/collect.trycmd
@@ -2,7 +2,7 @@
 $ collect --help
 Command-line DAP-PPM collector from ISRG's Divvi Up
 
-Usage: collect [OPTIONS] --task-id <TASK_ID> --leader <LEADER> --vdaf <VDAF> <--dap-auth-token <DAP_AUTH_TOKEN>|--authorization-bearer-token <AUTHORIZATION_BEARER_TOKEN>> <--hpke-config <HPKE_CONFIG>|--hpke-private-key <HPKE_PRIVATE_KEY>|--hpke-config-json <HPKE_CONFIG_JSON>> <--batch-interval-start <BATCH_INTERVAL_START>|--batch-interval-duration <BATCH_INTERVAL_DURATION>|--batch-id <BATCH_ID>|--current-batch>
+Usage: collect [OPTIONS] --task-id <TASK_ID> --leader <LEADER> --vdaf <VDAF> <--dap-auth-token <DAP_AUTH_TOKEN>|--authorization-bearer-token <AUTHORIZATION_BEARER_TOKEN>> <--hpke-config <HPKE_CONFIG>|--hpke-private-key <HPKE_PRIVATE_KEY>|--hpke-config-json <HPKE_CONFIG_JSON>|--hpke-config-json-contents <HPKE_CONFIG_JSON_CONTENTS>> <--batch-interval-start <BATCH_INTERVAL_START>|--batch-interval-duration <BATCH_INTERVAL_DURATION>|--batch-id <BATCH_ID>|--current-batch>
 
 Options:
   -h, --help
@@ -18,6 +18,18 @@ DAP Task Parameters:
       --leader <LEADER>
           The leader aggregator's endpoint URL
 
+Authorization:
+      --dap-auth-token <DAP_AUTH_TOKEN>
+          Authentication token for the DAP-Auth-Token HTTP header
+          
+          [env: DAP_AUTH_TOKEN]
+
+      --authorization-bearer-token <AUTHORIZATION_BEARER_TOKEN>
+          Authentication token for the "Authorization: Bearer ..." HTTP header
+          
+          [env: AUTHORIZATION_BEARER_TOKEN]
+
+HPKE Configuration:
       --hpke-config <HPKE_CONFIG>
           DAP message for the collector's HPKE configuration, encoded with base64url
 
@@ -29,16 +41,10 @@ DAP Task Parameters:
       --hpke-config-json <HPKE_CONFIG_JSON>
           Path to a JSON document containing the collector's HPKE configuration and private key, in the format output by `divviup collector-credential generate`
 
-Authorization:
-      --dap-auth-token <DAP_AUTH_TOKEN>
-          Authentication token for the DAP-Auth-Token HTTP header
+      --hpke-config-json-contents <HPKE_CONFIG_JSON_CONTENTS>
+          Contents of a JSON document containing the collector's HPKE configuration and private key, in the format output by `divviup collector-credential generate`
           
-          [env: DAP_AUTH_TOKEN]
-
-      --authorization-bearer-token <AUTHORIZATION_BEARER_TOKEN>
-          Authentication token for the "Authorization: Bearer ..." HTTP header
-          
-          [env: AUTHORIZATION_BEARER_TOKEN]
+          [env: HPKE_CONFIG_JSON_CONTENTS]
 
 VDAF Algorithm and Parameters:
       --vdaf <VDAF>

--- a/tools/tests/cmd/collect_fpvec_bounded_l2.trycmd
+++ b/tools/tests/cmd/collect_fpvec_bounded_l2.trycmd
@@ -2,7 +2,7 @@
 $ collect --help
 Command-line DAP-PPM collector from ISRG's Divvi Up
 
-Usage: collect [OPTIONS] --task-id <TASK_ID> --leader <LEADER> --vdaf <VDAF> <--dap-auth-token <DAP_AUTH_TOKEN>|--authorization-bearer-token <AUTHORIZATION_BEARER_TOKEN>> <--hpke-config <HPKE_CONFIG>|--hpke-private-key <HPKE_PRIVATE_KEY>|--hpke-config-json <HPKE_CONFIG_JSON>> <--batch-interval-start <BATCH_INTERVAL_START>|--batch-interval-duration <BATCH_INTERVAL_DURATION>|--batch-id <BATCH_ID>|--current-batch>
+Usage: collect [OPTIONS] --task-id <TASK_ID> --leader <LEADER> --vdaf <VDAF> <--dap-auth-token <DAP_AUTH_TOKEN>|--authorization-bearer-token <AUTHORIZATION_BEARER_TOKEN>> <--hpke-config <HPKE_CONFIG>|--hpke-private-key <HPKE_PRIVATE_KEY>|--hpke-config-json <HPKE_CONFIG_JSON>|--hpke-config-json-contents <HPKE_CONFIG_JSON_CONTENTS>> <--batch-interval-start <BATCH_INTERVAL_START>|--batch-interval-duration <BATCH_INTERVAL_DURATION>|--batch-id <BATCH_ID>|--current-batch>
 
 Options:
   -h, --help
@@ -18,6 +18,18 @@ DAP Task Parameters:
       --leader <LEADER>
           The leader aggregator's endpoint URL
 
+Authorization:
+      --dap-auth-token <DAP_AUTH_TOKEN>
+          Authentication token for the DAP-Auth-Token HTTP header
+          
+          [env: DAP_AUTH_TOKEN]
+
+      --authorization-bearer-token <AUTHORIZATION_BEARER_TOKEN>
+          Authentication token for the "Authorization: Bearer ..." HTTP header
+          
+          [env: AUTHORIZATION_BEARER_TOKEN]
+
+HPKE Configuration:
       --hpke-config <HPKE_CONFIG>
           DAP message for the collector's HPKE configuration, encoded with base64url
 
@@ -29,16 +41,10 @@ DAP Task Parameters:
       --hpke-config-json <HPKE_CONFIG_JSON>
           Path to a JSON document containing the collector's HPKE configuration and private key, in the format output by `divviup collector-credential generate`
 
-Authorization:
-      --dap-auth-token <DAP_AUTH_TOKEN>
-          Authentication token for the DAP-Auth-Token HTTP header
+      --hpke-config-json-contents <HPKE_CONFIG_JSON_CONTENTS>
+          Contents of a JSON document containing the collector's HPKE configuration and private key, in the format output by `divviup collector-credential generate`
           
-          [env: DAP_AUTH_TOKEN]
-
-      --authorization-bearer-token <AUTHORIZATION_BEARER_TOKEN>
-          Authentication token for the "Authorization: Bearer ..." HTTP header
-          
-          [env: AUTHORIZATION_BEARER_TOKEN]
+          [env: HPKE_CONFIG_JSON_CONTENTS]
 
 VDAF Algorithm and Parameters:
       --vdaf <VDAF>


### PR DESCRIPTION
Stacked on #2302.

Allows specifying the `HPKE_CONFIG_JSON_CONTENTS` environment variable, which is the contents of the file generated by `divviup collector-credential generate`. Suitable for integration with systems that don't have neat support for files.

Also removes needless use of `Derivative`--all our structs already use `Derivative` to hide their sensitive contents.