### PR TITLE
Set HTTP client timeouts (backport #2632)

### DIFF
--- a/aggregator/src/binaries/aggregation_job_driver.rs
+++ b/aggregator/src/binaries/aggregation_job_driver.rs
@@ -21,6 +21,14 @@ pub async fn main_callback(ctx: BinaryContext<RealClock, Options, Config>) -> Re
     let aggregation_job_driver = Arc::new(AggregationJobDriver::new(
         reqwest::Client::builder()
             .user_agent(CLIENT_USER_AGENT)
+            .timeout(Duration::from_secs(
+                ctx.config.job_driver_config.http_request_timeout_secs,
+            ))
+            .connect_timeout(Duration::from_secs(
+                ctx.config
+                    .job_driver_config
+                    .http_request_connection_timeout_secs,
+            ))
             .build()
             .context("couldn't create HTTP client")?,
         &ctx.meter,
@@ -152,6 +160,8 @@ mod tests {
                 worker_lease_duration_secs: 600,
                 worker_lease_clock_skew_allowance_secs: 60,
                 maximum_attempts_before_failure: 5,
+                http_request_timeout_secs: 10,
+                http_request_connection_timeout_secs: 30,
             },
             batch_aggregation_shard_count: 32,
             taskprov_config: TaskprovConfig::default(),

--- a/aggregator/src/binaries/collection_job_driver.rs
+++ b/aggregator/src/binaries/collection_job_driver.rs
@@ -21,6 +21,14 @@ pub async fn main_callback(ctx: BinaryContext<RealClock, Options, Config>) -> Re
     let collection_job_driver = Arc::new(CollectionJobDriver::new(
         reqwest::Client::builder()
             .user_agent(CLIENT_USER_AGENT)
+            .timeout(Duration::from_secs(
+                ctx.config.job_driver_config.http_request_timeout_secs,
+            ))
+            .connect_timeout(Duration::from_secs(
+                ctx.config
+                    .job_driver_config
+                    .http_request_connection_timeout_secs,
+            ))
             .build()
             .context("couldn't create HTTP client")?,
         &ctx.meter,
@@ -148,6 +156,8 @@ mod tests {
                 worker_lease_duration_secs: 600,
                 worker_lease_clock_skew_allowance_secs: 60,
                 maximum_attempts_before_failure: 5,
+                http_request_timeout_secs: 10,
+                http_request_connection_timeout_secs: 30,
             },
             batch_aggregation_shard_count: 32,
         })

--- a/aggregator/tests/integration/graceful_shutdown.rs
+++ b/aggregator/tests/integration/graceful_shutdown.rs
@@ -317,6 +317,8 @@ async fn aggregation_job_driver_shutdown() {
             worker_lease_duration_secs: 600,
             worker_lease_clock_skew_allowance_secs: 60,
             maximum_attempts_before_failure: 5,
+            http_request_timeout_secs: 10,
+            http_request_connection_timeout_secs: 30,
         },
         taskprov_config: TaskprovConfig { enabled: false },
         batch_aggregation_shard_count: 32,
@@ -346,6 +348,8 @@ async fn collection_job_driver_shutdown() {
             worker_lease_duration_secs: 600,
             worker_lease_clock_skew_allowance_secs: 60,
             maximum_attempts_before_failure: 5,
+            http_request_timeout_secs: 10,
+            http_request_connection_timeout_secs: 30,
         },
         batch_aggregation_shard_count: 32,
     };

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -142,6 +142,10 @@ static COLLECTOR_USER_AGENT: &str = concat!(
 /// Construct a [`reqwest::Client`] suitable for use in a DAP [`Collector`].
 pub fn default_http_client() -> Result<reqwest::Client, Error> {
     Ok(reqwest::Client::builder()
+        // Clients may override default timeouts using
+        // CollectorBuilder::with_http_client
+        .timeout(StdDuration::from_secs(30))
+        .connect_timeout(StdDuration::from_secs(10))
         .user_agent(COLLECTOR_USER_AGENT)
         .build()?)
 }

--- a/docs/samples/advanced_config/aggregation_job_driver.yaml
+++ b/docs/samples/advanced_config/aggregation_job_driver.yaml
@@ -87,6 +87,17 @@ worker_lease_clock_skew_allowance_secs: 60
 # (required)
 maximum_attempts_before_failure: 10
 
+# Timeout to apply when establishing connections to the helper for HTTP requests, in seconds. See
+# https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.connect_timeout for
+# details. (optional; defaults to 10 seconds)
+http_request_connection_timeout_secs: 10
+
+# Timeout to apply to HTTP requests overall (including connection establishment) when communicating
+# with the helper. See
+# https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.timeout for details.
+# (optional; defaults to 30 seconds)
+http_request_timeout_secs: 30
+
 # Number of sharded database records per batch aggregation. Must not be greater
 # than the equivalent setting in the collection job driver. (required)
 batch_aggregation_shard_count: 32

--- a/docs/samples/advanced_config/collection_job_driver.yaml
+++ b/docs/samples/advanced_config/collection_job_driver.yaml
@@ -87,6 +87,17 @@ worker_lease_clock_skew_allowance_secs: 60
 # (required)
 maximum_attempts_before_failure: 10
 
+# Timeout to apply when establishing connections to the helper for HTTP requests, in seconds. See
+# https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.connect_timeout for
+# details. (optional; defaults to 10 seconds)
+http_request_connection_timeout_secs: 10
+
+# Timeout to apply to HTTP requests overall (including connection establishment) when communicating
+# with the helper. See
+# https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.timeout for details.
+# (optional; defaults to 30 seconds)
+http_request_timeout_secs: 30
+
 # Number of sharded database records per batch aggregation. Must not be less
 # than the equivalent setting in the aggregator and aggregation job driver.
 # (required)

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -183,6 +183,8 @@ impl JanusInProcess {
                 worker_lease_duration_secs: 10,
                 worker_lease_clock_skew_allowance_secs: 1,
                 maximum_attempts_before_failure: 3,
+                http_request_timeout_secs: 30,
+                http_request_connection_timeout_secs: 10,
             },
             taskprov_config: TaskprovConfig::default(),
             batch_aggregation_shard_count: 32,
@@ -198,6 +200,8 @@ impl JanusInProcess {
                 worker_lease_duration_secs: 10,
                 worker_lease_clock_skew_allowance_secs: 1,
                 maximum_attempts_before_failure: 3,
+                http_request_timeout_secs: 30,
+                http_request_connection_timeout_secs: 10,
             },
             batch_aggregation_shard_count: 32,
         };


### PR DESCRIPTION
* client, collector: default timeouts for requests

Apply default timeouts (10 s to connect, 30 s overall) to HTTP requests made by the client and collector crates. Additionally, we remove `ClientParameters::new_with_backoff`: since that struct was private to the crate anyway, we can just write directly to its `http_request_retry_parameters` field, and `ClientBuilder::with_backoff` provides a public API affordance for achieving this.

Resolves #426

* Apply timeouts to leader->helper HTTP requests

Set default timeouts for HTTP requests made from leader to helper, and wire up config options for them.