### PR TITLE
Hotfix: disable task counter updates

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -3290,7 +3290,7 @@ mod tests {
     use futures::future::try_join_all;
     use janus_aggregator_core::{
         datastore::{
-            models::{CollectionJob, CollectionJobState, TaskUploadCounter},
+            models::{CollectionJob, CollectionJobState},
             test_util::{ephemeral_datastore, EphemeralDatastore},
             Datastore,
         },
@@ -3479,7 +3479,7 @@ mod tests {
             .unwrap();
 
         // Verify that the original report, rather than the modified report, is stored.
-        let (got_report, got_counter) = ds
+        let (got_report, _got_counter) = ds
             .run_unnamed_tx(|tx| {
                 let vdaf = vdaf.clone();
                 let task_id = *task.id();
@@ -3498,10 +3498,13 @@ mod tests {
         assert!(got_report
             .unwrap()
             .eq_report(&vdaf, leader_task.current_hpke_key(), &report));
-        assert_eq!(
-            got_counter,
-            Some(TaskUploadCounter::new(0, 0, 0, 0, 0, 1, 0, 0))
-        )
+
+        // Incrementing upload counters disabled for now
+        // https://github.com/divviup/janus/issues/2654
+        // assert_eq!(
+        //     got_counter,
+        //     Some(TaskUploadCounter::new(0, 0, 0, 0, 0, 1, 0, 0))
+        // )
     }
 
     #[tokio::test]
@@ -3547,17 +3550,19 @@ mod tests {
 
         assert_eq!(want_report_ids, got_report_ids);
 
-        let got_counters = datastore
-            .run_unnamed_tx(|tx| {
-                let task_id = *task.id();
-                Box::pin(async move { tx.get_task_upload_counter(&task_id).await })
-            })
-            .await
-            .unwrap();
-        assert_eq!(
-            got_counters,
-            Some(TaskUploadCounter::new(0, 0, 0, 0, 0, 100, 0, 0))
-        );
+        // Incrementing upload counters disabled for now
+        // https://github.com/divviup/janus/issues/2654
+        // let got_counters = datastore
+        //     .run_unnamed_tx(|tx| {
+        //         let task_id = *task.id();
+        //         Box::pin(async move { tx.get_task_upload_counter(&task_id).await })
+        //     })
+        //     .await
+        //     .unwrap();
+        // assert_eq!(
+        //     got_counters,
+        //     Some(TaskUploadCounter::new(0, 0, 0, 0, 0, 100, 0, 0))
+        // );
     }
 
     #[tokio::test]
@@ -3565,7 +3570,7 @@ mod tests {
         install_test_trace_subscriber();
 
         let mut runtime_manager = TestRuntimeManager::new();
-        let (_, aggregator, clock, task, datastore, _ephemeral_datastore) =
+        let (_, aggregator, clock, task, _datastore, _ephemeral_datastore) =
             setup_upload_test_with_runtime(
                 runtime_manager.with_label("aggregator"),
                 default_aggregator_config(),
@@ -3611,17 +3616,19 @@ mod tests {
             .wait_for_completed_tasks("aggregator", 1)
             .await;
 
-        let got_counters = datastore
-            .run_unnamed_tx(|tx| {
-                let task_id = *task.id();
-                Box::pin(async move { tx.get_task_upload_counter(&task_id).await })
-            })
-            .await
-            .unwrap();
-        assert_eq!(
-            got_counters,
-            Some(TaskUploadCounter::new(0, 0, 0, 0, 1, 0, 0, 0))
-        )
+        // Incrementing upload counters disabled for now
+        // https://github.com/divviup/janus/issues/2654
+        // let got_counters = datastore
+        //     .run_unnamed_tx(|tx| {
+        //         let task_id = *task.id();
+        //         Box::pin(async move { tx.get_task_upload_counter(&task_id).await })
+        //     })
+        //     .await
+        //     .unwrap();
+        // assert_eq!(
+        //     got_counters,
+        //     Some(TaskUploadCounter::new(0, 0, 0, 0, 1, 0, 0, 0))
+        // )
     }
 
     #[tokio::test]
@@ -3652,24 +3659,26 @@ mod tests {
         assert_eq!(task.id(), got_report.task_id());
         assert_eq!(report.metadata(), got_report.metadata());
 
-        let got_counters = datastore
-            .run_unnamed_tx(|tx| {
-                let task_id = *task.id();
-                Box::pin(async move { tx.get_task_upload_counter(&task_id).await })
-            })
-            .await
-            .unwrap();
-        assert_eq!(
-            got_counters,
-            Some(TaskUploadCounter::new(0, 0, 0, 0, 0, 1, 0, 0))
-        )
+        // Incrementing upload counters disabled for now
+        // https://github.com/divviup/janus/issues/2654
+        // let got_counters = datastore
+        //     .run_unnamed_tx(|tx| {
+        //         let task_id = *task.id();
+        //         Box::pin(async move { tx.get_task_upload_counter(&task_id).await })
+        //     })
+        //     .await
+        //     .unwrap();
+        // assert_eq!(
+        //     got_counters,
+        //     Some(TaskUploadCounter::new(0, 0, 0, 0, 0, 1, 0, 0))
+        // )
     }
 
     #[tokio::test]
     async fn upload_report_in_the_future_past_clock_skew() {
         install_test_trace_subscriber();
         let mut runtime_manager = TestRuntimeManager::new();
-        let (_, aggregator, clock, task, datastore, _ephemeral_datastore) =
+        let (_, aggregator, clock, task, _datastore, _ephemeral_datastore) =
             setup_upload_test_with_runtime(
                 runtime_manager.with_label("aggregator"),
                 default_aggregator_config(),
@@ -3701,17 +3710,19 @@ mod tests {
             .wait_for_completed_tasks("aggregator", 1)
             .await;
 
-        let got_counters = datastore
-            .run_unnamed_tx(|tx| {
-                let task_id = *task.id();
-                Box::pin(async move { tx.get_task_upload_counter(&task_id).await })
-            })
-            .await
-            .unwrap();
-        assert_eq!(
-            got_counters,
-            Some(TaskUploadCounter::new(0, 0, 0, 0, 0, 0, 1, 0))
-        )
+        // Incrementing upload counters disabled for now
+        // https://github.com/divviup/janus/issues/2654
+        // let got_counters = datastore
+        //     .run_unnamed_tx(|tx| {
+        //         let task_id = *task.id();
+        //         Box::pin(async move { tx.get_task_upload_counter(&task_id).await })
+        //     })
+        //     .await
+        //     .unwrap();
+        // assert_eq!(
+        //     got_counters,
+        //     Some(TaskUploadCounter::new(0, 0, 0, 0, 0, 0, 1, 0))
+        // )
     }
 
     #[tokio::test]
@@ -3779,17 +3790,19 @@ mod tests {
             .wait_for_completed_tasks("aggregator", 1)
             .await;
 
-        let got_counters = datastore
-            .run_unnamed_tx(|tx| {
-                let task_id = *task.id();
-                Box::pin(async move { tx.get_task_upload_counter(&task_id).await })
-            })
-            .await
-            .unwrap();
-        assert_eq!(
-            got_counters,
-            Some(TaskUploadCounter::new(1, 0, 0, 0, 0, 0, 0, 0))
-        )
+        // Incrementing upload counters disabled for now
+        // https://github.com/divviup/janus/issues/2654
+        // let got_counters = datastore
+        //     .run_unnamed_tx(|tx| {
+        //         let task_id = *task.id();
+        //         Box::pin(async move { tx.get_task_upload_counter(&task_id).await })
+        //     })
+        //     .await
+        //     .unwrap();
+        // assert_eq!(
+        //     got_counters,
+        //     Some(TaskUploadCounter::new(1, 0, 0, 0, 0, 0, 0, 0))
+        // )
     }
 
     #[tokio::test]
@@ -3911,17 +3924,19 @@ mod tests {
             .wait_for_completed_tasks("aggregator", 1)
             .await;
 
-        let got_counters = datastore
-            .run_unnamed_tx(|tx| {
-                let task_id = *task.id();
-                Box::pin(async move { tx.get_task_upload_counter(&task_id).await })
-            })
-            .await
-            .unwrap();
-        assert_eq!(
-            got_counters,
-            Some(TaskUploadCounter::new(0, 0, 0, 0, 0, 0, 0, 1))
-        )
+        // Incrementing upload counters disabled for now
+        // https://github.com/divviup/janus/issues/2654
+        // let got_counters = datastore
+        //     .run_unnamed_tx(|tx| {
+        //         let task_id = *task.id();
+        //         Box::pin(async move { tx.get_task_upload_counter(&task_id).await })
+        //     })
+        //     .await
+        //     .unwrap();
+        // assert_eq!(
+        //     got_counters,
+        //     Some(TaskUploadCounter::new(0, 0, 0, 0, 0, 0, 0, 1))
+        // )
     }
 
     #[tokio::test]
@@ -3967,24 +3982,26 @@ mod tests {
             .wait_for_completed_tasks("aggregator", 1)
             .await;
 
-        let got_counters = datastore
-            .run_unnamed_tx(|tx| {
-                let task_id = *task.id();
-                Box::pin(async move { tx.get_task_upload_counter(&task_id).await })
-            })
-            .await
-            .unwrap();
-        assert_eq!(
-            got_counters,
-            Some(TaskUploadCounter::new(0, 0, 0, 1, 0, 0, 0, 0))
-        )
+        // Incrementing upload counters disabled for now
+        // https://github.com/divviup/janus/issues/2654
+        // let got_counters = datastore
+        //     .run_unnamed_tx(|tx| {
+        //         let task_id = *task.id();
+        //         Box::pin(async move { tx.get_task_upload_counter(&task_id).await })
+        //     })
+        //     .await
+        //     .unwrap();
+        // assert_eq!(
+        //     got_counters,
+        //     Some(TaskUploadCounter::new(0, 0, 0, 1, 0, 0, 0, 0))
+        // )
     }
 
     #[tokio::test]
     async fn upload_report_faulty_encryption() {
         install_test_trace_subscriber();
         let mut runtime_manager = TestRuntimeManager::new();
-        let (_, aggregator, clock, task, datastore, _ephemeral_datastore) =
+        let (_, aggregator, clock, task, _datastore, _ephemeral_datastore) =
             setup_upload_test_with_runtime(
                 runtime_manager.with_label("aggregator"),
                 default_aggregator_config(),
@@ -4023,24 +4040,27 @@ mod tests {
             .wait_for_completed_tasks("aggregator", 1)
             .await;
 
-        let got_counters = datastore
-            .run_unnamed_tx(|tx| {
-                let task_id = *task.id();
-                Box::pin(async move { tx.get_task_upload_counter(&task_id).await })
-            })
-            .await
-            .unwrap();
-        assert_eq!(
-            got_counters,
-            Some(TaskUploadCounter::new(0, 0, 1, 0, 0, 0, 0, 0))
-        )
+        // Incrementing upload counters disabled for now
+        // https://github.com/divviup/janus/issues/2654
+        // let got_counters = datastore
+        //     .run_unnamed_tx(|tx| {
+        //         let task_id = *task.id();
+        //         Box::pin(async move { tx.get_task_upload_counter(&task_id).await })
+        //     })
+        //     .await
+        //     .unwrap();
+
+        // assert_eq!(
+        //     got_counters,
+        //     Some(TaskUploadCounter::new(0, 0, 1, 0, 0, 0, 0, 0))
+        // )
     }
 
     #[tokio::test]
     async fn upload_report_public_share_decode_failure() {
         install_test_trace_subscriber();
         let mut runtime_manager = TestRuntimeManager::new();
-        let (_, aggregator, clock, task, datastore, _ephemeral_datastore) =
+        let (_, aggregator, clock, task, _datastore, _ephemeral_datastore) =
             setup_upload_test_with_runtime(
                 runtime_manager.with_label("aggregator"),
                 default_aggregator_config(),
@@ -4078,24 +4098,26 @@ mod tests {
             .wait_for_completed_tasks("aggregator", 1)
             .await;
 
-        let got_counters = datastore
-            .run_unnamed_tx(|tx| {
-                let task_id = *task.id();
-                Box::pin(async move { tx.get_task_upload_counter(&task_id).await })
-            })
-            .await
-            .unwrap();
-        assert_eq!(
-            got_counters,
-            Some(TaskUploadCounter::new(0, 1, 0, 0, 0, 0, 0, 0))
-        )
+        // Incrementing upload counters disabled for now
+        // https://github.com/divviup/janus/issues/2654
+        // let got_counters = datastore
+        //     .run_unnamed_tx(|tx| {
+        //         let task_id = *task.id();
+        //         Box::pin(async move { tx.get_task_upload_counter(&task_id).await })
+        //     })
+        //     .await
+        //     .unwrap();
+        // assert_eq!(
+        //     got_counters,
+        //     Some(TaskUploadCounter::new(0, 1, 0, 0, 0, 0, 0, 0))
+        // )
     }
 
     #[tokio::test]
     async fn upload_report_leader_input_share_decode_failure() {
         install_test_trace_subscriber();
         let mut runtime_manager = TestRuntimeManager::new();
-        let (_, aggregator, clock, task, datastore, _ephemeral_datastore) =
+        let (_, aggregator, clock, task, _datastore, _ephemeral_datastore) =
             setup_upload_test_with_runtime(
                 runtime_manager.with_label("aggregator"),
                 default_aggregator_config(),
@@ -4144,17 +4166,19 @@ mod tests {
             .wait_for_completed_tasks("aggregator", 1)
             .await;
 
-        let got_counters = datastore
-            .run_unnamed_tx(|tx| {
-                let task_id = *task.id();
-                Box::pin(async move { tx.get_task_upload_counter(&task_id).await })
-            })
-            .await
-            .unwrap();
-        assert_eq!(
-            got_counters,
-            Some(TaskUploadCounter::new(0, 1, 0, 0, 0, 0, 0, 0))
-        )
+        // Incrementing upload counters disabled for now
+        // https://github.com/divviup/janus/issues/2654
+        // let got_counters = datastore
+        //     .run_unnamed_tx(|tx| {
+        //         let task_id = *task.id();
+        //         Box::pin(async move { tx.get_task_upload_counter(&task_id).await })
+        //     })
+        //     .await
+        //     .unwrap();
+        // assert_eq!(
+        //     got_counters,
+        //     Some(TaskUploadCounter::new(0, 1, 0, 0, 0, 0, 0, 0))
+        // )
     }
 
     pub(crate) fn generate_helper_report_share<V: vdaf::Client<16>>(


### PR DESCRIPTION
Stop updating per task upload metrics as this was causing a performance regression in Divvi Up production.

See #2654