### PR TITLE
Add cargo-deny configuration, run in CI

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -133,6 +133,8 @@ jobs:
       run: cargo clippy --profile ci --workspace --all-targets --all-features
     - name: Document
       run: cargo doc --profile ci --workspace
+    - name: cargo-deny
+      uses: EmbarkStudios/cargo-deny-action@v1
 
   janus_docker:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,12 +367,6 @@ checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
@@ -945,7 +939,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e084d341709e4a0e1dfe97e39769eecdd6463a3eda53d9ff7c6bcaade144ec5"
 dependencies = [
- "base64 0.21.5",
+ "base64",
  "email_address",
  "janus_messages 0.6.2",
  "log",
@@ -1499,11 +1493,11 @@ dependencies = [
 
 [[package]]
 name = "hdrhistogram"
-version = "7.5.2"
+version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f19b9f54f7c7f55e31401bb647626ce0cf0f67b0004982ce815b3ee72a02aa8"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "byteorder",
  "flate2",
  "nom",
@@ -1886,7 +1880,7 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "backoff",
- "base64 0.21.5",
+ "base64",
  "bytes",
  "chrono",
  "clap",
@@ -1968,7 +1962,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "async-trait",
- "base64 0.21.5",
+ "base64",
  "derivative",
  "futures",
  "janus_aggregator_core",
@@ -2001,7 +1995,7 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "backoff",
- "base64 0.21.5",
+ "base64",
  "bytes",
  "chrono",
  "deadpool",
@@ -2077,7 +2071,7 @@ version = "0.6.6"
 dependencies = [
  "assert_matches",
  "backoff",
- "base64 0.21.5",
+ "base64",
  "chrono",
  "derivative",
  "fixed",
@@ -2106,7 +2100,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "backoff",
- "base64 0.21.5",
+ "base64",
  "chrono",
  "derivative",
  "fixed",
@@ -2149,7 +2143,7 @@ version = "0.6.6"
 dependencies = [
  "anyhow",
  "backoff",
- "base64 0.21.5",
+ "base64",
  "divviup-client",
  "futures",
  "hex",
@@ -2182,7 +2176,7 @@ version = "0.6.6"
 dependencies = [
  "anyhow",
  "backoff",
- "base64 0.21.5",
+ "base64",
  "clap",
  "derivative",
  "fixed",
@@ -2225,7 +2219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e471b004b89352cf02ffa0e5764a4e5d88428ccb9302cb51665ba843fd09c221"
 dependencies = [
  "anyhow",
- "base64 0.21.5",
+ "base64",
  "derivative",
  "hex",
  "num_enum",
@@ -2242,7 +2236,7 @@ version = "0.6.6"
 dependencies = [
  "anyhow",
  "assert_matches",
- "base64 0.21.5",
+ "base64",
  "derivative",
  "hex",
  "num_enum",
@@ -2260,7 +2254,7 @@ version = "0.6.6"
 dependencies = [
  "anyhow",
  "assert_matches",
- "base64 0.21.5",
+ "base64",
  "cfg-if",
  "clap",
  "derivative",
@@ -2317,7 +2311,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edc3606fd16aca7989db2f84bb25684d0270c6d6fa1dbcd0025af7b4130523a6"
 dependencies = [
- "base64 0.21.5",
+ "base64",
  "bytes",
  "chrono",
  "serde",
@@ -2351,7 +2345,7 @@ version = "0.87.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7266548b9269d9fa19022620d706697e64f312fb2ba31b93e6986453fcc82c92"
 dependencies = [
- "base64 0.21.5",
+ "base64",
  "bytes",
  "chrono",
  "either",
@@ -2904,7 +2898,7 @@ version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3163d2912b7c3b52d651a055f2c7eec9ba5cd22d26ef75b8dd3a59980b185923"
 dependencies = [
- "base64 0.21.5",
+ "base64",
  "serde",
 ]
 
@@ -3050,7 +3044,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b6c5ef183cd3ab4ba005f1ca64c21e8bd97ce4699cfea9e8d9a2c4958ca520"
 dependencies = [
- "base64 0.21.5",
+ "base64",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -3397,7 +3391,7 @@ version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
 dependencies = [
- "base64 0.21.5",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3611,7 +3605,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64 0.21.5",
+ "base64",
 ]
 
 [[package]]
@@ -3620,7 +3614,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35e4980fa29e4c4b212ffb3db068a564cbf560e51d3944b7c88bd8bf5bec64f4"
 dependencies = [
- "base64 0.21.5",
+ "base64",
  "rustls-pki-types",
 ]
 
@@ -4195,7 +4189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e37195395df71fd068f6e2082247891bc11e3289624bbc776a0cdfa1ca7f1ea4"
 dependencies = [
  "atoi",
- "base64 0.21.5",
+ "base64",
  "bitflags 2.4.1",
  "byteorder",
  "bytes",
@@ -4237,7 +4231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6ac0ac3b7ccd10cc96c7ab29791a7dd236bd94021f31eec7ba3d46a74aa1c24"
 dependencies = [
  "atoi",
- "base64 0.21.5",
+ "base64",
  "bitflags 2.4.1",
  "byteorder",
  "crc",
@@ -4665,7 +4659,7 @@ checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
  "async-trait",
  "axum",
- "base64 0.21.5",
+ "base64",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4694,7 +4688,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.21.5",
+ "base64",
  "bytes",
  "h2",
  "http 0.2.11",
@@ -4738,7 +4732,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55ae70283aba8d2a8b411c695c437fe25b8b5e44e23e780662002fc72fb47a82"
 dependencies = [
- "base64 0.21.5",
+ "base64",
  "bitflags 2.4.1",
  "bytes",
  "futures-core",

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,17 @@
+targets = [
+    { triple = "x86_64-unknown-linux-gnu" },
+    { triple = "x86_64-unknown-linux-musl" },
+]
+all-features = true
+
+[bans]
+deny = [
+    { name = "tracing", deny-multiple-versions = true },
+    { name = "opentelemetry", deny-multiple-versions = true },
+]
+skip = [{ name = "janus_messages" }]
+
+[licenses]
+copyleft = "allow"
+default = "allow"
+unlicensed = "allow"

--- a/deny.toml
+++ b/deny.toml
@@ -2,7 +2,6 @@ targets = [
     { triple = "x86_64-unknown-linux-gnu" },
     { triple = "x86_64-unknown-linux-musl" },
 ]
-all-features = true
 
 [bans]
 multiple-versions = "allow"

--- a/deny.toml
+++ b/deny.toml
@@ -5,11 +5,11 @@ targets = [
 all-features = true
 
 [bans]
+multiple-versions = "allow"
 deny = [
     { name = "tracing", deny-multiple-versions = true },
     { name = "opentelemetry", deny-multiple-versions = true },
 ]
-skip = [{ name = "janus_messages" }]
 
 [licenses]
 copyleft = "allow"


### PR DESCRIPTION
This sets up cargo-deny to prevent multiple dependencies on different versions of `tracing` or `opentelemetry`, either of which could lead to lost observability data.

Closes #2332.