### PR TITLE
Remove batch_aggregations.{batch,client_timestamp}_interval.

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -3285,7 +3285,6 @@ fn empty_batch_aggregations<
                 BatchAggregationState::Collected,
                 None,
                 0,
-                Interval::EMPTY,
                 ReportIdChecksum::default(),
             ))
         } else {

--- a/aggregator/src/aggregator/accumulator.rs
+++ b/aggregator/src/aggregator/accumulator.rs
@@ -11,11 +11,8 @@ use janus_aggregator_core::{
     query_type::AccumulableQueryType,
     task::AggregatorTask,
 };
-use janus_core::{
-    report_id::ReportIdChecksumExt,
-    time::{Clock, IntervalExt},
-};
-use janus_messages::{Interval, ReportId, ReportIdChecksum, Time};
+use janus_core::{report_id::ReportIdChecksumExt, time::Clock};
+use janus_messages::{ReportId, ReportIdChecksum, Time};
 use prio::vdaf;
 use rand::{thread_rng, Rng};
 use std::{
@@ -82,8 +79,6 @@ impl<const SEED_SIZE: usize, Q: AccumulableQueryType, A: vdaf::Aggregator<SEED_S
     ) -> Result<(), datastore::Error> {
         let batch_identifier =
             Q::to_batch_identifier(&self.task, partial_batch_identifier, client_timestamp)?;
-        let client_timestamp_interval =
-            Interval::from_time(client_timestamp).map_err(|e| datastore::Error::User(e.into()))?;
         let batch_aggregation_fn = || {
             BatchAggregation::new(
                 *self.task.id(),
@@ -93,7 +88,6 @@ impl<const SEED_SIZE: usize, Q: AccumulableQueryType, A: vdaf::Aggregator<SEED_S
                 BatchAggregationState::Aggregating,
                 Some(A::AggregateShare::from(output_share.clone())),
                 1,
-                client_timestamp_interval,
                 ReportIdChecksum::for_report_id(report_id),
             )
         };

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -3028,7 +3028,6 @@ mod tests {
             BatchAggregationState::Aggregating,
             Some(leader_aggregate_share),
             1,
-            Interval::from_time(report.metadata().time()).unwrap(),
             ReportIdChecksum::for_report_id(report.metadata().id()),
         )]);
         let want_active_batch =
@@ -3144,7 +3143,6 @@ mod tests {
                     *agg.state(),
                     agg.aggregate_share().cloned(),
                     agg.report_count(),
-                    *agg.client_timestamp_interval(),
                     *agg.checksum(),
                 )
             })
@@ -3415,7 +3413,6 @@ mod tests {
             BatchAggregationState::Aggregating,
             Some(leader_aggregate_share),
             1,
-            Interval::from_time(report.metadata().time()).unwrap(),
             ReportIdChecksum::for_report_id(report.metadata().id()),
         )]);
         let want_batch = Batch::<VERIFY_KEY_LENGTH, FixedSize, Poplar1<XofTurboShake128, 16>>::new(
@@ -3501,7 +3498,6 @@ mod tests {
                     *agg.state(),
                     agg.aggregate_share().cloned(),
                     agg.report_count(),
-                    *agg.client_timestamp_interval(),
                     *agg.checksum(),
                 )
             })

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -742,7 +742,6 @@ mod tests {
                             BatchAggregationState::Aggregating,
                             Some(dummy_vdaf::AggregateShare(0)),
                             5,
-                            Interval::from_time(&report_timestamp).unwrap(),
                             ReportIdChecksum::get_decoded(&[3; 32]).unwrap(),
                         ),
                     )
@@ -760,7 +759,6 @@ mod tests {
                             BatchAggregationState::Aggregating,
                             Some(dummy_vdaf::AggregateShare(0)),
                             5,
-                            Interval::from_time(&report_timestamp).unwrap(),
                             ReportIdChecksum::get_decoded(&[2; 32]).unwrap(),
                         ),
                     )
@@ -918,7 +916,6 @@ mod tests {
                         BatchAggregationState::Aggregating,
                         Some(dummy_vdaf::AggregateShare(0)),
                         5,
-                        Interval::from_time(&report_timestamp).unwrap(),
                         ReportIdChecksum::get_decoded(&[3; 32]).unwrap(),
                     ),
                 )
@@ -938,7 +935,6 @@ mod tests {
                         BatchAggregationState::Aggregating,
                         Some(dummy_vdaf::AggregateShare(0)),
                         5,
-                        Interval::from_time(&report_timestamp).unwrap(),
                         ReportIdChecksum::get_decoded(&[2; 32]).unwrap(),
                     ),
                 )

