### PR TITLE
Aggregator API: return 200 with zero counters for fresh task

### DIFF
--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -7526,8 +7526,13 @@ async fn roundtrip_task_upload_counter(ephemeral_datastore: EphemeralDatastore) 
         .run_unnamed_tx(|tx| {
             let task_id = *task.id();
             Box::pin(async move {
-                let counter = tx.get_task_upload_counter(&task_id).await.unwrap();
+                // Returns None for non-existent task.
+                let counter = tx.get_task_upload_counter(&random()).await.unwrap();
                 assert_eq!(counter, None);
+
+                // Returns Some for a task that has just been created and has no counters.
+                let counter = tx.get_task_upload_counter(&task_id).await.unwrap();
+                assert_eq!(counter, Some(TaskUploadCounter::default()));
 
                 let ord = thread_rng().gen_range(0..32);
                 tx.increment_task_upload_counter(


### PR DESCRIPTION
Fresh tasks, or tasks that otherwise don't have any counters, would return 404 when `/{task_id}/metrics/uploads` was called. This is not correct behavior. Fix the underlying database query.

Here's some query plans, doesn't appear to be regressive:

Before:
```
postgres=> EXPLAIN SELECT
                    SUM(interval_collected)::BIGINT AS interval_collected,
                    SUM(report_decode_failure)::BIGINT AS report_decode_failure,
                    SUM(report_decrypt_failure)::BIGINT AS report_decrypt_failure,
                    SUM(report_expired)::BIGINT AS report_expired,
                    SUM(report_outdated_key)::BIGINT AS report_outdated_key,
                    SUM(report_success)::BIGINT AS report_success,
                    SUM(report_too_early)::BIGINT AS report_too_early,
                    SUM(task_expired)::BIGINT AS task_expired
                FROM task_upload_counters
                WHERE task_id = (SELECT id FROM tasks WHERE task_id = '\xsometaskfromproduction');
                                                  QUERY PLAN
---------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=78.07..78.10 rows=1 width=64)
   InitPlan 1 (returns $0)
     ->  Index Scan using task_id_index on tasks  (cost=0.14..2.36 rows=1 width=8)
           Index Cond: (task_id = '\xsometaskfromproduction'::bytea)
   ->  Bitmap Heap Scan on task_upload_counters  (cost=29.32..74.87 rows=41 width=64)
         Recheck Cond: (task_id = $0)
         ->  Bitmap Index Scan on task_upload_counters_unique  (cost=0.00..29.31 rows=41 width=0)
               Index Cond: (task_id = $0)
```

After:
```
postgres=> EXPLAIN SELECT
                    tasks.id,
                    COALESCE(SUM(interval_collected)::BIGINT, 0) AS interval_collected,
                    COALESCE(SUM(report_decode_failure)::BIGINT, 0) AS report_decode_failure,
                    COALESCE(SUM(report_decrypt_failure)::BIGINT, 0) AS report_decrypt_failure,
                    COALESCE(SUM(report_expired)::BIGINT, 0) AS report_expired,
                    COALESCE(SUM(report_outdated_key)::BIGINT, 0) AS report_outdated_key,
                    COALESCE(SUM(report_success)::BIGINT, 0) AS report_success,
                    COALESCE(SUM(report_too_early)::BIGINT, 0) AS report_too_early,
                    COALESCE(SUM(task_expired)::BIGINT, 0) AS task_expired
                FROM task_upload_counters
                RIGHT JOIN tasks on tasks.id = task_upload_counters.task_id
                WHERE tasks.task_id = '\xsometaskfromproduction'
                GROUP BY tasks.id;
                                                       QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------
 GroupAggregate  (cost=67.50..67.60 rows=1 width=72)
   Group Key: tasks.id
   ->  Sort  (cost=67.50..67.50 rows=2 width=72)
         Sort Key: tasks.id
         ->  Nested Loop Left Join  (cost=29.39..67.49 rows=2 width=72)
               ->  Index Scan using task_id_index on tasks  (cost=0.14..2.36 rows=1 width=8)
                     Index Cond: (task_id = '\xsometaskfromproduction'::bytea)
               ->  Bitmap Heap Scan on task_upload_counters  (cost=29.25..64.80 rows=32 width=72)
                     Recheck Cond: (tasks.id = task_id)
                     ->  Bitmap Index Scan on task_upload_counters_unique  (cost=0.00..29.24 rows=32 width=0)
                           Index Cond: (task_id = tasks.id)
```