### PR TITLE
Split delete_expired_client_reports() query, 0.6 backport

### DIFF
--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -31,7 +31,7 @@ use opentelemetry::{
     metrics::{Counter, Histogram, Meter, Unit},
     KeyValue,
 };
-use postgres_types::{FromSql, Json, ToSql};
+use postgres_types::{FromSql, Json, Timestamp, ToSql};
 use prio::{
     codec::{decode_u16_items, encode_u16_items, CodecError, Decode, Encode, ParameterizedDecode},
     topology::ping_pong::PingPongTransition,
@@ -4111,13 +4111,40 @@ impl<C: Clock> Transaction<'_, C> {
         task_id: &TaskId,
         limit: u64,
     ) -> Result<u64, Error> {
-        let stmt = self
+        // Calculation of a report timestamp threshold is split apart from the main body of the
+        // query so that the query planner can see concrete timestamp value, compare it against the
+        // client_timestamp column's histogram, and make an accurate row count estimate. If the
+        // threshold is determined in a single query via a join, the query planner is not able to
+        // predict the task's report_expiry_age, and the accuracy of the row count estimate suffers.
+        let stmt_1 = self
+            .prepare_cached(
+                "SELECT
+                    id,
+                    COALESCE(
+                        $2::TIMESTAMP - tasks.report_expiry_age * '1 second'::INTERVAL,
+                        '-infinity'::TIMESTAMP
+                    ) AS threshold
+                FROM tasks WHERE tasks.task_id = $1",
+            )
+            .await?;
+        let row = self
+            .query_one(
+                &stmt_1,
+                &[
+                    /* task_id */ &task_id.get_encoded(),
+                    /* now */ &self.clock.now().as_naive_date_time()?,
+                ],
+            )
+            .await?;
+        let id = row.get::<_, i64>("id");
+        let threshold = row.get::<_, Timestamp<NaiveDateTime>>("threshold");
+
+        let stmt_2 = self
             .prepare_cached(
                 "WITH client_reports_to_delete AS (
                     SELECT client_reports.id FROM client_reports
-                    JOIN tasks ON tasks.id = client_reports.task_id
-                    WHERE tasks.task_id = $1
-                      AND client_reports.client_timestamp < COALESCE($2::TIMESTAMP - tasks.report_expiry_age * '1 second'::INTERVAL, '-infinity'::TIMESTAMP)
+                    WHERE client_reports.task_id = $1
+                        AND client_reports.client_timestamp < $2::TIMESTAMP
                     LIMIT $3
                 )
                 DELETE FROM client_reports
@@ -4126,10 +4153,10 @@ impl<C: Clock> Transaction<'_, C> {
             )
             .await?;
         self.execute(
-            &stmt,
+            &stmt_2,
             &[
-                /* task_id */ &task_id.get_encoded(),
-                /* now */ &self.clock.now().as_naive_date_time()?,
+                /* id */ &id,
+                /* threshold */ &threshold,
                 /* limit */ &i64::try_from(limit)?,
             ],
         )

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -5628,6 +5628,80 @@ async fn delete_expired_client_reports(ephemeral_datastore: EphemeralDatastore) 
 
 #[rstest_reuse::apply(schema_versions_template)]
 #[tokio::test]
+async fn delete_expired_client_reports_noop(ephemeral_datastore: EphemeralDatastore) {
+    install_test_trace_subscriber();
+
+    let clock = MockClock::default();
+    let ds = ephemeral_datastore.datastore(clock.clone()).await;
+    let vdaf = dummy_vdaf::Vdaf::new();
+
+    // Setup.
+    let (task_id, new_report_id, old_report_id) = ds
+        .run_unnamed_tx(|tx| {
+            Box::pin(async move {
+                let task = TaskBuilder::new(task::QueryType::TimeInterval, VdafInstance::Fake)
+                    .with_report_expiry_age(None)
+                    .build()
+                    .leader_view()
+                    .unwrap();
+                tx.put_aggregator_task(&task).await?;
+
+                let old_report = LeaderStoredReport::new_dummy(
+                    *task.id(),
+                    OLDEST_ALLOWED_REPORT_TIMESTAMP
+                        .sub(&Duration::from_seconds(1))
+                        .unwrap(),
+                );
+                let new_report =
+                    LeaderStoredReport::new_dummy(*task.id(), OLDEST_ALLOWED_REPORT_TIMESTAMP);
+                tx.put_client_report(&dummy_vdaf::Vdaf::new(), &old_report)
+                    .await?;
+                tx.put_client_report(&dummy_vdaf::Vdaf::new(), &new_report)
+                    .await?;
+
+                Ok((
+                    *task.id(),
+                    *new_report.metadata().id(),
+                    *old_report.metadata().id(),
+                ))
+            })
+        })
+        .await
+        .unwrap();
+
+    // Run.
+    let deleted_report_count = ds
+        .run_unnamed_tx(|tx| {
+            Box::pin(async move {
+                tx.delete_expired_client_reports(&task_id, u64::try_from(i64::MAX)?)
+                    .await
+            })
+        })
+        .await
+        .unwrap();
+
+    // Verify.
+    assert_eq!(0, deleted_report_count);
+    let want_report_ids = HashSet::from([new_report_id, old_report_id]);
+    let got_report_ids = ds
+        .run_unnamed_tx(|tx| {
+            let vdaf = vdaf.clone();
+            Box::pin(async move {
+                let task_client_reports = tx.get_client_reports_for_task(&vdaf, &task_id).await?;
+                Ok(HashSet::from_iter(
+                    task_client_reports
+                        .into_iter()
+                        .map(|report| *report.metadata().id()),
+                ))
+            })
+        })
+        .await
+        .unwrap();
+    assert_eq!(want_report_ids, got_report_ids);
+}
+
+#[rstest_reuse::apply(schema_versions_template)]
+#[tokio::test]
 async fn delete_expired_aggregation_artifacts(ephemeral_datastore: EphemeralDatastore) {
     install_test_trace_subscriber();
 


### PR DESCRIPTION
This backports #2560.