### PR TITLE
Save Taskprov task_info field in database

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -763,7 +763,8 @@ impl<C: Clock> Aggregator<C> {
                 [],
                 task::AggregatorTaskParameters::TaskprovHelper,
             )
-            .map_err(|err| Error::InvalidTask(*task_id, OptOutReason::TaskParameters(err)))?,
+            .map_err(|err| Error::InvalidTask(*task_id, OptOutReason::TaskParameters(err)))?
+            .with_taskprov_task_info(task_config.task_info().to_vec()),
         );
         self.datastore
             .run_tx("taskprov_put_task", |tx| {

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -205,6 +205,7 @@ where
         .with_min_batch_size(min_batch_size as u64)
         .with_time_precision(Duration::from_seconds(1))
         .with_tolerable_clock_skew(Duration::from_seconds(1))
+        .with_taskprov_task_info(task_config.task_info().to_vec())
         .build();
 
         Self {
@@ -402,7 +403,9 @@ async fn taskprov_aggregate_init() {
                 .state()
                 .eq(&AggregationJobState::InProgress)
     );
-    assert_eq!(test.task.taskprov_helper_view().unwrap(), got_task.unwrap());
+    let got_task = got_task.unwrap();
+    assert_eq!(test.task.taskprov_helper_view().unwrap(), got_task);
+    assert_eq!(got_task.taskprov_task_info(), Some(b"foobar".as_slice()));
 }
 
 #[tokio::test]

--- a/db/00000000000001_initial_schema.up.sql
+++ b/db/00000000000001_initial_schema.up.sql
@@ -105,6 +105,7 @@ CREATE TABLE tasks(
     tolerable_clock_skew        BIGINT NOT NULL,           -- the maximum acceptable clock skew to allow between client and aggregator, in seconds
     collector_hpke_config       BYTEA,                     -- the HPKE config of the collector (encoded HpkeConfig message)
     vdaf_verify_key             BYTEA NOT NULL,            -- the VDAF verification key (encrypted)
+    taskprov_task_info          BYTEA,                     -- if applicable, the task_info field of a Taskprov TaskConfig structure
 
     -- Authentication token used to authenticate messages to/from the other aggregator.
     -- These columns are NULL if the task was provisioned by taskprov.


### PR DESCRIPTION
This closes #2720. I chose to not plumb this field to the YAML or JSON representations of tasks.