### PR TITLE
Implement From<{BearerToken,DapAuthToken}> for AuthenticationToken

### DIFF
--- a/core/src/auth_tokens.rs
+++ b/core/src/auth_tokens.rs
@@ -139,6 +139,12 @@ impl AsRef<[u8]> for DapAuthToken {
     }
 }
 
+impl From<DapAuthToken> for AuthenticationToken {
+    fn from(value: DapAuthToken) -> Self {
+        Self::DapAuth(value)
+    }
+}
+
 impl TryFrom<String> for DapAuthToken {
     type Error = anyhow::Error;
 
@@ -238,6 +244,12 @@ impl AsRef<str> for BearerToken {
 impl AsRef<[u8]> for BearerToken {
     fn as_ref(&self) -> &[u8] {
         self.0.as_bytes()
+    }
+}
+
+impl From<BearerToken> for AuthenticationToken {
+    fn from(value: BearerToken) -> Self {
+        Self::Bearer(value)
     }
 }
 


### PR DESCRIPTION
Smol API nit: If we have a DapAuthToken, such as in situations where we deserialized an explicit DapAuthToken:
```rust
#[derive(Deserialize)]
struct DeserializeMe {
    dap_auth_token: DapAuthToken,
}
```
we may wish to `.into()` it when giving it to other functions that take a `AuthenticationToken`.
```rust
let auth_token: AuthenticationToken = dap_auth_token.into();
```
This is a little bit bit nicer to do than `AuthenticationToken::DapAuth(dap_auth_token)`. In other situations, we get the bonus of being able to do `AuthenticationToken::from(dap_auth_token)` without having to actually care about the token type.