### PR TITLE
Make use of Weak::new() in constant contexts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2021"
 homepage = "https://divviup.org"
 license = "MPL-2.0"
 repository = "https://github.com/divviup/janus"
-rust-version = "1.71.0"
+rust-version = "1.73.0"
 version = "0.6.7"
 
 [workspace.dependencies]

--- a/core/src/test_util/testcontainers.rs
+++ b/core/src/test_util/testcontainers.rs
@@ -3,20 +3,15 @@
 use std::{
     collections::HashMap,
     process::Command,
-    sync::{Arc, Mutex, OnceLock, Weak},
+    sync::{Arc, Mutex, Weak},
 };
 use testcontainers::{clients::Cli, core::WaitFor, Image};
 
 /// Returns a container client, possibly shared with other callers to this function.
 pub fn container_client() -> Arc<Cli> {
-    // Once `Weak::new` is const in stable Rust, in version 1.73, this should be replaced by a
-    // static variable initialized to `Mutex::new(Weak::new())`.
-    static CONTAINER_CLIENT_MU: OnceLock<Mutex<Weak<Cli>>> = OnceLock::new();
+    static CONTAINER_CLIENT_MU: Mutex<Weak<Cli>> = Mutex::new(Weak::new());
 
-    let mut container_client = CONTAINER_CLIENT_MU
-        .get_or_init(|| Mutex::new(Weak::new()))
-        .lock()
-        .unwrap();
+    let mut container_client = CONTAINER_CLIENT_MU.lock().unwrap();
     container_client.upgrade().unwrap_or_else(|| {
         let client = Arc::new(Cli::default());
         *container_client = Arc::downgrade(&client);


### PR DESCRIPTION
This bumps `rust-version` to 1.73, and uses `Weak::new()` in two static variable initializers, now that it's stable in const contexts.