### PR TITLE
Use base64 encoding for HpkePrivateKey's FromStr; implement FromStr for HpkePublicKey

### DIFF
--- a/core/src/hpke.rs
+++ b/core/src/hpke.rs
@@ -23,6 +23,8 @@ pub enum Error {
     InvalidConfiguration(&'static str),
     #[error("unsupported KEM")]
     UnsupportedKem,
+    #[error("base64 decode failure: {0}")]
+    Base64Decode(#[from] base64::DecodeError),
 }
 
 /// Checks whether the algorithms used by the provided [`HpkeConfig`] are supported.
@@ -109,10 +111,10 @@ impl From<Vec<u8>> for HpkePrivateKey {
 }
 
 impl FromStr for HpkePrivateKey {
-    type Err = hex::FromHexError;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(HpkePrivateKey(hex::decode(s)?))
+        Ok(Self::from(URL_SAFE_NO_PAD.decode(s)?))
     }
 }
 

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -1067,6 +1067,14 @@ impl Display for HpkePublicKey {
     }
 }
 
+impl FromStr for HpkePublicKey {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from(URL_SAFE_NO_PAD.decode(s)?))
+    }
+}
+
 /// This customized implementation serializes a [`HpkePublicKey`] as a base64url-encoded string,
 /// instead of as a byte array. This is more compact and ergonomic when serialized to YAML.
 impl Serialize for HpkePublicKey {


### PR DESCRIPTION
Makes FromStr implementations consistent with what we have in the `janus_messages` crate.