### PR TITLE
Fix unused dependencies, add periodic workflow to monitor

### DIFF
--- a/.github/workflows/unused-dependencies.yml
+++ b/.github/workflows/unused-dependencies.yml
@@ -1,0 +1,70 @@
+name: unused-dependencies
+
+on:
+  schedule:
+    - cron: "21 4 * * mon"
+  workflow_dispatch:
+
+jobs:
+  cargo-udeps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
+      issues: "write"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Install cargo-udeps
+        uses: taiki-e/install-action@cargo-udeps
+      - name: Run cargo-udeps, all features
+        run: cargo +nightly udeps --all-features | tee log_all_features.txt
+      - name: Run cargo-udeps, default features
+        if: success() || failure()
+        run: cargo +nightly udeps | tee log_default_features.txt
+      - name: Create issue
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+
+            const tryReadFile = (file) => {
+              try {
+                return fs.readFileSync(file, 'utf8').toString();
+              } catch (err) {
+                console.log(`${file}: ${err}`);
+              }
+              return '';
+            };
+
+            const logAllFeatures = tryReadFile('log_all_features.txt');
+            const logDefaultFeatures = tryReadFile('log_default_features.txt');
+
+            let output;
+            if (logAllFeatures.length == 0 && logDefaultFeatures == 0) {
+              output = `### Unused dependencies
+
+              An error was encountered when checking for unused dependencies.
+
+              `;
+            } else {
+              output = `### Unused dependencies
+
+              Unused dependencies were detected in the Cargo workspace.
+
+              `;
+            }
+            output += `#### Details
+            - Run URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            - Git SHA: ${{ github.sha }}
+            `;
+
+            github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Unused dependencies',
+              body: output,
+            });

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,9 +290,9 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http 0.2.11",
- "http-body 0.4.5",
- "hyper 0.14.27",
+ "http",
+ "http-body",
+ "hyper",
  "itoa",
  "matchit",
  "memchr",
@@ -316,8 +316,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 0.2.11",
- "http-body 0.4.5",
+ "http",
+ "http-body",
  "mime",
  "rustversion",
  "tower-layer",
@@ -1438,7 +1438,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.11",
+ "http",
  "indexmap 1.9.3",
  "slab",
  "tokio",
@@ -1600,23 +1600,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "http"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
 name = "http-api-problem"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bce650a2c63171c9d92f95887c8d81154b77385301c8a581b9af96491f52d765"
 dependencies = [
- "http 0.2.11",
+ "http",
  "serde",
  "serde_json",
 ]
@@ -1628,18 +1617,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http 0.2.11",
+ "http",
  "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
-dependencies = [
- "bytes",
- "http 1.0.0",
 ]
 
 [[package]]
