### PR TITLE
Parameterize number of proofs in multiproof Prio3

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -874,11 +874,13 @@ impl<C: Clock> TaskAggregator<C> {
             }
 
             VdafInstance::Prio3SumVecField64MultiproofHmacSha256Aes128 {
+                proofs,
                 bits,
                 length,
                 chunk_length,
             } => {
                 let vdaf = new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128(
+                    *proofs,
                     *bits,
                     *length,
                     *chunk_length,

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -316,12 +316,14 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
             (
                 task::QueryType::TimeInterval,
                 VdafInstance::Prio3SumVecField64MultiproofHmacSha256Aes128 {
+                    proofs,
                     bits,
                     length,
                     chunk_length,
                 },
             ) => {
                 let vdaf = Arc::new(new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128(
+                    *proofs,
                     *bits,
                     *length,
                     *chunk_length,
@@ -434,12 +436,14 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                     batch_time_window_size,
                 },
                 VdafInstance::Prio3SumVecField64MultiproofHmacSha256Aes128 {
+                    proofs,
                     bits,
                     length,
                     chunk_length,
                 },
             ) => {
                 let vdaf = Arc::new(new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128(
+                    *proofs,
                     *bits,
                     *length,
                     *chunk_length,

--- a/integration_tests/src/client.rs
+++ b/integration_tests/src/client.rs
@@ -84,11 +84,13 @@ fn json_encode_vdaf(vdaf: &VdafInstance) -> Value {
             "chunk_length": format!("{chunk_length}"),
         }),
         VdafInstance::Prio3SumVecField64MultiproofHmacSha256Aes128 {
+            proofs,
             bits,
             length,
             chunk_length,
         } => json!({
             "type": "Prio3SumVecField64MultiproofHmacSha256Aes128",
+            "proofs": format!("{proofs}"),
             "bits": format!("{bits}"),
             "length": format!("{length}"),
             "chunk_length": format!("{chunk_length}"),

--- a/integration_tests/tests/integration/common.rs
+++ b/integration_tests/tests/integration/common.rs
@@ -461,11 +461,13 @@ pub async fn submit_measurements_and_verify_aggregate(
             .await;
         }
         VdafInstance::Prio3SumVecField64MultiproofHmacSha256Aes128 {
+            proofs,
             bits,
             length,
             chunk_length,
         } => {
             let vdaf = new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128(
+                *proofs,
                 *bits,
                 *length,
                 *chunk_length,

--- a/integration_tests/tests/integration/janus.rs
+++ b/integration_tests/tests/integration/janus.rs
@@ -362,6 +362,7 @@ async fn janus_in_process_customized_sum_vec() {
 
     let janus_pair = JanusInProcessPair::new(
         VdafInstance::Prio3SumVecField64MultiproofHmacSha256Aes128 {
+            proofs: 2,
             bits: 16,
             length: 15,
             chunk_length: 16,

--- a/interop_binaries/src/bin/janus_interop_client.rs
+++ b/interop_binaries/src/bin/janus_interop_client.rs
@@ -136,16 +136,19 @@ async fn handle_upload(
         }
 
         VdafInstance::Prio3SumVecField64MultiproofHmacSha256Aes128 {
+            proofs,
             bits,
             length,
             chunk_length,
         } => {
             let measurement = parse_vector_measurement::<u64>(request.measurement.clone())?;
-            let vdaf =
-                new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128(bits, length, chunk_length)
-                    .context(
-                        "failed to construct Prio3SumVecField64MultiproofHmacSha256Aes128 VDAF",
-                    )?;
+            let vdaf = new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128(
+                proofs,
+                bits,
+                length,
+                chunk_length,
+            )
+            .context("failed to construct Prio3SumVecField64MultiproofHmacSha256Aes128 VDAF")?;
             handle_upload_generic(http_client, vdaf, request, measurement).await?;
         }
 

--- a/interop_binaries/src/bin/janus_interop_collector.rs
+++ b/interop_binaries/src/bin/janus_interop_collector.rs
@@ -359,16 +359,19 @@ async fn handle_collection_start(
         (
             ParsedQuery::TimeInterval(batch_interval),
             VdafInstance::Prio3SumVecField64MultiproofHmacSha256Aes128 {
+                proofs,
                 bits,
                 length,
                 chunk_length,
             },
         ) => {
-            let vdaf =
-                new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128(bits, length, chunk_length)
-                    .context(
-                        "failed to construct Prio3SumVecField64MultiproofHmacSha256Aes128 VDAF",
-                    )?;
+            let vdaf = new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128(
+                proofs,
+                bits,
+                length,
+                chunk_length,
+            )
+            .context("failed to construct Prio3SumVecField64MultiproofHmacSha256Aes128 VDAF")?;
             handle_collect_generic(
                 http_client,
                 task_state,
@@ -563,16 +566,19 @@ async fn handle_collection_start(
         (
             ParsedQuery::FixedSize(fixed_size_query),
             VdafInstance::Prio3SumVecField64MultiproofHmacSha256Aes128 {
+                proofs,
                 bits,
                 length,
                 chunk_length,
             },
         ) => {
-            let vdaf =
-                new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128(bits, length, chunk_length)
-                    .context(
-                        "failed to construct Prio3SumVecField64MultiproofHmacSha256Aes128 VDAF",
-                    )?;
+            let vdaf = new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128(
+                proofs,
+                bits,
+                length,
+                chunk_length,
+            )
+            .context("failed to construct Prio3SumVecField64MultiproofHmacSha256Aes128 VDAF")?;
             handle_collect_generic(
                 http_client,
                 task_state,

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -117,6 +117,7 @@ pub enum VdafObject {
         chunk_length: NumberAsString<usize>,
     },
     Prio3SumVecField64MultiproofHmacSha256Aes128 {
+        proofs: NumberAsString<u8>,
         bits: NumberAsString<usize>,
         length: NumberAsString<usize>,
         chunk_length: NumberAsString<usize>,
@@ -154,10 +155,12 @@ impl From<VdafInstance> for VdafObject {
             },
 
             VdafInstance::Prio3SumVecField64MultiproofHmacSha256Aes128 {
+                proofs,
                 bits,
                 length,
                 chunk_length,
             } => VdafObject::Prio3SumVecField64MultiproofHmacSha256Aes128 {
+                proofs: NumberAsString(proofs),
                 bits: NumberAsString(bits),
                 length: NumberAsString(length),
                 chunk_length: NumberAsString(chunk_length),
@@ -205,10 +208,12 @@ impl From<VdafObject> for VdafInstance {
             },
 
             VdafObject::Prio3SumVecField64MultiproofHmacSha256Aes128 {
+                proofs,
                 bits,
                 length,
                 chunk_length,
             } => VdafInstance::Prio3SumVecField64MultiproofHmacSha256Aes128 {
+                proofs: proofs.0,
                 bits: bits.0,
                 length: length.0,
                 chunk_length: chunk_length.0,

--- a/messages/src/taskprov.rs
+++ b/messages/src/taskprov.rs
@@ -339,6 +339,8 @@ pub enum VdafType {
         length: u32,
         /// Size of each proof chunk.
         chunk_length: u32,
+        /// Number of proofs.
+        proofs: u8,
     },
     Prio3Histogram {
         /// Number of buckets.
@@ -395,10 +397,12 @@ impl Encode for VdafType {
                 bits,
                 length,
                 chunk_length,
+                proofs,
             } => {
                 bits.encode(bytes)?;
                 length.encode(bytes)?;
                 chunk_length.encode(bytes)?;
+                proofs.encode(bytes)?;
             }
             Self::Prio3Histogram {
                 length,
@@ -420,7 +424,7 @@ impl Encode for VdafType {
                 Self::Prio3Count => 0,
                 Self::Prio3Sum { .. } => 1,
                 Self::Prio3SumVec { .. } => 9,
-                Self::Prio3SumVecField64MultiproofHmacSha256Aes128 { .. } => 9,
+                Self::Prio3SumVecField64MultiproofHmacSha256Aes128 { .. } => 10,
                 Self::Prio3Histogram { .. } => 8,
                 Self::Poplar1 { .. } => 2,
             },
@@ -446,6 +450,7 @@ impl Decode for VdafType {
                     bits: u8::decode(bytes)?,
                     length: u32::decode(bytes)?,
                     chunk_length: u32::decode(bytes)?,
+                    proofs: u8::decode(bytes)?,
                 }
             }
             Self::PRIO3HISTOGRAM => Self::Prio3Histogram {
@@ -619,12 +624,14 @@ mod tests {
                     bits: 8,
                     length: 12,
                     chunk_length: 14,
+                    proofs: 2,
                 },
                 concat!(
                     "FFFF1003", // vdaf_type_code
                     "08",       // bits
                     "0000000C", // length
-                    "0000000E"  // chunk_length
+                    "0000000E", // chunk_length
+                    "02"        // proofs
                 ),
             ),
             (
@@ -730,6 +737,7 @@ mod tests {
                         bits: 8,
                         length: 12,
                         chunk_length: 14,
+                        proofs: 2,
                     },
                 )
                 .unwrap(),
@@ -745,6 +753,7 @@ mod tests {
                         "08",       // bits
                         "0000000C", // length
                         "0000000E", // chunk_length
+                        "02"        // proofs
                     )
                 ),
             ),


### PR DESCRIPTION
This makes the number of proofs a VDAF parameter, whereas previously it was hardcoded to 3. I added a check in the constructor function to disallow using only one proof with Field64. I wrote the Taskprov VdafConfig serialization/deserialization to be compatible with Daphne, with the number of proofs occurring last.