### PR TITLE
Abandon collection jobs early when a fatal error is encountered

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -1500,7 +1500,7 @@ mod tests {
         assert_matches!(
             error.downcast().unwrap(),
             Error::Http(error_response) => {
-                assert_eq!(*error_response.status().unwrap(), StatusCode::INTERNAL_SERVER_ERROR);
+                assert_eq!(error_response.status(), StatusCode::INTERNAL_SERVER_ERROR);
                 assert_eq!(*error_response.dap_problem_type().unwrap(), DapProblemType::UnauthorizedRequest);
             }
         );
@@ -2072,7 +2072,7 @@ mod tests {
         assert_matches!(
             error.downcast().unwrap(),
             Error::Http(error_response) => {
-                assert_eq!(*error_response.status().unwrap(), StatusCode::INTERNAL_SERVER_ERROR);
+                assert_eq!(error_response.status(), StatusCode::INTERNAL_SERVER_ERROR);
                 assert_eq!(*error_response.dap_problem_type().unwrap(), DapProblemType::UnauthorizedRequest);
             }
         );
@@ -2794,7 +2794,7 @@ mod tests {
         assert_matches!(
             error.downcast().unwrap(),
             Error::Http(error_response) => {
-                assert_eq!(*error_response.status().unwrap(), StatusCode::INTERNAL_SERVER_ERROR);
+                assert_eq!(error_response.status(), StatusCode::INTERNAL_SERVER_ERROR);
                 assert_eq!(*error_response.dap_problem_type().unwrap(), DapProblemType::UnrecognizedTask);
             }
         );
@@ -3182,7 +3182,7 @@ mod tests {
         assert_matches!(
             error.downcast().unwrap(),
             Error::Http(error_response) => {
-                assert_eq!(*error_response.status().unwrap(), StatusCode::INTERNAL_SERVER_ERROR);
+                assert_eq!(error_response.status(), StatusCode::INTERNAL_SERVER_ERROR);
                 assert_eq!(*error_response.dap_problem_type().unwrap(), DapProblemType::UnrecognizedTask);
             }
         );

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -580,7 +580,7 @@ mod tests {
         assert_matches!(
             client.upload(&1).await,
             Err(Error::Http(error_response)) => {
-                assert_eq!(*error_response.status().unwrap(), StatusCode::NOT_IMPLEMENTED);
+                assert_eq!(error_response.status(), StatusCode::NOT_IMPLEMENTED);
             }
         );
 
@@ -613,7 +613,7 @@ mod tests {
         assert_matches!(
             client.upload(&1).await,
             Err(Error::Http(error_response)) => {
-                assert_eq!(*error_response.status().unwrap(), StatusCode::BAD_REQUEST);
+                assert_eq!(error_response.status(), StatusCode::BAD_REQUEST);
                 assert_eq!(
                     error_response.type_uri().unwrap(),
                     "urn:ietf:params:ppm:dap:error:invalidMessage"

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -1408,7 +1408,7 @@ mod tests {
             .await
             .unwrap_err();
         assert_matches!(error, Error::Http(error_response) => {
-            assert_eq!(*error_response.status().unwrap(), StatusCode::INTERNAL_SERVER_ERROR);
+            assert_eq!(error_response.status(), StatusCode::INTERNAL_SERVER_ERROR);
             assert!(error_response.dap_problem_type().is_none());
         });
 
@@ -1432,7 +1432,7 @@ mod tests {
             .await
             .unwrap_err();
         assert_matches!(error, Error::Http(error_response) => {
-            assert_eq!(*error_response.status().unwrap(), StatusCode::INTERNAL_SERVER_ERROR);
+            assert_eq!(error_response.status(), StatusCode::INTERNAL_SERVER_ERROR);
             assert_eq!(error_response.type_uri().unwrap(), "http://example.com/test_server_error");
             assert!(error_response.dap_problem_type().is_none());
         });
@@ -1461,7 +1461,7 @@ mod tests {
             .await
             .unwrap_err();
         assert_matches!(error, Error::Http(error_response) => {
-            assert_eq!(*error_response.status().unwrap(), StatusCode::BAD_REQUEST);
+            assert_eq!(error_response.status(), StatusCode::BAD_REQUEST);
             assert_eq!(error_response.type_uri().unwrap(), "urn:ietf:params:ppm:dap:error:invalidMessage");
             assert_eq!(error_response.detail().unwrap(), "The message type for a response was incorrect or the payload was malformed.");
             assert_eq!(*error_response.dap_problem_type().unwrap(), DapProblemType::InvalidMessage);
@@ -1506,7 +1506,7 @@ mod tests {
             .unwrap();
         let error = collector.poll_once(&job).await.unwrap_err();
         assert_matches!(error, Error::Http(error_response) => {
-            assert_eq!(*error_response.status().unwrap(), StatusCode::INTERNAL_SERVER_ERROR);
+            assert_eq!(error_response.status(), StatusCode::INTERNAL_SERVER_ERROR);
             assert!(error_response.dap_problem_type().is_none());
         });
 
@@ -1528,7 +1528,7 @@ mod tests {
 
         let error = collector.poll_once(&job).await.unwrap_err();
         assert_matches!(error, Error::Http(error_response) => {
-            assert_eq!(*error_response.status().unwrap(), StatusCode::INTERNAL_SERVER_ERROR);
+            assert_eq!(error_response.status(), StatusCode::INTERNAL_SERVER_ERROR);
             assert_eq!(error_response.type_uri().unwrap(), "http://example.com/test_server_error");
             assert!(error_response.dap_problem_type().is_none());
         });
@@ -1552,7 +1552,7 @@ mod tests {
 
         let error = collector.poll_once(&job).await.unwrap_err();
         assert_matches!(error, Error::Http(error_response) => {
-            assert_eq!(*error_response.status().unwrap(), StatusCode::BAD_REQUEST);
+            assert_eq!(error_response.status(), StatusCode::BAD_REQUEST);
             assert_eq!(error_response.type_uri().unwrap(), "urn:ietf:params:ppm:dap:error:invalidMessage");
             assert_eq!(error_response.detail().unwrap(), "The message type for a response was incorrect or the payload was malformed.");
             assert_eq!(*error_response.dap_problem_type().unwrap(), DapProblemType::InvalidMessage);
@@ -1701,7 +1701,7 @@ mod tests {
             .await;
         let error = collector.poll_until_complete(&job).await.unwrap_err();
         assert_matches!(error, Error::Http(error_response) => {
-            assert_eq!(*error_response.status().unwrap(), StatusCode::INTERNAL_SERVER_ERROR);
+            assert_eq!(error_response.status(), StatusCode::INTERNAL_SERVER_ERROR);
             assert!(error_response.dap_problem_type().is_none());
         });
         mock_collection_job_always_fail.assert_async().await;
@@ -1948,7 +1948,7 @@ mod tests {
             .await
             .unwrap_err();
         assert_matches!(error, Error::Http(error_response) => {
-            assert_eq!(*error_response.status().unwrap(), StatusCode::INTERNAL_SERVER_ERROR);
+            assert_eq!(error_response.status(), StatusCode::INTERNAL_SERVER_ERROR);
         });
 
         mock_error.assert_async().await;

--- a/core/src/http.rs
+++ b/core/src/http.rs
@@ -36,8 +36,9 @@ impl HttpErrorResponse {
     }
 
     /// The HTTP status code returned by the server.
-    pub fn status(&self) -> Option<&StatusCode> {
-        self.problem_details.status.as_ref()
+    pub fn status(&self) -> StatusCode {
+        // Unwrap safety: Self::from_response() always populates this field.
+        self.problem_details.status.unwrap()
     }
 
     /// A URI that identifies the problem type.


### PR DESCRIPTION
This sets a collection job to immediately abandon on failure, except in a narrow set of retryable errors.

The `is_retryable_error()` function is relatively narrow. It basically only retries on particular HTTP status codes and database errors. It's tricky to enumerate all possible retryable rrors. I'm welcome to input if there are other errors that should be retried.

Note that it retries on 500 errors. I don't really want it to, but this is done to share the logic with the other HTTP retry logic we have. I will address whether we should generally retry on 500 errors in a future PR.

I will give the same treatment to aggregation jobs in another PR (see https://github.com/divviup/janus/issues/235)