### PR TITLE
Hoist all dependencies up to top-level Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,14 +25,28 @@ version = "0.7.1"
 [workspace.dependencies]
 anyhow = "1"
 assert_matches = "1"
+async-trait = "0.1"
+backoff = "0.4.0"
 base64 = "0.22.0"
 bytes = "1"
+cfg-if = "1.0.0"
 # Disable default features to disable compatibility with the old `time` crate, and we also don't
 # (yet) need other default features.
 # https://docs.rs/chrono/latest/chrono/#duration
 chrono = { version = "0.4.33", default-features = false }
 clap = { version = "4.5.3", features = ["cargo", "derive", "env"] }
+console-subscriber = "0.2.0"
+deadpool = "0.10.0"
+deadpool-postgres = "0.12.1"
 derivative = "2.2.0"
+divviup-client = "0.1"
+fixed = "1.27"
+fixed-macro = "1.1.1"
+futures = "0.3.30"
+git-version = "0.3.9"
+hex = "0.4.3"
+hex-literal = "0.4.1"
+hpke-dispatch = "0.5.1"
 http = "1.1"
 http-api-problem = "0.58.0"
 itertools = "0.12"
@@ -47,30 +61,71 @@ janus_interop_binaries = { version = "0.7.1", path = "interop_binaries" }
 janus_messages = { version = "0.7.1", path = "messages" }
 k8s-openapi = { version = "0.20.0", features = ["v1_26"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
 kube = { version = "0.87.2", default-features = false, features = ["client", "rustls-tls"] }
+mockito = "1.4.0"
+num_enum = "0.7.2"
 opentelemetry = { version = "0.22", features = ["metrics"] }
+opentelemetry-otlp = "0.15"
+opentelemetry-prometheus = "0.15"
 opentelemetry_sdk = { version = "0.22", features = ["metrics"] }
-prio = { version = "0.16.2", features = ["multithreaded", "experimental"] }
+opentelemetry-semantic-conventions = "0.14"
+pem = "3"
+postgres-protocol = "0.6.6"
+postgres-types = "0.2.6"
+# Disable default features so that individual workspace crates can choose to
+# re-enable them
+prio = { version = "0.16.2", default-features = false, features = ["multithreaded", "experimental"] }
+prometheus = "0.13.3"
+querystring = "1.1.0"
+rand = "0.8"
+reqwest = { version = "0.12.2", default-features = false, features = ["rustls-tls"] }
+regex = "1.10.4"
+retry-after = "0.4.0"
+ring = "0.17.8"
+rstest = "0.18.2"
+rstest_reuse = "0.6.0"
+rustc_version = "0.4.0"
+rustls = "0.22.3"
+rustls-pemfile = "2.1.1"
+sec1 = "0.7"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"
 serde_test = "1.0.175"
+serde_urlencoded = "0.7.1"
 serde_yaml = "0.9.34"
-rand = "0.8"
-reqwest = { version = "0.12.2", default-features = false, features = ["rustls-tls"] }
-rstest = "0.18.2"
+signal-hook = "0.3.17"
+signal-hook-tokio = "0.3.1"
+sqlx = "0.7.4"
+stopper = "0.2.7"
+tempfile = "3.10.1"
 testcontainers = "0.15.0"
 thiserror = "1.0"
+tracing = "0.1.40"
+tracing-chrome = "0.7.2"
+tracing-log = "0.2.0"
+tracing-opentelemetry = "0.23"
+tracing-stackdriver = "0.10.0"
+tracing-subscriber = "0.3"
 tokio = { version = "1.37", features = ["full", "tracing"] }
+tokio-postgres = "0.7.10"
+tokio-postgres-rustls = "0.11.1"
+tokio-stream = "0.1.15"
 trillium = "0.2.17"
 trillium-api = { version = "0.2.0-rc.10", default-features = false }
 trillium-caching-headers = "0.2.2"
 trillium-head = "0.2.1"
+trillium-macros = "0.0.5"
 trillium-opentelemetry = "0.6.0"
+trillium-prometheus = "0.1.0"
+trillium-proxy = { version = "0.5.3", default-features = false }
 trillium-router = "0.3.6"
 trillium-rustls = "0.4.2"
 trillium-testing = "0.5.0"
 trillium-tokio = "0.3.4"
+trycmd = "0.15.0"
 url = { version = "2.5.0", features = ["serde"] }
 uuid = { version = "1.8.0", features = ["v4"] }
+wait-timeout = "0.2.0"
+zstd = "0.13"
 
 [profile.ci]
 # Disabling debug info improves build speeds & reduces build artifact sizes, which helps CI caching.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ cfg-if = "1.0.0"
 chrono = { version = "0.4.33", default-features = false }
 clap = { version = "4.5.3", features = ["cargo", "derive", "env"] }
 console-subscriber = "0.2.0"
-deadpool = "0.10.0"
-deadpool-postgres = "0.12.1"
+deadpool = "0.11.0"
+deadpool-postgres = "0.13.0"
 derivative = "2.2.0"
 divviup-client = "0.1"
 fixed = "1.27"

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -47,6 +47,9 @@ base64.workspace = true
 bytes.workspace = true
 chrono.workspace = true
 clap.workspace = true
+console-subscriber = { workspace = true, optional = true }
+deadpool = { workspace = true, features = ["rt_tokio_1"] }
+deadpool-postgres = { workspace = true }
 derivative.workspace = true
 fixed = { workspace = true, optional = true }
 futures = { workspace = true }

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -41,20 +41,17 @@ test-util = [
 [dependencies]
 anyhow.workspace = true
 assert_matches = { workspace = true, optional = true }
-async-trait = "0.1"
-backoff = { version = "0.4.0", features = ["tokio"] }
+async-trait = { workspace = true }
+backoff = { workspace = true, features = ["tokio"] }
 base64.workspace = true
 bytes.workspace = true
 chrono.workspace = true
 clap.workspace = true
-console-subscriber = { version = "0.2.0", optional = true }
-deadpool = { version = "0.11.0", features = ["rt_tokio_1"] }
-deadpool-postgres = "0.13.0"
 derivative.workspace = true
-fixed = { version = "1.27", optional = true }
-futures = "0.3.30"
-git-version = "0.3.9"
-hex = { version = "0.4.3", features = ["serde"], optional = true }
+fixed = { workspace = true, optional = true }
+futures = { workspace = true }
+git-version = { workspace = true }
+hex = { workspace = true, features = ["serde"], optional = true }
 http.workspace = true
 http-api-problem.workspace = true
 itertools.workspace = true
@@ -65,45 +62,45 @@ janus_messages.workspace = true
 k8s-openapi.workspace = true
 kube.workspace = true
 opentelemetry.workspace = true
-opentelemetry-otlp = { version = "0.15", optional = true, features = ["metrics"] }
-opentelemetry-prometheus = { version = "0.15", optional = true }
+opentelemetry-otlp = { workspace = true, features = ["metrics"], optional = true }
+opentelemetry-prometheus = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, features = ["rt-tokio"], optional = true }
-opentelemetry-semantic-conventions = { version = "0.14", optional = true }
-pem = "3"
-postgres-protocol = "0.6.6"
-postgres-types = { version = "0.2.6", features = ["derive", "array-impls"] }
+opentelemetry-semantic-conventions = { workspace = true, optional = true }
+pem.workspace = true
+postgres-protocol = { workspace = true }
+postgres-types = { workspace = true, features = ["derive", "array-impls"] }
 prio.workspace = true
-prometheus = { version = "0.13.3", optional = true }
+prometheus = { workspace = true, optional = true }
 rand = { workspace = true, features = ["min_const_gen"] }
-regex = "1"
+regex = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
-ring = "0.17.8"
-rustls = "0.22.3"
-rustls-pemfile = "2.1.1"
-sec1 = "0.7"
+ring = { workspace = true }
+rustls = { workspace = true }
+rustls-pemfile = { workspace = true }
+sec1.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-serde_urlencoded = "0.7.1"
+serde_urlencoded = { workspace = true }
 serde_yaml.workspace = true
-signal-hook = "0.3.17"
-signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
+signal-hook = { workspace = true }
+signal-hook-tokio = { workspace = true, features = ["futures-v0_3"] }
 testcontainers = { workspace = true, optional = true }
 thiserror.workspace = true
 tokio.workspace = true
-tokio-postgres = { version = "0.7.10", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1", "array-impls"] }
-tokio-postgres-rustls = "0.11.1"
-tracing = "0.1.40"
-tracing-chrome = "0.7.2"
-tracing-log = "0.2.0"
-tracing-opentelemetry = { version = "0.23", optional = true }
-tracing-stackdriver = "0.10.0"
-tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt", "json"] }
+tokio-postgres = { workspace = true, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1", "array-impls"] }
+tokio-postgres-rustls = { workspace = true }
+tracing = { workspace = true }
+tracing-chrome = { workspace = true }
+tracing-log = { workspace = true }
+tracing-opentelemetry = { workspace = true, optional = true }
+tracing-stackdriver = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["std", "env-filter", "fmt", "json"] }
 trillium.workspace = true
 trillium-api.workspace = true
 trillium-caching-headers.workspace = true
 trillium-head.workspace = true
 trillium-opentelemetry.workspace = true
-trillium-prometheus = { version = "0.1.0", optional = true }
+trillium-prometheus = { workspace = true, optional = true }
 trillium-router.workspace = true
 trillium-testing = { workspace = true, optional = true }
 trillium-tokio.workspace = true
@@ -112,14 +109,14 @@ url.workspace = true
 [dev-dependencies]
 janus_aggregator = { path = ".", features = ["fpvec_bounded_l2", "test-util"] }
 janus_aggregator_core = { workspace = true, features = ["test-util"] }
-mockito = "1.4.0"
+mockito = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
 rstest.workspace = true
-tempfile = "3.10.1"
-tokio = { version = "1", features = ["test-util"] } # ensure this remains compatible with the non-dev dependency
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] } # ensure this remains compatible with the non-dev dependency
 trillium-testing.workspace = true
-trycmd = "0.15.0"
-wait-timeout = "0.2.0"
+trycmd = { workspace = true }
+wait-timeout = { workspace = true }
 
 [build-dependencies]
-rustc_version = "0.4.0"
+rustc_version = { workspace = true }

--- a/aggregator_api/Cargo.toml
+++ b/aggregator_api/Cargo.toml
@@ -10,20 +10,20 @@ version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-async-trait = "0.1"
+async-trait = { workspace = true }
 base64.workspace = true
 derivative.workspace = true
 janus_aggregator_core.workspace = true
 janus_core.workspace = true
 janus_messages.workspace = true
 opentelemetry.workspace = true
-querystring = "1.1.0"
+querystring = { workspace = true }
 rand = { workspace = true, features = ["min_const_gen"] }
-ring = "0.17.8"
+ring = { workspace = true }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-tracing = "0.1.40"
+tracing = { workspace = true }
 trillium.workspace = true
 trillium-api.workspace = true
 trillium-opentelemetry.workspace = true
@@ -32,7 +32,7 @@ url.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true
-futures = "0.3.30"
+futures = { workspace = true }
 janus_aggregator_core = { workspace = true, features = ["test-util"] }
 rstest.workspace = true
 serde_test.workspace = true

--- a/aggregator_core/Cargo.toml
+++ b/aggregator_core/Cargo.toml
@@ -22,16 +22,16 @@ test-util = [
 
 [dependencies]
 anyhow.workspace = true
-async-trait = "0.1"
-backoff = { version = "0.4.0", features = ["tokio"] }
+async-trait = { workspace = true }
+backoff = { workspace = true, features = ["tokio"] }
 base64.workspace = true
 bytes.workspace = true
 chrono.workspace = true
-deadpool = { version = "0.11.0", features = ["rt_tokio_1"] }
-deadpool-postgres = "0.13.0"
+deadpool = { workspace = true, features = ["rt_tokio_1"] }
+deadpool-postgres = { workspace = true }
 derivative.workspace = true
-futures = "0.3.30"
-hex = { version = "0.4.3", features = ["serde"], optional = true }
+futures = { workspace = true }
+hex = { workspace = true, features = ["serde"], optional = true }
 http.workspace = true
 http-api-problem.workspace = true
 itertools = { workspace = true, optional = true }
@@ -40,25 +40,25 @@ janus_messages.workspace = true
 k8s-openapi.workspace = true
 kube.workspace = true
 opentelemetry.workspace = true
-postgres-protocol = "0.6.6"
-postgres-types = { version = "0.2.6", features = ["derive", "array-impls"] }
+postgres-protocol = { workspace = true }
+postgres-types = { workspace = true, features = ["derive", "array-impls"] }
 prio = { workspace = true, features = ["experimental"] }
 rand = { workspace = true, features = ["min_const_gen"] }
-regex = "1"
+regex = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
-ring = "0.17.8"
+ring = { workspace = true }
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
-sqlx = { version = "0.7.4", optional = true, features = ["runtime-tokio-rustls", "migrate", "postgres"] }
+sqlx = { workspace = true, features = ["runtime-tokio-rustls", "migrate", "postgres"], optional = true }
 testcontainers = { workspace = true, optional = true }
 thiserror.workspace = true
 tokio.workspace = true
-tokio-postgres = { version = "0.7.10", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1", "array-impls"] }
-tracing = "0.1.40"
-tracing-log = "0.2.0"
+tokio-postgres = { workspace = true, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1", "array-impls"] }
+tracing = { workspace = true }
+tracing-log = { workspace = true }
 trillium.workspace = true
-trillium-macros = "0.0.5"
+trillium-macros = { workspace = true }
 trillium-router.workspace = true
 url.workspace = true
 
@@ -67,10 +67,10 @@ assert_matches.workspace = true
 janus_aggregator_core = { path = ".", features = ["test-util"] }
 janus_core = { workspace = true, features = ["test-util"] }
 rstest.workspace = true
-rstest_reuse = "0.6.0"
+rstest_reuse = { workspace = true }
 serde_test.workspace = true
-tempfile = "3.10.1"
-tokio = { version = "1", features = ["test-util"] }  # ensure this remains compatible with the non-dev dependency
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }  # ensure this remains compatible with the non-dev dependency
 
 [build-dependencies]
-rustc_version = "0.4.0"
+rustc_version = { workspace = true }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-backoff = { version = "0.4.0", features = ["tokio"] }
+backoff = { workspace = true, features = ["tokio"] }
 derivative.workspace = true
 http.workspace = true
 itertools.workspace = true
@@ -21,13 +21,13 @@ rand.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 thiserror.workspace = true
 tokio.workspace = true
-tracing = "0.1.40"
-url = "2.5.0"
+tracing = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 assert_matches.workspace = true
-hex-literal = "0.4.1"
+hex-literal = { workspace = true }
 janus_core = { workspace = true, features = ["test-util"]}
-mockito = "1.4.0"
-tracing-log = "0.2.0"
-tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt"] }
+mockito = { workspace = true }
+tracing-log = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["std", "env-filter", "fmt"] }

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -18,28 +18,28 @@ fpvec_bounded_l2 = ["dep:fixed", "janus_core/fpvec_bounded_l2", "prio/experiment
 test-util = []
 
 [dependencies]
-backoff = { version = "0.4.0", features = ["tokio"] }
+backoff = { workspace = true, features = ["tokio"] }
 chrono.workspace = true
 derivative.workspace = true
 janus_core.workspace = true
 janus_messages.workspace = true
-fixed = { version = "1.27", optional = true }
+fixed = { workspace = true, optional = true }
 prio.workspace = true
 rand = { workspace = true, features = ["min_const_gen"] }
 reqwest = { workspace = true, features = ["json"] }
-retry-after = "0.4.0"
+retry-after = { workspace = true }
 thiserror.workspace = true
 tokio.workspace = true
-tracing = "0.1.40"
-url = "2.5.0"
+tracing = { workspace = true }
+url = { workspace = true }
 serde = { workspace = true }
-hpke-dispatch = { version = "0.5.1", features = ["serde"] }
+hpke-dispatch = { workspace = true, features = ["serde"] }
 serde_json.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true
 base64.workspace = true
-fixed-macro = "1.1.1"
+fixed-macro = { workspace = true }
 janus_collector = { path = ".", features = ["fpvec_bounded_l2", "test-util"] }
 janus_core = { workspace = true, features = ["fpvec_bounded_l2", "test-util"] }
-mockito = "1.4.0"
+mockito = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,45 +33,45 @@ test-util = [
 
 [dependencies]
 anyhow.workspace = true
-assert_matches = { version = "1", optional = true }
-backoff = { version = "0.4.0", features = ["tokio"] }
+assert_matches = { workspace = true, optional = true }
+backoff = { workspace = true, features = ["tokio"] }
 base64.workspace = true
 bytes.workspace = true
 chrono = { workspace = true, features = ["clock"] }
 derivative.workspace = true
-fixed = { version = "1.27", optional = true }
-futures = "0.3.30"
-hex = "0.4"
-hpke-dispatch = { version = "0.5.1", features = ["serde"] }
+fixed = { workspace = true, optional = true }
+futures = { workspace = true }
+hex = { workspace = true }
+hpke-dispatch = { workspace = true, features = ["serde"] }
 http.workspace = true
 http-api-problem.workspace = true
 janus_messages.workspace = true
 kube = { workspace = true, optional = true, features = ["rustls-tls"] }
 k8s-openapi = { workspace = true, optional = true }
-prio.workspace = true
+prio = { workspace = true, default-features = true, features = ["multithreaded", "experimental"] }
 rand.workspace = true
-regex = "1.10.4"
+regex = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
-ring = "0.17.8"
+ring = { workspace = true }
 serde.workspace = true
 serde_json = { workspace = true, optional = true }
 serde_yaml.workspace = true
-stopper = { version = "0.2.7", optional = true }
-tempfile = { version = "3", optional = true }
+stopper = { workspace = true, optional = true }
+tempfile = { workspace = true, optional = true }
 testcontainers = { workspace = true, optional = true }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["macros", "net", "rt"] }
-tokio-stream = { version = "0.1.15", features = ["net"], optional = true }
-tracing = "0.1.40"
-tracing-log = { version = "0.2.0", optional = true }
-tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt"], optional = true }
+tokio-stream = { workspace = true, features = ["net"], optional = true }
+tracing = { workspace = true }
+tracing-log = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, features = ["std", "env-filter", "fmt"], optional = true }
 trillium.workspace = true
-url = "2.5.0"
+url = { workspace = true }
 
 [dev-dependencies]
-fixed = "1.27"
-hex = { version = "0.4", features = ["serde"] }  # ensure this remains compatible with the non-dev dependency
+fixed = { workspace = true }
+hex = { workspace = true, features = ["serde"] }  # ensure this remains compatible with the non-dev dependency
 janus_core = { path = ".", features = ["test-util"] }
-mockito = "1.4.0"
+mockito = { workspace = true }
 rstest.workspace = true
 serde_test.workspace = true

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -16,11 +16,11 @@ in-cluster-rate-limits = []
 [dependencies]
 anyhow.workspace = true
 assert_matches.workspace = true
-backoff = { version = "0.4", features = ["tokio"] }
+backoff = { workspace = true, features = ["tokio"] }
 base64.workspace = true
 clap.workspace = true
-futures = "0.3.30"
-hex = "0.4"
+futures = { workspace = true }
+hex = { workspace = true }
 http.workspace = true
 itertools.workspace = true
 janus_aggregator = { workspace = true, features = ["test-util"] }
@@ -36,7 +36,7 @@ prio = { workspace = true, features = ["test-util"] }
 rand.workspace = true
 reqwest.workspace = true
 serde.workspace = true
-serde_json = "1.0.114"
+serde_json = { workspace = true }
 testcontainers.workspace = true
 tokio.workspace = true
 trillium-tokio.workspace = true
@@ -45,8 +45,8 @@ uuid.workspace = true
 
 [dev-dependencies]
 chrono.workspace = true
-divviup-client = { version = "0.1", features = ["admin"] }
+divviup-client = { workspace = true, features = ["admin"] }
 janus_collector = { workspace = true, features = ["test-util"] }
 rstest.workspace = true
-tempfile = "3"
+tempfile = { workspace = true }
 trillium-rustls.workspace = true

--- a/interop_binaries/Cargo.toml
+++ b/interop_binaries/Cargo.toml
@@ -20,13 +20,13 @@ testcontainer = ["test-util"]
 
 [dependencies]
 anyhow.workspace = true
-backoff = { version = "0.4", features = ["tokio"] }
+backoff = { workspace = true, features = ["tokio"] }
 base64.workspace = true
 clap.workspace = true
 derivative.workspace = true
-fixed = { version = "1.27", optional = true }
-futures = { version = "0.3.30", optional = true }
-hex = { version = "0.4", optional = true }
+fixed = { workspace = true, optional = true }
+futures = { workspace = true, optional = true }
+hex = { workspace = true, optional = true }
 janus_aggregator.workspace = true
 janus_aggregator_core = { workspace = true, features = ["test-util"] }
 janus_client.workspace = true
@@ -35,26 +35,26 @@ janus_core.workspace = true
 janus_messages.workspace = true
 prio.workspace = true
 rand.workspace = true
-regex = { version = "1", optional = true }
+regex = { workspace = true, optional = true }
 reqwest.workspace = true
-ring = "0.17.8"
+ring = { workspace = true }
 serde.workspace = true
-serde_json = "1.0.114"
+serde_json = { workspace = true }
 testcontainers.workspace = true
 tokio.workspace = true
-tracing = "0.1.40"
-tracing-log = "0.2.0"
-tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt"] }
+tracing = { workspace = true }
+tracing-log = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["std", "env-filter", "fmt"] }
 trillium.workspace = true
 trillium-api.workspace = true
-trillium-proxy = { version = "0.5.3", default-features = false }
+trillium-proxy = { workspace = true }
 trillium-router.workspace = true
 trillium-tokio.workspace = true
 url.workspace = true
-zstd = { version = "0.13", optional = true }
+zstd = { workspace = true, optional = true }
 
 [dev-dependencies]
-fixed-macro = "1.1.1"
+fixed-macro = { workspace = true }
 janus_core = { workspace = true, features = ["test-util", "fpvec_bounded_l2"] }
 janus_interop_binaries = { path = ".", features = ["fpvec_bounded_l2", "test-util"] }
 reqwest = { workspace = true, default-features = false, features = ["json"] }

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -16,15 +16,15 @@ test-util = []
 anyhow.workspace = true
 base64.workspace = true
 derivative.workspace = true
-hex = "0.4"
-num_enum = "0.7.2"
-# We can't pull prio in from the workspace because that would enable default features, and we do not
-# want prio/crypto-dependencies
-prio = { version = "0.16.2", default-features = false, features = ["multithreaded", "experimental"] }
+hex = { workspace = true }
+num_enum = { workspace = true }
+# Make sure not to enable default-features on prio, as we want clients to be
+# able to get message definitions without pulling in prio/crypto-dependencies
+prio = { workspace = true, features = ["multithreaded", "experimental"] }
 rand.workspace = true
 serde.workspace = true
 thiserror.workspace = true
-url = "2.5.0"
+url = { workspace = true }
 
 [dev-dependencies]
 assert_matches.workspace = true

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -12,11 +12,11 @@ version.workspace = true
 fpvec_bounded_l2 = ["dep:fixed", "janus_collector/fpvec_bounded_l2", "prio/experimental"]
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 base64.workspace = true
 clap.workspace = true
 derivative.workspace = true
-fixed = { version = "1.27", optional = true }
+fixed = { workspace = true, optional = true }
 janus_collector.workspace = true
 janus_core.workspace = true
 janus_messages.workspace = true
@@ -26,14 +26,14 @@ reqwest = { workspace = true, features = ["json"] }
 serde_json.workspace = true
 serde_yaml.workspace = true
 tokio.workspace = true
-tracing = "0.1.40"
-tracing-log = "0.2.0"
-tracing-subscriber = { version = "0.3", features = ["std", "env-filter", "fmt"] }
-url = "2.5.0"
+tracing = { workspace = true }
+tracing-log = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["std", "env-filter", "fmt"] }
+url = { workspace = true }
 
 [dev-dependencies]
 assert_matches.workspace = true
-cfg-if = "1.0.0"
+cfg-if = { workspace = true }
 janus_core = { workspace = true, features = ["test-util"] }
-tempfile = "3.10.1"
-trycmd = "0.15.0"
+tempfile = { workspace = true }
+trycmd = { workspace = true }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,4 +13,4 @@ anyhow.workspace = true
 clap.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tempfile = "3.10.1"
+tempfile = { workspace = true }


### PR DESCRIPTION
Use `cargo-autoinherit` to rewrite all the workspace `Cargo.toml`s to pull in dependencies from the top-level using `workspace = true`. I then hand-sorted the top-level `Cargo.toml` because I couldn't get `cargo-sort` to work.