### PR TITLE
CI optimizations

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -86,7 +86,7 @@ jobs:
         RUST_LOG: info
         JANUS_E2E_LOGS_PATH: ${{ github.workspace }}/test-logs
         DIVVIUP_TS_INTEROP_CONTAINER: ${{ steps.default-input-values.outputs.divviup_ts_interop_container }}
-      run: cargo xtask test-docker --profile=ci --locked
+      run: cargo run --package xtask --profile=ci -- test-docker --profile=ci --locked
       # Continue on error so we can upload logs
       continue-on-error: true
     - name: Upload container logs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,8 @@ uuid = { version = "1.7.0", features = ["v4"] }
 # Disabling debug info improves build speeds & reduces build artifact sizes, which helps CI caching.
 inherits = "dev"
 debug = 0
+# Incremental compilation is also disabled via environment variable by the Swatinem/rust-cache action.
+incremental = false
 
 [profile.small]
 # We define a profile intended to minimize the eventual binary size, while still allowing for

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM rust:1.76.0-alpine AS chef
+ENV CARGO_INCREMENTAL=0
 RUN apk add --no-cache libc-dev
 RUN cargo install cargo-chef --version 0.1.60 && \
     rm -r $CARGO_HOME/registry

--- a/Dockerfile.interop
+++ b/Dockerfile.interop
@@ -2,6 +2,7 @@ ARG BINARY
 ARG PROFILE=release
 
 FROM rust:1.76.0-alpine AS chef
+ENV CARGO_INCREMENTAL=0
 RUN apk add --no-cache libc-dev
 RUN cargo install cargo-chef --version 0.1.60 && \
     rm -r $CARGO_HOME/registry

--- a/Dockerfile.interop_aggregator
+++ b/Dockerfile.interop_aggregator
@@ -1,6 +1,7 @@
 ARG PROFILE=release
 
 FROM rust:1.76.0-alpine AS chef
+ENV CARGO_INCREMENTAL=0
 RUN apk add --no-cache libc-dev
 RUN cargo install cargo-chef --version 0.1.60 && \
     rm -r $CARGO_HOME/registry
@@ -64,6 +65,7 @@ RUN cargo build --features fpvec_bounded_l2 --profile $PROFILE -p janus_interop_
     --bin janus_interop_aggregator
 
 FROM rust:1.76.0-alpine AS sqlx
+ENV CARGO_INCREMENTAL=0
 ARG SQLX_VERSION=0.7.2
 RUN apk add --no-cache libc-dev
 RUN cargo install sqlx-cli \

--- a/Dockerfile.sqlx
+++ b/Dockerfile.sqlx
@@ -1,4 +1,5 @@
 FROM rust:1.76.0-alpine as builder
+ENV CARGO_INCREMENTAL=0
 ARG SQLX_VERSION
 RUN apk add libc-dev
 RUN cargo install sqlx-cli \


### PR DESCRIPTION
This includes loosely related CI optimizations, primarily about reducing the volume of data we cache.

- Incremental compilation is disabled in all Dockerfiles with an environment variable, since there won't be a subsequent compilation in which to use the files. This only has an impact when we compile with the `small` profile; the `release` built-in profile already disables this. Our `docker-bake.hcl` file only applies `PROFILE=small` to the interop containers, but I added the environment variables throughout to avoid blocking layer reuse between Dockerfiles, and as insurance for future builds with other profiles. When I tested this, it reduced total layer size of builder stages for the interop test containers by 1.4GiB, but I hadn't pulled in #2873 yet, so this will ultimately be a lesser win.
- Incremental compilation is explicitly disabled in the `ci` Cargo profile, for consistency. I found that the Swatinem/rust-cache action we use already sets CARGO_INCREMENTAL=0, so I documented this in a comment.
- The `xtask` project is now compiled with the `ci` profile. The `cargo xtask` alias does not allow setting the profile it uses, so I wrote out the full `cargo run` command to allow adding this. This change should yield a small win by eliminating duplication of `anyhow`, `clap`, `serde`, `serde_json`, and `tempfile` between `target/debug` and `target/ci`.