### PR TITLE
Fix global mismatch with trillium-opentelemetry, 0.5 backport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1883,11 +1883,11 @@ dependencies = [
  "lazy_static",
  "mockito",
  "once_cell",
- "opentelemetry 0.21.0",
+ "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-prometheus",
  "opentelemetry-semantic-conventions",
- "opentelemetry_sdk 0.21.1",
+ "opentelemetry_sdk",
  "postgres-protocol",
  "postgres-types",
  "prio",
@@ -1944,7 +1944,7 @@ dependencies = [
  "janus_aggregator_core",
  "janus_core",
  "janus_messages",
- "opentelemetry 0.21.0",
+ "opentelemetry",
  "querystring",
  "rand",
  "ring 0.17.6",
@@ -1987,7 +1987,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "lazy_static",
- "opentelemetry 0.21.0",
+ "opentelemetry",
  "postgres-protocol",
  "postgres-types",
  "prio",
@@ -2169,7 +2169,7 @@ dependencies = [
  "janus_interop_binaries",
  "janus_messages",
  "lazy_static",
- "opentelemetry 0.21.0",
+ "opentelemetry",
  "prio",
  "rand",
  "regex",
@@ -2654,16 +2654,6 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "opentelemetry"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
-dependencies = [
- "opentelemetry_api",
- "opentelemetry_sdk 0.20.0",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
@@ -2687,10 +2677,10 @@ dependencies = [
  "async-trait",
  "futures-core",
  "http 0.2.11",
- "opentelemetry 0.21.0",
+ "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
- "opentelemetry_sdk 0.21.1",
+ "opentelemetry_sdk",
  "prost 0.11.9",
  "thiserror",
  "tokio",
@@ -2704,8 +2694,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8f082da115b0dcb250829e3ed0b8792b8f963a1ad42466e48422fbe6a079bd"
 dependencies = [
  "once_cell",
- "opentelemetry 0.21.0",
- "opentelemetry_sdk 0.21.1",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prometheus",
  "protobuf",
 ]
@@ -2716,8 +2706,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2e155ce5cc812ea3d1dffbd1539aed653de4bf4882d60e6e04dcf0901d674e1"
 dependencies = [
- "opentelemetry 0.21.0",
- "opentelemetry_sdk 0.21.1",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prost 0.11.9",
  "tonic 0.9.2",
 ]
@@ -2728,43 +2718,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5774f1ef1f982ef2a447f6ee04ec383981a3ab99c8e77a1a7b30182e65bbc84"
 dependencies = [
- "opentelemetry 0.21.0",
-]
-
-[[package]]
-name = "opentelemetry_api"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a81f725323db1b1206ca3da8bb19874bbd3f57c3bcd59471bfb04525b265b9b"
-dependencies = [
- "futures-channel",
- "futures-util",
- "indexmap 1.9.3",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror",
- "urlencoding",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8e705a0612d48139799fcbaba0d4a90f06277153e43dd2bdc16c6f0edd8026"
-dependencies = [
- "async-trait",
- "crossbeam-channel",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "once_cell",
- "opentelemetry_api",
- "ordered-float 3.7.0",
- "percent-encoding",
- "rand",
- "regex",
- "thiserror",
+ "opentelemetry",
 ]
 
 [[package]]
@@ -2780,7 +2734,7 @@ dependencies = [
  "futures-util",
  "glob",
  "once_cell",
- "opentelemetry 0.21.0",
+ "opentelemetry",
  "ordered-float 4.1.1",
  "percent-encoding",
  "rand",
@@ -2794,15 +2748,6 @@ name = "ordered-float"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "ordered-float"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc2dbde8f8a79f2102cc474ceb0ad68e3b80b85289ea62389b60e66777e4213"
 dependencies = [
  "num-traits",
 ]
@@ -4763,8 +4708,8 @@ checksum = "c67ac25c5407e7b961fafc6f7e9aa5958fd297aada2d20fa2ae1737357e55596"
 dependencies = [
  "js-sys",
  "once_cell",
- "opentelemetry 0.21.0",
- "opentelemetry_sdk 0.21.1",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -4902,11 +4847,11 @@ dependencies = [
 
 [[package]]
 name = "trillium-opentelemetry"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2711073179f57337f0fb429befd5102415dff434a255ffbef2e84036c566812b"
+checksum = "0903b25c38ea1a1506cb4f3ff8fad8f8331f3de5dc6bf6d36312777ce10e0f80"
 dependencies = [
- "opentelemetry 0.20.0",
+ "opentelemetry",
  "trillium",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ trillium = "0.2.11"
 trillium-api = { version = "0.2.0-rc.7", default-features = false }
 trillium-caching-headers = "0.2.1"
 trillium-head = "0.2.0"
-trillium-opentelemetry = "0.3.0"
+trillium-opentelemetry = "0.4.0"
 trillium-router = "0.3.5"
 trillium-testing = "0.5.0"
 trillium-tokio = "0.3.2"

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -23,7 +23,7 @@ use prio::codec::Encode;
 use ring::digest::{digest, SHA256};
 use routefinder::Captures;
 use serde::Deserialize;
-use std::time::Duration as StdDuration;
+use std::{borrow::Cow, time::Duration as StdDuration};
 use std::{io::Cursor, sync::Arc};
 use tracing::warn;
 use trillium::{Conn, Handler, KnownHeaderName, Status};
@@ -33,6 +33,7 @@ use trillium_opentelemetry::metrics;
 use trillium_router::{Router, RouterConnExt};
 
 /// Newtype holding a textual error code, to be stored in a Trillium connection's state.
+#[derive(Clone, Copy)]
 struct ErrorCode(&'static str);
 
 #[async_trait]
@@ -224,7 +225,15 @@ async fn aggregator_handler_with_aggregator<C: Clock>(
 ) -> Result<impl Handler, Error> {
     Ok((
         State(aggregator),
-        metrics("janus_aggregator").with_route(|conn| conn.route().map(ToString::to_string)),
+        metrics(meter)
+            .with_route(|conn| {
+                conn.route()
+                    .map(|route_spec| Cow::Owned(route_spec.to_string()))
+            })
+            .with_error_type(|conn| {
+                conn.state::<ErrorCode>()
+                    .map(|error_code| Cow::Borrowed(error_code.0))
+            }),
         Router::new()
             .without_options_handling()
             .get("hpke_config", instrumented(api(hpke_config::<C>)))

--- a/aggregator_api/src/lib.rs
+++ b/aggregator_api/src/lib.rs
@@ -12,9 +12,10 @@ use janus_core::{http::extract_bearer_token, task::AuthenticationToken, time::Cl
 use janus_messages::HpkeConfigId;
 use janus_messages::TaskId;
 
+use opentelemetry::metrics::Meter;
 use ring::constant_time;
 use routes::*;
-use std::{str::FromStr, sync::Arc};
+use std::{borrow::Cow, str::FromStr, sync::Arc};
 use tracing::error;
 use trillium::{
     Conn, Handler,
@@ -69,13 +70,20 @@ impl Handler for ReplaceMimeTypes {
 
 /// Returns a new handler for an instance of the aggregator API, backed by the given datastore,
 /// according to the given configuration.
-pub fn aggregator_api_handler<C: Clock>(ds: Arc<Datastore<C>>, cfg: Config) -> impl Handler {
+pub fn aggregator_api_handler<C: Clock>(
+    ds: Arc<Datastore<C>>,
+    cfg: Config,
+    meter: &Meter,
+) -> impl Handler {
     (
         // State used by endpoint handlers.
         State(ds),
         State(Arc::new(cfg)),
         // Metrics.
-        metrics("janus_aggregator").with_route(|conn| conn.route().map(ToString::to_string)),
+        metrics(meter).with_route(|conn| {
+            conn.route()
+                .map(|route_spec| Cow::Owned(route_spec.to_string()))
+        }),
         // Authorization check.
         api(auth_check),
         // Check content type and accept headers

--- a/aggregator_api/src/tests.rs
+++ b/aggregator_api/src/tests.rs
@@ -18,6 +18,7 @@ use janus_aggregator_core::{
         Datastore,
     },
     task::{test_util::TaskBuilder, QueryType, Task},
+    test_util::noop_meter,
     SecretBytes,
 };
 use janus_core::{
@@ -63,6 +64,7 @@ async fn setup_api_test() -> (impl Handler, EphemeralDatastore, Arc<Datastore<Mo
             ]),
             public_dap_url: "https://dap.url".parse().unwrap(),
         },
+        &noop_meter(),
     );
 
     (handler, ephemeral_datastore, datastore)


### PR DESCRIPTION
This is a backport of #2331.