### PR TITLE
Update http ecosystem crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,9 +465,9 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.5",
+ "hyper 0.14.27",
  "itoa",
  "matchit",
  "memchr",
@@ -491,8 +491,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.5",
  "mime",
  "rustversion",
  "tower-layer",
@@ -1673,7 +1673,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
  "indexmap 2.2.1",
  "slab",
  "tokio",
@@ -1841,12 +1841,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-api-problem"
-version = "0.57.0"
+name = "http"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce650a2c63171c9d92f95887c8d81154b77385301c8a581b9af96491f52d765"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
- "http",
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-api-problem"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bfa6ba9e2d8cf5299faf4721520ff7997989431d2c8fdf702eb8b1a4313b625"
+dependencies = [
+ "http 1.1.0",
  "serde",
  "serde_json",
 ]
@@ -1858,7 +1869,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cb79eb393015dadd30fc252023adb0b2400a0caee0fa2a077e6e21a551e840"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -1907,8 +1941,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.5",
  "httparse",
  "httpdate",
  "itoa",
@@ -1921,14 +1955,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.27",
  "log",
  "rustls 0.21.9",
  "rustls-native-certs",
@@ -1937,15 +1990,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.2.0",
+ "hyper-util",
+ "rustls 0.22.2",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.27",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.2.0",
+ "pin-project-lite",
+ "socket2 0.5.5",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2097,7 +2187,7 @@ dependencies = [
  "futures",
  "git-version",
  "hex",
- "http",
+ "http 1.1.0",
  "http-api-problem",
  "itertools 0.11.0",
  "janus_aggregator",
@@ -2205,7 +2295,7 @@ dependencies = [
  "derivative",
  "futures",
  "hex",
- "http",
+ "http 1.1.0",
  "http-api-problem",
  "itertools 0.11.0",
  "janus_aggregator_core",
@@ -2250,7 +2340,7 @@ dependencies = [
  "backoff",
  "derivative",
  "hex-literal",
- "http",
+ "http 1.1.0",
  "itertools 0.11.0",
  "janus_core",
  "janus_messages 0.7.0-prerelease-5",
@@ -2309,7 +2399,7 @@ dependencies = [
  "futures",
  "hex",
  "hpke-dispatch",
- "http",
+ "http 1.1.0",
  "http-api-problem",
  "janus_core",
  "janus_messages 0.7.0-prerelease-5",
@@ -2352,7 +2442,7 @@ dependencies = [
  "divviup-client",
  "futures",
  "hex",
- "http",
+ "http 1.1.0",
  "itertools 0.11.0",
  "janus_aggregator",
  "janus_aggregator_core",
@@ -2561,10 +2651,10 @@ dependencies = [
  "either",
  "futures",
  "home",
- "http",
- "http-body",
- "hyper",
- "hyper-rustls",
+ "http 0.2.12",
+ "http-body 0.4.5",
+ "hyper 0.14.27",
+ "hyper-rustls 0.24.1",
  "hyper-timeout",
  "jsonpath-rust",
  "k8s-openapi",
@@ -2595,7 +2685,7 @@ checksum = "b5bba93d054786eba7994d03ce522f368ef7d48c88a1826faa28478d85fb63ae"
 dependencies = [
  "chrono",
  "form_urlencoded",
- "http",
+ "http 0.2.12",
  "k8s-openapi",
  "once_cell",
  "serde",
@@ -2755,7 +2845,7 @@ dependencies = [
  "assert-json-diff",
  "colored",
  "futures-core",
- "hyper",
+ "hyper 0.14.27",
  "log",
  "rand",
  "regex",
@@ -2951,7 +3041,7 @@ checksum = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb"
 dependencies = [
  "async-trait",
  "futures-core",
- "http",
+ "http 0.2.12",
  "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
@@ -3689,20 +3779,20 @@ checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
 
 [[package]]
 name = "reqwest"
-version = "0.11.26"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bf93c4af7a8bb7d879d51cebe797356ff10ae8516ace542b5182d9dcac10b2"
+checksum = "58b48d98d932f4ee75e541614d32a7f44c889b72bd9c2e04d95edd135989df88"
 dependencies = [
  "base64 0.21.7",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-rustls",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-rustls 0.26.0",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -3710,32 +3800,32 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.9",
+ "rustls 0.22.2",
  "rustls-pemfile 1.0.4",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls 0.25.0",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.25.2",
+ "webpki-roots 0.26.1",
  "winreg",
 ]
 
 [[package]]
 name = "retry-after"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d55dc93b909e04874b53878316eb687633459706f8fc647de333cc0620caa"
+checksum = "f0a2a3fe45c9b89f416bc92174669d954594e152d158df845e6df173a9b7aed4"
 dependencies = [
  "chrono",
- "http",
+ "http 1.1.0",
  "thiserror",
 ]
 
@@ -4327,9 +4417,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "smartcow"
@@ -4715,27 +4805,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5031,9 +5100,9 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.5",
+ "hyper 0.14.27",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -5058,9 +5127,9 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.5",
+ "hyper 0.14.27",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -5104,8 +5173,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.5",
  "http-range-header",
  "mime",
  "pin-project-lite",
@@ -5497,7 +5566,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 0.2.12",
  "httparse",
  "log",
  "rand",
@@ -5791,6 +5860,15 @@ name = "webpki-roots"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "whoami"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ bytes = "1"
 chrono = { version = "0.4", default-features = false }
 clap = { version = "4.5.3", features = ["cargo", "derive", "env"] }
 derivative = "2.2.0"
+http = "1.1"
+http-api-problem = "0.58.0"
 itertools = "0.11"
 janus_aggregator = { version = "0.7.0-prerelease-5", path = "aggregator" }
 janus_aggregator_api = { version = "0.7.0-prerelease-5", path = "aggregator_api" }
@@ -53,6 +55,7 @@ serde_json = "1.0.114"
 serde_test = "1.0.175"
 serde_yaml = "0.9.33"
 rand = "0.8"
+reqwest = { version = "0.12.0", default-features = false, features = ["rustls-tls"] }
 rstest = "0.18.2"
 testcontainers = "0.15.0"
 thiserror = "1.0"

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -54,8 +54,8 @@ fixed = { version = "1.26", optional = true }
 futures = "0.3.30"
 git-version = "0.3.9"
 hex = { version = "0.4.3", features = ["serde"], optional = true }
-http = "0.2.12"
-http-api-problem = "0.57.0"
+http.workspace = true
+http-api-problem.workspace = true
 itertools.workspace = true
 janus_aggregator_api.workspace = true
 janus_aggregator_core.workspace = true
@@ -74,7 +74,7 @@ prio.workspace = true
 prometheus = { version = "0.13.3", optional = true }
 rand = { workspace = true, features = ["min_const_gen"] }
 regex = "1"
-reqwest = { version = "0.11.26", default-features = false, features = ["rustls-tls", "json"] }
+reqwest = { workspace = true, features = ["json"] }
 ring = "0.17.8"
 rustls = "0.22.2"
 rustls-pemfile = "2.1.1"

--- a/aggregator_core/Cargo.toml
+++ b/aggregator_core/Cargo.toml
@@ -32,8 +32,8 @@ deadpool-postgres = "0.12.1"
 derivative.workspace = true
 futures = "0.3.30"
 hex = { version = "0.4.3", features = ["serde"], optional = true }
-http = "0.2.12"
-http-api-problem = "0.57.0"
+http.workspace = true
+http-api-problem.workspace = true
 itertools = { workspace = true, optional = true }
 janus_core.workspace = true
 janus_messages.workspace = true
@@ -45,7 +45,7 @@ postgres-types = { version = "0.2.6", features = ["derive", "array-impls"] }
 prio = { workspace = true, features = ["experimental"] }
 rand = { workspace = true, features = ["min_const_gen"] }
 regex = "1"
-reqwest = { version = "0.11.26", default-features = false, features = ["rustls-tls", "json"] }
+reqwest = { workspace = true, features = ["json"] }
 ring = "0.17.8"
 serde.workspace = true
 serde_json.workspace = true

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -12,13 +12,13 @@ version.workspace = true
 [dependencies]
 backoff = { version = "0.4.0", features = ["tokio"] }
 derivative.workspace = true
-http = "0.2.12"
+http.workspace = true
 itertools.workspace = true
 janus_core.workspace = true
 janus_messages.workspace = true
 prio.workspace = true
 rand.workspace = true
-reqwest = { version = "0.11.26", default-features = false, features = ["rustls-tls", "json"] }
+reqwest = { workspace = true, features = ["json"] }
 thiserror.workspace = true
 tokio.workspace = true
 tracing = "0.1.40"

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -26,8 +26,8 @@ janus_messages.workspace = true
 fixed = { version = "1.26", optional = true }
 prio.workspace = true
 rand = { workspace = true, features = ["min_const_gen"] }
-reqwest = { version = "0.11.26", default-features = false, features = ["rustls-tls", "json"] }
-retry-after = "0.3.1"
+reqwest = { workspace = true, features = ["json"] }
+retry-after = "0.4.0"
 thiserror.workspace = true
 tokio.workspace = true
 tracing = "0.1.40"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -43,15 +43,15 @@ fixed = { version = "1.26", optional = true }
 futures = "0.3.30"
 hex = "0.4"
 hpke-dispatch = { version = "0.5.1", features = ["serde"] }
-http = "0.2.12"
-http-api-problem = "0.57.0"
+http.workspace = true
+http-api-problem.workspace = true
 janus_messages.workspace = true
 kube = { workspace = true, optional = true, features = ["rustls-tls"] }
 k8s-openapi = { workspace = true, optional = true }
 prio.workspace = true
 rand.workspace = true
 regex = "1.10.3"
-reqwest = { version = "0.11.26", default-features = false, features = ["rustls-tls", "json"] }
+reqwest = { workspace = true, features = ["json"] }
 ring = "0.17.8"
 serde.workspace = true
 serde_json = { workspace = true, optional = true }

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -21,7 +21,7 @@ base64.workspace = true
 clap.workspace = true
 futures = "0.3.30"
 hex = "0.4"
-http = "0.2"
+http.workspace = true
 itertools.workspace = true
 janus_aggregator = { workspace = true, features = ["test-util"] }
 janus_aggregator_core = { workspace = true, features = ["test-util"] }
@@ -34,7 +34,7 @@ k8s-openapi = { workspace = true, optional = true }
 kube = { workspace = true, optional = true }
 prio = { workspace = true, features = ["test-util"] }
 rand.workspace = true
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
+reqwest.workspace = true
 serde.workspace = true
 serde_json = "1.0.114"
 testcontainers.workspace = true

--- a/interop_binaries/Cargo.toml
+++ b/interop_binaries/Cargo.toml
@@ -37,7 +37,7 @@ opentelemetry.workspace = true
 prio.workspace = true
 rand.workspace = true
 regex = { version = "1", optional = true }
-reqwest = { version = "0.11.26", default-features = false, features = ["rustls-tls"] }
+reqwest.workspace = true
 ring = "0.17.8"
 serde.workspace = true
 serde_json = "1.0.114"
@@ -58,4 +58,4 @@ zstd = { version = "0.13", optional = true }
 fixed-macro = "1.1.1"
 janus_interop_binaries = { path = ".", features = ["fpvec_bounded_l2", "test-util"] }
 janus_core = { workspace = true, features = ["test-util", "fpvec_bounded_l2"] }
-reqwest = { version = "0.11.26", default-features = false, features = ["json"] }
+reqwest = { workspace = true, features = ["json"] }

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -22,7 +22,7 @@ janus_core.workspace = true
 janus_messages.workspace = true
 prio.workspace = true
 rand.workspace = true
-reqwest = { version = "0.11.26", default-features = false, features = ["rustls-tls", "json"] }
+reqwest = { workspace = true, features = ["json"] }
 serde_json.workspace = true
 serde_yaml.workspace = true
 tokio.workspace = true


### PR DESCRIPTION
This updates all crates in the `http` ecosystem. Closes #2295.