### PR TITLE
Return server error for abandoned collection jobs

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -2745,17 +2745,7 @@ impl VdafOps {
                     .get_encoded(),
                 ))
             }
-
-            CollectionJobState::Abandoned => {
-                // TODO(#248): decide how to respond for abandoned collection jobs.
-                warn!(
-                    %collection_job_id,
-                    task_id = %task.id(),
-                    "Attempting to collect abandoned collection job"
-                );
-                Ok(None)
-            }
-
+            CollectionJobState::Abandoned => Err(Error::AbandonedCollectionJob(*collection_job_id)),
             CollectionJobState::Deleted => Err(Error::DeletedCollectionJob(*collection_job_id)),
         }
     }

--- a/aggregator/src/aggregator/error.rs
+++ b/aggregator/src/aggregator/error.rs
@@ -66,6 +66,9 @@ pub enum Error {
     /// An attempt was made to act on a known but deleted collection job.
     #[error("deleted collection job: {0}")]
     DeletedCollectionJob(CollectionJobId),
+    /// An attempt was made to act on a collection job that has been abandoned by the aggregator.
+    #[error("abandoned collection job: {0}")]
+    AbandonedCollectionJob(CollectionJobId),
     /// Corresponds to `outdatedHpkeConfig` in DAP.
     #[error("task {0}: outdated HPKE config: {1}")]
     OutdatedHpkeConfig(TaskId, HpkeConfigId),
@@ -204,6 +207,7 @@ impl Error {
             Error::MissingTaskId => "missing_task_id",
             Error::UnrecognizedAggregationJob(_, _) => "unrecognized_aggregation_job",
             Error::DeletedCollectionJob(_) => "deleted_collection_job",
+            Error::AbandonedCollectionJob(_) => "abandoned_collection_job",
             Error::UnrecognizedCollectionJob(_) => "unrecognized_collection_job",
             Error::OutdatedHpkeConfig(_, _) => "outdated_hpke_config",
             Error::UnauthorizedRequest(_) => "unauthorized_request",

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -74,7 +74,7 @@ impl Handler for Error {
             Error::DeletedCollectionJob(_) => conn.with_status(Status::NoContent),
             Error::AbandonedCollectionJob(collection_job_id) => conn.with_problem_document(
                 &ProblemDocument::new(
-                    "https://docs.divviup.org/references/janus_errors#collection-job-abandoned",
+                    "https://docs.divviup.org/references/janus-errors#collection-job-abandoned",
                     "The collection job has been abandoned.",
                     Status::InternalServerError,
                 )

--- a/aggregator/src/aggregator/problem_details.rs
+++ b/aggregator/src/aggregator/problem_details.rs
@@ -1,4 +1,4 @@
-use janus_messages::{problem_type::DapProblemType, TaskId};
+use janus_messages::{problem_type::DapProblemType, CollectionJobId, TaskId};
 use serde::Serialize;
 use trillium::{Conn, KnownHeaderName, Status};
 use trillium_api::ApiConnExt;
@@ -36,17 +36,28 @@ pub struct ProblemDocument<'a> {
     taskid: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     detail: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    collection_job_id: Option<String>,
 }
 
 impl<'a> ProblemDocument<'a> {
-    pub fn new(error_type: DapProblemType) -> Self {
+    pub fn new(type_: &'static str, title: &'static str, status: Status) -> Self {
         Self {
-            type_: error_type.type_uri(),
-            title: error_type.description(),
-            status: error_type.http_status().into(),
+            type_,
+            title,
+            status: status.into(),
             taskid: None,
             detail: None,
+            collection_job_id: None,
         }
+    }
+
+    pub fn new_dap(error_type: DapProblemType) -> Self {
+        Self::new(
+            error_type.type_uri(),
+            error_type.description(),
+            error_type.http_status().into(),
+        )
     }
 
     pub fn with_task_id(self, taskid: &TaskId) -> Self {
@@ -59,6 +70,13 @@ impl<'a> ProblemDocument<'a> {
     pub fn with_detail(self, detail: &'a str) -> Self {
         Self {
             detail: Some(detail),
+            ..self
+        }
+    }
+
+    pub fn with_collection_job_id(self, collection_job_id: &CollectionJobId) -> Self {
+        Self {
+            collection_job_id: Some(collection_job_id.to_string()),
             ..self
         }
     }

--- a/aggregator/src/aggregator/problem_details.rs
+++ b/aggregator/src/aggregator/problem_details.rs
@@ -41,6 +41,12 @@ pub struct ProblemDocument<'a> {
 }
 
 impl<'a> ProblemDocument<'a> {
+    /// Creates a general problem document for errors that aren't defined in DAP. Follow
+    /// [RFC 9457][1] for guidance on a good problem document.
+    ///
+    /// If the error is defined in DAP, use [`Self::new_dap`] instead.
+    ///
+    /// [1]: https://www.rfc-editor.org/rfc/rfc9457
     pub fn new(type_: &'static str, title: &'static str, status: Status) -> Self {
         Self {
             type_,
@@ -52,6 +58,7 @@ impl<'a> ProblemDocument<'a> {
         }
     }
 
+    /// Creates a problem document corresponding to a [`DapProblemType`].
     pub fn new_dap(error_type: DapProblemType) -> Self {
         Self::new(
             error_type.type_uri(),

--- a/aggregator/src/aggregator/problem_details.rs
+++ b/aggregator/src/aggregator/problem_details.rs
@@ -56,7 +56,7 @@ impl<'a> ProblemDocument<'a> {
         Self::new(
             error_type.type_uri(),
             error_type.description(),
-            error_type.http_status().into(),
+            error_type.http_status(),
         )
     }
 

--- a/messages/src/problem_type.rs
+++ b/messages/src/problem_type.rs
@@ -1,6 +1,8 @@
 use std::str::FromStr;
 
-/// Representation of the different problem types defined in Table 1 in §3.2.
+/// Representation of the different problem types defined in [DAP][1].
+///
+/// [1]: https://www.ietf.org/archive/id/draft-ietf-ppm-dap-07.html#table-1
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DapProblemType {
     InvalidMessage,


### PR DESCRIPTION
Fixes #248.

I opted not to embed an abandonment reason into the DB. There is no action that a user can take for this error except to contact the operators, so we're going to have to go log crawling anyway. The current cases that cause this also do not have straightforward fixes (why is the collection job retrying so many times? why is there a batch mismatch?). Thus I don't think it's worth the additional complexity.

~Note that this PR is insufficient to stop collectors from infinite looping, [because our retry logic in `core.rs` retries on all server errors](https://github.com/divviup/janus/blob/main/core/src/retries.rs#L89). I will address this in a future PR. I think we need to not retry on 500 errors, but also give a pass through `aggregator/src/aggregator/http_handlers.rs` to provide `503 Service Unavailable` for retryable errors, e.g. DB pool timeouts.~ Nope, not quite. We do have a `max_elapsed_time` set for our default backoff config, so a collector will retry the 500 error for up to ten minutes before giving up.