@@ -1687,8 +1666,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.11",
- "http-body 0.4.5",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -1701,27 +1680,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5aa53871fc917b1a9ed87b683a5d86db645e23acb32c2e0785a353e522fb75"
-dependencies = [
- "bytes",
- "http 1.0.0",
- "http-body 1.0.0",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "hyper-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
  "futures-util",
- "http 0.2.11",
- "hyper 0.14.27",
+ "http",
+ "hyper",
  "log",
  "rustls",
  "rustls-native-certs",
@@ -1735,7 +1701,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper 0.14.27",
+ "hyper",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -1879,9 +1845,8 @@ dependencies = [
  "futures",
  "git-version",
  "hex",
- "http 0.2.11",
+ "http",
  "http-api-problem",
- "hyper 1.1.0",
  "itertools 0.11.0",
  "janus_aggregator",
  "janus_aggregator_api",
@@ -1989,9 +1954,8 @@ dependencies = [
  "derivative",
  "futures",
  "hex",
- "http 0.2.11",
+ "http",
  "http-api-problem",
- "hyper 1.1.0",
  "janus_aggregator_core",
  "janus_core",
  "janus_messages 0.6.8",
@@ -2034,7 +1998,7 @@ dependencies = [
  "backoff",
  "derivative",
  "hex-literal",
- "http 0.2.11",
+ "http",
  "itertools 0.11.0",
  "janus_core",
  "janus_messages 0.6.8",
@@ -2092,7 +2056,7 @@ dependencies = [
  "futures",
  "hex",
  "hpke-dispatch",
- "http 0.2.11",
+ "http",
  "http-api-problem",
  "janus_core",
  "janus_messages 0.6.8",
@@ -2133,7 +2097,7 @@ dependencies = [
  "divviup-client",
  "futures",
  "hex",
- "http 0.2.11",
+ "http",
  "itertools 0.11.0",
  "janus_aggregator",
  "janus_aggregator_core",
@@ -2340,9 +2304,9 @@ dependencies = [
  "either",
  "futures",
  "home",
- "http 0.2.11",
- "http-body 0.4.5",
- "hyper 0.14.27",
+ "http",
+ "http-body",
+ "hyper",
  "hyper-rustls",
  "hyper-timeout",
  "jsonpath-rust",
@@ -2374,7 +2338,7 @@ checksum = "b5bba93d054786eba7994d03ce522f368ef7d48c88a1826faa28478d85fb63ae"
 dependencies = [
  "chrono",
  "form_urlencoded",
- "http 0.2.11",
+ "http",
  "k8s-openapi",
  "once_cell",
  "serde",
@@ -2525,7 +2489,7 @@ dependencies = [
  "assert-json-diff",
  "colored",
  "futures",
- "hyper 0.14.27",
+ "hyper",
  "log",
  "rand",
  "regex",
@@ -2730,7 +2694,7 @@ checksum = "f24cda83b20ed2433c68241f918d0f6fdec8b1d43b7a9590ab4420c5095ca930"
 dependencies = [
  "async-trait",
  "futures-core",
- "http 0.2.11",
+ "http",
  "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
@@ -3431,9 +3395,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.11",
- "http-body 0.4.5",
- "hyper 0.14.27",
+ "http",
+ "http-body",
+ "hyper",
  "hyper-rustls",
  "ipnet",
  "js-sys",
@@ -3466,7 +3430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "128d55dc93b909e04874b53878316eb687633459706f8fc647de333cc0620caa"
 dependencies = [
  "chrono",
- "http 0.2.11",
+ "http",
  "thiserror",
 ]
 
@@ -4697,9 +4661,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.11",
- "http-body 0.4.5",
- "hyper 0.14.27",
+ "http",
+ "http-body",
+ "hyper",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -4724,9 +4688,9 @@ dependencies = [
  "base64",
  "bytes",
  "h2",
- "http 0.2.11",
- "http-body 0.4.5",
- "hyper 0.14.27",
+ "http",
+ "http-body",
+ "hyper",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -4770,8 +4734,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 0.2.11",
- "http-body 0.4.5",
+ "http",
+ "http-body",
  "http-range-header",
  "mime",
  "pin-project-lite",
@@ -5134,7 +5098,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 0.2.11",
+ "http",
  "httparse",
  "log",
  "rand",

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -48,7 +48,6 @@ git-version = "0.3.9"
 hex = { version = "0.4.3", features = ["serde"], optional = true }
 http = "0.2.11"
 http-api-problem = "0.57.0"
-hyper = "1.1.0"
 itertools.workspace = true
 janus_aggregator_api.workspace = true
 janus_aggregator_core.workspace = true
@@ -102,7 +101,6 @@ url = { version = "2.5.0", features = ["serde"] }
 
 [dev-dependencies]
 assert_matches.workspace = true
-hyper = "1.1.0"
 janus_aggregator = { path = ".", features = ["fpvec_bounded_l2", "test-util"] }
 janus_aggregator_core = { workspace = true, features = ["test-util"] }
 mockito = "1.2.0"

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -17,11 +17,19 @@ default = []
 fpvec_bounded_l2 = ["dep:fixed", "janus_core/fpvec_bounded_l2"]
 tokio-console = ["dep:console-subscriber"]
 otlp = [
-    "dep:tracing-opentelemetry",
+    "dep:git-version",
     "dep:opentelemetry-otlp",
     "dep:opentelemetry-semantic-conventions",
+    "dep:opentelemetry_sdk",
+    "dep:tracing-opentelemetry",
 ]
-prometheus = ["dep:opentelemetry-prometheus", "dep:prometheus"]
+prometheus = [
+    "dep:git-version",
+    "dep:opentelemetry-prometheus",
+    "dep:opentelemetry_sdk",
+    "dep:prometheus",
+    "dep:trillium-prometheus",
+]
 test-util = [
     "janus_core/test-util",
     "janus_messages/test-util",
@@ -44,7 +52,7 @@ deadpool-postgres = "0.12.1"
 derivative.workspace = true
 fixed = { version = "1.24", optional = true }
 futures = "0.3.30"
-git-version = "0.3.9"
+git-version = { version = "0.3.9", optional = true }
 hex = { version = "0.4.3", features = ["serde"], optional = true }
 http = "0.2.11"
 http-api-problem = "0.57.0"
@@ -58,7 +66,7 @@ kube.workspace = true
 opentelemetry.workspace = true
 opentelemetry-otlp = { version = "0.14", optional = true, features = ["metrics"] }
 opentelemetry-prometheus = { version = "0.14", optional = true }
-opentelemetry_sdk = { workspace = true, features = ["rt-tokio"] }
+opentelemetry_sdk = { workspace = true, features = ["rt-tokio"], optional = true }
 opentelemetry-semantic-conventions = { version = "0.13", optional = true }
 postgres-protocol = "0.6.6"
 postgres-types = { version = "0.2.6", features = ["derive", "array-impls"] }
@@ -93,7 +101,7 @@ trillium-api.workspace = true
 trillium-caching-headers.workspace = true
 trillium-head.workspace = true
 trillium-opentelemetry.workspace = true
-trillium-prometheus = "0.1.0"
+trillium-prometheus = { version = "0.1.0", optional = true }
 trillium-router.workspace = true
 trillium-testing = { workspace = true, optional = true }
 trillium-tokio.workspace = true

--- a/aggregator_api/Cargo.toml
+++ b/aggregator_api/Cargo.toml
@@ -22,7 +22,6 @@ rand = { workspace = true, features = ["min_const_gen"] }
 ring = "0.17.7"
 serde.workspace = true
 serde_json.workspace = true
-serde_test.workspace = true
 thiserror.workspace = true
 tracing = "0.1.40"
 trillium.workspace = true
@@ -36,5 +35,6 @@ assert_matches.workspace = true
 futures = "0.3.30"
 janus_aggregator_core = { workspace = true, features = ["test-util"] }
 rstest.workspace = true
+serde_test.workspace = true
 tokio.workspace = true
 trillium-testing = { workspace = true, features = ["tokio"] }

--- a/aggregator_core/Cargo.toml
+++ b/aggregator_core/Cargo.toml
@@ -26,7 +26,6 @@ futures = "0.3.30"
 hex = { version = "0.4.3", features = ["serde"], optional = true }
 http = "0.2.11"
 http-api-problem = "0.57.0"
-hyper = "1.1.0"
 janus_core.workspace = true
 janus_messages.workspace = true
 k8s-openapi.workspace = true
@@ -56,7 +55,6 @@ url = { version = "2.5.0", features = ["serde"] }
 
 [dev-dependencies]
 assert_matches.workspace = true
-hyper = "1.1.0"
 janus_aggregator_core = { path = ".", features = ["test-util"] }
 janus_core = { workspace = true, features = ["test-util"] }
 rstest.workspace = true

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -14,7 +14,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-fpvec_bounded_l2 = ["dep:fixed", "dep:fixed-macro", "janus_core/fpvec_bounded_l2", "prio/experimental"]
+fpvec_bounded_l2 = ["dep:fixed", "janus_core/fpvec_bounded_l2", "prio/experimental"]
 test-util = []
 
 [dependencies]
@@ -24,7 +24,6 @@ derivative.workspace = true
 janus_core.workspace = true
 janus_messages.workspace = true
 fixed = { version = "1.24", optional = true }
-fixed-macro = { version = "1.1.1", optional = true }
 prio.workspace = true
 rand = { workspace = true, features = ["min_const_gen"] }
 reqwest = { version = "0.11.23", default-features = false, features = ["rustls-tls", "json"] }
@@ -40,6 +39,7 @@ serde_json.workspace = true
 [dev-dependencies]
 assert_matches.workspace = true
 base64.workspace = true
+fixed-macro = "1.1.1"
 janus_collector = { path = ".", features = ["fpvec_bounded_l2", "test-util"] }
 janus_core = { workspace = true, features = ["fpvec_bounded_l2", "test-util"] }
 mockito = "1.2.0"

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -35,7 +35,6 @@ kube = { workspace = true, optional = true }
 prio.workspace = true
 rand.workspace = true
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
-rstest.workspace = true
 serde.workspace = true
 serde_json = "1.0.110"
 testcontainers.workspace = true
@@ -45,4 +44,5 @@ trillium-tokio.workspace = true
 
 [dev-dependencies]
 janus_collector = { workspace = true, features = ["test-util"] }
+rstest.workspace = true
 tempfile = "3"

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -18,7 +18,6 @@ anyhow.workspace = true
 assert_matches.workspace = true
 backoff = { version = "0.4", features = ["tokio"] }
 base64.workspace = true
-divviup-client = { version = "0.1", features = ["admin"] }
 futures = "0.3.30"
 hex = "0.4"
 http = "0.2"
@@ -43,6 +42,7 @@ url = { version = "2.5.0", features = ["serde"] }
 trillium-tokio.workspace = true
 
 [dev-dependencies]
+divviup-client = { version = "0.1", features = ["admin"] }
 janus_collector = { workspace = true, features = ["test-util"] }
 rstest.workspace = true
 tempfile = "3"

--- a/interop_binaries/Cargo.toml
+++ b/interop_binaries/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [features]
-fpvec_bounded_l2 = ["dep:fixed", "dep:fixed-macro", "janus_core/fpvec_bounded_l2", "janus_aggregator/fpvec_bounded_l2", "prio/experimental"]
+fpvec_bounded_l2 = ["dep:fixed", "janus_core/fpvec_bounded_l2", "janus_aggregator/fpvec_bounded_l2", "prio/experimental"]
 test-util = [
     "dep:hex",
     "dep:futures",
@@ -26,7 +26,6 @@ clap = "4.4.12"
 derivative.workspace = true
 futures = { version = "0.3.30", optional = true }
 fixed = { version = "1.24", optional = true }
-fixed-macro = { version = "1.1.1", optional = true }
 hex = { version = "0.4", optional = true }
 janus_aggregator_core = { workspace = true, features = ["test-util"] }
 janus_aggregator.workspace = true
@@ -56,6 +55,7 @@ url = { version = "2.5.0", features = ["serde"] }
 zstd = { version = "0.13", optional = true }
 
 [dev-dependencies]
+fixed-macro = "1.1.1"
 janus_interop_binaries = { path = ".", features = ["fpvec_bounded_l2", "test-util"] }
 janus_core = { workspace = true, features = ["test-util", "fpvec_bounded_l2"] }
 reqwest = { version = "0.11.23", default-features = false, features = ["json"] }


### PR DESCRIPTION
This implements #2392.  We had a variety of small issues to clean up before `cargo-udeps` would run cleanly. I think we'll have to merge this PR before we can test the GHA workflow, but I added a workflow_dispatch trigger to speed that up.

I had the workflow create an issue because by default, only the last person to touch a scheduled workflow gets alerted when it fails.