--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -232,7 +232,6 @@ async fn setup_fixed_size_current_batch_collection_job_test_case(
                             BatchAggregationState::Aggregating,
                             Some(dummy_vdaf::AggregateShare(0)),
                             task.min_batch_size() + 1,
-                            interval,
                             ReportIdChecksum::default(),
                         ),
                     )

--- a/aggregator/src/aggregator/garbage_collector.rs
+++ b/aggregator/src/aggregator/garbage_collector.rs
@@ -280,7 +280,6 @@ mod tests {
                             BatchAggregationState::Collected,
                             Some(AggregateShare(11)),
                             1,
-                            Interval::from_time(&client_timestamp).unwrap(),
                             random(),
                         ),
                     )
@@ -468,7 +467,6 @@ mod tests {
                             BatchAggregationState::Collected,
                             Some(AggregateShare(11)),
                             1,
-                            Interval::from_time(&client_timestamp).unwrap(),
                             random(),
                         ),
                     )
@@ -649,7 +647,6 @@ mod tests {
                             BatchAggregationState::Collected,
                             Some(AggregateShare(11)),
                             1,
-                            Interval::from_time(&client_timestamp).unwrap(),
                             random(),
                         ),
                     )
@@ -846,7 +843,6 @@ mod tests {
                             BatchAggregationState::Collected,
                             Some(AggregateShare(11)),
                             1,
-                            Interval::from_time(&client_timestamp).unwrap(),
                             random(),
                         ),
                     )

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -828,7 +828,7 @@ mod tests {
             run_vdaf,
             runtime::TestRuntime,
         },
-        time::{Clock, DurationExt, IntervalExt, MockClock, TimeExt},
+        time::{Clock, DurationExt, MockClock, TimeExt},
         vdaf::{VdafInstance, VERIFY_KEY_LENGTH},
     };
     use janus_messages::{
@@ -2190,7 +2190,6 @@ mod tests {
                                 BatchAggregationState::Collected,
                                 Some(OutputShare().into()),
                                 1,
-                                interval,
                                 ReportIdChecksum::for_report_id(&random()),
                             );
                         tx.put_batch_aggregation(&batch_aggregation).await.unwrap();
@@ -3302,7 +3301,6 @@ mod tests {
                     BatchAggregationState::Aggregating,
                     agg.aggregate_share().cloned(),
                     agg.report_count(),
-                    *agg.client_timestamp_interval(),
                     *agg.checksum(),
                 )
             })
@@ -3337,7 +3335,6 @@ mod tests {
                 BatchAggregationState::Aggregating,
                 Some(aggregate_share),
                 2,
-                Interval::from_time(report_metadata_0.time()).unwrap(),
                 checksum,
             ),])
         );
@@ -3611,7 +3608,6 @@ mod tests {
                     BatchAggregationState::Aggregating,
                     agg.aggregate_share().cloned(),
                     agg.report_count(),
-                    *agg.client_timestamp_interval(),
                     *agg.checksum(),
                 )
             })
@@ -3651,7 +3647,6 @@ mod tests {
                 BatchAggregationState::Aggregating,
                 Some(first_aggregate_share),
                 3,
-                Interval::from_time(report_metadata_0.time()).unwrap(),
                 first_checksum,
             ),
         );
@@ -4885,7 +4880,6 @@ mod tests {
                             BatchAggregationState::Aggregating,
                             Some(dummy_vdaf::AggregateShare(0)),
                             10,
-                            interval,
                             ReportIdChecksum::get_decoded(&[2; 32]).unwrap(),
                         ),
                     )
@@ -4949,7 +4943,6 @@ mod tests {
                             BatchAggregationState::Aggregating,
                             Some(dummy_vdaf::AggregateShare(0)),
                             10,
-                            interval,
                             ReportIdChecksum::get_decoded(&[2; 32]).unwrap(),
                         ),
                     )
@@ -5273,7 +5266,6 @@ mod tests {
                             BatchAggregationState::Aggregating,
                             Some(dummy_vdaf::AggregateShare(64)),
                             interval_1_report_count,
-                            interval_1,
                             interval_1_checksum,
                         ))
                         .await
@@ -5301,7 +5293,6 @@ mod tests {
                             BatchAggregationState::Aggregating,
                             Some(dummy_vdaf::AggregateShare(128)),
                             interval_2_report_count,
-                            interval_2,
                             interval_2_checksum,
                         ))
                         .await
