### PR TITLE
Remove Prio3CountVec

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -858,15 +858,6 @@ impl<C: Clock> TaskAggregator<C> {
                 VdafOps::Prio3Count(Arc::new(vdaf), verify_key)
             }
 
-            VdafInstance::Prio3CountVec {
-                length,
-                chunk_length,
-            } => {
-                let vdaf = Prio3::new_sum_vec_multithreaded(2, 1, *length, *chunk_length)?;
-                let verify_key = task.vdaf_verify_key()?;
-                VdafOps::Prio3CountVec(Arc::new(vdaf), verify_key)
-            }
-
             VdafInstance::Prio3Sum { bits } => {
                 let vdaf = Prio3::new_sum(2, *bits)?;
                 let verify_key = task.vdaf_verify_key()?;
@@ -1147,7 +1138,6 @@ mod vdaf_ops_strategies {
 #[allow(clippy::enum_variant_names)]
 enum VdafOps {
     Prio3Count(Arc<Prio3Count>, VerifyKey<VERIFY_KEY_LENGTH>),
-    Prio3CountVec(Arc<Prio3SumVecMultithreaded>, VerifyKey<VERIFY_KEY_LENGTH>),
     Prio3Sum(Arc<Prio3Sum>, VerifyKey<VERIFY_KEY_LENGTH>),
     Prio3SumVec(Arc<Prio3SumVecMultithreaded>, VerifyKey<VERIFY_KEY_LENGTH>),
     Prio3SumVecField64MultiproofHmacSha256Aes128(
@@ -1187,16 +1177,6 @@ macro_rules! vdaf_ops_dispatch {
                 let $vdaf = vdaf;
                 let $verify_key = verify_key;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Count;
-                const $VERIFY_KEY_LENGTH: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
-                type $DpStrategy = janus_core::dp::NoDifferentialPrivacy;
-                let $dp_strategy = &Arc::new(janus_core::dp::NoDifferentialPrivacy);
-                $body
-            }
-
-            crate::aggregator::VdafOps::Prio3CountVec(vdaf, verify_key) => {
-                let $vdaf = vdaf;
-                let $verify_key = verify_key;
-                type $Vdaf = ::prio::vdaf::prio3::Prio3SumVecMultithreaded;
                 const $VERIFY_KEY_LENGTH: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 type $DpStrategy = janus_core::dp::NoDifferentialPrivacy;
                 let $dp_strategy = &Arc::new(janus_core::dp::NoDifferentialPrivacy);

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -289,25 +289,6 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                     .await
             }
 
-            (
-                task::QueryType::TimeInterval,
-                VdafInstance::Prio3CountVec {
-                    length,
-                    chunk_length,
-                },
-            ) => {
-                let vdaf = Arc::new(Prio3::new_sum_vec_multithreaded(
-                    2,
-                    1,
-                    *length,
-                    *chunk_length,
-                )?);
-                self.create_aggregation_jobs_for_time_interval_task_no_param::<
-                    VERIFY_KEY_LENGTH,
-                    Prio3SumVecMultithreaded
-                >(task, vdaf).await
-            }
-
             (task::QueryType::TimeInterval, VdafInstance::Prio3Sum { bits }) => {
                 let vdaf = Arc::new(Prio3::new_sum(2, *bits)?);
                 self.create_aggregation_jobs_for_time_interval_task_no_param::<VERIFY_KEY_LENGTH, Prio3Sum>(task, vdaf)
@@ -403,30 +384,6 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                 self.create_aggregation_jobs_for_fixed_size_task_no_param::<
                     VERIFY_KEY_LENGTH,
                     Prio3Count,
-                >(task, vdaf, max_batch_size, batch_time_window_size).await
-            }
-
-            (
-                task::QueryType::FixedSize {
-                    max_batch_size,
-                    batch_time_window_size,
-                },
-                VdafInstance::Prio3CountVec {
-                    length,
-                    chunk_length,
-                },
-            ) => {
-                let vdaf = Arc::new(Prio3::new_sum_vec_multithreaded(
-                    2,
-                    1,
-                    *length,
-                    *chunk_length,
-                )?);
-                let max_batch_size = *max_batch_size;
-                let batch_time_window_size = *batch_time_window_size;
-                self.create_aggregation_jobs_for_fixed_size_task_no_param::<
-                    VERIFY_KEY_LENGTH,
-                    Prio3SumVecMultithreaded
                 >(task, vdaf, max_batch_size, batch_time_window_size).await
             }
 

--- a/aggregator/src/bin/janus_cli.rs
+++ b/aggregator/src/bin/janus_cli.rs
@@ -669,7 +669,8 @@ mod tests {
                 max_batch_size: Some(100),
                 batch_time_window_size: None,
             },
-            VdafInstance::Prio3CountVec {
+            VdafInstance::Prio3SumVec {
+                bits: 1,
                 length: 4,
                 chunk_length: 2,
             },

--- a/aggregator_api/src/models.rs
+++ b/aggregator_api/src/models.rs
@@ -45,7 +45,6 @@ pub(crate) enum SupportedVdaf {
     Prio3Sum,
     Prio3Histogram,
     Prio3SumVec,
-    Prio3CountVec,
 }
 
 #[derive(Serialize)]

--- a/aggregator_api/src/routes.rs
+++ b/aggregator_api/src/routes.rs
@@ -41,7 +41,6 @@ pub(super) async fn get_config(
             SupportedVdaf::Prio3Count,
             SupportedVdaf::Prio3Sum,
             SupportedVdaf::Prio3Histogram,
-            SupportedVdaf::Prio3CountVec,
             SupportedVdaf::Prio3SumVec,
         ],
         query_types: vec![

--- a/aggregator_api/src/tests.rs
+++ b/aggregator_api/src/tests.rs
@@ -88,7 +88,7 @@ async fn get_config() {
         Status::Ok,
         concat!(
             r#"{"protocol":"DAP-07","dap_url":"https://dap.url/","role":"Either","vdafs":"#,
-            r#"["Prio3Count","Prio3Sum","Prio3Histogram","Prio3CountVec","Prio3SumVec"],"#,
+            r#"["Prio3Count","Prio3Sum","Prio3Histogram","Prio3SumVec"],"#,
             r#""query_types":["TimeInterval","FixedSize"],"#,
             r#""features":["TokenHash"]}"#,
         )
@@ -1621,7 +1621,8 @@ fn post_task_req_serialization() {
                 max_batch_size: Some(999),
                 batch_time_window_size: None,
             },
-            vdaf: VdafInstance::Prio3CountVec {
+            vdaf: VdafInstance::Prio3SumVec {
+                bits: 1,
                 length: 5,
                 chunk_length: 2,
             },
@@ -1663,9 +1664,11 @@ fn post_task_req_serialization() {
             Token::Str("vdaf"),
             Token::StructVariant {
                 name: "VdafInstance",
-                variant: "Prio3CountVec",
-                len: 2,
+                variant: "Prio3SumVec",
+                len: 3,
             },
+            Token::Str("bits"),
+            Token::U64(1),
             Token::Str("length"),
             Token::U64(5),
             Token::Str("chunk_length"),
@@ -1731,7 +1734,8 @@ fn post_task_req_serialization() {
                 max_batch_size: Some(999),
                 batch_time_window_size: None,
             },
-            vdaf: VdafInstance::Prio3CountVec {
+            vdaf: VdafInstance::Prio3SumVec {
+                bits: 1,
                 length: 5,
                 chunk_length: 2,
             },
@@ -1777,9 +1781,11 @@ fn post_task_req_serialization() {
             Token::Str("vdaf"),
             Token::StructVariant {
                 name: "VdafInstance",
-                variant: "Prio3CountVec",
-                len: 2,
+                variant: "Prio3SumVec",
+                len: 3,
             },
+            Token::Str("bits"),
+            Token::U64(1),
             Token::Str("length"),
             Token::U64(5),
             Token::Str("chunk_length"),
@@ -1873,7 +1879,8 @@ fn task_resp_serialization() {
             max_batch_size: Some(999),
             batch_time_window_size: None,
         },
-        VdafInstance::Prio3CountVec {
+        VdafInstance::Prio3SumVec {
+            bits: 1,
             length: 5,
             chunk_length: 2,
         },
@@ -1939,9 +1946,11 @@ fn task_resp_serialization() {
             Token::Str("vdaf"),
             Token::StructVariant {
                 name: "VdafInstance",
-                variant: "Prio3CountVec",
-                len: 2,
+                variant: "Prio3SumVec",
+                len: 3,
             },
+            Token::Str("bits"),
+            Token::U64(1),
             Token::Str("length"),
             Token::U64(5),
             Token::Str("chunk_length"),

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -112,14 +112,16 @@ async fn roundtrip_task(ephemeral_datastore: EphemeralDatastore) {
     for (vdaf, role) in [
         (VdafInstance::Prio3Count, Role::Leader),
         (
-            VdafInstance::Prio3CountVec {
+            VdafInstance::Prio3SumVec {
+                bits: 1,
                 length: 8,
                 chunk_length: 3,
             },
             Role::Leader,
         ),
         (
-            VdafInstance::Prio3CountVec {
+            VdafInstance::Prio3SumVec {
+                bits: 1,
                 length: 64,
                 chunk_length: 10,
             },

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -1632,7 +1632,8 @@ mod tests {
                     max_batch_size: Some(10),
                     batch_time_window_size: None,
                 },
-                VdafInstance::Prio3CountVec {
+                VdafInstance::Prio3SumVec {
+                    bits: 1,
                     length: 8,
                     chunk_length: 3,
                 },
@@ -1695,9 +1696,11 @@ mod tests {
                 Token::Str("vdaf"),
                 Token::StructVariant {
                     name: "VdafInstance",
-                    variant: "Prio3CountVec",
-                    len: 2,
+                    variant: "Prio3SumVec",
+                    len: 3,
                 },
+                Token::Str("bits"),
+                Token::U64(1),
                 Token::Str("length"),
                 Token::U64(8),
                 Token::Str("chunk_length"),

--- a/core/src/vdaf.rs
+++ b/core/src/vdaf.rs
@@ -65,8 +65,6 @@ pub mod vdaf_dp_strategies {
 pub enum VdafInstance {
     /// A `Prio3` counter.
     Prio3Count,
-    /// A vector of `Prio3` counters.
-    Prio3CountVec { length: usize, chunk_length: usize },
     /// A `Prio3` sum.
     Prio3Sum { bits: usize },
     /// A vector of `Prio3` sums.
@@ -173,24 +171,6 @@ macro_rules! vdaf_dispatch_impl_base {
             ::janus_core::vdaf::VdafInstance::Prio3Count => {
                 let $vdaf = ::prio::vdaf::prio3::Prio3::new_count(2)?;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Count;
-                const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
-                type $DpStrategy = janus_core::dp::NoDifferentialPrivacy;
-                let $dp_strategy = janus_core::dp::NoDifferentialPrivacy;
-                $body
-            }
-
-            ::janus_core::vdaf::VdafInstance::Prio3CountVec {
-                length,
-                chunk_length,
-            } => {
-                // Prio3CountVec is implemented as a 1-bit sum vec
-                let $vdaf = ::prio::vdaf::prio3::Prio3::new_sum_vec_multithreaded(
-                    2,
-                    1,
-                    *length,
-                    *chunk_length,
-                )?;
-                type $Vdaf = ::prio::vdaf::prio3::Prio3SumVecMultithreaded;
                 const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 type $DpStrategy = janus_core::dp::NoDifferentialPrivacy;
                 let $dp_strategy = janus_core::dp::NoDifferentialPrivacy;
@@ -387,7 +367,6 @@ macro_rules! vdaf_dispatch_impl {
     (impl match all $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LEN:ident, $dp_strategy:ident, $DpStrategy:ident) => $body:tt) => {
         match $vdaf_instance {
             ::janus_core::vdaf::VdafInstance::Prio3Count
-            | ::janus_core::vdaf::VdafInstance::Prio3CountVec { .. }
             | ::janus_core::vdaf::VdafInstance::Prio3Sum { .. }
             | ::janus_core::vdaf::VdafInstance::Prio3SumVec { .. }
             | ::janus_core::vdaf::VdafInstance::Prio3SumVecField64MultiproofHmacSha256Aes128 { .. }
@@ -418,7 +397,6 @@ macro_rules! vdaf_dispatch_impl {
     (impl match all $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LEN:ident, $dp_strategy:ident, $DpStrategy:ident) => $body:tt) => {
         match $vdaf_instance {
             ::janus_core::vdaf::VdafInstance::Prio3Count
-            | ::janus_core::vdaf::VdafInstance::Prio3CountVec { .. }
             | ::janus_core::vdaf::VdafInstance::Prio3Sum { .. }
             | ::janus_core::vdaf::VdafInstance::Prio3SumVec { .. }
             | ::janus_core::vdaf::VdafInstance::Prio3SumVecField64MultiproofHmacSha256Aes128 { .. }
@@ -443,7 +421,6 @@ macro_rules! vdaf_dispatch_impl {
     (impl match all $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LEN:ident, $dp_strategy:ident, $DpStrategy:ident) => $body:tt) => {
         match $vdaf_instance {
             ::janus_core::vdaf::VdafInstance::Prio3Count
-            | ::janus_core::vdaf::VdafInstance::Prio3CountVec { .. }
             | ::janus_core::vdaf::VdafInstance::Prio3Sum { .. }
             | ::janus_core::vdaf::VdafInstance::Prio3SumVec { .. }
             | ::janus_core::vdaf::VdafInstance::Prio3SumVecField64MultiproofHmacSha256Aes128 { .. }
@@ -470,7 +447,6 @@ macro_rules! vdaf_dispatch_impl {
     (impl match all $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LEN:ident, $dp_strategy:ident, $DpStrategy:ident) => $body:tt) => {
         match $vdaf_instance {
             ::janus_core::vdaf::VdafInstance::Prio3Count
-            | ::janus_core::vdaf::VdafInstance::Prio3CountVec { .. }
             | ::janus_core::vdaf::VdafInstance::Prio3Sum { .. }
             | ::janus_core::vdaf::VdafInstance::Prio3SumVec { .. }
             | ::janus_core::vdaf::VdafInstance::Prio3SumVecField64MultiproofHmacSha256Aes128 { .. }
@@ -541,24 +517,6 @@ mod tests {
                 name: "VdafInstance",
                 variant: "Prio3Count",
             }],
-        );
-        assert_tokens(
-            &VdafInstance::Prio3CountVec {
-                length: 8,
-                chunk_length: 3,
-            },
-            &[
-                Token::StructVariant {
-                    name: "VdafInstance",
-                    variant: "Prio3CountVec",
-                    len: 2,
-                },
-                Token::Str("length"),
-                Token::U64(8),
-                Token::Str("chunk_length"),
-                Token::U64(3),
-                Token::StructVariantEnd,
-            ],
         );
         assert_tokens(
             &VdafInstance::Prio3Sum { bits: 64 },

--- a/integration_tests/tests/integration/in_cluster.rs
+++ b/integration_tests/tests/integration/in_cluster.rs
@@ -416,13 +416,6 @@ impl InClusterJanusPair {
                     length: length.try_into().unwrap(),
                     chunk_length: Some(chunk_length.try_into().unwrap()),
                 }),
-                VdafInstance::Prio3CountVec {
-                    length,
-                    chunk_length,
-                } => Vdaf::CountVec {
-                    length: length.try_into().unwrap(),
-                    chunk_length: Some(chunk_length.try_into().unwrap()),
-                },
                 other => panic!("unsupported vdaf {other:?}"),
             },
             min_batch_size: task.min_batch_size(),

--- a/interop_binaries/src/bin/janus_interop_collector.rs
+++ b/interop_binaries/src/bin/janus_interop_collector.rs
@@ -474,30 +474,6 @@ async fn handle_collection_start(
             .await?
         }
 
-        (
-            ParsedQuery::FixedSize(fixed_size_query),
-            VdafInstance::Prio3CountVec {
-                length,
-                chunk_length,
-            },
-        ) => {
-            let vdaf = Prio3::new_sum_vec_multithreaded(2, 1, length, chunk_length)
-                .context("failed to construct Prio3CountVec VDAF")?;
-            handle_collect_generic(
-                http_client,
-                task_state,
-                Query::new_fixed_size(fixed_size_query),
-                vdaf,
-                &agg_param,
-                |selector| Some(*selector.batch_id()),
-                |result| {
-                    let converted = result.iter().cloned().map(NumberAsString).collect();
-                    AggregationResult::NumberVec(converted)
-                },
-            )
-            .await?
-        }
-
         #[cfg(feature = "fpvec_bounded_l2")]
         (
             ParsedQuery::FixedSize(fixed_size_query),

--- a/tools/tests/cmd/collect.trycmd
+++ b/tools/tests/cmd/collect.trycmd
@@ -66,13 +66,12 @@ VDAF Algorithm and Parameters:
 
           Possible values:
           - count:     Prio3Count
-          - countvec:  Prio3CountVec
           - sum:       Prio3Sum
           - sumvec:    Prio3SumVec
           - histogram: Prio3Histogram
 
       --length <LENGTH>
-          Number of vector elements, when used with --vdaf=countvec and --vdaf=sumvec or number of histogram buckets, when used with --vdaf=histogram
+          Number of vector elements, when used with --vdaf=sumvec or number of histogram buckets, when used with --vdaf=histogram
 
       --bits <BITS>
           Bit length of measurements, for use with --vdaf=sum and --vdaf=sumvec

--- a/tools/tests/cmd/collect_fpvec_bounded_l2.trycmd
+++ b/tools/tests/cmd/collect_fpvec_bounded_l2.trycmd
@@ -66,7 +66,6 @@ VDAF Algorithm and Parameters:
 
           Possible values:
           - count:                          Prio3Count
-          - countvec:                       Prio3CountVec
           - sum:                            Prio3Sum
           - sumvec:                         Prio3SumVec
           - histogram:                      Prio3Histogram
@@ -75,7 +74,7 @@ VDAF Algorithm and Parameters:
           - fixedpoint64bitboundedl2vecsum: Prio3FixedPoint64BitBoundedL2VecSum
 
       --length <LENGTH>
-          Number of vector elements, when used with --vdaf=countvec and --vdaf=sumvec or number of histogram buckets, when used with --vdaf=histogram
+          Number of vector elements, when used with --vdaf=sumvec or number of histogram buckets, when used with --vdaf=histogram
 
       --bits <BITS>
           Bit length of measurements, for use with --vdaf=sum and --vdaf=sumvec


### PR DESCRIPTION
This removes Prio3CountVec throughout. It was formerly polyfilled using Prio3SumVec inside the aggregator. Prio3CountVec is removed from the list of supported VDAFs exposed via the aggregator API, so the control plane should handle this change gracefully. I replaced Prio3CountVec with Prio3SumVec when it was incidentally used in tests.

Closes #2608. Stacked on #2633.