### PR TITLE
[0.6] Time-interval: create aggregation jobs touching fewer batches.

### DIFF
--- a/aggregator/src/aggregator/batch_creator.rs
+++ b/aggregator/src/aggregator/batch_creator.rs
@@ -372,16 +372,12 @@ where
                         time_bucket_start,
                     ))
             ),
-            async move {
-                if !unaggregated_report_ids.is_empty() {
-                    tx.mark_reports_unaggregated(
-                        &self.properties.task_id,
-                        &unaggregated_report_ids,
-                    )
-                    .await?;
-                }
-                Ok(())
-            }
+            try_join_all(
+                unaggregated_report_ids
+                    .iter()
+                    .map(|report_id| tx
+                        .mark_report_unaggregated(&self.properties.task_id, report_id))
+            ),
         )?;
         Ok(())
     }

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -1234,18 +1234,17 @@ impl<C: Clock> Transaction<'_, C> {
             .collect::<Result<Vec<_>, Error>>()
     }
 
-    /// `mark_reports_unaggregated` resets the aggregation-started flag on the given client reports,
-    /// so that they may once again be returned by `get_unaggregated_client_report_ids_for_task`. It
+    /// `mark_report_unaggregated` resets the aggregation-started flag on the given client report,
+    /// so that it may once again be returned by `get_unaggregated_client_report_ids_for_task`. It
     /// should generally only be called on report IDs returned from
     /// `get_unaggregated_client_report_ids_for_task`, as part of the same transaction, for any
     /// client reports that are not added to an aggregation job.
-    #[tracing::instrument(skip(self, report_ids), err(level = Level::DEBUG))]
-    pub async fn mark_reports_unaggregated(
+    #[tracing::instrument(skip(self), err(level = Level::DEBUG))]
+    pub async fn mark_report_unaggregated(
         &self,
         task_id: &TaskId,
-        report_ids: &[ReportId],
+        report_id: &ReportId,
     ) -> Result<(), Error> {
-        let report_ids: Vec<_> = report_ids.iter().map(ReportId::get_encoded).collect();
         let stmt = self
             .prepare_cached(
                 "UPDATE client_reports
@@ -1253,26 +1252,23 @@ impl<C: Clock> Transaction<'_, C> {
                 FROM tasks
                 WHERE client_reports.task_id = tasks.id
                   AND tasks.task_id = $1
-                  AND client_reports.report_id IN (SELECT * FROM UNNEST($2::BYTEA[]))
+                  AND client_reports.report_id = $2
                   AND client_reports.client_timestamp >= COALESCE($3::TIMESTAMP - tasks.report_expiry_age * '1 second'::INTERVAL, '-infinity'::TIMESTAMP)",
             )
             .await?;
-        let row_count = self
-            .execute(
+        check_single_row_mutation(
+            self.execute(
                 &stmt,
                 &[
                     /* task_id */ &task_id.as_ref(),
-                    /* report_ids */ &report_ids,
+                    /* report_ids */ &report_id.get_encoded(),
                     /* now */ &self.clock.now().as_naive_date_time()?,
                     /* updated_at */ &self.clock.now().as_naive_date_time()?,
                     /* updated_by */ &self.name,
                 ],
             )
-            .await?;
-        if TryInto::<usize>::try_into(row_count)? != report_ids.len() {
-            return Err(Error::MutationTargetNotFound);
-        }
-        Ok(())
+            .await?,
+        )
     }
 
     #[cfg(feature = "test-util")]

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -848,7 +848,7 @@ async fn get_unaggregated_client_reports_for_task(ephemeral_datastore: Ephemeral
     ds.run_tx("test-unaggregated-reports", |tx| {
         let (task, first_unaggregated_report) = (task.clone(), first_unaggregated_report.clone());
         Box::pin(async move {
-            tx.mark_reports_unaggregated(task.id(), &[*first_unaggregated_report.metadata().id()])
+            tx.mark_report_unaggregated(task.id(), first_unaggregated_report.metadata().id())
                 .await
         })
     })

--- a/core/src/time.rs
+++ b/core/src/time.rs
@@ -205,6 +205,7 @@ impl TimeExt for Time {
         &self,
         time_precision: &Duration,
     ) -> Result<Self, janus_messages::Error> {
+        // This function will return an error if and only if `time_precision` is 0.
         let rem = self
             .as_seconds_since_epoch()
             .checked_rem(time_precision.as_seconds())


### PR DESCRIPTION
The implementation strategy is to consider only a given batch at a time, generating as many aggregation jobs as possible. Only once there are too few reports from the batch remaining to generate any more aggregation jobs do we move on to the next batch, rolling in the leftovers from the current batch (effectively smearing across batches when necessary).

Note that this will not necessarily avoid multi-batch aggregation jobs in all cases. For example, if aggregation jobs are generated with sizes in [5, 10], and there are 11 reports available for aggregation in the current batch, this logic will generate a single batch of size 10, rolling the leftover report into the next batch. It is instead possible to generate two aggregation jobs of (say) 5 and 6, with no leftovers to be rolled into the next batch. I'm OK with this, as we generally want to create larger aggregation jobs when possible, but we may want to lean even more towards avoiding multi-batch aggregation jobs in the future.