### PR TITLE
Integration test using dummy VDAF with agg param

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3440,8 +3440,7 @@ dependencies = [
 [[package]]
 name = "prio"
 version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5247468645c68d3f5eaa958ca8b7ce5539bb604a1dcb9baa6a3cb7831f8fa8"
+source = "git+https://github.com/divviup/libprio-rs?rev=8774573dee1932c19c28ab83173b358b42a52b78#8774573dee1932c19c28ab83173b358b42a52b78"
 dependencies = [
  "aes",
  "bitvec",
@@ -3466,6 +3465,7 @@ dependencies = [
  "sha3",
  "subtle",
  "thiserror",
+ "zipf",
 ]
 
 [[package]]
@@ -3623,9 +3623,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
+checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
 dependencies = [
  "either",
  "rayon-core",
@@ -6122,6 +6122,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.46",
+]
+
+[[package]]
+name = "zipf"
+version = "7.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "390e51da0ed8cc3ade001d15fa5ba6f966b99c858fb466ec6b06d1682f1f94dd"
+dependencies = [
+ "rand",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,8 @@ k8s-openapi = { version = "0.20.0", features = ["v1_26"] }  # keep this version 
 kube = { version = "0.87.2", default-features = false, features = ["client", "rustls-tls"] }
 opentelemetry = { version = "0.22", features = ["metrics"] }
 opentelemetry_sdk = { version = "0.22", features = ["metrics"] }
-prio = { version = "0.16.1", features = ["multithreaded", "experimental"] }
+# TODO(timg): go back to released prio
+prio = { git = "https://github.com/divviup/libprio-rs", features = ["multithreaded", "experimental"], rev = "8774573dee1932c19c28ab83173b358b42a52b78" }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"
 serde_test = "1.0.175"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,7 @@ k8s-openapi = { version = "0.20.0", features = ["v1_26"] }  # keep this version 
 kube = { version = "0.87.2", default-features = false, features = ["client", "rustls-tls"] }
 opentelemetry = { version = "0.22", features = ["metrics"] }
 opentelemetry_sdk = { version = "0.22", features = ["metrics"] }
-# TODO(timg): go back to released prio
-prio = { git = "https://github.com/divviup/libprio-rs", features = ["multithreaded", "experimental"], rev = "8774573dee1932c19c28ab83173b358b42a52b78" }
+prio = { version = "0.16.2", features = ["multithreaded", "experimental"] }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"
 serde_test = "1.0.175"

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -942,7 +942,7 @@ impl<C: Clock> TaskAggregator<C> {
             }
 
             #[cfg(feature = "test-util")]
-            VdafInstance::Fake => VdafOps::Fake(Arc::new(dummy::Vdaf::new(1))),
+            VdafInstance::Fake { rounds } => VdafOps::Fake(Arc::new(dummy::Vdaf::new(*rounds))),
 
             #[cfg(feature = "test-util")]
             VdafInstance::FakeFailsPrepInit => VdafOps::Fake(Arc::new(

--- a/aggregator/src/aggregator/aggregate_init_tests.rs
+++ b/aggregator/src/aggregator/aggregate_init_tests.rs
@@ -176,7 +176,7 @@ pub(super) struct AggregationJobInitTestCase<
 pub(super) async fn setup_aggregate_init_test() -> AggregationJobInitTestCase<0, dummy::Vdaf> {
     setup_aggregate_init_test_for_vdaf(
         dummy::Vdaf::new(1),
-        VdafInstance::Fake,
+        VdafInstance::Fake { rounds: 1 },
         dummy::AggregationParam(0),
         0,
     )
@@ -324,7 +324,7 @@ pub(crate) async fn put_aggregation_job(
 async fn aggregation_job_init_authorization_dap_auth_token() {
     let test_case = setup_aggregate_init_test_without_sending_request(
         dummy::Vdaf::new(1),
-        VdafInstance::Fake,
+        VdafInstance::Fake { rounds: 1 },
         dummy::AggregationParam(0),
         0,
         AuthenticationToken::DapAuth(random()),
@@ -360,7 +360,7 @@ async fn aggregation_job_init_authorization_dap_auth_token() {
 async fn aggregation_job_init_malformed_authorization_header(#[case] header_value: &'static str) {
     let test_case = setup_aggregate_init_test_without_sending_request(
         dummy::Vdaf::new(1),
-        VdafInstance::Fake,
+        VdafInstance::Fake { rounds: 1 },
         dummy::AggregationParam(0),
         0,
         AuthenticationToken::Bearer(random()),
@@ -395,7 +395,7 @@ async fn aggregation_job_init_malformed_authorization_header(#[case] header_valu
 async fn aggregation_job_init_unexpected_taskprov_extension() {
     let test_case = setup_aggregate_init_test_without_sending_request(
         dummy::Vdaf::new(1),
-        VdafInstance::Fake,
+        VdafInstance::Fake { rounds: 1 },
         dummy::AggregationParam(0),
         0,
         random(),
@@ -541,7 +541,7 @@ async fn aggregation_job_mutation_report_aggregations() {
 async fn aggregation_job_intolerable_clock_skew() {
     let mut test_case = setup_aggregate_init_test_without_sending_request(
         dummy::Vdaf::new(1),
-        VdafInstance::Fake,
+        VdafInstance::Fake { rounds: 1 },
         dummy::AggregationParam(0),
         0,
         AuthenticationToken::Bearer(random()),

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -3437,14 +3437,18 @@ mod tests {
         let (mut quiescent_check_agg_jobs, _) = job_creator
             .datastore
             .run_unnamed_tx(|tx| {
-                let (task, vdaf) = (Arc::clone(&task), Arc::clone(&vdaf));
+                let (task, vdaf, expected_report_aggregations) = (
+                    Arc::clone(&task),
+                    Arc::clone(&vdaf),
+                    expected_report_aggregations.clone(),
+                );
                 Box::pin(async move {
                     Ok(
                         read_and_verify_aggregate_info_for_task::<0, TimeInterval, dummy::Vdaf, _>(
                             tx,
                             &vdaf,
                             task.id(),
-                            &HashMap::new(),
+                            &expected_report_aggregations,
                         )
                         .await,
                     )

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -3539,7 +3539,7 @@ mod tests {
         .unwrap();
 
         // Verify that all reports we saw a report aggregation for are scrubbed, if the aggregation
-        // parameter is not the unit type.
+        // parameter is the unit type.
         let all_seen_report_ids: HashSet<_> = agg_jobs_and_report_ids
             .iter()
             .flat_map(|(agg_job, report_aggs)| {
@@ -3551,8 +3551,8 @@ mod tests {
                 })
             })
             .collect();
-        for (_, report_id) in &all_seen_report_ids {
-            if is_unit_type::<A::AggregationParam>() {
+        if is_unit_type::<A::AggregationParam>() {
+            for (_, report_id) in &all_seen_report_ids {
                 tx.verify_client_report_scrubbed(task_id, report_id).await;
             }
         }
@@ -3560,8 +3560,8 @@ mod tests {
         // Verify that reports aggregated with a non-unit aggregation parameter do not get scrubbed.
         // We check that a report is scrubbed by reading the report, since reading a report will
         // fail if the report is scrubbed.
-        for (report_id, agg_param) in want_ra_states.keys() {
-            if is_unit_type::<A::AggregationParam>() {
+        if !is_unit_type::<A::AggregationParam>() {
+            for (report_id, agg_param) in want_ra_states.keys() {
                 if all_seen_report_ids.contains(&(agg_param.clone(), report_id)) {
                     continue;
                 }

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -758,7 +758,7 @@ mod tests {
         CollectionJob<0, TimeInterval, dummy::Vdaf>,
     ) {
         let time_precision = Duration::from_seconds(500);
-        let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake)
+        let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake { rounds: 1 })
             .with_helper_aggregator_endpoint(server.url().parse().unwrap())
             .with_time_precision(time_precision)
             .with_min_batch_size(10)
@@ -900,7 +900,7 @@ mod tests {
         let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
 
         let time_precision = Duration::from_seconds(500);
-        let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake)
+        let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake { rounds: 1 })
             .with_helper_aggregator_endpoint(server.url().parse().unwrap())
             .with_time_precision(time_precision)
             .with_min_batch_size(10)

--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -132,7 +132,7 @@ pub(crate) async fn setup_collection_job_test_case(
 ) -> CollectionJobTestCase {
     install_test_trace_subscriber();
 
-    let task = TaskBuilder::new(query_type, VdafInstance::Fake).build();
+    let task = TaskBuilder::new(query_type, VdafInstance::Fake { rounds: 1 }).build();
     let role_task = task.view_for_role(role).unwrap();
     let clock = MockClock::default();
     let ephemeral_datastore = ephemeral_datastore().await;

--- a/aggregator/src/aggregator/garbage_collector.rs
+++ b/aggregator/src/aggregator/garbage_collector.rs
@@ -216,11 +216,14 @@ mod tests {
             .run_unnamed_tx(|tx| {
                 let (clock, vdaf) = (clock.clone(), vdaf.clone());
                 Box::pin(async move {
-                    let task = TaskBuilder::new(task::QueryType::TimeInterval, VdafInstance::Fake)
-                        .with_report_expiry_age(Some(REPORT_EXPIRY_AGE))
-                        .build()
-                        .leader_view()
-                        .unwrap();
+                    let task = TaskBuilder::new(
+                        task::QueryType::TimeInterval,
+                        VdafInstance::Fake { rounds: 1 },
+                    )
+                    .with_report_expiry_age(Some(REPORT_EXPIRY_AGE))
+                    .build()
+                    .leader_view()
+                    .unwrap();
                     tx.put_aggregator_task(&task).await?;
 
                     // Client report artifacts.
@@ -364,11 +367,14 @@ mod tests {
             .run_unnamed_tx(|tx| {
                 let clock = clock.clone();
                 Box::pin(async move {
-                    let task = TaskBuilder::new(task::QueryType::TimeInterval, VdafInstance::Fake)
-                        .with_report_expiry_age(Some(REPORT_EXPIRY_AGE))
-                        .build()
-                        .helper_view()
-                        .unwrap();
+                    let task = TaskBuilder::new(
+                        task::QueryType::TimeInterval,
+                        VdafInstance::Fake { rounds: 1 },
+                    )
+                    .with_report_expiry_age(Some(REPORT_EXPIRY_AGE))
+                    .build()
+                    .helper_view()
+                    .unwrap();
                     tx.put_aggregator_task(&task).await?;
 
                     // Client report artifacts.
@@ -538,7 +544,7 @@ mod tests {
                             max_batch_size: Some(10),
                             batch_time_window_size: None,
                         },
-                        VdafInstance::Fake,
+                        VdafInstance::Fake { rounds: 1 },
                     )
                     .with_report_expiry_age(Some(REPORT_EXPIRY_AGE))
                     .build()
@@ -699,7 +705,7 @@ mod tests {
                             max_batch_size: Some(10),
                             batch_time_window_size: None,
                         },
-                        VdafInstance::Fake,
+                        VdafInstance::Fake { rounds: 1 },
                     )
                     .with_report_expiry_age(Some(REPORT_EXPIRY_AGE))
                     .build()

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -5292,7 +5292,7 @@ mod tests {
                                 0,
                                 interval_1,
                                 BatchAggregationState::Aggregating {
-                                    aggregate_share: Some(dummy::AggregateShare(64)),
+                                    aggregate_share: Some(dummy::AggregateShare(16)),
                                     report_count: interval_1_report_count,
                                     checksum: interval_1_checksum,
                                     aggregation_jobs_created: 1,
@@ -5311,7 +5311,7 @@ mod tests {
                                 0,
                                 interval_2,
                                 BatchAggregationState::Aggregating {
-                                    aggregate_share: Some(dummy::AggregateShare(128)),
+                                    aggregate_share: Some(dummy::AggregateShare(32)),
                                     report_count: interval_2_report_count,
                                     checksum: interval_2_checksum,
                                     aggregation_jobs_created: 1,
@@ -5330,7 +5330,7 @@ mod tests {
                                 0,
                                 interval_3,
                                 BatchAggregationState::Aggregating {
-                                    aggregate_share: Some(dummy::AggregateShare(256)),
+                                    aggregate_share: Some(dummy::AggregateShare(64)),
                                     report_count: interval_3_report_count,
                                     checksum: interval_3_checksum,
                                     aggregation_jobs_created: 1,
@@ -5349,7 +5349,7 @@ mod tests {
                                 0,
                                 interval_4,
                                 BatchAggregationState::Aggregating {
-                                    aggregate_share: Some(dummy::AggregateShare(512)),
+                                    aggregate_share: Some(dummy::AggregateShare(128)),
                                     report_count: interval_4_report_count,
                                     checksum: interval_4_checksum,
                                     aggregation_jobs_created: 1,
@@ -5501,7 +5501,7 @@ mod tests {
                     10,
                     ReportIdChecksum::get_decoded(&[3 ^ 2; 32]).unwrap(),
                 ),
-                dummy::AggregateShare(64 + 128),
+                dummy::expected_aggregate_result(0, [16, 32]),
             ),
             (
                 "third and fourth batches",
@@ -5518,7 +5518,7 @@ mod tests {
                     ReportIdChecksum::get_decoded(&[8 ^ 4; 32]).unwrap(),
                 ),
                 // Should get sum over the third and fourth batches
-                dummy::AggregateShare(256 + 512),
+                dummy::expected_aggregate_result(0, [64, 128]),
             ),
         ] {
             // Request the aggregate share multiple times. If the request parameters don't change,
@@ -5569,7 +5569,8 @@ mod tests {
                 let decoded_aggregate_share =
                     dummy::AggregateShare::get_decoded(aggregate_share.as_ref()).unwrap();
                 assert_eq!(
-                    decoded_aggregate_share, expected_result,
+                    decoded_aggregate_share,
+                    dummy::AggregateShare(expected_result),
                     "test case: {label:?}, iteration: {iteration}"
                 );
 

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -1763,7 +1763,8 @@ mod tests {
     async fn aggregate_init() {
         let (clock, _ephemeral_datastore, datastore, handler) = setup_http_handler_test().await;
 
-        let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake).build();
+        let task =
+            TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake { rounds: 1 }).build();
 
         let helper_task = task.helper_view().unwrap();
 
@@ -2240,7 +2241,7 @@ mod tests {
                 max_batch_size: Some(100),
                 batch_time_window_size: None,
             },
-            VdafInstance::Fake,
+            VdafInstance::Fake { rounds: 1 },
         )
         .build();
 
@@ -2334,7 +2335,8 @@ mod tests {
     async fn aggregate_init_with_reports_encrypted_by_global_key() {
         let (clock, _ephemeral_datastore, datastore, _) = setup_http_handler_test().await;
 
-        let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake).build();
+        let task =
+            TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake { rounds: 1 }).build();
 
         let helper_task = task.helper_view().unwrap();
         datastore.put_aggregator_task(&helper_task).await.unwrap();
@@ -2673,7 +2675,8 @@ mod tests {
     async fn aggregate_init_duplicated_report_id() {
         let (clock, _ephemeral_datastore, datastore, handler) = setup_http_handler_test().await;
 
-        let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake).build();
+        let task =
+            TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake { rounds: 1 }).build();
 
         let helper_task = task.helper_view().unwrap();
         let prep_init_generator = PrepareInitGenerator::new(
@@ -4333,7 +4336,8 @@ mod tests {
         let (_, _ephemeral_datastore, datastore, handler) = setup_http_handler_test().await;
 
         // Prepare parameters.
-        let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake).build();
+        let task =
+            TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake { rounds: 1 }).build();
         let helper_task = task.helper_view().unwrap();
         let aggregation_job_id = random();
         let report_metadata = ReportMetadata::new(
@@ -4518,7 +4522,7 @@ mod tests {
         let (_, _ephemeral_datastore, datastore, handler) = setup_http_handler_test().await;
 
         // Prepare parameters.
-        let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake)
+        let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake { rounds: 1 })
             .with_min_batch_size(1)
             .build();
         let leader_task = task.leader_view().unwrap();
@@ -5093,7 +5097,8 @@ mod tests {
         let (_, _ephemeral_datastore, datastore, handler) = setup_http_handler_test().await;
 
         // Prepare parameters.
-        let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake).build();
+        let task =
+            TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake { rounds: 1 }).build();
         let leader_task = task.leader_view().unwrap();
         datastore.put_aggregator_task(&leader_task).await.unwrap();
 
@@ -5136,7 +5141,7 @@ mod tests {
 
         // Prepare parameters.
         const REPORT_EXPIRY_AGE: Duration = Duration::from_seconds(3600);
-        let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake)
+        let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake { rounds: 1 })
             .with_report_expiry_age(Some(REPORT_EXPIRY_AGE))
             .build();
         let helper_task = task.helper_view().unwrap();
@@ -5211,7 +5216,7 @@ mod tests {
     async fn aggregate_share_request() {
         let (_, _ephemeral_datastore, datastore, handler) = setup_http_handler_test().await;
 
-        let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake)
+        let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake { rounds: 1 })
             .with_max_batch_query_count(1)
             .with_time_precision(Duration::from_seconds(500))
             .with_min_batch_size(10)

--- a/aggregator/src/binary_utils/job_driver.rs
+++ b/aggregator/src/binary_utils/job_driver.rs
@@ -392,7 +392,7 @@ mod tests {
                                 .iter()
                                 .map(|job| {
                                     Lease::new_dummy(
-                                        (job.task_id, VdafInstance::Fake, job.job_id),
+                                        (job.task_id, VdafInstance::Fake { rounds: 1 }, job.job_id),
                                         job.lease_expiry,
                                     )
                                 })
@@ -413,7 +413,7 @@ mod tests {
                             let mut test_state = test_state.lock().await;
                             let job_acquire_counter = test_state.job_acquire_counter;
 
-                            assert_eq!(lease.leased().1, VdafInstance::Fake);
+                            assert_eq!(lease.leased().1, VdafInstance::Fake { rounds: 1 });
 
                             test_state.stepped_jobs.push(SteppedJob {
                                 observed_jobs_acquire_counter: job_acquire_counter,

--- a/aggregator_api/src/tests.rs
+++ b/aggregator_api/src/tests.rs
@@ -97,7 +97,7 @@ async fn get_task_ids() {
         .run_unnamed_tx(|tx| {
             Box::pin(async move {
                 let tasks: Vec<_> = iter::repeat_with(|| {
-                    TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake)
+                    TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake { rounds: 1 })
                         .build()
                         .leader_view()
                         .unwrap()
@@ -624,7 +624,7 @@ async fn get_task(#[case] role: Role) {
     // Setup: write a task to the datastore.
     let (handler, _ephemeral_datastore, ds) = setup_api_test().await;
 
-    let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake)
+    let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake { rounds: 1 })
         .build()
         .view_for_role(role)
         .unwrap();
@@ -688,10 +688,11 @@ async fn delete_task() {
     let task_id = ds
         .run_unnamed_tx(|tx| {
             Box::pin(async move {
-                let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake)
-                    .build()
-                    .leader_view()
-                    .unwrap();
+                let task =
+                    TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake { rounds: 1 })
+                        .build()
+                        .leader_view()
+                        .unwrap();
 
                 tx.put_aggregator_task(&task).await?;
 
@@ -760,10 +761,11 @@ async fn get_task_upload_metrics() {
     let task_id = ds
         .run_unnamed_tx(|tx| {
             Box::pin(async move {
-                let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake)
-                    .build()
-                    .leader_view()
-                    .unwrap();
+                let task =
+                    TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake { rounds: 1 })
+                        .build()
+                        .leader_view()
+                        .unwrap();
                 let task_id = *task.id();
                 tx.put_aggregator_task(&task).await.unwrap();
 

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -1256,6 +1256,7 @@ impl<C: Clock> Transaction<'_, C> {
     /// This function deliberately ignores the `client_reports.aggregation_started` column, which
     /// only has meaning for VDAFs without aggregation parameters.
     #[tracing::instrument(skip(self), err)]
+    #[cfg(feature = "test-util")]
     pub async fn get_unaggregated_client_report_ids_by_collect_for_task<const SEED_SIZE: usize, A>(
         &self,
         task_id: &TaskId,

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -362,7 +362,6 @@ pub struct AggregationJob<const SEED_SIZE: usize, Q: QueryType, A: vdaf::Aggrega
     /// The ID of this aggregation job.
     aggregation_job_id: AggregationJobId,
     /// The aggregation parameter this job is run with.
-    #[derivative(Debug = "ignore")]
     aggregation_parameter: A::AggregationParam,
     /// The partial identifier for the batch this aggregation job contributes to (fixed size
     /// tasks only; for time interval tasks, aggregation jobs may span multiple batches).

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -362,6 +362,7 @@ pub struct AggregationJob<const SEED_SIZE: usize, Q: QueryType, A: vdaf::Aggrega
     /// The ID of this aggregation job.
     aggregation_job_id: AggregationJobId,
     /// The aggregation parameter this job is run with.
+    #[derivative(Debug = "ignore")]
     aggregation_parameter: A::AggregationParam,
     /// The partial identifier for the batch this aggregation job contributes to (fixed size
     /// tasks only; for time interval tasks, aggregation jobs may span multiple batches).

--- a/aggregator_core/src/query_type.rs
+++ b/aggregator_core/src/query_type.rs
@@ -397,7 +397,7 @@ mod tests {
     #[test]
     fn validate_collect_identifier() {
         let time_precision_secs = 3600;
-        let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake)
+        let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake { rounds: 1 })
             .with_time_precision(Duration::from_seconds(time_precision_secs))
             .build()
             .leader_view()

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -32,7 +32,7 @@ janus_interop_binaries = { workspace = true, features = ["test-util"] }
 janus_messages.workspace = true
 k8s-openapi = { workspace = true, optional = true }
 kube = { workspace = true, optional = true }
-prio.workspace = true
+prio = { workspace = true, features = ["test-util"] }
 rand.workspace = true
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
 serde.workspace = true

--- a/integration_tests/src/client.rs
+++ b/integration_tests/src/client.rs
@@ -8,7 +8,7 @@ use janus_messages::{Duration, TaskId};
 use prio::{
     codec::Encode,
     vdaf::{
-        self,
+        self, dummy,
         prio3::{Prio3Count, Prio3Histogram, Prio3Sum, Prio3SumVecMultithreaded},
     },
 };
@@ -61,6 +61,12 @@ impl InteropClientEncoding for Prio3SumVecField64MultiproofHmacSha256Aes128 {
                 .map(|value| Value::String(format!("{value}")))
                 .collect(),
         )
+    }
+}
+
+impl InteropClientEncoding for dummy::Vdaf {
+    fn json_encode_measurement(&self, measurement: &Self::Measurement) -> Value {
+        Value::String(format!("{measurement}"))
     }
 }
 

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -20,9 +20,7 @@ hex = "0.4"
 num_enum = "0.7.2"
 # We can't pull prio in from the workspace because that would enable default features, and we do not
 # want prio/crypto-dependencies
-# TODO(timg) go back to released prio
-#prio = { version = "0.16.1", default-features = false, features = ["multithreaded", "experimental"] }
-prio = { git = "https://github.com/divviup/libprio-rs", default-features = false, features = ["multithreaded", "experimental"], rev = "8774573dee1932c19c28ab83173b358b42a52b78" }
+prio = { version = "0.16.2", default-features = false, features = ["multithreaded", "experimental"] }
 rand.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -20,7 +20,9 @@ hex = "0.4"
 num_enum = "0.7.2"
 # We can't pull prio in from the workspace because that would enable default features, and we do not
 # want prio/crypto-dependencies
-prio = { version = "0.16.1", default-features = false, features = ["multithreaded", "experimental"] }
+# TODO(timg) go back to released prio
+#prio = { version = "0.16.1", default-features = false, features = ["multithreaded", "experimental"] }
+prio = { git = "https://github.com/divviup/libprio-rs", default-features = false, features = ["multithreaded", "experimental"], rev = "8774573dee1932c19c28ab83173b358b42a52b78" }
 rand.workspace = true
 serde.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
Enable Janus to run the dummy VDAF from crate `prio` with arbitrary rounds
(by extending the representation of `VdafInstance::Fake`) and with multiple
aggregation parameters chosen by the test.

To that end, this resurrects some functionality previously deleted in #1508.
At the time, we had that code gated on `#[cfg(test)]`, with some cautions
about its likely performance problems. I'm bringing it back in the release
configuration of Janus. I don't think we need a feature flag for this: the
various `VdafInstance::Fake` variants that would use these codepaths are not
currently compiled into release Janus builds. Even if they were, deployments
can avoid this risky code by simply not using those VDAFs.

This wires up some tests for both time interval and fixed size tasks, running
multiple collections against a single batch with varying aggregation
parameters. However, a few tests are disabled because of stuff that doesn't
work yet:

- creating fixed size aggregation jobs w/ agg param
- using `Vdaf.is_valid` to check whether subsequent collections against a
  single batch are valid

Part of #225

- [x] Release a `prio` with https://github.com/divviup/libprio-rs/pull/970 and depend on that in this PR
- [x] Rebase after we take #2782 