### PR TITLE
Fix writing aggregation jobs touching GC'ed batches.

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_writer.rs
+++ b/aggregator/src/aggregator/aggregation_job_writer.rs
@@ -22,6 +22,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 use tokio::try_join;
+use tracing::{debug, error};
 
 /// AggregationJobWriter contains the logic used to write aggregation jobs, both initially &
 /// on updates. It is used only by the Leader.
@@ -300,7 +301,7 @@ impl<const SEED_SIZE: usize, Q: CollectableQueryType, A: vdaf::Aggregator<SEED_S
             .by_batch_identifier_index
             .iter()
             .flat_map(|(batch_identifier, by_aggregation_job_index)| {
-                let (operation, mut batch) = match batches.remove(batch_identifier) {
+                let (batch_op, mut batch) = match batches.remove(batch_identifier) {
                     Some(batch) => (Operation::Update, batch),
                     None => (
                         Operation::Put,
@@ -332,15 +333,53 @@ impl<const SEED_SIZE: usize, Q: CollectableQueryType, A: vdaf::Aggregator<SEED_S
                 for (aggregation_job_id, report_aggregation_ords) in by_aggregation_job_index.iter()
                 {
                     // unwrap safety: index lookup
-                    let (op, agg_job, report_aggs) =
+                    let (agg_job_op, agg_job, report_aggs) =
                         by_aggregation_job.get(aggregation_job_id).unwrap();
-                    if op == &Operation::Put
+                    if agg_job_op == &Operation::Put
                         && matches!(agg_job.state(), AggregationJobState::InProgress)
                     {
                         outstanding_aggregation_jobs += 1;
-                    } else if op == &Operation::Update
+                    } else if agg_job_op == &Operation::Update
                         && !matches!(agg_job.state(), AggregationJobState::InProgress)
                     {
+                        // GC hack: if we are Putting the batch, that means that it does not exist
+                        // in the datastore. But since we first write the batch when an aggregation
+                        // job referencing that batch is created, and we are completing the
+                        // aggregation job here, we must have deleted the batch at some point
+                        // between creating & completing this aggregation job. This should only be
+                        // possible if the batch is GC'ed, as part of a time-interval task. In that
+                        // case, it is acceptable to skip writing the batch entirely; and indeed, we
+                        // must do so, since otherwise we might underflow the
+                        // outstanding_aggregation_jobs counter.
+                        //
+                        // See https://github.com/divviup/janus/issues/2464 for more detail.
+                        if batch_op == Operation::Put {
+                            // Guard to ensure we are in the situation we think we're in:
+                            // `to_batch_interval` returns a value only for the time-interval query
+                            // type; this code effectively checks that the query type is
+                            // time-interval, and the batch interval is past the GC window.
+                            if !Q::to_batch_interval(batch_identifier)
+                                .map(|interval| interval.end() < tx.clock().now())
+                                .unwrap_or(false)
+                            {
+                                error!(
+                                    task_id = ?self.task.id(),
+                                    batch_id = ?batch_identifier,
+                                    ?aggregation_job_id,
+                                    "Unexpectedly missing batch while writing completed aggregation job"
+                                );
+                                panic!("Unexpectedly missing batch while writing completed aggregation job");
+                            }
+
+                            debug!(
+                                task_id = ?self.task.id(),
+                                batch_id = ?batch_identifier,
+                                ?aggregation_job_id,
+                                "Skipping batch write for GC'ed batch"
+                            );
+                            return None;
+                        }
+
                         outstanding_aggregation_jobs -= 1;
                     }
 
@@ -366,7 +405,7 @@ impl<const SEED_SIZE: usize, Q: CollectableQueryType, A: vdaf::Aggregator<SEED_S
                 Some(Ok((
                     batch_identifier,
                     (
-                        operation,
+                        batch_op,
                         batch
                             .with_outstanding_aggregation_jobs(outstanding_aggregation_jobs)
                             .with_client_timestamp_interval(client_timestamp_interval),

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -546,6 +546,11 @@ impl<C: Clock> Transaction<'_, C> {
         Ok((version, description))
     }
 
+    /// Returns the clock used by this transaction.
+    pub fn clock(&self) -> &C {
+        self.clock
+    }
+
     /// Writes a task into the datastore.
     #[tracing::instrument(skip(self, task), fields(task_id = ?task.id()), err)]
     pub async fn put_aggregator_task(&self, task: &AggregatorTask) -> Result<(), Error> {


### PR DESCRIPTION
This issue should only exist in the time-interval query type, as fixed-size is arranged such that aggregation jobs touching a given batch must be GC'ed before the batch. I include a guard to ensure that the new codepath is only taken in the expected case of an already-GC'ed batch for a time-interval query, as otherwise we might drop batch writes if we fell into it unexpectedly.