### PR TITLE
collect: fix crash when supplying --hpke-config and --hpke-private-key

### DIFF
--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -1555,7 +1555,7 @@ mod tests {
 
         let mut collector_credential_file_mutually_exclusive = correct_arguments.clone();
         collector_credential_file_mutually_exclusive
-            .push(format!("--collector-credential-file=foo"));
+            .push("--collector-credential-file=foo".to_string());
         assert_eq!(
             Options::try_parse_from(collector_credential_file_mutually_exclusive)
                 .unwrap_err()


### PR DESCRIPTION
https://github.com/divviup/janus/pull/2330 broke providing the `--hpke-config` and `--hpke-private-key` flags.
```
thread 'main' panicked at tools/src/bin/collect.rs:463:18:
internal error: entered unreachable code: collector credential arguments are mutually exclusive
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This was due to a missing match arm handling the case where no `--collector-credential*` argument was provided.

This made it past unit testing since #2330 change some aspects of credential evaluation to be done after clap parsing. I have updated the unit tests to catch this case, and other possible cases.

