### PR TITLE
Pin to last working version of cargo-deny-action

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -134,7 +134,7 @@ jobs:
     - name: Document
       run: cargo doc --profile ci --workspace
     - name: cargo-deny
-      uses: EmbarkStudios/cargo-deny-action@v1
+      uses: EmbarkStudios/cargo-deny-action@v1.5.10
       with:
         command: check bans
 
@@ -188,6 +188,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: cargo-deny
-      uses: EmbarkStudios/cargo-deny-action@v1
+      uses: EmbarkStudios/cargo-deny-action@v1.5.10
       with:
         command: check advisories


### PR DESCRIPTION
We're running into an issue (likely with prerelease dependencies) when using cargo-deny 0.14.9, but not 0.14.8. The issue appears to have been fixed in cargo-deny 0.14.10. This PR downgrades the version of the action to fix the issue, and Dependabot can update us once the new version makes its way to the action repository.