### PR TITLE
datastore: Migration for adding updated_at to tasks table

### DIFF
--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -100,7 +100,7 @@ macro_rules! supported_schema_versions {
 // version is seen, [`Datastore::new`] fails.
 //
 // Note that the latest supported version must be first in the list.
-supported_schema_versions!(4, 3);
+supported_schema_versions!(5, 4, 3);
 
 /// Datastore represents a datastore for Janus, with support for transactional reads and writes.
 /// In practice, Datastore instances are currently backed by a PostgreSQL database.

--- a/db/00000000000005_tasks_updated_at.down.sql
+++ b/db/00000000000005_tasks_updated_at.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tasks DROP COLUMN updated_at;

--- a/db/00000000000005_tasks_updated_at.up.sql
+++ b/db/00000000000005_tasks_updated_at.up.sql
@@ -1,0 +1,2 @@
+-- This column needs to be nullable for this migration to be zero downtime.
+ALTER TABLE tasks ADD COLUMN updated_at TIMESTAMP;


### PR DESCRIPTION
Supports https://github.com/divviup/janus/issues/2819.

This is just the migration for this change.

Notice the new column is nullable. I think this is the only way to make this migration work with zero downtime--if we apply the migration, older versions of Janus would fail to insert tasks due to the NOT NULL constraint. It also means we don't have to backfill for existing tasks.

Since this column is only for debugging, I think it's fine to have null values for `updated_at`. We'll just have to note that on this version of Janus, a null `updated_at` means the task was never updated.

This migration will acquire an exclusive table lock for the duration of the migration. This will block every query that needs to join against `tasks`... which is almost all of them. However, the tasks table is relatively small and this migration doesn't force a table rewrite, so it should complete quickly.