### PR TITLE
Log version information on startup

### DIFF
--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -17,14 +17,12 @@ default = []
 fpvec_bounded_l2 = ["dep:fixed", "janus_core/fpvec_bounded_l2"]
 tokio-console = ["dep:console-subscriber"]
 otlp = [
-    "dep:git-version",
     "dep:opentelemetry-otlp",
     "dep:opentelemetry-semantic-conventions",
     "dep:opentelemetry_sdk",
     "dep:tracing-opentelemetry",
 ]
 prometheus = [
-    "dep:git-version",
     "dep:opentelemetry-prometheus",
     "dep:opentelemetry_sdk",
     "dep:prometheus",
@@ -52,7 +50,7 @@ deadpool-postgres = "0.12.1"
 derivative.workspace = true
 fixed = { version = "1.24", optional = true }
 futures = "0.3.30"
-git-version = { version = "0.3.9", optional = true }
+git-version = "0.3.9"
 hex = { version = "0.4.3", features = ["serde"], optional = true }
 http = "0.2.11"
 http-api-problem = "0.57.0"

--- a/aggregator/src/bin/janus_cli.rs
+++ b/aggregator/src/bin/janus_cli.rs
@@ -4,6 +4,7 @@ use clap::Parser;
 use janus_aggregator::{
     binary_utils::{database_pool, datastore, read_config, CommonBinaryOptions},
     config::{BinaryConfig, CommonConfig},
+    git_revision,
     metrics::{install_metrics_exporter, MetricsExporterHandle},
     trace::{install_trace_subscriber, TraceGuards},
 };
@@ -37,6 +38,9 @@ async fn main() -> Result<()> {
     info!(
         common_options = ?&command_line_options.common_options,
         config = ?config_file,
+        version = env!("CARGO_PKG_VERSION"),
+        git_revision = git_revision(),
+        rust_version = env!("RUSTC_SEMVER"),
         "Starting up"
     );
 

--- a/aggregator/src/binary_utils.rs
+++ b/aggregator/src/binary_utils.rs
@@ -4,6 +4,7 @@ pub mod job_driver;
 
 use crate::{
     config::{BinaryConfig, DbConfig},
+    git_revision,
     metrics::install_metrics_exporter,
     trace::{install_trace_subscriber, TraceReloadHandle},
 };
@@ -251,7 +252,14 @@ where
     let stopper = Stopper::new();
     setup_signal_handler(stopper.clone()).context("failed to register SIGTERM signal handler")?;
 
-    info!(common_options = ?options.common_options(), ?config, "Starting up");
+    info!(
+        common_options = ?options.common_options(),
+        ?config,
+        version = env!("CARGO_PKG_VERSION"),
+        git_revision = git_revision(),
+        rust_version = env!("RUSTC_SEMVER"),
+        "Starting up"
+    );
 
     // Connect to database.
     let pool = database_pool(

--- a/aggregator/src/lib.rs
+++ b/aggregator/src/lib.rs
@@ -1,6 +1,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::too_many_arguments)]
 
+use git_version::git_version;
+
 pub mod aggregator;
 pub mod binaries;
 pub mod binary_utils;
@@ -13,4 +15,16 @@ pub mod trace;
 enum Operation {
     Put,
     Update,
+}
+
+/// Returns the git revision used to build this crate, using `git describe` if available, or the
+/// environment variable `GIT_REVISION`. Returns `"unknown"` instead if neither is available.
+pub fn git_revision() -> &'static str {
+    let mut git_revision: &'static str = git_version!(fallback = "unknown");
+    if git_revision == "unknown" {
+        if let Some(value) = option_env!("GIT_REVISION") {
+            git_revision = value;
+        }
+    }
+    git_revision
 }

--- a/aggregator/src/metrics.rs
+++ b/aggregator/src/metrics.rs
@@ -32,7 +32,7 @@ use {
 
 #[cfg(any(feature = "otlp", feature = "prometheus"))]
 use {
-    git_version::git_version,
+    crate::git_revision,
     janus_aggregator_core::datastore::TRANSACTION_RETRIES_METER_NAME,
     opentelemetry::{metrics::MetricsError, KeyValue},
     opentelemetry_sdk::{
@@ -282,17 +282,10 @@ fn resource() -> Resource {
     // Note that the implementation of `Default` pulls in attributes set via environment variables.
     let default_resource = Resource::default();
 
-    let mut git_revision = git_version!(fallback = "unknown");
-    if git_revision == "unknown" {
-        if let Some(value) = option_env!("GIT_REVISION") {
-            git_revision = value;
-        }
-    }
-
     let version_info_resource = Resource::new([
         KeyValue::new(
             "service.version",
-            format!("{}-{}", env!("CARGO_PKG_VERSION"), git_revision),
+            format!("{}-{}", env!("CARGO_PKG_VERSION"), git_revision()),
         ),
         KeyValue::new("process.runtime.name", "Rust"),
         KeyValue::new("process.runtime.version", env!("RUSTC_SEMVER")),


### PR DESCRIPTION
#2474 was merged after we branched `release/0.6` from main so it needs to be backported.