### PR TITLE
Release Janus 0.7.0-prerelease-1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2066,7 +2066,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "janus_aggregator"
-version = "0.7.0"
+version = "0.7.0-prerelease-1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2091,7 +2091,7 @@ dependencies = [
  "janus_aggregator_api",
  "janus_aggregator_core",
  "janus_core",
- "janus_messages 0.7.0",
+ "janus_messages 0.7.0-prerelease-1",
  "k8s-openapi",
  "kube",
  "mockito",
@@ -2147,7 +2147,7 @@ dependencies = [
 
 [[package]]
 name = "janus_aggregator_api"
-version = "0.7.0"
+version = "0.7.0-prerelease-1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2157,7 +2157,7 @@ dependencies = [
  "futures",
  "janus_aggregator_core",
  "janus_core",
- "janus_messages 0.7.0",
+ "janus_messages 0.7.0-prerelease-1",
  "opentelemetry",
  "querystring",
  "rand",
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "janus_aggregator_core"
-version = "0.7.0"
+version = "0.7.0-prerelease-1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2197,7 +2197,7 @@ dependencies = [
  "http-api-problem",
  "janus_aggregator_core",
  "janus_core",
- "janus_messages 0.7.0",
+ "janus_messages 0.7.0-prerelease-1",
  "k8s-openapi",
  "kube",
  "opentelemetry",
@@ -2231,7 +2231,7 @@ dependencies = [
 
 [[package]]
 name = "janus_client"
-version = "0.7.0"
+version = "0.7.0-prerelease-1"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -2240,7 +2240,7 @@ dependencies = [
  "http",
  "itertools 0.11.0",
  "janus_core",
- "janus_messages 0.7.0",
+ "janus_messages 0.7.0-prerelease-1",
  "mockito",
  "prio 0.16.0",
  "rand",
@@ -2255,7 +2255,7 @@ dependencies = [
 
 [[package]]
 name = "janus_collector"
-version = "0.7.0"
+version = "0.7.0-prerelease-1"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -2267,7 +2267,7 @@ dependencies = [
  "hpke-dispatch",
  "janus_collector",
  "janus_core",
- "janus_messages 0.7.0",
+ "janus_messages 0.7.0-prerelease-1",
  "mockito",
  "prio 0.16.0",
  "rand",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "janus_core"
-version = "0.7.0"
+version = "0.7.0-prerelease-1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2298,7 +2298,7 @@ dependencies = [
  "http",
  "http-api-problem",
  "janus_core",
- "janus_messages 0.7.0",
+ "janus_messages 0.7.0-prerelease-1",
  "k8s-openapi",
  "kube",
  "mockito",
@@ -2327,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "janus_integration_tests"
-version = "0.7.0"
+version = "0.7.0-prerelease-1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2346,7 +2346,7 @@ dependencies = [
  "janus_collector",
  "janus_core",
  "janus_interop_binaries",
- "janus_messages 0.7.0",
+ "janus_messages 0.7.0-prerelease-1",
  "k8s-openapi",
  "kube",
  "prio 0.16.0",
@@ -2366,7 +2366,7 @@ dependencies = [
 
 [[package]]
 name = "janus_interop_binaries"
-version = "0.7.0"
+version = "0.7.0-prerelease-1"
 dependencies = [
  "anyhow",
  "backoff",
@@ -2383,7 +2383,7 @@ dependencies = [
  "janus_collector",
  "janus_core",
  "janus_interop_binaries",
- "janus_messages 0.7.0",
+ "janus_messages 0.7.0-prerelease-1",
  "opentelemetry",
  "prio 0.16.0",
  "rand",
@@ -2426,7 +2426,7 @@ dependencies = [
 
 [[package]]
 name = "janus_messages"
-version = "0.7.0"
+version = "0.7.0-prerelease-1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2444,7 +2444,7 @@ dependencies = [
 
 [[package]]
 name = "janus_tools"
-version = "0.7.0"
+version = "0.7.0-prerelease-1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2455,7 +2455,7 @@ dependencies = [
  "fixed",
  "janus_collector",
  "janus_core",
- "janus_messages 0.7.0",
+ "janus_messages 0.7.0-prerelease-1",
  "prio 0.16.0",
  "rand",
  "reqwest",
@@ -6058,7 +6058,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.7.0"
+version = "0.7.0-prerelease-1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://divviup.org"
 license = "MPL-2.0"
 repository = "https://github.com/divviup/janus"
 rust-version = "1.73.0"
-version = "0.7.0"
+version = "0.7.0-prerelease-1"
 
 [workspace.dependencies]
 anyhow = "1"
@@ -33,15 +33,15 @@ chrono = { version = "0.4", default-features = false }
 clap = { version = "4.4.17", features = ["cargo", "derive", "env"] }
 derivative = "2.2.0"
 itertools = "0.11"
-janus_aggregator = { version = "0.7", path = "aggregator" }
-janus_aggregator_api = { version = "0.7", path = "aggregator_api" }
-janus_aggregator_core = { version = "0.7", path = "aggregator_core" }
-janus_client = { version = "0.7", path = "client" }
-janus_collector = { version = "0.7", path = "collector" }
-janus_core = { version = "0.7", path = "core" }
-janus_integration_tests = { version = "0.7", path = "integration_tests" }
-janus_interop_binaries = { version = "0.7", path = "interop_binaries" }
-janus_messages = { version = "0.7", path = "messages" }
+janus_aggregator = { version = "0.7.0-prerelease-1", path = "aggregator" }
+janus_aggregator_api = { version = "0.7.0-prerelease-1", path = "aggregator_api" }
+janus_aggregator_core = { version = "0.7.0-prerelease-1", path = "aggregator_core" }
+janus_client = { version = "0.7.0-prerelease-1", path = "client" }
+janus_collector = { version = "0.7.0-prerelease-1", path = "collector" }
+janus_core = { version = "0.7.0-prerelease-1", path = "core" }
+janus_integration_tests = { version = "0.7.0-prerelease-1", path = "integration_tests" }
+janus_interop_binaries = { version = "0.7.0-prerelease-1", path = "interop_binaries" }
+janus_messages = { version = "0.7.0-prerelease-1", path = "messages" }
 k8s-openapi = { version = "0.20.0", features = ["v1_26"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
 kube = { version = "0.87.2", default-features = false, features = ["client", "rustls-tls"] }
 opentelemetry = { version = "0.21", features = ["metrics"] }


### PR DESCRIPTION
Bump crate versions for release. Use prerelease version tags so we can break the SQL schema a few times.