### PR TITLE
Fix Clippy lints, 0.5 branch

### DIFF
--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -1919,7 +1919,7 @@ mod tests {
             // Validate response.
             assert_eq!(aggregate_resp.prepare_steps().len(), 9);
 
-            let prepare_step_0 = aggregate_resp.prepare_steps().get(0).unwrap();
+            let prepare_step_0 = aggregate_resp.prepare_steps().first().unwrap();
             assert_eq!(prepare_step_0.report_id(), report_share_0.metadata().id());
             assert_matches!(prepare_step_0.result(), &PrepareStepResult::Continued(..));
 
@@ -2218,7 +2218,7 @@ mod tests {
         // Validate response.
         assert_eq!(aggregate_resp.prepare_steps().len(), 4);
 
-        let prepare_step_same_id = aggregate_resp.prepare_steps().get(0).unwrap();
+        let prepare_step_same_id = aggregate_resp.prepare_steps().first().unwrap();
         assert_eq!(
             prepare_step_same_id.report_id(),
             report_share_same_id.metadata().id()
@@ -2297,7 +2297,7 @@ mod tests {
 
         assert_eq!(aggregate_resp.prepare_steps().len(), 1);
 
-        let prepare_step = aggregate_resp.prepare_steps().get(0).unwrap();
+        let prepare_step = aggregate_resp.prepare_steps().first().unwrap();
         assert_eq!(
             prepare_step.report_id(),
             mutated_timestamp_report_share.metadata().id()
@@ -2388,7 +2388,7 @@ mod tests {
         // Validate response.
         assert_eq!(aggregate_resp.prepare_steps().len(), 1);
 
-        let prepare_step = aggregate_resp.prepare_steps().get(0).unwrap();
+        let prepare_step = aggregate_resp.prepare_steps().first().unwrap();
         assert_eq!(prepare_step.report_id(), report_share.metadata().id());
         assert_matches!(
             prepare_step.result(),
@@ -2458,7 +2458,7 @@ mod tests {
         // Validate response.
         assert_eq!(aggregate_resp.prepare_steps().len(), 1);
 
-        let prepare_step = aggregate_resp.prepare_steps().get(0).unwrap();
+        let prepare_step = aggregate_resp.prepare_steps().first().unwrap();
         assert_eq!(prepare_step.report_id(), report_share.metadata().id());
         assert_matches!(
             prepare_step.result(),

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -290,7 +290,7 @@ async fn taskprov_aggregate_init() {
     let aggregate_resp = AggregationJobResp::get_decoded(&body_bytes).unwrap();
 
     assert_eq!(aggregate_resp.prepare_steps().len(), 1);
-    let prepare_step = aggregate_resp.prepare_steps().get(0).unwrap();
+    let prepare_step = aggregate_resp.prepare_steps().first().unwrap();
     assert_eq!(prepare_step.report_id(), test.report_share.metadata().id());
     assert_matches!(prepare_step.result(), &PrepareStepResult::Continued(..));
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -166,7 +166,7 @@ pub async fn aggregator_hpke_config(
     // we support any HpkeConfig we can decode, and it should be the server's preferred one.
     let hpke_config = hpke_configs
         .hpke_configs()
-        .get(0)
+        .first()
         .ok_or(Error::UnexpectedServerResponse(
             "aggregator provided empty HpkeConfigList",
         ))?

--- a/core/src/test_util/kubernetes.rs
+++ b/core/src/test_util/kubernetes.rs
@@ -85,7 +85,7 @@ impl Cluster {
         let matching_pods = pods.list(&lp).await.unwrap();
         let pod = matching_pods
             .items
-            .get(0)
+            .first()
             .unwrap_or_else(|| panic!("could not find any pods for the service {service_name}"));
         let pod_name = pod.name_unchecked();
 


### PR DESCRIPTION
This fixes Clippy lints that show up with the latest stable Rust toolchain. This was more straightforward than #2419 for 0.6.