### PR TITLE
datastore: Add updated_at to tasks table

### DIFF
--- a/db/00000000000001_initial_schema.up.sql
+++ b/db/00000000000001_initial_schema.up.sql
@@ -130,6 +130,7 @@ CREATE TABLE tasks(
 
     -- creation/update records
     created_at TIMESTAMP NOT NULL,  -- when the row was created
+    updated_at TIMESTAMP NOT NULL,  -- when the row was last changed
     updated_by TEXT NOT NULL        -- the name of the transaction that last updated the row
 );
 CREATE INDEX task_id_index ON tasks(task_id);


### PR DESCRIPTION
Supports https://github.com/divviup/janus/issues/2819, follow up to https://github.com/divviup/janus/pull/2824 since task rows are no longer immutable.