### PR TITLE
Remove extra extension member from problem details

### DIFF
--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -79,11 +79,10 @@ async fn run_error_handler(error: &Error, mut conn: Conn) -> Conn {
         Error::MissingTaskId => {
             conn.with_problem_document(&ProblemDocument::new_dap(DapProblemType::MissingTaskId))
         }
-        Error::UnrecognizedAggregationJob(task_id, aggregation_job_id) => conn
+        Error::UnrecognizedAggregationJob(task_id, _aggregation_job_id) => conn
             .with_problem_document(
                 &ProblemDocument::new_dap(DapProblemType::UnrecognizedAggregationJob)
-                    .with_task_id(task_id)
-                    .with_aggregation_job_id(aggregation_job_id),
+                    .with_task_id(task_id),
             ),
         Error::DeletedAggregationJob(task_id, aggregation_job_id) => conn.with_problem_document(
             &ProblemDocument::new(


### PR DESCRIPTION
This removes an extra extension member from our `urn:ietf:params:ppm:dap:error:unrecognizedAggregationJob` problem details documents. Closes #2593.

I decided to just remove the aggregation job ID and not template it into the `detail` string. Doing that would require a broader refactor -- I think we'd want to start using a value-carrying enum instead of a C-style enum and multiple optional fields provided via builder methods, and then build the entire document in one place, removing the detail method that currently returns a `&'static str`.