### PR TITLE
Sort dependencies in Cargo.toml files

### DIFF
--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -67,8 +67,8 @@ kube.workspace = true
 opentelemetry.workspace = true
 opentelemetry-otlp = { workspace = true, features = ["metrics"], optional = true }
 opentelemetry-prometheus = { workspace = true, optional = true }
-opentelemetry_sdk = { workspace = true, features = ["rt-tokio"], optional = true }
 opentelemetry-semantic-conventions = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, features = ["rt-tokio"], optional = true }
 pem.workspace = true
 postgres-protocol = { workspace = true }
 postgres-types = { workspace = true, features = ["derive", "array-impls"] }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -27,7 +27,7 @@ url = { workspace = true }
 [dev-dependencies]
 assert_matches.workspace = true
 hex-literal = { workspace = true }
-janus_core = { workspace = true, features = ["test-util"]}
+janus_core = { workspace = true, features = ["test-util"] }
 mockito = { workspace = true }
 tracing-log = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["std", "env-filter", "fmt"] }

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -21,20 +21,20 @@ test-util = []
 backoff = { workspace = true, features = ["tokio"] }
 chrono.workspace = true
 derivative.workspace = true
+fixed = { workspace = true, optional = true }
+hpke-dispatch = { workspace = true, features = ["serde"] }
 janus_core.workspace = true
 janus_messages.workspace = true
-fixed = { workspace = true, optional = true }
 prio.workspace = true
 rand = { workspace = true, features = ["min_const_gen"] }
 reqwest = { workspace = true, features = ["json"] }
 retry-after = { workspace = true }
+serde = { workspace = true }
+serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing = { workspace = true }
 url = { workspace = true }
-serde = { workspace = true }
-hpke-dispatch = { workspace = true, features = ["serde"] }
-serde_json.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -46,8 +46,8 @@ hpke-dispatch = { workspace = true, features = ["serde"] }
 http.workspace = true
 http-api-problem.workspace = true
 janus_messages.workspace = true
-kube = { workspace = true, optional = true, features = ["rustls-tls"] }
 k8s-openapi = { workspace = true, optional = true }
+kube = { workspace = true, optional = true, features = ["rustls-tls"] }
 prio = { workspace = true, default-features = true, features = ["multithreaded", "experimental"] }
 rand.workspace = true
 regex = { workspace = true }


### PR DESCRIPTION
This sorts dependencies in remaining Cargo.toml files.

I have a hacked-up version of `cargo-sort` sitting around that compiles, but adds extra spaces when pretty-printing, so I used that as an oracle to fix alphabetization.