### PR TITLE
Disable default features on trillium-proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5423,12 +5423,11 @@ dependencies = [
 
 [[package]]
 name = "trillium-proxy"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2a7e6aa0e67f5bd645a25f19623e973aac00cd12c5b72c4f36eba4a4285a57f"
+checksum = "bb2c1ed289507cbc921292ba3cb59375aeb3fbead166e868bedcb1adb3ad8e5c"
 dependencies = [
  "event-listener 4.0.3",
- "fastrand 2.0.1",
  "full-duplex-async-copy",
  "futures-lite 2.2.0",
  "log",
@@ -5438,7 +5437,6 @@ dependencies = [
  "trillium-client",
  "trillium-forwarding",
  "trillium-http",
- "trillium-server-common",
  "url",
 ]
 

--- a/interop_binaries/Cargo.toml
+++ b/interop_binaries/Cargo.toml
@@ -47,7 +47,7 @@ tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt"] }
 trillium.workspace = true
 trillium-api.workspace = true
-trillium-proxy = "0.5.2"
+trillium-proxy = { version = "0.5.3", default-features = false }
 trillium-router.workspace = true
 trillium-tokio.workspace = true
 url.workspace = true


### PR DESCRIPTION
This disables the default features of the new trillium-proxy dependency. We only have one upstream, so we don't need either `upstream-random` or `upstream-connection-counting`.