### PR TITLE
Reverse proxy inside `janus_interop_aggregator`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,6 +710,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cidr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d18b093eba54c9aaa1e3784d4361eb2ba944cf7d0a932a830132238f483e8d8"
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1432,6 +1438,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "full-duplex-async-copy"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb69fcc211c8359cc56981e36370c21f6410d6f9820c68dab273bed4bc58d99e"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-lite 1.13.0",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -2398,7 +2415,6 @@ dependencies = [
  "janus_core",
  "janus_interop_binaries",
  "janus_messages 0.7.0-prerelease-5",
- "opentelemetry",
  "prio 0.16.2",
  "rand",
  "regex",
@@ -2406,7 +2422,6 @@ dependencies = [
  "ring 0.17.8",
  "serde",
  "serde_json",
- "sqlx",
  "testcontainers",
  "tokio",
  "tracing",
@@ -2414,6 +2429,7 @@ dependencies = [
  "tracing-subscriber",
  "trillium",
  "trillium-api",
+ "trillium-proxy",
  "trillium-router",
  "trillium-tokio",
  "url",
@@ -4326,6 +4342,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sluice"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7400c0eff44aa2fcb5e31a5f24ba9716ed90138769e4977a2ba6014ae63eb5"
+dependencies = [
+ "async-channel 1.9.0",
+ "futures-core",
+ "futures-io",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5308,6 +5335,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "trillium-forwarding"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c9d3277d2479cd05fd8915e825cee7535d3ccc7ccf06d4c57465a666437d74"
+dependencies = [
+ "cidr",
+ "log",
+ "trillium",
+]
+
+[[package]]
 name = "trillium-head"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5381,6 +5419,27 @@ dependencies = [
  "tracing",
  "trillium",
  "trillium-router",
+]
+
+[[package]]
+name = "trillium-proxy"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2a7e6aa0e67f5bd645a25f19623e973aac00cd12c5b72c4f36eba4a4285a57f"
+dependencies = [
+ "event-listener 4.0.3",
+ "fastrand 2.0.1",
+ "full-duplex-async-copy",
+ "futures-lite 2.2.0",
+ "log",
+ "size",
+ "sluice",
+ "trillium",
+ "trillium-client",
+ "trillium-forwarding",
+ "trillium-http",
+ "trillium-server-common",
+ "url",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM rust:1.76.0-alpine AS chef
 RUN apk add --no-cache libc-dev
-ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 RUN cargo install cargo-chef --version 0.1.60 && \
     rm -r $CARGO_HOME/registry
 WORKDIR /src

--- a/Dockerfile.interop
+++ b/Dockerfile.interop
@@ -3,7 +3,6 @@ ARG PROFILE=release
 
 FROM rust:1.76.0-alpine AS chef
 RUN apk add --no-cache libc-dev
-ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 RUN cargo install cargo-chef --version 0.1.60 && \
     rm -r $CARGO_HOME/registry
 WORKDIR /src

--- a/Dockerfile.interop_aggregator
+++ b/Dockerfile.interop_aggregator
@@ -2,7 +2,6 @@ ARG PROFILE=release
 
 FROM rust:1.76.0-alpine AS chef
 RUN apk add --no-cache libc-dev
-ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 RUN cargo install cargo-chef --version 0.1.60 && \
     rm -r $CARGO_HOME/registry
 WORKDIR /src

--- a/Dockerfile.interop_aggregator
+++ b/Dockerfile.interop_aggregator
@@ -40,6 +40,7 @@ COPY messages /src/messages
 COPY tools /src/tools
 COPY xtask /src/xtask
 RUN cargo build --features fpvec_bounded_l2 --profile $PROFILE -p janus_aggregator \
+    --bin aggregator \
     --bin aggregation_job_creator \
     --bin aggregation_job_driver \
     --bin collection_job_driver
@@ -63,6 +64,13 @@ COPY tools /src/tools
 RUN cargo build --features fpvec_bounded_l2 --profile $PROFILE -p janus_interop_binaries \
     --bin janus_interop_aggregator
 
+FROM rust:1.76.0-alpine AS sqlx
+ARG SQLX_VERSION=0.7.2
+RUN apk add --no-cache libc-dev
+RUN cargo install sqlx-cli \
+    --version ${SQLX_VERSION} \
+    --no-default-features --features postgres
+
 FROM postgres:15-alpine AS final
 RUN mkdir /logs && mkdir /etc/janus
 RUN apk add --no-cache supervisor && rm -rf /tmp/* /var/cache/apk/*
@@ -70,6 +78,7 @@ COPY db /etc/janus/migrations
 COPY interop_binaries/setup.sh /usr/local/bin/setup.sh
 COPY interop_binaries/config/supervisord.conf \
     interop_binaries/config/janus_interop_aggregator.yaml \
+    interop_binaries/config/aggregator.yaml \
     interop_binaries/config/aggregation_job_creator.yaml \
     interop_binaries/config/aggregation_job_driver.yaml \
     interop_binaries/config/collection_job_driver.yaml \
@@ -77,10 +86,12 @@ COPY interop_binaries/config/supervisord.conf \
 ARG PROFILE
 COPY --from=builder-interop /src/target/$PROFILE/janus_interop_aggregator /usr/local/bin/
 COPY --from=builder-aggregator \
+    /src/target/$PROFILE/aggregator \
     /src/target/$PROFILE/aggregation_job_creator \
     /src/target/$PROFILE/aggregation_job_driver \
     /src/target/$PROFILE/collection_job_driver \
     /usr/local/bin/
+COPY --from=sqlx /usr/local/cargo/bin/sqlx /usr/local/bin/
 ENV RUST_LOG=info
 EXPOSE 8080
 ENTRYPOINT ["/usr/bin/supervisord", "-c", "/etc/janus/supervisord.conf"]

--- a/interop_binaries/Cargo.toml
+++ b/interop_binaries/Cargo.toml
@@ -24,11 +24,11 @@ backoff = { version = "0.4", features = ["tokio"] }
 base64.workspace = true
 clap.workspace = true
 derivative.workspace = true
-futures = { version = "0.3.30", optional = true }
 fixed = { version = "1.26", optional = true }
+futures = { version = "0.3.30", optional = true }
 hex = { version = "0.4", optional = true }
-janus_aggregator_core = { workspace = true, features = ["test-util"] }
 janus_aggregator.workspace = true
+janus_aggregator_core = { workspace = true, features = ["test-util"] }
 janus_client.workspace = true
 janus_collector.workspace = true
 janus_core.workspace = true
@@ -55,6 +55,6 @@ zstd = { version = "0.13", optional = true }
 
 [dev-dependencies]
 fixed-macro = "1.1.1"
-janus_interop_binaries = { path = ".", features = ["fpvec_bounded_l2", "test-util"] }
 janus_core = { workspace = true, features = ["test-util", "fpvec_bounded_l2"] }
+janus_interop_binaries = { path = ".", features = ["fpvec_bounded_l2", "test-util"] }
 reqwest = { version = "0.11.26", default-features = false, features = ["json"] }

--- a/interop_binaries/Cargo.toml
+++ b/interop_binaries/Cargo.toml
@@ -33,7 +33,6 @@ janus_client.workspace = true
 janus_collector.workspace = true
 janus_core.workspace = true
 janus_messages.workspace = true
-opentelemetry.workspace = true
 prio.workspace = true
 rand.workspace = true
 regex = { version = "1", optional = true }
@@ -41,7 +40,6 @@ reqwest = { version = "0.11.26", default-features = false, features = ["rustls-t
 ring = "0.17.8"
 serde.workspace = true
 serde_json = "1.0.114"
-sqlx = { version = "0.7.4", features = ["runtime-tokio-rustls", "migrate", "postgres"] }
 testcontainers.workspace = true
 tokio.workspace = true
 tracing = "0.1.40"
@@ -49,6 +47,7 @@ tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt"] }
 trillium.workspace = true
 trillium-api.workspace = true
+trillium-proxy = "0.5.2"
 trillium-router.workspace = true
 trillium-tokio.workspace = true
 url.workspace = true

--- a/interop_binaries/config/aggregator.yaml
+++ b/interop_binaries/config/aggregator.yaml
@@ -3,8 +3,10 @@
 database:
   url: postgres://postgres@127.0.0.1:5432/postgres
   check_schema_version: false
-health_check_listen_address: 0.0.0.0:8000
+health_check_listen_address: 0.0.0.0:8004
 logging_config:
   force_json_output: true
-listen_address: 0.0.0.0:8080
-aggregator_address: 127.0.0.1:8081
+listen_address: 0.0.0.0:8081
+max_upload_batch_size: 100
+max_upload_batch_write_delay_ms: 100
+batch_aggregation_shard_count: 32

--- a/interop_binaries/config/supervisord.conf
+++ b/interop_binaries/config/supervisord.conf
@@ -15,6 +15,13 @@ serverurl=unix:///tmp/janus-supervisor.sock
 command=/usr/local/bin/janus_interop_aggregator --config-file /etc/janus/janus_interop_aggregator.yaml
 autostart=false
 environment=DATASTORE_KEYS=OSjfC8QVPATwO3uVJcAnTA
+stdout_logfile=/logs/interop_stdout.log
+stderr_logfile=/logs/interop_stderr.log
+
+[program:aggregator]
+command=/usr/local/bin/aggregator --config-file /etc/janus/aggregator.yaml
+autostart=false
+environment=DATASTORE_KEYS=OSjfC8QVPATwO3uVJcAnTA
 stdout_logfile=/logs/aggregator_stdout.log
 stderr_logfile=/logs/aggregator_stderr.log
 

--- a/interop_binaries/setup.sh
+++ b/interop_binaries/setup.sh
@@ -2,7 +2,9 @@
 set -e
 
 timeout 5m bash -c 'until pg_isready -U postgres; do sleep 1; done'
+sqlx migrate run --source /etc/janus/migrations --database-url postgres://postgres@127.0.0.1:5432/postgres
 /usr/bin/supervisorctl -c /etc/janus/supervisord.conf start janus_interop_aggregator
+/usr/bin/supervisorctl -c /etc/janus/supervisord.conf start aggregator
 /usr/bin/supervisorctl -c /etc/janus/supervisord.conf start aggregation_job_creator
 /usr/bin/supervisorctl -c /etc/janus/supervisord.conf start aggregation_job_driver
 /usr/bin/supervisorctl -c /etc/janus/supervisord.conf start collection_job_driver


### PR DESCRIPTION
This closes #446. The aggregator interop container is changed so that it runs the aggregator component as a separate process, managed by supervisord, and the `janus_interop_aggregator` binary reverse proxies DAP requests it receives to the aggregator. I also moved schema migration out of `janus_interop_aggregator`, so we can sequence it before starting other processes. This was necessary because the aggregator component doesn't tolerate missing tables well when it loads global HPKE keys at startup. With this change, the `janus_interop_aggregator` binary is much smaller, since it doesn't include the entire aggregator.

I also cleaned up old `ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse` lines, because this option is now the default, and has been for a while.