### PR TITLE
Clean up all CLI help texts

### DIFF
--- a/aggregator/src/bin/janus_cli.rs
+++ b/aggregator/src/bin/janus_cli.rs
@@ -52,25 +52,26 @@ async fn main() -> Result<()> {
 
 #[derive(Debug, Parser)]
 enum Command {
-    /// Write a set of tasks identified in a file to the datastore.
+    /// Write a set of tasks identified in a file to the datastore
     ProvisionTasks {
         #[clap(flatten)]
         kubernetes_secret_options: KubernetesSecretOptions,
 
-        /// A YAML file containing a list of tasks to be written. Existing tasks (matching by task
-        /// ID) will be overwritten.
+        /// A YAML file containing a list of tasks to be written
+        ///
+        /// Existing tasks (matching by task ID) will be overwritten
         tasks_file: PathBuf,
 
-        /// If true, task parameters omitted from the YAML tasks file will be randomly generated.
+        /// If true, task parameters omitted from the YAML tasks file will be randomly generated
         #[clap(long, default_value = "false")]
         generate_missing_parameters: bool,
 
-        /// Write the YAML representation of the tasks that are written to stdout.
+        /// Write the YAML representation of the tasks that are written to stdout
         #[clap(long, default_value = "false")]
         echo_tasks: bool,
     },
 
-    /// Create a datastore key and write it to a Kubernetes secret.
+    /// Create a datastore key and write it to a Kubernetes secret
     CreateDatastoreKey {
         #[clap(flatten)]
         kubernetes_secret_options: KubernetesSecretOptions,
@@ -335,25 +336,22 @@ struct CommandLineOptions {
     #[clap(flatten)]
     common_options: CommonBinaryOptions,
 
-    /// When in dry-run mode, the tool will print out what it would do but will not make any real,
-    /// permanent changes.
+    /// Do not make permanent changes
+    ///
+    /// The tool will print out what it would do but will not make any real, permanent changes.
     #[clap(long, default_value = "false")]
     dry_run: bool,
 }
 
 #[derive(Debug, Parser)]
 struct KubernetesSecretOptions {
-    /// The Kubernetes namespace where secrets are stored.
-    #[clap(
-        long,
-        env = "SECRETS_K8S_NAMESPACE",
-        num_args = 1,
-        long_help = "Kubernetes namespace where the datastore key is stored. Required if \
-                     --datastore-keys is not set or if command is create-datastore-key."
-    )]
+    /// The Kubernetes namespace where secrets are stored
+    ///
+    /// Required if --datastore-keys is not set or if the command is `create-datastore-key`.
+    #[clap(long, env = "SECRETS_K8S_NAMESPACE", num_args = 1)]
     secrets_k8s_namespace: Option<String>,
 
-    /// Kubernetes secret containing the datastore key(s).
+    /// Kubernetes secret containing the datastore key(s)
     #[clap(
         long,
         env = "DATASTORE_KEYS_SECRET_NAME",
@@ -367,7 +365,6 @@ struct KubernetesSecretOptions {
         long,
         env = "DATASTORE_KEYS_SECRET_KEY",
         num_args = 1,
-        help = "Key into data of datastore key Kubernetes secret",
         default_value = "datastore_key"
     )]
     datastore_keys_secret_data_key: String,

--- a/aggregator/src/binaries/aggregator.rs
+++ b/aggregator/src/binaries/aggregator.rs
@@ -197,14 +197,15 @@ pub struct Options {
     #[clap(flatten)]
     pub common: CommonBinaryOptions,
 
-    /// Aggregator API authentication tokens.
+    /// Aggregator API authentication tokens
+    ///
+    /// API tokens are encoded in unpadded url-safe base64, then comma-separated.
     #[clap(
         long,
         env = "AGGREGATOR_API_AUTH_TOKENS",
         hide_env_values = true,
         num_args = 0..=1,
         use_value_delimiter = true,
-        help = "aggregator API auth tokens, encoded in base64 then comma-separated"
     )]
     pub aggregator_api_auth_tokens: Vec<String>,
 }

--- a/aggregator/src/binary_utils.rs
+++ b/aggregator/src/binary_utils.rs
@@ -185,34 +185,25 @@ pub trait BinaryOptions: Parser + Debug {
 #[cfg_attr(doc, doc = "Common options that are used by all Janus binaries.")]
 #[derive(Default, Clone, Parser)]
 pub struct CommonBinaryOptions {
-    /// Path to configuration YAML.
-    #[clap(
-        long,
-        env = "CONFIG_FILE",
-        num_args = 1,
-        required(true),
-        help = "path to configuration file"
-    )]
+    /// Path to configuration YAML file
+    #[clap(long, env = "CONFIG_FILE", num_args = 1, required(true))]
     pub config_file: PathBuf,
 
