### PR TITLE
Scrub report in setup_cancel_aggregation_job_test

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -3589,6 +3589,8 @@ mod tests {
                 Box::pin(async move {
                     tx.put_aggregator_task(&task).await?;
                     tx.put_client_report(vdaf.borrow(), &report).await?;
+                    tx.scrub_client_report(report.task_id(), report.metadata().id())
+                        .await?;
                     tx.put_aggregation_job(&aggregation_job).await?;
                     tx.put_report_aggregation(&report_aggregation).await?;
 


### PR DESCRIPTION
This makes a small fix to a couple tests to scrub client reports before running the aggregation job driver. In practice, the aggregation job creator does this when setting up a job, so we should mirror that in this fixture as well.