### PR TITLE
Make `hpke_keypair()` infallible, remove `hpke_keypair_infallible()`

### DIFF
--- a/collector/src/credential.rs
+++ b/collector/src/credential.rs
@@ -1,4 +1,3 @@
-use crate::Error;
 use hpke_dispatch::{Aead, Kdf, Kem};
 use janus_core::{
     auth_tokens::{AuthenticationToken, BearerToken},
@@ -29,15 +28,8 @@ impl PrivateCollectorCredential {
         self.token.clone().map(AuthenticationToken::Bearer)
     }
 
-    /// Returns the [`HpkeKeypair`] necessary for decrypting aggregate shares. This cannot fail
-    /// currently, but returns a `Result` for historical reasons.
-    #[deprecated = "Use `hpke_keypair_infallible` instead"]
-    pub fn hpke_keypair(&self) -> Result<HpkeKeypair, Error> {
-        Ok(self.hpke_keypair_infallible())
-    }
-
     /// Returns the [`HpkeKeypair`] necessary for decrypting aggregate shares.
-    pub fn hpke_keypair_infallible(&self) -> HpkeKeypair {
+    pub fn hpke_keypair(&self) -> HpkeKeypair {
         HpkeKeypair::new(
             HpkeConfig::new(
                 self.id,
@@ -99,7 +91,7 @@ mod tests {
         );
         let expected_token = AuthenticationToken::Bearer("Krx-CLfdWo1ULAfsxhr0rA".parse().unwrap());
 
-        assert_eq!(credential.hpke_keypair_infallible(), expected_keypair);
+        assert_eq!(credential.hpke_keypair(), expected_keypair);
         assert_eq!(credential.authentication_token(), Some(expected_token));
     }
 }

--- a/integration_tests/tests/integration/in_cluster.rs
+++ b/integration_tests/tests/integration/in_cluster.rs
@@ -204,7 +204,7 @@ impl InClusterJanusPair {
             helper_aggregator_id,
             collector_credential_id,
             collector_credential.authentication_token().unwrap(),
-            collector_credential.hpke_keypair_infallible(),
+            collector_credential.hpke_keypair(),
             InClusterJanus {
                 aggregator_port_forward: None,
             },

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -498,9 +498,7 @@ impl Options {
             (Some(config), Some(private), None) => {
                 Ok(HpkeKeypair::new(config.clone(), private.clone()))
             }
-            (None, None, Some(collector_credential)) => {
-                Ok(collector_credential.hpke_keypair_infallible())
-            }
+            (None, None, Some(collector_credential)) => Ok(collector_credential.hpke_keypair()),
             _ => unreachable!(
                 "hpke arguments are mutually exclusive with collector credential arguments"
             ),
@@ -1428,7 +1426,7 @@ mod tests {
                 .unwrap(),
             (
                 collector_credential.authentication_token().unwrap(),
-                collector_credential.hpke_keypair_infallible()
+                collector_credential.hpke_keypair()
             ),
         );
 
@@ -1444,7 +1442,7 @@ mod tests {
                 .unwrap(),
             (
                 AuthenticationToken::Bearer(bearer_token.clone()),
-                collector_credential.hpke_keypair_infallible()
+                collector_credential.hpke_keypair()
             ),
         );
 
@@ -1460,7 +1458,7 @@ mod tests {
                 .unwrap(),
             (
                 collector_credential.authentication_token().unwrap(),
-                collector_credential.hpke_keypair_infallible()
+                collector_credential.hpke_keypair()
             ),
         );
     }


### PR DESCRIPTION
Supports https://github.com/divviup/janus/issues/2588. Cleans up the public API.