### PR TITLE
Add workflow for automatically generating release

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -17,6 +17,8 @@ jobs:
       matrix:
         target_branch: ${{ fromJSON(inputs.target_branch) }}
     runs-on: ubuntu-latest
+    env:
+      CARGO_EDIT_VERSION: 0.12.2
     steps:
       - uses: actions/checkout@v4
         with:
@@ -24,28 +26,21 @@ jobs:
           token: '${{ secrets.DIVVIUP_GITHUB_AUTOMATION_RELEASE_PAT }}'
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@stable
 
-      - name: Restore cargo-edit from cache
-        id: cache-cargo-edit-restore
-        uses: actions/cache/restore@v4
+      - name: Cache cargo edit
+        uses: actions/cache@v4
         with:
-          path: |
-            ~/.cargo/bin
-          key: ${{ runner.os }}-cargo-edit
-
-      - run: cargo install cargo-edit --no-default-features --features set-version
-        if: steps.cache-cargo-edit-restore.outputs.cache-hit != 'true'
-
-      - name: Save cargo-edit to cache
-        id: cache-cargo-edit-save
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            ~/.cargo/bin
-          key: ${{ steps.cache-cargo-edit-restore.outputs.cache-primary-key }}
+          path: ${{ runner.tool_cache }}/cargo-edit
+          key: cargo-edit-${{ env.CARGO_EDIT_VERSION }}
+      - name: Add the tool cache directory to the search path
+        run: echo "${{ runner.tool_cache }}/cargo-edit/bin/" >>$GITHUB_PATH
+      - name: Ensure cargo-edit is installed
+        run: |
+          cargo install \
+            --root ${{ runner.tool_cache }}/cargo-edit \
+            --version ${{ env.CARGO_EDIT_VERSION }} \
+            cargo-edit
       
       - run: cargo set-version --bump patch
       - run: git diff

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -1,0 +1,97 @@
+name: make-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: >-
+          JSON array of branches to target. The first branch in the array will
+          be marked as the latest release.
+        required: false
+        type: string
+        default: '["release/0.6","release/0.5"]'
+
+jobs:
+  bump-version:
+    strategy:
+      matrix:
+        target_branch: ${{ fromJSON(inputs.target_branch) }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: '${{ matrix.target_branch }}'
+          token: '${{ secrets.DIVVIUP_GITHUB_AUTOMATION_RELEASE_PAT }}'
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
+      - name: Restore cargo-edit from cache
+        id: cache-cargo-edit-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.cargo/bin
+          key: ${{ runner.os }}-cargo-edit
+
+      - run: cargo install cargo-edit --no-default-features --features set-version
+        if: steps.cache-cargo-edit-restore.outputs.cache-hit != 'true'
+
+      - name: Save cargo-edit to cache
+        id: cache-cargo-edit-save
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.cargo/bin
+          key: ${{ steps.cache-cargo-edit-restore.outputs.cache-primary-key }}
+      
+      - run: cargo set-version --bump patch
+      - run: git diff
+      - name: Push changes
+        run: |
+          git config user.email "divviup-github-automation@divviup.org"
+          git config user.name "divviup-github-automation"
+          git commit -am "Bump Janus patch version, triggered by @${{ github.actor }}"
+          git push
+
+  # This job is kept separate from the previous one to enable retrying it without
+  # bumping the version number again.
+  make-release:
+    strategy:
+      matrix:
+        target_branch: ${{ fromJSON(inputs.target_branch) }}
+    runs-on: ubuntu-latest
+    needs: [bump-version]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: '${{ matrix.target_branch }}'
+          token: '${{ secrets.DIVVIUP_GITHUB_AUTOMATION_RELEASE_PAT }}'
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
+      - name: Create release
+        run: |
+          # Determine the workspace version.
+          VERSION=$(cargo metadata --no-deps | jq -er '.packages[0].version')
+          TARGET_BRANCH="${{ matrix.target_branch }}"
+          FIRST_BRANCH="${{ fromJSON(inputs.target_branch)[0] }}"
+
+          LATEST=
+          if [ "$TARGET_BRANCH" == "$FIRST_BRANCH" ]; then
+              LATEST="--latest=true"
+          else
+              LATEST="--latest=false"
+          fi
+
+          gh release create "$VERSION" \
+              --generate-notes \
+              --target "$TARGET_BRANCH" \
+              $LATEST
+        env:
+          GH_TOKEN: '${{ secrets.DIVVIUP_GITHUB_AUTOMATION_RELEASE_PAT }}'

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Create release
         run: |
           # Determine the workspace version.
-          VERSION=$(cargo metadata --no-deps | jq -er '.packages[0].version')
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -er '.packages[0].version')
           TARGET_BRANCH="${{ matrix.target_branch }}"
           FIRST_BRANCH="${{ fromJSON(inputs.target_branch)[0] }}"
 


### PR DESCRIPTION
Automates the Janus release process.

This workflow, when triggered by workflow_dispatch, will push a version bump commit to each active branch, then create a release on that new commit. That release will then trigger our other workflows, like publishing SQL schema and to crates.io.

There are a few tradeoffs to this approach:

This bypasses status checks. An operator should check the status of the main branch before using this workflow. I omitted an automated check for the latest status check because I don't want to end up in a situation where we have to make arbitrary commits to get the latest status check passing. I generally think that with per-PR status checks, it's very unlikely to release code that is flat out broken--likely blocking status checks would involve new clippy lints when stable is updated, or rustsec violations.

This workflow elegantly but also inelegantly handles prerelease branches. `cargo-edit` bumps version `0.7.0-prerelease-1` to `0.7.0`. This is great for when we're ready to release it for real, but not so great when we need incremental prerelease versions. I don't think there's a tidy solution to this, so we'll just have to handle incremental prerelease versions manually.

There is no facility for supplying extra release notes. I figure we can just edit the created release if we need to add more detail to a set of release notes.

Even with these tradeoffs, this workflow should make releasing Janus a 1-click process (modulo prerelease branches).

### Deploying

I will need @branlwyd's help with creating the `DIVVIUP_GITHUB_AUTOMATION_RELEASE_PAT` secret. We will want to make this an organization secret, so we can roll out this approach to multiple repositories. It will need `repo` scopes, and it *must* have an expiration date (otherwise repo cloning won't work).

We will also need to assign `divviup-github-automation` to the bypass list in the branch protection rules. This is denoted `Allow specified actors to bypass required pull requests`. I will do this if this PR is approved.