### PR TITLE
Add additional context to report upload rejection errors

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1403,7 +1403,7 @@ impl VdafOps {
             .map_err(|err| Arc::new(Error::from(err)))?;
 
         // Reject reports from too far in the future.
-        // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-02.html#section-4.3.2
+        // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-07.html#section-4.4.2-21
         if report.metadata().time().is_after(&report_deadline) {
             return Err(Arc::new(Error::ReportTooEarly(
                 *task.id(),
@@ -1413,7 +1413,7 @@ impl VdafOps {
         }
 
         // Reject reports after a task has expired.
-        // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-02.html#section-4.3.2
+        // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-07.html#section-4.4.2-20
         if let Some(task_expiration) = task.task_expiration() {
             if report.metadata().time().is_after(task_expiration) {
                 return Err(reject_report(ReportRejectedReason::TaskExpired));
@@ -1477,7 +1477,7 @@ impl VdafOps {
 
         let decryption_result = match (task_hpke_keypair, global_hpke_keypair) {
             // Verify that the report's HPKE config ID is known.
-            // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-02.html#section-4.3.2
+            // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-07.html#section-4.4.2-17
             (None, None) => {
                 return Err(Arc::new(Error::OutdatedHpkeConfig(
                     *task.id(),

--- a/aggregator/src/aggregator/error.rs
+++ b/aggregator/src/aggregator/error.rs
@@ -12,7 +12,12 @@ use std::{
 };
 use tracing::info;
 
-/// Errors returned by functions and methods in this module
+/// Errors returned by functions and methods in this module.
+///
+/// Some variants correspond to errors defined in DAP. See the [DAP specification] for error
+/// message details.
+///
+/// [1]: https://www.ietf.org/archive/id/draft-ietf-ppm-dap-07.html#name-errors
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// An invalid configuration was passed.
@@ -24,17 +29,18 @@ pub enum Error {
     /// Error handling a message.
     #[error("invalid message: {0}")]
     Message(#[from] janus_messages::Error),
-    /// Corresponds to `reportRejected`, §3.2
+    /// Corresponds to `reportRejected` in DAP. A report was rejected for some reason that is not
+    /// specified in DAP.
     #[error("task {0}: report {1} rejected: {2}")]
     ReportRejected(TaskId, ReportId, Time, ReportRejectedReason),
-    /// Corresponds to `reportTooEarly`, §3.2. A report was rejected because the timestamp is too
-    /// far in the future, §4.3.2.
+    /// Corresponds to `reportTooEarly` in DAP. A report was rejected because the timestamp is too
+    /// far in the future.
     #[error("task {0}: report {1} too early: {2}")]
     ReportTooEarly(TaskId, ReportId, Time),
-    /// Corresponds to `invalidMessage`, §3.2
+    /// Corresponds to `invalidMessage` in DAP.
     #[error("task {0:?}: invalid message: {1}")]
     InvalidMessage(Option<TaskId>, &'static str),
-    /// Corresponds to `stepMismatch`
+    /// Corresponds to `stepMismatch in DAP`
     #[error(
         "task {task_id}: unexpected step in aggregation job {aggregation_job_id} (expected \
          {expected_step}, got {got_step})"
@@ -45,10 +51,10 @@ pub enum Error {
         expected_step: AggregationJobStep,
         got_step: AggregationJobStep,
     },
-    /// Corresponds to `unrecognizedTask`, §3.2
+    /// Corresponds to `unrecognizedTask` in DAP.
     #[error("task {0}: unrecognized task")]
     UnrecognizedTask(TaskId),
-    /// Corresponds to `missingTaskID`, §3.2
+    /// Corresponds to `missingTaskID` in DAP.
     #[error("no task ID in request")]
     MissingTaskId,
     /// An attempt was made to act on an unknown aggregation job.
@@ -60,10 +66,10 @@ pub enum Error {
     /// An attempt was made to act on a known but deleted collection job.
     #[error("deleted collection job: {0}")]
     DeletedCollectionJob(CollectionJobId),
-    /// Corresponds to `outdatedHpkeConfig`, §3.2
+    /// Corresponds to `outdatedHpkeConfig` in DAP.
     #[error("task {0}: outdated HPKE config: {1}")]
     OutdatedHpkeConfig(TaskId, HpkeConfigId),
-    /// Corresponds to `unauthorizedRequest`, §3.2
+    /// Corresponds to `unauthorizedRequest` in DAP.
     #[error("task {0}: unauthorized request")]
     UnauthorizedRequest(TaskId),
     /// An error from the datastore.
@@ -72,21 +78,23 @@ pub enum Error {
     /// An error from the underlying VDAF library.
     #[error("VDAF error: {0}")]
     Vdaf(#[from] VdafError),
-    /// A collect or aggregate share request was rejected because the interval failed boundary
-    /// checks (§4.5.6).
+    /// Corresponds to `batchInvalid` in DAP. A collect or aggregate share request was rejected
+    /// because the interval failed boundary checks.
     #[error("task {0}: invalid batch interval: {1}")]
     BatchInvalid(TaskId, String),
-    /// The number of reports in the batch is invalid for the task's parameters.
+    /// Corresponds to `invalidBatchSize in DAP. The number of reports in the batch is invalid for
+    /// the task's parameters.
     #[error("task {0}: invalid number of reports ({1})")]
     InvalidBatchSize(TaskId, u64),
     #[error("URL parse error: {0}")]
     Url(#[from] url::ParseError),
-    /// The checksum or report count in one aggregator's aggregate share does not match the other
-    /// aggregator's aggregate share, suggesting different sets of reports were aggregated.
+    /// Corresponds to `batchMismatch` in DAP. The checksum or report count in one aggregator's
+    /// aggregate share does not match the other aggregator's aggregate share, suggesting different
+    /// sets of reports were aggregated.
     #[error("{0}")]
     BatchMismatch(Box<BatchMismatch>),
-    /// A collect or aggregate share request was rejected because the queries against a single batch
-    /// exceed the task's `max_batch_query_count` (§4.5.6).
+    /// Corresponds to `batchQueriedTooManyTimes` in DAP. A collect or aggregate share request was
+    /// rejected because the queries against a single batch exceed the task's `max_batch_query_count`.
     #[error("task {0}: batch queried too many times ({1})")]
     BatchQueriedTooManyTimes(TaskId, u64),
     /// A collect or aggregate share request was rejected because the batch overlaps with a
@@ -124,7 +132,9 @@ pub enum Error {
     /// A catch-all error representing an issue with a request.
     #[error("request error: {0}")]
     BadRequest(String),
-    /// Corresponds to taskprov invalidType (§2)
+    /// Corresponds to taskprov `invalidTask`. See the [Taskprov specification][1] for details.
+    ///
+    /// [1]: https://www.ietf.org/archive/id/draft-wang-ppm-dap-taskprov-04.html#name-conventions-and-definitions
     #[error("aggregator has opted out of the indicated task: {1}")]
     InvalidTask(TaskId, OptOutReason),
     /// An error occurred when trying to ensure differential privacy.

--- a/aggregator/src/aggregator/error.rs
+++ b/aggregator/src/aggregator/error.rs
@@ -26,7 +26,7 @@ pub enum Error {
     Message(#[from] janus_messages::Error),
     /// Corresponds to `reportRejected`, §3.2
     #[error("task {0}: report {1} rejected: {2}")]
-    ReportRejected(TaskId, ReportId, Time),
+    ReportRejected(TaskId, ReportId, Time, ReportRejectedReason),
     /// Corresponds to `reportTooEarly`, §3.2. A report was rejected becuase the timestamp is too
     /// far in the future, §4.3.2.
     #[error("task {0}: report {1} too early: {2}")]
@@ -132,6 +132,25 @@ pub enum Error {
     DifferentialPrivacy(VdafError),
 }
 
+#[derive(Debug)]
+pub enum ReportRejectedReason {
+    IntervalAlreadyCollected,
+    TaskExpired,
+    TooOld,
+}
+
+impl ReportRejectedReason {
+    pub fn detail(&self) -> &'static str {
+        match self {
+            ReportRejectedReason::IntervalAlreadyCollected => {
+                "Report falls into a time interval that has already been collected."
+            }
+            ReportRejectedReason::TaskExpired => "Task has expired.",
+            ReportRejectedReason::TooOld => "Report timestamp is too old.",
+        }
+    }
+}
+
 /// Errors that cause the aggregator to opt-out of a taskprov task.
 #[derive(Debug, thiserror::Error)]
 pub enum OptOutReason {
@@ -155,7 +174,7 @@ impl Error {
             Error::InvalidConfiguration(_) => "invalid_configuration",
             Error::MessageDecode(_) => "message_decode",
             Error::Message(_) => "message",
-            Error::ReportRejected(_, _, _) => "report_rejected",
+            Error::ReportRejected(_, _, _, _) => "report_rejected",
             Error::ReportTooEarly(_, _, _) => "report_too_early",
             Error::InvalidMessage(_, _) => "unrecognized_message",
             Error::StepMismatch { .. } => "step_mismatch",

--- a/aggregator/src/aggregator/error.rs
+++ b/aggregator/src/aggregator/error.rs
@@ -27,7 +27,7 @@ pub enum Error {
     /// Corresponds to `reportRejected`, §3.2
     #[error("task {0}: report {1} rejected: {2}")]
     ReportRejected(TaskId, ReportId, Time, ReportRejectedReason),
-    /// Corresponds to `reportTooEarly`, §3.2. A report was rejected becuase the timestamp is too
+    /// Corresponds to `reportTooEarly`, §3.2. A report was rejected because the timestamp is too
     /// far in the future, §4.3.2.
     #[error("task {0}: report {1} too early: {2}")]
     ReportTooEarly(TaskId, ReportId, Time),
@@ -135,6 +135,9 @@ pub enum Error {
 #[derive(Debug)]
 pub enum ReportRejectedReason {
     IntervalAlreadyCollected,
+    LeaderDecryptFailure,
+    LeaderInputShareDecodeFailure,
+    PublicShareDecodeFailure,
     TaskExpired,
     TooOld,
 }
@@ -144,6 +147,15 @@ impl ReportRejectedReason {
         match self {
             ReportRejectedReason::IntervalAlreadyCollected => {
                 "Report falls into a time interval that has already been collected."
+            }
+            ReportRejectedReason::LeaderDecryptFailure => {
+                "Leader's report share could not be decrypted."
+            }
+            ReportRejectedReason::LeaderInputShareDecodeFailure => {
+                "Leader's input share could not be decoded."
+            }
+            ReportRejectedReason::PublicShareDecodeFailure => {
+                "Report public share could not be decoded."
             }
             ReportRejectedReason::TaskExpired => "Task has expired.",
             ReportRejectedReason::TooOld => "Report timestamp is too old.",

--- a/aggregator/src/aggregator/problem_details.rs
+++ b/aggregator/src/aggregator/problem_details.rs
@@ -13,9 +13,9 @@ impl DapProblemTypeExt for DapProblemType {
     /// Returns the HTTP status code that should be used in responses whose body is a problem
     /// document of this type.
     fn http_status(&self) -> Status {
-        // Per the errors section of the protocol, error responses should use "HTTP status code 400
-        // Bad Request unless explicitly specified otherwise."
-        // https://datatracker.ietf.org/doc/html/draft-ietf-ppm-dap-03#name-errors
+        // Per the errors section of the protocol, error responses should use HTTP status code 400
+        // Bad Request unless explicitly specified otherwise.
+        // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-07.html#section-3.2-7
         Status::BadRequest
     }
 }
@@ -23,8 +23,9 @@ impl DapProblemTypeExt for DapProblemType {
 /// The media type for problem details formatted as a JSON document, per RFC 7807.
 static PROBLEM_DETAILS_JSON_MEDIA_TYPE: &str = "application/problem+json";
 
-/// Serialization helper struct for JSON problem details error responses. See
-/// https://datatracker.ietf.org/doc/html/draft-ietf-ppm-dap-03#section-3.2.
+/// Serialization helper struct for [DAP JSON problem details error responses][1].
+///
+/// [1]: https://datatracker.ietf.org/doc/html/draft-ietf-ppm-dap-03#section-3.2.
 #[derive(Debug, Serialize)]
 pub struct ProblemDocument<'a> {
     #[serde(rename = "type")]

--- a/aggregator/src/aggregator/problem_details.rs
+++ b/aggregator/src/aggregator/problem_details.rs
@@ -25,7 +25,7 @@ static PROBLEM_DETAILS_JSON_MEDIA_TYPE: &str = "application/problem+json";
 
 /// Serialization helper struct for [DAP JSON problem details error responses][1].
 ///
-/// [1]: https://datatracker.ietf.org/doc/html/draft-ietf-ppm-dap-03#section-3.2.
+/// [1]: https://datatracker.ietf.org/doc/html/draft-ietf-ppm-dap-07#section-3.2.
 #[derive(Debug, Serialize)]
 pub struct ProblemDocument<'a> {
     #[serde(rename = "type")]

--- a/aggregator/src/aggregator/query_type.rs
+++ b/aggregator/src/aggregator/query_type.rs
@@ -1,4 +1,4 @@
-use super::Error;
+use super::{error::ReportRejectedReason, Error};
 use async_trait::async_trait;
 use janus_aggregator_core::{
     datastore::{self, models::LeaderStoredReport, Transaction},
@@ -60,6 +60,7 @@ impl UploadableQueryType for TimeInterval {
                     *report.task_id(),
                     *report.metadata().id(),
                     *report.metadata().time(),
+                    ReportRejectedReason::IntervalAlreadyCollected,
                 )
                 .into(),
             ));


### PR DESCRIPTION
From discussion in Slack and somewhat alluded to in https://github.com/divviup/janus/issues/2293.

Client upload errors are opaque at the moment. They don't provide much detail as to went wrong, and some classes of errors don't return errors at all. This makes troubleshooting a misconfigured client cumbersome.

First, introduce usage of the `detail` field in HTTP problem documents as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807.html#page-5). 

The plumbing is relatively straightforward. `aggregator::Error`'s variants can contain an additional `Reason` enum which is provided to `ProblemDetailsConnExt::with_problem_details()`. This pattern will be useful for taskprov as well, where opt-out rationale is opaque because of the lack of a `detail` field.

Then, expose all errors encountered in `handle_upload_generic` to the client, with appropriate reasons.