### PR TITLE
Unify interop test binary targets

### DIFF
--- a/Dockerfile.interop
+++ b/Dockerfile.interop
@@ -45,9 +45,9 @@ FROM alpine:3.19.1 AS final
 ARG BINARY
 ARG PROFILE
 RUN mkdir /logs
-COPY --from=builder /src/target/$PROFILE/janus_interop_binaries /janus_interop_binaries
-RUN ln -s /janus_interop_binaries /janus_interop_client
-RUN ln -s /janus_interop_binaries /janus_interop_collector
+COPY --from=builder /src/target/$PROFILE/janus_interop /janus_interop
+RUN ln -s /janus_interop /janus_interop_client
+RUN ln -s /janus_interop /janus_interop_collector
 EXPOSE 8080
 # Store the build argument in an environment variable so we can reference it
 # from the ENTRYPOINT at runtime.

--- a/Dockerfile.interop
+++ b/Dockerfile.interop
@@ -39,15 +39,15 @@ COPY interop_binaries /src/interop_binaries
 COPY messages /src/messages
 COPY tools /src/tools
 COPY xtask /src/xtask
-ARG BINARY
-RUN cargo build --features fpvec_bounded_l2 --profile $PROFILE -p janus_interop_binaries \
-    --bin $BINARY
+RUN cargo build --features fpvec_bounded_l2 --profile $PROFILE -p janus_interop_binaries
 
 FROM alpine:3.19.1 AS final
 ARG BINARY
 ARG PROFILE
 RUN mkdir /logs
-COPY --from=builder /src/target/$PROFILE/$BINARY /$BINARY
+COPY --from=builder /src/target/$PROFILE/janus_interop_binaries /janus_interop_binaries
+RUN ln -s /janus_interop_binaries /janus_interop_client
+RUN ln -s /janus_interop_binaries /janus_interop_collector
 EXPOSE 8080
 # Store the build argument in an environment variable so we can reference it
 # from the ENTRYPOINT at runtime.

--- a/Dockerfile.interop_aggregator
+++ b/Dockerfile.interop_aggregator
@@ -83,7 +83,7 @@ COPY interop_binaries/config/supervisord.conf \
     interop_binaries/config/collection_job_driver.yaml \
     /etc/janus/
 ARG PROFILE
-COPY --from=builder-interop /src/target/$PROFILE/janus_interop_binaries /usr/local/bin/janus_interop_aggregator
+COPY --from=builder-interop /src/target/$PROFILE/janus_interop /usr/local/bin/janus_interop_aggregator
 COPY --from=builder-aggregator \
     /src/target/$PROFILE/aggregator \
     /src/target/$PROFILE/aggregation_job_creator \

--- a/Dockerfile.interop_aggregator
+++ b/Dockerfile.interop_aggregator
@@ -60,8 +60,8 @@ COPY integration_tests /src/integration_tests
 COPY interop_binaries /src/interop_binaries
 COPY messages /src/messages
 COPY tools /src/tools
-RUN cargo build --features fpvec_bounded_l2 --profile $PROFILE -p janus_interop_binaries \
-    --bin janus_interop_aggregator
+COPY xtask /src/xtask
+RUN cargo build --features fpvec_bounded_l2 --profile $PROFILE -p janus_interop_binaries
 
 FROM rust:1.76.0-alpine AS sqlx
 ARG SQLX_VERSION=0.7.2
@@ -83,7 +83,7 @@ COPY interop_binaries/config/supervisord.conf \
     interop_binaries/config/collection_job_driver.yaml \
     /etc/janus/
 ARG PROFILE
-COPY --from=builder-interop /src/target/$PROFILE/janus_interop_aggregator /usr/local/bin/
+COPY --from=builder-interop /src/target/$PROFILE/janus_interop_binaries /usr/local/bin/janus_interop_aggregator
 COPY --from=builder-aggregator \
     /src/target/$PROFILE/aggregator \
     /src/target/$PROFILE/aggregation_job_creator \

--- a/aggregator/src/bin/aggregation_job_creator.rs
+++ b/aggregator/src/bin/aggregation_job_creator.rs
@@ -1,9 +1,11 @@
+use clap::Parser;
 use janus_aggregator::{
-    binaries::aggregation_job_creator::main_callback, binary_utils::janus_main,
+    binaries::aggregation_job_creator::{main_callback, Options},
+    binary_utils::janus_main,
 };
 use janus_core::time::RealClock;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    janus_main(RealClock::default(), main_callback).await
