### PR TITLE
Upgrade tokio-postgres-rustls and rustls, 0.6 backport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,7 +222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd10f063fb367d26334e10c50c67ea31ac542b8c3402be2251db4cfc5d74ba66"
 dependencies = [
  "futures-io",
- "rustls",
+ "rustls 0.21.9",
 ]
 
 [[package]]
@@ -386,6 +386,16 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bcder"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c627747a6774aab38beb35990d88309481378558875a41da1a4b2e373c906ef0"
+dependencies = [
+ "bytes",
+ "smallvec",
+]
 
 [[package]]
 name = "bitflags"
@@ -1683,10 +1693,10 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls",
+ "rustls 0.21.9",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -1866,7 +1876,7 @@ dependencies = [
  "routefinder",
  "rstest",
  "rustc_version",
- "rustls",
+ "rustls 0.22.2",
  "rustls-pemfile 2.0.0",
  "serde",
  "serde_json",
@@ -2310,10 +2320,10 @@ dependencies = [
  "jsonpath-rust",
  "k8s-openapi",
  "kube-core",
- "pem",
+ "pem 3.0.2",
  "pin-project",
  "rand",
- "rustls",
+ "rustls 0.21.9",
  "rustls-pemfile 1.0.4",
  "secrecy",
  "serde",
@@ -2842,6 +2852,16 @@ name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "pem"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b13fe415cdf3c8e44518e18a7c95a13431d9bdf6d15367d82b23c377fdd441a"
+dependencies = [
+ "base64",
+ "serde",
+]
 
 [[package]]
 name = "pem"
@@ -3404,14 +3424,14 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.21.9",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "system-configuration",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3584,6 +3604,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+dependencies = [
+ "log",
+ "ring 0.17.7",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-native-certs"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3637,6 +3671,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring 0.17.7",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4ca26037c909dedb327b48c3327d0ba91d3dd3c4e05dad328f210ffb68e95b"
+dependencies = [
+ "ring 0.17.7",
+ "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -4132,7 +4177,7 @@ dependencies = [
  "once_cell",
  "paste",
  "percent-encoding",
- "rustls",
+ "rustls 0.21.9",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -4564,16 +4609,17 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres-rustls"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5831152cb0d3f79ef5523b357319ba154795d64c7078b2daa95a803b54057f"
+checksum = "23ca59f99c85e77d01626fa504cd56bcd8ece31c1c9bc218460e3c526690a09f"
 dependencies = [
  "futures",
- "ring 0.16.20",
- "rustls",
+ "ring 0.17.7",
+ "rustls 0.22.2",
  "tokio",
  "tokio-postgres",
- "tokio-rustls",
+ "tokio-rustls 0.25.0",
+ "x509-certificate",
 ]
 
 [[package]]
@@ -4582,7 +4628,18 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.9",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.2",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -5039,7 +5096,7 @@ checksum = "0dbc8492bf036593ba6f7de10e15a9c26ca521772fffb3c8c0ebb2bc280b35af"
 dependencies = [
  "async-rustls",
  "log",
- "rustls",
+ "rustls 0.21.9",
  "rustls-native-certs",
  "rustls-pemfile 1.0.4",
  "rustls-webpki 0.100.3",
@@ -5636,6 +5693,24 @@ dependencies = [
  "curve25519-dalek",
  "rand_core 0.6.4",
  "zeroize",
+]
+
+[[package]]
+name = "x509-certificate"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5d27c90840e84503cf44364de338794d5d5680bdd1da6272d13f80b0769ee0"
+dependencies = [
+ "bcder",
+ "bytes",
+ "chrono",
+ "der 0.7.7",
+ "hex",
+ "pem 2.0.1",
+ "ring 0.16.20",
+ "signature",
+ "spki",
+ "thiserror",
 ]
 
 [[package]]

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -75,7 +75,7 @@ regex = "1"
 reqwest = { version = "0.11.23", default-features = false, features = ["rustls-tls", "json"] }
 ring = "0.17.7"
 routefinder = "0.5.3"
-rustls = "0.21.9"
+rustls = "0.22.2"
 rustls-pemfile = "2.0.0"
 serde.workspace = true
 serde_json.workspace = true
@@ -87,7 +87,7 @@ testcontainers = { workspace = true, optional = true }
 thiserror.workspace = true
 tokio.workspace = true
 tokio-postgres = { version = "0.7.10", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1", "array-impls"] }
-tokio-postgres-rustls = "0.10.0"
+tokio-postgres-rustls = "0.11.0"
 tracing = "0.1.40"
 tracing-chrome = "0.7.1"
 tracing-log = "0.2.0"

--- a/aggregator/src/binary_utils.rs
+++ b/aggregator/src/binary_utils.rs
@@ -76,7 +76,6 @@ pub async fn database_pool(db_config: &DbConfig, db_password: Option<&str>) -> R
     let conn_mgr = if let Some(ref path) = db_config.tls_trust_store_path {
         let root_store = load_pem_trust_store(path).context("failed to load TLS trust store")?;
         let rustls_config = rustls::ClientConfig::builder()
-            .with_safe_defaults()
             .with_root_certificates(root_store)
             .with_no_client_auth();
         Manager::new(database_config, MakeRustlsConnect::new(rustls_config))
@@ -172,7 +171,7 @@ fn load_pem_trust_store(path: impl AsRef<Path>) -> Result<RootCertStore, io::Err
     let mut buf_read = BufReader::new(File::open(path)?);
     let der_certs = rustls_pemfile::certs(&mut buf_read).collect::<Result<Vec<_>, _>>()?;
     let mut root_cert_store = RootCertStore::empty();
-    let (added, ignored) = root_cert_store.add_parsable_certificates(&der_certs);
+    let (added, ignored) = root_cert_store.add_parsable_certificates(der_certs);
     info!("loaded {added} root certificates for database connections, ignored {ignored}");
     Ok(root_cert_store)
 }


### PR DESCRIPTION
This is a backport of #2500.