-    /// Password for the PostgreSQL database connection. If specified, must not be specified in the
-    /// connection string.
-    #[clap(
-        long,
-        env = "PGPASSWORD",
-        hide_env_values = true,
-        help = "PostgreSQL password"
-    )]
+    /// Password for the PostgreSQL database connection
+    ///
+    /// If specified, it must not be specified in the connection string.
+    #[clap(long, env = "PGPASSWORD", hide_env_values = true)]
     pub database_password: Option<String>,
 
-    /// Datastore encryption keys.
+    /// Datastore encryption keys
+    ///
+    /// Keys are encoded in unpadded url-safe base64, then comma separated.
     #[clap(
         long,
         env = "DATASTORE_KEYS",
         hide_env_values = true,
         num_args = 1,
-        use_value_delimiter = true,
-        help = "datastore encryption keys, encoded in url-safe unpadded base64 then comma-separated"
+        use_value_delimiter = true
     )]
     pub datastore_keys: Vec<String>,
 }

--- a/aggregator/tests/cmd/aggregation_job_creator.trycmd
+++ b/aggregator/tests/cmd/aggregation_job_creator.trycmd
@@ -6,13 +6,27 @@ Usage: aggregation_job_creator [OPTIONS] --config-file <CONFIG_FILE>
 
 Options:
       --config-file <CONFIG_FILE>
-          path to configuration file [env: CONFIG_FILE=]
+          Path to configuration YAML file
+          
+          [env: CONFIG_FILE=]
+
       --database-password <DATABASE_PASSWORD>
-          PostgreSQL password [env: PGPASSWORD]
+          Password for the PostgreSQL database connection
+          
+          If specified, it must not be specified in the connection string.
+          
+          [env: PGPASSWORD]
+
       --datastore-keys <DATASTORE_KEYS>
-          datastore encryption keys, encoded in url-safe unpadded base64 then comma-separated [env: DATASTORE_KEYS]
+          Datastore encryption keys
+          
+          Keys are encoded in unpadded url-safe base64, then comma separated.
+          
+          [env: DATASTORE_KEYS]
+
   -h, --help
-          Print help
+          Print help (see a summary with '-h')
+
   -V, --version
           Print version
 

--- a/aggregator/tests/cmd/aggregation_job_driver.trycmd
+++ b/aggregator/tests/cmd/aggregation_job_driver.trycmd
@@ -6,13 +6,27 @@ Usage: aggregation_job_driver [OPTIONS] --config-file <CONFIG_FILE>
 
 Options:
       --config-file <CONFIG_FILE>
-          path to configuration file [env: CONFIG_FILE=]
+          Path to configuration YAML file
+          
+          [env: CONFIG_FILE=]
+
       --database-password <DATABASE_PASSWORD>
-          PostgreSQL password [env: PGPASSWORD]
+          Password for the PostgreSQL database connection
+          
+          If specified, it must not be specified in the connection string.
+          
+          [env: PGPASSWORD]
+
       --datastore-keys <DATASTORE_KEYS>
-          datastore encryption keys, encoded in url-safe unpadded base64 then comma-separated [env: DATASTORE_KEYS]
+          Datastore encryption keys
+          
+          Keys are encoded in unpadded url-safe base64, then comma separated.
+          
+          [env: DATASTORE_KEYS]
+
   -h, --help
-          Print help
+          Print help (see a summary with '-h')
+
   -V, --version
           Print version
 

--- a/aggregator/tests/cmd/aggregator.trycmd
+++ b/aggregator/tests/cmd/aggregator.trycmd
@@ -6,15 +6,34 @@ Usage: aggregator [OPTIONS] --config-file <CONFIG_FILE>
 
 Options:
       --config-file <CONFIG_FILE>
-          path to configuration file [env: CONFIG_FILE=]
+          Path to configuration YAML file
+          
+          [env: CONFIG_FILE=]
+
       --database-password <DATABASE_PASSWORD>
-          PostgreSQL password [env: PGPASSWORD]
+          Password for the PostgreSQL database connection
+          
+          If specified, it must not be specified in the connection string.
+          
+          [env: PGPASSWORD]
+
       --datastore-keys <DATASTORE_KEYS>
-          datastore encryption keys, encoded in url-safe unpadded base64 then comma-separated [env: DATASTORE_KEYS]
+          Datastore encryption keys
+          
+          Keys are encoded in unpadded url-safe base64, then comma separated.
+          
+          [env: DATASTORE_KEYS]
+
       --aggregator-api-auth-tokens [<AGGREGATOR_API_AUTH_TOKENS>]
-          aggregator API auth tokens, encoded in base64 then comma-separated [env: AGGREGATOR_API_AUTH_TOKENS]
+          Aggregator API authentication tokens
+          
+          API tokens are encoded in unpadded url-safe base64, then comma-separated.
+          
+          [env: AGGREGATOR_API_AUTH_TOKENS]
+
   -h, --help
