### PR TITLE
Prepare to branch for `release/0.6`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -125,3 +125,65 @@ updates:
     target-branch: "release/0.5"
     ignore:
       - dependency-name: "postgres"
+
+  # Manage dependencies on the `release/0.6` branch
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "release/0.6"
+    open-pull-requests-limit: 20
+    ignore:
+      - dependency-name: prio
+        update-types:
+          - version-update:semver-minor
+    groups:
+      serde:
+        patterns:
+          - serde
+          - serde_*
+      tracing:
+        patterns:
+          - tracing
+          - tracing-*
+      opentelemetry:
+        patterns:
+          - opentelemetry
+          - opentelemetry-*
+      trillium:
+        patterns:
+          - trillium
+          - trillium-*
+      kube:
+        patterns:
+          - kube
+          - k8s-openapi
+      postgres:
+        patterns:
+          - tokio-postgres
+          - postgres-*
+      deadpool:
+        patterns:
+          - deadpool
+          - deadpool-*
+      error-handling:
+        patterns:
+          - thiserror
+          - anyhow
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "release/0.6"
+    groups:
+      docker:
+        patterns:
+          - docker/*
+          - crazymax/ghaction-github-runtime
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "release/0.6"
+    ignore:
+      - dependency-name: "postgres"

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ mechanical protocol changes and was not implemented or deployed by anyone else.
 There is a bug in Janus' `release/0.6` branch wherein `PrepareResp` messages are
 incorrectly encoded, making Janus incompatible with other DAP Aggregator
 implementations.
-See [issue #2389](https://github.com/divviup/janus/issues/2389) for details.
+See [issue #2466](https://github.com/divviup/janus/issues/2466) for details.
 
 ## Versioning and Stability
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ branch.
 | `release/0.4` | [`draft-ietf-ppm-dap-04`][dap-04] | Yes | Unmaintained as of May 24, 2023 |
 | `release/0.subscriber-01` | [`draft-ietf-ppm-dap-02`][dap-02] plus extensions | No | Unmaintained as of November 1, 2023 |
 | `release/0.5` | [`draft-ietf-ppm-dap-04`][dap-04] | Yes | Supported |
-| `main` | [`draft-ietf-ppm-dap-07`][dap-07] | Yes | Supported |
+| `release/0.6` | [`draft-ietf-ppm-dap-07`][dap-07] | Yes, [with errata](#draft-ietf-ppm-dap-07-errata) | Supported |
+| `main` | [`draft-ietf-ppm-dap-09`][dap-09] | [Partially](https://github.com/divviup/janus/issues/2389) | Supported |
 
 Note that no version of Janus supports `draft-ietf-ppm-dap-05` or `-06`. Draft
 05 was skipped because there were flaws in its usage of the new ping-pong
@@ -51,12 +52,22 @@ but was skipped because it was published from the wrong commit of
 `draft-ietf-ppm-dap-07` is effectively identical to draft 6, but with those bugs
 fixed.
 
+`draft-ietf-ppm-dap-08` was also skipped, since it contained only minor
+mechanical protocol changes and was not implemented or deployed by anyone else.
+
 [dap-01]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/01/
 [dap-02]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/02/
 [dap-03]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/03/
 [dap-04]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/04/
 [dap-07]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/07/
+[dap-09]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/09/
 [dap-gh]: https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap
+
+### `draft-ietf-ppm-dap-07` errata
+
+There is a bug in Janus' `release/0.6` branch wherein `PrepareResp` messages are
+incorrectly encoded, making Janus incompatible with other DAP implementations.
+See [issue #2389](https://github.com/divviup/janus/issues/2389) for details.
 
 ## Versioning and Stability
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ mechanical protocol changes and was not implemented or deployed by anyone else.
 ### `draft-ietf-ppm-dap-07` errata
 
 There is a bug in Janus' `release/0.6` branch wherein `PrepareResp` messages are
-incorrectly encoded, making Janus incompatible with other DAP implementations.
+incorrectly encoded, making Janus incompatible with other DAP Aggregator
+implementations.
 See [issue #2389](https://github.com/divviup/janus/issues/2389) for details.
 
 ## Versioning and Stability


### PR DESCRIPTION
The `main` branch will soon start implementing `draft-ietf-ppm-dap-09` (#2389).

- Update dependabot config
- Update draft version table in README
- Mention errata in DAP-07 implementation