### PR TITLE
Fix fanning out transaction error from ReportWriteBatcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5260,9 +5260,9 @@ dependencies = [
 
 [[package]]
 name = "trillium"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d52e722b482f0be8a770830ad793f3b386d9c4f5bc56291580862d44e36432"
+checksum = "acca545b3933760b2b88b822d83e62ccf9aab8c24d16ae82e56df1f2a5af11c1"
 dependencies = [
  "async-trait",
  "futures-lite 2.2.0",

--- a/aggregator/src/aggregator/error.rs
+++ b/aggregator/src/aggregator/error.rs
@@ -12,6 +12,8 @@ use prio::{topology::ping_pong::PingPongError, vdaf::VdafError};
 use std::{
     fmt::{self, Display, Formatter},
     num::TryFromIntError,
+    ops::Deref,
+    sync::Arc,
 };
 use tracing::info;
 
@@ -144,6 +146,25 @@ pub enum Error {
     /// An error occurred when trying to ensure differential privacy.
     #[error("differential privacy error: {0}")]
     DifferentialPrivacy(VdafError),
+}
+
+/// A newtype around `Arc<Error>`. This is needed to host a customized implementation of
+/// `trillium::Handler`.
+#[derive(Clone)]
+pub(crate) struct ArcError(Arc<Error>);
+
+impl From<Arc<Error>> for ArcError {
+    fn from(value: Arc<Error>) -> Self {
+        Self(value)
+    }
+}
+
+impl Deref for ArcError {
+    type Target = Error;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 /// Contains details that describe the report and why it was rejected.


### PR DESCRIPTION
This fixes #2655. Transaction-level errors in ReportWriteBatcher were resulting in panics during response handling. I think that database connection pool timeouts were the most likely cause of such errors, during periods of high load. This PR adds a unit test simulating this condition, and fixes the panic in two ways, by upgrading trillium, and by using a newtype around `Arc<Error>` as a `Handler`, allowing us to specify our own (no-op) init method.

Reviewer note: I recommend flipping "ignore whitespace" on, because I turned an existing method into a function, and an existing function into a method.