+    janus_main(Options::parse(), RealClock::default(), main_callback).await
 }

--- a/aggregator/src/bin/aggregation_job_driver.rs
+++ b/aggregator/src/bin/aggregation_job_driver.rs
@@ -1,7 +1,11 @@
-use janus_aggregator::{binaries::aggregation_job_driver::main_callback, binary_utils::janus_main};
+use clap::Parser;
+use janus_aggregator::{
+    binaries::aggregation_job_driver::{main_callback, Options},
+    binary_utils::janus_main,
+};
 use janus_core::time::RealClock;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    janus_main(RealClock::default(), main_callback).await
+    janus_main(Options::parse(), RealClock::default(), main_callback).await
 }

--- a/aggregator/src/bin/aggregator.rs
+++ b/aggregator/src/bin/aggregator.rs
@@ -1,7 +1,11 @@
-use janus_aggregator::{binaries::aggregator::main_callback, binary_utils::janus_main};
+use clap::Parser;
+use janus_aggregator::{
+    binaries::aggregator::{main_callback, Options},
+    binary_utils::janus_main,
+};
 use janus_core::time::RealClock;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    janus_main(RealClock::default(), main_callback).await
+    janus_main(Options::parse(), RealClock::default(), main_callback).await
 }

--- a/aggregator/src/bin/collection_job_driver.rs
+++ b/aggregator/src/bin/collection_job_driver.rs
@@ -1,7 +1,11 @@
-use janus_aggregator::{binaries::collection_job_driver::main_callback, binary_utils::janus_main};
+use clap::Parser;
+use janus_aggregator::{
+    binaries::collection_job_driver::{main_callback, Options},
+    binary_utils::janus_main,
+};
 use janus_core::time::RealClock;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    janus_main(RealClock::default(), main_callback).await
+    janus_main(Options::parse(), RealClock::default(), main_callback).await
 }

--- a/aggregator/src/binary_utils.rs
+++ b/aggregator/src/binary_utils.rs
@@ -240,7 +240,11 @@ pub struct BinaryContext<C: Clock, Options: BinaryOptions, Config: BinaryConfig>
     pub stopper: Stopper,
 }
 
-pub async fn janus_main<C, Options, Config, F, Fut>(clock: C, f: F) -> anyhow::Result<()>
+pub async fn janus_main<C, Options, Config, F, Fut>(
+    options: Options,
+    clock: C,
+    f: F,
+) -> anyhow::Result<()>
 where
     C: Clock,
     Options: BinaryOptions,
