### PR TITLE
Downgrade log level for update_task_expiration

### DIFF
--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -743,7 +743,7 @@ impl<C: Clock> Transaction<'_, C> {
     }
 
     /// Sets or unsets the expiration date of a task.
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self), err(level = Level::DEBUG))]
     pub async fn update_task_expiration(
         &self,
         task_id: &TaskId,


### PR DESCRIPTION
I thought I took this suggestion https://github.com/divviup/janus/pull/2824#discussion_r1529437708 but it didn't stick.