### PR TITLE
Update minimum version of chrono

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.36"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3313f40d6fa9e783bbb01e814800bde9618da2207c72e9782f35e8dc7c77dabc"
+checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ bytes = "1"
 # Disable default features to disable compatibility with the old `time` crate, and we also don't
 # (yet) need other default features.
 # https://docs.rs/chrono/latest/chrono/#duration
-chrono = { version = "0.4", default-features = false }
+chrono = { version = "0.4.33", default-features = false }
 clap = { version = "4.5.3", features = ["cargo", "derive", "env"] }
 derivative = "2.2.0"
 http = "1.1"


### PR DESCRIPTION
This sets the minimum version of chrono to 0.4.33, which is when `Duration::try_seconds()` was introduced.