### PR TITLE
Unused dependencies: followup

### DIFF
--- a/.github/workflows/unused-dependencies.yml
+++ b/.github/workflows/unused-dependencies.yml
@@ -19,9 +19,11 @@ jobs:
       - name: Install cargo-udeps
         uses: taiki-e/install-action@cargo-udeps
       - name: Run cargo-udeps, all features
+        shell: bash   # Set this explicitly for -o pipefail behavior
         run: cargo +nightly udeps --all-features | tee log_all_features.txt
       - name: Run cargo-udeps, default features
         if: success() || failure()
+        shell: bash   # Set this explicitly for -o pipefail behavior
         run: cargo +nightly udeps | tee log_default_features.txt
       - name: Create issue
         if: failure()

--- a/.github/workflows/unused-dependencies.yml
+++ b/.github/workflows/unused-dependencies.yml
@@ -57,6 +57,26 @@ jobs:
 
               Unused dependencies were detected in the Cargo workspace.
 
+              #### --all-features
+
+              <details><summary>Show output</summary>
+
+              \`\`\`
+              ${logAllFeatures}
+              \`\`\`
+
+              </details>
+
+              #### Default features
+
+              <details><summary>Show output</summary>
+
+              \`\`\`
+              ${logDefaultFeatures}
+              \`\`\`
+
+              </details>
+
               `;
             }
             output += `#### Details


### PR DESCRIPTION
This is a follow-up to #2433, after testing the workflow. I needed to explicitly set `shell: bash` to get `-o pipefail` behavior. This PR additionally includes the cargo-udeps output in the body of issues created by the workflow.