@@ -248,8 +252,7 @@ where
     F: FnOnce(BinaryContext<C, Options, Config>) -> Fut,
     Fut: Future<Output = anyhow::Result<()>>,
 {
-    // Parse arguments, then read & parse config.
-    let options = Options::parse();
+    // Read and parse config.
     let config: Config = read_config(options.common_options())?;
 
     // Install tracing/metrics handlers.

--- a/interop_binaries/src/bin/janus_interop.rs
+++ b/interop_binaries/src/bin/janus_interop.rs
@@ -12,7 +12,7 @@ enum Options {
     Aggregator(janus_interop_aggregator::Options),
     #[clap(name = "janus_interop_collector")]
     Collector(janus_interop_collector::Options),
-    #[clap(name = "janus_interop_binaries", subcommand)]
+    #[clap(name = "janus_interop", subcommand)]
     Default(Nested),
 }
 

--- a/interop_binaries/src/commands/janus_interop_client.rs
+++ b/interop_binaries/src/commands/janus_interop_client.rs
@@ -1,6 +1,11 @@
-use anyhow::{anyhow, Context};
+use crate::{
+    install_tracing_subscriber,
+    status::{ERROR, SUCCESS},
+    ErrorHandler, NumberAsString, VdafObject,
+};
+use anyhow::Context;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-use clap::{value_parser, Arg, Command};
+use clap::Parser;
 use derivative::Derivative;
 #[cfg(feature = "fpvec_bounded_l2")]
 use fixed::{
@@ -10,11 +15,6 @@ use fixed::{
 #[cfg(feature = "fpvec_bounded_l2")]
 use janus_core::vdaf::Prio3FixedPointBoundedL2VecSumBitSize;
 use janus_core::vdaf::{new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128, VdafInstance};
-use janus_interop_binaries::{
-    install_tracing_subscriber,
-    status::{ERROR, SUCCESS},
-    ErrorHandler, NumberAsString, VdafObject,
-};
 use janus_messages::{Duration, TaskId, Time};
 #[cfg(feature = "fpvec_bounded_l2")]
 use prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded;
@@ -220,36 +220,34 @@ fn handler() -> anyhow::Result<impl Handler> {
     ))
 }
 
-fn app() -> clap::Command {
-    Command::new("Janus interoperation test client").arg(
-        Arg::new("port")
-            .long("port")
-            .short('p')
-            .default_value("8080")
-            .value_parser(value_parser!(u16))
-            .help("Port number to listen on."),
-    )
+#[derive(Debug, Parser)]
+/// Janus interoperation test client
+pub struct Options {
+    /// Port number to listen on.
+    #[clap(long, short, default_value = "8080")]
+    port: u16,
 }
 
-fn main() -> anyhow::Result<()> {
-    install_tracing_subscriber()?;
-    let matches = app().get_matches();
-    let port = matches
-        .try_get_one::<u16>("port")?
-        .ok_or_else(|| anyhow!("port argument missing"))?;
-    trillium_tokio::config()
-        .with_host(&Ipv4Addr::UNSPECIFIED.to_string())
-        .with_port(*port)
-        .run(handler()?);
-    Ok(())
+impl Options {
+    pub async fn run(self) -> anyhow::Result<()> {
+        install_tracing_subscriber()?;
+        trillium_tokio::config()
+            .with_host(&Ipv4Addr::UNSPECIFIED.to_string())
+            .with_port(self.port)
+            .run_async(handler()?)
+            .await;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::app;
+    use clap::CommandFactory;
+
+    use super::Options;
 
     #[test]
     fn verify_clap_app() {
-        app().debug_assert();
+        Options::command().debug_assert();
     }
 }

--- a/interop_binaries/src/commands/mod.rs
+++ b/interop_binaries/src/commands/mod.rs
@@ -1,0 +1,3 @@
+pub mod janus_interop_aggregator;
+pub mod janus_interop_client;
+pub mod janus_interop_collector;

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -35,6 +35,8 @@ use trillium::{async_trait, Conn, Handler, Status};
 use trillium_api::ApiConnExt;
 use url::Url;
 
+pub mod commands;
+
 #[cfg(feature = "testcontainer")]
 pub mod testcontainer;
 

--- a/interop_binaries/src/main.rs
+++ b/interop_binaries/src/main.rs
@@ -1,0 +1,44 @@
+use clap::{Parser, Subcommand};
+use janus_interop_binaries::commands::{
+    janus_interop_aggregator, janus_interop_client, janus_interop_collector,
+};
+
+#[derive(Debug, Parser)]
+#[clap(multicall = true)]
+enum Options {
+    #[clap(name = "janus_interop_client")]
+    Client(janus_interop_client::Options),
+    #[clap(name = "janus_interop_aggregator")]
+    Aggregator(janus_interop_aggregator::Options),
+    #[clap(name = "janus_interop_collector")]
+    Collector(janus_interop_collector::Options),
+    #[clap(name = "janus_interop_binaries", subcommand)]
+    Default(Nested),
+}
+
+#[derive(Debug, Subcommand)]
+#[clap(
+    about = "Janus interoperation test binaries",
+    version = env!("CARGO_PKG_VERSION"),
+)]
+enum Nested {
+    #[clap(name = "janus_interop_client")]
+    Client(janus_interop_client::Options),
+    #[clap(name = "janus_interop_aggregator")]
+    Aggregator(janus_interop_aggregator::Options),
+    #[clap(name = "janus_interop_collector")]
+    Collector(janus_interop_collector::Options),
+}
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    match Options::parse() {
+        Options::Client(options) | Options::Default(Nested::Client(options)) => options.run().await,
+        Options::Aggregator(options) | Options::Default(Nested::Aggregator(options)) => {
+            options.run().await
+        }
+        Options::Collector(options) | Options::Default(Nested::Collector(options)) => {
+            options.run().await
+        }
+    }
+}


### PR DESCRIPTION
This combines the three binary targets under `janus_interop_binaries` into one. It can either be used via symlinks with the original names of the three binaries, dispatching on argv[0], or with its default name and a subcommand. Dockerfiles are updated so that they work the same way as before. Moreover, we can now share builder layers between all three interop test containers. Overall, this should slightly improve build time and total image size. This is a warm-up for #2312. Note that I had to move `Options::parse()` out of `janus_main()` here; this will be doubly necessary when implementing #2312.