### PR TITLE
Add conditions on aggregation_jobs.task_id back to queries

### DIFF
--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -2599,37 +2599,37 @@ impl<C: Clock> Transaction<'_, C> {
                 let stmt = self
                     .prepare_cached(
                         "INSERT INTO report_aggregations
-                        (task_id, aggregation_job_id, ord, client_report_id, client_timestamp,
-                        state, public_share, leader_extensions, leader_input_share,
-                        helper_encrypted_input_share, created_at, updated_at, updated_by)
-                    SELECT
-                        $1, aggregation_jobs.id, $3, $4, $5, 'START'::REPORT_AGGREGATION_STATE,
-                        client_reports.public_share, client_reports.extensions,
-                        client_reports.leader_input_share,
-                        client_reports.helper_encrypted_input_share, $6, $7, $8
-                    FROM aggregation_jobs
-                    JOIN client_reports
-                        ON aggregation_jobs.task_id = client_reports.task_id
-                       AND client_reports.report_id = $4
-                    WHERE aggregation_jobs.task_id = $1
-                      AND aggregation_job_id = $2
-                    ON CONFLICT(task_id, aggregation_job_id, ord) DO UPDATE
-                        SET (
-                            client_report_id, client_timestamp, last_prep_resp, state, public_share,
-                            leader_extensions, leader_input_share, helper_encrypted_input_share,
-                            leader_prep_transition, helper_prep_state, error_code, created_at,
-                            updated_at, updated_by
-                        ) = (
-                            excluded.client_report_id, excluded.client_timestamp,
-                            excluded.last_prep_resp, excluded.state, excluded.public_share,
-                            excluded.leader_extensions, excluded.leader_input_share,
-                            excluded.helper_encrypted_input_share, excluded.leader_prep_transition,
-                            excluded.helper_prep_state, excluded.error_code, excluded.created_at,
-                            excluded.updated_at, excluded.updated_by
-                        )
-                        WHERE (SELECT UPPER(client_timestamp_interval)
-                               FROM aggregation_jobs
-                               WHERE id = report_aggregations.aggregation_job_id) >= $9",
+                            (task_id, aggregation_job_id, ord, client_report_id, client_timestamp,
+                            state, public_share, leader_extensions, leader_input_share,
+                            helper_encrypted_input_share, created_at, updated_at, updated_by)
+                        SELECT
+                            $1, aggregation_jobs.id, $3, $4, $5, 'START'::REPORT_AGGREGATION_STATE,
+                            client_reports.public_share, client_reports.extensions,
+                            client_reports.leader_input_share,
+                            client_reports.helper_encrypted_input_share, $6, $7, $8
+                        FROM aggregation_jobs
+                        JOIN client_reports
+                            ON aggregation_jobs.task_id = client_reports.task_id
+                        AND client_reports.report_id = $4
+                        WHERE aggregation_jobs.task_id = $1
+                        AND aggregation_job_id = $2
+                        ON CONFLICT(task_id, aggregation_job_id, ord) DO UPDATE
+                            SET (
+                                client_report_id, client_timestamp, last_prep_resp, state, public_share,
+                                leader_extensions, leader_input_share, helper_encrypted_input_share,
+                                leader_prep_transition, helper_prep_state, error_code, created_at,
+                                updated_at, updated_by
+                            ) = (
+                                excluded.client_report_id, excluded.client_timestamp,
+                                excluded.last_prep_resp, excluded.state, excluded.public_share,
+                                excluded.leader_extensions, excluded.leader_input_share,
+                                excluded.helper_encrypted_input_share, excluded.leader_prep_transition,
+                                excluded.helper_prep_state, excluded.error_code, excluded.created_at,
+                                excluded.updated_at, excluded.updated_by
+                            )
+                            WHERE (SELECT UPPER(client_timestamp_interval)
+                                FROM aggregation_jobs
+                                WHERE id = report_aggregations.aggregation_job_id) >= $9",
                     )
                     .await?;
                 check_insert(
@@ -4488,22 +4488,22 @@ impl<C: Clock> Transaction<'_, C> {
         let stmt = self
             .prepare_cached(
                 "WITH non_gc_batches AS (
-                SELECT batch_identifier, SUM(report_count) AS report_count
-                FROM batch_aggregations
-                WHERE task_id = $1
-                GROUP BY batch_identifier
-                HAVING MAX(UPPER(client_timestamp_interval)) >= $3
-            ),
-            selected_outstanding_batch AS (
-                SELECT outstanding_batches.id
-                FROM outstanding_batches
-                WHERE task_id = $1
-                  AND (SELECT report_count FROM non_gc_batches
-                       WHERE batch_identifier = outstanding_batches.batch_id) >= $2::BIGINT
-                LIMIT 1
-            )
-            DELETE FROM outstanding_batches WHERE id IN (SELECT id FROM selected_outstanding_batch)
-            RETURNING batch_id",
+                    SELECT batch_identifier, SUM(report_count) AS report_count
+                    FROM batch_aggregations
+                    WHERE task_id = $1
+                    GROUP BY batch_identifier
+                    HAVING MAX(UPPER(client_timestamp_interval)) >= $3
+                ),
+                selected_outstanding_batch AS (
+                    SELECT outstanding_batches.id
+                    FROM outstanding_batches
+                    WHERE task_id = $1
+                    AND (SELECT report_count FROM non_gc_batches
+                        WHERE batch_identifier = outstanding_batches.batch_id) >= $2::BIGINT
+                    LIMIT 1
+                )
+                DELETE FROM outstanding_batches WHERE id IN (SELECT id FROM selected_outstanding_batch)
+                RETURNING batch_id",
             )
             .await?;
 


### PR DESCRIPTION
This is a follow-up to #2857 to add conditions on `aggregation_jobs.task_id` back to some queries. The importance of these predicates varies: some are in `test-util` methods, some may be fine as it is if other joined tables can be searched over first, and some don't have any such compensating factors. These conditions will help when looking up aggregation jobs by their `aggregation_job_id` column, because there is only one index covering this column, and its first column is `task_id`. We know that all `report_aggregations` rows linked to an aggregation job will share the same `task_id` as the `aggregation_jobs` row, but the database doesn't, so supplying this redundant constraint when joining across both opens up new opportunities for efficient index scans. Without this, my concern is that doing a full table scan of aggregation jobs would be the best way to look up a job by its DAP AggregationJobId only.

I also fixed the indentation of some queries where the enclosing method call got reformatted. Enable "Hide whitespace" to just view the substantive changes.

FWIW, I left `delete_expired_aggregation_artifacts()` alone, where a `report_aggregations.task_id` predicate was removed from a subquery, because in that case the lookup on `report_aggregations` is being done by aggregation job foreign key, which there is an index for, and the aggregation job primary keys were looked up in an earlier CTE.