### PR TITLE
Cancel on disconnect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2108,7 +2108,6 @@ dependencies = [
  "regex",
  "reqwest",
  "ring 0.17.7",
- "routefinder",
  "rstest",
  "rustc_version",
  "rustls 0.22.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "gimli",
 ]
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -220,12 +220,12 @@ dependencies = [
 
 [[package]]
 name = "async-dup"
-version = "1.2.2"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7427a12b8dc09291528cfb1da2447059adb4a257388c2acd6497a79d55cf6f7c"
+checksum = "7c2886ab563af5038f79ec016dd7b87947ed138b794e8dd64992962c9cca0411"
 dependencies = [
+ "async-lock 3.3.0",
  "futures-io",
- "simple-mutex",
 ]
 
 [[package]]
@@ -234,7 +234,7 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c"
 dependencies = [
- "async-lock 3.2.0",
+ "async-lock 3.3.0",
  "async-task",
  "concurrent-queue",
  "fastrand 2.0.1",
@@ -251,7 +251,7 @@ dependencies = [
  "async-channel 2.1.1",
  "async-executor",
  "async-io 2.2.2",
- "async-lock 3.2.0",
+ "async-lock 3.3.0",
  "blocking",
  "futures-lite 2.2.0",
  "once_cell",
@@ -283,7 +283,7 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6afaa937395a620e33dc6a742c593c01aced20aa376ffb0f628121198578ccc7"
 dependencies = [
- "async-lock 3.2.0",
+ "async-lock 3.3.0",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
@@ -307,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7125e42787d53db9dd54261812ef17e937c95a51e4d291373b670342fa44310c"
+checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
 dependencies = [
  "event-listener 4.0.3",
  "event-listener-strategy",
@@ -407,7 +407,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -424,7 +424,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -531,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
 dependencies = [
  "addr2line",
  "cc",
@@ -615,7 +615,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
 dependencies = [
  "async-channel 2.1.1",
- "async-lock 3.2.0",
+ "async-lock 3.3.0",
  "async-task",
  "fastrand 2.0.1",
  "futures-io",
@@ -636,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "bytemuck"
@@ -755,7 +755,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -783,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "2.2.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c"
+checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1528,7 +1528,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1602,9 +1602,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.3"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "git-version"
@@ -1623,7 +1623,7 @@ checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1732,9 +1732,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
 
 [[package]]
 name = "hex"
@@ -2223,7 +2223,7 @@ dependencies = [
  "tracing",
  "tracing-log",
  "trillium",
- "trillium-macros 0.0.5",
+ "trillium-macros",
  "trillium-router",
  "url",
 ]
@@ -2471,18 +2471,18 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2643,9 +2643,9 @@ checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -2722,18 +2722,18 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
  "wasi",
@@ -2900,23 +2900,23 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "object"
-version = "0.31.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
@@ -3090,15 +3090,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.3.5",
+ "redox_syscall 0.4.1",
  "smallvec",
- "windows-targets 0.48.1",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3163,7 +3163,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3212,7 +3212,7 @@ checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3336,7 +3336,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3476,9 +3476,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.74"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2de98502f212cfcea8d0bb305bd0f49d7ebdd75b64ba0a68f937d888f4e0d6db"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -3541,7 +3541,7 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3647,9 +3647,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
@@ -3851,7 +3851,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.46",
+ "syn 2.0.48",
  "unicode-ident",
 ]
 
@@ -3864,7 +3864,7 @@ dependencies = [
  "quote",
  "rand",
  "rustc_version",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4128,7 +4128,7 @@ checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4312,15 +4312,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
 
 [[package]]
-name = "simple-mutex"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38aabbeafa6f6dead8cebf246fe9fae1f9215c8d29b3a69f93bd62a9e4a3dcd6"
-dependencies = [
- "event-listener 2.5.3",
-]
-
-[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4343,9 +4334,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "smartcow"
@@ -4712,9 +4703,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.46"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89456b690ff72fddcecf231caedbe615c59480c93358a93dfae7fc29e3ebbf0e"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4800,7 +4791,7 @@ checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4895,7 +4886,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5158,7 +5149,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5282,7 +5273,7 @@ dependencies = [
  "serde_path_to_error",
  "thiserror",
  "trillium",
- "trillium-macros 0.0.5",
+ "trillium-macros",
 ]
 
 [[package]]
@@ -5330,9 +5321,9 @@ dependencies = [
 
 [[package]]
 name = "trillium-http"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6997c0854d48d4f117bad350a0e1ac3f64e8cc3b639b3834be5f3fba382f488"
+checksum = "f8afd3a7e9a46df93d81229fcd2011e089ed522c55ef633edee8893a23cb88e9"
 dependencies = [
  "encoding_rs",
  "futures-lite 2.2.0",
@@ -5347,18 +5338,7 @@ dependencies = [
  "smartstring",
  "stopper",
  "thiserror",
- "trillium-macros 0.0.5",
-]
-
-[[package]]
-name = "trillium-macros"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d19bf7f37bc3e66beae9792c0f7a0e3500465cf431da63fdb6af593b0e353a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.46",
+ "trillium-macros",
 ]
 
 [[package]]
@@ -5369,7 +5349,7 @@ checksum = "916054381183f0cfed7604bf7de2044a760624a50d26eef5492468fb73083bbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5441,18 +5421,21 @@ dependencies = [
 
 [[package]]
 name = "trillium-testing"
-version = "0.5.0"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556cad53e12159259c9f8eb56fc1fe6b6d54057c61d1da80a59cbf9ebf162ba6"
+checksum = "7d3a22281ea7a75259e5abd011999647e8e6ba9adb01a736be86c9507e0629a5"
 dependencies = [
- "async-channel 1.9.0",
+ "async-channel 2.1.1",
  "async-dup",
  "cfg-if",
- "futures-lite 1.13.0",
+ "dashmap",
+ "fastrand 2.0.1",
+ "futures-lite 2.2.0",
+ "once_cell",
  "portpicker",
  "trillium",
  "trillium-http",
- "trillium-macros 0.0.4",
+ "trillium-macros",
  "trillium-server-common",
  "trillium-tokio",
  "url",
@@ -5472,7 +5455,7 @@ dependencies = [
  "tokio-stream",
  "trillium",
  "trillium-http",
- "trillium-macros 0.0.5",
+ "trillium-macros",
  "trillium-server-common",
  "url",
 ]
@@ -5532,15 +5515,15 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
@@ -5640,9 +5623,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"
-version = "1.4.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a72e1902dde2bd6441347de2b70b7f5d59bf157c6c62f0c44572607a1d55bbe"
+checksum = "126e423afe2dd9ac52142e7e9d5ce4135d7e13776c529d27fd6bc49f19e3280b"
 
 [[package]]
 name = "vcpkg"
@@ -5698,9 +5681,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -5708,16 +5691,16 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
@@ -5735,9 +5718,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5745,22 +5728,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
 
 [[package]]
 name = "web-sys"
@@ -5844,7 +5827,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets 0.48.1",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5853,7 +5836,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.1",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5867,17 +5850,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5897,9 +5880,9 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -5909,9 +5892,9 @@ checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5921,9 +5904,9 @@ checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5933,9 +5916,9 @@ checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5945,9 +5928,9 @@ checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5957,9 +5940,9 @@ checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5969,9 +5952,9 @@ checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6056,22 +6039,22 @@ checksum = "735a71d46c4d68d71d4b24d03fdc2b98e38cea81730595801db779c04fe80d70"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.31"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.31"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -6091,7 +6074,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ trillium-head = "0.2.1"
 trillium-opentelemetry = "0.4.0"
 trillium-router = "0.3.6"
 trillium-rustls = "0.4.2"
-trillium-testing = "0.5.0"
+trillium-testing = "0.5.4"
 trillium-tokio = "0.3.4"
 url = { version = "2.5.0", features = ["serde"] }
 uuid = { version = "1.7.0", features = ["v4"] }

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -76,7 +76,6 @@ rand = { workspace = true, features = ["min_const_gen"] }
 regex = "1"
 reqwest = { version = "0.11.24", default-features = false, features = ["rustls-tls", "json"] }
 ring = "0.17.7"
-routefinder = "0.5.4"
 rustls = "0.22.2"
 rustls-pemfile = "2.0.0"
 serde.workspace = true

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1172,6 +1172,7 @@ enum VdafOps {
 /// length, also for explicitly specifying type parameters.
 macro_rules! vdaf_ops_dispatch {
     ($vdaf_ops:expr, ($vdaf:pat_param, $verify_key:pat_param, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident, $dp_strategy:ident, $DpStrategy:ident) => $body:tt) => {
+        #[allow(unused_braces)]
         match $vdaf_ops {
             crate::aggregator::VdafOps::Prio3Count(vdaf, verify_key) => {
                 let $vdaf = vdaf;

--- a/aggregator/src/aggregator/error.rs
+++ b/aggregator/src/aggregator/error.rs
@@ -144,7 +144,7 @@ pub enum Error {
     /// An error occurred when trying to ensure differential privacy.
     #[error("differential privacy error: {0}")]
     DifferentialPrivacy(VdafError),
-    /// the http client disconnected while we were still executing
+    /// The http client disconnected while we were still executing.
     #[error("http client disconnect")]
     ClientDisconnected,
 }

--- a/aggregator/src/aggregator/error.rs
+++ b/aggregator/src/aggregator/error.rs
@@ -144,6 +144,9 @@ pub enum Error {
     /// An error occurred when trying to ensure differential privacy.
     #[error("differential privacy error: {0}")]
     DifferentialPrivacy(VdafError),
+    /// the http client disconnected while we were still executing
+    #[error("http client disconnect")]
+    ClientDisconnected,
 }
 
 /// Contains details that describe the report and why it was rejected.
@@ -307,6 +310,7 @@ impl Error {
             Error::BadRequest(_) => "bad_request",
             Error::InvalidTask(_, _) => "invalid_task",
             Error::DifferentialPrivacy(_) => "differential_privacy",
+            Error::ClientDisconnected => "client_disconnected",
         }
     }
 }

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -163,12 +163,14 @@ impl Handler for Error {
     }
 }
 
-/// The number of seconds we send in the Access-Control-Max-Age header. This determines for how
-/// long clients will cache the results of CORS preflight requests. Of popular browsers, Mozilla
-/// Firefox has the highest Max-Age cap, at 24 hours, so we use that. Our CORS preflight handlers
-/// are tightly scoped to relevant endpoints, and our CORS settings are unlikely to change.
-/// See: <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age>.
-const CORS_PREFLIGHT_CACHE_AGE: &str = "86400"; //24 * 60 * 60;
+/// The number of seconds we send in the Access-Control-Max-Age header. This determines for how long
+/// clients will cache the results of CORS preflight requests. Of popular browsers, Mozilla Firefox
+/// has the highest Max-Age cap, at 24 hours, so we use that (`24 * 60 * 60 = 86400`). Our CORS
+/// preflight handlers are tightly scoped to relevant endpoints, and our CORS settings are unlikely
+/// to change.  See [Access-Control-Max-Age on mdn][mdn].
+///
+/// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
+const CORS_PREFLIGHT_CACHE_AGE: &str = "86400";
 
 /// Wrapper around a type that implements [`Encode`]. It acts as a Trillium handler, encoding the
 /// inner object and sending it as the response body, setting the Content-Type header to the

--- a/aggregator_api/src/lib.rs
+++ b/aggregator_api/src/lib.rs
@@ -10,10 +10,10 @@ use janus_aggregator_core::{
     instrumented,
 };
 use janus_core::{auth_tokens::AuthenticationToken, hpke, http::extract_bearer_token, time::Clock};
-use janus_messages::{HpkeConfigId, RoleParseError, TaskId};
+use janus_messages::RoleParseError;
 use opentelemetry::metrics::Meter;
 use routes::*;
-use std::{borrow::Cow, str::FromStr, sync::Arc};
+use std::{borrow::Cow, sync::Arc};
 use tracing::error;
 use trillium::{
     Conn, Handler,
@@ -21,7 +21,7 @@ use trillium::{
     Status,
     Status::{NotAcceptable, UnsupportedMediaType},
 };
-use trillium_api::{api, Halt, State};
+use trillium_api::{api, cancel_on_disconnect, Halt, State};
 use trillium_opentelemetry::metrics;
 use trillium_router::{Router, RouterConnExt};
 use url::Url;
@@ -88,50 +88,59 @@ pub fn aggregator_api_handler<C: Clock>(
         ReplaceMimeTypes,
         // Main functionality router.
         Router::new()
-            .get("/", instrumented(api(get_config)))
-            .get("/task_ids", instrumented(api(get_task_ids::<C>)))
-            .post("/tasks", instrumented(api(post_task::<C>)))
-            .get("/tasks/:task_id", instrumented(api(get_task::<C>)))
-            .delete("/tasks/:task_id", instrumented(api(delete_task::<C>)))
+            .get("/", instrumented(cancel_on_disconnect(get_config)))
+            .get(
+                "/task_ids",
+                instrumented(cancel_on_disconnect(get_task_ids::<C>)),
+            )
+            .post("/tasks", instrumented(cancel_on_disconnect(post_task::<C>)))
+            .get(
+                "/tasks/:task_id",
+                instrumented(cancel_on_disconnect(get_task::<C>)),
+            )
+            .delete(
+                "/tasks/:task_id",
+                instrumented(cancel_on_disconnect(delete_task::<C>)),
+            )
             .get(
                 "/tasks/:task_id/metrics/uploads",
-                instrumented(api(get_task_upload_metrics::<C>)),
+                instrumented(cancel_on_disconnect(get_task_upload_metrics::<C>)),
             )
             .get(
                 "/tasks/:task_id/metrics",
-                instrumented(api(get_task_metrics::<C>)),
+                instrumented(cancel_on_disconnect(get_task_metrics::<C>)),
             )
             .get(
                 "/hpke_configs",
-                instrumented(api(get_global_hpke_configs::<C>)),
+                instrumented(cancel_on_disconnect(get_global_hpke_configs::<C>)),
             )
             .get(
                 "/hpke_configs/:config_id",
-                instrumented(api(get_global_hpke_config::<C>)),
+                instrumented(cancel_on_disconnect(get_global_hpke_config::<C>)),
             )
             .put(
                 "/hpke_configs",
-                instrumented(api(put_global_hpke_config::<C>)),
+                instrumented(cancel_on_disconnect(put_global_hpke_config::<C>)),
             )
             .patch(
                 "/hpke_configs/:config_id",
-                instrumented(api(patch_global_hpke_config::<C>)),
+                instrumented(cancel_on_disconnect(patch_global_hpke_config::<C>)),
             )
             .delete(
                 "/hpke_configs/:config_id",
-                instrumented(api(delete_global_hpke_config::<C>)),
+                instrumented(cancel_on_disconnect(delete_global_hpke_config::<C>)),
             )
             .get(
                 "/taskprov/peer_aggregators",
-                instrumented(api(get_taskprov_peer_aggregators::<C>)),
+                instrumented(cancel_on_disconnect(get_taskprov_peer_aggregators::<C>)),
             )
             .post(
                 "/taskprov/peer_aggregators",
-                instrumented(api(post_taskprov_peer_aggregator::<C>)),
+                instrumented(cancel_on_disconnect(post_taskprov_peer_aggregator::<C>)),
             )
             .delete(
                 "/taskprov/peer_aggregators",
-                instrumented(api(delete_taskprov_peer_aggregator::<C>)),
+                instrumented(cancel_on_disconnect(delete_taskprov_peer_aggregator::<C>)),
             ),
     )
 }
@@ -218,29 +227,5 @@ impl Handler for Error {
                 .with_body(err.to_string()),
         }
         .halt()
-    }
-}
-
-trait ConnExt {
-    fn task_id_param(&self) -> Result<TaskId, Error>;
-    fn hpke_config_id_param(&self) -> Result<HpkeConfigId, Error>;
-}
-
-impl ConnExt for Conn {
-    fn task_id_param(&self) -> Result<TaskId, Error> {
-        TaskId::from_str(
-            self.param("task_id")
-                .ok_or_else(|| Error::Internal("Missing task_id parameter".to_string()))?,
-        )
-        .map_err(|err| Error::BadRequest(format!("{:?}", err)))
-    }
-
-    fn hpke_config_id_param(&self) -> Result<HpkeConfigId, Error> {
-        Ok(HpkeConfigId::from(
-            self.param("config_id")
-                .ok_or_else(|| Error::Internal("Missing config_id parameter".to_string()))?
-                .parse::<u8>()
-                .map_err(|_| Error::BadRequest("Invalid config_id parameter".to_string()))?,
-        ))
     }
 }

--- a/aggregator_api/src/routes.rs
+++ b/aggregator_api/src/routes.rs
@@ -5,7 +5,7 @@ use crate::{
         PatchGlobalHpkeConfigReq, PostTaskReq, PostTaskprovPeerAggregatorReq,
         PutGlobalHpkeConfigReq, SupportedVdaf, TaskResp, TaskprovPeerAggregatorResp,
     },
-    Config, ConnExt, Error,
+    Config, Error,
 };
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use janus_aggregator_core::{
@@ -25,14 +25,14 @@ use janus_messages::{
 use querystring::querify;
 use rand::random;
 use ring::digest::{digest, SHA256};
-use std::{str::FromStr, sync::Arc, unreachable};
-use trillium::{Conn, Status};
-use trillium_api::{Json, State};
+use std::{ops::Deref, str::FromStr, sync::Arc, unreachable};
+use trillium::{async_trait, Conn, Status};
+use trillium_api::{Json, State, TryFromConn};
+use trillium_router::RouterConnExt;
 
-pub(super) async fn get_config(
-    _: &mut Conn,
-    State(config): State<Arc<Config>>,
-) -> Json<AggregatorApiConfig> {
+type Store<C> = State<Arc<Datastore<C>>>;
+
+pub(super) async fn get_config(State(config): State<Arc<Config>>) -> Json<AggregatorApiConfig> {
     Json(AggregatorApiConfig {
         protocol: "DAP-07",
         dap_url: config.public_dap_url.clone(),
@@ -52,18 +52,24 @@ pub(super) async fn get_config(
     })
 }
 
-pub(super) async fn get_task_ids<C: Clock>(
-    conn: &mut Conn,
-    State(ds): State<Arc<Datastore<C>>>,
-) -> Result<Json<GetTaskIdsResp>, Error> {
-    const PAGINATION_TOKEN_KEY: &str = "pagination_token";
-    let lower_bound = querify(conn.querystring())
-        .into_iter()
-        .find(|&(k, _)| k == PAGINATION_TOKEN_KEY)
-        .map(|(_, v)| TaskId::from_str(v))
-        .transpose()
-        .map_err(|err| Error::BadRequest(format!("Couldn't parse pagination_token: {:?}", err)))?;
+pub(crate) struct LowerBound(Option<TaskId>);
+#[async_trait]
+impl TryFromConn for LowerBound {
+    type Error = Error;
+    async fn try_from_conn(conn: &mut Conn) -> Result<Self, Self::Error> {
+        querify(conn.querystring())
+            .into_iter()
+            .find(|&(k, _)| k == "pagination_token")
+            .map(|(_, v)| TaskId::from_str(v))
+            .transpose()
+            .map(Self)
+            .map_err(|err| Error::BadRequest(format!("Couldn't parse pagination_token: {:?}", err)))
+    }
+}
 
+pub(super) async fn get_task_ids<C: Clock>(
+    (LowerBound(lower_bound), ds): (LowerBound, Store<C>),
+) -> Result<Json<GetTaskIdsResp>, Error> {
     let task_ids = ds
         .run_tx("get_task_ids", |tx| {
             Box::pin(async move { tx.get_task_ids(lower_bound).await })
@@ -78,8 +84,7 @@ pub(super) async fn get_task_ids<C: Clock>(
 }
 
 pub(super) async fn post_task<C: Clock>(
-    _: &mut Conn,
-    (State(ds), Json(req)): (State<Arc<Datastore<C>>>, Json<PostTaskReq>),
+    (ds, Json(req)): (Store<C>, Json<PostTaskReq>),
 ) -> Result<Json<TaskResp>, Error> {
     if !matches!(req.role, Role::Leader | Role::Helper) {
         return Err(Error::BadRequest(format!("invalid role {}", req.role)));
@@ -222,12 +227,54 @@ pub(super) async fn post_task<C: Clock>(
     Ok(Json(task_resp))
 }
 
-pub(super) async fn get_task<C: Clock>(
-    conn: &mut Conn,
-    State(ds): State<Arc<Datastore<C>>>,
-) -> Result<Json<TaskResp>, Error> {
-    let task_id = conn.task_id_param()?;
+#[derive(Copy, Clone)]
+pub(crate) struct TaskIdParam(TaskId);
+impl Deref for TaskIdParam {
+    type Target = TaskId;
 
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[async_trait]
+impl TryFromConn for TaskIdParam {
+    type Error = Error;
+    async fn try_from_conn(conn: &mut Conn) -> Result<Self, Self::Error> {
+        TaskId::from_str(
+            conn.param("task_id")
+                .ok_or_else(|| Error::Internal("Missing task_id parameter".to_string()))?,
+        )
+        .map_err(|err| Error::BadRequest(format!("{:?}", err)))
+        .map(Self)
+    }
+}
+
+#[derive(Copy, Clone)]
+pub(crate) struct HpkeConfigIdParam(HpkeConfigId);
+impl Deref for HpkeConfigIdParam {
+    type Target = HpkeConfigId;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+#[async_trait]
+impl TryFromConn for HpkeConfigIdParam {
+    type Error = Error;
+    async fn try_from_conn(conn: &mut Conn) -> Result<Self, Self::Error> {
+        Ok(Self(HpkeConfigId::from(
+            conn.param("config_id")
+                .ok_or_else(|| Error::Internal("Missing config_id parameter".to_string()))?
+                .parse::<u8>()
+                .map_err(|_| Error::BadRequest("Invalid config_id parameter".to_string()))?,
+        )))
+    }
+}
+
+pub(super) async fn get_task<C: Clock>(
+    (task_id, ds): (TaskIdParam, Store<C>),
+) -> Result<Json<TaskResp>, Error> {
     let task = ds
         .run_tx("get_task", |tx| {
             Box::pin(async move { tx.get_aggregator_task(&task_id).await })
@@ -241,10 +288,8 @@ pub(super) async fn get_task<C: Clock>(
 }
 
 pub(super) async fn delete_task<C: Clock>(
-    conn: &mut Conn,
-    State(ds): State<Arc<Datastore<C>>>,
+    (TaskIdParam(task_id), ds): (TaskIdParam, Store<C>),
 ) -> Result<Status, Error> {
-    let task_id = conn.task_id_param()?;
     match ds
         .run_tx("delete_task", |tx| {
             Box::pin(async move { tx.delete_task(&task_id).await })
@@ -257,11 +302,8 @@ pub(super) async fn delete_task<C: Clock>(
 }
 
 pub(super) async fn get_task_metrics<C: Clock>(
-    conn: &mut Conn,
-    State(ds): State<Arc<Datastore<C>>>,
+    (task_id, ds): (TaskIdParam, Store<C>),
 ) -> Result<Json<GetTaskMetricsResp>, Error> {
-    let task_id = conn.task_id_param()?;
-
     let (reports, report_aggregations) = ds
         .run_tx("get_task_metrics", |tx| {
             Box::pin(async move { tx.get_task_metrics(&task_id).await })
@@ -276,10 +318,8 @@ pub(super) async fn get_task_metrics<C: Clock>(
 }
 
 pub(super) async fn get_task_upload_metrics<C: Clock>(
-    conn: &mut Conn,
-    State(ds): State<Arc<Datastore<C>>>,
+    (task_id, ds): (TaskIdParam, Store<C>),
 ) -> Result<Json<GetTaskUploadMetricsResp>, Error> {
-    let task_id = conn.task_id_param()?;
     Ok(Json(GetTaskUploadMetricsResp(
         ds.run_tx("get_task_upload_metrics", |tx| {
             Box::pin(async move { tx.get_task_upload_counter(&task_id).await })
@@ -290,8 +330,7 @@ pub(super) async fn get_task_upload_metrics<C: Clock>(
 }
 
 pub(super) async fn get_global_hpke_configs<C: Clock>(
-    _: &mut Conn,
-    State(ds): State<Arc<Datastore<C>>>,
+    ds: Store<C>,
 ) -> Result<Json<Vec<GlobalHpkeConfigResp>>, Error> {
     Ok(Json(
         ds.run_tx("get_global_hpke_configs", |tx| {
@@ -305,10 +344,8 @@ pub(super) async fn get_global_hpke_configs<C: Clock>(
 }
 
 pub(super) async fn get_global_hpke_config<C: Clock>(
-    conn: &mut Conn,
-    State(ds): State<Arc<Datastore<C>>>,
+    (config_id, ds): (HpkeConfigIdParam, Store<C>),
 ) -> Result<Json<GlobalHpkeConfigResp>, Error> {
-    let config_id = conn.hpke_config_id_param()?;
     Ok(Json(GlobalHpkeConfigResp::from(
         ds.run_tx("get_global_hpke_config", |tx| {
             Box::pin(async move { tx.get_global_hpke_keypair(&config_id).await })
@@ -319,8 +356,7 @@ pub(super) async fn get_global_hpke_config<C: Clock>(
 }
 
 pub(super) async fn put_global_hpke_config<C: Clock>(
-    _: &mut Conn,
-    (State(ds), Json(req)): (State<Arc<Datastore<C>>>, Json<PutGlobalHpkeConfigReq>),
+    (ds, Json(req)): (Store<C>, Json<PutGlobalHpkeConfigReq>),
 ) -> Result<(Status, Json<GlobalHpkeConfigResp>), Error> {
     let existing_keypairs = ds
         .run_tx("put_global_hpke_config_determine_id", |tx| {
@@ -363,11 +399,8 @@ pub(super) async fn put_global_hpke_config<C: Clock>(
 }
 
 pub(super) async fn patch_global_hpke_config<C: Clock>(
-    conn: &mut Conn,
-    (State(ds), Json(req)): (State<Arc<Datastore<C>>>, Json<PatchGlobalHpkeConfigReq>),
+    (Json(req), config_id, ds): (Json<PatchGlobalHpkeConfigReq>, HpkeConfigIdParam, Store<C>),
 ) -> Result<Status, Error> {
-    let config_id = conn.hpke_config_id_param()?;
-
     ds.run_tx("patch_hpke_global_keypair", |tx| {
         Box::pin(async move {
             tx.set_global_hpke_keypair_state(&config_id, &req.state)
@@ -380,10 +413,8 @@ pub(super) async fn patch_global_hpke_config<C: Clock>(
 }
 
 pub(super) async fn delete_global_hpke_config<C: Clock>(
-    conn: &mut Conn,
-    State(ds): State<Arc<Datastore<C>>>,
+    (config_id, ds): (HpkeConfigIdParam, Store<C>),
 ) -> Result<Status, Error> {
-    let config_id = conn.hpke_config_id_param()?;
     match ds
         .run_tx("delete_global_hpke_config", |tx| {
             Box::pin(async move { tx.delete_global_hpke_keypair(&config_id).await })
@@ -396,8 +427,7 @@ pub(super) async fn delete_global_hpke_config<C: Clock>(
 }
 
 pub(super) async fn get_taskprov_peer_aggregators<C: Clock>(
-    _: &mut Conn,
-    State(ds): State<Arc<Datastore<C>>>,
+    ds: Store<C>,
 ) -> Result<Json<Vec<TaskprovPeerAggregatorResp>>, Error> {
     Ok(Json(
         ds.run_tx("get_taskprov_peer_aggregators", |tx| {
@@ -417,11 +447,7 @@ pub(super) async fn get_taskprov_peer_aggregators<C: Clock>(
 /// token rotation cumbersome and fragile. Since token rotation is the main use case for updating
 /// an existing peer aggregator, we will resolve peer aggregator updates in that issue.
 pub(super) async fn post_taskprov_peer_aggregator<C: Clock>(
-    _: &mut Conn,
-    (State(ds), Json(req)): (
-        State<Arc<Datastore<C>>>,
-        Json<PostTaskprovPeerAggregatorReq>,
-    ),
+    (ds, Json(req)): (Store<C>, Json<PostTaskprovPeerAggregatorReq>),
 ) -> Result<(Status, Json<TaskprovPeerAggregatorResp>), Error> {
     let to_insert = PeerAggregator::new(
         req.endpoint,
@@ -451,11 +477,7 @@ pub(super) async fn post_taskprov_peer_aggregator<C: Clock>(
 }
 
 pub(super) async fn delete_taskprov_peer_aggregator<C: Clock>(
-    _: &mut Conn,
-    (State(ds), Json(req)): (
-        State<Arc<Datastore<C>>>,
-        Json<DeleteTaskprovPeerAggregatorReq>,
-    ),
+    (ds, req): (Store<C>, Json<DeleteTaskprovPeerAggregatorReq>),
 ) -> Result<Status, Error> {
     match ds
         .run_tx("delete_taskprov_peer_aggregator", |tx| {


### PR DESCRIPTION
This uses two different approaches to the new cancel-on-disconnect api. I'm interested in feedback on which of them y'all prefer, and I can convert whichever to the other or leave them as is.

aggregator-api uses trillium-api's cancel on disconnect handler, which requires extracting all context from the conn prior to running the handler.

The DAP endpoints use Conn::cancel_on_disconnect for a less invasive change.

Since these endpoints really only have one await point each, they are entirely equivalent in terms of cancellation behavior.