-          Print help
+          Print help (see a summary with '-h')
+
   -V, --version
           Print version
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -97,3 +97,32 @@ To create a new migration:
   ```
 
   Explanation of `.unwrap()` is not necessary in test code.
+
+* Use `clap` as the CLI argument parser, with the `derive` feature.
+
+  * Ensure that environment variables that contain secrets won't output their
+    contents when `--help` is used, by using [`hide_env_values`][hide_env_values].
+
+  * Prefer to keep all help text inside a Rust doccomment. The first line should
+    be very brief and without punctuation. Additional help text should be
+    included on subsequent lines and contain punctuation.
+
+    Example:
+    ```rust
+        /// Poll an existing collection job once
+        ///
+        /// The supplied query options must exactly match the ones used to create
+        /// the collection job, so that the collection job state can be correctly
+        /// reconstructed.
+        ///
+        /// If the collection job is ready, the exit status is 0 and the job
+        /// results are output to stdout. If it is not ready, the exit status 
+        /// is 75 (EX_TEMPFAIL).
+        PollJob {
+            /// Job ID for an existing collection job, encoded with unpadded base64url
+            #[clap(value_parser = CollectionJobIdValueParser::new(), required = true)]
+            collection_job_id: CollectionJobId,
+        },
+    ```
+
+[hide_env_values]: https://docs.rs/clap/latest/clap/struct.Arg.html#method.hide_env_values

--- a/tools/src/bin/dap_decode.rs
+++ b/tools/src/bin/dap_decode.rs
@@ -139,10 +139,12 @@ enum MediaType {
     rename_all = "kebab-case"
 )]
 struct Options {
-    /// Path to file containing message to decode. Pass "-" to read from stdin.
+    /// Path to file containing message to decode.
+    ///
+    /// Pass "-" to read from stdin.
     message_file: String,
 
-    /// Media type of the message to decode.
+    /// Media type of the message to decode
     #[arg(long, short = 't', required = true)]
     media_type: MediaType,
 }

--- a/tools/src/bin/hpke_keygen.rs
+++ b/tools/src/bin/hpke_keygen.rs
@@ -152,18 +152,18 @@ impl Display for AeadAlgorithm {
 #[derive(Debug, Parser)]
 #[command(name = "hpke_keygen", about = "DAP-compatible HPKE keypair generator")]
 struct Options {
-    /// Numeric identifier of the HPKE configuration.
+    /// Numeric identifier of the HPKE configuration
     id: u8,
 
-    /// HPKE Key Encapsulation Mechanism algorithm.
+    /// HPKE Key Encapsulation Mechanism algorithm
     #[arg(long, default_value_t = KemAlgorithm::X25519HkdfSha256)]
     kem: KemAlgorithm,
 
-    /// HPKE Key Derivation Function algorithm.
+    /// HPKE Key Derivation Function algorithm
     #[arg(long, default_value_t = KdfAlgorithm::HkdfSha256)]
     kdf: KdfAlgorithm,
 
-    /// HPKE Authenticated Encryption with Associated Data algorithm.
+    /// HPKE Authenticated Encryption with Associated Data algorithm
     #[arg(long, default_value_t = AeadAlgorithm::Aes128Gcm)]
     aead: AeadAlgorithm,
 }

--- a/tools/tests/cmd/dap_decode.trycmd
+++ b/tools/tests/cmd/dap_decode.trycmd
@@ -5,11 +5,21 @@ Distributed Aggregation Protocol message decoder
 Usage: dap_decode --media-type <MEDIA_TYPE> <MESSAGE_FILE>
 
 Arguments:
-  <MESSAGE_FILE>  Path to file containing message to decode. Pass "-" to read from stdin
+  <MESSAGE_FILE>
+          Path to file containing message to decode.
+          
+          Pass "-" to read from stdin.
 
 Options:
-  -t, --media-type <MEDIA_TYPE>  Media type of the message to decode [possible values: hpke-config, hpke-config-list, report, aggregation-job-init-req, aggregation-job-resp, aggregation-job-continue-req, aggregate-share-req, aggregate-share, collect-req, collection]
-  -h, --help                     Print help
-  -V, --version                  Print version
+  -t, --media-type <MEDIA_TYPE>
+          Media type of the message to decode
+          
+          [possible values: hpke-config, hpke-config-list, report, aggregation-job-init-req, aggregation-job-resp, aggregation-job-continue-req, aggregate-share-req, aggregate-share, collect-req, collection]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 
 ```


### PR DESCRIPTION
As alluded to in https://github.com/divviup/janus/pull/2234#discussion_r1397689826. Makes our CLI help texts consistent, and adds coding style guidelines to our documentation.

Some texts also were in need of minor content touch-ups. I removed usage of `help` as clap's derive macro does a good job of filling that out for us.