### PR TITLE
Add metric for aggregation success.

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1001,7 +1001,7 @@ impl<C: Clock> TaskAggregator<C> {
             .handle_upload(
                 clock,
                 global_hpke_keypairs,
-                &metrics,
+                metrics,
                 &self.task,
                 &self.report_writer,
                 report,

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -5,8 +5,8 @@ use crate::{
     aggregator::{
         aggregate_share::compute_aggregate_share,
         aggregation_job_writer::{
-            AggregationJobWriter, InitialWrite, ReportAggregationUpdate as _,
-            WritableReportAggregation, AggregationJobWriterMetrics,
+            AggregationJobWriter, AggregationJobWriterMetrics, InitialWrite,
+            ReportAggregationUpdate as _, WritableReportAggregation,
         },
         error::{handle_ping_pong_error, ReportRejection, ReportRejectionReason},
         error::{BatchMismatch, OptOutReason},

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -3,11 +3,10 @@ use crate::aggregator::{
     aggregation_job_writer::{
         AggregationJobWriter, AggregationJobWriterMetrics, UpdateWrite, WritableReportAggregation,
     },
-    aggregation_success_counter,
     error::handle_ping_pong_error,
     http_handlers::AGGREGATION_JOB_ROUTE,
     query_type::CollectableQueryType,
-    send_request_to_helper, Error, RequestBody,
+    report_aggregation_success_counter, send_request_to_helper, Error, RequestBody,
 };
 use anyhow::{anyhow, Result};
 use backoff::backoff::Backoff;
@@ -78,7 +77,7 @@ where
         meter: &Meter,
         batch_aggregation_shard_count: u64,
     ) -> Self {
-        let aggregation_success_counter = aggregation_success_counter(meter);
+        let aggregation_success_counter = report_aggregation_success_counter(meter);
         let aggregate_step_failure_counter = aggregate_step_failure_counter(meter);
 
         let job_cancel_counter = meter
@@ -681,7 +680,7 @@ where
                 Arc::clone(&task),
                 self.batch_aggregation_shard_count,
                 Some(AggregationJobWriterMetrics {
-                    aggregation_success_counter: self.aggregation_success_counter.clone(),
+                    report_aggregation_success_counter: self.aggregation_success_counter.clone(),
                     aggregate_step_failure_counter: self.aggregate_step_failure_counter.clone(),
                 }),
             );

--- a/aggregator/src/aggregator/aggregation_job_writer.rs
+++ b/aggregator/src/aggregator/aggregation_job_writer.rs
@@ -42,9 +42,16 @@ where
     aggregation_parameter: Option<A::AggregationParam>,
     aggregation_jobs: HashMap<AggregationJobId, AggregationJobInfo<SEED_SIZE, Q, A, RA>>,
     by_batch_identifier_index: HashMap<Q::BatchIdentifier, HashMap<AggregationJobId, Vec<usize>>>,
-    failure_counter: Option<Counter<u64>>,
+    metrics: Option<AggregationJobWriterMetrics>,
 
     _phantom_wt: PhantomData<WT>,
+}
+
+/// Metrics for the aggregation job writer.
+#[derive(Clone)]
+pub struct AggregationJobWriterMetrics {
+    pub aggregation_success_counter: Counter<u64>,
+    pub aggregate_step_failure_counter: Counter<u64>,
 }
 
 #[allow(private_bounds)]
@@ -60,7 +67,7 @@ where
     pub fn new(
         task: Arc<AggregatorTask>,
         batch_aggregation_shard_count: u64,
-        failure_counter: Option<Counter<u64>>,
+        metrics: Option<AggregationJobWriterMetrics>,
     ) -> Self {
         Self {
             task,
@@ -68,7 +75,7 @@ where
             aggregation_parameter: None,
             aggregation_jobs: HashMap::new(),
             by_batch_identifier_index: HashMap::new(),
-            failure_counter,
+            metrics,
 
             _phantom_wt: PhantomData,
         }
@@ -657,12 +664,16 @@ where
 
                     match ra_batch_aggregation.merged_with(batch_aggregation) {
                         Ok(merged_batch_aggregation) => {
+                            if let Some(metrics) = self.writer.metrics.as_ref() {
+                                metrics.aggregation_success_counter.add(1, &[])
+                            }
                             *batch_aggregation = merged_batch_aggregation
                         }
                         Err(err) => {
                             warn!(report_id = %report_aggregation.report_id(), ?err, "Couldn't update batch aggregation");
-                            if let Some(failure_counter) = self.writer.failure_counter.as_ref() {
-                                failure_counter
+                            if let Some(metrics) = self.writer.metrics.as_ref() {
+                                metrics
+                                    .aggregate_step_failure_counter
                                     .add(1, &[KeyValue::new("type", "accumulate_failure")]);
                             }
                             *report_aggregation.to_mut() = report_aggregation

--- a/aggregator/src/metrics.rs
+++ b/aggregator/src/metrics.rs
@@ -38,7 +38,7 @@ use {
 use {
     crate::git_revision,
     janus_aggregator_core::datastore::TRANSACTION_RETRIES_METER_NAME,
-    opentelemetry::{metrics::MetricsError, KeyValue},
+    opentelemetry::metrics::MetricsError,
     opentelemetry_sdk::{
         metrics::{
             new_view, Aggregation, Instrument, InstrumentKind, SdkMeterProvider, Stream, View,

--- a/aggregator/src/metrics.rs
+++ b/aggregator/src/metrics.rs
@@ -2,6 +2,10 @@
 
 #[cfg(any(not(feature = "prometheus"), not(feature = "otlp")))]
 use anyhow::anyhow;
+use opentelemetry::{
+    metrics::{Counter, Meter, Unit},
+    KeyValue,
+};
 use serde::{Deserialize, Serialize};
 use std::net::AddrParseError;
 
@@ -294,4 +298,57 @@ fn resource() -> Resource {
     ]);
 
     version_info_resource.merge(&default_resource)
+}
+
+pub(crate) fn report_aggregation_success_counter(meter: &Meter) -> Counter<u64> {
+    let report_aggregation_success_counter = meter
+        .u64_counter("janus_report_aggregation_success_counter")
+        .with_description("Number of successfully-aggregated report shares")
+        .with_unit(Unit::new("{report}"))
+        .init();
+    report_aggregation_success_counter.add(0, &[]);
+    report_aggregation_success_counter
+}
+
+pub(crate) fn aggregate_step_failure_counter(meter: &Meter) -> Counter<u64> {
+    let aggregate_step_failure_counter = meter
+        .u64_counter("janus_step_failures")
+        .with_description(concat!(
+            "Failures while stepping aggregation jobs; these failures are ",
+            "related to individual client reports rather than entire aggregation jobs."
+        ))
+        .with_unit(Unit::new("{error}"))
+        .init();
+
+    // Initialize counters with desired status labels. This causes Prometheus to see the first
+    // non-zero value we record.
+    for failure_type in [
+        "missing_prepare_message",
+        "missing_leader_input_share",
+        "missing_helper_input_share",
+        "prepare_init_failure",
+        "prepare_step_failure",
+        "prepare_message_failure",
+        "unknown_hpke_config_id",
+        "decrypt_failure",
+        "input_share_decode_failure",
+        "public_share_decode_failure",
+        "prepare_message_decode_failure",
+        "leader_prep_share_decode_failure",
+        "helper_prep_share_decode_failure",
+        "continue_mismatch",
+        "accumulate_failure",
+        "finish_mismatch",
+        "helper_step_failure",
+        "plaintext_input_share_decode_failure",
+        "duplicate_extension",
+        "missing_client_report",
+        "missing_prepare_message",
+        "missing_or_malformed_taskprov_extension",
+        "unexpected_taskprov_extension",
+    ] {
+        aggregate_step_failure_counter.add(0, &[KeyValue::new("type", failure_type)]);
+    }
+
+    aggregate_step_failure_counter
 }


### PR DESCRIPTION
The new "janus_aggregation_success_counter" tracks the number of successfully-aggregated reports. This metric is not keyed by task ID or anything else, so it will be most useful (a) in single-teneant deployments or (b) as an overall metric of aggregation throughput.