### PR TITLE
Add customized Prio3SumVec VDAF

### DIFF
--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -777,7 +777,7 @@ pub mod test_util {
         },
         time::DurationExt,
         url_ensure_trailing_slash,
-        vdaf::{VdafInstance, VERIFY_KEY_LENGTH},
+        vdaf::{VdafInstance, VERIFY_KEY_LENGTH, VERIFY_KEY_LENGTH_HMACSHA256_AES128},
     };
     use janus_messages::{
         AggregationJobId, CollectionJobId, Duration, HpkeConfigId, Role, TaskId, Time,
@@ -793,8 +793,11 @@ pub mod test_util {
             | VdafInstance::FakeFailsPrepInit
             | VdafInstance::FakeFailsPrepStep => 0,
 
-            // All "real" VDAFs use a verify key of length 16 currently. (Poplar1 may not, but it's
-            // not yet done being specified, so choosing 16 bytes is fine for testing.)
+            VdafInstance::Prio3SumVecField64MultiproofHmacSha256Aes128 { .. } => {
+                VERIFY_KEY_LENGTH_HMACSHA256_AES128
+            }
+
+            // All other VDAFs (Prio3 as-specified and Poplar1) have the same verify key length.
             _ => VERIFY_KEY_LENGTH,
         }
     }

--- a/core/src/dp.rs
+++ b/core/src/dp.rs
@@ -111,6 +111,19 @@ impl TypeWithNoise<NoDifferentialPrivacy>
     }
 }
 
+impl TypeWithNoise<NoDifferentialPrivacy>
+    for prio::flp::types::SumVec<Field64, ParallelSum<Field64, Mul<Field64>>>
+{
+    fn add_noise_to_result(
+        &self,
+        _dp_strategy: &NoDifferentialPrivacy,
+        _agg_result: &mut [Self::Field],
+        _num_measurements: usize,
+    ) -> Result<(), prio::flp::FlpError> {
+        Ok(())
+    }
+}
+
 #[cfg(feature = "fpvec_bounded_l2")]
 impl<T, SPoly, SBlindPoly> TypeWithNoise<NoDifferentialPrivacy>
     for FixedPointBoundedL2VecSum<T, SPoly, SBlindPoly>

--- a/core/src/vdaf.rs
+++ b/core/src/vdaf.rs
@@ -123,65 +123,27 @@ impl TryFrom<&taskprov::VdafType> for VdafInstance {
     }
 }
 