@@ -5329,7 +5320,6 @@ mod tests {
                             BatchAggregationState::Aggregating,
                             Some(dummy_vdaf::AggregateShare(256)),
                             interval_3_report_count,
-                            interval_3,
                             interval_3_checksum,
                         ))
                         .await
@@ -5357,7 +5347,6 @@ mod tests {
                             BatchAggregationState::Aggregating,
                             Some(dummy_vdaf::AggregateShare(512)),
                             interval_4_report_count,
-                            interval_4,
                             interval_4_checksum,
                         ))
                         .await

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -934,7 +934,6 @@ async fn taskprov_aggregate_share() {
                     BatchAggregationState::Aggregating,
                     Some(transcript.helper_aggregate_share),
                     1,
-                    interval,
                     ReportIdChecksum::get_decoded(&[3; 32]).unwrap(),
                 ))
                 .await

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -4153,8 +4153,6 @@ async fn roundtrip_batch_aggregation_time_interval(ephemeral_datastore: Ephemera
                         BatchAggregationState::Aggregating,
                         Some(aggregate_share),
                         0,
-                        Interval::new(Time::from_seconds_since_epoch(1100), time_precision)
-                            .unwrap(),
                         ReportIdChecksum::default(),
                     );
 
@@ -4168,8 +4166,6 @@ async fn roundtrip_batch_aggregation_time_interval(ephemeral_datastore: Ephemera
                         BatchAggregationState::Collected,
                         None,
                         0,
-                        Interval::new(Time::from_seconds_since_epoch(1200), time_precision)
-                            .unwrap(),
                         ReportIdChecksum::default(),
                     );
 
@@ -4183,8 +4179,6 @@ async fn roundtrip_batch_aggregation_time_interval(ephemeral_datastore: Ephemera
                         BatchAggregationState::Aggregating,
                         Some(aggregate_share),
                         0,
-                        Interval::new(Time::from_seconds_since_epoch(1300), time_precision)
-                            .unwrap(),
                         ReportIdChecksum::default(),
                     );
 
@@ -4199,8 +4193,6 @@ async fn roundtrip_batch_aggregation_time_interval(ephemeral_datastore: Ephemera
                         BatchAggregationState::Collected,
                         None,
                         0,
-                        Interval::new(Time::from_seconds_since_epoch(1000), time_precision)
-                            .unwrap(),
                         ReportIdChecksum::default(),
                     ),
                 )
@@ -4236,8 +4228,6 @@ async fn roundtrip_batch_aggregation_time_interval(ephemeral_datastore: Ephemera
                         BatchAggregationState::Aggregating,
                         Some(aggregate_share),
                         0,
-                        Interval::new(Time::from_seconds_since_epoch(1000), time_precision)
-                            .unwrap(),
                         ReportIdChecksum::default(),
                     ),
                 )
@@ -4254,8 +4244,6 @@ async fn roundtrip_batch_aggregation_time_interval(ephemeral_datastore: Ephemera
                         BatchAggregationState::Collected,
                         None,
                         0,
-                        Interval::new(Time::from_seconds_since_epoch(1400), time_precision)
-                            .unwrap(),
                         ReportIdChecksum::default(),
                     ),
                 )
@@ -4281,8 +4269,6 @@ async fn roundtrip_batch_aggregation_time_interval(ephemeral_datastore: Ephemera
                         BatchAggregationState::Aggregating,
                         Some(aggregate_share),
                         0,
-                        Interval::new(Time::from_seconds_since_epoch(1200), time_precision)
-                            .unwrap(),
                         ReportIdChecksum::default(),
                     ),
                 )
@@ -4356,7 +4342,6 @@ async fn roundtrip_batch_aggregation_time_interval(ephemeral_datastore: Ephemera
                     *first_batch_aggregation.state(),
                     Some(AggregateShare(92)),
                     1,
-                    *first_batch_aggregation.client_timestamp_interval(),
                     ReportIdChecksum::get_decoded(&[1; 32]).unwrap(),
                 );
             tx.update_batch_aggregation(&first_batch_aggregation)
@@ -4493,8 +4478,6 @@ async fn roundtrip_batch_aggregation_fixed_size(ephemeral_datastore: EphemeralDa
                     BatchAggregationState::Aggregating,
                     Some(aggregate_share),
                     0,
-                    Interval::new(OLDEST_ALLOWED_REPORT_TIMESTAMP, Duration::from_seconds(1))
-                        .unwrap(),
                     ReportIdChecksum::default(),
                 );
 
