### PR TITLE
Add schema for report upload counters (release/0.6 backport)

### DIFF
--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -99,7 +99,7 @@ macro_rules! supported_schema_versions {
 // version is seen, [`Datastore::new`] fails.
 //
 // Note that the latest supported version must be first in the list.
-supported_schema_versions!(1);
+supported_schema_versions!(2, 1);
 
 /// Datastore represents a datastore for Janus, with support for transactional reads and writes.
 /// In practice, Datastore instances are currently backed by a PostgreSQL database.

--- a/db/00000000000002_task_upload_counters.down.sql
+++ b/db/00000000000002_task_upload_counters.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE task_upload_counters;

--- a/db/00000000000002_task_upload_counters.up.sql
+++ b/db/00000000000002_task_upload_counters.up.sql
@@ -1,0 +1,19 @@
+-- Per task report upload counters.
+CREATE TABLE task_upload_counters(
+    id                     BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,  -- artificial ID, internal-only
+    task_id                BIGINT NOT NULL,
+
+    interval_collected     BIGINT NOT NULL DEFAULT 0, -- Reports submitted for an interval that was already collected.
+    report_decode_failure  BIGINT NOT NULL DEFAULT 0, -- Reports which failed to decode.
+    report_decrypt_failure BIGINT NOT NULL DEFAULT 0, -- Reports which failed to decrypt.
+    report_expired         BIGINT NOT NULL DEFAULT 0, -- Reports that were older than the task's report_expiry_age.
+    report_outdated_key    BIGINT NOT NULL DEFAULT 0, -- Reports that were encrypted with an unknown or outdated HPKE key.
+    report_success         BIGINT NOT NULL DEFAULT 0, -- Reports that were successfully uploaded.
+    report_too_early       BIGINT NOT NULL DEFAULT 0, -- Reports whose timestamp is too far in the future.
+    task_expired           BIGINT NOT NULL DEFAULT 0, -- Reports sent to the task while it is expired.
+
+    ord                    BIGINT NOT NULL,           -- Index of this task_upload_counters shard.
+
+    CONSTRAINT fk_task_id FOREIGN KEY(task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+    CONSTRAINT task_upload_counters_unique UNIQUE(task_id, ord)
+);


### PR DESCRIPTION
Supports https://github.com/divviup/janus/issues/2293, partial backport of https://github.com/divviup/janus/pull/2508.

This is just the database schema, so we can roll this changeset out without having downtime or crashing replicas.