+pub type Prio3SumVecField64MultiproofHmacSha256Aes128 =
+    Prio3<SumVec<Field64, ParallelSum<Field64, Mul<Field64>>>, XofHmacSha256Aes128, 32>;
+
+/// Construct a customized Prio3SumVec VDAF, using the [`Field64`] field, three proofs, and
+/// [`XofHmacSha256Aes128`] as the XOF.
+pub fn new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128(
+    bits: usize,
+    length: usize,
+    chunk_length: usize,
+) -> Result<Prio3SumVecField64MultiproofHmacSha256Aes128, VdafError> {
+    Prio3::new(
+        2,
+        3,
+        ALGORITHM_ID_PRIO3_SUM_VEC_FIELD64_MULTIPROOF_HMACSHA256_AES128,
+        SumVec::new(bits, length, chunk_length)?,
+    )
+}
+
 /// Internal implementation details of [`vdaf_dispatch`](crate::vdaf_dispatch).
 #[macro_export]
 macro_rules! vdaf_dispatch_impl_base {
-    // Provide the dispatched type only, don't construct a VDAF instance.
-    (impl match base $vdaf_instance:expr, (_, $Vdaf:ident, $VERIFY_KEY_LEN:ident, $dp_strategy:ident, $DpStrategy:ident) => $body:tt) => {
-        match $vdaf_instance {
-            ::janus_core::vdaf::VdafInstance::Prio3Count => {
-                type $Vdaf = ::prio::vdaf::prio3::Prio3Count;
-                const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
-                type $DpStrategy = janus_core::dp::NoDifferentialPrivacy;
-                let $dp_strategy = janus_core::dp::NoDifferentialPrivacy;
-                $body
-            }
-
-            ::janus_core::vdaf::VdafInstance::Prio3CountVec { length } => {
-                type $Vdaf = ::prio::vdaf::prio3::Prio3SumVecMultithreaded;
-                const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
-                type $DpStrategy = janus_core::dp::NoDifferentialPrivacy;
-                let $dp_strategy = janus_core::dp::NoDifferentialPrivacy;
-                $body
-            }
-
-            ::janus_core::vdaf::VdafInstance::Prio3Sum { bits } => {
-                type $Vdaf = ::prio::vdaf::prio3::Prio3Sum;
-                const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
-                type $DpStrategy = janus_core::dp::NoDifferentialPrivacy;
-                let $dp_strategy = janus_core::dp::NoDifferentialPrivacy;
-                $body
-            }
-
-            ::janus_core::vdaf::VdafInstance::Prio3SumVec { bits, length } => {
-                type $Vdaf = ::prio::vdaf::prio3::Prio3SumVecMultithreaded;
-                const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
-                type $DpStrategy = janus_core::dp::NoDifferentialPrivacy;
-                let $dp_strategy = janus_core::dp::NoDifferentialPrivacy;
-                $body
-            }
-
-            ::janus_core::vdaf::VdafInstance::Prio3Histogram { buckets } => {
-                type $Vdaf = ::prio::vdaf::prio3::Prio3Histogram;
-                const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
-                type $DpStrategy = janus_core::dp::NoDifferentialPrivacy;
-                let $dp_strategy = janus_core::dp::NoDifferentialPrivacy;
-                $body
-            }
-
-            ::janus_core::vdaf::VdafInstance::Poplar1 { bits } => {
-                type $Vdaf = ::prio::vdaf::poplar1::Poplar1<::prio::vdaf::prg::PrgSha3, 16>;
-                const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
-                type $DpStrategy = janus_core::dp::NoDifferentialPrivacy;
-                let $dp_strategy = janus_core::dp::NoDifferentialPrivacy;
-                $body
-            }
-
-            _ => unreachable!(),
-        }
-    };
-
-    // Construct a VDAF instance, and provide that to the block as well.
     (impl match base $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LEN:ident, $dp_strategy:ident, $DpStrategy:ident) => $body:tt) => {
         match $vdaf_instance {
             ::janus_core::vdaf::VdafInstance::Prio3Count => {
@@ -269,19 +231,6 @@ macro_rules! vdaf_dispatch_impl_base {
 #[cfg(feature = "fpvec_bounded_l2")]
 #[macro_export]
 macro_rules! vdaf_dispatch_impl_fpvec_bounded_l2 {
-    // Provide the dispatched type only, don't construct a VDAF instance.
-    (impl match fpvec_bounded_l2 $vdaf_instance:expr, (_, $Vdaf:ident, $VERIFY_KEY_LEN:ident) => $body:tt) => {
-        match $vdaf_instance {
-            ::janus_core::vdaf::VdafInstance::Prio3FixedPointBoundedL2VecSum { bitsize, dp_strategy, length } => {
-                const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
-                janus_core::vdaf_dispatch_impl_fpvec_bounded_l2!(@dispatch_bitsize bitsize, $Vdaf => $body)
-            }
-
-            _ => unreachable!(),
-        }
-    };
-
-    // Construct a VDAF instance, and provide that to the block as well.
     (impl match fpvec_bounded_l2 $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LEN:ident, $dp_strategy:ident, $DpStrategy:ident) => $body:tt) => {
         match $vdaf_instance {
             ::janus_core::vdaf::VdafInstance::Prio3FixedPointBoundedL2VecSum { bitsize, dp_strategy, length } => {
@@ -335,38 +284,6 @@ macro_rules! vdaf_dispatch_impl_fpvec_bounded_l2 {
 #[cfg(feature = "test-util")]
 #[macro_export]
 macro_rules! vdaf_dispatch_impl_test_util {
-    // Provide the dispatched type only, don't construct a VDAF instance.
-    (impl match test_util $vdaf_instance:expr, (_, $Vdaf:ident, $VERIFY_KEY_LEN:ident, $dp_strategy:ident, $DpStrategy:ident) => $body:tt) => {
-        match $vdaf_instance {
-            ::janus_core::vdaf::VdafInstance::Fake => {
-                type $Vdaf = ::janus_core::test_util::dummy_vdaf::Vdaf;
-                const $VERIFY_KEY_LEN: usize = 0;
-                type $DpStrategy = janus_core::dp::NoDifferentialPrivacy;
-                let $dp_strategy = janus_core::dp::NoDifferentialPrivacy;
-                $body
-            }
-
-            ::janus_core::vdaf::VdafInstance::FakeFailsPrepInit => {
-                type $Vdaf = ::janus_core::test_util::dummy_vdaf::Vdaf;
-                const $VERIFY_KEY_LEN: usize = 0;
-                type $DpStrategy = janus_core::dp::NoDifferentialPrivacy;
-                let $dp_strategy = janus_core::dp::NoDifferentialPrivacy;
-                $body
-            }
-
-            ::janus_core::vdaf::VdafInstance::FakeFailsPrepStep => {
-                type $Vdaf = ::janus_core::test_util::dummy_vdaf::Vdaf;
-                const $VERIFY_KEY_LEN: usize = 0;
-                type $DpStrategy = janus_core::dp::NoDifferentialPrivacy;
-                let $dp_strategy = janus_core::dp::NoDifferentialPrivacy;
-                $body
-            }
-
-            _ => unreachable!(),
-        }
-    };
-
-    // Construct a VDAF instance, and provide that to the block as well.
     (impl match test_util $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LEN:ident, $dp_strategy:ident, $DpStrategy:ident) => $body:tt) => {
         match $vdaf_instance {
             ::janus_core::vdaf::VdafInstance::Fake => {
@@ -424,33 +341,6 @@ macro_rules! vdaf_dispatch_impl_test_util {
 #[cfg(all(feature = "fpvec_bounded_l2", feature = "test-util"))]
 #[macro_export]
 macro_rules! vdaf_dispatch_impl {
-    // Provide the dispatched type only, don't construct a VDAF instance.
-    (impl match all $vdaf_instance:expr, (_, $Vdaf:ident, $VERIFY_KEY_LEN:ident, $dp_strategy:ident, $DpStrategy:ident) => $body:tt) => {
-        match $vdaf_instance {
-            ::janus_core::vdaf::VdafInstance::Prio3Count
-            | ::janus_core::vdaf::VdafInstance::Prio3CountVec { .. }
-            | ::janus_core::vdaf::VdafInstance::Prio3Sum { .. }
-            | ::janus_core::vdaf::VdafInstance::Prio3SumVec { .. }
-            | ::janus_core::vdaf::VdafInstance::Prio3Histogram { .. }
-            | ::janus_core::vdaf::VdafInstance::Poplar1 { .. } => {
-                ::janus_core::vdaf_dispatch_impl_base!(impl match base $vdaf_instance, (_, $Vdaf, $VERIFY_KEY_LEN, $dp_strategy, $DpStrategy) => $body)
-            }
-
-            ::janus_core::vdaf::VdafInstance::Prio3FixedPointBoundedL2VecSum { .. } => {
-                ::janus_core::vdaf_dispatch_impl_fpvec_bounded_l2!(impl match fpvec_bounded_l2 $vdaf_instance, (_, $Vdaf, $VERIFY_KEY_LEN, $dp_strategy, $DpStrategy) => $body)
-            }
-
-            ::janus_core::vdaf::VdafInstance::Fake
-            | ::janus_core::vdaf::VdafInstance::FakeFailsPrepInit
-            | ::janus_core::vdaf::VdafInstance::FakeFailsPrepStep => {
-                ::janus_core::vdaf_dispatch_impl_test_util!(impl match test_util $vdaf_instance, (_, $Vdaf, $VERIFY_KEY_LEN, $dp_strategy, $DpStrategy) => $body)
-            }
-
-            _ => panic!("VDAF {:?} is not yet supported", $vdaf_instance),
-        }
-    };
-
-    // Construct a VDAF instance, and provide that to the block as well.
     (impl match all $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LEN:ident, $dp_strategy:ident, $DpStrategy:ident) => $body:tt) => {
         match $vdaf_instance {
             ::janus_core::vdaf::VdafInstance::Prio3Count
@@ -481,27 +371,6 @@ macro_rules! vdaf_dispatch_impl {
 #[cfg(all(feature = "fpvec_bounded_l2", not(feature = "test-util")))]
 #[macro_export]
 macro_rules! vdaf_dispatch_impl {
-    // Provide the dispatched type only, don't construct a VDAF instance.
-    (impl match all $vdaf_instance:expr, (_, $Vdaf:ident, $VERIFY_KEY_LEN:ident, $dp_strategy:ident, $DpStrategy:ident) => $body:tt) => {
-        match $vdaf_instance {
-            ::janus_core::vdaf::VdafInstance::Prio3Count
-            | ::janus_core::vdaf::VdafInstance::Prio3CountVec { .. }
-            | ::janus_core::vdaf::VdafInstance::Prio3Sum { .. }
-            | ::janus_core::vdaf::VdafInstance::Prio3SumVec { .. }
-            | ::janus_core::vdaf::VdafInstance::Prio3Histogram { .. }
-            | ::janus_core::vdaf::VdafInstance::Poplar1 { .. } => {
-                ::janus_core::vdaf_dispatch_impl_base!(impl match base $vdaf_instance, (_, $Vdaf, $VERIFY_KEY_LEN, $dp_strategy, $DpStrategy) => $body)
-            }
-
-            ::janus_core::vdaf::VdafInstance::Prio3FixedPointBoundedL2VecSum { .. } => {
-                ::janus_core::vdaf_dispatch_impl_fpvec_bounded_l2!(impl match fpvec_bounded_l2 $vdaf_instance, (_, $Vdaf, $VERIFY_KEY_LEN, $dp_strategy, $DpStrategy) => $body)
-            }
-
-            _ => panic!("VDAF {:?} is not yet supported", $vdaf_instance),
-        }
-    };
-
-    // Construct a VDAF instance, and provide that to the block as well.
     (impl match all $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LEN:ident, $dp_strategy:ident, $DpStrategy:ident) => $body:tt) => {
         match $vdaf_instance {
             ::janus_core::vdaf::VdafInstance::Prio3Count
@@ -526,29 +395,6 @@ macro_rules! vdaf_dispatch_impl {
 #[cfg(all(not(feature = "fpvec_bounded_l2"), feature = "test-util"))]
 #[macro_export]
 macro_rules! vdaf_dispatch_impl {
-    // Provide the dispatched type only, don't construct a VDAF instance.
-    (impl match all $vdaf_instance:expr, (_, $Vdaf:ident, $VERIFY_KEY_LEN:ident, $dp_strategy:ident, $DpStrategy:ident) => $body:tt) => {
-        match $vdaf_instance {
-            ::janus_core::vdaf::VdafInstance::Prio3Count
-            | ::janus_core::vdaf::VdafInstance::Prio3CountVec { .. }
-            | ::janus_core::vdaf::VdafInstance::Prio3Sum { .. }
-            | ::janus_core::vdaf::VdafInstance::Prio3SumVec { .. }
-            | ::janus_core::vdaf::VdafInstance::Prio3Histogram { .. }
-            | ::janus_core::vdaf::VdafInstance::Poplar1 { .. } => {
-                ::janus_core::vdaf_dispatch_impl_base!(impl match base $vdaf_instance, (_, $Vdaf, $VERIFY_KEY_LEN, $dp_strategy, $DpStrategy) => $body)
-            }
-
-            ::janus_core::vdaf::VdafInstance::Fake
-            | ::janus_core::vdaf::VdafInstance::FakeFailsPrepInit
-            | ::janus_core::vdaf::VdafInstance::FakeFailsPrepStep => {
-                ::janus_core::vdaf_dispatch_impl_test_util!(impl match test_util $vdaf_instance, (_, $Vdaf, $VERIFY_KEY_LEN, $dp_strategy, $DpStrategy) => $body)
-            }
-
-            _ => panic!("VDAF {:?} is not yet supported", $vdaf_instance),
-        }
-    };
-
-    // Construct a VDAF instance, and provide that to the block as well.
     (impl match all $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LEN:ident, $dp_strategy:ident, $DpStrategy:ident) => $body:tt) => {
         match $vdaf_instance {
             ::janus_core::vdaf::VdafInstance::Prio3Count
@@ -575,23 +421,6 @@ macro_rules! vdaf_dispatch_impl {
 #[cfg(all(not(feature = "fpvec_bounded_l2"), not(feature = "test-util")))]
 #[macro_export]
 macro_rules! vdaf_dispatch_impl {
-    // Provide the dispatched type only, don't construct a VDAF instance.
-    (impl match all $vdaf_instance:expr, (_, $Vdaf:ident, $VERIFY_KEY_LEN:ident, $dp_strategy:ident, $DpStrategy:ident) => $body:tt) => {
-        match $vdaf_instance {
-            ::janus_core::vdaf::VdafInstance::Prio3Count
-            | ::janus_core::vdaf::VdafInstance::Prio3CountVec { .. }
-            | ::janus_core::vdaf::VdafInstance::Prio3Sum { .. }
-            | ::janus_core::vdaf::VdafInstance::Prio3SumVec { .. }
-            | ::janus_core::vdaf::VdafInstance::Prio3Histogram { .. }
-            | ::janus_core::vdaf::VdafInstance::Poplar1 { .. } => {
-                ::janus_core::vdaf_dispatch_impl_base!(impl match base $vdaf_instance, (_, $Vdaf, $VERIFY_KEY_LEN, $dp_strategy, $DpStrategy) => $body)
-            }
-
-            _ => panic!("VDAF {:?} is not yet supported", $vdaf_instance),
-        }
-    };
-
-    // Construct a VDAF instance, and provide that to the block as well.
     (impl match all $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LEN:ident, $dp_strategy:ident, $DpStrategy:ident) => $body:tt) => {
         match $vdaf_instance {
             ::janus_core::vdaf::VdafInstance::Prio3Count

--- a/integration_tests/src/client.rs
+++ b/integration_tests/src/client.rs
@@ -2,7 +2,7 @@ use crate::TaskParameters;
 use anyhow::anyhow;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use janus_client::Client;
-use janus_core::vdaf::VdafInstance;
+use janus_core::vdaf::{Prio3SumVecField64MultiproofHmacSha256Aes128, VdafInstance};
 use janus_interop_binaries::{get_rust_log_level, ContainerLogsDropGuard};
 use janus_messages::{Duration, TaskId};
 use prio::{
@@ -53,6 +53,17 @@ impl InteropClientEncoding for Prio3SumVecMultithreaded {
     }
 }
 
+impl InteropClientEncoding for Prio3SumVecField64MultiproofHmacSha256Aes128 {
+    fn json_encode_measurement(&self, measurement: &Self::Measurement) -> Value {
+        Value::Array(
+            measurement
+                .iter()
+                .map(|value| Value::String(format!("{value}")))
+                .collect(),
+        )
+    }
+}
+
 fn json_encode_vdaf(vdaf: &VdafInstance) -> Value {
     match vdaf {
         VdafInstance::Prio3Count => json!({
@@ -68,6 +79,16 @@ fn json_encode_vdaf(vdaf: &VdafInstance) -> Value {
             chunk_length,
         } => json!({
             "type": "Prio3SumVec",
+            "bits": format!("{bits}"),
+            "length": format!("{length}"),
+            "chunk_length": format!("{chunk_length}"),
+        }),
+        VdafInstance::Prio3SumVecField64MultiproofHmacSha256Aes128 {
+            bits,
+            length,
+            chunk_length,
+        } => json!({
+            "type": "Prio3SumVecField64MultiproofHmacSha256Aes128",
             "bits": format!("{bits}"),
             "length": format!("{length}"),
             "chunk_length": format!("{chunk_length}"),

--- a/integration_tests/tests/integration/janus.rs
+++ b/integration_tests/tests/integration/janus.rs
@@ -346,7 +346,32 @@ async fn janus_in_process_sum_vec() {
     .await;
 
     submit_measurements_and_verify_aggregate(
-        "",
+        "janus_in_process_sum_vec",
+        &janus_pair.task_parameters,
+        (janus_pair.leader.port(), janus_pair.helper.port()),
+        &ClientBackend::InProcess,
+    )
+    .await;
+}
+
+/// This test exercises Prio3SumVecField64MultiproofHmacSha256Aes128 with Janus as both the leader
+/// and the helper.
+#[tokio::test(flavor = "multi_thread")]
+async fn janus_in_process_customized_sum_vec() {
+    install_test_trace_subscriber();
+
+    let janus_pair = JanusInProcessPair::new(
+        VdafInstance::Prio3SumVecField64MultiproofHmacSha256Aes128 {
+            bits: 16,
+            length: 15,
+            chunk_length: 16,
+        },
+        QueryType::TimeInterval,
+    )
+    .await;
+
+    submit_measurements_and_verify_aggregate(
+        "janus_in_process_customized_sum_vec",
         &janus_pair.task_parameters,
         (janus_pair.leader.port(), janus_pair.helper.port()),
         &ClientBackend::InProcess,

--- a/interop_binaries/src/bin/janus_interop_client.rs
+++ b/interop_binaries/src/bin/janus_interop_client.rs
@@ -9,7 +9,7 @@ use fixed::{
 };
 #[cfg(feature = "fpvec_bounded_l2")]
 use janus_core::vdaf::Prio3FixedPointBoundedL2VecSumBitSize;
-use janus_core::vdaf::VdafInstance;
+use janus_core::vdaf::{new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128, VdafInstance};
 use janus_interop_binaries::{
     install_tracing_subscriber,
     status::{ERROR, SUCCESS},
@@ -132,6 +132,20 @@ async fn handle_upload(
             let measurement = parse_vector_measurement::<u128>(request.measurement.clone())?;
             let vdaf = Prio3::new_sum_vec_multithreaded(2, bits, length, chunk_length)
                 .context("failed to construct Prio3SumVec VDAF")?;
+            handle_upload_generic(http_client, vdaf, request, measurement).await?;
+        }
+
+        VdafInstance::Prio3SumVecField64MultiproofHmacSha256Aes128 {
+            bits,
+            length,
+            chunk_length,
+        } => {
+            let measurement = parse_vector_measurement::<u64>(request.measurement.clone())?;
+            let vdaf =
+                new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128(bits, length, chunk_length)
+                    .context(
+                        "failed to construct Prio3SumVecField64MultiproofHmacSha256Aes128 VDAF",
+                    )?;
             handle_upload_generic(http_client, vdaf, request, measurement).await?;
         }
 

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -116,6 +116,11 @@ pub enum VdafObject {
         length: NumberAsString<usize>,
         chunk_length: NumberAsString<usize>,
     },
+    Prio3SumVecField64MultiproofHmacSha256Aes128 {
+        bits: NumberAsString<usize>,
+        length: NumberAsString<usize>,
+        chunk_length: NumberAsString<usize>,
+    },
     Prio3Histogram {
         length: NumberAsString<usize>,
         chunk_length: NumberAsString<usize>,
@@ -143,6 +148,16 @@ impl From<VdafInstance> for VdafObject {
                 length,
                 chunk_length,
             } => VdafObject::Prio3SumVec {
+                bits: NumberAsString(bits),
+                length: NumberAsString(length),
+                chunk_length: NumberAsString(chunk_length),
+            },
+
+            VdafInstance::Prio3SumVecField64MultiproofHmacSha256Aes128 {
+                bits,
+                length,
+                chunk_length,
+            } => VdafObject::Prio3SumVecField64MultiproofHmacSha256Aes128 {
                 bits: NumberAsString(bits),
                 length: NumberAsString(length),
                 chunk_length: NumberAsString(chunk_length),
@@ -184,6 +199,16 @@ impl From<VdafObject> for VdafInstance {
                 length,
                 chunk_length,
             } => VdafInstance::Prio3SumVec {
+                bits: bits.0,
+                length: length.0,
+                chunk_length: chunk_length.0,
+            },
+
+            VdafObject::Prio3SumVecField64MultiproofHmacSha256Aes128 {
+                bits,
+                length,
+                chunk_length,
+            } => VdafInstance::Prio3SumVecField64MultiproofHmacSha256Aes128 {
                 bits: bits.0,
                 length: length.0,
                 chunk_length: chunk_length.0,


### PR DESCRIPTION
This adds support for a customized variant of Prio3. It uses a smaller field and more FLP proofs, and uses a different XOF. I chose the same algorithm ID that Daphne uses, from the private use range, so we can interoperate. This VDAF needs a different verify key length, but fortunately this required just a bit more plumbing to support. Unlike in Daphne, I hardcoded the number of proofs to 3 (the minimum allowed number when using Field64) to avoid misuse with choices that could compromise robustness.

I also noticed that the `vdaf_dispatch!()` macro no longer gets called in the mode that doesn't construct the VDAF, so I dropped a bunch of code before adding this VDAF to it.