### PR TITLE
Add report_too_early to PrepareError

### DIFF
--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -2934,7 +2934,7 @@ mod tests {
         AggregationJobContinueReq, AggregationJobInitializeReq, AggregationJobResp,
         AggregationJobStep, BatchId, BatchSelector, Collection, CollectionReq, Duration, Extension,
         ExtensionType, FixedSize, FixedSizeQuery, HpkeAeadId, HpkeCiphertext, HpkeConfig,
-        HpkeConfigId, HpkeKdfId, HpkeKemId, HpkePublicKey, InputShareAad, Interval,
+        HpkeConfigId, HpkeConfigList, HpkeKdfId, HpkeKemId, HpkePublicKey, InputShareAad, Interval,
         PartialBatchSelector, PlaintextInputShare, PrepareContinue, PrepareError, PrepareInit,
         PrepareResp, PrepareStepResult, Query, Report, ReportId, ReportIdChecksum, ReportMetadata,
         ReportShare, Role, TaskId, Time, TimeInterval, Url,
@@ -3350,6 +3350,53 @@ mod tests {
                 ),
             ),
         ])
+    }
+
+    #[test]
+    fn roundtrip_hpke_config_list() {
+        roundtrip_encoding(&[(
+            HpkeConfigList::new(Vec::from([
+                HpkeConfig::new(
+                    HpkeConfigId::from(12),
+                    HpkeKemId::P256HkdfSha256,
+                    HpkeKdfId::HkdfSha512,
+                    HpkeAeadId::Aes256Gcm,
+                    HpkePublicKey::from(Vec::new()),
+                ),
+                HpkeConfig::new(
+                    HpkeConfigId::from(12),
+                    HpkeKemId::P256HkdfSha256,
+                    HpkeKdfId::HkdfSha512,
+                    HpkeAeadId::Other(0x9999),
+                    HpkePublicKey::from(Vec::new()),
+                ),
+            ])),
+            concat!(
+                "0012",
+                concat!(
+                    "0C",   // id
+                    "0010", // kem_id
+                    "0003", // kdf_id
+                    "0002", // aead_id
+                    concat!(
+                        // public_key
+                        "0000", // length
+                        "",     // opaque data
+                    )
+                ),
+                concat!(
+                    "0C",   // id
+                    "0010", // kem_id
+                    "0003", // kdf_id
+                    "9999", // aead_id
+                    concat!(
+                        // public_key
+                        "0000", // length
+                        "",     // opaque data
+                    )
+                ),
+            ),
+        )]);
     }
 
     #[test]

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -2335,6 +2335,7 @@ pub enum PrepareError {
     BatchSaturated = 6,
     TaskExpired = 7,
     InvalidMessage = 8,
+    ReportTooEarly = 9,
 }
 
 impl Encode for PrepareError {
@@ -4313,6 +4314,10 @@ mod tests {
             (PrepareError::HpkeUnknownConfigId, "03"),
             (PrepareError::HpkeDecryptError, "04"),
             (PrepareError::VdafPrepError, "05"),
+            (PrepareError::BatchSaturated, "06"),
+            (PrepareError::TaskExpired, "07"),
+            (PrepareError::InvalidMessage, "08"),
+            (PrepareError::ReportTooEarly, "09"),
         ])
     }
 


### PR DESCRIPTION
This adds a missing error code to PrepareError. The DAP changelog says this was added in draft 03, so all maintained branches will need this fix backported. If we tried to aggregate with a different helper implementation that uses this error code, we would fail to parse responses that contained this error code, which would turn an entire aggregation job into a dead letter.

I also fleshed out the related serialization unit test, and added an unrelated unit test that we were missing.