### PR TITLE
aggregator api: Allow patching a task's expiration time

### DIFF
--- a/aggregator_api/src/lib.rs
+++ b/aggregator_api/src/lib.rs
@@ -92,6 +92,7 @@ pub fn aggregator_api_handler<C: Clock>(
             .get("/task_ids", instrumented(api(get_task_ids::<C>)))
             .post("/tasks", instrumented(api(post_task::<C>)))
             .get("/tasks/:task_id", instrumented(api(get_task::<C>)))
+            .patch("/tasks/:task_id", instrumented(api(patch_task::<C>)))
             .delete("/tasks/:task_id", instrumented(api(delete_task::<C>)))
             .get(
                 "/tasks/:task_id/metrics/uploads",

--- a/aggregator_api/src/models.rs
+++ b/aggregator_api/src/models.rs
@@ -13,7 +13,7 @@ use janus_messages::{
     query_type::Code as SupportedQueryType, Duration, HpkeAeadId, HpkeConfig, HpkeKdfId, HpkeKemId,
     Role, TaskId, Time,
 };
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use url::Url;
 
 #[allow(dead_code)]
@@ -88,6 +88,12 @@ pub(crate) struct PostTaskReq {
     /// sub-protocol requests received from the helper. If this aggregator is the helper, the value
     /// is `None`.
     pub(crate) collector_auth_token_hash: Option<AuthenticationTokenHash>,
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct PatchTaskReq {
+    #[serde(default, deserialize_with = "deserialize_some")]
+    pub(crate) task_expiration: Option<Option<Time>>,
 }
 
 #[derive(Clone, Derivative, PartialEq, Eq, Serialize, Deserialize)]
@@ -236,4 +242,14 @@ pub(crate) struct PostTaskprovPeerAggregatorReq {
 pub(crate) struct DeleteTaskprovPeerAggregatorReq {
     pub(crate) endpoint: Url,
     pub(crate) role: Role,
+}
+
+// Any value that is present is considered Some value, including null. See
+// https://github.com/serde-rs/serde/issues/984#issuecomment-314143738
+fn deserialize_some<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    T: Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    Deserialize::deserialize(deserializer).map(Some)
 }

--- a/aggregator_api/src/routes.rs
+++ b/aggregator_api/src/routes.rs
@@ -1,9 +1,9 @@
 use crate::{
     models::{
         AggregatorApiConfig, AggregatorRole, DeleteTaskprovPeerAggregatorReq, GetTaskIdsResp,
-        GetTaskUploadMetricsResp, GlobalHpkeConfigResp, PatchGlobalHpkeConfigReq, PostTaskReq,
-        PostTaskprovPeerAggregatorReq, PutGlobalHpkeConfigReq, SupportedVdaf, TaskResp,
-        TaskprovPeerAggregatorResp,
+        GetTaskUploadMetricsResp, GlobalHpkeConfigResp, PatchGlobalHpkeConfigReq, PatchTaskReq,
+        PostTaskReq, PostTaskprovPeerAggregatorReq, PutGlobalHpkeConfigReq, SupportedVdaf,
+        TaskResp, TaskprovPeerAggregatorResp,
     },
     Config, ConnExt, Error,
 };
@@ -255,6 +255,29 @@ pub(super) async fn delete_task<C: Clock>(
         Ok(_) | Err(datastore::Error::MutationTargetNotFound) => Ok(Status::NoContent),
         Err(err) => Err(err.into()),
     }
+}
+
+pub(super) async fn patch_task<C: Clock>(
+    conn: &mut Conn,
+    (State(ds), Json(req)): (State<Arc<Datastore<C>>>, Json<PatchTaskReq>),
+) -> Result<Json<TaskResp>, Error> {
+    let task_id = conn.task_id_param()?;
+    let task = ds
+        .run_tx("patch_task", |tx| {
+            Box::pin(async move {
+                if let Some(task_expiration) = req.task_expiration {
+                    tx.update_task_expiration(&task_id, task_expiration.as_ref())
+                        .await?;
+                }
+                tx.get_aggregator_task(&task_id).await
+            })
+        })
+        .await?
+        .ok_or(Error::NotFound)?;
+
+    Ok(Json(
+        TaskResp::try_from(&task).map_err(|err| Error::Internal(err.to_string()))?,
+    ))
 }
 
 pub(super) async fn get_task_upload_metrics<C: Clock>(

--- a/aggregator_api/src/tests.rs
+++ b/aggregator_api/src/tests.rs
@@ -755,7 +755,7 @@ async fn patch_task(#[case] role: Role) {
     // Setup: write a task to the datastore.
     let (handler, _ephemeral_datastore, ds) = setup_api_test().await;
 
-    let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake)
+    let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake { rounds: 1 })
         .with_task_expiration(Some(Time::from_seconds_since_epoch(1000)))
         .build()
         .view_for_role(role)

--- a/aggregator_api/src/tests.rs
+++ b/aggregator_api/src/tests.rs
@@ -629,15 +629,7 @@ async fn get_task(#[case] role: Role) {
         .view_for_role(role)
         .unwrap();
 
-    ds.run_unnamed_tx(|tx| {
-        let task = task.clone();
-        Box::pin(async move {
-            tx.put_aggregator_task(&task).await?;
-            Ok(())
-        })
-    })
-    .await
-    .unwrap();
+    ds.put_aggregator_task(&task).await.unwrap();
 
     // Verify: getting the task returns the expected result.
     let want_task_resp = TaskResp::try_from(&task).unwrap();
@@ -752,6 +744,124 @@ async fn delete_task() {
             .await,
         Status::Unauthorized,
         ""
+    );
+}
+
+#[rstest::rstest]
+#[case::leader(Role::Leader)]
+#[case::helper(Role::Helper)]
+#[tokio::test]
+async fn patch_task(#[case] role: Role) {
+    // Setup: write a task to the datastore.
+    let (handler, _ephemeral_datastore, ds) = setup_api_test().await;
+
+    let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake)
+        .with_task_expiration(Some(Time::from_seconds_since_epoch(1000)))
+        .build()
+        .view_for_role(role)
+        .unwrap();
+
+    ds.put_aggregator_task(&task).await.unwrap();
+    let task_id = *task.id();
+
+    // Verify: patching the task with empty body does nothing.
+    let want_task_resp = TaskResp::try_from(&task).unwrap();
+    let mut conn = patch(&format!("/tasks/{}", task.id()))
+        .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
+        .with_request_header("Accept", CONTENT_TYPE)
+        .with_request_body("{}")
+        .run_async(&handler)
+        .await;
+    assert_status!(conn, Status::Ok);
+    let got_task_resp = serde_json::from_slice(
+        &conn
+            .take_response_body()
+            .unwrap()
+            .into_bytes()
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(want_task_resp, got_task_resp);
+    let task = ds
+        .run_unnamed_tx(|tx| Box::pin(async move { tx.get_aggregator_task(&task_id).await }))
+        .await
+        .unwrap();
+    assert_eq!(
+        task.unwrap().task_expiration(),
+        Some(&Time::from_seconds_since_epoch(1000))
+    );
+
+    // Verify: patching the task with a null task expiration returns the expected result.
+    let mut conn = patch(&format!("/tasks/{}", task_id))
+        .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
+        .with_request_header("Accept", CONTENT_TYPE)
+        .with_request_body(r#"{"task_expiration": null}"#)
+        .run_async(&handler)
+        .await;
+    assert_status!(conn, Status::Ok);
+    let got_task_resp: TaskResp = serde_json::from_slice(
+        &conn
+            .take_response_body()
+            .unwrap()
+            .into_bytes()
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(got_task_resp.task_expiration, None);
+    let task = ds
+        .run_unnamed_tx(|tx| Box::pin(async move { tx.get_aggregator_task(&task_id).await }))
+        .await
+        .unwrap();
+    assert_eq!(task.unwrap().task_expiration(), None);
+
+    // Verify: patching the task with a task expiration returns the expected result.
+    let expected_time = Some(Time::from_seconds_since_epoch(2000));
+    let mut conn = patch(&format!("/tasks/{}", task_id))
+        .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
+        .with_request_header("Accept", CONTENT_TYPE)
+        .with_request_body(r#"{"task_expiration": 2000}"#)
+        .run_async(&handler)
+        .await;
+    assert_status!(conn, Status::Ok);
+    let got_task_resp: TaskResp = serde_json::from_slice(
+        &conn
+            .take_response_body()
+            .unwrap()
+            .into_bytes()
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(got_task_resp.task_expiration, expected_time);
+    let task = ds
+        .run_unnamed_tx(|tx| Box::pin(async move { tx.get_aggregator_task(&task_id).await }))
+        .await
+        .unwrap();
+    assert_eq!(task.unwrap().task_expiration(), expected_time.as_ref());
+
+    // Verify: patching a nonexistent task returns NotFound.
+    assert_response!(
+        patch(&format!("/tasks/{}", random::<TaskId>()))
+            .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
+            .with_request_header("Accept", CONTENT_TYPE)
+            .with_request_body("{}")
+            .run_async(&handler)
+            .await,
+        Status::NotFound,
+        "",
+    );
+
+    // Verify: unauthorized requests are denied appropriately.
+    assert_response!(
+        patch(&format!("/tasks/{}", task_id))
+            .with_request_header("Accept", CONTENT_TYPE)
+            .with_request_body("{}")
+            .run_async(&handler)
+            .await,
+        Status::Unauthorized,
+        "",
     );
 }
 

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -281,6 +281,55 @@ async fn roundtrip_task(ephemeral_datastore: EphemeralDatastore) {
 
 #[rstest_reuse::apply(schema_versions_template)]
 #[tokio::test]
+async fn update_task_expiration(ephemeral_datastore: EphemeralDatastore) {
+    install_test_trace_subscriber();
+    let ds = ephemeral_datastore.datastore(MockClock::default()).await;
+
+    let task = TaskBuilder::new(task::QueryType::TimeInterval, VdafInstance::Prio3Count)
+        .with_task_expiration(Some(Time::from_seconds_since_epoch(1000)))
+        .build()
+        .leader_view()
+        .unwrap();
+    ds.put_aggregator_task(&task).await.unwrap();
+
+    ds.run_unnamed_tx(|tx| {
+        let task_id = *task.id();
+        Box::pin(async move {
+            let task = tx.get_aggregator_task(&task_id).await.unwrap().unwrap();
+            assert_eq!(
+                task.task_expiration().cloned(),
+                Some(Time::from_seconds_since_epoch(1000))
+            );
+
+            tx.update_task_expiration(&task_id, Some(&Time::from_seconds_since_epoch(2000)))
+                .await
+                .unwrap();
+
+            let task = tx.get_aggregator_task(&task_id).await.unwrap().unwrap();
+            assert_eq!(
+                task.task_expiration().cloned(),
+                Some(Time::from_seconds_since_epoch(2000))
+            );
+
+            tx.update_task_expiration(&task_id, None).await.unwrap();
+
+            let task = tx.get_aggregator_task(&task_id).await.unwrap().unwrap();
+            assert_eq!(task.task_expiration().cloned(), None);
+
+            let result = tx
+                .update_task_expiration(&random(), Some(&Time::from_seconds_since_epoch(2000)))
+                .await;
+            assert_matches!(result, Err(Error::MutationTargetNotFound));
+
+            Ok(())
+        })
+    })
+    .await
+    .unwrap();
+}
+
+#[rstest_reuse::apply(schema_versions_template)]
+#[tokio::test]
 async fn put_task_invalid_aggregator_auth_tokens(ephemeral_datastore: EphemeralDatastore) {
     install_test_trace_subscriber();
     let ds = ephemeral_datastore.datastore(MockClock::default()).await;


### PR DESCRIPTION
Lets us issue `PATCH /tasks/:task_id` with the following bodies and results
- `{}` -> no changes, returns the task as-is.
- `{"task_expiration": null}` -> unsets the task expiration. There currently isn't a use case for this, but I did it for consistency with how PUT of a task works, i.e. you can make a task with no expiration.
- `{"task_expiration": 1000}` -> works as you'd expect, content is seconds since epoch.

Supports https://github.com/divviup/divviup-api/issues/862