### PR TITLE
Add gauge metrics for DB connection pool status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca33f4bc4ed1babef42cad36cc1f51fa88be00420404e5b1e80ab1b18f7678c"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 4.0.3",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-compat"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,6 +229,111 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-executor"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c"
+dependencies = [
+ "async-lock 3.2.0",
+ "async-task",
+ "concurrent-queue",
+ "fastrand 2.0.0",
+ "futures-lite 2.2.0",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.1.1",
+ "async-executor",
+ "async-io 2.2.2",
+ "async-lock 3.2.0",
+ "blocking",
+ "futures-lite 2.2.0",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
+dependencies = [
+ "async-lock 2.8.0",
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-lite 1.13.0",
+ "log",
+ "parking",
+ "polling 2.8.0",
+ "rustix 0.37.27",
+ "slab",
+ "socket2 0.4.9",
+ "waker-fn",
+]
+
+[[package]]
+name = "async-io"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6afaa937395a620e33dc6a742c593c01aced20aa376ffb0f628121198578ccc7"
+dependencies = [
+ "async-lock 3.2.0",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite 2.2.0",
+ "parking",
+ "polling 3.3.1",
+ "rustix 0.38.28",
+ "slab",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+dependencies = [
+ "event-listener 2.5.3",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7125e42787d53db9dd54261812ef17e937c95a51e4d291373b670342fa44310c"
+dependencies = [
+ "event-listener 4.0.3",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88"
+dependencies = [
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
+ "async-signal",
+ "blocking",
+ "cfg-if",
+ "event-listener 3.1.0",
+ "futures-lite 1.13.0",
+ "rustix 0.38.28",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "async-rustls"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,6 +341,51 @@ checksum = "bd10f063fb367d26334e10c50c67ea31ac542b8c3402be2251db4cfc5d74ba66"
 dependencies = [
  "futures-io",
  "rustls 0.21.9",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5"
+dependencies = [
+ "async-io 2.2.2",
+ "async-lock 2.8.0",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 0.38.28",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "async-std"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite 1.13.0",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -246,6 +409,12 @@ dependencies = [
  "quote",
  "syn 2.0.46",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d90cd0b264dfdd8eb5bad0a2c217c1f88fa96a8573f40e7b12de23fb468f46"
 
 [[package]]
 name = "async-trait"
@@ -272,6 +441,12 @@ checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atomic-write-file"
@@ -431,6 +606,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
+dependencies = [
+ "async-channel 2.1.1",
+ "async-lock 3.2.0",
+ "async-task",
+ "fastrand 2.0.0",
+ "futures-io",
+ "futures-lite 2.2.0",
+ "piper",
+ "tracing",
 ]
 
 [[package]]
@@ -1074,12 +1265,33 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
 dependencies = [
  "concurrent-queue",
  "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
+dependencies = [
+ "event-listener 4.0.3",
  "pin-project-lite",
 ]
 
@@ -1419,6 +1631,18 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "group"
@@ -1789,6 +2013,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1801,7 +2036,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "rustix",
+ "rustix 0.38.28",
  "windows-sys 0.48.0",
 ]
 
@@ -2355,6 +2590,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2388,6 +2632,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
@@ -2407,6 +2657,9 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "matchers"
@@ -2753,6 +3006,7 @@ version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f16aec8a98a457a52664d69e0091bac3a0abd18ead9b641cb00202ba4e0efe4"
 dependencies = [
+ "async-std",
  "async-trait",
  "crossbeam-channel",
  "futures-channel",
@@ -2764,6 +3018,7 @@ dependencies = [
  "ordered-float 4.1.1",
  "percent-encoding",
  "rand",
+ "serde_json",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -2984,6 +3239,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
+dependencies = [
+ "atomic-waker",
+ "fastrand 2.0.0",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3009,6 +3275,36 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "polling"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf63fa624ab313c11656b4cda960bfc46c410187ad493c41f6ba2d8c1e991c9e"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "pin-project-lite",
+ "rustix 0.38.28",
+ "tracing",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "poly1305"
@@ -3607,6 +3903,20 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.37.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
 version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
@@ -3614,7 +3924,7 @@ dependencies = [
  "bitflags 2.4.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.12",
  "windows-sys 0.52.0",
 ]
 
@@ -4472,7 +4782,7 @@ dependencies = [
  "cfg-if",
  "fastrand 2.0.0",
  "redox_syscall 0.4.1",
- "rustix",
+ "rustix 0.38.28",
  "windows-sys 0.52.0",
 ]
 
@@ -5155,7 +5465,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556cad53e12159259c9f8eb56fc1fe6b6d54057c61d1da80a59cbf9ebf162ba6"
 dependencies = [
- "async-channel",
+ "async-channel 1.9.0",
  "async-dup",
  "cfg-if",
  "futures-lite 1.13.0",
@@ -5347,6 +5657,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "value-bag"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a72e1902dde2bd6441347de2b70b7f5d59bf157c6c62f0c44572607a1d55bbe"
 
 [[package]]
 name = "vcpkg"

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -110,6 +110,7 @@ assert_matches.workspace = true
 janus_aggregator = { path = ".", features = ["fpvec_bounded_l2", "test-util"] }
 janus_aggregator_core = { workspace = true, features = ["test-util"] }
 mockito = "1.2.0"
+opentelemetry_sdk = { workspace = true, features = ["testing"] }
 rstest.workspace = true
 tempfile = "3.9.0"
 tokio = { version = "1", features = ["test-util"] } # ensure this remains compatible with the non-dev dependency

--- a/aggregator/src/binary_utils.rs
+++ b/aggregator/src/binary_utils.rs
@@ -17,7 +17,7 @@ use deadpool_postgres::{Manager, Pool, PoolError, Runtime, Timeouts};
 use futures::StreamExt;
 use janus_aggregator_core::datastore::{Crypter, Datastore};
 use janus_core::time::Clock;
-use opentelemetry::metrics::Meter;
+use opentelemetry::metrics::{Meter, MetricsError};
 use ring::aead::{LessSafeKey, UnboundKey, AES_128_GCM};
 use rustls::RootCertStore;
 use std::{
@@ -268,7 +268,7 @@ where
     .await
     .context("couldn't create database connection pool")?;
     let datastore = datastore(
-        pool,
+        pool.clone(),
         clock.clone(),
         &meter,
         &options.common_options().datastore_keys,
@@ -276,6 +276,8 @@ where
     )
     .await
     .context("couldn't create datastore")?;
+
+    register_database_pool_status_metrics(pool, &meter)?;
 
     let health_check_listen_address = config.common_config().health_check_listen_address;
     let zpages_task_handle = tokio::task::spawn(async move {
@@ -295,6 +297,52 @@ where
     zpages_task_handle.abort();
 
     result
+}
+
+/// Set up metrics to monitor the database connection pool's status.
+fn register_database_pool_status_metrics(pool: Pool, meter: &Meter) -> Result<(), MetricsError> {
+    let available_connections_gauge = meter
+        .u64_observable_gauge("janus_database_pool_available_connections")
+        .with_description(
+            "Number of available database connections in the database connection pool.",
+        )
+        .init();
+    let total_connections_gauge = meter
+        .u64_observable_gauge("janus_database_pool_total_connections")
+        .with_description("Total number of connections in the database connection pool.")
+        .init();
+    let waiting_tasks_gauge = meter
+        .u64_observable_gauge("janus_database_pool_waiting_tasks")
+        .with_description(
+            "Number of tasks waiting for a connection from the database connection pool.",
+        )
+        .init();
+    meter.register_callback(
+        &[
+            available_connections_gauge.as_any(),
+            total_connections_gauge.as_any(),
+            waiting_tasks_gauge.as_any(),
+        ],
+        move |observer| {
+            let status = pool.status();
+            observer.observe_u64(
+                &available_connections_gauge,
+                u64::try_from(status.available).unwrap_or(u64::MAX),
+                &[],
+            );
+            observer.observe_u64(
+                &total_connections_gauge,
+                u64::try_from(status.size).unwrap_or(u64::MAX),
+                &[],
+            );
+            observer.observe_u64(
+                &waiting_tasks_gauge,
+                u64::try_from(status.waiting).unwrap_or(u64::MAX),
+                &[],
+            );
+        },
+    )?;
+    Ok(())
 }
 
 /// A trillium server which serves z-pages, which are utility endpoints for health checks and
@@ -426,16 +474,27 @@ pub async fn setup_server(
 mod tests {
     use crate::{
         aggregator::http_handlers::test_util::take_response_body,
-        binary_utils::{database_pool, zpages_handler, CommonBinaryOptions},
+        binary_utils::{
+            database_pool, register_database_pool_status_metrics, zpages_handler,
+            CommonBinaryOptions,
+        },
         config::DbConfig,
     };
     use clap::CommandFactory;
+    use janus_aggregator_core::datastore::test_util::ephemeral_datastore;
     use janus_core::test_util::{
         install_test_trace_subscriber,
         testcontainers::{container_client, Postgres, Volume},
     };
-    use std::fs;
+    use opentelemetry::metrics::MeterProvider as _;
+    use opentelemetry_sdk::{
+        metrics::{data::Gauge, MeterProvider, PeriodicReader},
+        runtime::Tokio,
+        testing::metrics::InMemoryMetricsExporter,
+    };
+    use std::{collections::HashMap, fs};
     use testcontainers::RunnableImage;
+    use tokio::task::spawn_blocking;
     use tracing_subscriber::{reload, EnvFilter};
     use trillium::Status;
     use trillium_testing::prelude::*;
@@ -579,5 +638,88 @@ mod tests {
         let pool = database_pool(&db_config, None).await.unwrap();
         let conn = pool.get().await.unwrap();
         conn.query_one("SELECT 1", &[]).await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn database_pool_metrics() {
+        install_test_trace_subscriber();
+
+        let ephemeral_datastore = ephemeral_datastore().await;
+        let pool = ephemeral_datastore.pool();
+
+        let exporter = InMemoryMetricsExporter::default();
+        let reader = PeriodicReader::builder(exporter.clone(), Tokio).build();
+        let meter_provider = MeterProvider::builder().with_reader(reader.clone()).build();
+        let meter = meter_provider.meter("tests");
+
+        register_database_pool_status_metrics(pool.clone(), &meter).unwrap();
+
+        check_database_pool_gauges(&meter_provider, &exporter, 0, 0, 0).await;
+        let connection = pool.get().await.unwrap();
+        check_database_pool_gauges(&meter_provider, &exporter, 0, 1, 0).await;
+        drop(connection);
+        check_database_pool_gauges(&meter_provider, &exporter, 1, 1, 0).await;
+
+        spawn_blocking(move || {
+            // TODO: PeriodicReader::shutdown() currently has a bug that results in this method
+            // always returning an error. Ignore this until the fix makes it into the next release.
+            // See https://github.com/open-telemetry/opentelemetry-rust/pull/1375.
+            let _ = meter_provider.shutdown();
+        })
+        .await
+        .unwrap();
+    }
+
+    async fn check_database_pool_gauges(
+        meter_provider: &MeterProvider,
+        exporter: &InMemoryMetricsExporter,
+        expected_available: u64,
+        expected_total: u64,
+        expected_waiting: u64,
+    ) {
+        spawn_blocking({
+            let meter_provider = meter_provider.clone();
+            move || {
+                meter_provider.force_flush().unwrap();
+            }
+        })
+        .await
+        .unwrap();
+
+        let finished_metrics = exporter.get_finished_metrics().unwrap();
+        let metrics = finished_metrics
+            .into_iter()
+            .flat_map(|rm| rm.scope_metrics.into_iter())
+            .flat_map(|sm| sm.metrics.into_iter())
+            .map(|metric| (metric.name.into_owned(), metric.data))
+            .collect::<HashMap<_, _>>();
+
+        assert_eq!(
+            metrics["janus_database_pool_available_connections"]
+                .as_any()
+                .downcast_ref::<Gauge<u64>>()
+                .unwrap()
+                .data_points[0]
+                .value,
+            expected_available
+        );
+        assert_eq!(
+            metrics["janus_database_pool_total_connections"]
+                .as_any()
+                .downcast_ref::<Gauge<u64>>()
+                .unwrap()
+                .data_points[0]
+                .value,
+            expected_total
+        );
+        assert_eq!(
+            metrics["janus_database_pool_waiting_tasks"]
+                .as_any()
+                .downcast_ref::<Gauge<u64>>()
+                .unwrap()
+                .data_points[0]
+                .value,
+            expected_waiting
+        );
     }
 }

--- a/aggregator/src/binary_utils.rs
+++ b/aggregator/src/binary_utils.rs
@@ -311,6 +311,10 @@ fn register_database_pool_status_metrics(pool: Pool, meter: &Meter) -> Result<()
         .u64_observable_gauge("janus_database_pool_total_connections")
         .with_description("Total number of connections in the database connection pool.")
         .init();
+    let maximum_size_gauge = meter
+        .u64_observable_gauge("janus_database_pool_maximum_size_connections")
+        .with_description("Maximum size of the database connection pool.")
+        .init();
     let waiting_tasks_gauge = meter
         .u64_observable_gauge("janus_database_pool_waiting_tasks")
         .with_description(
@@ -321,6 +325,7 @@ fn register_database_pool_status_metrics(pool: Pool, meter: &Meter) -> Result<()
         &[
             available_connections_gauge.as_any(),
             total_connections_gauge.as_any(),
+            maximum_size_gauge.as_any(),
             waiting_tasks_gauge.as_any(),
         ],
         move |observer| {
@@ -333,6 +338,11 @@ fn register_database_pool_status_metrics(pool: Pool, meter: &Meter) -> Result<()
             observer.observe_u64(
                 &total_connections_gauge,
                 u64::try_from(status.size).unwrap_or(u64::MAX),
+                &[],
+            );
+            observer.observe_u64(
+                &maximum_size_gauge,
+                u64::try_from(status.max_size).unwrap_or(u64::MAX),
                 &[],
             );
             observer.observe_u64(


### PR DESCRIPTION
This closes #2478. It adds three new metrics, `janus_database_pool_available_connections`, `janus_database_pool_total_connections`, and `janus_database_pool_waiting_tasks`, to report the status of the database connection pool. These gauges are updated on-demand from a callback. I included a unit test to confirm that the first two are operating as intended.