### PR TITLE
Run VDAF preparation on a threadpool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2223,6 +2223,7 @@ dependencies = [
  "prio 0.16.2",
  "prometheus",
  "rand",
+ "rayon",
  "regex",
  "reqwest",
  "ring 0.17.8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ prio = { version = "0.16.2", default-features = false, features = ["multithreade
 prometheus = "0.13.3"
 querystring = "1.1.0"
 rand = "0.8"
+rayon = "1.10.0"
 reqwest = { version = "0.12.3", default-features = false, features = ["rustls-tls"] }
 regex = "1.10.4"
 retry-after = "0.4.0"

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -75,6 +75,7 @@ postgres-types = { workspace = true, features = ["derive", "array-impls"] }
 prio.workspace = true
 prometheus = { workspace = true, optional = true }
 rand = { workspace = true, features = ["min_const_gen"] }
+rayon.workspace = true
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 ring = { workspace = true }

--- a/aggregator/src/main.rs
+++ b/aggregator/src/main.rs
@@ -48,13 +48,20 @@ enum Nested {
 async fn main() -> anyhow::Result<()> {
     match Options::parse() {
         Options::Aggregator(options) | Options::Default(Nested::Aggregator(options)) => {
-            janus_main(options, RealClock::default(), aggregator::main_callback).await
+            janus_main(
+                options,
+                RealClock::default(),
+                true,
+                aggregator::main_callback,
+            )
+            .await
         }
         Options::AggregationJobCreator(options)
         | Options::Default(Nested::AggregationJobCreator(options)) => {
             janus_main(
                 options,
                 RealClock::default(),
+                false,
                 aggregation_job_creator::main_callback,
             )
             .await
@@ -64,6 +71,7 @@ async fn main() -> anyhow::Result<()> {
             janus_main(
                 options,
                 RealClock::default(),
+                true,
                 aggregation_job_driver::main_callback,
             )
             .await
@@ -73,6 +81,7 @@ async fn main() -> anyhow::Result<()> {
             janus_main(
                 options,
                 RealClock::default(),
+                false,
                 collection_job_driver::main_callback,
             )
             .await

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -82,6 +82,7 @@ impl TryFrom<&taskprov::Query> for QueryType {
 
 /// A verification key for a VDAF, with a fixed length. It must be kept secret from clients to
 /// maintain robustness, and it must be shared between aggregators.
+#[derive(Clone, Copy)]
 pub struct VerifyKey<const SEED_SIZE: usize>([u8; SEED_SIZE]);
 
 impl<const SEED_SIZE: usize> VerifyKey<SEED_SIZE> {

--- a/interop_binaries/src/commands/janus_interop_aggregator.rs
+++ b/interop_binaries/src/commands/janus_interop_aggregator.rs
@@ -254,7 +254,7 @@ impl BinaryConfig for Config {
 
 impl Options {
     pub async fn run(self) -> anyhow::Result<()> {
-        janus_main::<_, _, Config, _, _>(self, RealClock::default(), |ctx| async move {
+        janus_main::<_, _, Config, _, _>(self, RealClock::default(), true, |ctx| async move {
             let datastore = Arc::new(ctx.datastore);
 
             // Run an HTTP server with both the DAP aggregator endpoints and the interoperation test


### PR DESCRIPTION
This should address #2955. I'm going to open this as a draft now before doing performance testing on it.

This moves VDAF preparation in three places to a `rayon` threadpool. Various inputs are moved into a closure, the closure is sent into a new threadpool task, and the task sends the result back to the initiating future via a Tokio oneshot channel. I created a new tracing span at the beginning of the threadpool task, and linked it to a parent span.

I hemmed and hawed between `rayon::spawn()` and `rayon::spawn_fifo()`, but ultimately went with the former. This means tasks will be handled in LIFO order when picked up by the same thread, or FIFO order when other threads do work stealing. I figure having some LIFO behavior is preferable, because when overloaded, we'd rather successfully handle some requests than waste work on old requests that are likely to hit a timeout. If we wanted pure LIFO behavior, we would need to use a different threadpool implementation.

This PR doesn't addresss two other places where VDAF preparation happens in the leader, `AggregationJobDriver::step_aggregation_job_aggregate_continue()` and `AggregationJobDriver::process_response_from_helper()`. We may want to move these off the async runtime as well, but I think these later steps should be cheaper to begin with or not applicable, for the VDAFs we're concerned with.

Reveiwer note: this PR indents a lot of code by two tabstops, so it would benefit from the "ignore whitespace" option