### PR TITLE
Add UploadMetrics feature to aggregator API

### DIFF
--- a/aggregator_api/src/routes.rs
+++ b/aggregator_api/src/routes.rs
@@ -48,8 +48,9 @@ pub(super) async fn get_config(
             SupportedQueryType::TimeInterval,
             SupportedQueryType::FixedSize,
         ],
-        // Unconditionally indicate to divviup-api that we support collector auth token hashes
-        features: &["TokenHash"],
+        // Unconditionally indicate to divviup-api that we support collector auth token hashes and
+        // upload metrics.
+        features: &["TokenHash", "UploadMetrics"],
     })
 }
 

--- a/aggregator_api/src/tests.rs
+++ b/aggregator_api/src/tests.rs
@@ -90,7 +90,7 @@ async fn get_config() {
             r#"{"protocol":"DAP-07","dap_url":"https://dap.url/","role":"Either","vdafs":"#,
             r#"["Prio3Count","Prio3Sum","Prio3Histogram","Prio3CountVec","Prio3SumVec"],"#,
             r#""query_types":["TimeInterval","FixedSize"],"#,
-            r#""features":["TokenHash"]}"#,
+            r#""features":["TokenHash","UploadMetrics"]}"#,
         )
     );
 }


### PR DESCRIPTION
Supports #2293.

See https://github.com/divviup/divviup-api/pull/809#issuecomment-1954906298. It's necessary to communicate this feature to divviup-api so it can change its behavior for versions of Janus that don't contain this feature (i.e. Janus 0.5).

I will overload issue https://github.com/divviup/janus/issues/2066 to phase out this feature flag once Janus 0.5 (and any older versions) aren't in production use anymore.