### PR TITLE
Add limit to transaction retries

### DIFF
--- a/aggregator/src/bin/janus_cli.rs
+++ b/aggregator/src/bin/janus_cli.rs
@@ -322,6 +322,7 @@ async fn datastore_from_opts(
             .datastore_keys(&command_line_options.common_options, kube_client)
             .await?,
         config_file.common_config().database.check_schema_version,
+        config_file.common_config().max_transaction_retries,
     )
     .await
 }
@@ -463,7 +464,7 @@ mod tests {
     use janus_aggregator::{
         binary_utils::CommonBinaryOptions,
         config::test_util::{generate_db_config, generate_metrics_config, generate_trace_config},
-        config::CommonConfig,
+        config::{default_max_transaction_retries, CommonConfig},
     };
     use janus_aggregator_core::{
         datastore::{test_util::ephemeral_datastore, Datastore},
@@ -882,6 +883,7 @@ mod tests {
                 logging_config: generate_trace_config(),
                 metrics_config: generate_metrics_config(),
                 health_check_listen_address: SocketAddr::from((Ipv4Addr::UNSPECIFIED, 8080)),
+                max_transaction_retries: default_max_transaction_retries(),
             },
         })
     }

--- a/aggregator/src/binaries/aggregation_job_creator.rs
+++ b/aggregator/src/binaries/aggregation_job_creator.rs
@@ -108,6 +108,7 @@ impl BinaryConfig for Config {
 mod tests {
     use super::{Config, Options};
     use crate::config::{
+        default_max_transaction_retries,
         test_util::{generate_db_config, generate_metrics_config, generate_trace_config},
         CommonConfig,
     };
@@ -128,6 +129,7 @@ mod tests {
                 logging_config: generate_trace_config(),
                 metrics_config: generate_metrics_config(),
                 health_check_listen_address: SocketAddr::from((Ipv4Addr::UNSPECIFIED, 8080)),
+                max_transaction_retries: default_max_transaction_retries(),
             },
             batch_aggregation_shard_count: 32,
             tasks_update_frequency_secs: 3600,

--- a/aggregator/src/binaries/aggregation_job_driver.rs
+++ b/aggregator/src/binaries/aggregation_job_driver.rs
@@ -137,6 +137,7 @@ impl BinaryConfig for Config {
 mod tests {
     use super::{Config, Options};
     use crate::config::{
+        default_max_transaction_retries,
         test_util::{generate_db_config, generate_metrics_config, generate_trace_config},
         CommonConfig, JobDriverConfig, TaskprovConfig,
     };
@@ -157,6 +158,7 @@ mod tests {
                 logging_config: generate_trace_config(),
                 metrics_config: generate_metrics_config(),
                 health_check_listen_address: SocketAddr::from((Ipv4Addr::UNSPECIFIED, 8080)),
+                max_transaction_retries: default_max_transaction_retries(),
             },
             job_driver_config: JobDriverConfig {
                 job_discovery_interval_secs: 10,

--- a/aggregator/src/binaries/aggregator.rs
+++ b/aggregator/src/binaries/aggregator.rs
@@ -454,6 +454,7 @@ mod tests {
     use crate::{
         aggregator,
         config::{
+            default_max_transaction_retries,
             test_util::{generate_db_config, generate_metrics_config, generate_trace_config},
             BinaryConfig, CommonConfig, TaskprovConfig,
         },
@@ -504,6 +505,7 @@ mod tests {
                 logging_config: generate_trace_config(),
                 metrics_config: generate_metrics_config(),
                 health_check_listen_address: SocketAddr::from((Ipv4Addr::UNSPECIFIED, 8080)),
+                max_transaction_retries: default_max_transaction_retries(),
             },
             response_headers: Vec::from([HeaderEntry {
                 name: "name".to_owned(),

--- a/aggregator/src/binaries/collection_job_driver.rs
+++ b/aggregator/src/binaries/collection_job_driver.rs
@@ -139,6 +139,7 @@ impl BinaryConfig for Config {
 mod tests {
     use super::{Config, Options};
     use crate::config::{
+        default_max_transaction_retries,
         test_util::{generate_db_config, generate_metrics_config, generate_trace_config},
         CommonConfig, JobDriverConfig,
     };
@@ -159,6 +160,7 @@ mod tests {
                 logging_config: generate_trace_config(),
                 metrics_config: generate_metrics_config(),
                 health_check_listen_address: SocketAddr::from((Ipv4Addr::UNSPECIFIED, 8080)),
+                max_transaction_retries: default_max_transaction_retries(),
             },
             job_driver_config: JobDriverConfig {
                 job_discovery_interval_secs: 10,

--- a/aggregator/src/config.rs
+++ b/aggregator/src/config.rs
@@ -43,10 +43,20 @@ pub struct CommonConfig {
     /// Address to serve HTTP health check requests on.
     #[serde(default = "default_health_check_listen_address")]
     pub health_check_listen_address: SocketAddr,
+
+    /// The maximum number of times a transaction can be retried. The intent is to guard against bugs
+    /// that induce infinite retries. It should be set to a reasonably high limit to prevent legitimate
+    /// work from being cancelled.
+    #[serde(default = "default_max_transaction_retries")]
+    pub max_transaction_retries: u64,
 }
 
 fn default_health_check_listen_address() -> SocketAddr {
     SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9001)
+}
+
+pub fn default_max_transaction_retries() -> u64 {
+    1000
 }
 
 /// Trait describing configuration structures for various Janus binaries.
@@ -277,6 +287,7 @@ pub mod test_util {
 mod tests {
     use crate::{
         config::{
+            default_max_transaction_retries,
             test_util::{generate_db_config, generate_metrics_config, generate_trace_config},
             CommonConfig, DbConfig, JobDriverConfig,
         },
@@ -307,6 +318,7 @@ mod tests {
             logging_config: generate_trace_config(),
             metrics_config: generate_metrics_config(),
             health_check_listen_address: SocketAddr::from((Ipv4Addr::UNSPECIFIED, 8080)),
+            max_transaction_retries: default_max_transaction_retries(),
         })
     }
 

--- a/aggregator/tests/integration/graceful_shutdown.rs
+++ b/aggregator/tests/integration/graceful_shutdown.rs
@@ -11,7 +11,10 @@ use janus_aggregator::{
         aggregator::{AggregatorApi, Config as AggregatorConfig},
         collection_job_driver::Config as CollectionJobDriverConfig,
     },
-    config::{BinaryConfig, CommonConfig, DbConfig, JobDriverConfig, TaskprovConfig},
+    config::{
+        default_max_transaction_retries, BinaryConfig, CommonConfig, DbConfig, JobDriverConfig,
+        TaskprovConfig,
+    },
     metrics::MetricsConfiguration,
     trace::TraceConfiguration,
 };
@@ -252,6 +255,7 @@ async fn aggregator_shutdown() {
             logging_config: TraceConfiguration::default(),
             metrics_config: MetricsConfiguration::default(),
             health_check_listen_address: "127.0.0.1:9001".parse().unwrap(),
+            max_transaction_retries: default_max_transaction_retries(),
         },
         taskprov_config: TaskprovConfig::default(),
         garbage_collection: None,
@@ -286,6 +290,7 @@ async fn aggregation_job_creator_shutdown() {
             logging_config: TraceConfiguration::default(),
             metrics_config: MetricsConfiguration::default(),
             health_check_listen_address: "127.0.0.1:9001".parse().unwrap(),
+            max_transaction_retries: default_max_transaction_retries(),
         },
         batch_aggregation_shard_count: 32,
         tasks_update_frequency_secs: 3600,
@@ -312,6 +317,7 @@ async fn aggregation_job_driver_shutdown() {
             logging_config: TraceConfiguration::default(),
             metrics_config: MetricsConfiguration::default(),
             health_check_listen_address: "127.0.0.1:9001".parse().unwrap(),
+            max_transaction_retries: default_max_transaction_retries(),
         },
         job_driver_config: JobDriverConfig {
             job_discovery_interval_secs: 10,
@@ -346,6 +352,7 @@ async fn collection_job_driver_shutdown() {
             logging_config: TraceConfiguration::default(),
             metrics_config: MetricsConfiguration::default(),
             health_check_listen_address: "127.0.0.1:9001".parse().unwrap(),
+            max_transaction_retries: default_max_transaction_retries(),
         },
         job_driver_config: JobDriverConfig {
             job_discovery_interval_secs: 10,

--- a/aggregator_core/src/datastore/test_util.rs
+++ b/aggregator_core/src/datastore/test_util.rs
@@ -109,13 +109,37 @@ pub struct EphemeralDatastore {
     migrator: Migrator,
 }
 
+pub const TEST_DATASTORE_MAX_TRANSACTION_RETRIES: u64 = 1000;
+
 impl EphemeralDatastore {
     /// Creates a Datastore instance based on this EphemeralDatastore. All returned Datastore
     /// instances will refer to the same underlying durable state.
     pub async fn datastore<C: Clock>(&self, clock: C) -> Datastore<C> {
-        Datastore::new(self.pool(), self.crypter(), clock, &noop_meter())
-            .await
-            .unwrap()
+        Datastore::new(
+            self.pool(),
+            self.crypter(),
+            clock,
+            &noop_meter(),
+            TEST_DATASTORE_MAX_TRANSACTION_RETRIES,
+        )
+        .await
+        .unwrap()
+    }
+
+    pub async fn datastore_with_max_transaction_retries<C: Clock>(
+        &self,
+        clock: C,
+        max_transaction_retries: u64,
+    ) -> Datastore<C> {
+        Datastore::new(
+            self.pool(),
+            self.crypter(),
+            clock,
+            &noop_meter(),
+            max_transaction_retries,
+        )
+        .await
+        .unwrap()
     }
 
     /// Retrieves the connection pool used for this EphemeralDatastore. Typically, this would be

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -110,8 +110,9 @@ async fn down_migrations(
 #[tokio::test]
 async fn retry_limit() {
     install_test_trace_subscriber();
+    let ephemeral_datastore = EphemeralDatastoreBuilder::new().build().await;
+
     for max_transaction_retries in [0, 1, 1000] {
-        let ephemeral_datastore = EphemeralDatastoreBuilder::new().build().await;
         let datastore = ephemeral_datastore
             .datastore_with_max_transaction_retries(MockClock::default(), max_transaction_retries)
             .await;

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -17,7 +17,9 @@ use janus_aggregator::{
         },
     },
     binary_utils::{BinaryContext, CommonBinaryOptions},
-    config::{CommonConfig, DbConfig, JobDriverConfig, TaskprovConfig},
+    config::{
+        default_max_transaction_retries, CommonConfig, DbConfig, JobDriverConfig, TaskprovConfig,
+    },
     metrics::MetricsConfiguration,
     trace::{TokioConsoleConfiguration, TraceConfiguration},
 };
@@ -144,6 +146,7 @@ impl JanusInProcess {
             logging_config,
             metrics_config: MetricsConfiguration { exporter: None },
             health_check_listen_address: (Ipv4Addr::LOCALHOST, 0).into(),
+            max_transaction_retries: default_max_transaction_retries(),
         };
         let aggregator_options = AggregatorOptions {
             common: common_binary_options.clone(),


### PR DESCRIPTION
Closes https://github.com/divviup/janus/issues/2124.

Breaks out of the transaction loop if it's tried too many times. This is governed by the config option `max_transaction_retries`. We could hard code this limit, but it's not a big deal to plumb it through to configuration in the off chance we need to raise it.