### PR TITLE
Pin to last working version of cargo-deny-action, 0.6 backport

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -134,7 +134,7 @@ jobs:
     - name: Document
       run: cargo doc --profile ci --workspace
     - name: cargo-deny
-      uses: EmbarkStudios/cargo-deny-action@v1
+      uses: EmbarkStudios/cargo-deny-action@v1.5.10
       with:
         command: check bans
 
@@ -188,6 +188,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: cargo-deny
-      uses: EmbarkStudios/cargo-deny-action@v1
+      uses: EmbarkStudios/cargo-deny-action@v1.5.10
       with:
         command: check advisories


### PR DESCRIPTION
This is a backport of #2542.