### PR TITLE
Integration test for rate limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2163,6 +2163,7 @@ dependencies = [
  "prio",
  "rand",
  "reqwest",
+ "rstest",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2144,6 +2144,7 @@ name = "janus_integration_tests"
 version = "0.6.6"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "backoff",
  "base64 0.21.5",
  "divviup-client",

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -11,6 +11,7 @@ version.workspace = true
 [features]
 in-cluster = ["dep:k8s-openapi", "dep:kube"]
 testcontainer = ["janus_interop_binaries/testcontainer"]
+in-cluster-rate-limits = []
 
 [dependencies]
 anyhow.workspace = true
@@ -33,6 +34,7 @@ kube = { workspace = true, optional = true }
 prio.workspace = true
 rand.workspace = true
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
+rstest.workspace = true
 serde.workspace = true
 serde_json = "1.0.108"
 testcontainers.workspace = true

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -15,6 +15,7 @@ in-cluster-rate-limits = []
 
 [dependencies]
 anyhow.workspace = true
+assert_matches.workspace = true
 backoff = { version = "0.4", features = ["tokio"] }
 base64.workspace = true
 divviup-client = { version = "0.1", features = ["admin"] }

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -13,6 +13,7 @@ pub mod janus;
 
 /// Task parameters needed for an integration test. This encompasses the parameters used by either
 /// the client or collector.
+#[derive(Clone)]
 pub struct TaskParameters {
     pub task_id: TaskId,
     pub endpoint_fragments: EndpointFragments,
@@ -25,7 +26,7 @@ pub struct TaskParameters {
 }
 
 /// Components of one aggregator's DAP endpoint. The scheme is assumed to always be `http:`.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum AggregatorEndpointFragments {
     /// The aggregator is in a virtual network, (a Docker network or a Kind cluster) so different
     /// URLs must be used depending on whether it is accessed from within the same virtual network
@@ -78,6 +79,7 @@ impl AggregatorEndpointFragments {
 }
 
 /// Components of DAP endpoints for a leader and helper aggregator.
+#[derive(Clone)]
 pub struct EndpointFragments {
     pub leader: AggregatorEndpointFragments,
     pub helper: AggregatorEndpointFragments,

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -13,7 +13,6 @@ pub mod janus;
 
 /// Task parameters needed for an integration test. This encompasses the parameters used by either
 /// the client or collector.
-#[derive(Clone)]
 pub struct TaskParameters {
     pub task_id: TaskId,
     pub endpoint_fragments: EndpointFragments,
@@ -26,7 +25,7 @@ pub struct TaskParameters {
 }
 
 /// Components of one aggregator's DAP endpoint. The scheme is assumed to always be `http:`.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum AggregatorEndpointFragments {
     /// The aggregator is in a virtual network, (a Docker network or a Kind cluster) so different
     /// URLs must be used depending on whether it is accessed from within the same virtual network
@@ -79,7 +78,6 @@ impl AggregatorEndpointFragments {
 }
 
 /// Components of DAP endpoints for a leader and helper aggregator.
-#[derive(Clone)]
 pub struct EndpointFragments {
     pub leader: AggregatorEndpointFragments,
     pub helper: AggregatorEndpointFragments,

--- a/integration_tests/tests/integration/in_cluster.rs
+++ b/integration_tests/tests/integration/in_cluster.rs
@@ -333,3 +333,217 @@ async fn in_cluster_fixed_size() {
     )
     .await;
 }
+
+mod rate_limits {
+    #![cfg(feature = "in-cluster-rate-limits")]
+
+    use super::InClusterJanusPair;
+    use http::Method;
+    use janus_aggregator_core::task::QueryType;
+    use janus_core::{test_util::install_test_trace_subscriber, vdaf::VdafInstance};
+    use janus_messages::{AggregationJobId, CollectionJobId, TaskId};
+    use rand::random;
+    use reqwest::StatusCode;
+    use serde::Deserialize;
+    use std::{env, fs::File};
+    use url::Url;
+
+    /// Configuration for the rate limit test. We need to know the QPS and the window over which
+    /// it is enforced so that we can send the appropriate number of requests. We load this config
+    /// from a file so that an integration test harness that knows what rate limits have been
+    /// deployed to the cluster we test against can set the values.
+    #[derive(Deserialize)]
+    struct TestConfig {
+        window: u64,
+        upload_qps: u64,
+        aggregation_job_qps: u64,
+        collection_job_qps: u64,
+    }
+
+    impl TestConfig {
+        fn load() -> Self {
+            serde_json::from_reader(
+                File::open(
+                    env::var("JANUS_E2E_RATE_LIMIT_TEST_CONFIG")
+                        .unwrap()
+                        .as_str(),
+                )
+                .unwrap(),
+            )
+            .unwrap()
+        }
+    }
+
+    async fn run_rate_limit_test(
+        request_url_maker: &dyn Fn(&Url, &Url, &TaskId, &TaskId) -> (Url, Url),
+        rate_limit_picker: &dyn Fn(&TestConfig) -> u64,
+        method: Method,
+    ) {
+        install_test_trace_subscriber();
+        let test_config = TestConfig::load();
+
+        let janus_pair =
+            InClusterJanusPair::new(VdafInstance::Prio3Count, QueryType::TimeInterval).await;
+
+        let (leader_url, helper_url) = janus_pair
+            .task_parameters
+            .endpoint_fragments
+            .endpoints_for_host_client(janus_pair.leader.port(), janus_pair.helper.port());
+        let other_task_id = random();
+
+        // Send requests to two different tasks, to prove that rate limits are per-task ID. It
+        // doesn't matter that one of the tasks doesn't exist for purposes of rate limits.
+        let (first_request_url, second_request_url) = request_url_maker(
+            &leader_url,
+            &helper_url,
+            &janus_pair.task_parameters.task_id,
+            &other_task_id,
+        );
+        let rate_limit = rate_limit_picker(&test_config);
+        let rate_limit_excess = 0.1;
+        let total_requests_count =
+            ((1.0 + rate_limit_excess) * (rate_limit * test_config.window) as f64) as u64;
+
+        let mut acceptable_status_count = 0;
+        let mut too_many_requests_count = 0;
+
+        // Send ten requests at a time, because otherwise the kubectl port-forward gets overwhelmed
+        for _ in 0..(total_requests_count / 10) {
+            let mut handles = Vec::new();
+            for _ in 0..(10) {
+                for url in [first_request_url.clone(), second_request_url.clone()] {
+                    let method = method.clone();
+                    handles.push(tokio::spawn(async move {
+                        // We avoid using janus_client here because we don't want it to automatically
+                        // retry on HTTP 429 for us.
+                        let response = reqwest::Client::builder()
+                            .build()
+                            .unwrap()
+                            .request(method, url)
+                            .send()
+                            .await
+                            .unwrap();
+
+                        // We could look at the retry-after header, but currently the rate limiting
+                        // plugin only ever sets that value to 0 when run in the distributed mode
+                        // https://github.com/mholt/caddy-ratelimit/blob/1ef5298afeec6792f08a00d8bc9ce66edccbfa18/distributed.go#L198
+                        response.status()
+                    }));
+                }
+            }
+
+            for handle in handles {
+                let status = handle.await.unwrap();
+
+                // Every request this test send should get rejected due to a missing body if it gets
+                // past the rate limiter.
+                if status == StatusCode::BAD_REQUEST {
+                    acceptable_status_count += 1
+                } else if status == StatusCode::TOO_MANY_REQUESTS {
+                    too_many_requests_count += 1
+                } else {
+                    panic!("unexpected status {status:?}");
+                }
+            }
+        }
+
+        let ratio = too_many_requests_count as f64
+            / (acceptable_status_count + too_many_requests_count) as f64;
+        // We expect some exact percentage of requests to be rejected with HTTP 429, but allow a
+        // margin for error to account for cases where the test takes more than a second to run, or
+        // errors introduced by Caddy distributed rate limiting.
+        let expected_429_rate = rate_limit_excess / (1.0 + rate_limit_excess);
+        assert!(
+            ratio > expected_429_rate - 0.05 && ratio <= expected_429_rate + 0.05,
+            "ratio: {ratio} expected 429 rate: {expected_429_rate} \
+            count of HTTP 429: {too_many_requests_count} \
+            count of acceptable HTTP status: {acceptable_status_count}",
+        );
+    }
+
+    #[tokio::test]
+    async fn upload() {
+        run_rate_limit_test(
+            &|leader_url, _, task_id_1, task_id_2| {
+                (
+                    leader_url
+                        .join(&format!("tasks/{task_id_1}/reports"))
+                        .unwrap(),
+                    leader_url
+                        .join(&format!("tasks/{task_id_2}/reports"))
+                        .unwrap(),
+                )
+            },
+            &|test_config| test_config.upload_qps,
+            Method::PUT,
+        )
+        .await
+    }
+
+    #[rstest::rstest]
+    #[case::put(Method::PUT)]
+    #[case::post(Method::POST)]
+    #[case::delete(Method::DELETE)]
+    #[tokio::test]
+    async fn collection_job(#[case] method: Method) {
+        run_rate_limit_test(
+            &|leader_url, _, task_id_1, task_id_2| {
+                let job_id: CollectionJobId = random();
+
+                (
+                    leader_url
+                        .join(&format!("tasks/{task_id_1}/collection_jobs/{job_id}"))
+                        .unwrap(),
+                    leader_url
+                        .join(&format!("tasks/{task_id_2}/collection_jobs/{job_id}"))
+                        .unwrap(),
+                )
+            },
+            &|test_config| test_config.collection_job_qps,
+            method,
+        )
+        .await
+    }
+
+    #[rstest::rstest]
+    #[case::put(Method::PUT)]
+    #[case::post(Method::POST)]
+    #[tokio::test]
+    async fn aggregation_job_put(#[case] method: Method) {
+        run_rate_limit_test(
+            &|_, helper_url, task_id_1, task_id_2| {
+                let job_id: AggregationJobId = random();
+                (
+                    helper_url
+                        .join(&format!("tasks/{task_id_1}/aggregation_jobs/{job_id}"))
+                        .unwrap(),
+                    helper_url
+                        .join(&format!("tasks/{task_id_2}/aggregation_jobs/{job_id}"))
+                        .unwrap(),
+                )
+            },
+            &|test_config| test_config.aggregation_job_qps,
+            method,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn aggregate_share_post() {
+        run_rate_limit_test(
+            &|_, helper_url, task_id_1, task_id_2| {
+                (
+                    helper_url
+                        .join(&format!("tasks/{task_id_1}/aggregate_shares"))
+                        .unwrap(),
+                    helper_url
+                        .join(&format!("tasks/{task_id_2}/aggregate_shares"))
+                        .unwrap(),
+                )
+            },
+            &|test_config| test_config.collection_job_qps,
+            Method::POST,
+        )
+        .await
+    }
+}

--- a/integration_tests/tests/integration/in_cluster.rs
+++ b/integration_tests/tests/integration/in_cluster.rs
@@ -412,7 +412,7 @@ mod rate_limits {
             first_task_id: &janus_pair.task_parameters.task_id,
             second_task_id: &other_task_id,
         });
-        let rate_limit = rate_limit_picker(&test_config);
+        let rate_limit = rate_limit_picker(test_config);
         let rate_limit_excess = test_config.rate_limit_excess;
         let total_requests_count =
             ((1.0 + rate_limit_excess) * (rate_limit * test_config.window) as f64) as u64;


### PR DESCRIPTION
Adds tests to exercise Divvi Up's rate limiting to the existing `in_cluster` test module. The test setup reads in rate limit configuration from a file whose path is specified via environment variable, akin to the existing `JANUS_E2E_*` variables.

These tests don't actually exercise any part of Janus itself, but they rely on the test support for forwarding ports and otherwise working with a pair of Januses in a Kubernetes cluster, so this is a convenient place to define them.