### PR TITLE
Set HTTP client timeouts

### DIFF
--- a/aggregator/src/binaries/aggregation_job_driver.rs
+++ b/aggregator/src/binaries/aggregation_job_driver.rs
@@ -21,6 +21,8 @@ pub async fn main_callback(ctx: BinaryContext<RealClock, Options, Config>) -> Re
     let aggregation_job_driver = Arc::new(AggregationJobDriver::new(
         reqwest::Client::builder()
             .user_agent(CLIENT_USER_AGENT)
+            .timeout(ctx.config.job_driver_config.http_request_timeout)
+            .connect_timeout(ctx.config.job_driver_config.http_request_connection_timeout)
             .build()
             .context("couldn't create HTTP client")?,
         &ctx.meter,
@@ -130,7 +132,10 @@ mod tests {
     };
     use clap::CommandFactory;
     use janus_core::test_util::roundtrip_encoding;
-    use std::net::{Ipv4Addr, SocketAddr};
+    use std::{
+        net::{Ipv4Addr, SocketAddr},
+        time::Duration,
+    };
 
     #[test]
     fn verify_app() {
@@ -152,6 +157,8 @@ mod tests {
                 worker_lease_duration_secs: 600,
                 worker_lease_clock_skew_allowance_secs: 60,
                 maximum_attempts_before_failure: 5,
+                http_request_connection_timeout: Duration::from_secs(10),
+                http_request_timeout: Duration::from_secs(30),
             },
             batch_aggregation_shard_count: 32,
             taskprov_config: TaskprovConfig::default(),

--- a/aggregator/src/binaries/aggregation_job_driver.rs
+++ b/aggregator/src/binaries/aggregation_job_driver.rs
@@ -21,8 +21,14 @@ pub async fn main_callback(ctx: BinaryContext<RealClock, Options, Config>) -> Re
     let aggregation_job_driver = Arc::new(AggregationJobDriver::new(
         reqwest::Client::builder()
             .user_agent(CLIENT_USER_AGENT)
-            .timeout(ctx.config.job_driver_config.http_request_timeout)
-            .connect_timeout(ctx.config.job_driver_config.http_request_connection_timeout)
+            .timeout(Duration::from_secs(
+                ctx.config.job_driver_config.http_request_timeout_secs,
+            ))
+            .connect_timeout(Duration::from_secs(
+                ctx.config
+                    .job_driver_config
+                    .http_request_connection_timeout_secs,
+            ))
             .build()
             .context("couldn't create HTTP client")?,
         &ctx.meter,
@@ -132,10 +138,7 @@ mod tests {
     };
     use clap::CommandFactory;
     use janus_core::test_util::roundtrip_encoding;
-    use std::{
-        net::{Ipv4Addr, SocketAddr},
-        time::Duration,
-    };
+    use std::net::{Ipv4Addr, SocketAddr};
 
     #[test]
     fn verify_app() {
@@ -157,8 +160,8 @@ mod tests {
                 worker_lease_duration_secs: 600,
                 worker_lease_clock_skew_allowance_secs: 60,
                 maximum_attempts_before_failure: 5,
-                http_request_connection_timeout: Duration::from_secs(10),
-                http_request_timeout: Duration::from_secs(30),
+                http_request_timeout_secs: 10,
+                http_request_connection_timeout_secs: 30,
             },
             batch_aggregation_shard_count: 32,
             taskprov_config: TaskprovConfig::default(),

--- a/aggregator/src/binaries/collection_job_driver.rs
+++ b/aggregator/src/binaries/collection_job_driver.rs
@@ -21,6 +21,8 @@ pub async fn main_callback(ctx: BinaryContext<RealClock, Options, Config>) -> Re
     let collection_job_driver = Arc::new(CollectionJobDriver::new(
         reqwest::Client::builder()
             .user_agent(CLIENT_USER_AGENT)
+            .timeout(ctx.config.job_driver_config.http_request_timeout)
+            .connect_timeout(ctx.config.job_driver_config.http_request_connection_timeout)
             .build()
             .context("couldn't create HTTP client")?,
         &ctx.meter,
@@ -126,7 +128,10 @@ mod tests {
     };
     use clap::CommandFactory;
     use janus_core::test_util::roundtrip_encoding;
-    use std::net::{Ipv4Addr, SocketAddr};
+    use std::{
+        net::{Ipv4Addr, SocketAddr},
+        time::Duration,
+    };
 
     #[test]
     fn verify_app() {
@@ -148,6 +153,8 @@ mod tests {
                 worker_lease_duration_secs: 600,
                 worker_lease_clock_skew_allowance_secs: 60,
                 maximum_attempts_before_failure: 5,
+                http_request_connection_timeout: Duration::from_secs(10),
+                http_request_timeout: Duration::from_secs(30),
             },
             batch_aggregation_shard_count: 32,
         })

--- a/aggregator/src/binaries/collection_job_driver.rs
+++ b/aggregator/src/binaries/collection_job_driver.rs
@@ -21,8 +21,14 @@ pub async fn main_callback(ctx: BinaryContext<RealClock, Options, Config>) -> Re
     let collection_job_driver = Arc::new(CollectionJobDriver::new(
         reqwest::Client::builder()
             .user_agent(CLIENT_USER_AGENT)
-            .timeout(ctx.config.job_driver_config.http_request_timeout)
-            .connect_timeout(ctx.config.job_driver_config.http_request_connection_timeout)
+            .timeout(Duration::from_secs(
+                ctx.config.job_driver_config.http_request_timeout_secs,
+            ))
+            .connect_timeout(Duration::from_secs(
+                ctx.config
+                    .job_driver_config
+                    .http_request_connection_timeout_secs,
+            ))
             .build()
             .context("couldn't create HTTP client")?,
         &ctx.meter,
@@ -128,10 +134,7 @@ mod tests {
     };
     use clap::CommandFactory;
     use janus_core::test_util::roundtrip_encoding;
-    use std::{
-        net::{Ipv4Addr, SocketAddr},
-        time::Duration,
-    };
+    use std::net::{Ipv4Addr, SocketAddr};
 
     #[test]
     fn verify_app() {
@@ -153,8 +156,8 @@ mod tests {
                 worker_lease_duration_secs: 600,
                 worker_lease_clock_skew_allowance_secs: 60,
                 maximum_attempts_before_failure: 5,
-                http_request_connection_timeout: Duration::from_secs(10),
-                http_request_timeout: Duration::from_secs(30),
+                http_request_timeout_secs: 10,
+                http_request_connection_timeout_secs: 30,
             },
             batch_aggregation_shard_count: 32,
         })

--- a/aggregator/src/config.rs
+++ b/aggregator/src/config.rs
@@ -7,6 +7,7 @@ use std::{
     fmt::Debug,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::PathBuf,
+    time::Duration,
 };
 use url::Url;
 
@@ -154,6 +155,24 @@ pub struct JobDriverConfig {
     /// The number of attempts to drive a work item before it is placed in a permanent failure
     /// state.
     pub maximum_attempts_before_failure: usize,
+    /// Timeout to apply when making connections to the server for HTTP requests. See
+    /// [`reqwest::ClientBuilder::connect_timeout`] for details.
+    #[serde(default = "JobDriverConfig::default_http_connection_timeout")]
+    pub http_request_connection_timeout: Duration,
+    /// Timeout to apply to requests overall when making HTTP requests. See
+    /// [`reqwest::ClientBuilder::timeout`] for details.
+    #[serde(default = "JobDriverConfig::default_http_request_timeout")]
+    pub http_request_timeout: Duration,
+}
+
+impl JobDriverConfig {
+    fn default_http_connection_timeout() -> Duration {
+        Duration::from_secs(10)
+    }
+
+    fn default_http_request_timeout() -> Duration {
+        Duration::from_secs(30)
+    }
 }
 
 #[cfg(feature = "test-util")]
@@ -251,6 +270,8 @@ mod tests {
             worker_lease_duration_secs: 600,
             worker_lease_clock_skew_allowance_secs: 60,
             maximum_attempts_before_failure: 5,
+            http_request_connection_timeout: JobDriverConfig::default_http_connection_timeout(),
+            http_request_timeout: JobDriverConfig::default_http_request_timeout(),
         })
     }
 

--- a/aggregator/src/config.rs
+++ b/aggregator/src/config.rs
@@ -7,7 +7,6 @@ use std::{
     fmt::Debug,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::PathBuf,
-    time::Duration,
 };
 use url::Url;
 
@@ -155,23 +154,23 @@ pub struct JobDriverConfig {
     /// The number of attempts to drive a work item before it is placed in a permanent failure
     /// state.
     pub maximum_attempts_before_failure: usize,
-    /// Timeout to apply when making connections to the server for HTTP requests. See
+    /// Timeout to apply when establishing connections to the helper for HTTP requests. See
     /// [`reqwest::ClientBuilder::connect_timeout`] for details.
     #[serde(default = "JobDriverConfig::default_http_connection_timeout")]
-    pub http_request_connection_timeout: Duration,
-    /// Timeout to apply to requests overall when making HTTP requests. See
-    /// [`reqwest::ClientBuilder::timeout`] for details.
+    pub http_request_connection_timeout_secs: u64,
+    /// Timeout to apply to HTTP requests overall (including connection establishment) when
+    /// communicating with the helper. See [`reqwest::ClientBuilder::timeout`] for details.
     #[serde(default = "JobDriverConfig::default_http_request_timeout")]
-    pub http_request_timeout: Duration,
+    pub http_request_timeout_secs: u64,
 }
 
 impl JobDriverConfig {
-    fn default_http_connection_timeout() -> Duration {
-        Duration::from_secs(10)
+    fn default_http_connection_timeout() -> u64 {
+        10
     }
 
-    fn default_http_request_timeout() -> Duration {
-        Duration::from_secs(30)
+    fn default_http_request_timeout() -> u64 {
+        30
     }
 }
 
@@ -270,8 +269,9 @@ mod tests {
             worker_lease_duration_secs: 600,
             worker_lease_clock_skew_allowance_secs: 60,
             maximum_attempts_before_failure: 5,
-            http_request_connection_timeout: JobDriverConfig::default_http_connection_timeout(),
-            http_request_timeout: JobDriverConfig::default_http_request_timeout(),
+            http_request_connection_timeout_secs: JobDriverConfig::default_http_connection_timeout(
+            ),
+            http_request_timeout_secs: JobDriverConfig::default_http_request_timeout(),
         })
     }
 

--- a/aggregator/tests/integration/graceful_shutdown.rs
+++ b/aggregator/tests/integration/graceful_shutdown.rs
@@ -28,7 +28,7 @@ use std::{
     net::{Ipv4Addr, SocketAddr},
     path::Path,
     process::{Child, Command, Stdio},
-    time::{Duration, Instant},
+    time::Instant,
 };
 use tokio::{
     io::{AsyncBufReadExt, BufReader},
@@ -317,8 +317,8 @@ async fn aggregation_job_driver_shutdown() {
             worker_lease_duration_secs: 600,
             worker_lease_clock_skew_allowance_secs: 60,
             maximum_attempts_before_failure: 5,
-            http_request_timeout: Duration::from_secs(10),
-            http_request_connection_timeout: Duration::from_secs(30),
+            http_request_timeout_secs: 10,
+            http_request_connection_timeout_secs: 30,
         },
         taskprov_config: TaskprovConfig { enabled: false },
         batch_aggregation_shard_count: 32,
@@ -348,8 +348,8 @@ async fn collection_job_driver_shutdown() {
             worker_lease_duration_secs: 600,
             worker_lease_clock_skew_allowance_secs: 60,
             maximum_attempts_before_failure: 5,
-            http_request_timeout: Duration::from_secs(10),
-            http_request_connection_timeout: Duration::from_secs(30),
+            http_request_timeout_secs: 10,
+            http_request_connection_timeout_secs: 30,
         },
         batch_aggregation_shard_count: 32,
     };

--- a/aggregator/tests/integration/graceful_shutdown.rs
+++ b/aggregator/tests/integration/graceful_shutdown.rs
@@ -28,7 +28,7 @@ use std::{
     net::{Ipv4Addr, SocketAddr},
     path::Path,
     process::{Child, Command, Stdio},
-    time::Instant,
+    time::{Duration, Instant},
 };
 use tokio::{
     io::{AsyncBufReadExt, BufReader},
@@ -317,6 +317,8 @@ async fn aggregation_job_driver_shutdown() {
             worker_lease_duration_secs: 600,
             worker_lease_clock_skew_allowance_secs: 60,
             maximum_attempts_before_failure: 5,
+            http_request_timeout: Duration::from_secs(10),
+            http_request_connection_timeout: Duration::from_secs(30),
         },
         taskprov_config: TaskprovConfig { enabled: false },
         batch_aggregation_shard_count: 32,
@@ -346,6 +348,8 @@ async fn collection_job_driver_shutdown() {
             worker_lease_duration_secs: 600,
             worker_lease_clock_skew_allowance_secs: 60,
             maximum_attempts_before_failure: 5,
+            http_request_timeout: Duration::from_secs(10),
+            http_request_connection_timeout: Duration::from_secs(30),
         },
         batch_aggregation_shard_count: 32,
     };

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -87,29 +87,12 @@ impl ClientParameters {
         helper_aggregator_endpoint: Url,
         time_precision: Duration,
     ) -> Self {
-        Self::new_with_backoff(
-            task_id,
-            leader_aggregator_endpoint,
-            helper_aggregator_endpoint,
-            time_precision,
-            http_request_exponential_backoff(),
-        )
-    }
-
-    /// Creates a new set of client task parameters with non-default HTTP request retry parameters.
-    pub fn new_with_backoff(
-        task_id: TaskId,
-        leader_aggregator_endpoint: Url,
-        helper_aggregator_endpoint: Url,
-        time_precision: Duration,
-        http_request_retry_parameters: ExponentialBackoff,
-    ) -> Self {
         Self {
             task_id,
             leader_aggregator_endpoint: url_ensure_trailing_slash(leader_aggregator_endpoint),
             helper_aggregator_endpoint: url_ensure_trailing_slash(helper_aggregator_endpoint),
             time_precision,
-            http_request_retry_parameters,
+            http_request_retry_parameters: http_request_exponential_backoff(),
         }
     }
 
@@ -192,6 +175,10 @@ async fn aggregator_hpke_config(
 /// Construct a [`reqwest::Client`] suitable for use in a DAP [`Client`].
 pub fn default_http_client() -> Result<reqwest::Client, Error> {
     Ok(reqwest::Client::builder()
+        // Clients wishing to override these timeouts may provide their own
+        // values using ClientBuilder::with_http_client.
+        .timeout(std::time::Duration::from_secs(30))
+        .connect_timeout(std::time::Duration::from_secs(10))
         .user_agent(CLIENT_USER_AGENT)
         .build()?)
 }
@@ -693,13 +680,13 @@ mod tests {
         let mut server = mockito::Server::new_async().await;
         let server_url = Url::parse(&server.url()).unwrap();
         let http_client = &default_http_client().unwrap();
-        let client_parameters = ClientParameters::new_with_backoff(
+        let mut client_parameters = ClientParameters::new(
             random(),
             server_url.clone(),
             server_url,
             Duration::from_seconds(1),
-            test_http_request_exponential_backoff(),
         );
+        client_parameters.http_request_retry_parameters = test_http_request_exponential_backoff();
 
         let keypair = generate_test_hpke_config_and_private_key();
         let hpke_config_list = HpkeConfigList::new(Vec::from([keypair.config().clone()]));
@@ -730,13 +717,13 @@ mod tests {
         let mut server = mockito::Server::new_async().await;
         let server_url = Url::parse(&server.url()).unwrap();
         let http_client = &default_http_client().unwrap();
-        let client_parameters = ClientParameters::new_with_backoff(
+        let mut client_parameters = ClientParameters::new(
             random(),
             server_url.clone(),
             server_url,
             Duration::from_seconds(1),
-            test_http_request_exponential_backoff(),
         );
+        client_parameters.http_request_retry_parameters = test_http_request_exponential_backoff();
 
         let encoded_bad_hpke_config = hex!(
             "64" // HpkeConfigId

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -142,6 +142,10 @@ static COLLECTOR_USER_AGENT: &str = concat!(
 /// Construct a [`reqwest::Client`] suitable for use in a DAP [`Collector`].
 pub fn default_http_client() -> Result<reqwest::Client, Error> {
     Ok(reqwest::Client::builder()
+        // Clients may override default timeouts using
+        // CollectorBuilder::with_http_client
+        .timeout(StdDuration::from_secs(30))
+        .connect_timeout(StdDuration::from_secs(10))
         .user_agent(COLLECTOR_USER_AGENT)
         .build()?)
 }

--- a/docs/samples/advanced_config/aggregation_job_driver.yaml
+++ b/docs/samples/advanced_config/aggregation_job_driver.yaml
@@ -87,6 +87,17 @@ worker_lease_clock_skew_allowance_secs: 60
 # (required)
 maximum_attempts_before_failure: 10
 
+# Timeout to apply when establishing connections to the helper for HTTP requests, in seconds. See
+# https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.connect_timeout for
+# details. (optional)
+http_request_connection_timeout_secs: 10
+
+# Timeout to apply to HTTP requests overall (including connection establishment) when communicating
+# with the helper. See
+# https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.timeout for details.
+# (optional)
+http_request_timeout_secs: 30
+
 # Number of sharded database records per batch aggregation. Must not be greater
 # than the equivalent setting in the collection job driver. (required)
 batch_aggregation_shard_count: 32

--- a/docs/samples/advanced_config/aggregation_job_driver.yaml
+++ b/docs/samples/advanced_config/aggregation_job_driver.yaml
@@ -89,13 +89,13 @@ maximum_attempts_before_failure: 10
 
 # Timeout to apply when establishing connections to the helper for HTTP requests, in seconds. See
 # https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.connect_timeout for
-# details. (optional)
+# details. (optional; defaults to 10 seconds)
 http_request_connection_timeout_secs: 10
 
 # Timeout to apply to HTTP requests overall (including connection establishment) when communicating
 # with the helper. See
 # https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.timeout for details.
-# (optional)
+# (optional; defaults to 30 seconds)
 http_request_timeout_secs: 30
 
 # Number of sharded database records per batch aggregation. Must not be greater

--- a/docs/samples/advanced_config/collection_job_driver.yaml
+++ b/docs/samples/advanced_config/collection_job_driver.yaml
@@ -87,6 +87,17 @@ worker_lease_clock_skew_allowance_secs: 60
 # (required)
 maximum_attempts_before_failure: 10
 
+# Timeout to apply when establishing connections to the helper for HTTP requests, in seconds. See
+# https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.connect_timeout for
+# details. (optional)
+http_request_connection_timeout_secs: 10
+
+# Timeout to apply to HTTP requests overall (including connection establishment) when communicating
+# with the helper. See
+# https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.timeout for details.
+# (optional)
+http_request_timeout_secs: 30
+
 # Number of sharded database records per batch aggregation. Must not be less
 # than the equivalent setting in the aggregator and aggregation job driver.
 # (required)

--- a/docs/samples/advanced_config/collection_job_driver.yaml
+++ b/docs/samples/advanced_config/collection_job_driver.yaml
@@ -89,13 +89,13 @@ maximum_attempts_before_failure: 10
 
 # Timeout to apply when establishing connections to the helper for HTTP requests, in seconds. See
 # https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.connect_timeout for
-# details. (optional)
+# details. (optional; defaults to 10 seconds)
 http_request_connection_timeout_secs: 10
 
 # Timeout to apply to HTTP requests overall (including connection establishment) when communicating
 # with the helper. See
 # https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.timeout for details.
-# (optional)
+# (optional; defaults to 30 seconds)
 http_request_timeout_secs: 30
 
 # Number of sharded database records per batch aggregation. Must not be less

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -33,10 +33,7 @@ use janus_interop_binaries::{
     ContainerLogsDropGuard,
 };
 use janus_messages::Role;
-use std::{
-    net::{Ipv4Addr, SocketAddr},
-    time::Duration,
-};
+use std::net::{Ipv4Addr, SocketAddr};
 #[cfg(feature = "testcontainer")]
 use testcontainers::{clients::Cli, RunnableImage};
 use trillium_tokio::Stopper;
@@ -186,8 +183,8 @@ impl JanusInProcess {
                 worker_lease_duration_secs: 10,
                 worker_lease_clock_skew_allowance_secs: 1,
                 maximum_attempts_before_failure: 3,
-                http_request_timeout: Duration::from_secs(30),
-                http_request_connection_timeout: Duration::from_secs(10),
+                http_request_timeout_secs: 30,
+                http_request_connection_timeout_secs: 10,
             },
             taskprov_config: TaskprovConfig::default(),
             batch_aggregation_shard_count: 32,
@@ -203,8 +200,8 @@ impl JanusInProcess {
                 worker_lease_duration_secs: 10,
                 worker_lease_clock_skew_allowance_secs: 1,
                 maximum_attempts_before_failure: 3,
-                http_request_timeout: Duration::from_secs(30),
-                http_request_connection_timeout: Duration::from_secs(10),
+                http_request_timeout_secs: 30,
+                http_request_connection_timeout_secs: 10,
             },
             batch_aggregation_shard_count: 32,
         };

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -33,7 +33,10 @@ use janus_interop_binaries::{
     ContainerLogsDropGuard,
 };
 use janus_messages::Role;
-use std::net::{Ipv4Addr, SocketAddr};
+use std::{
+    net::{Ipv4Addr, SocketAddr},
+    time::Duration,
+};
 #[cfg(feature = "testcontainer")]
 use testcontainers::{clients::Cli, RunnableImage};
 use trillium_tokio::Stopper;
@@ -183,6 +186,8 @@ impl JanusInProcess {
                 worker_lease_duration_secs: 10,
                 worker_lease_clock_skew_allowance_secs: 1,
                 maximum_attempts_before_failure: 3,
+                http_request_timeout: Duration::from_secs(30),
+                http_request_connection_timeout: Duration::from_secs(10),
             },
             taskprov_config: TaskprovConfig::default(),
             batch_aggregation_shard_count: 32,
@@ -198,6 +203,8 @@ impl JanusInProcess {
                 worker_lease_duration_secs: 10,
                 worker_lease_clock_skew_allowance_secs: 1,
                 maximum_attempts_before_failure: 3,
+                http_request_timeout: Duration::from_secs(30),
+                http_request_connection_timeout: Duration::from_secs(10),
             },
             batch_aggregation_shard_count: 32,
         };


### PR DESCRIPTION
Applies HTTP client timeouts in the `janus_client` and `janus_collector` crates, as well as in leader->helper HTTP requests.

Closes #426 