### PR TITLE
Fix test flakiness

### DIFF
--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -1622,7 +1622,12 @@ mod tests {
 
         // Wait for the pool to be exhausted by the above task.
         let pool = ephemeral_datastore.pool();
-        while pool.status().available > 0 {
+        loop {
+            let status = pool.status();
+            if status.available == 0 && status.size == status.max_size {
+                break;
+            }
+
             sleep(StdDuration::from_millis(100)).await;
         }
 


### PR DESCRIPTION
I noticed some flakiness in CI from the new test introduced by #2657. This PR attempts to fix it by waiting for the database connection pool to be both maxed out and not have any connections available.