### PR TITLE
Fix global mismatch with trillium-opentelemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1910,11 +1910,11 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "mockito",
- "opentelemetry 0.21.0",
+ "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-prometheus",
  "opentelemetry-semantic-conventions",
- "opentelemetry_sdk 0.21.1",
+ "opentelemetry_sdk",
  "postgres-protocol",
  "postgres-types",
  "prio",
@@ -1974,7 +1974,7 @@ dependencies = [
  "janus_aggregator_core",
  "janus_core",
  "janus_messages 0.6.6",
- "opentelemetry 0.21.0",
+ "opentelemetry",
  "querystring",
  "rand",
  "ring 0.17.5",
@@ -2017,7 +2017,7 @@ dependencies = [
  "janus_messages 0.6.6",
  "k8s-openapi",
  "kube",
- "opentelemetry 0.21.0",
+ "opentelemetry",
  "postgres-protocol",
  "postgres-types",
  "prio",
@@ -2196,7 +2196,7 @@ dependencies = [
  "janus_core",
  "janus_interop_binaries",
  "janus_messages 0.6.6",
- "opentelemetry 0.21.0",
+ "opentelemetry",
  "prio",
  "rand",
  "regex",
@@ -2725,16 +2725,6 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "opentelemetry"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
-dependencies = [
- "opentelemetry_api",
- "opentelemetry_sdk 0.20.0",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
@@ -2758,10 +2748,10 @@ dependencies = [
  "async-trait",
  "futures-core",
  "http 0.2.11",
- "opentelemetry 0.21.0",
+ "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
- "opentelemetry_sdk 0.21.1",
+ "opentelemetry_sdk",
  "prost 0.11.9",
  "thiserror",
  "tokio",
@@ -2775,8 +2765,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8f082da115b0dcb250829e3ed0b8792b8f963a1ad42466e48422fbe6a079bd"
 dependencies = [
  "once_cell",
- "opentelemetry 0.21.0",
- "opentelemetry_sdk 0.21.1",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prometheus",
  "protobuf",
 ]
@@ -2787,8 +2777,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2e155ce5cc812ea3d1dffbd1539aed653de4bf4882d60e6e04dcf0901d674e1"
 dependencies = [
- "opentelemetry 0.21.0",
- "opentelemetry_sdk 0.21.1",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prost 0.11.9",
  "tonic 0.9.2",
 ]
@@ -2799,43 +2789,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5774f1ef1f982ef2a447f6ee04ec383981a3ab99c8e77a1a7b30182e65bbc84"
 dependencies = [
- "opentelemetry 0.21.0",
-]
-
-[[package]]
-name = "opentelemetry_api"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a81f725323db1b1206ca3da8bb19874bbd3f57c3bcd59471bfb04525b265b9b"
-dependencies = [
- "futures-channel",
- "futures-util",
- "indexmap 1.9.3",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror",
- "urlencoding",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8e705a0612d48139799fcbaba0d4a90f06277153e43dd2bdc16c6f0edd8026"
-dependencies = [
- "async-trait",
- "crossbeam-channel",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "once_cell",
- "opentelemetry_api",
- "ordered-float 3.7.0",
- "percent-encoding",
- "rand",
- "regex",
- "thiserror",
+ "opentelemetry",
 ]
 
 [[package]]
@@ -2851,7 +2805,7 @@ dependencies = [
  "futures-util",
  "glob",
  "once_cell",
- "opentelemetry 0.21.0",
+ "opentelemetry",
  "ordered-float 4.1.1",
  "percent-encoding",
  "rand",
@@ -2865,15 +2819,6 @@ name = "ordered-float"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "ordered-float"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc2dbde8f8a79f2102cc474ceb0ad68e3b80b85289ea62389b60e66777e4213"
 dependencies = [
  "num-traits",
 ]
@@ -4883,8 +4828,8 @@ checksum = "c67ac25c5407e7b961fafc6f7e9aa5958fd297aada2d20fa2ae1737357e55596"
 dependencies = [
  "js-sys",
  "once_cell",
- "opentelemetry 0.21.0",
- "opentelemetry_sdk 0.21.1",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -5045,11 +4990,11 @@ dependencies = [
 
 [[package]]
 name = "trillium-opentelemetry"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2711073179f57337f0fb429befd5102415dff434a255ffbef2e84036c566812b"
+checksum = "0903b25c38ea1a1506cb4f3ff8fad8f8331f3de5dc6bf6d36312777ce10e0f80"
 dependencies = [
- "opentelemetry 0.20.0",
+ "opentelemetry",
  "trillium",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ trillium = "0.2.11"
 trillium-api = { version = "0.2.0-rc.7", default-features = false }
 trillium-caching-headers = "0.2.1"
 trillium-head = "0.2.0"
-trillium-opentelemetry = "0.3.0"
+trillium-opentelemetry = "0.4.0"
 trillium-router = "0.3.5"
 trillium-testing = "0.5.0"
 trillium-tokio = "0.3.2"

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -23,7 +23,7 @@ use prio::codec::Encode;
 use ring::digest::{digest, SHA256};
 use routefinder::Captures;
 use serde::Deserialize;
-use std::time::Duration as StdDuration;
+use std::{borrow::Cow, time::Duration as StdDuration};
 use std::{io::Cursor, sync::Arc};
 use tracing::warn;
 use trillium::{Conn, Handler, KnownHeaderName, Status};
@@ -235,7 +235,10 @@ async fn aggregator_handler_with_aggregator<C: Clock>(
 ) -> Result<impl Handler, Error> {
     Ok((
         State(aggregator),
-        metrics(meter).with_route(|conn| conn.route().map(ToString::to_string)),
+        metrics(meter).with_route(|conn| {
+            conn.route()
+                .map(|route_spec| Cow::Owned(route_spec.to_string()))
+        }),
         Router::new()
             .without_options_handling()
             .get("hpke_config", instrumented(api(hpke_config::<C>)))

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -235,7 +235,7 @@ async fn aggregator_handler_with_aggregator<C: Clock>(
 ) -> Result<impl Handler, Error> {
     Ok((
         State(aggregator),
-        metrics("janus_aggregator").with_route(|conn| conn.route().map(ToString::to_string)),
+        metrics(meter).with_route(|conn| conn.route().map(ToString::to_string)),
         Router::new()
             .without_options_handling()
             .get("hpke_config", instrumented(api(hpke_config::<C>)))

--- a/aggregator/src/binaries/aggregator.rs
+++ b/aggregator/src/binaries/aggregator.rs
@@ -73,6 +73,7 @@ async fn run_aggregator(
     let garbage_collector_future = {
         let datastore = Arc::clone(&datastore);
         let gc_config = config.garbage_collection.take();
+        let meter = meter.clone();
         async move {
             if let Some(gc_config) = gc_config {
                 let gc = GarbageCollector::new(

--- a/aggregator_api/src/lib.rs
+++ b/aggregator_api/src/lib.rs
@@ -13,7 +13,7 @@ use janus_core::{auth_tokens::AuthenticationToken, hpke, http::extract_bearer_to
 use janus_messages::{HpkeConfigId, RoleParseError, TaskId};
 use opentelemetry::metrics::Meter;
 use routes::*;
-use std::{str::FromStr, sync::Arc};
+use std::{borrow::Cow, str::FromStr, sync::Arc};
 use tracing::error;
 use trillium::{
     Conn, Handler,
@@ -78,7 +78,10 @@ pub fn aggregator_api_handler<C: Clock>(
         State(ds),
         State(Arc::new(cfg)),
         // Metrics.
-        metrics(meter).with_route(|conn| conn.route().map(ToString::to_string)),
+        metrics(meter).with_route(|conn| {
+            conn.route()
+                .map(|route_spec| Cow::Owned(route_spec.to_string()))
+        }),
         // Authorization check.
         api(auth_check),
         // Check content type and accept headers

--- a/aggregator_api/src/lib.rs
+++ b/aggregator_api/src/lib.rs
@@ -11,6 +11,7 @@ use janus_aggregator_core::{
 };
 use janus_core::{auth_tokens::AuthenticationToken, hpke, http::extract_bearer_token, time::Clock};
 use janus_messages::{HpkeConfigId, RoleParseError, TaskId};
+use opentelemetry::metrics::Meter;
 use routes::*;
 use std::{str::FromStr, sync::Arc};
 use tracing::error;
@@ -67,13 +68,17 @@ impl Handler for ReplaceMimeTypes {
 
 /// Returns a new handler for an instance of the aggregator API, backed by the given datastore,
 /// according to the given configuration.
-pub fn aggregator_api_handler<C: Clock>(ds: Arc<Datastore<C>>, cfg: Config) -> impl Handler {
+pub fn aggregator_api_handler<C: Clock>(
+    ds: Arc<Datastore<C>>,
+    cfg: Config,
+    meter: &Meter,
+) -> impl Handler {
     (
         // State used by endpoint handlers.
         State(ds),
         State(Arc::new(cfg)),
         // Metrics.
-        metrics("janus_aggregator").with_route(|conn| conn.route().map(ToString::to_string)),
+        metrics(meter).with_route(|conn| conn.route().map(ToString::to_string)),
         // Authorization check.
         api(auth_check),
         // Check content type and accept headers

--- a/aggregator_api/src/tests.rs
+++ b/aggregator_api/src/tests.rs
@@ -21,6 +21,7 @@ use janus_aggregator_core::{
     },
     task::{test_util::TaskBuilder, AggregatorTask, AggregatorTaskParameters, QueryType},
     taskprov::test_util::PeerAggregatorBuilder,
+    test_util::noop_meter,
     SecretBytes,
 };
 use janus_core::{
@@ -68,6 +69,7 @@ async fn setup_api_test() -> (impl Handler, EphemeralDatastore, Arc<Datastore<Mo
             ]),
             public_dap_url: "https://dap.url".parse().unwrap(),
         },
+        &noop_meter(),
     );
 
     (handler, ephemeral_datastore, datastore)


### PR DESCRIPTION
This PR upgrades trillium-opentelemetry and enlists the type system in making sure that it is using the correct MeterProvider, by passing a Meter directly. We currently are depending on two versions of opentelemetry transitively, which results in duplicate globals, and ultimately results in lost metrics. I also made use of the new `.with_error_type()` feature to use our error codes in labels on the built-in histogram metrics, in addition to our custom counter metric elsewhere.