### PR TITLE
Add option to ignore unrecognized DpMechanism

### DIFF
--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -1074,7 +1074,10 @@ mod tests {
             .unwrap();
 
         let cfg = Config {
-            taskprov_config: TaskprovConfig { enabled: true },
+            taskprov_config: TaskprovConfig {
+                enabled: true,
+                ignore_unknown_differential_privacy_mechanism: false,
+            },
             ..Default::default()
         };
 

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -122,7 +122,10 @@ impl TaskprovTestCase {
             TestRuntime::default(),
             &noop_meter(),
             Config {
-                taskprov_config: TaskprovConfig { enabled: true },
+                taskprov_config: TaskprovConfig {
+                    enabled: true,
+                    ignore_unknown_differential_privacy_mechanism: false,
+                },
                 ..Default::default()
             },
         )

--- a/aggregator/src/binaries/aggregator.rs
+++ b/aggregator/src/binaries/aggregator.rs
@@ -619,7 +619,10 @@ mod tests {
             )
             .unwrap()
             .taskprov_config,
-            TaskprovConfig { enabled: true },
+            TaskprovConfig {
+                enabled: true,
+                ignore_unknown_differential_privacy_mechanism: false
+            },
         );
     }
 

--- a/aggregator/src/config.rs
+++ b/aggregator/src/config.rs
@@ -117,6 +117,16 @@ pub struct TaskprovConfig {
     ///
     /// [spec]: https://datatracker.ietf.org/doc/draft-wang-ppm-dap-taskprov/
     pub enabled: bool,
+
+    /// If true, will silently ignore unknown differential privacy mechanisms, and continue without
+    /// differential privacy noise.
+    ///
+    /// This should only be used for testing purposes. This option will be removed once full
+    /// differential privacy support is implemented.
+    ///
+    /// Defaults to false, i.e. opt out of tasks with unrecognized differential privacy mechanisms.
+    #[serde(default)]
+    pub ignore_unknown_differential_privacy_mechanism: bool,
 }
 
 /// Non-secret configuration options for Janus Job Driver jobs.

--- a/aggregator/tests/integration/graceful_shutdown.rs
+++ b/aggregator/tests/integration/graceful_shutdown.rs
@@ -253,7 +253,7 @@ async fn aggregator_shutdown() {
             metrics_config: MetricsConfiguration::default(),
             health_check_listen_address: "127.0.0.1:9001".parse().unwrap(),
         },
-        taskprov_config: TaskprovConfig { enabled: false },
+        taskprov_config: TaskprovConfig::default(),
         garbage_collection: None,
         listen_address: aggregator_listen_address,
         aggregator_api: Some(AggregatorApi {
@@ -324,7 +324,7 @@ async fn aggregation_job_driver_shutdown() {
             retry_max_interval_millis: 30_000,
             retry_max_elapsed_time_millis: 300_000,
         },
-        taskprov_config: TaskprovConfig { enabled: false },
+        taskprov_config: TaskprovConfig::default(),
         batch_aggregation_shard_count: 32,
     };
 


### PR DESCRIPTION
This adds a configuration option inside the `TaskprovConfig` struct to ignore unrecognized DpMechanisms for testing purposes. `janus_messages` is updated to round-trip such mechanisms, rather than fail to decode them.