### PR TITLE
Replace &str and Box error types with messages::Error

### DIFF
--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -42,6 +42,8 @@ pub enum Error {
     /// An illegal arithmetic operation on a [`Time`] or [`Duration`].
     #[error("{0}")]
     IllegalTimeArithmetic(&'static str),
+    #[error("base64 decode failure: {0}")]
+    Base64Decode(#[from] base64::DecodeError),
 }
 
 /// Wire-representation of an ASCII-encoded URL with minimum length 1 and maximum
@@ -291,12 +293,20 @@ impl From<[u8; Self::LEN]> for BatchId {
 }
 
 impl<'a> TryFrom<&'a [u8]> for BatchId {
-    type Error = &'static str;
+    type Error = Error;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self(value.try_into().map_err(|_| {
-            "byte slice has incorrect length for BatchId"
+            Error::InvalidParameter("byte slice has incorrect length for BatchId")
         })?))
+    }
+}
+
+impl FromStr for BatchId {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::try_from(URL_SAFE_NO_PAD.decode(s)?.as_ref())
     }
 }
 
@@ -363,11 +373,11 @@ impl From<[u8; Self::LEN]> for ReportId {
 }
 
 impl<'a> TryFrom<&'a [u8]> for ReportId {
-    type Error = &'static str;
+    type Error = Error;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self(value.try_into().map_err(|_| {
-            "byte slice has incorrect length for ReportId"
+            Error::InvalidParameter("byte slice has incorrect length for ReportId")
         })?))
     }
 }
@@ -414,13 +424,10 @@ impl Decode for ReportId {
 }
 
 impl FromStr for ReportId {
-    type Err = Box<dyn Debug>;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let bytes = URL_SAFE_NO_PAD
-            .decode(s)
-            .map_err(|err| Box::new(err) as Box<dyn Debug>)?;
-        Self::try_from(bytes.as_ref()).map_err(|err| Box::new(err) as Box<dyn Debug>)
+        Self::try_from(URL_SAFE_NO_PAD.decode(s)?.as_ref())
     }
 }
 
@@ -446,11 +453,11 @@ impl From<[u8; Self::LEN]> for ReportIdChecksum {
 }
 
 impl<'a> TryFrom<&'a [u8]> for ReportIdChecksum {
-    type Error = &'static str;
+    type Error = Error;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self(value.try_into().map_err(|_| {
-            "byte slice has incorrect length for ReportIdChecksum"
+            Error::InvalidParameter("byte slice has incorrect length for ReportIdChecksum")
         })?))
     }
 }
@@ -675,11 +682,11 @@ impl From<[u8; Self::LEN]> for TaskId {
 }
 
 impl<'a> TryFrom<&'a [u8]> for TaskId {
-    type Error = &'static str;
+    type Error = Error;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self(value.try_into().map_err(|_| {
-            "byte slice has incorrect length for TaskId"
+            Error::InvalidParameter("byte slice has incorrect length for TaskId")
         })?))
     }
 }
@@ -691,13 +698,10 @@ impl AsRef<[u8; Self::LEN]> for TaskId {
 }
 
 impl FromStr for TaskId {
-    type Err = Box<dyn Debug>;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let bytes = URL_SAFE_NO_PAD
-            .decode(s)
-            .map_err(|err| Box::new(err) as Box<dyn Debug>)?;
-        Self::try_from(bytes.as_ref()).map_err(|err| Box::new(err) as Box<dyn Debug>)
+        Self::try_from(URL_SAFE_NO_PAD.decode(s)?.as_ref())
     }
 }
 
@@ -1668,23 +1672,20 @@ impl AsRef<[u8; Self::LEN]> for CollectionJobId {
 }
 
 impl TryFrom<&[u8]> for CollectionJobId {
-    type Error = &'static str;
+    type Error = Error;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self(value.try_into().map_err(|_| {
-            "byte slice has incorrect length for CollectionId"
+            Error::InvalidParameter("byte slice has incorrect length for CollectionId")
         })?))
     }
 }
 
 impl FromStr for CollectionJobId {
-    type Err = Box<dyn Debug>;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let bytes = URL_SAFE_NO_PAD
-            .decode(s)
-            .map_err(|err| Box::new(err) as Box<dyn Debug>)?;
-        Self::try_from(bytes.as_ref()).map_err(|err| Box::new(err) as Box<dyn Debug>)
+        Self::try_from(URL_SAFE_NO_PAD.decode(s)?.as_ref())
     }
 }
 
@@ -2436,13 +2437,10 @@ impl AsRef<[u8; Self::LEN]> for AggregationJobId {
 }
 
 impl FromStr for AggregationJobId {
-    type Err = Box<dyn Debug>;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let bytes = URL_SAFE_NO_PAD
-            .decode(s)
-            .map_err(|err| Box::new(err) as Box<dyn Debug>)?;
-        Self::try_from(bytes.as_ref()).map_err(|err| Box::new(err) as Box<dyn Debug>)
+        Self::try_from(URL_SAFE_NO_PAD.decode(s)?.as_ref())
     }
 }
 

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -85,104 +85,6 @@ enum VdafType {
 }
 
 #[derive(Clone)]
