### PR TITLE
Collection job driver: reduce work required to detect step readiness.

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -2857,7 +2857,8 @@ impl VdafOps {
                     let (batch_aggregations, _) = try_join!(
                         Q::get_batch_aggregations_for_collection_identifier(
                             tx,
-                            &task,
+                            task.id(),
+                            task.time_precision(),
                             vdaf.as_ref(),
                             aggregate_share_req.batch_selector().batch_identifier(),
                             &aggregation_param
@@ -2980,7 +2981,7 @@ fn empty_batch_aggregations<
         .map(|ba| (ba.batch_identifier(), ba.ord()))
         .collect();
     iproduct!(
-        Q::batch_identifiers_for_collection_identifier(task, batch_identifier),
+        Q::batch_identifiers_for_collection_identifier(task.time_precision(), batch_identifier),
         0..batch_aggregation_shard_count
     )
     .filter_map(|(batch_identifier, ord)| {

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -3444,7 +3444,7 @@ mod tests {
                             VERIFY_KEY_LENGTH,
                             Poplar1<XofTurboShake128, 16>,
                             _,
-                        >(tx, &task, &vdaf, &batch_id, &aggregation_param)
+                        >(tx, task.id(), task.time_precision(), &vdaf, &batch_id, &aggregation_param)
                         .await.unwrap());
                     Ok((
                         aggregation_job,

--- a/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
@@ -470,20 +470,21 @@ async fn aggregate_share_request() {
                     Box::pin(async move {
                         let batch_aggregations: Vec<_> = try_join_all(
                             TimeInterval::batch_identifiers_for_collection_identifier(
-                                &task.leader_view().unwrap(),
+                                task.time_precision(),
                                 &collection_interval,
                             )
                             .map(|batch_identifier| {
                                 let task_id = *task.id();
 
                                 async move {
-                                tx.get_batch_aggregations_for_batch::<0, TimeInterval, dummy::Vdaf>(
-                                    &dummy::Vdaf::new(1),
-                                    &task_id,
-                                    &batch_identifier,
-                                    &dummy::AggregationParam(0),
-                                ).await
-                            }}),
+                                    tx.get_batch_aggregations_for_batch::<0, TimeInterval, dummy::Vdaf>(
+                                        &dummy::Vdaf::new(1),
+                                        &task_id,
+                                        &batch_identifier,
+                                        &dummy::AggregationParam(0),
+                                    ).await
+                                }
+                            }),
                         )
                         .await
                         .unwrap()

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_continue.rs
@@ -675,7 +675,8 @@ async fn aggregate_continue_accumulate_batch_aggregation() {
                         _,
                     >(
                         tx,
-                        &task,
+                        task.id(),
+                        task.time_precision(),
                         &vdaf,
                         &Interval::new(
                             report_metadata_0
@@ -740,7 +741,8 @@ async fn aggregate_continue_accumulate_batch_aggregation() {
                     _,
                 >(
                     tx,
-                    &task,
+                    task.id(),
+                    task.time_precision(),
                     &vdaf,
                     &Interval::new(
                         report_metadata_2
@@ -975,7 +977,8 @@ async fn aggregate_continue_accumulate_batch_aggregation() {
                         _,
                     >(
                         tx,
-                        &task,
+                        task.id(),
+                        task.time_precision(),
                         &vdaf,
                         &Interval::new(
                             report_metadata_0
@@ -1052,7 +1055,8 @@ async fn aggregate_continue_accumulate_batch_aggregation() {
                     _,
                 >(
                     tx,
-                    &task,
+                    task.id(),
+                    task.time_precision(),
                     &vdaf,
                     &Interval::new(
                         report_metadata_2

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -683,6 +683,9 @@ pub struct AcquiredCollectionJob {
     collection_job_id: CollectionJobId,
     query_type: task::QueryType,
     vdaf: VdafInstance,
+    time_precision: Duration,
+    encoded_batch_identifier: Vec<u8>,
+    encoded_aggregation_param: Vec<u8>,
 }
 
 impl AcquiredCollectionJob {
@@ -692,12 +695,18 @@ impl AcquiredCollectionJob {
         collection_job_id: CollectionJobId,
         query_type: task::QueryType,
         vdaf: VdafInstance,
+        time_precision: Duration,
+        encoded_batch_identifier: Vec<u8>,
+        encoded_aggregation_param: Vec<u8>,
     ) -> Self {
         Self {
             task_id,
             collection_job_id,
             query_type,
             vdaf,
+            time_precision,
+            encoded_batch_identifier,
+            encoded_aggregation_param,
         }
     }
 
@@ -719,6 +728,22 @@ impl AcquiredCollectionJob {
     /// Returns the VDAF associated with this acquired collection job.
     pub fn vdaf(&self) -> &VdafInstance {
         &self.vdaf
+    }
+
+    /// Returns the time precision of the task associated with this acquired collection job.
+    pub fn time_precision(&self) -> &Duration {
+        &self.time_precision
+    }
+
+    /// Returns the batch identifier associated with this acquired collection job, encoded to bytes.
+    pub fn encoded_batch_identifier(&self) -> &[u8] {
+        &self.encoded_batch_identifier
+    }
+
+    /// Returns the aggregation parameter associated with this acquired collection job, encoded to
+    /// bytes.
+    pub fn encoded_aggregation_param(&self) -> &[u8] {
+        &self.encoded_aggregation_param
     }
 }
 

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -3637,6 +3637,7 @@ async fn run_collection_job_acquire_test_case<Q: TestQueryTypeExt>(
     ds.run_unnamed_tx(|tx| {
         let test_case = test_case.clone();
         let clock = clock.clone();
+
         Box::pin(async move {
             let leases = tx
                 .acquire_incomplete_collection_jobs(&StdDuration::from_secs(100), 10)
@@ -3660,6 +3661,9 @@ async fn run_collection_job_acquire_test_case<Q: TestQueryTypeExt>(
                             c.collection_job_id.unwrap(),
                             test_case.query_type,
                             VdafInstance::Fake { rounds: 1 },
+                            Duration::from_hours(8).unwrap(),
+                            c.batch_identifier.get_encoded().unwrap(),
+                            c.agg_param.get_encoded().unwrap(),
                         ),
                         clock.now().as_naive_date_time().unwrap()
                             + chrono::Duration::try_seconds(100).unwrap(),
@@ -4225,6 +4229,9 @@ async fn collection_job_acquire_job_max(ephemeral_datastore: EphemeralDatastore)
                             c.collection_job_id.unwrap(),
                             task::QueryType::TimeInterval,
                             VdafInstance::Fake { rounds: 1 },
+                            Duration::from_hours(8).unwrap(),
+                            c.batch_identifier.get_encoded().unwrap(),
+                            c.agg_param.get_encoded().unwrap(),
                         ),
                         clock.now().as_naive_date_time().unwrap()
                             + chrono::Duration::try_seconds(100).unwrap(),
@@ -4606,7 +4613,8 @@ async fn roundtrip_batch_aggregation_time_interval(ephemeral_datastore: Ephemera
                     _,
                 >(
                     tx,
-                    &task,
+                    task.id(),
+                    task.time_precision(),
                     &vdaf,
                     &Interval::new(
                         Time::from_seconds_since_epoch(1100),
@@ -4656,7 +4664,8 @@ async fn roundtrip_batch_aggregation_time_interval(ephemeral_datastore: Ephemera
                     _,
                 >(
                     tx,
-                    &task,
+                    task.id(),
+                    task.time_precision(),
                     &vdaf,
                     &Interval::new(
                         Time::from_seconds_since_epoch(1100),
@@ -4702,7 +4711,8 @@ async fn roundtrip_batch_aggregation_time_interval(ephemeral_datastore: Ephemera
                     _,
                 >(
                     tx,
-                    &task,
+                    task.id(),
+                    task.time_precision(),
                     &vdaf,
                     &Interval::new(
                         Time::from_seconds_since_epoch(1100),


### PR DESCRIPTION
Specifically, we now check if there are unaggregated reports, or unfinished aggregation jobs, in the same pipelined round-trip as reading the task and collection job. The outstanding aggregation job count is determined without reading the set of batch aggregations, which can be quite large in some cases as they include partial aggregate shares.

We also now check for a matching, already-completed collection job before reading the batch aggregations.