### PR TITLE
Don't block CI upon announcement of new advisories

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -135,6 +135,8 @@ jobs:
       run: cargo doc --profile ci --workspace
     - name: cargo-deny
       uses: EmbarkStudios/cargo-deny-action@v1
+      with:
+        command: check bans
 
   janus_docker:
     runs-on: ubuntu-latest
@@ -179,3 +181,13 @@ jobs:
         files: docker-bake.hcl
         workdir: .
         targets: interop_binaries_small
+
+  rustsec_advisories:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@v4
+    - name: cargo-deny
+      uses: EmbarkStudios/cargo-deny-action@v1
+      with:
+        command: check advisories


### PR DESCRIPTION
This splits out `cargo deny check advisories` into a separate GitHub Actions job, with `continue-on-error: true`. This is recommended in the action's README. This way, we will still see notice of advisories here, in addition to GitHub's Dependabot security alerts, but won't be blocked from merging unrelated changes when there's a new advisory about one of our dependencies.