### PR TITLE
Fix idempotency bug in `handle_aggregate_init_generic`

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -2034,7 +2034,7 @@ impl VdafOps {
 
                     if !replayed_request {
                         // Write report shares, aggregations, and batches.
-                        let (resulting_unwriteable_reports, resulting_report_share_data, _) = try_join!(
+                        (_, report_share_data, _) = try_join!(
                             accumulator.flush_to_datastore(tx, &vdaf),
                             try_join_all(report_share_data.into_iter().map(|mut rsd| {
                                 let task = Arc::clone(&task);
@@ -2089,12 +2089,6 @@ impl VdafOps {
                                 Ok(())
                             }}))
                         )?;
-                        report_share_data = resulting_report_share_data;
-
-                        // Sanity check: we should receive the same set of unwritable reports after
-                        // writing as we did in the beginning of this transaction. If not, this is
-                        // a bug and we shouldn't commit this transaction.
-                        assert_eq!(unwritable_reports, resulting_unwriteable_reports);
                     }
 
                     Ok(Self::aggregation_job_resp_for(

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1943,7 +1943,7 @@ impl VdafOps {
         let accumulator = Arc::new(accumulator);
 
         Ok(datastore
-            .run_tx("aggregate_init", |tx|  {
+            .run_tx("aggregate_init", |tx| {
                 let vdaf = vdaf.clone();
                 let task = Arc::clone(&task);
                 let req = Arc::clone(&req);
@@ -1953,58 +1953,55 @@ impl VdafOps {
                 let accumulator = Arc::clone(&accumulator);
 
                 Box::pin(async move {
-                    let unwritable_reports = accumulator.unwritable_reports(tx, &vdaf).await?;
-
                     for report_share_data in &mut report_share_data {
                         // Verify that we haven't seen this report ID and aggregation parameter
                         // before in another aggregation job, and that the report isn't for a batch
                         // interval that has already started collection.
-                        let (
-                            report_aggregation_exists,
-                            conflicting_aggregate_share_jobs,
-                        ) = try_join!(
-                            tx.check_other_report_aggregation_exists::<SEED_SIZE, A>(
-                                task.id(),
-                                report_share_data.report_share.metadata().id(),
-                                aggregation_job.aggregation_parameter(),
-                                aggregation_job.id(),
-                            ),
-                            Q::get_conflicting_aggregate_share_jobs::<SEED_SIZE, C, A>(
-                                tx,
-                                &vdaf,
-                                task.id(),
-                                req.batch_selector().batch_identifier(),
-                                report_share_data.report_share.metadata()
-                            ),
-                        )?;
+                        let (report_aggregation_exists, conflicting_aggregate_share_jobs) =
+                            try_join!(
+                                tx.check_other_report_aggregation_exists::<SEED_SIZE, A>(
+                                    task.id(),
+                                    report_share_data.report_share.metadata().id(),
+                                    aggregation_job.aggregation_parameter(),
+                                    aggregation_job.id(),
+                                ),
+                                Q::get_conflicting_aggregate_share_jobs::<SEED_SIZE, C, A>(
+                                    tx,
+                                    &vdaf,
+                                    task.id(),
+                                    req.batch_selector().batch_identifier(),
+                                    report_share_data.report_share.metadata(),
+                                ),
+                            )?;
 
                         if report_aggregation_exists {
-                            report_share_data.report_aggregation =
-                                report_share_data.report_aggregation
-                                    .clone()
-                                    .with_state(ReportAggregationState::Failed(
-                                        PrepareError::ReportReplayed))
-                                    .with_last_prep_resp(Some(PrepareResp::new(
-                                        *report_share_data.report_share.metadata().id(),
-                                        PrepareStepResult::Reject(PrepareError::ReportReplayed))
-                                    ));
-                        } else if !conflicting_aggregate_share_jobs.is_empty() ||
-                            unwritable_reports.contains(report_share_data.report_aggregation.report_id()) {
-                            report_share_data.report_aggregation =
-                                report_share_data.report_aggregation
-                                    .clone()
-                                    .with_state(ReportAggregationState::Failed(
-                                        PrepareError::BatchCollected))
-                                    .with_last_prep_resp(Some(PrepareResp::new(
-                                        *report_share_data.report_share.metadata().id(),
-                                        PrepareStepResult::Reject(PrepareError::BatchCollected))
-                                    ));
+                            report_share_data.report_aggregation = report_share_data
+                                .report_aggregation
+                                .clone()
+                                .with_state(ReportAggregationState::Failed(
+                                    PrepareError::ReportReplayed,
+                                ))
+                                .with_last_prep_resp(Some(PrepareResp::new(
+                                    *report_share_data.report_share.metadata().id(),
+                                    PrepareStepResult::Reject(PrepareError::ReportReplayed),
+                                )));
+                        } else if !conflicting_aggregate_share_jobs.is_empty() {
+                            report_share_data.report_aggregation = report_share_data
+                                .report_aggregation
+                                .clone()
+                                .with_state(ReportAggregationState::Failed(
+                                    PrepareError::BatchCollected,
+                                ))
+                                .with_last_prep_resp(Some(PrepareResp::new(
+                                    *report_share_data.report_share.metadata().id(),
+                                    PrepareStepResult::Reject(PrepareError::BatchCollected),
+                                )));
                         }
                     }
 
                     // Write aggregation job.
-                    let replayed_request = match tx.put_aggregation_job(&aggregation_job).await {
-                        Ok(_) => false,
+                    match tx.put_aggregation_job(&aggregation_job).await {
+                        Ok(_) => {}
                         Err(datastore::Error::MutationTargetAlreadyExists) => {
                             // Slow path: this request is writing an aggregation job that already
                             // exists in the datastore. PUT to an aggregation job is idempotent, so
@@ -2027,74 +2024,102 @@ impl VdafOps {
                                 ));
                             }
 
-                            true
+                            return Ok(Self::aggregation_job_resp_for(
+                                report_share_data
+                                    .into_iter()
+                                    .map(|data| data.report_aggregation),
+                            ));
                         }
                         Err(e) => return Err(e),
                     };
 
-                    if !replayed_request {
-                        // Write report shares, aggregations, and batches.
-                        (_, report_share_data, _) = try_join!(
-                            accumulator.flush_to_datastore(tx, &vdaf),
-                            try_join_all(report_share_data.into_iter().map(|mut rsd| {
-                                let task = Arc::clone(&task);
-                                async move {
-                                    if let Err(err) =
-                                        tx.put_report_share(task.id(), &rsd.report_share).await
-                                    {
-                                        match err {
-                                            datastore::Error::MutationTargetAlreadyExists => {
-                                                rsd.report_aggregation = rsd
-                                                    .report_aggregation
-                                                    .clone()
-                                                    .with_state(ReportAggregationState::Failed(
+                    // Write report shares, aggregations, and batches.
+                    let (unwritable_reports, report_share_data, _) = try_join!(
+                        accumulator.flush_to_datastore(tx, &vdaf),
+                        try_join_all(report_share_data.into_iter().map(|mut rsd| {
+                            let task = Arc::clone(&task);
+                            async move {
+                                if let Err(err) =
+                                    tx.put_report_share(task.id(), &rsd.report_share).await
+                                {
+                                    match err {
+                                        datastore::Error::MutationTargetAlreadyExists => {
+                                            rsd.report_aggregation = rsd
+                                                .report_aggregation
+                                                .clone()
+                                                .with_state(ReportAggregationState::Failed(
+                                                    PrepareError::ReportReplayed,
+                                                ))
+                                                .with_last_prep_resp(Some(PrepareResp::new(
+                                                    *rsd.report_share.metadata().id(),
+                                                    PrepareStepResult::Reject(
                                                         PrepareError::ReportReplayed,
-                                                    ))
-                                                    .with_last_prep_resp(Some(PrepareResp::new(
-                                                        *rsd.report_share.metadata().id(),
-                                                        PrepareStepResult::Reject(
-                                                            PrepareError::ReportReplayed,
-                                                        ),
-                                                    )));
-                                            }
-                                            err => return Err(err),
+                                                    ),
+                                                )));
                                         }
+                                        err => return Err(err),
                                     }
-                                    tx.put_report_aggregation(&rsd.report_aggregation).await?;
-                                    Ok(rsd)
                                 }
-                            })),
-                            try_join_all(interval_per_batch_identifier.iter().map(|(batch_identifier, interval)| {
+                                tx.put_report_aggregation(&rsd.report_aggregation).await?;
+                                Ok(rsd)
+                            }
+                        })),
+                        try_join_all(interval_per_batch_identifier.iter().map(
+                            |(batch_identifier, interval)| {
                                 let task = Arc::clone(&task);
                                 let aggregation_job = Arc::clone(&aggregation_job);
                                 async move {
-                                match tx.get_batch::<SEED_SIZE, Q, A>(
-                                    task.id(),
-                                    batch_identifier,
-                                    aggregation_job.aggregation_parameter(),
-                                ).await? {
-                                    Some(batch) => {
-                                        let interval = batch.client_timestamp_interval().merge(interval)?;
-                                        tx.update_batch(&batch.with_client_timestamp_interval(interval)).await?;
-                                    },
-                                    None => tx.put_batch(&Batch::<SEED_SIZE, Q, A>::new(
-                                        *task.id(),
-                                        batch_identifier.clone(),
-                                        aggregation_job.aggregation_parameter().clone(),
-                                        BatchState::Open,
-                                        0,
-                                        *interval,
-                                    )).await?
+                                    match tx
+                                        .get_batch::<SEED_SIZE, Q, A>(
+                                            task.id(),
+                                            batch_identifier,
+                                            aggregation_job.aggregation_parameter(),
+                                        )
+                                        .await?
+                                    {
+                                        Some(batch) => {
+                                            let interval = batch
+                                                .client_timestamp_interval()
+                                                .merge(interval)?;
+                                            tx.update_batch(
+                                                &batch.with_client_timestamp_interval(interval),
+                                            )
+                                            .await?;
+                                        }
+                                        None => {
+                                            tx.put_batch(&Batch::<SEED_SIZE, Q, A>::new(
+                                                *task.id(),
+                                                batch_identifier.clone(),
+                                                aggregation_job.aggregation_parameter().clone(),
+                                                BatchState::Open,
+                                                0,
+                                                *interval,
+                                            ))
+                                            .await?
+                                        }
+                                    }
+                                    Ok(())
                                 }
-                                Ok(())
-                            }}))
-                        )?;
-                    }
+                            }
+                        ))
+                    )?;
 
                     Ok(Self::aggregation_job_resp_for(
-                        report_share_data
-                            .into_iter()
-                            .map(|data| data.report_aggregation),
+                        report_share_data.into_iter().map(|data| {
+                            let id = data.report_share.metadata().id();
+                            if unwritable_reports.contains(id) {
+                                data.report_aggregation
+                                    .with_state(ReportAggregationState::Failed(
+                                        PrepareError::BatchCollected,
+                                    ))
+                                    .with_last_prep_resp(Some(PrepareResp::new(
+                                        *id,
+                                        PrepareStepResult::Reject(PrepareError::BatchCollected),
+                                    )))
+                            } else {
+                                data.report_aggregation
+                            }
+                        }),
                     ))
                 })
             })

--- a/aggregator/src/aggregator/accumulator.rs
+++ b/aggregator/src/aggregator/accumulator.rs
@@ -143,9 +143,7 @@ impl<const SEED_SIZE: usize, Q: AccumulableQueryType, A: vdaf::Aggregator<SEED_S
                 .map(|batch_aggregation| {
                     batch_aggregation.map(|batch_aggregation| {
                         if batch_aggregation.state() == &BatchAggregationState::Collected {
-                            // Unwrap safety: this only panics if the mutex is poisoned. If
-                            // it is, one of the other futures also panicked, so we can
-                            // panic too.
+                            // Unwrap safety: panic on mutex poisoning.
                             unmergeable_report_ids
                                 .lock()
                                 .unwrap()
@@ -158,9 +156,7 @@ impl<const SEED_SIZE: usize, Q: AccumulableQueryType, A: vdaf::Aggregator<SEED_S
         .await?;
 
         // Unwrap safety: at this point, `unmergeable_report_ids` is the only instance of this Arc,
-        // so `try_unwrap().unwrap()` will succeed. `into_inner().unwrap()` can only panic if code
-        // that held this mutex panicked; but in this case, we would have panicked already while
-        // awaiting the above future (and if not, we do want to panic now).
+        // so `try_unwrap().unwrap()` will succeed. Panic if the inner mutex is poisoned.
         Ok(Arc::try_unwrap(unmergeable_report_ids)
             .unwrap()
             .into_inner()
@@ -204,9 +200,7 @@ impl<const SEED_SIZE: usize, Q: AccumulableQueryType, A: vdaf::Aggregator<SEED_S
                             match batch_aggregation.merged_with(&data.batch_aggregation) {
                                 Ok(batch_aggregation) => batch_aggregation,
                                 Err(datastore::Error::AlreadyCollected) => {
-                                    // Unwrap safety: this only panics if the mutex is poisoned. If
-                                    // it is, one of the other futures also panicked, so we can
-                                    // panic too.
+                                    // Unwrap safety: panic on mutex poisoning.
                                     let mut unmergeable_report_ids =
                                         unmergeable_report_ids.lock().unwrap();
                                     unmergeable_report_ids.extend(&data.included_report_ids);
@@ -254,9 +248,7 @@ impl<const SEED_SIZE: usize, Q: AccumulableQueryType, A: vdaf::Aggregator<SEED_S
         .await?;
 
         // Unwrap safety: at this point, `unmergeable_report_ids` is the only instance of this Arc,
-        // so `try_unwrap().unwrap()` will succeed. `into_inner().unwrap()` can only panic if code
-        // that held this mutex panicked; but in this case, we would have panicked already while
-        // awaiting the above future (and if not, we do want to panic now).
+        // so `try_unwrap().unwrap()` will succeed. Panic if the inner mutex is poisoned.
         Ok(Arc::try_unwrap(unmergeable_report_ids)
             .unwrap()
             .into_inner()

--- a/aggregator/src/aggregator/accumulator.rs
+++ b/aggregator/src/aggregator/accumulator.rs
@@ -334,7 +334,7 @@ mod tests {
                     let interval = Interval::new(timestamp, Duration::from_seconds(1)).unwrap();
                     let batch = Batch::<0, FixedSize, dummy_vdaf::Vdaf>::new(
                         *task.id(),
-                        batch_id.clone(),
+                        batch_id,
                         AggregationParam(0),
                         BatchState::Open,
                         0,
@@ -348,7 +348,7 @@ mod tests {
                         let batch_aggregation =
                             BatchAggregation::<0, FixedSize, dummy_vdaf::Vdaf>::new(
                                 *task.id(),
-                                batch_id.clone(),
+                                batch_id,
                                 AggregationParam(0),
                                 shard,
                                 BatchAggregationState::Collected,

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -2045,7 +2045,6 @@ mod tests {
         datastore.put_aggregator_task(&helper_task).await.unwrap();
 
         let vdaf = dummy_vdaf::Vdaf::new();
-        let measurement = ();
         let prep_init_generator = PrepareInitGenerator::new(
             clock.clone(),
             helper_task.clone(),
@@ -2053,7 +2052,7 @@ mod tests {
             dummy_vdaf::AggregationParam(0),
         );
 
-        let (prepare_init, _) = prep_init_generator.next(&measurement);
+        let (prepare_init, _) = prep_init_generator.next(&());
 
         let aggregation_param = dummy_vdaf::AggregationParam(0);
         let batch_id = random();

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -73,3 +73,27 @@ To create a new migration:
   so a panic is appropriate. (Note that some `FromSql` implementations may
   return errors for other reasons, such as out-of-range values or serde
   deserialization falures)
+
+* In production code, use of `.unwrap()` should be preceded by a comment
+  that asserts the safety of the unwrap.
+
+  Example:
+  ```rust
+  // Unwrap safety: The constructor checks that max_concurrent_job_workers 
+  // can be converted to a u32.
+  // Unwrap safety: Semaphore::acquire is documented as only returning an error
+  // if the semaphore is closed, and we never close this semaphore.
+  let _: SemaphorePermit<'_> = sem
+      .acquire_many(u32::try_from(self.max_concurrent_job_workers).unwrap())
+      .await
+      .unwrap();
+  ```
+
+  If unwrapping a mutex lock, where panic is a desired outcome of mutex poisoning,
+  you can simply state:
+  ```rust
+  // Unwrap safety: panic on mutex poisoning.
+  mutex.lock().unwrap();
+  ```
+
+  Explanation of `.unwrap()` is not necessary in test code.


### PR DESCRIPTION
Calls to the helper's `/aggregate` endpoint were not actually idempotent.

This is because we invoked `accumulator.flush_to_datastore(tx, &vdaf)`, before checking whether the request was replayed. This function makes changes, and we would `Ok` on replayed requests, causing the changes to be committed. 

The overall effect was repeated `/aggregate` requests would count again against the underlying batch aggregations. This would render the batch uncollectable, since the checksums between helper and leader wouldn't match.

This was particularly noticeable when the helper was under heavy load. If the upstream LB times out the request, the request isn't cancelled and the changes are committed. Since the leader sees `502 Bad Gateway`, it retries the request.

`flush_to_datastore()` was at that spot because we were mostly interested in the reports that couldn't be applied to a batch because the batch has been collected. In this PR, introduce a function `unwritable_reports()` that yields those reports without the side effect of writing the batch aggregation.

I will backport this change to 0.5.