### PR TITLE
Fix Taskprov struct field order for Prio3SumVec

### DIFF
--- a/messages/src/taskprov.rs
+++ b/messages/src/taskprov.rs
@@ -325,18 +325,18 @@ pub enum VdafType {
         bits: u8,
     },
     Prio3SumVec {
-        /// Bit length of each summand.
-        bits: u8,
         /// Number of summands.
         length: u32,
+        /// Bit length of each summand.
+        bits: u8,
         /// Size of each proof chunk.
         chunk_length: u32,
     },
     Prio3SumVecField64MultiproofHmacSha256Aes128 {
-        /// Bit length of each summand.
-        bits: u8,
         /// Number of summands.
         length: u32,
+        /// Bit length of each summand.
+        bits: u8,
         /// Size of each proof chunk.
         chunk_length: u32,
         /// Number of proofs.
@@ -385,22 +385,22 @@ impl Encode for VdafType {
                 bits.encode(bytes)?;
             }
             Self::Prio3SumVec {
-                bits,
                 length,
+                bits,
                 chunk_length,
             } => {
-                bits.encode(bytes)?;
                 length.encode(bytes)?;
+                bits.encode(bytes)?;
                 chunk_length.encode(bytes)?;
             }
             Self::Prio3SumVecField64MultiproofHmacSha256Aes128 {
-                bits,
                 length,
+                bits,
                 chunk_length,
                 proofs,
             } => {
-                bits.encode(bytes)?;
                 length.encode(bytes)?;
+                bits.encode(bytes)?;
                 chunk_length.encode(bytes)?;
                 proofs.encode(bytes)?;
             }
@@ -441,14 +441,14 @@ impl Decode for VdafType {
                 bits: u8::decode(bytes)?,
             },
             Self::PRIO3SUMVEC => Self::Prio3SumVec {
-                bits: u8::decode(bytes)?,
                 length: u32::decode(bytes)?,
+                bits: u8::decode(bytes)?,
                 chunk_length: u32::decode(bytes)?,
             },
             Self::PRIO3SUMVECFIELD64MULTIPROOFHMACSHA256AES128 => {
                 Self::Prio3SumVecField64MultiproofHmacSha256Aes128 {
-                    bits: u8::decode(bytes)?,
                     length: u32::decode(bytes)?,
+                    bits: u8::decode(bytes)?,
                     chunk_length: u32::decode(bytes)?,
                     proofs: u8::decode(bytes)?,
                 }
@@ -641,8 +641,8 @@ mod tests {
                 },
                 concat!(
                     "00000002", // vdaf_type_code
-                    "08",       // bits
                     "0000000C", // length
+                    "08",       // bits
                     "0000000E"  // chunk_length
                 ),
             ),
@@ -655,8 +655,8 @@ mod tests {
                 },
                 concat!(
                     "FFFF1003", // vdaf_type_code
-                    "08",       // bits
                     "0000000C", // length
+                    "08",       // bits
                     "0000000E", // chunk_length
                     "02"        // proofs
                 ),
@@ -758,8 +758,8 @@ mod tests {
                 VdafConfig::new(
                     DpConfig::new(DpMechanism::None),
                     VdafType::Prio3SumVec {
-                        bits: 8,
                         length: 12,
+                        bits: 8,
                         chunk_length: 14,
                     },
                 )
@@ -773,8 +773,8 @@ mod tests {
                     concat!(
                         // vdaf_type
                         "00000002", // vdaf_type_code
-                        "08",       // bits
                         "0000000C", // length
+                        "08",       // bits
                         "0000000E", // chunk_length
                     )
                 ),
@@ -783,8 +783,8 @@ mod tests {
                 VdafConfig::new(
                     DpConfig::new(DpMechanism::None),
                     VdafType::Prio3SumVecField64MultiproofHmacSha256Aes128 {
-                        bits: 8,
                         length: 12,
+                        bits: 8,
                         chunk_length: 14,
                         proofs: 2,
                     },
@@ -799,8 +799,8 @@ mod tests {
                     concat!(
                         // vdaf_type
                         "FFFF1003", // vdaf_type_code
-                        "08",       // bits
                         "0000000C", // length
+                        "08",       // bits
                         "0000000E", // chunk_length
                         "02"        // proofs
                     )


### PR DESCRIPTION
We currently encode and decode two parameter fields for Prio3SumVec in the wrong order. See [this figure](https://wangshan.github.io/draft-wang-ppm-dap-taskprov/draft-wang-ppm-dap-taskprov.html#section-3-11). The length must come first, followed by the number of bits. I also changed the multiproof variant in the same manner, and with this fix, it now matches Daphne.