### PR TITLE
Fix Clippy lints

### DIFF
--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -1886,7 +1886,7 @@ mod tests {
             // Validate response.
             assert_eq!(aggregate_resp.prepare_resps().len(), 9);
 
-            let prepare_step_0 = aggregate_resp.prepare_resps().get(0).unwrap();
+            let prepare_step_0 = aggregate_resp.prepare_resps().first().unwrap();
             assert_eq!(
                 prepare_step_0.report_id(),
                 prepare_init_0.report_share().metadata().id()
@@ -2122,7 +2122,7 @@ mod tests {
         assert_eq!(test_conn.status(), Some(Status::Ok));
         let aggregate_resp: AggregationJobResp = decode_response_body(&mut test_conn).await;
 
-        let prepare_step = aggregate_resp.prepare_resps().get(0).unwrap();
+        let prepare_step = aggregate_resp.prepare_resps().first().unwrap();
         assert_eq!(
             prepare_step.report_id(),
             prepare_init.report_share().metadata().id()
@@ -2321,7 +2321,7 @@ mod tests {
         // Validate response.
         assert_eq!(aggregate_resp.prepare_resps().len(), 4);
 
-        let prepare_step_same_id = aggregate_resp.prepare_resps().get(0).unwrap();
+        let prepare_step_same_id = aggregate_resp.prepare_resps().first().unwrap();
         assert_eq!(
             prepare_step_same_id.report_id(),
             prepare_init_same_id.report_share().metadata().id()
@@ -2405,7 +2405,7 @@ mod tests {
 
         assert_eq!(aggregate_resp.prepare_resps().len(), 1);
 
-        let prepare_step = aggregate_resp.prepare_resps().get(0).unwrap();
+        let prepare_step = aggregate_resp.prepare_resps().first().unwrap();
         assert_eq!(
             prepare_step.report_id(),
             mutated_timestamp_prepare_init
@@ -2480,7 +2480,7 @@ mod tests {
         // Validate response.
         assert_eq!(aggregate_resp.prepare_resps().len(), 1);
 
-        let prepare_step = aggregate_resp.prepare_resps().get(0).unwrap();
+        let prepare_step = aggregate_resp.prepare_resps().first().unwrap();
         assert_eq!(
             prepare_step.report_id(),
             prepare_init.report_share().metadata().id()
@@ -2527,7 +2527,7 @@ mod tests {
         // Validate response.
         assert_eq!(aggregate_resp.prepare_resps().len(), 1);
 
-        let prepare_step = aggregate_resp.prepare_resps().get(0).unwrap();
+        let prepare_step = aggregate_resp.prepare_resps().first().unwrap();
         assert_eq!(
             prepare_step.report_id(),
             prepare_init.report_share().metadata().id()

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -315,7 +315,7 @@ async fn taskprov_aggregate_init() {
         let aggregate_resp: AggregationJobResp = decode_response_body(&mut test_conn).await;
 
         assert_eq!(aggregate_resp.prepare_resps().len(), 1, "{}", name);
-        let prepare_step = aggregate_resp.prepare_resps().get(0).unwrap();
+        let prepare_step = aggregate_resp.prepare_resps().first().unwrap();
         assert_eq!(
             prepare_step.report_id(),
             report_share.metadata().id(),

--- a/collector/src/credential.rs
+++ b/collector/src/credential.rs
@@ -2,7 +2,7 @@ use crate::Error;
 use hpke_dispatch::{Aead, Kdf, Kem};
 use janus_core::{
     auth_tokens::{AuthenticationToken, BearerToken},
-    hpke::{self, HpkeKeypair, HpkePrivateKey},
+    hpke::{HpkeKeypair, HpkePrivateKey},
 };
 use janus_messages::{HpkeConfig, HpkeConfigId, HpkePublicKey};
 use serde::{Deserialize, Serialize};
@@ -29,21 +29,15 @@ impl PrivateCollectorCredential {
         self.token.clone().map(AuthenticationToken::Bearer)
     }
 
-    /// Returns the [`HpkeKeypair`] necessary for decrypting aggregate shares. This errors if the
-    /// configuration references any HPKE parameters that are not supported by the application.
+    /// Returns the [`HpkeKeypair`] necessary for decrypting aggregate shares. This cannot fail
+    /// currently, but returns a `Result` for historical reasons.
     pub fn hpke_keypair(&self) -> Result<HpkeKeypair, Error> {
         Ok(HpkeKeypair::new(
             HpkeConfig::new(
                 self.id,
-                (self.kem as u16)
-                    .try_into()
-                    .map_err(|_| hpke::Error::InvalidConfiguration("did not recognize kem"))?,
-                (self.kdf as u16)
-                    .try_into()
-                    .map_err(|_| hpke::Error::InvalidConfiguration("did not recognize kdf"))?,
-                (self.aead as u16)
-                    .try_into()
-                    .map_err(|_| hpke::Error::InvalidConfiguration("did not recognize aead"))?,
+                (self.kem as u16).into(),
+                (self.kdf as u16).into(),
+                (self.aead as u16).into(),
                 self.public_key.clone(),
             ),
             self.private_key.clone(),

--- a/collector/src/credential.rs
+++ b/collector/src/credential.rs
@@ -31,8 +31,14 @@ impl PrivateCollectorCredential {
 
     /// Returns the [`HpkeKeypair`] necessary for decrypting aggregate shares. This cannot fail
     /// currently, but returns a `Result` for historical reasons.
+    #[deprecated = "Use `hpke_keypair_infallible` instead"]
     pub fn hpke_keypair(&self) -> Result<HpkeKeypair, Error> {
-        Ok(HpkeKeypair::new(
+        Ok(self.hpke_keypair_infallible())
+    }
+
+    /// Returns the [`HpkeKeypair`] necessary for decrypting aggregate shares.
+    pub fn hpke_keypair_infallible(&self) -> HpkeKeypair {
+        HpkeKeypair::new(
             HpkeConfig::new(
                 self.id,
                 (self.kem as u16).into(),
@@ -41,7 +47,7 @@ impl PrivateCollectorCredential {
                 self.public_key.clone(),
             ),
             self.private_key.clone(),
-        ))
+        )
     }
 }
 
@@ -93,7 +99,7 @@ mod tests {
         );
         let expected_token = AuthenticationToken::Bearer("Krx-CLfdWo1ULAfsxhr0rA".parse().unwrap());
 
-        assert_eq!(credential.hpke_keypair().unwrap(), expected_keypair);
+        assert_eq!(credential.hpke_keypair_infallible(), expected_keypair);
         assert_eq!(credential.authentication_token(), Some(expected_token));
     }
 }

--- a/core/src/test_util/kubernetes.rs
+++ b/core/src/test_util/kubernetes.rs
@@ -85,7 +85,7 @@ impl Cluster {
         let matching_pods = pods.list(&lp).await.unwrap();
         let pod = matching_pods
             .items
-            .get(0)
+            .first()
             .unwrap_or_else(|| panic!("could not find any pods for the service {service_name}"));
         let pod_name = pod.name_unchecked();
 

--- a/integration_tests/tests/integration/in_cluster.rs
+++ b/integration_tests/tests/integration/in_cluster.rs
@@ -148,9 +148,9 @@ impl InClusterJanusPair {
                 account.id,
                 &HpkeConfig::new(
                     u8::from(*hpke_config.id()).into(),
-                    u16::from(*hpke_config.kem_id()).try_into().unwrap(),
-                    u16::from(*hpke_config.kdf_id()).try_into().unwrap(),
-                    u16::from(*hpke_config.aead_id()).try_into().unwrap(),
+                    u16::from(*hpke_config.kem_id()).into(),
+                    u16::from(*hpke_config.kdf_id()).into(),
+                    u16::from(*hpke_config.aead_id()).into(),
                     hpke_config.public_key().as_ref().to_vec().into(),
                 ),
                 Some("Integration test key"),

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -498,9 +498,9 @@ impl Options {
             (Some(config), Some(private), None) => {
                 Ok(HpkeKeypair::new(config.clone(), private.clone()))
             }
-            (None, None, Some(collector_credential)) => Ok(collector_credential
-                .hpke_keypair()
-                .context("unsupported config")?),
+            (None, None, Some(collector_credential)) => {
+                Ok(collector_credential.hpke_keypair_infallible())
+            }
             _ => unreachable!(
                 "hpke arguments are mutually exclusive with collector credential arguments"
             ),
@@ -1425,7 +1425,7 @@ mod tests {
                 .unwrap(),
             (
                 collector_credential.authentication_token().unwrap(),
-                collector_credential.hpke_keypair().unwrap()
+                collector_credential.hpke_keypair_infallible()
             ),
         );
 
@@ -1441,7 +1441,7 @@ mod tests {
                 .unwrap(),
             (
                 AuthenticationToken::Bearer(bearer_token.clone()),
-                collector_credential.hpke_keypair().unwrap()
+                collector_credential.hpke_keypair_infallible()
             ),
         );
 
@@ -1457,7 +1457,7 @@ mod tests {
                 .unwrap(),
             (
                 collector_credential.authentication_token().unwrap(),
-                collector_credential.hpke_keypair().unwrap()
+                collector_credential.hpke_keypair_infallible()
             ),
         );
     }


### PR DESCRIPTION
This fixes some Clippy lints that surfaced with the latest Rust toolchain. Notably, this pointed out that `janus_collector::credential::PrivateCollectorCredential::hpke_keypair()` and `impl TryFrom<DivviUpHpkeConfig> for HpkeKeypair` have unnecessary error handling, ever since we made `janus_core::hpke::HpkeConfig` able to deserialize unsupported algorithms. (I didn't change the method's return value or the trait implemented since they are part of the public API)