### PR TITLE
Copy report shares within database when creating aggregation jobs

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -1,7 +1,7 @@
 use super::{error::handle_ping_pong_error, Error, RequestBody};
 use crate::aggregator::{
     accumulator::Accumulator, aggregate_step_failure_counter,
-    aggregation_job_writer::AggregationJobWriter, http_handlers::AGGREGATION_JOB_ROUTE,
+    aggregation_job_writer::UpdatedAggregationJobWriter, http_handlers::AGGREGATION_JOB_ROUTE,
     query_type::CollectableQueryType, send_request_to_helper,
 };
 use anyhow::{anyhow, Result};
@@ -699,7 +699,7 @@ where
         }
 
         // Write everything back to storage.
-        let mut aggregation_job_writer = AggregationJobWriter::new(Arc::clone(&task));
+        let mut aggregation_job_writer = UpdatedAggregationJobWriter::new(Arc::clone(&task));
         let new_step = aggregation_job.step().increment();
         aggregation_job_writer.update(
             aggregation_job.with_step(new_step),
@@ -841,7 +841,8 @@ where
                         task.aggregation_job_uri(lease.leased().aggregation_job_id());
                     let aggregator_auth_token = task.aggregator_auth_token().cloned();
 
-                    let mut aggregation_job_writer = AggregationJobWriter::new(Arc::new(task));
+                    let mut aggregation_job_writer =
+                        UpdatedAggregationJobWriter::new(Arc::new(task));
                     aggregation_job_writer.update(aggregation_job, report_aggregations)?;
 
                     try_join!(

--- a/aggregator/src/aggregator/aggregation_job_writer.rs
+++ b/aggregator/src/aggregator/aggregation_job_writer.rs
@@ -70,14 +70,11 @@ where
     /// operation (aggregation into a collected batch is not allowed). These report aggregations
     /// will be written with a `Failed(BatchCollected)` state, and the associated report IDs will be
     /// returned.
-    pub async fn write<'a, C: Clock>(
+    pub async fn write<C: Clock>(
         &self,
         tx: &Transaction<'_, C>,
         vdaf: Arc<A>,
-    ) -> Result<(), Error>
-    where
-        A: 'a,
-    {
+    ) -> Result<(), Error> {
         self.updates
             .write(tx, vdaf, NewAggregationJobBatchUpdate)
             .await?;

--- a/aggregator/src/aggregator/aggregation_job_writer.rs
+++ b/aggregator/src/aggregator/aggregation_job_writer.rs
@@ -690,7 +690,7 @@ where
             .collect();
 
         // Read all relevant batches and report counts from the datastore.
-        let (batches, batches_with_reports) = try_join!(
+        let (batches, batches_with_unaggregated_reports) = try_join!(
             try_join_all(
                 updates
                     .by_batch_identifier_index
@@ -725,8 +725,10 @@ where
             })
             .collect();
 
-        let batches_with_unaggregated_reports: HashSet<_> =
-            batches_with_reports.into_iter().flatten().collect();
+        let batches_with_unaggregated_reports: HashSet<_> = batches_with_unaggregated_reports
+            .into_iter()
+            .flatten()
+            .collect();
 
         Ok(Self {
             task: &updates.task,

--- a/aggregator/src/aggregator/aggregation_job_writer.rs
+++ b/aggregator/src/aggregator/aggregation_job_writer.rs
@@ -2,19 +2,21 @@
 
 use crate::{aggregator::query_type::CollectableQueryType, Operation};
 use anyhow::anyhow;
+use async_trait::async_trait;
 use futures::{future::try_join_all, TryFutureExt};
 use janus_aggregator_core::{
     datastore::{
         models::{
             AggregationJob, AggregationJobState, Batch, BatchState, CollectionJobState,
-            ReportAggregation, ReportAggregationState,
+            ReportAggregation, ReportAggregationMetadata, ReportAggregationMetadataState,
+            ReportAggregationState,
         },
         Error, Transaction,
     },
     task::AggregatorTask,
 };
 use janus_core::time::{Clock, IntervalExt};
-use janus_messages::{AggregationJobId, Interval, PrepareError, ReportId};
+use janus_messages::{AggregationJobId, Interval, PrepareError, ReportId, Time};
 use prio::{codec::Encode, vdaf};
 use std::{
     borrow::Cow,
@@ -24,140 +26,346 @@ use std::{
 use tokio::try_join;
 use tracing::{debug, error};
 
-/// AggregationJobWriter contains the logic used to write aggregation jobs, both initially &
-/// on updates. It is used only by the Leader.
-pub struct AggregationJobWriter<
+/// Contains logic used to write new aggregation jobs. It is used only by the leader.
+pub struct NewAggregationJobWriter<
     const SEED_SIZE: usize,
     Q: CollectableQueryType,
     A: vdaf::Aggregator<SEED_SIZE, 16>,
 > {
-    task: Arc<AggregatorTask>,
-    aggregation_jobs: HashMap<AggregationJobId, AggregationJobInfo<SEED_SIZE, Q, A>>,
-
-    // batch identifier -> aggregation job -> ord of report aggregation; populated by all report
-    // aggregations pertaining to the batch.
-    by_batch_identifier_index: HashMap<Q::BatchIdentifier, HashMap<AggregationJobId, Vec<usize>>>,
+    updates: AggregationJobUpdates<SEED_SIZE, Q, A, ReportAggregationMetadata>,
 }
 
-struct AggregationJobInfo<
-    const SEED_SIZE: usize,
+impl<const SEED_SIZE: usize, Q, A> NewAggregationJobWriter<SEED_SIZE, Q, A>
+where
     Q: CollectableQueryType,
-    A: vdaf::Aggregator<SEED_SIZE, 16>,
-> {
-    operation: Operation,
-    aggregation_job: AggregationJob<SEED_SIZE, Q, A>,
-    report_aggregations: Vec<ReportAggregation<SEED_SIZE, A>>,
-}
-
-impl<const SEED_SIZE: usize, Q: CollectableQueryType, A: vdaf::Aggregator<SEED_SIZE, 16>>
-    AggregationJobWriter<SEED_SIZE, Q, A>
+    A: vdaf::Aggregator<SEED_SIZE, 16> + Send + Sync,
+    A::AggregationParam: PartialEq + Eq,
+    A::PrepareState: Encode,
 {
     /// Creates a new, empty aggregation job writer.
     pub fn new(task: Arc<AggregatorTask>) -> Self {
         Self {
+            updates: AggregationJobUpdates::new(task),
+        }
+    }
+
+    /// Returns true if this aggregation job writer does not contain any aggregation jobs.
+    pub fn is_empty(&self) -> bool {
+        self.updates.is_empty()
+    }
+
+    /// Queues a new aggregation job to be written to the datastore. Nothing is actually written
+    /// until [`NewAggregationJobWriter::write`] is called.
+    pub fn put(
+        &mut self,
+        aggregation_job: AggregationJob<SEED_SIZE, Q, A>,
+        report_aggregations: Vec<ReportAggregationMetadata>,
+    ) -> Result<(), Error> {
+        self.updates.add(aggregation_job, report_aggregations)
+    }
+
+    /// Writes all queued aggregation jobs to the datastore.
+    ///
+    /// Some report aggregations may turn out to be unaggregatable due to a concurrent collection
+    /// operation (aggregation into a collected batch is not allowed). These report aggregations
+    /// will be written with a `Failed(BatchCollected)` state, and the associated report IDs will be
+    /// returned.
+    pub async fn write<'a, C: Clock>(
+        &self,
+        tx: &Transaction<'_, C>,
+        vdaf: Arc<A>,
+    ) -> Result<(), Error>
+    where
+        A: 'a,
+    {
+        self.updates
+            .write(tx, vdaf, NewAggregationJobBatchUpdate)
+            .await?;
+        Ok(())
+    }
+}
+
+/// This holds a flag and a callback used internally by [`AggregationJobUpdates`] when updating
+/// batches, and is specific to creation of new aggregation jobs.
+struct NewAggregationJobBatchUpdate;
+
+impl BatchUpdateCallback for NewAggregationJobBatchUpdate {
+    fn update_batch<'a, const SEED_SIZE: usize, Q, A, RA>(
+        &self,
+        batch: Batch<SEED_SIZE, Q, A>,
+        aggregation_jobs: impl Iterator<
+            Item = (
+                &'a AggregationJob<SEED_SIZE, Q, A>,
+                &'a [Cow<'a, RA>],
+                &'a [usize],
+            ),
+        >,
+    ) -> Result<Batch<SEED_SIZE, Q, A>, Error>
+    where
+        Q: CollectableQueryType,
+        A: vdaf::Aggregator<SEED_SIZE, 16> + 'a,
+        RA: ReportAggregationUpdate + Clone + 'a,
+    {
+        // Increment outstanding job count by the number of new, incomplete aggregation jobs we are
+        // writing. Update the time interval too.
+        let mut outstanding_aggregation_jobs = batch.outstanding_aggregation_jobs();
+        let mut client_timestamp_interval = *batch.client_timestamp_interval();
+        for (agg_job, report_aggs, report_aggregation_ords) in aggregation_jobs {
+            if let AggregationJobState::InProgress = agg_job.state() {
+                outstanding_aggregation_jobs += 1;
+            }
+            update_client_timestamp_interval(
+                &mut client_timestamp_interval,
+                report_aggs,
+                report_aggregation_ords,
+            )?;
+        }
+        Ok(batch
+            .with_outstanding_aggregation_jobs(outstanding_aggregation_jobs)
+            .with_client_timestamp_interval(client_timestamp_interval))
+    }
+
+    fn creating_aggregation_jobs(&self) -> bool {
+        true
+    }
+}
+
+/// Contains logic used to write updates to aggregation jobs. It is used only by the leader.
+pub struct UpdatedAggregationJobWriter<
+    const SEED_SIZE: usize,
+    Q: CollectableQueryType,
+    A: vdaf::Aggregator<SEED_SIZE, 16>,
+> {
+    updates: AggregationJobUpdates<SEED_SIZE, Q, A, ReportAggregation<SEED_SIZE, A>>,
+}
+
+impl<const SEED_SIZE: usize, Q, A> UpdatedAggregationJobWriter<SEED_SIZE, Q, A>
+where
+    Q: CollectableQueryType,
+    A: vdaf::Aggregator<SEED_SIZE, 16> + Send + Sync,
+    A::AggregationParam: PartialEq + Eq,
+    A::PublicShare: Sync,
+    A::InputShare: Sync,
+    A::PrepareMessage: Sync,
+    A::PrepareState: Encode + Sync,
+{
+    /// Creates a new, empty aggregation job writer.
+    pub fn new(task: Arc<AggregatorTask>) -> Self {
+        Self {
+            updates: AggregationJobUpdates::new(task),
+        }
+    }
+
+    /// Returns whether this aggregation job writer does not contain any aggregation jobs.
+    pub fn is_empty(&self) -> bool {
+        self.updates.is_empty()
+    }
+
+    /// Queues an update to an aggregation job to be written to the datastore. Nothing is actually
+    /// written until [`UpdatedAggregationJobWriter::write`] is called.
+    pub fn update(
+        &mut self,
+        aggregation_job: AggregationJob<SEED_SIZE, Q, A>,
+        report_aggregations: Vec<ReportAggregation<SEED_SIZE, A>>,
+    ) -> Result<(), Error> {
+        self.updates.add(aggregation_job, report_aggregations)
+    }
+
+    /// Writes all queued aggregation jobs to the datastore.
+    ///
+    /// Some report aggregations may turn out to be unaggregatable due to a concurrent collection
+    /// operation (aggregation into a collected batch is not allowed). These report aggregations
+    /// will be written with a `Failed(BatchCollected)` state, and the associated report IDs will be
+    /// returned.
+    pub async fn write<C: Clock>(
+        &self,
+        tx: &Transaction<'_, C>,
+        vdaf: Arc<A>,
+    ) -> Result<HashSet<ReportId>, Error> {
+        self.updates
+            .write(tx, vdaf, UpdatedAggregationJobBatchUpdate)
+            .await
+    }
+}
+
+/// This holds a flag and a callback used internally by [`AggregationJobUpdates`] when updating
+/// batches, and is specific to updates to existing aggregation jobs.
+struct UpdatedAggregationJobBatchUpdate;
+
+impl BatchUpdateCallback for UpdatedAggregationJobBatchUpdate {
+    fn update_batch<'a, const SEED_SIZE: usize, Q, A, RA>(
+        &self,
+        batch: Batch<SEED_SIZE, Q, A>,
+        aggregation_jobs: impl Iterator<
+            Item = (
+                &'a AggregationJob<SEED_SIZE, Q, A>,
+                &'a [Cow<'a, RA>],
+                &'a [usize],
+            ),
+        >,
+    ) -> Result<Batch<SEED_SIZE, Q, A>, Error>
+    where
+        Q: CollectableQueryType,
+        A: vdaf::Aggregator<SEED_SIZE, 16> + 'a,
+        RA: ReportAggregationUpdate + Clone + 'a,
+    {
+        // Decrement outstanding job count by the number of updated, complete aggregation jobs we
+        // are writing. (We assume any update to a terminal state is the first time we have updated
+        // to a terminal state, as the system does not touch aggregation jobs once they have reached
+        // a terminal state, and it would add code complexity and runtime cost to determine if we
+        // are in a repeated-terminal-write case.)
+        //
+        // Note that it is not necessary to update the client timestamp interval, as that was
+        // already done when creating the aggregation job previously.
+        let mut outstanding_aggregation_jobs = batch.outstanding_aggregation_jobs();
+        for (agg_job, _report_aggs, _report_aggregation_ords) in aggregation_jobs {
+            if !matches!(agg_job.state(), AggregationJobState::InProgress) {
+                outstanding_aggregation_jobs -= 1;
+            }
+        }
+        Ok(batch.with_outstanding_aggregation_jobs(outstanding_aggregation_jobs))
+    }
+
+    fn creating_aggregation_jobs(&self) -> bool {
+        false
+    }
+}
+
+/// Expands a client timestamp interval as necessary to include a set of report aggregations.
+///
+/// This takes a slice of report aggregations, and a slice of offsets within that list. Only those
+/// report aggregations pointed to by the offsets are considered when updating the client timestamp
+/// interval.
+///
+/// # Panics
+///
+/// This will panic if any offset points outside the bounds of the slice of report aggregations.
+fn update_client_timestamp_interval<RA>(
+    client_timestamp_interval: &mut Interval,
+    report_aggregations: &[Cow<'_, RA>],
+    report_aggregation_ords: &[usize],
+) -> Result<(), janus_messages::Error>
+where
+    RA: ReportAggregationUpdate + Clone,
+{
+    for ra_ord in report_aggregation_ords {
+        // unwrap safety: index lookup
+        let report_aggregation = report_aggregations.get(*ra_ord).unwrap();
+        *client_timestamp_interval =
+            client_timestamp_interval.merged_with(report_aggregation.time())?;
+    }
+    Ok(())
+}
+
+/// Buffers pending updates to aggregation jobs and their report aggregations. Generic storage and
+/// logic for both [`NewAggregationJobWriter`] and [`UpdatedAggregationJobWriter`].
+struct AggregationJobUpdates<const SEED_SIZE: usize, Q, A, RA>
+where
+    Q: CollectableQueryType,
+    A: vdaf::Aggregator<SEED_SIZE, 16>,
+{
+    task: Arc<AggregatorTask>,
+    aggregation_parameter: Option<A::AggregationParam>,
+    aggregation_jobs: HashMap<AggregationJobId, AggregationJobInfo<SEED_SIZE, Q, A, RA>>,
+    by_batch_identifier_index: HashMap<Q::BatchIdentifier, HashMap<AggregationJobId, Vec<usize>>>,
+}
+
+impl<const SEED_SIZE: usize, A, Q, RA> AggregationJobUpdates<SEED_SIZE, Q, A, RA>
+where
+    Q: CollectableQueryType,
+    A: vdaf::Aggregator<SEED_SIZE, 16>,
+    A::AggregationParam: PartialEq + Eq,
+    RA: ReportAggregationUpdate + Clone,
+{
+    /// Create a new, empty set of aggregation job updates.
+    fn new(task: Arc<AggregatorTask>) -> Self {
+        Self {
             task,
+            aggregation_parameter: None,
             aggregation_jobs: HashMap::new(),
             by_batch_identifier_index: HashMap::new(),
         }
     }
 
-    /// Returns whether this aggregation job writer is empty, i.e. whether it contains any
-    /// aggregation jobs.
-    pub fn is_empty(&self) -> bool {
+    /// Check if this set of updates is empty.
+    fn is_empty(&self) -> bool {
         self.aggregation_jobs.is_empty()
     }
 
-    /// Queues a new aggregation job to be written to the datastore. Nothing is actually written
-    /// until `write` is called.
-    pub fn put(
-        &mut self,
-        aggregation_job: AggregationJob<SEED_SIZE, Q, A>,
-        report_aggregations: Vec<ReportAggregation<SEED_SIZE, A>>,
-    ) -> Result<(), Error>
-    where
-        A::AggregationParam: PartialEq + Eq,
-    {
-        self.insert_aggregation_job_info(AggregationJobInfo {
-            operation: Operation::Put,
-            aggregation_job,
-            report_aggregations,
-        })
+    /// Returns the aggregation parameter of the aggregation jobs, if known.
+    ///
+    /// All aggregation jobs updated at once must have the same aggregation parameter. If at least
+    /// one aggregation job update has been stored, then its aggregation parameter will be returned.
+    /// Otherwise, if this set of updates is empty, `None` will be returned.
+    fn aggregation_parameter(&self) -> &Option<A::AggregationParam> {
+        &self.aggregation_parameter
     }
 
-    /// Queues an existing aggregation job to be updated in the datastore. Nothing is actually
-    /// written until `write` is called.
-    pub fn update(
-        &mut self,
-        aggregation_job: AggregationJob<SEED_SIZE, Q, A>,
-        report_aggregations: Vec<ReportAggregation<SEED_SIZE, A>>,
-    ) -> Result<(), Error>
-    where
-        A::AggregationParam: PartialEq + Eq,
-    {
-        self.insert_aggregation_job_info(AggregationJobInfo {
-            operation: Operation::Update,
-            aggregation_job,
-            report_aggregations,
-        })
-    }
-
-    fn insert_aggregation_job_info(
-        &mut self,
-        info: AggregationJobInfo<SEED_SIZE, Q, A>,
-    ) -> Result<(), Error>
-    where
-        A::AggregationParam: PartialEq + Eq,
-    {
+    /// Internal helper to optionally update the aggregation parameter.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a different aggregation parameter is provided than what was previously stored.
+    fn update_aggregation_parameter(&mut self, aggregation_parameter: &A::AggregationParam) {
         // We don't currently have (or need, at time of writing) logic to allow writing aggregation
         // jobs across different aggregation parameters. Verify that our caller is not trying to do
         // so.
-        assert!(self.aggregation_jobs.values().next().map_or(true, |i| {
-            info.aggregation_job.aggregation_parameter()
-                == i.aggregation_job.aggregation_parameter()
-        }));
+        if let Some(existing_aggregation_parameter) = self.aggregation_parameter.as_ref() {
+            assert_eq!(aggregation_parameter, existing_aggregation_parameter);
+        } else {
+            self.aggregation_parameter = Some(aggregation_parameter.clone());
+        }
+    }
+
+    /// Add a new or updated aggregation and its report aggregations.
+    fn add(
+        &mut self,
+        aggregation_job: AggregationJob<SEED_SIZE, Q, A>,
+        report_aggregations: Vec<RA>,
+    ) -> Result<(), Error> {
+        self.update_aggregation_parameter(aggregation_job.aggregation_parameter());
 
         // Compute batch identifiers first, since computing the batch identifier is fallible and
-        // it's nicer not to have to unwind state modifications if we encounter an error.
-        let batch_identifiers = info
-            .report_aggregations
+        // it's nicer to not have to unwind state modifications if we encounter an error.
+        let batch_identifiers = report_aggregations
             .iter()
             .map(|ra| {
                 Q::to_batch_identifier(
                     &self.task,
-                    info.aggregation_job.partial_batch_identifier(),
+                    aggregation_job.partial_batch_identifier(),
                     ra.time(),
                 )
             })
             .collect::<Result<Vec<_>, _>>()?;
-        assert_eq!(batch_identifiers.len(), info.report_aggregations.len());
+        assert_eq!(batch_identifiers.len(), report_aggregations.len());
 
         // Modify our state to record this aggregation job. (starting here, failure is not allowed)
         for (ord, batch_identifier) in batch_identifiers.into_iter().enumerate() {
             self.by_batch_identifier_index
                 .entry(batch_identifier)
                 .or_default()
-                .entry(*info.aggregation_job.id())
+                .entry(*aggregation_job.id())
                 .or_default()
                 .push(ord);
         }
 
-        self.aggregation_jobs
-            .insert(*info.aggregation_job.id(), info);
+        self.aggregation_jobs.insert(
+            *aggregation_job.id(),
+            AggregationJobInfo {
+                aggregation_job,
+                report_aggregations,
+            },
+        );
         Ok(())
     }
 
-    /// Writes all queued aggregation jobs to the datastore. Some report aggregations may turn out
-    /// to be unwritable due to a concurrent collection operation (aggregation into a collected
-    /// batch is not allowed). These report aggregations will be written with a
-    /// `Failed(BatchCollected)` state, and the associated report IDs will be returned.
-    ///
-    /// A call to write, successful or not, does not change the internal state of the aggregation
-    /// job writer; calling write again will cause the same set of aggregation jobs to be written.
-    #[tracing::instrument(name = "AggregationJobWriter::write", skip(self, tx), err)]
-    pub async fn write<C>(
+    /// Writes all queued aggregation job updates to the datastore. Returns report IDs of reports in
+    /// batches that were already collected.
+    async fn write<C>(
         &self,
         tx: &Transaction<'_, C>,
         vdaf: Arc<A>,
+        batch_update_callback: impl BatchUpdateCallback,
     ) -> Result<HashSet<ReportId>, Error>
     where
         C: Clock,
@@ -165,255 +373,27 @@ impl<const SEED_SIZE: usize, Q: CollectableQueryType, A: vdaf::Aggregator<SEED_S
         A::AggregationParam: PartialEq + Eq,
         A::PrepareState: Encode,
     {
-        // Create a copy-on-write instance of our state to allow efficient imperative updates.
-        // (Copy-on-write is used here as modifying state requires cloning it, but most pieces of
-        // state will not be modified, so using CoW avoids the cost of cloning in the common case.)
-        // Compute a by-batch-identifier index on the input aggregation jobs/report aggregations,
-        // too.
-        let aggregation_parameter = match self
-            .aggregation_jobs
-            .values()
-            .next()
-            .map(|info| info.aggregation_job.aggregation_parameter())
-        {
-            Some(aggregation_parameter) => aggregation_parameter,
-            None => return Ok(HashSet::new()), // None means there is nothing to write.
+        let aggregation_parameter = if let Some(agg_param) = self.aggregation_parameter().as_ref() {
+            agg_param
+        } else {
+            return Ok(HashSet::new()); // None means there is nothing to write.
         };
 
-        let mut by_aggregation_job: HashMap<_, _> = self
-            .aggregation_jobs
-            .iter()
-            .map(|(aggregation_job_id, info)| {
-                (
-                    *aggregation_job_id,
-                    (
-                        info.operation,
-                        Cow::Borrowed(&info.aggregation_job),
-                        info.report_aggregations
-                            .iter()
-                            .map(Cow::Borrowed)
-                            .collect::<Vec<_>>(),
-                    ),
-                )
-            })
-            .collect();
+        let mut indexed =
+            IndexedAggregationJobUpdates::new(tx, self, aggregation_parameter).await?;
 
-        // Read all relevant batches & report counts from the datastore.
-        let (batches, batches_with_reports) = try_join!(
-            try_join_all(
-                self.by_batch_identifier_index
-                    .keys()
-                    .map(|batch_identifier| {
-                        tx.get_batch::<SEED_SIZE, Q, A>(
-                            self.task.id(),
-                            batch_identifier,
-                            aggregation_parameter,
-                        )
-                    })
-            ),
-            try_join_all(self.by_batch_identifier_index.keys().map(
-                |batch_identifier| async move {
-                    if let Some(batch_interval) = Q::to_batch_interval(batch_identifier) {
-                        if tx
-                            .interval_has_unaggregated_reports(self.task.id(), batch_interval)
-                            .await?
-                        {
-                            return Ok::<_, Error>(Some(batch_identifier.clone()));
-                        }
-                    }
-                    Ok(None)
-                },
-            )),
-        )?;
+        indexed.fail_collected_report_aggregations();
 
-        let mut batches: HashMap<_, _> = batches
-            .into_iter()
-            .flat_map(|batch: Option<Batch<SEED_SIZE, Q, A>>| {
-                batch.map(|b| (b.batch_identifier().clone(), b))
-            })
-            .collect();
-        let batches_with_reports: HashSet<_> = batches_with_reports.into_iter().flatten().collect();
+        indexed.update_aggregation_job_state_from_ra_states();
 
-        // Update in-memory state of report aggregations: any report aggregations applying to a
-        // closed batch instead fail with a BatchCollected error (unless they were already in an
-        // failed state).
-        let mut unwritable_report_ids = HashSet::new();
-        for (batch_identifier, by_aggregation_job_index) in &self.by_batch_identifier_index {
-            if batches.get(batch_identifier).map(|b| *b.state()) != Some(BatchState::Closed) {
-                continue;
-            }
-            for (aggregation_job_id, report_aggregation_ords) in by_aggregation_job_index {
-                for ord in report_aggregation_ords {
-                    // unwrap safety: index lookup
-                    let report_aggregation = by_aggregation_job
-                        .get_mut(aggregation_job_id)
-                        .unwrap()
-                        .2
-                        .get_mut(*ord)
-                        .unwrap();
-                    if matches!(
-                        report_aggregation.state(),
-                        ReportAggregationState::Failed { .. }
-                    ) {
-                        continue;
-                    }
-
-                    unwritable_report_ids.insert(*report_aggregation.report_id());
-                    *report_aggregation =
-                        Cow::Owned(report_aggregation.as_ref().clone().with_state(
-                            ReportAggregationState::Failed {
-                                prepare_error: PrepareError::BatchCollected,
-                            },
-                        ));
-                }
-            }
-        }
-
-        // Update in-memory state of aggregation jobs: any aggregation jobs whose report
-        // aggregations are all in a terminal state should be considered Finished (unless the
-        // aggregation job was already in a terminal state).
-        for (_, aggregation_job, report_aggregations) in by_aggregation_job.values_mut() {
-            if matches!(
-                aggregation_job.state(),
-                AggregationJobState::Finished | AggregationJobState::Abandoned
-            ) {
-                continue;
-            }
-
-            if report_aggregations.iter().all(|ra| {
-                matches!(
-                    ra.state(),
-                    ReportAggregationState::Finished | ReportAggregationState::Failed { .. }
-                )
-            }) {
-                *aggregation_job = Cow::Owned(
-                    aggregation_job
-                        .as_ref()
-                        .clone()
-                        .with_state(AggregationJobState::Finished),
-                );
-            }
-        }
-
-        // Update in-memory state of batches: outstanding job counts will change based on new or
-        // completed aggregation jobs affecting each batch; the client timestamp interval will
-        // change based on the report aggregations included in the batch.
-        let mut newly_closed_batches = Vec::new();
-        let batches: HashMap<_, _> = self
-            .by_batch_identifier_index
-            .iter()
-            .flat_map(|(batch_identifier, by_aggregation_job_index)| {
-                let (batch_op, mut batch) = match batches.remove(batch_identifier) {
-                    Some(batch) => (Operation::Update, batch),
-                    None => (
-                        Operation::Put,
-                        Batch::new(
-                            *self.task.id(),
-                            batch_identifier.clone(),
-                            aggregation_parameter.clone(),
-                            BatchState::Open,
-                            0,
-                            Interval::EMPTY,
-                        ),
-                    ),
-                };
-                if batch.state() == &BatchState::Closed {
-                    // Never update a closed batch.
-                    return None;
-                }
-
-                // Increment outstanding job count by the number of new, incomplete aggregation jobs
-                // we are writing; decrement outstanding job count by the number of updated,
-                // complete aggregation jobs we are writing. (We assume any update to a terminal
-                // state is the first time we have updated to a terminal state, as the system does
-                // not touch aggregation jobs once they have reached a terminal state, and it would
-                // add code complexity & runtime cost to determine if we are in a
-                // repeated-terminal-write case.)
-                // Update the time interval too.
-                let mut outstanding_aggregation_jobs = batch.outstanding_aggregation_jobs();
-                let mut client_timestamp_interval = *batch.client_timestamp_interval();
-                for (aggregation_job_id, report_aggregation_ords) in by_aggregation_job_index.iter()
-                {
-                    // unwrap safety: index lookup
-                    let (agg_job_op, agg_job, report_aggs) =
-                        by_aggregation_job.get(aggregation_job_id).unwrap();
-                    if agg_job_op == &Operation::Put
-                        && matches!(agg_job.state(), AggregationJobState::InProgress)
-                    {
-                        outstanding_aggregation_jobs += 1;
-                    } else if agg_job_op == &Operation::Update
-                        && !matches!(agg_job.state(), AggregationJobState::InProgress)
-                    {
-                        // If we are Putting the batch, that means that it does not exist in the
-                        // datastore. But since we first write the batch when an aggregation job
-                        // referencing that batch is created, and we are completing the aggregation
-                        // job here, we must have deleted the batch at some point between creating &
-                        // completing this aggregation job. This should only be possible if the
-                        // batch is GC'ed. In that case, it is acceptable to skip writing the batch
-                        // entirely; and indeed, we must do so, since otherwise we might underflow
-                        // the outstanding_aggregation_jobs counter.
-                        //
-                        // See https://github.com/divviup/janus/issues/2464 for more detail.
-                        if batch_op == Operation::Put {
-                            if Q::is_batch_garbage_collected(tx.clock(), batch_identifier) != Some(true) {
-                                error!(
-                                    task_id = ?self.task.id(),
-                                    batch_id = ?batch_identifier,
-                                    ?aggregation_job_id,
-                                    "Unexpectedly missing batch while writing completed aggregation job"
-                                );
-                                panic!("Unexpectedly missing batch while writing completed aggregation job");
-                            }
-
-                            debug!(
-                                task_id = ?self.task.id(),
-                                batch_id = ?batch_identifier,
-                                ?aggregation_job_id,
-                                "Skipping batch write for GC'ed batch"
-                            );
-                            return None;
-                        }
-
-                        outstanding_aggregation_jobs -= 1;
-                    }
-
-                    for ra_ord in report_aggregation_ords {
-                        // unwrap safety: index lookup
-                        let report_aggregation = report_aggs.get(*ra_ord).unwrap();
-                        client_timestamp_interval = match client_timestamp_interval
-                            .merged_with(report_aggregation.time())
-                        {
-                            Ok(client_timestamp_interval) => client_timestamp_interval,
-                            Err(err) => return Some(Err(err)),
-                        };
-                    }
-                }
-                if batch.state() == &BatchState::Closing
-                    && outstanding_aggregation_jobs == 0
-                    && !batches_with_reports.contains(batch.batch_identifier())
-                {
-                    batch = batch.with_state(BatchState::Closed);
-                    newly_closed_batches.push(batch_identifier);
-                }
-
-                Some(Ok((
-                    batch_identifier,
-                    (
-                        batch_op,
-                        batch
-                            .with_outstanding_aggregation_jobs(outstanding_aggregation_jobs)
-                            .with_client_timestamp_interval(client_timestamp_interval),
-                    ),
-                )))
-            })
-            .collect::<Result<_, _>>()?;
+        let creating_aggregation_jobs = batch_update_callback.creating_aggregation_jobs();
+        indexed.update_batches(batch_update_callback, tx.clock(), creating_aggregation_jobs)?;
 
         // Write batches, aggregation jobs, and report aggregations.
-        let (_, _, affected_collection_jobs) = try_join!(
-            // Write updated batches.
-            try_join_all(batches.values().map(|(op, batch)| async move {
-                match op {
-                    Operation::Put => {
+        let write_batches_future = try_join_all(indexed.batches.values().map(
+            |(batch_op, batch)| async move {
+                match (creating_aggregation_jobs, batch_op) {
+                    (true, Operation::Put) => {
                         let rslt = tx.put_batch(batch).await;
                         if matches!(rslt, Err(Error::MutationTargetAlreadyExists)) {
                             // This codepath can be taken due to a quirk of how the Repeatable Read
@@ -442,44 +422,36 @@ impl<const SEED_SIZE: usize, Q: CollectableQueryType, A: vdaf::Aggregator<SEED_S
                         }
                         rslt
                     }
-                    Operation::Update => tx.update_batch(batch).await,
+                    (_, Operation::Update) => tx.update_batch(batch).await,
+                    (false, Operation::Put) => panic!(
+                        "Unexpectedly missing batch while updating existing aggregation jobs"
+                    ),
                 }
-            })),
-            // Write updated aggregation jobs & report aggregations.
-            try_join_all(by_aggregation_job.values().map(
-                |(op, aggregation_job, report_aggregations)| async move {
-                    match op {
-                        Operation::Put => {
-                            // These operations must occur serially since report aggregation rows
-                            // have a foreign-key constraint on the related aggregation job
-                            // existing. We could speed things up for initial writes by switching to
-                            // DEFERRED constraints:
-                            // https://www.postgresql.org/docs/current/sql-set-constraints.html
-                            tx.put_aggregation_job(aggregation_job).await?;
-                            try_join_all(
-                                report_aggregations
-                                    .iter()
-                                    .map(|ra| tx.put_report_aggregation(ra)),
-                            )
-                            .await?;
-                        }
-                        Operation::Update => {
-                            try_join!(
-                                tx.update_aggregation_job(aggregation_job),
-                                try_join_all(
-                                    report_aggregations
-                                        .iter()
-                                        .map(|ra| tx.update_report_aggregation(ra)),
-                                )
-                            )?;
-                        }
-                    };
-                    Ok(())
-                }
-            )),
-            // Read any collection jobs associated with a batch which just transitioned to CLOSED
-            // state.
-            try_join_all(newly_closed_batches.into_iter().map(|batch_identifier| {
+            },
+        ));
+        let write_agg_jobs_future = try_join_all(indexed.by_aggregation_job.values().map(
+            |CowAggregationJobInfo {
+                 aggregation_job,
+                 report_aggregations,
+             }| async move {
+                if creating_aggregation_jobs {
+                    // These operations must occur serially since report aggregation rows have a
+                    // foreign-key constraint on the related aggregation job existing. We could
+                    // speed things up for initial writes by switching to DEFERRED constraints:
+                    // https://www.postgresql.org/docs/current/sql-set-constraints.html
+                    tx.put_aggregation_job(aggregation_job).await?;
+                    try_join_all(report_aggregations.iter().map(|ra| ra.write_new(tx))).await?;
+                } else {
+                    try_join!(
+                        tx.update_aggregation_job(aggregation_job),
+                        try_join_all(report_aggregations.iter().map(|ra| ra.write_update(tx)),)
+                    )?;
+                };
+                Ok(())
+            },
+        ));
+        let collection_jobs_future =
+            try_join_all(indexed.newly_closed_batches.iter().map(|batch_identifier| {
                 Q::get_collection_jobs_including(
                     tx,
                     vdaf.as_ref(),
@@ -496,13 +468,21 @@ impl<const SEED_SIZE: usize, Q: CollectableQueryType, A: vdaf::Aggregator<SEED_S
                         _ => None,
                     })
                     .collect::<HashMap<_, _>>()
-            })
+            });
+        let (_, _, affected_collection_jobs) = try_join!(
+            // Write updated batches.
+            write_batches_future,
+            // Write updated aggregation jobs & report aggregations.
+            write_agg_jobs_future,
+            // Read any collection jobs associated with a batch which just transitioned to CLOSED
+            // state.
+            collection_jobs_future
         )?;
 
         // Find all batches which are relevant to a collection job that just had a batch move into
         // CLOSED state.
         let relevant_batches: Arc<HashMap<_, _>> = Arc::new({
-            let batches = Arc::new(Mutex::new(batches));
+            let batches = Arc::new(Mutex::new(indexed.batches));
             let relevant_batch_identifiers: HashSet<_> = affected_collection_jobs
                 .values()
                 .flat_map(|collection_job| {
@@ -522,7 +502,7 @@ impl<const SEED_SIZE: usize, Q: CollectableQueryType, A: vdaf::Aggregator<SEED_S
                             // lock is dropped by the time we call `get_batch`.
                             let batch = batches.lock().unwrap().remove(&batch_identifier);
                             let batch = match batch {
-                                Some((_, batch)) => Some(batch),
+                                Some((_batch_op, batch)) => Some(batch),
                                 None => {
                                     tx.get_batch::<SEED_SIZE, Q, A>(
                                         self.task.id(),
@@ -593,6 +573,442 @@ impl<const SEED_SIZE: usize, Q: CollectableQueryType, A: vdaf::Aggregator<SEED_S
         )
         .await?;
 
-        Ok(unwritable_report_ids)
+        Ok(indexed.unwritable_report_ids)
+    }
+}
+
+/// Generic callback used in the internals of aggregation job writers. Different implementations are
+/// used when creating new aggregation jobs versus updating existing aggregation jobs.
+trait BatchUpdateCallback {
+    /// This takes one batch and an iterator of aggregation jobs, and returns that batch updated to
+    /// reflect changes due to the aggregation job. Particularly, it will update the
+    /// `outstanding_aggregation_jobs` counter and the `client_timestamp_interval`.
+    fn update_batch<'a, const SEED_SIZE: usize, Q, A, RA>(
+        &self,
+        batch: Batch<SEED_SIZE, Q, A>,
+        aggregation_jobs: impl Iterator<
+            Item = (
+                &'a AggregationJob<SEED_SIZE, Q, A>,
+                &'a [Cow<'a, RA>],
+                &'a [usize],
+            ),
+        >,
+    ) -> Result<Batch<SEED_SIZE, Q, A>, Error>
+    where
+        Q: CollectableQueryType,
+        A: vdaf::Aggregator<SEED_SIZE, 16> + 'a,
+        RA: ReportAggregationUpdate + Clone + 'a;
+
+    /// Returns a flag indicating whether aggregation jobs are being created or updated.
+    fn creating_aggregation_jobs(&self) -> bool;
+}
+
+/// Contains internal implementation details of [`AggregationJobUpdates::write`].
+///
+/// This tracks adjustments to aggregation jobs and report aggregations, before they can be written
+/// to the datastore, behind copy-on-write smart pointers, and maintains multiple maps to look up
+/// aggregation jobs, report aggregations, and batches.
+struct IndexedAggregationJobUpdates<'a, const SEED_SIZE: usize, Q, A, RA>
+where
+    Q: CollectableQueryType,
+    A: vdaf::Aggregator<SEED_SIZE, 16>,
+    RA: Clone,
+{
+    task: &'a AggregatorTask,
+    aggregation_parameter: &'a A::AggregationParam,
+    by_batch_identifier_index:
+        &'a HashMap<Q::BatchIdentifier, HashMap<AggregationJobId, Vec<usize>>>,
+    by_aggregation_job: HashMap<AggregationJobId, CowAggregationJobInfo<'a, SEED_SIZE, Q, A, RA>>,
+    batches: HashMap<Q::BatchIdentifier, (Operation, Batch<SEED_SIZE, Q, A>)>,
+    batches_with_unaggregated_reports: HashSet<Q::BatchIdentifier>,
+    unwritable_report_ids: HashSet<ReportId>,
+    newly_closed_batches: Vec<Q::BatchIdentifier>,
+}
+
+/// An aggregation job and its accompanying report aggregations.
+struct AggregationJobInfo<const SEED_SIZE: usize, Q, A, RA>
+where
+    Q: CollectableQueryType,
+    A: vdaf::Aggregator<SEED_SIZE, 16>,
+{
+    aggregation_job: AggregationJob<SEED_SIZE, Q, A>,
+    report_aggregations: Vec<RA>,
+}
+
+/// Copy-on-write version of [`AggregationJobInfo`].
+struct CowAggregationJobInfo<'a, const SEED_SIZE: usize, Q, A, RA>
+where
+    Q: CollectableQueryType,
+    A: vdaf::Aggregator<SEED_SIZE, 16>,
+    RA: Clone,
+{
+    aggregation_job: Cow<'a, AggregationJob<SEED_SIZE, Q, A>>,
+    report_aggregations: Vec<Cow<'a, RA>>,
+}
+
+impl<'a, const SEED_SIZE: usize, Q, A, RA> IndexedAggregationJobUpdates<'a, SEED_SIZE, Q, A, RA>
+where
+    Q: CollectableQueryType,
+    A: vdaf::Aggregator<SEED_SIZE, 16>,
+    RA: ReportAggregationUpdate + Clone,
+{
+    /// Construct a new set of lookup maps and copy-on-write data structures, from a set of
+    /// aggregation job updates and the current state of the datastore.
+    pub async fn new<C>(
+        tx: &Transaction<'_, C>,
+        updates: &'a AggregationJobUpdates<SEED_SIZE, Q, A, RA>,
+        aggregation_parameter: &'a A::AggregationParam,
+    ) -> Result<Self, Error>
+    where
+        C: Clock,
+    {
+        // Create a copy-on-write instance of our state to allow efficient imperative updates.
+        // (Copy-on-write is used here as modifying state requires cloning it, but most pieces of
+        // state will not be modified, so using CoW avoids the cost of cloning in the common case.)
+        let by_aggregation_job = updates
+            .aggregation_jobs
+            .iter()
+            .map(
+                |(
+                    aggregation_job_id,
+                    AggregationJobInfo {
+                        aggregation_job,
+                        report_aggregations,
+                    },
+                )| {
+                    (
+                        *aggregation_job_id,
+                        CowAggregationJobInfo {
+                            aggregation_job: Cow::Borrowed(aggregation_job),
+                            report_aggregations: report_aggregations
+                                .iter()
+                                .map(Cow::Borrowed)
+                                .collect::<Vec<_>>(),
+                        },
+                    )
+                },
+            )
+            .collect();
+
+        // Read all relevant batches and report counts from the datastore.
+        let (batches, batches_with_reports) = try_join!(
+            try_join_all(
+                updates
+                    .by_batch_identifier_index
+                    .keys()
+                    .map(|batch_identifier| {
+                        tx.get_batch::<SEED_SIZE, Q, A>(
+                            updates.task.id(),
+                            batch_identifier,
+                            aggregation_parameter,
+                        )
+                    })
+            ),
+            try_join_all(updates.by_batch_identifier_index.keys().map(
+                |batch_identifier| async move {
+                    if let Some(batch_interval) = Q::to_batch_interval(batch_identifier) {
+                        if tx
+                            .interval_has_unaggregated_reports(updates.task.id(), batch_interval)
+                            .await?
+                        {
+                            return Ok::<_, Error>(Some(batch_identifier.clone()));
+                        }
+                    }
+                    Ok(None)
+                },
+            )),
+        )?;
+
+        let batches: HashMap<_, _> = batches
+            .into_iter()
+            .flat_map(|batch: Option<Batch<SEED_SIZE, Q, A>>| {
+                batch.map(|b| (b.batch_identifier().clone(), (Operation::Update, b)))
+            })
+            .collect();
+
+        let batches_with_unaggregated_reports: HashSet<_> =
+            batches_with_reports.into_iter().flatten().collect();
+
+        Ok(Self {
+            task: &updates.task,
+            aggregation_parameter,
+            by_batch_identifier_index: &updates.by_batch_identifier_index,
+            by_aggregation_job,
+            batches,
+            batches_with_unaggregated_reports,
+            unwritable_report_ids: HashSet::new(),
+            newly_closed_batches: Vec::new(),
+        })
+    }
+
+    /// Update report aggregations with failure states if they land in previously collected batches.
+    fn fail_collected_report_aggregations(&mut self) {
+        // Update in-memory state of report aggregations: any report aggregations applying to a
+        // closed batch instead fail with a BatchCollected error (unless they were already in an
+        // failed state).
+        for (batch_identifier, by_aggregation_job_index) in self.by_batch_identifier_index {
+            if self.batches.get(batch_identifier).map(|(_, b)| *b.state())
+                != Some(BatchState::Closed)
+            {
+                continue;
+            }
+            for (aggregation_job_id, report_aggregation_ords) in by_aggregation_job_index {
+                for ord in report_aggregation_ords {
+                    // unwrap safety: index lookup
+                    let report_aggregation = self
+                        .by_aggregation_job
+                        .get_mut(aggregation_job_id)
+                        .unwrap()
+                        .report_aggregations
+                        .get_mut(*ord)
+                        .unwrap();
+                    if report_aggregation.is_failed() {
+                        continue;
+                    }
+
+                    self.unwritable_report_ids
+                        .insert(*report_aggregation.report_id());
+                    *report_aggregation = Cow::Owned(
+                        report_aggregation
+                            .as_ref()
+                            .clone()
+                            .with_failure(PrepareError::BatchCollected),
+                    );
+                }
+            }
+        }
+    }
+
+    /// Update aggregation job states if all their report aggregations have reached a terminal
+    /// state.
+    fn update_aggregation_job_state_from_ra_states(&mut self) {
+        // Update in-memory state of aggregation jobs: any aggregation jobs whose report
+        // aggregations are all in a terminal state should be considered Finished (unless the
+        // aggregation job was already in a terminal state).
+        for CowAggregationJobInfo {
+            aggregation_job,
+            report_aggregations,
+        } in self.by_aggregation_job.values_mut()
+        {
+            if matches!(
+                aggregation_job.state(),
+                AggregationJobState::Finished | AggregationJobState::Abandoned
+            ) {
+                continue;
+            }
+
+            if report_aggregations.iter().all(|ra| ra.is_terminal()) {
+                *aggregation_job = Cow::Owned(
+                    aggregation_job
+                        .as_ref()
+                        .clone()
+                        .with_state(AggregationJobState::Finished),
+                );
+            }
+        }
+    }
+
+    /// Update batches to reflect updates to aggregation jobs.
+    fn update_batches(
+        &mut self,
+        batch_update_callback: impl BatchUpdateCallback,
+        clock: &impl Clock,
+        creating_aggregation_jobs: bool,
+    ) -> Result<(), Error> {
+        // Update in-memory state of batches: outstanding job counts will change based on new or
+        // completed aggregation jobs affecting each batch; the client timestamp interval will
+        // change based on the report aggregations included in the batch.
+        self.batches = self
+            .by_batch_identifier_index
+            .iter()
+            .flat_map(|(batch_identifier, by_aggregation_job_index)| {
+                let (batch_op, mut batch) = match (
+                    creating_aggregation_jobs,
+                    self.batches.remove(batch_identifier),
+                ) {
+                    (_, Some((batch_op, batch))) => (batch_op, batch),
+                    (true, None) => (
+                        Operation::Put,
+                        Batch::new(
+                            *self.task.id(),
+                            batch_identifier.clone(),
+                            self.aggregation_parameter.clone(),
+                            BatchState::Open,
+                            0,
+                            Interval::EMPTY,
+                        ),
+                    ),
+                    (false, None) => {
+                        // The batch does not currently exist in the datastore. But since we first
+                        // write the batch when an aggregation job referencing that batch is
+                        // created, and we are stepping the aggregation job here, we must have
+                        // deleted the batch at some point between creating and stepping this
+                        // aggregation job. This should only be possible if the batch is GC'ed. In
+                        // that case, it is acceptable to skip writing the batch entirely; and
+                        // indeed, we must do so, since otherwise we might underflow the
+                        // outstanding_aggregation_jobs counter.
+                        //
+                        // See https://github.com/divviup/janus/issues/2464 for more detail.
+                        if Q::is_batch_garbage_collected(clock, batch_identifier) != Some(true) {
+                            error!(
+                                task_id = ?self.task.id(),
+                                batch_id = ?batch_identifier,
+                                "Unexpectedly missing batch while updating existing aggregation \
+                                jobs"
+                            );
+                            panic!(
+                                "Unexpectedly missing batch while updating existing aggregation \
+                                jobs"
+                            );
+                        }
+
+                        debug!(
+                            task_id = ?self.task.id(),
+                            batch_id = ?batch_identifier,
+                            "Skipping batch write for GC'ed batch"
+                        );
+                        return None;
+                    }
+                };
+                if batch.state() == &BatchState::Closed {
+                    // Never update a closed batch.
+                    return None;
+                }
+
+                let agg_job_iter = by_aggregation_job_index.iter().map(
+                    |(aggregation_job_id, report_aggregation_ords)| {
+                        // unwrap safety: index lookup
+                        let CowAggregationJobInfo {
+                            aggregation_job,
+                            report_aggregations,
+                        } = self.by_aggregation_job.get(aggregation_job_id).unwrap();
+                        (
+                            aggregation_job.as_ref(),
+                            report_aggregations.as_slice(),
+                            report_aggregation_ords.as_slice(),
+                        )
+                    },
+                );
+                batch = match batch_update_callback.update_batch(batch, agg_job_iter) {
+                    Ok(batch) => batch,
+                    Err(error) => return Some(Err(error)),
+                };
+                if batch.state() == &BatchState::Closing
+                    && batch.outstanding_aggregation_jobs() == 0
+                    && !self
+                        .batches_with_unaggregated_reports
+                        .contains(batch.batch_identifier())
+                {
+                    batch = batch.with_state(BatchState::Closed);
+                    self.newly_closed_batches.push(batch_identifier.clone());
+                }
+
+                Some(Ok((batch_identifier.clone(), (batch_op, batch))))
+            })
+            .collect::<Result<_, _>>()?;
+        Ok(())
+    }
+}
+
+/// Abstracts over multiple representations of a report aggregation.
+///
+/// See [`ReportAggregation`] and [`ReportAggregationMetadata`].
+#[async_trait]
+trait ReportAggregationUpdate {
+    /// Returns the report ID associated with this report aggregation.
+    fn report_id(&self) -> &ReportId;
+
+    /// Returns the client timestamp associated with this report aggregation.
+    fn time(&self) -> &Time;
+
+    /// Returns whether this report aggregation is in a terminal state ("Finished" or "Failed").
+    fn is_terminal(&self) -> bool;
+
+    /// Returns whether this report aggregation is failed.
+    fn is_failed(&self) -> bool;
+
+    /// Returns a new report aggregation corresponding to this report aggregation updated to have
+    /// the "Failed" state, with the given [`PrepareError`].
+    fn with_failure(self, prepare_error: PrepareError) -> Self;
+
+    /// Write this report aggregation to the datastore. This must be used only with newly-created
+    /// report aggregations.
+    async fn write_new(&self, tx: &Transaction<impl Clock>) -> Result<(), Error>;
+
+    /// Write this report aggregation to the datastore. This must be used only for updates to
+    /// existing report aggregations.
+    async fn write_update(&self, tx: &Transaction<impl Clock>) -> Result<(), Error>;
+}
+
+#[async_trait]
+impl<const SEED_SIZE: usize, A> ReportAggregationUpdate for ReportAggregation<SEED_SIZE, A>
+where
+    A: vdaf::Aggregator<SEED_SIZE, 16>,
+    A::PublicShare: Sync,
+    A::InputShare: Sync,
+    A::PrepareMessage: Sync,
+    A::PrepareState: Encode + Sync,
+{
+    fn report_id(&self) -> &ReportId {
+        self.report_id()
+    }
+
+    fn time(&self) -> &Time {
+        self.time()
+    }
+
+    fn is_failed(&self) -> bool {
+        matches!(self.state(), ReportAggregationState::Failed { .. })
+    }
+
+    fn is_terminal(&self) -> bool {
+        matches!(
+            self.state(),
+            ReportAggregationState::Finished { .. } | ReportAggregationState::Failed { .. }
+        )
+    }
+
+    fn with_failure(self, prepare_error: PrepareError) -> Self {
+        self.with_state(ReportAggregationState::Failed { prepare_error })
+    }
+
+    async fn write_new(&self, tx: &Transaction<impl Clock>) -> Result<(), Error> {
+        tx.put_report_aggregation(self).await
+    }
+
+    async fn write_update(&self, tx: &Transaction<impl Clock>) -> Result<(), Error> {
+        tx.update_report_aggregation(self).await
+    }
+}
+
+#[async_trait]
+impl ReportAggregationUpdate for ReportAggregationMetadata {
+    fn report_id(&self) -> &ReportId {
+        self.report_id()
+    }
+
+    fn time(&self) -> &Time {
+        self.time()
+    }
+
+    fn is_failed(&self) -> bool {
+        matches!(self.state(), ReportAggregationMetadataState::Failed { .. })
+    }
+
+    fn is_terminal(&self) -> bool {
+        // Note that ReportAggregationMetadata can only represent the Start and Failed states, not Finished.
+        self.is_failed()
+    }
+
+    fn with_failure(self, prepare_error: PrepareError) -> Self {
+        self.with_state(ReportAggregationMetadataState::Failed { prepare_error })
+    }
+
+    async fn write_new(&self, tx: &Transaction<impl Clock>) -> Result<(), Error> {
+        tx.create_leader_report_aggregation(self).await
+    }
+
+    async fn write_update(&self, _tx: &Transaction<impl Clock>) -> Result<(), Error> {
+        panic!("tried to update an existing report aggregation via ReportAggregationMetadata")
     }
 }

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -5,8 +5,8 @@ use self::models::{
     AggregatorRole, AuthenticationTokenType, Batch, BatchAggregation, BatchAggregationState,
     BatchAggregationStateCode, CollectionJob, CollectionJobState, CollectionJobStateCode,
     GlobalHpkeKeypair, HpkeKeyState, LeaderStoredReport, Lease, LeaseToken, OutstandingBatch,
-    ReportAggregation, ReportAggregationMetadata, ReportAggregationState,
-    ReportAggregationStateCode, SqlInterval, TaskUploadCounter,
+    ReportAggregation, ReportAggregationMetadata, ReportAggregationMetadataState,
+    ReportAggregationState, ReportAggregationStateCode, SqlInterval, TaskUploadCounter,
 };
 use crate::{
     query_type::{AccumulableQueryType, CollectableQueryType},
@@ -2374,45 +2374,93 @@ impl<C: Clock> Transaction<'_, C> {
         &self,
         report_aggregation_metadata: &ReportAggregationMetadata,
     ) -> Result<(), Error> {
-        let stmt = self
-            .prepare_cached(
-                "INSERT INTO report_aggregations
-                    (task_id, aggregation_job_id, client_report_id, client_timestamp, ord,
-                    state, public_share, leader_extensions, leader_input_share,
-                    helper_encrypted_input_share, created_at, updated_at, updated_by)
-                SELECT
-                    tasks.id, aggregation_jobs.id, $3::BYTEA, $4::TIMESTAMP, $5::BIGINT,
-                    'START'::REPORT_AGGREGATION_STATE, client_reports.public_share,
-                    client_reports.extensions, client_reports.leader_input_share,
-                    client_reports.helper_encrypted_input_share, $6, $7, $8
-                FROM aggregation_jobs
-                JOIN tasks ON tasks.id = aggregation_jobs.task_id
-                JOIN client_reports
-                    ON tasks.id = client_reports.task_id
-                    AND client_reports.report_id = $3::BYTEA
-                WHERE tasks.task_id = $1
-                AND aggregation_job_id = $2
-                AND UPPER(aggregation_jobs.client_timestamp_interval) >= COALESCE($9::TIMESTAMP - tasks.report_expiry_age * '1 second'::INTERVAL, '-infinity'::TIMESTAMP)
-                ON CONFLICT DO NOTHING",
-            )
-            .await?;
-        self.execute(
-            &stmt,
-            &[
-                /* task_id */ &report_aggregation_metadata.task_id().as_ref(),
-                /* aggregation_job_id */
-                &report_aggregation_metadata.aggregation_job_id().as_ref(),
-                /* client_report_id */ &report_aggregation_metadata.report_id().as_ref(),
-                /* client_timestamp */
-                &report_aggregation_metadata.time().as_naive_date_time()?,
-                /* ord */ &TryInto::<i64>::try_into(report_aggregation_metadata.ord())?,
-                /* created_at */ &self.clock.now().as_naive_date_time()?,
-                /* updated_at */ &self.clock.now().as_naive_date_time()?,
-                /* updated_by */ &self.name,
-                /* now */ &self.clock.now().as_naive_date_time()?,
-            ],
-        )
-        .await?;
+        match report_aggregation_metadata.state() {
+            ReportAggregationMetadataState::Start => {
+                let stmt = self
+                .prepare_cached(
+                    "INSERT INTO report_aggregations
+                        (task_id, aggregation_job_id, client_report_id, client_timestamp, ord,
+                        state, public_share, leader_extensions, leader_input_share,
+                        helper_encrypted_input_share, created_at, updated_at, updated_by)
+                    SELECT
+                        tasks.id, aggregation_jobs.id, $3::BYTEA, $4::TIMESTAMP, $5::BIGINT,
+                        'START'::REPORT_AGGREGATION_STATE, client_reports.public_share,
+                        client_reports.extensions, client_reports.leader_input_share,
+                        client_reports.helper_encrypted_input_share, $6, $7, $8
+                    FROM aggregation_jobs
+                    JOIN tasks ON tasks.id = aggregation_jobs.task_id
+                    JOIN client_reports
+                        ON tasks.id = client_reports.task_id
+                        AND client_reports.report_id = $3::BYTEA
+                    WHERE tasks.task_id = $1
+                    AND aggregation_job_id = $2
+                    AND UPPER(aggregation_jobs.client_timestamp_interval) >= COALESCE($9::TIMESTAMP - tasks.report_expiry_age * '1 second'::INTERVAL, '-infinity'::TIMESTAMP)
+                    ON CONFLICT DO NOTHING",
+                )
+                .await?;
+                self.execute(
+                    &stmt,
+                    &[
+                        /* task_id */ &report_aggregation_metadata.task_id().as_ref(),
+                        /* aggregation_job_id */
+                        &report_aggregation_metadata.aggregation_job_id().as_ref(),
+                        /* client_report_id */
+                        &report_aggregation_metadata.report_id().as_ref(),
+                        /* client_timestamp */
+                        &report_aggregation_metadata.time().as_naive_date_time()?,
+                        /* ord */
+                        &TryInto::<i64>::try_into(report_aggregation_metadata.ord())?,
+                        /* created_at */ &self.clock.now().as_naive_date_time()?,
+                        /* updated_at */ &self.clock.now().as_naive_date_time()?,
+                        /* updated_by */ &self.name,
+                        /* now */ &self.clock.now().as_naive_date_time()?,
+                    ],
+                )
+                .await?;
+            }
+            ReportAggregationMetadataState::Failed { prepare_error } => {
+                let stmt = self
+                    .prepare_cached(
+                        "INSERT INTO report_aggregations
+                            (task_id, aggregation_job_id, client_report_id, client_timestamp, ord,
+                            state, error_code, created_at, updated_at, updated_by)
+                        SELECT
+                            tasks.id, aggregation_jobs.id, $3::BYTEA, $4::TIMESTAMP, $5::BIGINT,
+                            'FAILED'::REPORT_AGGREGATION_STATE, $6, $7, $8, $9
+                        FROM aggregation_jobs
+                        JOIN tasks ON tasks.id = aggregation_jobs.task_id
+                        JOIN client_reports
+                            ON tasks.id = client_reports.task_id
+                            AND client_reports.report_id = $3::BYTEA
+                        WHERE tasks.task_id = $1
+                        AND aggregation_job_id = $2
+                        AND UPPER(aggregation_jobs.client_timestamp_interval) >= COALESCE($10::TIMESTAMP - tasks.report_expiry_age * '1 second'::INTERVAL, '-infinity'::TIMESTAMP)
+                        ON CONFLICT DO NOTHING",
+                    )
+                    .await?;
+                self.execute(
+                    &stmt,
+                    &[
+                        /* task_id */ &report_aggregation_metadata.task_id().as_ref(),
+                        /* aggregation_job_id */
+                        &report_aggregation_metadata.aggregation_job_id().as_ref(),
+                        /* client_report_id */
+                        &report_aggregation_metadata.report_id().as_ref(),
+                        /* client_timestamp */
+                        &report_aggregation_metadata.time().as_naive_date_time()?,
+                        /* ord */
+                        &TryInto::<i64>::try_into(report_aggregation_metadata.ord())?,
+                        /* error_code */ &(*prepare_error as i16),
+                        /* created_at */ &self.clock.now().as_naive_date_time()?,
+                        /* updated_at */ &self.clock.now().as_naive_date_time()?,
+                        /* updated_by */ &self.name,
+                        /* now */ &self.clock.now().as_naive_date_time()?,
+                    ],
+                )
+                .await?;
+            }
+        }
+
         Ok(())
     }
 

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -2367,7 +2367,7 @@ impl<C: Clock> Transaction<'_, C> {
     ///
     /// Report shares are copied directly from the `client_reports` table.
     #[tracing::instrument(skip(self), err(level = Level::DEBUG))]
-    pub async fn create_leader_report_aggregation(
+    pub async fn put_leader_report_aggregation(
         &self,
         report_aggregation_metadata: &ReportAggregationMetadata,
     ) -> Result<(), Error> {

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -1055,6 +1055,68 @@ where
 {
 }
 
+/// Metadata from the state of a single client report's ongoing aggregation. This is like
+/// [`ReportAggregation`], but omits the report aggregation state and report shares.
+///
+/// This is only used with report aggregations in the `StartLeader` state.
+#[derive(Clone, Debug)]
+pub struct ReportAggregationMetadata {
+    task_id: TaskId,
+    aggregation_job_id: AggregationJobId,
+    report_id: ReportId,
+    time: Time,
+    ord: u64,
+}
+
+impl ReportAggregationMetadata {
+    /// Creates a new [`ReportAggregationMetadata`].
+    pub fn new(
+        task_id: TaskId,
+        aggregation_job_id: AggregationJobId,
+        report_id: ReportId,
+        time: Time,
+        ord: u64,
+    ) -> Self {
+        Self {
+            task_id,
+            aggregation_job_id,
+            report_id,
+            time,
+            ord,
+        }
+    }
+
+    /// Returns the task ID associated with this report aggregation.
+    pub fn task_id(&self) -> &TaskId {
+        &self.task_id
+    }
+
+    /// Returns the aggregation job ID associated with this report aggregation.
+    pub fn aggregation_job_id(&self) -> &AggregationJobId {
+        &self.aggregation_job_id
+    }
+
+    /// Returns the report ID associated with this report aggregation.
+    pub fn report_id(&self) -> &ReportId {
+        &self.report_id
+    }
+
+    /// Returns the client timestamp associated with this report aggregation.
+    pub fn time(&self) -> &Time {
+        &self.time
+    }
+
+    /// Returns a [`ReportMetadata`] corresponding to this report.
+    pub fn report_metadata(&self) -> ReportMetadata {
+        ReportMetadata::new(self.report_id, self.time)
+    }
+
+    /// Returns the order of this report aggregation in its aggregation job.
+    pub fn ord(&self) -> u64 {
+        self.ord
+    }
+}
+
 /// BatchAggregation corresponds to a row in the `batch_aggregations` table and represents the
 /// possibly-ongoing aggregation of the set of input shares that fall within the batch identified by
 /// `batch_identifier` with the aggregation parameter `aggregation_parameter`. This is the

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -1067,7 +1067,7 @@ pub enum ReportAggregationMetadataState {
 /// Metadata from the state of a single client report's ongoing aggregation. This is like
 /// [`ReportAggregation`], but omits the report aggregation state and report shares.
 ///
-/// This is only used with report aggregations in the `StartLeader` state.
+/// This is only used with report aggregations in the `StartLeader` or `Failed` states.
 #[derive(Clone, Debug)]
 pub struct ReportAggregationMetadata {
     task_id: TaskId,

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -1055,6 +1055,15 @@ where
 {
 }
 
+/// Limited set of report aggregation states usable with [`ReportAggregationMetadata`].
+///
+/// See also [`ReportAggregationState`].
+#[derive(Clone, Debug)]
+pub enum ReportAggregationMetadataState {
+    Start,
+    Failed { prepare_error: PrepareError },
+}
+
 /// Metadata from the state of a single client report's ongoing aggregation. This is like
 /// [`ReportAggregation`], but omits the report aggregation state and report shares.
 ///
@@ -1066,6 +1075,7 @@ pub struct ReportAggregationMetadata {
     report_id: ReportId,
     time: Time,
     ord: u64,
+    state: ReportAggregationMetadataState,
 }
 
 impl ReportAggregationMetadata {
@@ -1076,6 +1086,7 @@ impl ReportAggregationMetadata {
         report_id: ReportId,
         time: Time,
         ord: u64,
+        state: ReportAggregationMetadataState,
     ) -> Self {
         Self {
             task_id,
@@ -1083,6 +1094,7 @@ impl ReportAggregationMetadata {
             report_id,
             time,
             ord,
+            state,
         }
     }
 
@@ -1114,6 +1126,17 @@ impl ReportAggregationMetadata {
     /// Returns the order of this report aggregation in its aggregation job.
     pub fn ord(&self) -> u64 {
         self.ord
+    }
+
+    /// Returns the state of the report aggregation.
+    pub fn state(&self) -> &ReportAggregationMetadataState {
+        &self.state
+    }
+
+    /// Returns a new [`ReportAggregationMetadata`] corresponding to this report aggregation updated
+    /// to have the given state.
+    pub fn with_state(self, state: ReportAggregationMetadataState) -> Self {
+        Self { state, ..self }
     }
 }
 

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -160,6 +160,7 @@ where
         &self.helper_encrypted_input_share
     }
 
+    #[cfg(feature = "test-util")]
     pub fn as_start_leader_report_aggregation(
         &self,
         aggregation_job_id: AggregationJobId,

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -4,8 +4,8 @@ use crate::{
             AcquiredAggregationJob, AcquiredCollectionJob, AggregateShareJob, AggregationJob,
             AggregationJobState, Batch, BatchAggregation, BatchAggregationState, BatchState,
             CollectionJob, CollectionJobState, GlobalHpkeKeypair, HpkeKeyState, LeaderStoredReport,
-            Lease, OutstandingBatch, ReportAggregation, ReportAggregationState, SqlInterval,
-            TaskUploadCounter,
+            Lease, OutstandingBatch, ReportAggregation, ReportAggregationMetadata,
+            ReportAggregationState, SqlInterval, TaskUploadCounter,
         },
         schema_versions_template,
         test_util::{ephemeral_datastore_schema_version, generate_aead_key, EphemeralDatastore},
@@ -2477,6 +2477,135 @@ async fn get_report_aggregations_for_aggregation_job(ephemeral_datastore: Epheme
         .await
         .unwrap();
     assert!(got_report_aggregations.is_empty());
+}
+
+#[rstest_reuse::apply(schema_versions_template)]
+#[tokio::test]
+async fn create_report_aggregation_from_client_reports_table(
+    ephemeral_datastore: EphemeralDatastore,
+) {
+    install_test_trace_subscriber();
+
+    let clock = MockClock::new(OLDEST_ALLOWED_REPORT_TIMESTAMP);
+    let ds = ephemeral_datastore.datastore(clock.clone()).await;
+
+    let report_id = random();
+    let vdaf = Arc::new(Poplar1::new_turboshake128(1));
+    let verify_key: [u8; VERIFY_KEY_LENGTH] = random();
+    let aggregation_param =
+        Poplar1AggregationParam::try_from_prefixes(Vec::from([IdpfInput::from_bools(&[false])]))
+            .unwrap();
+
+    let vdaf_transcript = run_vdaf(
+        vdaf.as_ref(),
+        &verify_key,
+        &aggregation_param,
+        &report_id,
+        &IdpfInput::from_bools(&[false]),
+    );
+
+    let task = TaskBuilder::new(
+        task::QueryType::TimeInterval,
+        VdafInstance::Poplar1 { bits: 1 },
+    )
+    .with_report_expiry_age(Some(REPORT_EXPIRY_AGE))
+    .build()
+    .leader_view()
+    .unwrap();
+    let aggregation_job_id = random();
+    let want_report_aggregations = ds
+        .run_unnamed_tx(|tx| {
+            let clock = clock.clone();
+            let task = task.clone();
+            let vdaf = vdaf.clone();
+            let vdaf_transcript = vdaf_transcript.clone();
+            let aggregation_param = aggregation_param.clone();
+            Box::pin(async move {
+                tx.put_aggregator_task(&task).await.unwrap();
+                tx.put_aggregation_job(&AggregationJob::<
+                    VERIFY_KEY_LENGTH,
+                    TimeInterval,
+                    Poplar1<XofTurboShake128, 16>,
+                >::new(
+                    *task.id(),
+                    aggregation_job_id,
+                    aggregation_param,
+                    (),
+                    Interval::new(OLDEST_ALLOWED_REPORT_TIMESTAMP, Duration::from_seconds(1))
+                        .unwrap(),
+                    AggregationJobState::InProgress,
+                    AggregationJobStep::from(0),
+                ))
+                .await
+                .unwrap();
+
+                let report_id = random();
+                let timestamp = clock.now();
+                let leader_stored_report = LeaderStoredReport::new(
+                    *task.id(),
+                    ReportMetadata::new(report_id, timestamp),
+                    vdaf_transcript.public_share,
+                    Vec::new(),
+                    vdaf_transcript.leader_input_share,
+                    HpkeCiphertext::new(
+                        HpkeConfigId::from(9),
+                        Vec::from(b"encapsulated"),
+                        Vec::from(b"encrypted helper share"),
+                    ),
+                );
+                tx.put_client_report(vdaf.as_ref(), &leader_stored_report)
+                    .await
+                    .unwrap();
+
+                let report_aggregation_metadata = ReportAggregationMetadata::new(
+                    *task.id(),
+                    aggregation_job_id,
+                    report_id,
+                    timestamp,
+                    0,
+                );
+                tx.create_leader_report_aggregation(&report_aggregation_metadata)
+                    .await
+                    .unwrap();
+
+                Ok(Vec::from([ReportAggregation::new(
+                    *task.id(),
+                    aggregation_job_id,
+                    report_id,
+                    timestamp,
+                    0,
+                    None,
+                    ReportAggregationState::<16, Poplar1<XofTurboShake128, 16>>::StartLeader {
+                        public_share: leader_stored_report.public_share().clone(),
+                        leader_extensions: leader_stored_report.leader_extensions().to_owned(),
+                        leader_input_share: leader_stored_report.leader_input_share().clone(),
+                        helper_encrypted_input_share: leader_stored_report
+                            .helper_encrypted_input_share()
+                            .clone(),
+                    },
+                )]))
+            })
+        })
+        .await
+        .unwrap();
+
+    let got_report_aggregations = ds
+        .run_unnamed_tx(|tx| {
+            let vdaf = vdaf.clone();
+            let task = task.clone();
+            Box::pin(async move {
+                tx.get_report_aggregations_for_aggregation_job(
+                    vdaf.as_ref(),
+                    &Role::Leader,
+                    task.id(),
+                    &aggregation_job_id,
+                )
+                .await
+            })
+        })
+        .await
+        .unwrap();
+    assert_eq!(want_report_aggregations, got_report_aggregations);
 }
 
 #[tokio::test]

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -2568,7 +2568,7 @@ async fn create_report_aggregation_from_client_reports_table(
                     0,
                     ReportAggregationMetadataState::Start,
                 );
-                tx.create_leader_report_aggregation(&report_aggregation_metadata)
+                tx.put_leader_report_aggregation(&report_aggregation_metadata)
                     .await
                     .unwrap();
 

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -5,7 +5,7 @@ use crate::{
             AggregationJobState, Batch, BatchAggregation, BatchAggregationState, BatchState,
             CollectionJob, CollectionJobState, GlobalHpkeKeypair, HpkeKeyState, LeaderStoredReport,
             Lease, OutstandingBatch, ReportAggregation, ReportAggregationMetadata,
-            ReportAggregationState, SqlInterval, TaskUploadCounter,
+            ReportAggregationMetadataState, ReportAggregationState, SqlInterval, TaskUploadCounter,
         },
         schema_versions_template,
         test_util::{ephemeral_datastore_schema_version, generate_aead_key, EphemeralDatastore},
@@ -2563,6 +2563,7 @@ async fn create_report_aggregation_from_client_reports_table(
                     report_id,
                     timestamp,
                     0,
+                    ReportAggregationMetadataState::Start,
                 );
                 tx.create_leader_report_aggregation(&report_aggregation_metadata)
                     .await

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -631,13 +631,13 @@ async fn get_unaggregated_client_reports_for_task(ephemeral_datastore: Ephemeral
         })
         .await
         .unwrap();
-    got_reports.sort_by_key(|report| *report.metadata().id());
+    got_reports.sort_by_key(|report_metadata| *report_metadata.id());
 
     let mut want_reports = Vec::from([
-        first_unaggregated_report.clone(),
-        second_unaggregated_report.clone(),
+        first_unaggregated_report.metadata().clone(),
+        second_unaggregated_report.metadata().clone(),
     ]);
-    want_reports.sort_by_key(|report| *report.metadata().id());
+    want_reports.sort_by_key(|report_metadata| *report_metadata.id());
 
     assert_eq!(got_reports, want_reports);
 
@@ -702,7 +702,10 @@ async fn get_unaggregated_client_reports_for_task(ephemeral_datastore: Ephemeral
         .await
         .unwrap();
 
-    assert_eq!(got_reports, Vec::from([first_unaggregated_report.clone()]),);
+    assert_eq!(
+        got_reports,
+        Vec::from([first_unaggregated_report.metadata().clone()])
+    );
 
     ds.run_unnamed_tx(|tx| {
         let (first_unaggregated_report, second_unaggregated_report) = (


### PR DESCRIPTION
This refactors the aggregation job writer, providing separate APIs for creating versus updating aggregation jobs, and changes aggregation job creation so that it does not read entire reports into memory, or write them back out from meory, but instead copies directly between the two database tables. This should improve the performance of the aggregation job creator, which we haven't yet scaled horizontally, and will mainly benefit tasks with very large VDAF messages.

Behavior differences between new aggregation jobs and updated aggregation jobs are controlled through a combination of static dispatch with traits and conditionals. There's one trait for updating a batch to reflect aggregation job changes, and another that abstracts over `ReportAggregation` and the new `ReportAggregationMetadata`. Amidst the aggregation job writer refactor, I moved up the check against updates to a garbage-collected batch -- this now happens at the top of the loop over batch identifiers, rather than within the nested loop over aggregation job updates. This can happen because we now require that all aggregation job "operations" are the same, and so we know whether to expect all referenced batches to already exist.

Closes #2689.