### PR TITLE
Ignore Docker cache export errors

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -77,7 +77,7 @@ target "janus_aggregator" {
     "type=gha,scope=${GITHUB_BASE_REF}-janus",
     "type=gha,scope=${GITHUB_REF_NAME}-janus",
   ]
-  cache-to = ["type=gha,scope=${GITHUB_REF_NAME}-janus,mode=max"]
+  cache-to = ["type=gha,scope=${GITHUB_REF_NAME}-janus,mode=max,ignore-error=true"]
   tags     = ["janus_aggregator:${VERSION}"]
 }
 
@@ -184,7 +184,7 @@ target "janus_db_migrator" {
     "type=gha,scope=${GITHUB_BASE_REF}-sqlx",
     "type=gha,scope=${GITHUB_REF_NAME}-sqlx",
   ]
-  cache-to = ["type=gha,scope=${GITHUB_REF_NAME}-sqlx,mode=max"]
+  cache-to = ["type=gha,scope=${GITHUB_REF_NAME}-sqlx,mode=max,ignore-error=true"]
   tags     = ["janus_db_migrator:${VERSION}"]
 }
 
@@ -224,7 +224,7 @@ target "janus_interop_aggregator" {
     "type=gha,scope=${GITHUB_BASE_REF}-interop",
     "type=gha,scope=${GITHUB_REF_NAME}-interop",
   ]
-  cache-to = ["type=gha,scope=${GITHUB_REF_NAME}-interop,mode=max"]
+  cache-to = ["type=gha,scope=${GITHUB_REF_NAME}-interop,mode=max,ignore-error=true"]
   tags     = ["janus_interop_aggregator:${VERSION}"]
 }
 
@@ -283,7 +283,7 @@ target "janus_interop_aggregator_small" {
     "type=gha,scope=${GITHUB_BASE_REF}-interop-small",
     "type=gha,scope=${GITHUB_REF_NAME}-interop-small",
   ]
-  cache-to   = ["type=gha,scope=${GITHUB_REF_NAME}-interop-small,mode=max"]
+  cache-to   = ["type=gha,scope=${GITHUB_REF_NAME}-interop-small,mode=max,ignore-error=true"]
   dockerfile = "Dockerfile.interop_aggregator"
 }
 


### PR DESCRIPTION
This changes our use of the GitHub Actions cache backend for Docker BuildKit so that errors writing to the cache are ignored. This should improve our Monday flakiness significantly, at the expense of skipping some cache writes.