-struct TaskIdValueParser {
-    inner: NonEmptyStringValueParser,
-}
-
-impl TaskIdValueParser {
-    fn new() -> TaskIdValueParser {
-        TaskIdValueParser {
-            inner: NonEmptyStringValueParser::new(),
-        }
-    }
-}
-
-impl TypedValueParser for TaskIdValueParser {
-    type Value = TaskId;
-
-    fn parse_ref(
-        &self,
-        cmd: &clap::Command,
-        arg: Option<&clap::Arg>,
-        value: &std::ffi::OsStr,
-    ) -> Result<Self::Value, clap::Error> {
-        let input = self.inner.parse_ref(cmd, arg, value)?;
-        let task_id_bytes: [u8; TaskId::LEN] = URL_SAFE_NO_PAD
-            .decode(input)
-            .map_err(|err| clap::Error::raw(ErrorKind::ValueValidation, err))?
-            .try_into()
-            .map_err(|_| {
-                clap::Error::raw(ErrorKind::ValueValidation, "task ID length incorrect")
-            })?;
-        Ok(TaskId::from(task_id_bytes))
-    }
-}
-
-#[derive(Clone)]
-struct CollectionJobIdValueParser {
-    inner: NonEmptyStringValueParser,
-}
-
-impl CollectionJobIdValueParser {
-    fn new() -> CollectionJobIdValueParser {
-        CollectionJobIdValueParser {
-            inner: NonEmptyStringValueParser::new(),
-        }
-    }
-}
-
-impl TypedValueParser for CollectionJobIdValueParser {
-    type Value = CollectionJobId;
-
-    fn parse_ref(
-        &self,
-        cmd: &clap::Command,
-        arg: Option<&clap::Arg>,
-        value: &std::ffi::OsStr,
-    ) -> Result<Self::Value, clap::Error> {
-        let input = self.inner.parse_ref(cmd, arg, value)?;
-        let collection_job_id = input
-            .parse()
-            .map_err(|err| clap::Error::raw(ErrorKind::ValueValidation, format!("{:?}", err)))?;
-        Ok(collection_job_id)
-    }
-}
-
-#[derive(Clone)]
-struct BatchIdValueParser {
-    inner: NonEmptyStringValueParser,
-}
-
-impl BatchIdValueParser {
-    fn new() -> BatchIdValueParser {
-        BatchIdValueParser {
-            inner: NonEmptyStringValueParser::new(),
-        }
-    }
-}
-
-impl TypedValueParser for BatchIdValueParser {
-    type Value = BatchId;
-
-    fn parse_ref(
-        &self,
-        cmd: &clap::Command,
-        arg: Option<&clap::Arg>,
-        value: &std::ffi::OsStr,
-    ) -> Result<Self::Value, clap::Error> {
-        let input = self.inner.parse_ref(cmd, arg, value)?;
-        let batch_id_bytes: [u8; BatchId::LEN] = URL_SAFE_NO_PAD
-            .decode(input)
-            .map_err(|err| clap::Error::raw(ErrorKind::ValueValidation, err))?
-            .try_into()
-            .map_err(|_| {
-                clap::Error::raw(ErrorKind::ValueValidation, "batch ID length incorrect")
-            })?;
-        Ok(BatchId::from(batch_id_bytes))
-    }
-}
-
-#[derive(Clone)]
 struct HpkeConfigValueParser {
     inner: NonEmptyStringValueParser,
 }
@@ -297,7 +199,6 @@ struct QueryOptions {
     /// Batch identifier, encoded with base64url
     #[clap(
         long,
-        value_parser = BatchIdValueParser::new(),
         conflicts_with_all = ["batch_interval_start", "batch_interval_duration", "current_batch"],
         help_heading = "Collect Request Parameters (Fixed Size)",
     )]
@@ -376,7 +277,6 @@ enum Subcommands {
         /// Job ID to use for the new collection job. If absent, an ID is randomly generated
         ///
         /// A valid ID consists of 16 randomly selected bytes, encoded with unpadded base64url.
-        #[clap(value_parser = CollectionJobIdValueParser::new())]
         collection_job_id: Option<CollectionJobId>,
     },
     /// Poll an existing collection job once
@@ -388,7 +288,7 @@ enum Subcommands {
     /// stdout. If it is not ready, the exit status is 75 (EX_TEMPFAIL).
     PollJob {
         /// Job ID for an existing collection job, encoded with unpadded base64url
-        #[clap(value_parser = CollectionJobIdValueParser::new(), required = true)]
+        #[clap(required = true)]
         collection_job_id: CollectionJobId,
     },
 }
@@ -409,12 +309,7 @@ struct Options {
     subcommand: Option<Subcommands>,
 
     /// DAP task identifier, encoded with unpadded base64url
-    #[clap(
-        long,
-        value_parser = TaskIdValueParser::new(),
-        help_heading = "DAP Task Parameters",
-        display_order = 0
-    )]
+    #[clap(long, help_heading = "DAP Task Parameters", display_order = 0)]
     task_id: TaskId,
     /// The leader aggregator's endpoint URL
     #[clap(long, help_heading = "DAP Task Parameters", display_order = 1)]


### PR DESCRIPTION
Closes https://github.com/divviup/janus/issues/2236

Cleanup: replace `&'static str` and `Box<dyn Debug>` error types with the existing `messages::Error` type. This mostly affects `FromStr` and `TryFrom` impls.

`thiserror::Error` derived types implement `Into<std::error::Error>`. This leads to simplification of clap argument parsing in collect.rs, because clap able to transparently deal with types where `<T as FromStr>::Err: Into<std::error::Error>`.