### PR TITLE
Run E2E integration tests against cloud env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2104,6 +2104,8 @@ dependencies = [
  "assert_matches",
  "backoff",
  "base64",
+ "chrono",
+ "clap",
  "divviup-client",
  "futures",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-rustls"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd10f063fb367d26334e10c50c67ea31ac542b8c3402be2251db4cfc5d74ba66"
+dependencies = [
+ "futures-io",
+ "rustls",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2117,8 +2127,10 @@ dependencies = [
  "tempfile",
  "testcontainers",
  "tokio",
+ "trillium-rustls",
  "trillium-tokio",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -3419,7 +3431,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.25.2",
  "winreg",
 ]
 
@@ -3581,7 +3593,7 @@ checksum = "629648aced5775d558af50b2b4c7b02983a04b312126d45eeead26e7caa498b9"
 dependencies = [
  "log",
  "ring 0.17.7",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
 ]
 
@@ -3621,6 +3633,16 @@ name = "rustls-pki-types"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb0a1f9b9efec70d32e6d6aa3e58ebd88c3754ec98dfe9145c63cf54cc829b83"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6a5fc258f1c1276dfe3016516945546e2d5383911efc0fc4f1cdc5df3a4ae3"
+dependencies = [
+ "ring 0.16.20",
+ "untrusted 0.7.1",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -4136,7 +4158,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "webpki-roots",
+ "webpki-roots 0.25.2",
 ]
 
 [[package]]
@@ -5013,6 +5035,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "trillium-rustls"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3016aa92cfc68551ad7291c2f0dee6bb87f1bd08133d61ca93e61cebd1d3b4ce"
+dependencies = [
+ "async-rustls",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile 1.0.4",
+ "rustls-webpki 0.100.3",
+ "trillium-server-common",
+ "webpki-roots 0.23.1",
+]
+
+[[package]]
 name = "trillium-server-common"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5364,6 +5402,15 @@ checksum = "57099a701fb3a8043f993e8228dc24229c7b942e2b009a1b962e54489ba1d3bf"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
+dependencies = [
+ "rustls-webpki 0.100.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,8 +61,11 @@ trillium-caching-headers = "0.2.1"
 trillium-head = "0.2.0"
 trillium-opentelemetry = "0.4.0"
 trillium-router = "0.3.5"
+trillium-rustls = "0.4.0"
 trillium-testing = "0.5.0"
 trillium-tokio = "0.3.2"
+url = { version = "2.5.0", features = ["serde"] }
+uuid = { version = "1.6.1", features = ["v4"] }
 
 [profile.ci]
 # Disabling debug info improves build speeds & reduces build artifact sizes, which helps CI caching.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ base64 = "0.21.5"
 # (yet) need other default features.
 # https://docs.rs/chrono/latest/chrono/#duration
 chrono = { version = "0.4", default-features = false }
+clap = { version = "4.4.12", features = ["cargo", "derive", "env"] }
 derivative = "2.2.0"
 itertools = "0.11"
 janus_aggregator = { version = "0.6", path = "aggregator" }

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -105,7 +105,7 @@ trillium-prometheus = { version = "0.1.0", optional = true }
 trillium-router.workspace = true
 trillium-testing = { workspace = true, optional = true }
 trillium-tokio.workspace = true
-url = { version = "2.5.0", features = ["serde"] }
+url.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -45,7 +45,7 @@ backoff = { version = "0.4.0", features = ["tokio"] }
 base64.workspace = true
 bytes = "1.5.0"
 chrono.workspace = true
-clap = { version = "4.4.12", features = ["derive", "env"] }
+clap.workspace = true
 console-subscriber = { version = "0.2.0", optional = true }
 deadpool = { version = "0.10.0", features = ["rt_tokio_1"] }
 deadpool-postgres = "0.12.1"

--- a/aggregator_api/Cargo.toml
+++ b/aggregator_api/Cargo.toml
@@ -28,7 +28,7 @@ trillium.workspace = true
 trillium-api.workspace = true
 trillium-opentelemetry.workspace = true
 trillium-router.workspace = true
-url = { version = "2.5.0", features = ["serde"] }
+url.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true

--- a/aggregator_core/Cargo.toml
+++ b/aggregator_core/Cargo.toml
@@ -18,7 +18,7 @@ async-trait = "0.1"
 backoff = { version = "0.4.0", features = ["tokio"] }
 base64.workspace = true
 bytes = "1.5.0"
-chrono = "0.4"
+chrono.workspace = true
 deadpool = { version = "0.10.0", features = ["rt_tokio_1"] }
 deadpool-postgres = "0.12.1"
 derivative.workspace = true

--- a/aggregator_core/Cargo.toml
+++ b/aggregator_core/Cargo.toml
@@ -51,7 +51,7 @@ tracing-log = "0.2.0"
 trillium.workspace = true
 trillium-macros = "0.0.4"
 trillium-router.workspace = true
-url = { version = "2.5.0", features = ["serde"] }
+url.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace = true
 in-cluster = ["dep:k8s-openapi", "dep:kube"]
 testcontainer = ["janus_interop_binaries/testcontainer"]
 in-cluster-rate-limits = []
+in-cluster-in-cloud = []
 
 [dependencies]
 anyhow.workspace = true
@@ -38,8 +39,10 @@ serde.workspace = true
 serde_json = "1.0.110"
 testcontainers.workspace = true
 tokio.workspace = true
-url = { version = "2.5.0", features = ["serde"] }
+trillium-rustls.workspace = true
 trillium-tokio.workspace = true
+url.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
 divviup-client = { version = "0.1", features = ["admin"] }

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -12,13 +12,13 @@ version.workspace = true
 in-cluster = ["dep:k8s-openapi", "dep:kube"]
 testcontainer = ["janus_interop_binaries/testcontainer"]
 in-cluster-rate-limits = []
-in-cluster-in-cloud = []
 
 [dependencies]
 anyhow.workspace = true
 assert_matches.workspace = true
 backoff = { version = "0.4", features = ["tokio"] }
 base64.workspace = true
+clap.workspace = true
 futures = "0.3.30"
 hex = "0.4"
 http = "0.2"
@@ -45,6 +45,7 @@ url.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
+chrono.workspace = true
 divviup-client = { version = "0.1", features = ["admin"] }
 janus_collector = { workspace = true, features = ["test-util"] }
 rstest.workspace = true

--- a/integration_tests/tests/integration/common.rs
+++ b/integration_tests/tests/integration/common.rs
@@ -86,8 +86,6 @@ pub fn test_task_builder_host(
 
 /// Returns a tuple of [`TaskParameters`] and a task builder. This is suitable for test aggregators
 /// running remotely, say in a staging environment.
-// This is dead code if feature in-cluster-in-cloud is not enabled.
-#[allow(dead_code)]
 pub fn test_task_builder_remote(
     vdaf: VdafInstance,
     query_type: QueryType,

--- a/integration_tests/tests/integration/common.rs
+++ b/integration_tests/tests/integration/common.rs
@@ -86,6 +86,7 @@ pub fn test_task_builder_host(
 
 /// Returns a tuple of [`TaskParameters`] and a task builder. This is suitable for test aggregators
 /// running remotely, say in a staging environment.
+#[cfg(feature = "in-cluster")]
 pub fn test_task_builder_remote(
     vdaf: VdafInstance,
     query_type: QueryType,

--- a/integration_tests/tests/integration/common.rs
+++ b/integration_tests/tests/integration/common.rs
@@ -236,8 +236,8 @@ pub async fn submit_measurements_and_verify_aggregate_generic<V>(
     .with_collect_poll_backoff(
         ExponentialBackoffBuilder::new()
             .with_initial_interval(time::Duration::from_millis(500))
-            .with_max_interval(time::Duration::from_secs(30))
-            .with_max_elapsed_time(Some(time::Duration::from_secs(600)))
+            .with_max_interval(task_parameters.collector_max_interval)
+            .with_max_elapsed_time(Some(task_parameters.collector_max_elapsed_time))
             .build(),
     )
     .build()

--- a/integration_tests/tests/integration/daphne.rs
+++ b/integration_tests/tests/integration/daphne.rs
@@ -11,6 +11,7 @@ use janus_integration_tests::{
 };
 use janus_interop_binaries::test_util::generate_network_name;
 use janus_messages::Role;
+use std::time::Duration;
 
 // This test places Daphne in the leader role & Janus in the helper role.
 #[tokio::test(flavor = "multi_thread")]
@@ -22,8 +23,12 @@ async fn daphne_janus() {
 
     // Start servers.
     let network = generate_network_name();
-    let (mut task_parameters, task_builder) =
-        test_task_builder(VdafInstance::Prio3Count, QueryType::TimeInterval);
+    let (mut task_parameters, task_builder) = test_task_builder(
+        VdafInstance::Prio3Count,
+        QueryType::TimeInterval,
+        Duration::from_millis(500),
+        Duration::from_secs(60),
+    );
 
     // Daphne is hardcoded to serve from a path starting with /v04/.
     task_parameters
@@ -61,8 +66,12 @@ async fn janus_daphne() {
 
     // Start servers.
     let network = generate_network_name();
-    let (mut task_parameters, task_builder) =
-        test_task_builder(VdafInstance::Prio3Count, QueryType::TimeInterval);
+    let (mut task_parameters, task_builder) = test_task_builder(
+        VdafInstance::Prio3Count,
+        QueryType::TimeInterval,
+        Duration::from_millis(500),
+        Duration::from_secs(60),
+    );
 
     // Daphne is hardcoded to serve from a path starting with /v04/.
     task_parameters
@@ -101,8 +110,12 @@ async fn janus_in_process_daphne() {
     // Start servers.
     let network = generate_network_name();
     let container_client = container_client();
-    let (mut task_parameters, mut task_builder) =
-        test_task_builder(VdafInstance::Prio3Count, QueryType::TimeInterval);
+    let (mut task_parameters, mut task_builder) = test_task_builder(
+        VdafInstance::Prio3Count,
+        QueryType::TimeInterval,
+        Duration::from_millis(500),
+        Duration::from_secs(60),
+    );
     task_parameters.endpoint_fragments.leader = AggregatorEndpointFragments::Localhost {
         path: "/".to_owned(),
     };

--- a/integration_tests/tests/integration/divviup_ts.rs
+++ b/integration_tests/tests/integration/divviup_ts.rs
@@ -13,6 +13,7 @@ use janus_integration_tests::{
 };
 use janus_interop_binaries::test_util::generate_network_name;
 use janus_messages::Role;
+use std::time::Duration;
 use testcontainers::clients::Cli;
 
 async fn run_divviup_ts_integration_test(
@@ -20,7 +21,12 @@ async fn run_divviup_ts_integration_test(
     container_client: &Cli,
     vdaf: VdafInstance,
 ) {
-    let (task_parameters, task_builder) = test_task_builder(vdaf, QueryType::TimeInterval);
+    let (task_parameters, task_builder) = test_task_builder(
+        vdaf,
+        QueryType::TimeInterval,
+        Duration::from_millis(500),
+        Duration::from_secs(60),
+    );
     let task = task_builder.build();
     let network = generate_network_name();
     let leader =

--- a/integration_tests/tests/integration/in_cluster.rs
+++ b/integration_tests/tests/integration/in_cluster.rs
@@ -1,12 +1,16 @@
 #![cfg(feature = "in-cluster")]
 
-use crate::common::{submit_measurements_and_verify_aggregate, test_task_builder};
+use crate::common::{
+    submit_measurements_and_verify_aggregate, test_task_builder, test_task_builder_remote,
+};
 use divviup_client::{
     Client, DivviupClient, Histogram, HpkeConfig, NewAggregator, NewSharedAggregator, NewTask, Vdaf,
 };
-use janus_aggregator_core::task::QueryType;
+use janus_aggregator_core::task::{test_util::TaskBuilder, QueryType};
+use janus_collector::PrivateCollectorCredential;
 use janus_core::{
     auth_tokens::AuthenticationToken,
+    hpke::HpkeKeypair,
     test_util::{
         install_test_trace_subscriber,
         kubernetes::{Cluster, PortForward},
@@ -15,9 +19,11 @@ use janus_core::{
 };
 use janus_integration_tests::{client::ClientBackend, TaskParameters};
 use janus_messages::TaskId;
-use std::{env, str::FromStr};
+use std::{env, str::FromStr, time::Duration};
+use trillium_rustls::RustlsConfig;
 use trillium_tokio::ClientConfig;
 use url::Url;
+use uuid::Uuid;
 
 struct InClusterJanusPair {
     /// Task parameters needed by the client and collector, for the task configured in both Janus
@@ -32,8 +38,185 @@ struct InClusterJanusPair {
 
 impl InClusterJanusPair {
     /// Set up a new DAP task, using the given VDAF and query type, in a pair of existing Janus
-    /// instances in a Kubernetes cluster. `divviup-api` is used to configure the task in each Janus
-    /// instance. The following environment variables must be set.
+    /// instances, which can be running either in a local Kubernetes cluster accessed over port-
+    /// forwards, or remotely, depending on whether feature `in-cluster-in-cloud` is enabled.
+    /// `divviup-api` is used to provision the task into the aggregators.
+    async fn new(vdaf: VdafInstance, query_type: QueryType) -> Self {
+        if cfg!(feature = "in-cluster-in-cloud") {
+            Self::new_in_cloud(vdaf, query_type).await
+        } else {
+            Self::new_in_kind(vdaf, query_type).await
+        }
+    }
+
+    /// Set up a new DAP task in a pair of aggregators. `divviup-api` is used to provision the task
+    /// into the two aggregators. Unlike [`Self::new_in_kind`], this does not create a new account
+    /// and pair new aggregators. While tasks created by this test can eventually be garbage
+    /// collected, accounts and paired aggregators would (currently) hang around forever.
+    ///
+    /// The following environment variables must be set:
+    ///
+    ///  - `JANUS_E2E_DIVVIUP_API_URL` (URL): API endpoint for `divviup-api`, used to provision
+    ///    tasks.
+    ///  - `JANUS_E2E_DIVVIUP_API_TOKEN` (Bearer token): API token with which to authenticate to the
+    ///    `divviup-api` instance at `JANUS_E2E_DIVVIUP_API_URL` as a member of account
+    ///    `JANUS_E2E_DIVVIUP_ACCOUNT_ID`.
+    ///  - `JANUS_E2E_DIVVIUP_ACCOUNT_ID` (UUID): Account ID in which to create a task.
+    ///  - `JANUS_E2E_LEADER_AGGREGATOR_ID` (UUID): ID of the aggregator to use as DAP leader in the
+    ///    task.
+    ///  - `JANUS_E2E_HELPER_AGGREGATOR_ID` (UUID): ID of the aggregator to use as DAP helper in the
+    ///    task.
+    ///  - `JANUS_E2E_COLLECTOR_CREDENTIAL_ID` (UUID): ID of the collector credential to use when
+    ///    collecting aggregate shares in the task.
+    ///  - `JANUS_E2E_COLLECTOR_CREDENTIAL_JSON`: JSON representation of the collector credential,
+    ///    including the auth token and the HPKE private key. Example:
+    ///
+    ///    {
+    ///      "aead": "AesGcm128",
+    ///      "id": 66,
+    ///      "kdf": "Sha256",
+    ///      "kem": "X25519HkdfSha256",
+    ///      "private_key": "uKkTvzKLfYNUPZcoKI7hV64zS06OWgBkbivBL4Sw4mo",
+    ///      "public_key": "CcDghts2boltt9GQtBUxdUsVR83SCVYHikcGh33aVlU",
+    ///      "token": "Krx-CLfdWo1ULAfsxhr0rA"
+    ///    }
+    async fn new_in_cloud(vdaf: VdafInstance, query_type: QueryType) -> Self {
+        let (
+            divviup_api_url,
+            divviup_api_token,
+            divviup_account_id,
+            leader_aggregator_id,
+            helper_aggregator_id,
+            collector_credential_id,
+            collector_credential,
+        ) = match (
+            env::var("JANUS_E2E_DIVVIUP_API_URL"),
+            env::var("JANUS_E2E_DIVVIUP_API_TOKEN"),
+            env::var("JANUS_E2E_DIVVIUP_ACCOUNT_ID"),
+            env::var("JANUS_E2E_LEADER_AGGREGATOR_ID"),
+            env::var("JANUS_E2E_HELPER_AGGREGATOR_ID"),
+            env::var("JANUS_E2E_COLLECTOR_CREDENTIAL_ID"),
+            env::var("JANUS_E2E_COLLECTOR_CREDENTIAL_JSON"),
+        ) {
+            (
+                Ok(divviup_api_url),
+                Ok(divviup_api_token),
+                Ok(divviup_account_id),
+                Ok(leader_aggregator_id),
+                Ok(helper_aggregator_id),
+                Ok(collector_credential_id),
+                Ok(collector_credential_json),
+            ) => (
+                divviup_api_url.parse().unwrap(),
+                divviup_api_token,
+                Uuid::parse_str(&divviup_account_id).unwrap(),
+                Uuid::parse_str(&leader_aggregator_id).unwrap(),
+                Uuid::parse_str(&helper_aggregator_id).unwrap(),
+                Uuid::parse_str(&collector_credential_id).unwrap(),
+                serde_json::from_str::<PrivateCollectorCredential>(&collector_credential_json)
+                    .unwrap(),
+            ),
+            _ => panic!("missing or invalid environment variables"),
+        };
+
+        let mut divviup_api = DivviupClient::new(
+            divviup_api_token,
+            Client::new(RustlsConfig::<ClientConfig>::default()).with_default_pool(),
+        );
+        divviup_api.set_url(divviup_api_url);
+
+        let aggregators = divviup_api.aggregators(divviup_account_id).await.unwrap();
+        let leader_aggregator_dap_url = aggregators
+            .iter()
+            .find(|a| a.id == leader_aggregator_id)
+            .map(|a| &a.dap_url)
+            .unwrap();
+        let helper_aggregator_dap_url = aggregators
+            .iter()
+            .find(|a| a.id == helper_aggregator_id)
+            .map(|a| &a.dap_url)
+            .unwrap();
+
+        let (mut task_parameters, task_builder) = test_task_builder_remote(
+            vdaf,
+            query_type,
+            leader_aggregator_dap_url,
+            helper_aggregator_dap_url,
+            Duration::from_secs(30),
+            Duration::from_secs(600),
+        );
+        let task = task_builder.with_min_batch_size(100).build();
+        task_parameters.min_batch_size = 100;
+
+        let provision_task_request = NewTask {
+            name: format!("Integration test task {}", Uuid::new_v4()),
+            leader_aggregator_id,
+            helper_aggregator_id,
+            vdaf: match task.vdaf().to_owned() {
+                VdafInstance::Prio3Count => Vdaf::Count,
+                VdafInstance::Prio3Sum { bits } => Vdaf::Sum {
+                    bits: bits.try_into().unwrap(),
+                },
+                VdafInstance::Prio3SumVec {
+                    bits,
+                    length,
+                    chunk_length,
+                } => Vdaf::SumVec {
+                    bits: bits.try_into().unwrap(),
+                    length: length.try_into().unwrap(),
+                    chunk_length: Some(chunk_length.try_into().unwrap()),
+                },
+                VdafInstance::Prio3Histogram {
+                    length,
+                    chunk_length,
+                } => Vdaf::Histogram(Histogram::Length {
+                    length: length.try_into().unwrap(),
+                    chunk_length: Some(chunk_length.try_into().unwrap()),
+                }),
+                VdafInstance::Prio3CountVec {
+                    length,
+                    chunk_length,
+                } => Vdaf::CountVec {
+                    length: length.try_into().unwrap(),
+                    chunk_length: Some(chunk_length.try_into().unwrap()),
+                },
+                other => panic!("unsupported vdaf {other:?}"),
+            },
+            min_batch_size: task.min_batch_size(),
+            max_batch_size: match task.query_type() {
+                QueryType::TimeInterval => None,
+                QueryType::FixedSize { max_batch_size, .. } => Some(*max_batch_size),
+            },
+            time_precision_seconds: task.time_precision().as_seconds(),
+            collector_credential_id,
+        };
+
+        // Provision the task into both aggregators via divviup-api
+        let provisioned_task = divviup_api
+            .create_task(divviup_account_id, provision_task_request)
+            .await
+            .unwrap();
+
+        // Update the task parameters with the ID and collector auth token from divviup-api.
+        task_parameters.task_id = TaskId::from_str(&provisioned_task.id).unwrap();
+        task_parameters.collector_auth_token = collector_credential.authentication_token().unwrap();
+        task_parameters.collector_hpke_keypair = collector_credential.hpke_keypair().unwrap();
+
+        Self {
+            task_parameters,
+            leader: InClusterJanus {
+                aggregator_port_forward: None,
+            },
+            helper: InClusterJanus {
+                aggregator_port_forward: None,
+            },
+        }
+    }
+
+    /// Set up a new DAP task, using the given VDAF and query type, in a pair of existing Janus
+    /// instances in a Kubernetes cluster. `divviup-api` is used to create an account, pair both
+    /// aggregators and configure the task in each Janus instance. The following environment
+    /// variables must be set.
     ///
     ///  - `JANUS_E2E_KUBE_CONFIG_PATH`: The path to a kubeconfig file, containing the information
     ///    needed to connect to the cluster.
@@ -46,7 +229,7 @@ impl InClusterJanusPair {
     ///     helper's aggregator API are authenticated.
     ///  - `JANUS_E2E_DIVVIUP_API_NAMESPACE`: The Kubernetes namespace where `divviup-api` is
     ///     deployed.
-    async fn new(vdaf: VdafInstance, query_type: QueryType) -> Self {
+    async fn new_in_kind(vdaf: VdafInstance, query_type: QueryType) -> Self {
         let (
             kubeconfig_path,
             kubectl_context_name,
@@ -86,9 +269,12 @@ impl InClusterJanusPair {
 
         let cluster = Cluster::new(&kubeconfig_path, &kubectl_context_name);
 
-        let (mut task_parameters, task_builder) = test_task_builder(vdaf, query_type);
-        let task = task_builder.with_min_batch_size(100).build();
-        task_parameters.min_batch_size = 100;
+        let (task_parameters, task_builder) = test_task_builder(
+            vdaf,
+            query_type,
+            Duration::from_millis(500),
+            Duration::from_secs(60),
+        );
 
         // From outside the cluster, the aggregators are reached at a dynamically allocated port on
         // localhost. When the aggregators talk to each other, they do so in the cluster's network,
@@ -102,7 +288,7 @@ impl InClusterJanusPair {
 
         let mut divviup_api = DivviupClient::new(
             "DUATignored".into(),
-            Client::new(ClientConfig::new()).with_default_pool(),
+            Client::new(RustlsConfig::<ClientConfig>::default()).with_default_pool(),
         );
         divviup_api.set_url(format!("http://127.0.0.1:{port}").parse().unwrap());
 
@@ -142,7 +328,8 @@ impl InClusterJanusPair {
             .await
             .unwrap();
 
-        let hpke_config = task.collector_hpke_keypair().config();
+        let hpke_keypair = task_builder.collector_hpke_keypair().clone();
+        let hpke_config = hpke_keypair.config();
         let collector_credential = divviup_api
             .create_collector_credential(
                 account.id,
@@ -158,10 +345,53 @@ impl InClusterJanusPair {
             .await
             .unwrap();
 
+        Self::new_common(
+            divviup_api,
+            account.id,
+            task_parameters,
+            task_builder,
+            paired_leader_aggregator.id,
+            paired_helper_aggregator.id,
+            collector_credential.id,
+            collector_credential
+                .token
+                .map(|t| AuthenticationToken::new_bearer_token_from_string(t).unwrap())
+                .unwrap(),
+            hpke_keypair.clone(),
+            InClusterJanus::new(&cluster, &leader_namespace).await,
+            InClusterJanus::new(&cluster, &helper_namespace).await,
+        )
+        .await
+    }
+
+    fn in_cluster_aggregator_api_url(namespace: &str) -> Url {
+        Url::parse(&format!(
+            "http://aggregator.{namespace}.svc.cluster.local:80/aggregator-api/"
+        ))
+        .unwrap()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn new_common(
+        divviup_api: DivviupClient,
+        divviup_account_id: Uuid,
+        mut task_parameters: TaskParameters,
+        task_builder: TaskBuilder,
+        leader_aggregator_id: Uuid,
+        helper_aggregator_id: Uuid,
+        collector_credential_id: Uuid,
+        collector_auth_token: AuthenticationToken,
+        collector_hpke_keypair: HpkeKeypair,
+        leader: InClusterJanus,
+        helper: InClusterJanus,
+    ) -> Self {
+        let task = task_builder.with_min_batch_size(100).build();
+        task_parameters.min_batch_size = 100;
+
         let provision_task_request = NewTask {
-            name: "Integration test task".to_string(),
-            leader_aggregator_id: paired_leader_aggregator.id,
-            helper_aggregator_id: paired_helper_aggregator.id,
+            name: format!("Integration test task {}", Uuid::new_v4()),
+            leader_aggregator_id,
+            helper_aggregator_id,
             vdaf: match task.vdaf().to_owned() {
                 VdafInstance::Prio3Count => Vdaf::Count,
                 VdafInstance::Prio3Sum { bits } => Vdaf::Sum {
@@ -198,39 +428,30 @@ impl InClusterJanusPair {
                 QueryType::FixedSize { max_batch_size, .. } => Some(*max_batch_size),
             },
             time_precision_seconds: task.time_precision().as_seconds(),
-            collector_credential_id: collector_credential.id,
+            collector_credential_id,
         };
 
         // Provision the task into both aggregators via divviup-api
         let provisioned_task = divviup_api
-            .create_task(account.id, provision_task_request)
+            .create_task(divviup_account_id, provision_task_request)
             .await
             .unwrap();
 
         // Update the task parameters with the ID and collector auth token from divviup-api.
         task_parameters.task_id = TaskId::from_str(&provisioned_task.id).unwrap();
-        task_parameters.collector_auth_token = AuthenticationToken::new_bearer_token_from_string(
-            collector_credential.token.clone().unwrap(),
-        )
-        .unwrap();
+        task_parameters.collector_auth_token = collector_auth_token;
+        task_parameters.collector_hpke_keypair = collector_hpke_keypair;
 
         Self {
             task_parameters,
-            leader: InClusterJanus::new(&cluster, &leader_namespace).await,
-            helper: InClusterJanus::new(&cluster, &helper_namespace).await,
+            leader,
+            helper,
         }
-    }
-
-    fn in_cluster_aggregator_api_url(namespace: &str) -> Url {
-        Url::parse(&format!(
-            "http://aggregator.{namespace}.svc.cluster.local:80/aggregator-api/"
-        ))
-        .unwrap()
     }
 }
 
 struct InClusterJanus {
-    aggregator_port_forward: PortForward,
+    aggregator_port_forward: Option<PortForward>,
 }
 
 impl InClusterJanus {
@@ -241,12 +462,15 @@ impl InClusterJanus {
             .forward_port(aggregator_namespace, "aggregator", 80)
             .await;
         Self {
-            aggregator_port_forward,
+            aggregator_port_forward: Some(aggregator_port_forward),
         }
     }
 
     fn port(&self) -> u16 {
-        self.aggregator_port_forward.local_port()
+        self.aggregator_port_forward
+            .as_ref()
+            .map(PortForward::local_port)
+            .unwrap_or(0)
     }
 }
 

--- a/integration_tests/tests/integration/in_cluster.rs
+++ b/integration_tests/tests/integration/in_cluster.rs
@@ -200,8 +200,7 @@ impl InClusterJanusPair {
         // Update the task parameters with the ID and collector auth token from divviup-api.
         task_parameters.task_id = TaskId::from_str(&provisioned_task.id).unwrap();
         task_parameters.collector_auth_token = collector_credential.authentication_token().unwrap();
-        task_parameters.collector_hpke_keypair =
-            collector_credential.hpke_keypair_infallible().unwrap();
+        task_parameters.collector_hpke_keypair = collector_credential.hpke_keypair_infallible();
 
         Self {
             task_parameters,

--- a/integration_tests/tests/integration/in_cluster.rs
+++ b/integration_tests/tests/integration/in_cluster.rs
@@ -81,7 +81,7 @@ impl InClusterJanusPair {
             .rev();
 
         let options = Options::from_arg_matches(
-            &mut Options::command()
+            &Options::command()
                 // Parse arguments permissively so that an invocation like
                 // `cargo test <args for cargo> -- <args for test runner>` or
                 // `cargo test <args for cargo> -- <args for test runner> --` will be accepted.

--- a/integration_tests/tests/integration/in_cluster.rs
+++ b/integration_tests/tests/integration/in_cluster.rs
@@ -200,7 +200,8 @@ impl InClusterJanusPair {
         // Update the task parameters with the ID and collector auth token from divviup-api.
         task_parameters.task_id = TaskId::from_str(&provisioned_task.id).unwrap();
         task_parameters.collector_auth_token = collector_credential.authentication_token().unwrap();
-        task_parameters.collector_hpke_keypair = collector_credential.hpke_keypair().unwrap();
+        task_parameters.collector_hpke_keypair =
+            collector_credential.hpke_keypair_infallible().unwrap();
 
         Self {
             task_parameters,

--- a/integration_tests/tests/integration/janus.rs
+++ b/integration_tests/tests/integration/janus.rs
@@ -11,6 +11,7 @@ use janus_integration_tests::{client::ClientBackend, janus::JanusInProcess, Task
 #[cfg(feature = "testcontainer")]
 use janus_interop_binaries::test_util::generate_network_name;
 use janus_messages::Role;
+use std::time::Duration;
 #[cfg(feature = "testcontainer")]
 use testcontainers::clients::Cli;
 
@@ -37,7 +38,12 @@ impl<'a> JanusContainerPair<'a> {
         vdaf: VdafInstance,
         query_type: QueryType,
     ) -> JanusContainerPair<'a> {
-        let (task_parameters, task_builder) = test_task_builder(vdaf, query_type);
+        let (task_parameters, task_builder) = test_task_builder(
+            vdaf,
+            query_type,
+            Duration::from_millis(500),
+            Duration::from_secs(60),
+        );
         let task = task_builder.build();
 
         let network = generate_network_name();
@@ -70,7 +76,12 @@ impl JanusInProcessPair {
     /// Set up a new pair of in-process Janus test instances, and set up a new task in each using
     /// the given VDAF and query type.
     pub async fn new(vdaf: VdafInstance, query_type: QueryType) -> JanusInProcessPair {
-        let (task_parameters, mut task_builder) = test_task_builder_host(vdaf, query_type);
+        let (task_parameters, mut task_builder) = test_task_builder_host(
+            vdaf,
+            query_type,
+            Duration::from_millis(500),
+            Duration::from_secs(60),
+        );
 
         let helper = JanusInProcess::new(&task_builder.clone().build(), Role::Helper).await;
         let helper_url = task_parameters

--- a/interop_binaries/Cargo.toml
+++ b/interop_binaries/Cargo.toml
@@ -51,7 +51,7 @@ trillium.workspace = true
 trillium-api.workspace = true
 trillium-router.workspace = true
 trillium-tokio.workspace = true
-url = { version = "2.5.0", features = ["serde"] }
+url.workspace = true
 zstd = { version = "0.13", optional = true }
 
 [dev-dependencies]

--- a/interop_binaries/Cargo.toml
+++ b/interop_binaries/Cargo.toml
@@ -22,7 +22,7 @@ testcontainer = ["test-util"]
 anyhow.workspace = true
 backoff = { version = "0.4", features = ["tokio"] }
 base64.workspace = true
-clap = "4.4.12"
+clap.workspace = true
 derivative.workspace = true
 futures = { version = "0.3.30", optional = true }
 fixed = { version = "1.24", optional = true }

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -14,7 +14,7 @@ fpvec_bounded_l2 = ["dep:fixed", "janus_collector/fpvec_bounded_l2", "prio/exper
 [dependencies]
 anyhow = "1"
 base64.workspace = true
-clap = { version = "4.4.12", features = ["cargo", "derive", "env"] }
+clap.workspace = true
 derivative.workspace = true
 fixed = { version = "1.24", optional = true }
 janus_collector.workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-clap = { version = "4.4.12", features = ["derive"] }
+clap.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tempfile = "3.9.0"


### PR DESCRIPTION
Extends the test harness in
`janus_integration_tests::integration::in_cluster` so that it can run
tests against remote instances of divviup-api, a Janus leader and a
Janus helper.

Concretely, this means connecting to those services at some remote URL
rather than over a `kubectl port-forward` to a local Kind cluster. Past
that, we also exercise less of the `divviup-api` surface.

In Kind, we do everything from creating an account through provisioning
a task. This works because the `divviup-api` used in that context has
authentication disabled and also because that entire environment is
understood to be ephemeral -- we can litter it with tasks and paired
aggregators and anything else we want and not clean up, because our
expectation is that the entire Kubernetes cluster and all its storage
will be destroyed.

But in this new configuration, we expect to run the test in long-running
staging environments, or even production. While I'm not concerned about
adding new tasks, reports and aggregatons there -- task expiry and
garbage collection will eventually clean those up -- I don't want to
create new accounts and paired aggregators on every test run. That means
that the test needs to be run with a handful of `JANUS_E2E_` environment
variables defined that provide an authentication token and IDs for
various resources to be used. See the doccomment on
`InClusterJanusPair::new_in_cloud` for details.

This change also adds yet more code to Janus that is very, very useful
for testing Divvi Up, but not necessarily relevant to Janus (after all,
someone could be running Janus without `divviup-api` or without
Kubernetes). I'm interested in moving this chunk of test harness
elsewhere, but for now this is the best way to get a reviewable diff.

Relevant to https://github.com/divviup/janus-ops/issues/86
