### PR TITLE
Datastore: treat writes to logically GC'ed rows as new writes.

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -24,7 +24,7 @@ use fixed::{
     types::extra::{U15, U31},
     FixedI16, FixedI32,
 };
-use futures::future::try_join_all;
+use futures::{future::try_join_all, TryFutureExt as _};
 use http::{header::CONTENT_TYPE, Method};
 use itertools::iproduct;
 use janus_aggregator_core::{
@@ -93,7 +93,7 @@ use std::{
     sync::{Arc, Mutex as SyncMutex},
     time::{Duration as StdDuration, Instant},
 };
-use tokio::{join, sync::Mutex, try_join};
+use tokio::{sync::Mutex, try_join};
 use tracing::{debug, info, trace_span, warn, Level};
 use url::Url;
 
@@ -2098,6 +2098,7 @@ impl VdafOps {
                     }
 
                     // Write report shares, and ensure this isn't a repeated report aggregation.
+                    // TODO(#225): on repeated aggregation, verify input share matches previously-received input share
                     try_join_all(report_share_data.iter_mut().map(|rsd| {
                         let task = Arc::clone(&task);
                         let aggregation_job = Arc::clone(&aggregation_job);
@@ -2105,8 +2106,14 @@ impl VdafOps {
                         async move {
                             // Verify that we haven't seen this report ID and aggregation parameter
                             // before in another aggregation job.
-                            let put_report_share_fut =
-                                tx.put_report_share(task.id(), &rsd.report_share);
+                            let put_report_share_fut = tx
+                                .put_scrubbed_report(task.id(), &rsd.report_share)
+                                .or_else(|err| async move {
+                                    match err {
+                                        datastore::Error::MutationTargetAlreadyExists => Ok(()),
+                                        _ => Err(err),
+                                    }
+                                });
                             let report_aggregation_exists_fut = tx
                                 .check_other_report_aggregation_exists::<SEED_SIZE, A>(
                                     task.id(),
@@ -2114,17 +2121,10 @@ impl VdafOps {
                                     aggregation_job.aggregation_parameter(),
                                     aggregation_job.id(),
                                 );
-                            let (put_report_share_rslt, report_aggregation_exists_rslt) =
-                                join!(put_report_share_fut, report_aggregation_exists_fut);
+                            let (_, report_aggregation_exists) =
+                                try_join!(put_report_share_fut, report_aggregation_exists_fut)?;
 
-                            let report_share_exists = match put_report_share_rslt {
-                                Ok(()) => false,
-                                Err(datastore::Error::MutationTargetAlreadyExists) => true,
-                                Err(err) => return Err(err),
-                            };
-                            let report_aggregation_exists = report_aggregation_exists_rslt?;
-
-                            if report_share_exists || report_aggregation_exists {
+                            if report_aggregation_exists {
                                 rsd.report_aggregation = rsd
                                     .report_aggregation
                                     .clone()

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -2104,8 +2104,6 @@ impl VdafOps {
                         let aggregation_job = Arc::clone(&aggregation_job);
 
                         async move {
-                            // Verify that we haven't seen this report ID and aggregation parameter
-                            // before in another aggregation job.
                             let put_report_share_fut = tx
                                 .put_scrubbed_report(task.id(), &rsd.report_share)
                                 .or_else(|err| async move {
@@ -2114,6 +2112,8 @@ impl VdafOps {
                                         _ => Err(err),
                                     }
                                 });
+                            // Verify that we haven't seen this report ID and aggregation parameter
+                            // before in another aggregation job.
                             let report_aggregation_exists_fut = tx
                                 .check_other_report_aggregation_exists::<SEED_SIZE, A>(
                                     task.id(),

--- a/aggregator/src/aggregator/aggregate_init_tests.rs
+++ b/aggregator/src/aggregator/aggregate_init_tests.rs
@@ -9,10 +9,7 @@ use crate::aggregator::{
 use assert_matches::assert_matches;
 use http::StatusCode;
 use janus_aggregator_core::{
-    datastore::{
-        test_util::{ephemeral_datastore, EphemeralDatastore},
-        Datastore,
-    },
+    datastore::test_util::{ephemeral_datastore, EphemeralDatastore},
     task::{
         test_util::{Task, TaskBuilder},
         AggregatorTask, QueryType,
@@ -173,7 +170,6 @@ pub(super) struct AggregationJobInitTestCase<
     aggregation_job_init_resp: Option<AggregationJobResp>,
     pub(super) aggregation_param: V::AggregationParam,
     pub(super) handler: Box<dyn Handler>,
-    pub(super) datastore: Arc<Datastore<MockClock>>,
     _ephemeral_datastore: EphemeralDatastore,
 }
 
@@ -302,7 +298,6 @@ async fn setup_aggregate_init_test_without_sending_request<
         aggregation_job_init_resp: None,
         aggregation_param,
         handler: Box::new(handler),
-        datastore,
         _ephemeral_datastore: ephemeral_datastore,
     }
 }

--- a/aggregator/src/aggregator/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/aggregation_job_continue.rs
@@ -427,7 +427,7 @@ mod tests {
 
                 Box::pin(async move {
                     tx.put_aggregator_task(&task).await.unwrap();
-                    tx.put_report_share(task.id(), prepare_init.report_share())
+                    tx.put_scrubbed_report(task.id(), prepare_init.report_share())
                         .await
                         .unwrap();
 
@@ -654,7 +654,7 @@ mod tests {
                     test_case.aggregation_job_id,
                 );
                 Box::pin(async move {
-                    tx.put_report_share(&task_id, unrelated_prepare_init.report_share())
+                    tx.put_scrubbed_report(&task_id, unrelated_prepare_init.report_share())
                         .await
                         .unwrap();
 

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -1283,12 +1283,11 @@ mod tests {
                         .await.unwrap()
                         .unwrap();
                     let report_aggregation = tx
-                        .get_report_aggregation(
+                        .get_report_aggregation_by_report_id(
                             vdaf.as_ref(),
                             &Role::Leader,
                             task.id(),
                             &aggregation_job_id,
-                            aggregation_job.aggregation_parameter(),
                             &report_id,
                         )
                         .await.unwrap()
@@ -1590,24 +1589,22 @@ mod tests {
                         .unwrap()
                         .unwrap();
                     let report_aggregation = tx
-                        .get_report_aggregation(
+                        .get_report_aggregation_by_report_id(
                             vdaf.as_ref(),
                             &Role::Leader,
                             task.id(),
                             &aggregation_job_id,
-                            aggregation_job.aggregation_parameter(),
                             &report_id,
                         )
                         .await
                         .unwrap()
                         .unwrap();
                     let repeated_extension_report_aggregation = tx
-                        .get_report_aggregation(
+                        .get_report_aggregation_by_report_id(
                             vdaf.as_ref(),
                             &Role::Leader,
                             task.id(),
                             &aggregation_job_id,
-                            aggregation_job.aggregation_parameter(),
                             &repeated_extension_report_id,
                         )
                         .await
@@ -1872,12 +1869,11 @@ mod tests {
                         .await.unwrap()
                         .unwrap();
                     let report_aggregation = tx
-                        .get_report_aggregation(
+                        .get_report_aggregation_by_report_id(
                             vdaf.as_ref(),
                             &Role::Leader,
                             task.id(),
                             &aggregation_job_id,
-                            aggregation_job.aggregation_parameter(),
                             &report_id,
                         )
                         .await.unwrap()
@@ -2516,12 +2512,11 @@ mod tests {
                         .unwrap()
                         .unwrap();
                     let report_aggregation = tx
-                        .get_report_aggregation(
+                        .get_report_aggregation_by_report_id(
                             vdaf.as_ref(),
                             &Role::Leader,
                             task.id(),
                             &aggregation_job_id,
-                            aggregation_job.aggregation_parameter(),
                             &report_id,
                         )
                         .await
@@ -2784,12 +2779,11 @@ mod tests {
                         .await.unwrap()
                         .unwrap();
                     let report_aggregation = tx
-                        .get_report_aggregation(
+                        .get_report_aggregation_by_report_id(
                             vdaf.as_ref(),
                             &Role::Leader,
                             task.id(),
                             &aggregation_job_id,
-                            aggregation_job.aggregation_parameter(),
                             &report_id,
                         )
                         .await.unwrap()
@@ -3130,12 +3124,11 @@ mod tests {
                         .await.unwrap()
                         .unwrap();
                     let report_aggregation = tx
-                        .get_report_aggregation(
+                        .get_report_aggregation_by_report_id(
                             vdaf.as_ref(),
                             &Role::Leader,
                             task.id(),
                             &aggregation_job_id,
-                            aggregation_job.aggregation_parameter(),
                             report_metadata.id(),
                         )
                         .await.unwrap()
@@ -3428,12 +3421,11 @@ mod tests {
                         .await.unwrap()
                         .unwrap();
                     let report_aggregation = tx
-                        .get_report_aggregation(
+                        .get_report_aggregation_by_report_id(
                             vdaf.as_ref(),
                             &Role::Leader,
                             task.id(),
                             &aggregation_job_id,
-                            aggregation_job.aggregation_parameter(),
                             report_metadata.id(),
                         )
                         .await.unwrap()
@@ -3665,12 +3657,11 @@ mod tests {
                         .unwrap()
                         .unwrap();
                     let report_aggregation = tx
-                        .get_report_aggregation(
+                        .get_report_aggregation_by_report_id(
                             vdaf.as_ref(),
                             &Role::Leader,
                             task.id(),
                             aggregation_job.id(),
-                            aggregation_job.aggregation_parameter(),
                             &report_id,
                         )
                         .await

--- a/aggregator/src/aggregator/garbage_collector.rs
+++ b/aggregator/src/aggregator/garbage_collector.rs
@@ -382,7 +382,9 @@ mod tests {
                             Vec::from("payload_0"),
                         ),
                     );
-                    tx.put_report_share(task.id(), &report_share).await.unwrap();
+                    tx.put_scrubbed_report(task.id(), &report_share)
+                        .await
+                        .unwrap();
 
                     // Aggregation artifacts.
                     let aggregation_job_id = random();
@@ -721,7 +723,9 @@ mod tests {
                             Vec::from("payload_0"),
                         ),
                     );
-                    tx.put_report_share(task.id(), &report_share).await.unwrap();
+                    tx.put_scrubbed_report(task.id(), &report_share)
+                        .await
+                        .unwrap();
 
                     // Aggregation artifacts.
                     let batch_id = random();

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -888,7 +888,7 @@ async fn taskprov_aggregate_continue() {
                 tx.put_aggregator_task(&task.taskprov_helper_view().unwrap())
                     .await?;
 
-                tx.put_report_share(task.id(), &report_share).await?;
+                tx.put_scrubbed_report(task.id(), &report_share).await?;
 
                 tx.put_aggregation_job(
                     &AggregationJob::<VERIFY_KEY_LENGTH, FixedSize, TestVdaf>::new(

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -1446,7 +1446,7 @@ impl<C: Clock> Transaction<'_, C> {
                         excluded.leader_input_share, excluded.helper_encrypted_input_share,
                         excluded.created_at, excluded.updated_at, excluded.updated_by
                     )
-                    WHERE COALESCE(client_reports.client_timestamp < COALESCE($11::TIMESTAMP - (SELECT report_expiry_age FROM tasks WHERE id = client_reports.task_id) * '1 second'::INTERVAL, '-infinity'::TIMESTAMP), FALSE)",
+                    WHERE client_reports.client_timestamp < COALESCE($11::TIMESTAMP - (SELECT report_expiry_age FROM tasks WHERE id = client_reports.task_id) * '1 second'::INTERVAL, '-infinity'::TIMESTAMP)",
             )
             .await?;
         check_insert(
@@ -1565,7 +1565,7 @@ impl<C: Clock> Transaction<'_, C> {
                     excluded.leader_input_share, excluded.helper_encrypted_input_share,
                     excluded.created_at, excluded.updated_at, excluded.updated_by
                 )
-                WHERE COALESCE(client_reports.client_timestamp < COALESCE($7::TIMESTAMP - (SELECT report_expiry_age FROM tasks WHERE id = client_reports.task_id) * '1 second'::INTERVAL, '-infinity'::TIMESTAMP), FALSE)",
+                WHERE client_reports.client_timestamp < COALESCE($7::TIMESTAMP - (SELECT report_expiry_age FROM tasks WHERE id = client_reports.task_id) * '1 second'::INTERVAL, '-infinity'::TIMESTAMP)",
             )
             .await?;
         check_insert(
@@ -1842,7 +1842,7 @@ impl<C: Clock> Transaction<'_, C> {
                         excluded.last_request_hash, excluded.created_at, excluded.updated_at,
                         excluded.updated_by
                     )
-                    WHERE COALESCE(UPPER(aggregation_jobs.client_timestamp_interval) < COALESCE($12::TIMESTAMP - (SELECT report_expiry_age FROM tasks WHERE id = aggregation_jobs.task_id) * '1 second'::INTERVAL, '-infinity'::TIMESTAMP), FALSE)",
+                    WHERE UPPER(aggregation_jobs.client_timestamp_interval) < COALESCE($12::TIMESTAMP - (SELECT report_expiry_age FROM tasks WHERE id = aggregation_jobs.task_id) * '1 second'::INTERVAL, '-infinity'::TIMESTAMP)",
             )
             .await?;
         check_insert(
@@ -2958,7 +2958,7 @@ impl<C: Clock> Transaction<'_, C> {
                         excluded.batch_interval, excluded.state, excluded.created_at,
                         excluded.updated_at, excluded.updated_by
                     )
-                    WHERE COALESCE(COALESCE(LOWER(collection_jobs.batch_interval), (SELECT MAX(UPPER(ba.client_timestamp_interval)) FROM batch_aggregations ba WHERE ba.task_id = collection_jobs.task_id AND ba.batch_identifier = collection_jobs.batch_identifier AND ba.aggregation_param = collection_jobs.aggregation_param), '-infinity'::TIMESTAMP) < COALESCE($11::TIMESTAMP - (SELECT report_expiry_age FROM tasks WHERE id = collection_jobs.task_id) * '1 second'::INTERVAL, '-infinity'::TIMESTAMP), FALSE)",
+                    WHERE COALESCE(LOWER(collection_jobs.batch_interval), (SELECT MAX(UPPER(ba.client_timestamp_interval)) FROM batch_aggregations ba WHERE ba.task_id = collection_jobs.task_id AND ba.batch_identifier = collection_jobs.batch_identifier AND ba.aggregation_param = collection_jobs.aggregation_param), '-infinity'::TIMESTAMP) < COALESCE($11::TIMESTAMP - (SELECT report_expiry_age FROM tasks WHERE id = collection_jobs.task_id) * '1 second'::INTERVAL, '-infinity'::TIMESTAMP)",
             )
             .await?;
 
@@ -3516,7 +3516,7 @@ impl<C: Clock> Transaction<'_, C> {
                         excluded.aggregation_jobs_created, excluded.aggregation_jobs_terminated,
                         excluded.created_at, excluded.updated_at, excluded.updated_by
                     )
-                    WHERE COALESCE(GREATEST(UPPER(COALESCE(batch_aggregations.batch_interval, batch_aggregations.client_timestamp_interval)), (SELECT MAX(UPPER(COALESCE(ba.batch_interval, ba.client_timestamp_interval))) FROM batch_aggregations ba WHERE ba.task_id = batch_aggregations.task_id AND ba.batch_identifier = batch_aggregations.batch_identifier AND ba.aggregation_param = batch_aggregations.aggregation_param)) < COALESCE($16::TIMESTAMP - (SELECT report_expiry_age FROM tasks WHERE id = batch_aggregations.task_id) * '1 second'::INTERVAL, '-infinity'::TIMESTAMP), FALSE)",
+                    WHERE GREATEST(UPPER(COALESCE(batch_aggregations.batch_interval, batch_aggregations.client_timestamp_interval)), (SELECT MAX(UPPER(COALESCE(ba.batch_interval, ba.client_timestamp_interval))) FROM batch_aggregations ba WHERE ba.task_id = batch_aggregations.task_id AND ba.batch_identifier = batch_aggregations.batch_identifier AND ba.aggregation_param = batch_aggregations.aggregation_param)) < COALESCE($16::TIMESTAMP - (SELECT report_expiry_age FROM tasks WHERE id = batch_aggregations.task_id) * '1 second'::INTERVAL, '-infinity'::TIMESTAMP)",
             )
             .await?;
         check_insert(
@@ -3586,8 +3586,7 @@ impl<C: Clock> Transaction<'_, C> {
                   AND batch_aggregations.batch_identifier = $11
                   AND batch_aggregations.aggregation_param = $12
                   AND ord = $13
-                  AND GREATEST(UPPER($1::TSRANGE), (SELECT MAX(UPPER(COALESCE(batch_interval, client_timestamp_interval))) FROM batch_aggregations ba WHERE ba.task_id = batch_aggregations.task_id AND ba.batch_identifier = batch_aggregations.batch_identifier AND ba.aggregation_param = batch_aggregations.aggregation_param)) >= COALESCE($14::TIMESTAMP - tasks.report_expiry_age * '1 second'::INTERVAL, '-infinity'::TIMESTAMP)
-                  ",
+                  AND GREATEST(UPPER($1::TSRANGE), (SELECT MAX(UPPER(COALESCE(batch_interval, client_timestamp_interval))) FROM batch_aggregations ba WHERE ba.task_id = batch_aggregations.task_id AND ba.batch_identifier = batch_aggregations.batch_identifier AND ba.aggregation_param = batch_aggregations.aggregation_param)) >= COALESCE($14::TIMESTAMP - tasks.report_expiry_age * '1 second'::INTERVAL, '-infinity'::TIMESTAMP)",
             )
             .await?;
         check_single_row_mutation(
@@ -3861,7 +3860,7 @@ impl<C: Clock> Transaction<'_, C> {
                         excluded.helper_aggregate_share, excluded.report_count, excluded.checksum,
                         excluded.created_at, excluded.updated_by
                     )
-                    WHERE COALESCE(COALESCE(LOWER(aggregate_share_jobs.batch_interval), (SELECT MAX(UPPER(ba.client_timestamp_interval)) FROM batch_aggregations ba WHERE ba.task_id = aggregate_share_jobs.task_id AND ba.batch_identifier = aggregate_share_jobs.batch_identifier AND ba.aggregation_param = aggregate_share_jobs.aggregation_param), '-infinity'::TIMESTAMP) < COALESCE($10::TIMESTAMP - (SELECT report_expiry_age FROM tasks WHERE id = aggregate_share_jobs.task_id) * '1 second'::INTERVAL, '-infinity'::TIMESTAMP), FALSE)",
+                    WHERE COALESCE(LOWER(aggregate_share_jobs.batch_interval), (SELECT MAX(UPPER(ba.client_timestamp_interval)) FROM batch_aggregations ba WHERE ba.task_id = aggregate_share_jobs.task_id AND ba.batch_identifier = aggregate_share_jobs.batch_identifier AND ba.aggregation_param = aggregate_share_jobs.aggregation_param), '-infinity'::TIMESTAMP) < COALESCE($10::TIMESTAMP - (SELECT report_expiry_age FROM tasks WHERE id = aggregate_share_jobs.task_id) * '1 second'::INTERVAL, '-infinity'::TIMESTAMP)",
             )
             .await?;
         check_insert(

--- a/db/00000000000001_initial_schema.up.sql
+++ b/db/00000000000001_initial_schema.up.sql
@@ -253,9 +253,9 @@ CREATE TABLE report_aggregations(
     id                  BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY, -- artificial ID, internal-only
     task_id             BIGINT NOT NULL,                    -- ID of related task
     aggregation_job_id  BIGINT NOT NULL,                    -- the aggregation job ID this report aggregation is associated with
+    ord                 BIGINT NOT NULL,                    -- a value used to specify the ordering of client reports in the aggregation job
     client_report_id    BYTEA NOT NULL,                     -- the client report ID this report aggregation is associated with
     client_timestamp    TIMESTAMP NOT NULL,                 -- the client timestamp this report aggregation is associated with
-    ord                 BIGINT NOT NULL,                    -- a value used to specify the ordering of client reports in the aggregation job
     last_prep_resp      BYTEA,                              -- the last PrepareResp message sent to the Leader, to assist in replay (opaque DAP message, populated for Helper only)
     state               REPORT_AGGREGATION_STATE NOT NULL,  -- the current state of this report aggregation
 


### PR DESCRIPTION
Previously, such writes would lead to a MutationTargetAlreadyExists error. However, the same error would happen if two transactions concurrently wrote the same entity (regardless of GC), which would have to be manually retried (by `tx.retry()`) by application code if it was sure the row shouldn't exist. This could lead to infinitely-repeated retries if the MutationTargetAlreadyExists error was due to the row being GC'ed rather than a concurrent write.

Now, we perform an upsert if the existing row is logically GC'ed. This allows overwriting logically-nonexistent rows with a put, but more importantly, this should allow concurrent writes to receive a serialization failure, rather than a
MutationTargetAlreadyExists error. This removes the need for application-level retries entirely, which should remove the possibility of further infinite-retry bugs.

Also:
* Remove delete-after-put for all put operations. We will wait for the next GC run to delete these rows. This is a tradeoff in complexity for the new upserts. I think writing GC'ed rows should be rare enough that this delay will not matter in practice.
* put_report_share renamed to put_scrubbed_report, and it now has the same semantics as all other put datastore methods. Note that this required some changes to the application code using this functionality, please review carefully.
* put_report_aggregation & similar now properly reports MutationTargetAlreadyExists.
* put_client_report: fix the expiry check.
* get_report_aggregation renamed to get_report_aggregation_for_report_id, now test-only. This was already only used for tests.