### PR TITLE
collect: Use collector credential nomenclature

### DIFF
--- a/tools/tests/cmd/collect.trycmd
+++ b/tools/tests/cmd/collect.trycmd
@@ -4,7 +4,7 @@ Command-line DAP-PPM collector from ISRG's Divvi Up
 
 The default subcommand is "run", which will create a collection job and poll it to completion
 
-Usage: collect [OPTIONS] --task-id <TASK_ID> --leader <LEADER> --vdaf <VDAF> <--dap-auth-token <DAP_AUTH_TOKEN>|--authorization-bearer-token <AUTHORIZATION_BEARER_TOKEN>> <--hpke-config <HPKE_CONFIG>|--hpke-private-key <HPKE_PRIVATE_KEY>|--hpke-config-json <HPKE_CONFIG_JSON>|--hpke-config-json-contents <HPKE_CONFIG_JSON_CONTENTS>> <--batch-interval-start <BATCH_INTERVAL_START>|--batch-interval-duration <BATCH_INTERVAL_DURATION>|--batch-id <BATCH_ID>|--current-batch> [COMMAND]
+Usage: collect [OPTIONS] --task-id <TASK_ID> --leader <LEADER> --vdaf <VDAF> <--dap-auth-token <DAP_AUTH_TOKEN>|--authorization-bearer-token <AUTHORIZATION_BEARER_TOKEN>> <--hpke-config <HPKE_CONFIG>|--hpke-private-key <HPKE_PRIVATE_KEY>|--collector-credential-file <COLLECTOR_CREDENTIAL_FILE>|--collector-credential <COLLECTOR_CREDENTIAL>> <--batch-interval-start <BATCH_INTERVAL_START>|--batch-interval-duration <BATCH_INTERVAL_DURATION>|--batch-id <BATCH_ID>|--current-batch> [COMMAND]
 
 Commands:
   run       Create a new collection job and poll it to completion
@@ -46,13 +46,19 @@ HPKE Configuration:
           
           [env: HPKE_PRIVATE_KEY]
 
-      --hpke-config-json <HPKE_CONFIG_JSON>
-          Path to a JSON document containing the collector's HPKE configuration and private key, in the format output by `divviup collector-credential generate`
-
-      --hpke-config-json-contents <HPKE_CONFIG_JSON_CONTENTS>
-          Contents of a JSON document containing the collector's HPKE configuration and private key, in the format output by `divviup collector-credential generate`
+      --collector-credential-file <COLLECTOR_CREDENTIAL_FILE>
+          Path to a file containing private collector credentials
           
-          [env: HPKE_CONFIG_JSON_CONTENTS]
+          This can be obtained with the command `divviup collector-credential generate`.
+          
+          [aliases: hpke-config-json]
+
+      --collector-credential <COLLECTOR_CREDENTIAL>
+          Private collector credentials
+          
+          This can be obtained with the command `divviup collector-credential generate`.
+          
+          [env: COLLECTOR_CREDENTIAL]
 
 VDAF Algorithm and Parameters:
       --vdaf <VDAF>

--- a/tools/tests/cmd/collect_fpvec_bounded_l2.trycmd
+++ b/tools/tests/cmd/collect_fpvec_bounded_l2.trycmd
@@ -4,7 +4,7 @@ Command-line DAP-PPM collector from ISRG's Divvi Up
 
 The default subcommand is "run", which will create a collection job and poll it to completion
 
-Usage: collect [OPTIONS] --task-id <TASK_ID> --leader <LEADER> --vdaf <VDAF> <--dap-auth-token <DAP_AUTH_TOKEN>|--authorization-bearer-token <AUTHORIZATION_BEARER_TOKEN>> <--hpke-config <HPKE_CONFIG>|--hpke-private-key <HPKE_PRIVATE_KEY>|--hpke-config-json <HPKE_CONFIG_JSON>|--hpke-config-json-contents <HPKE_CONFIG_JSON_CONTENTS>> <--batch-interval-start <BATCH_INTERVAL_START>|--batch-interval-duration <BATCH_INTERVAL_DURATION>|--batch-id <BATCH_ID>|--current-batch> [COMMAND]
+Usage: collect [OPTIONS] --task-id <TASK_ID> --leader <LEADER> --vdaf <VDAF> <--dap-auth-token <DAP_AUTH_TOKEN>|--authorization-bearer-token <AUTHORIZATION_BEARER_TOKEN>> <--hpke-config <HPKE_CONFIG>|--hpke-private-key <HPKE_PRIVATE_KEY>|--collector-credential-file <COLLECTOR_CREDENTIAL_FILE>|--collector-credential <COLLECTOR_CREDENTIAL>> <--batch-interval-start <BATCH_INTERVAL_START>|--batch-interval-duration <BATCH_INTERVAL_DURATION>|--batch-id <BATCH_ID>|--current-batch> [COMMAND]
 
 Commands:
   run       Create a new collection job and poll it to completion
@@ -46,13 +46,19 @@ HPKE Configuration:
           
           [env: HPKE_PRIVATE_KEY]
 
-      --hpke-config-json <HPKE_CONFIG_JSON>
-          Path to a JSON document containing the collector's HPKE configuration and private key, in the format output by `divviup collector-credential generate`
-
-      --hpke-config-json-contents <HPKE_CONFIG_JSON_CONTENTS>
-          Contents of a JSON document containing the collector's HPKE configuration and private key, in the format output by `divviup collector-credential generate`
+      --collector-credential-file <COLLECTOR_CREDENTIAL_FILE>
+          Path to a file containing private collector credentials
           
-          [env: HPKE_CONFIG_JSON_CONTENTS]
+          This can be obtained with the command `divviup collector-credential generate`.
+          
+          [aliases: hpke-config-json]
+
+      --collector-credential <COLLECTOR_CREDENTIAL>
+          Private collector credentials
+          
+          This can be obtained with the command `divviup collector-credential generate`.
+          
+          [env: COLLECTOR_CREDENTIAL]
 
 VDAF Algorithm and Parameters:
       --vdaf <VDAF>


### PR DESCRIPTION
Stacked on https://github.com/divviup/janus/pull/2324. Uses the collector credential nomenclature.

Note that this collides slightly with https://github.com/divviup/janus/pull/2307, in that we change the environment variable name. Since this PR hasn't made it into a release yet, this is not a breaking change. This PR also addresses the confusing naming of `--hpke-config-json` vs `--hpke-config-json-contents`.

We support the alias `--hpke-config-json` as `--collector-credential-file` for backwards compatibility.

