### PR TITLE
Re-enable divviup-ts integration test

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -34,7 +34,7 @@ jobs:
       id: default-input-values
       run: |
         DIVVIUP_TS_INTEROP_CONTAINER= ${{ inputs.divviup_ts_interop_container }}
-        echo "divviup_ts_interop_container=${DIVVIUP_TS_INTEROP_CONTAINER:-us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-ts/divviup_ts_interop_client:dap-draft-04@sha256:43ccdf68e319c677f12f0cb730c63e73b872477cf0e1310b727f449b74a14ac2}" >> $GITHUB_OUTPUT
+        echo "divviup_ts_interop_container=${DIVVIUP_TS_INTEROP_CONTAINER:-us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-ts/divviup_ts_interop_client:dap-draft-07@sha256:3c7ee0bc6e82bd24c8502b7630ac3ff6eb9c87c91498d5765cff0403683231cc}" >> $GITHUB_OUTPUT
     - name: Get OS version
       id: os-version
       run: echo "release=$(lsb_release --release --short)" >> $GITHUB_OUTPUT

--- a/integration_tests/src/client.rs
+++ b/integration_tests/src/client.rs
@@ -117,8 +117,8 @@ impl InteropClient {
                 name: "us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-ts/\
                        divviup_ts_interop_client"
                     .to_string(),
-                tag: "dap-draft-04@sha256:\
-                      43ccdf68e319c677f12f0cb730c63e73b872477cf0e1310b727f449b74a14ac2"
+                tag: "dap-draft-07@sha256:\
+                      3c7ee0bc6e82bd24c8502b7630ac3ff6eb9c87c91498d5765cff0403683231cc"
                     .to_string(),
             }
         }

--- a/integration_tests/tests/integration/divviup_ts.rs
+++ b/integration_tests/tests/integration/divviup_ts.rs
@@ -43,7 +43,6 @@ async fn run_divviup_ts_integration_test(
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "divviup-ts does not currently support DAP-07 (issue #1669)"]
 async fn janus_divviup_ts_count() {
     install_test_trace_subscriber();
 
@@ -56,7 +55,6 @@ async fn janus_divviup_ts_count() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "divviup-ts does not currently support DAP-07 (issue #1669)"]
 async fn janus_divviup_ts_sum() {
     install_test_trace_subscriber();
 
@@ -69,7 +67,6 @@ async fn janus_divviup_ts_sum() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "divviup-ts does not currently support DAP-07 (issue #1669)"]
 async fn janus_divviup_ts_histogram() {
     install_test_trace_subscriber();
 


### PR DESCRIPTION
divviup-ts long since has support for draft-ietf-ppm-dap-07. Update the referenced container image and turn that test back on (just in time for us to go do draft 9).