### PR TITLE
Fix trycmd tests

### DIFF
--- a/aggregator/tests/cmd/aggregation_job_creator.trycmd
+++ b/aggregator/tests/cmd/aggregation_job_creator.trycmd
@@ -1,8 +1,8 @@
 ```
-$ aggregation_job_creator --help
+$ janus_aggregator aggregation_job_creator --help
 Janus aggregation job creator
 
-Usage: aggregation_job_creator [OPTIONS] --config-file <CONFIG_FILE>
+Usage: janus_aggregator aggregation_job_creator [OPTIONS] --config-file <CONFIG_FILE>
 
 Options:
       --config-file <CONFIG_FILE>

--- a/aggregator/tests/cmd/aggregation_job_driver.trycmd
+++ b/aggregator/tests/cmd/aggregation_job_driver.trycmd
@@ -1,8 +1,8 @@
 ```
-$ aggregation_job_driver --help
+$ janus_aggregator aggregation_job_driver --help
 Janus aggregation job driver
 
-Usage: aggregation_job_driver [OPTIONS] --config-file <CONFIG_FILE>
+Usage: janus_aggregator aggregation_job_driver [OPTIONS] --config-file <CONFIG_FILE>
 
 Options:
       --config-file <CONFIG_FILE>

--- a/aggregator/tests/cmd/aggregator.trycmd
+++ b/aggregator/tests/cmd/aggregator.trycmd
@@ -1,8 +1,8 @@
 ```
-$ aggregator --help
+$ janus_aggregator aggregator --help
 DAP aggregator server
 
-Usage: aggregator [OPTIONS] --config-file <CONFIG_FILE>
+Usage: janus_aggregator aggregator [OPTIONS] --config-file <CONFIG_FILE>
 
 Options:
       --config-file <CONFIG_FILE>
@@ -32,7 +32,9 @@ Options:
           [env: AGGREGATOR_API_AUTH_TOKENS]
 
       --hpke-config-signing-key <HPKE_CONFIG_SIGNING_KEY>
-          The private key used to sign HPKE configs, as a PEM-encoding of a DER-encoding of an RFC5915 ECPrivateKey. Only P-256 keys are supported
+          The private key used to sign HPKE configs, as a PEM-encoded RFC5915 ECPrivateKey.
+          
+          Only P-256 keys are supported.
           
           [env: HPKE_CONFIG_SIGNING_KEY]
 


### PR DESCRIPTION
This fixes the trycmd tests, which were ignored since #2879.

There's not currently any way to opt out of this ignoring behavior, though there is an upstream open issue on the topic.

`trycmd` doesn't have any support for changing argv[0] -- trying to use `register_bins()` just results in invoking the binary with its filename in argv[0]. Thus, I changed the commands to use the non-multicall subcommands, which are functionally equivalent. (The other way to address this would be creating temporary symbolic links with the right names, and registering those)