### PR TITLE
Downgrade some `tracing::info!` calls to `debug!`

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1499,7 +1499,7 @@ impl VdafOps {
         let encoded_leader_input_share = match decryption_result {
             Ok(plaintext) => plaintext,
             Err(error) => {
-                info!(
+                debug!(
                     report.task_id = %task.id(),
                     report.metadata = ?report.metadata(),
                     ?error,
@@ -1717,7 +1717,7 @@ impl VdafOps {
             );
 
             let check_keypairs = if task_hpke_keypair.is_none() && global_hpke_keypair.is_none() {
-                info!(
+                debug!(
                     config_id = %prepare_init.report_share().encrypted_input_share().config_id(),
                     "Helper encrypted input share references unknown HPKE config ID"
                 );
@@ -1743,7 +1743,7 @@ impl VdafOps {
                     }
                 }
                 .map_err(|error| {
-                    info!(
+                    debug!(
                         task_id = %task.id(),
                         metadata = ?prepare_init.report_share().metadata(),
                         ?error,
@@ -1758,7 +1758,7 @@ impl VdafOps {
             let plaintext_input_share = plaintext.and_then(|plaintext| {
                 let plaintext_input_share =
                     PlaintextInputShare::get_decoded(&plaintext).map_err(|error| {
-                        info!(
+                        debug!(
                             task_id = %task.id(),
                             metadata = ?prepare_init.report_share().metadata(),
                             ?error, "Couldn't decode helper's plaintext input share",
@@ -1779,7 +1779,7 @@ impl VdafOps {
                     .iter()
                     .all(|extension| extension_types.insert(extension.extension_type()))
                 {
-                    info!(
+                    debug!(
                         task_id = %task.id(),
                         metadata = ?prepare_init.report_share().metadata(),
                         "Received report share with duplicate extensions",
@@ -1797,7 +1797,7 @@ impl VdafOps {
                     plaintext_input_share.payload(),
                 )
                 .map_err(|error| {
-                    info!(
+                    debug!(
                         task_id = %task.id(),
                         metadata = ?prepare_init.report_share().metadata(),
                         ?error, "Couldn't decode helper's input share",
@@ -1813,7 +1813,7 @@ impl VdafOps {
                 prepare_init.report_share().public_share(),
             )
             .map_err(|error| {
-                info!(
+                debug!(
                     task_id = %task.id(),
                     metadata = ?prepare_init.report_share().metadata(),
                     ?error, "Couldn't decode public share",

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1441,7 +1441,7 @@ impl VdafOps {
             match A::PublicShare::get_decoded_with_param(vdaf.as_ref(), report.public_share()) {
                 Ok(public_share) => public_share,
                 Err(err) => {
-                    warn!(
+                    debug!(
                         report.task_id = %task.id(),
                         report.metadata = ?report.metadata(),
                         ?err,
@@ -1526,7 +1526,7 @@ impl VdafOps {
         let (extensions, leader_input_share) = match decoded_leader_input_share {
             Ok(leader_input_share) => leader_input_share,
             Err(err) => {
-                warn!(
+                debug!(
                     report.task_id = %task.id(),
                     report.metadata = ?report.metadata(),
                     ?err,

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -40,7 +40,7 @@ use std::{
     time::Duration,
 };
 use tokio::try_join;
-use tracing::{info, trace_span, warn};
+use tracing::{debug, info, trace_span, warn};
 
 use super::error::handle_ping_pong_error;
 
@@ -355,7 +355,7 @@ impl AggregationJobDriver {
                 .iter()
                 .all(|extension| extension_types.insert(extension.extension_type()))
             {
-                info!(report_id = %report_aggregation.report_id(), "Received report with duplicate extensions");
+                debug!(report_id = %report_aggregation.report_id(), "Received report with duplicate extensions");
                 self.aggregate_step_failure_counter
                     .add(1, &[KeyValue::new("type", "duplicate_extension")]);
                 report_aggregations_to_write.push(

--- a/aggregator_core/src/lib.rs
+++ b/aggregator_core/src/lib.rs
@@ -6,7 +6,7 @@
 #![allow(clippy::single_component_path_imports)]
 
 use derivative::Derivative;
-use tracing::{info, info_span, Instrument, Span};
+use tracing::{debug, info_span, Instrument, Span};
 use trillium::{Conn, Handler, Status};
 use trillium_macros::Handler;
 use trillium_router::RouterConnExt;
@@ -79,7 +79,7 @@ impl<H: Handler> InstrumentedHandler<H> {
                     .status()
                     .as_ref()
                     .map_or("unknown", Status::canonical_reason);
-                info!(status, "Finished handling request");
+                debug!(status, "Finished handling request");
             });
             conn
         } else {


### PR DESCRIPTION
Janus was emitting traces at `info` every time it successfully handled a request (which yields one log statement per successful upload) as well as for a variety of client errors (e.g., undecodable input share). Downgrade those to `debug` to keep a lid of logging and log storage costs.