### PR TITLE
Remove `uuid` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1949,7 +1949,6 @@ dependencies = [
  "trillium-tokio",
  "trycmd",
  "url",
- "uuid",
  "wait-timeout",
 ]
 
@@ -2036,7 +2035,6 @@ dependencies = [
  "trillium-macros",
  "trillium-router",
  "url",
- "uuid",
 ]
 
 [[package]]

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -99,7 +99,6 @@ trillium-router.workspace = true
 trillium-testing = { workspace = true, optional = true }
 trillium-tokio.workspace = true
 url = { version = "2.5.0", features = ["serde"] }
-uuid = { version = "1.6.1", features = ["v4"] }
 
 [dev-dependencies]
 assert_matches.workspace = true

--- a/aggregator_core/Cargo.toml
+++ b/aggregator_core/Cargo.toml
@@ -53,7 +53,6 @@ trillium.workspace = true
 trillium-macros = "0.0.4"
 trillium-router.workspace = true
 url = { version = "2.5.0", features = ["serde"] }
-uuid = { version = "1.6.1", features = ["v4"] }
 
 [dev-dependencies]
 assert_matches.workspace = true


### PR DESCRIPTION
`janus_aggregator` and `janus_aggregator_core` have been carrying around a dependency on `uuid` for a while, but neither crate actually uses them.