### PR TITLE
Configurable LIMIT in unaggregated reports query

### DIFF
--- a/aggregator/src/binaries/aggregation_job_creator.rs
+++ b/aggregator/src/binaries/aggregation_job_creator.rs
@@ -19,6 +19,7 @@ pub async fn main_callback(ctx: BinaryContext<RealClock, Options, Config>) -> Re
         Duration::from_secs(ctx.config.aggregation_job_creation_interval_secs),
         ctx.config.min_aggregation_job_size,
         ctx.config.max_aggregation_job_size,
+        ctx.config.aggregation_job_creation_report_window,
     ));
     aggregation_job_creator.run(ctx.stopper).await;
 
@@ -78,6 +79,13 @@ pub struct Config {
     pub min_aggregation_job_size: usize,
     /// The maximum number of client reports to include in an aggregation job.
     pub max_aggregation_job_size: usize,
+    /// Maximum number of reports to load at a time when creating aggregation jobs.
+    #[serde(default = "default_aggregation_job_creation_report_window")]
+    pub aggregation_job_creation_report_window: usize,
+}
+
+fn default_aggregation_job_creation_report_window() -> usize {
+    5000
 }
 
 impl BinaryConfig for Config {
@@ -119,6 +127,7 @@ mod tests {
             aggregation_job_creation_interval_secs: 60,
             min_aggregation_job_size: 100,
             max_aggregation_job_size: 500,
+            aggregation_job_creation_report_window: 5000,
         })
     }
 

--- a/aggregator/tests/integration/graceful_shutdown.rs
+++ b/aggregator/tests/integration/graceful_shutdown.rs
@@ -291,6 +291,7 @@ async fn aggregation_job_creator_shutdown() {
         aggregation_job_creation_interval_secs: 60,
         min_aggregation_job_size: 100,
         max_aggregation_job_size: 100,
+        aggregation_job_creation_report_window: 5000,
     };
 
     graceful_shutdown(trycmd::cargo::cargo_bin!("aggregation_job_creator"), config).await;

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -1188,12 +1188,12 @@ impl<C: Clock> Transaction<'_, C> {
         &self,
         vdaf: &A,
         task_id: &TaskId,
+        limit: usize,
     ) -> Result<Vec<LeaderStoredReport<SEED_SIZE, A>>, Error>
     where
         A::InputShare: PartialEq,
         A::PublicShare: PartialEq,
     {
-        // TODO(#269): allow the number of returned results to be controlled?
         let stmt = self
             .prepare_cached(
                 "WITH unaggregated_reports AS (
@@ -1204,7 +1204,7 @@ impl<C: Clock> Transaction<'_, C> {
                       AND client_reports.client_timestamp >= COALESCE($2::TIMESTAMP - tasks.report_expiry_age * '1 second'::INTERVAL, '-infinity'::TIMESTAMP)
                     ORDER BY client_timestamp DESC
                     FOR UPDATE OF client_reports SKIP LOCKED
-                    LIMIT 5000
+                    LIMIT $5::BIGINT
                 )
                 UPDATE client_reports SET
                     aggregation_started = TRUE, updated_at = $3, updated_by = $4
@@ -1221,6 +1221,7 @@ impl<C: Clock> Transaction<'_, C> {
                     /* now */ &self.clock.now().as_naive_date_time()?,
                     /* updated_at */ &self.clock.now().as_naive_date_time()?,
                     /* updated_by */ &self.name,
+                    /* limit */ &i64::try_from(limit)?,
                 ],
             )
             .await?;

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -807,7 +807,11 @@ async fn get_unaggregated_client_reports_for_task(ephemeral_datastore: Ephemeral
                     .unwrap());
 
                 Ok(tx
-                    .get_unaggregated_client_reports_for_task(&dummy_vdaf::Vdaf::new(), task.id())
+                    .get_unaggregated_client_reports_for_task(
+                        &dummy_vdaf::Vdaf::new(),
+                        task.id(),
+                        5000,
+                    )
                     .await
                     .unwrap())
             })
@@ -836,7 +840,11 @@ async fn get_unaggregated_client_reports_for_task(ephemeral_datastore: Ephemeral
                     .unwrap());
 
                 Ok(tx
-                    .get_unaggregated_client_reports_for_task(&dummy_vdaf::Vdaf::new(), task.id())
+                    .get_unaggregated_client_reports_for_task(
+                        &dummy_vdaf::Vdaf::new(),
+                        task.id(),
+                        5000,
+                    )
                     .await
                     .unwrap())
             })
@@ -869,7 +877,11 @@ async fn get_unaggregated_client_reports_for_task(ephemeral_datastore: Ephemeral
                 );
 
                 Ok(tx
-                    .get_unaggregated_client_reports_for_task(&dummy_vdaf::Vdaf::new(), task.id())
+                    .get_unaggregated_client_reports_for_task(
+                        &dummy_vdaf::Vdaf::new(),
+                        task.id(),
+                        5000,
+                    )
                     .await
                     .unwrap())
             })

--- a/docs/samples/advanced_config/aggregation_job_creator.yaml
+++ b/docs/samples/advanced_config/aggregation_job_creator.yaml
@@ -81,3 +81,7 @@ min_aggregation_job_size: 10
 
 # Maximum aggregation job size, in reports. (required)
 max_aggregation_job_size: 100
+
+# Maximum number of reports to load at a time when creating aggregation jobs.
+# (optional, defaults to 5000)
+aggregation_job_creation_report_window: 5000

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -171,6 +171,7 @@ impl JanusInProcess {
             aggregation_job_creation_interval_secs: 1,
             min_aggregation_job_size: 1,
             max_aggregation_job_size: 100,
+            aggregation_job_creation_report_window: 5000,
         };
         let aggregation_job_driver_options = AggregationJobDriverOptions {
             common: common_binary_options.clone(),


### PR DESCRIPTION
This adds a configuration option to set how many reports the unaggregated reports query may return. Until we implement #2689, this query could potentially return enough to OOM a process, with large enough VDAF parameters. In the future, we may also want to experiment with this parameter to improve throughput.