### PR TITLE
expose `TaskBuilder` to integration tests

### DIFF
--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -1147,6 +1147,16 @@ pub mod test_util {
             })
         }
 
+        /// Gets the query type for the eventual task
+        pub fn query_type(&self) -> &QueryType {
+            self.0.query_type()
+        }
+
+        /// Gets the VDAF for the eventual task
+        pub fn vdaf(&self) -> &VdafInstance {
+            self.0.vdaf()
+        }
+
         /// Associates the eventual task with the given aggregator endpoint for the Leader.
         pub fn with_leader_aggregator_endpoint(self, leader_aggregator_endpoint: Url) -> Self {
             Self(Task {

--- a/integration_tests/tests/integration/common.rs
+++ b/integration_tests/tests/integration/common.rs
@@ -91,8 +91,10 @@ pub fn build_test_task(
         .with_leader_aggregator_endpoint(leader_endpoint)
         .with_helper_aggregator_endpoint(helper_endpoint)
         .with_min_batch_size(46)
-        // TODO(timg): is it OK to unconditionally set these? I think the remote case will ignore
-        // the values anyway
+        // The randomly generated auth tokens will only be used in the TestContext::VirtualNetwork
+        // and TestContext::Host cases. They will be ignored in the TestContext::Remote case,
+        // because the auth tokens will be provisioned via divviup-api, but it's harmless to set
+        // them in the task builder.
         .with_dap_auth_aggregator_token()
         .with_dap_auth_collector_token();
 

--- a/integration_tests/tests/integration/daphne.rs
+++ b/integration_tests/tests/integration/daphne.rs
@@ -1,5 +1,5 @@
-use crate::common::{submit_measurements_and_verify_aggregate, test_task_builder};
-use janus_aggregator_core::task::QueryType;
+use crate::common::{build_test_task, submit_measurements_and_verify_aggregate, TestContext};
+use janus_aggregator_core::task::{test_util::TaskBuilder, QueryType};
 use janus_core::{
     test_util::{install_test_trace_subscriber, testcontainers::container_client},
     vdaf::VdafInstance,
@@ -23,9 +23,9 @@ async fn daphne_janus() {
 
     // Start servers.
     let network = generate_network_name();
-    let (mut task_parameters, task_builder) = test_task_builder(
-        VdafInstance::Prio3Count,
-        QueryType::TimeInterval,
+    let (mut task_parameters, task_builder) = build_test_task(
+        TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Prio3Count),
+        TestContext::VirtualNetwork,
         Duration::from_millis(500),
         Duration::from_secs(60),
     );
@@ -66,9 +66,9 @@ async fn janus_daphne() {
 
     // Start servers.
     let network = generate_network_name();
-    let (mut task_parameters, task_builder) = test_task_builder(
-        VdafInstance::Prio3Count,
-        QueryType::TimeInterval,
+    let (mut task_parameters, task_builder) = build_test_task(
+        TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Prio3Count),
+        TestContext::VirtualNetwork,
         Duration::from_millis(500),
         Duration::from_secs(60),
     );
@@ -110,9 +110,9 @@ async fn janus_in_process_daphne() {
     // Start servers.
     let network = generate_network_name();
     let container_client = container_client();
-    let (mut task_parameters, mut task_builder) = test_task_builder(
-        VdafInstance::Prio3Count,
-        QueryType::TimeInterval,
+    let (mut task_parameters, mut task_builder) = build_test_task(
+        TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Prio3Count),
+        TestContext::VirtualNetwork,
         Duration::from_millis(500),
         Duration::from_secs(60),
     );

--- a/integration_tests/tests/integration/divviup_ts.rs
+++ b/integration_tests/tests/integration/divviup_ts.rs
@@ -1,8 +1,8 @@
 #![cfg(feature = "testcontainer")]
 //! These tests check interoperation between the divviup-ts client and Janus aggregators.
 
-use crate::common::{submit_measurements_and_verify_aggregate, test_task_builder};
-use janus_aggregator_core::task::QueryType;
+use crate::common::{build_test_task, submit_measurements_and_verify_aggregate, TestContext};
+use janus_aggregator_core::task::{test_util::TaskBuilder, QueryType};
 use janus_core::{
     test_util::{install_test_trace_subscriber, testcontainers::container_client},
     vdaf::VdafInstance,
@@ -21,9 +21,9 @@ async fn run_divviup_ts_integration_test(
     container_client: &Cli,
     vdaf: VdafInstance,
 ) {
-    let (task_parameters, task_builder) = test_task_builder(
-        vdaf,
-        QueryType::TimeInterval,
+    let (task_parameters, task_builder) = build_test_task(
+        TaskBuilder::new(QueryType::TimeInterval, vdaf),
+        TestContext::VirtualNetwork,
         Duration::from_millis(500),
         Duration::from_secs(60),
     );


### PR DESCRIPTION
Refactors integration test harness so that the top-level test functions can instantiate and manipulate a `TaskBuilder` value instead of having it constructed several calls deep in `test_task_builder_inner`.

This is useful because soon, we will want to run tests using VDAFs with non-trivial aggregation parameters. That means collecting a single batch multiple times, which means we want to set `max_batch_query_count` higher than 1. Exposing the `TaskBuilder` is an easier way to do that (or set other values) than to plumb more arguments into the `task_builder_*` functions.