### PR TITLE
Rephrase description of signing key option

### DIFF
--- a/aggregator/src/binaries/aggregator.rs
+++ b/aggregator/src/binaries/aggregator.rs
@@ -215,8 +215,10 @@ pub struct Options {
     )]
     pub aggregator_api_auth_tokens: Vec<String>,
 
-    /// The private key used to sign HPKE configs, as a PEM-encoding of a DER-encoding of an RFC5915
-    /// ECPrivateKey. Only P-256 keys are supported.
+    /// The private key used to sign HPKE configs, as the PEM encoding of a DER-encoded RFC5915
+    /// ECPrivateKey.
+    ///
+    /// Only P-256 keys are supported.
     #[clap(long, env = "HPKE_CONFIG_SIGNING_KEY", hide_env_values = true)]
     pub hpke_config_signing_key: Option<String>,
 }


### PR DESCRIPTION
This applies a late suggestion I made on #2880.

While trying to propagate this to the trycmd tests, I discovered that #2879 made trycmd ignore relevant tests, since binary names changed. I'll fix that separately.