@@ -4527,8 +4510,6 @@ async fn roundtrip_batch_aggregation_fixed_size(ephemeral_datastore: EphemeralDa
                     BatchAggregationState::Collected,
                     None,
                     0,
-                    Interval::new(OLDEST_ALLOWED_REPORT_TIMESTAMP, Duration::from_seconds(1))
-                        .unwrap(),
                     ReportIdChecksum::default(),
                 ))
                 .await?;
@@ -4553,8 +4534,6 @@ async fn roundtrip_batch_aggregation_fixed_size(ephemeral_datastore: EphemeralDa
                     BatchAggregationState::Aggregating,
                     Some(aggregate_share),
                     0,
-                    Interval::new(OLDEST_ALLOWED_REPORT_TIMESTAMP, Duration::from_seconds(1))
-                        .unwrap(),
                     ReportIdChecksum::default(),
                 ))
                 .await?;
@@ -4568,8 +4547,6 @@ async fn roundtrip_batch_aggregation_fixed_size(ephemeral_datastore: EphemeralDa
                     BatchAggregationState::Collected,
                     None,
                     0,
-                    Interval::new(OLDEST_ALLOWED_REPORT_TIMESTAMP, Duration::from_seconds(1))
-                        .unwrap(),
                     ReportIdChecksum::default(),
                 ))
                 .await?;
@@ -4607,7 +4584,6 @@ async fn roundtrip_batch_aggregation_fixed_size(ephemeral_datastore: EphemeralDa
                 *batch_aggregation.state(),
                 None,
                 1,
-                Interval::new(OLDEST_ALLOWED_REPORT_TIMESTAMP, Duration::from_seconds(1)).unwrap(),
                 ReportIdChecksum::get_decoded(&[1; 32]).unwrap(),
             );
             tx.update_batch_aggregation(&batch_aggregation).await?;
@@ -5202,8 +5178,6 @@ async fn roundtrip_outstanding_batch(ephemeral_datastore: EphemeralDatastore) {
                     BatchAggregationState::Aggregating,
                     Some(AggregateShare(0)),
                     1,
-                    Interval::new(OLDEST_ALLOWED_REPORT_TIMESTAMP, Duration::from_seconds(1))
-                        .unwrap(),
                     ReportIdChecksum::default(),
                 ))
                 .await?;
@@ -5215,8 +5189,6 @@ async fn roundtrip_outstanding_batch(ephemeral_datastore: EphemeralDatastore) {
                     BatchAggregationState::Aggregating,
                     Some(AggregateShare(0)),
                     1,
-                    Interval::new(OLDEST_ALLOWED_REPORT_TIMESTAMP, Duration::from_seconds(1))
-                        .unwrap(),
                     ReportIdChecksum::default(),
                 ))
                 .await?;
@@ -6142,7 +6114,6 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
             BatchAggregationState::Aggregating,
             None,
             0,
-            client_timestamp_interval,
             ReportIdChecksum::default(),
         );
         tx.put_batch_aggregation(&batch_aggregation).await.unwrap();

--- a/db/00000000000001_initial_schema.up.sql
+++ b/db/00000000000001_initial_schema.up.sql
@@ -316,13 +316,11 @@ CREATE TABLE batch_aggregations(
     id                         BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,  -- artificial ID, internal-only
     task_id                    BIGINT NOT NULL,                   -- the task ID
     batch_identifier           BYTEA NOT NULL,                    -- encoded query-type-specific batch identifier (corresponds to identifier in BatchSelector)
-    batch_interval             TSRANGE,                           -- batch interval, as a TSRANGE, populated only for time-interval tasks. (will always match batch_identifier)
     aggregation_param          BYTEA NOT NULL,                    -- the aggregation parameter (opaque VDAF message)
     ord                        BIGINT NOT NULL,                   -- the index of this batch aggregation shard, over (task ID, batch_identifier, aggregation_param).
     state                      BATCH_AGGREGATION_STATE NOT NULL,  -- the current state of this batch aggregation
     aggregate_share            BYTEA,                             -- the (possibly-incremental) aggregate share; NULL only if report_count is 0.
     report_count               BIGINT NOT NULL,                   -- the (possibly-incremental) client report count
-    client_timestamp_interval  TSRANGE NOT NULL,                  -- the minimal interval containing all of client timestamps included in this batch aggregation
     checksum                   BYTEA NOT NULL,                    -- the (possibly-incremental) checksum
 
     -- creation/update records


### PR DESCRIPTION
These fields were unused.

Closes #2251.