### PR TITLE
Fix deadlock in `Accumulator::flush_to_datastore()`

### DIFF
--- a/aggregator/src/aggregator/accumulator.rs
+++ b/aggregator/src/aggregator/accumulator.rs
@@ -137,7 +137,22 @@ impl<const SEED_SIZE: usize, Q: AccumulableQueryType, A: vdaf::Aggregator<SEED_S
     ) -> Result<HashSet<ReportId>, datastore::Error> {
         let unmergeable_report_ids = Arc::new(Mutex::new(HashSet::new()));
 
-        try_join_all(self.aggregations.values().map(|data| {
+        // Prevent deadlocks when inserting into shards by providing a deterministic order to shard
+        // updates. Suppose two concurrent processes are attempting to update a batch aggregation.
+        // We want to avert this situation:
+        //
+        // A> BEGIN;
+        // A> UPDATE batch_aggregations WHERE ord = 1 ... -- Row with ord 1 is locked for update.
+        // B> BEGIN;
+        // B> UPDATE batch_aggregations WHERE ord = 2 ... -- Row with ord 2 is locked for update.
+        // A> UPDATE batch_aggregations WHERE ord = 2 ... -- A is now blocked waiting for B to finish.
+        // B> UPDATE batch_aggregations WHERE ord = 1 ... -- Kaboom!
+        //
+        // This situation cannot happen if the UPDATE statements are ordered by `ord`.
+        let mut aggregations: Vec<_> = self.aggregations.values().collect();
+        aggregations.sort_unstable_by_key(|data| data.batch_aggregation.ord());
+
+        try_join_all(aggregations.into_iter().map(|data| {
             let unmergeable_report_ids = Arc::clone(&unmergeable_report_ids);
             async move {
                 match tx

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -213,7 +213,7 @@ impl TryFrom<SystemTime> for Time {
 
 /// DAP protocol message representing a half-open interval of time with a resolution of seconds;
 /// the start of the interval is included while the end of the interval is excluded.
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Interval {
     /// The start of the interval.
     start: Time,
@@ -1963,6 +1963,8 @@ pub mod query_type {
             + Hash
             + PartialEq
             + Eq
+            + PartialOrd
+            + Ord
             + Encode
             + Decode
             + Send
@@ -1975,6 +1977,8 @@ pub mod query_type {
             + Hash
             + PartialEq
             + Eq
+            + PartialOrd
+            + Ord
             + Encode
             + Decode
             + Send


### PR DESCRIPTION
A deadlock is possible in `Accumulator::flush_to_datastore()` because there is no deterministic order to shard updates. Fix this by sorting the batch aggregations by shard ID before calling `update_batch_aggregation()`.

The effect on the helper's `aggregate_init` is quite nice! Deadlocks turn out to be extremely costly.

I installed some metrics to categorize database retries by reason (i.e. serialization error or deadlock)[^1]. I then issued 31680 Prio3Count time interval reports at about 500 QPS. Here's the helper's retry metrics:
![image](https://github.com/divviup/janus/assets/57697428/c606870d-01a9-4592-b1d8-60806963d9ee)

After this change:
![image](https://github.com/divviup/janus/assets/57697428/597361ce-8b76-423b-b25d-8f6c3bb16d60)

Note there's still a few deadlocks in the aggregate_init's usage of `Transaction::update_batch()`, but the change has removed all deadlocks in `flush_to_datastore()`. I will investigate `update_batch()` in another PR.

The transaction duration stats also show massive improvement (before and after is shown in the same graph).
![image](https://github.com/divviup/janus/assets/57697428/abf078a9-dc85-4294-9f89-c21ad0af8e1e)

I repeated these results over 3 trials. I did not profile the leader's usage of `Accumulator`, but I imagine it's an improvement in any case.

[^1]: There is a metric `pg_stat_database_deadlocks`, accessible with `SELECT datname, deadlocks FROM pg_stat_database` but I was having trouble plumbing this through prometheus. Something to work on for ops.