### PR TITLE
dependabot-automerge: only run on opened/reopened

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,5 +1,7 @@
 name: Dependabot auto-merge
-on: pull_request
+on:
+  pull_request:
+    types: [opened, reopened]
 
 jobs:
   dependabot:


### PR DESCRIPTION
This backports #2352 to the release/0.5 branch.