### PR TITLE
Write upload counters in separate transaction from uploads

### DIFF
--- a/aggregator/src/aggregator/report_writer.rs
+++ b/aggregator/src/aggregator/report_writer.rs
@@ -27,7 +27,7 @@ use tokio::{
     sync::{mpsc, oneshot},
     time::{sleep_until, Instant},
 };
-use tracing::debug;
+use tracing::{debug, error};
 
 type ReportResult<C> = Result<Box<dyn ReportWriter<C>>, ReportRejection>;
 
@@ -185,19 +185,31 @@ impl<C: Clock> ReportWriteBatcher<C> {
                         }
                     }))
                     .await;
-
-                    // Failure of writing counters is considered a whole transaction failure.
-                    // The logic behind it is simple enough that if it is failing, then likely
-                    // something _very_ wrong is going on and we should rollback.
-                    task_upload_counters.write(counter_shard_count, tx).await?;
-
-                    Ok(results)
+                    Ok((results, task_upload_counters))
                 })
             })
             .await;
 
         match results {
-            Ok(results) => {
+            Ok((results, task_upload_counters)) => {
+                // Write the task upload counters in a separate transaction from uploads. This is
+                // to prevent seralization conflicts causing excess repeated work when INSERTing.
+                //
+                // We're fine with this being non-transactional with the actual report uploads.
+                // If the process dies before being able to write counters, it's not a big deal.
+                ds.run_tx("update_task_upload_counters", |tx| {
+                    let task_upload_counters = task_upload_counters.clone();
+                    Box::pin(
+                        async move { task_upload_counters.write(counter_shard_count, tx).await },
+                    )
+                })
+                .await
+                .map_err(|err| {
+                    error!(?err, "Failed to write upload metrics");
+                    err
+                })
+                .ok();
+
                 // Individual, per-request results.
                 assert_eq!(result_senders.len(), results.len()); // sanity check: should be guaranteed.
                 for (result_tx, result) in result_senders.into_iter().zip(results.into_iter()) {


### PR DESCRIPTION
Supports https://github.com/divviup/janus/issues/2654.

This is a half-measure of decoupling report upload metrics from the uploads themselves, that I'd like to try in production. We can still do more with this decoupling, i.e. batching the uploads separately from `ReportUploadBatcher`.

I've observed high latency spikes in production that are ostensibly coincident with serialization conflicts. I suspect two or more transactions having to retry many INSERTs is proving problematic. Some of the spikes are severe, so I don't think scaling out the shard count is not going ameliorate the 99th percentile as much as I'd like.

<img width="532" alt="image" src="https://github.com/divviup/janus/assets/57697428/e778a228-0553-4d91-8981-a2bd88f878ac">

(I have the narrow hope that this will finally fully fix the HOT update problem, but this is wishful thinking).