### PR TITLE
Exponential backoff for collection job polling.

### DIFF
--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -1807,7 +1807,7 @@ mod tests {
             assert_eq!(
                 want_delay_s,
                 got_delay_s,
-                "compute_reacquire_delay({step_attempts}, {min_delay_s}, {max_delay_s}, {exponential_factor})"
+                "RetryDelay({min_delay_s}, {max_delay_s}, {exponential_factor}).compute_retry_delay({step_attempts})"
             );
         }
 
@@ -1824,7 +1824,7 @@ mod tests {
                 StdDuration::from_secs(max_delay_s),
                 exponential_factor,
             )
-            .unwrap_err();
+            .expect_err(&format!("RetryDelay({min_delay_s}, {max_delay_s}, {exponential_factor})"));
         }
     }
 }

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -1824,7 +1824,9 @@ mod tests {
                 StdDuration::from_secs(max_delay_s),
                 exponential_factor,
             )
-            .expect_err(&format!("RetryDelay({min_delay_s}, {max_delay_s}, {exponential_factor})"));
+            .expect_err(&format!(
+                "RetryDelay({min_delay_s}, {max_delay_s}, {exponential_factor})"
+            ));
         }
     }
 }

--- a/aggregator/src/binaries/collection_job_driver.rs
+++ b/aggregator/src/binaries/collection_job_driver.rs
@@ -142,11 +142,17 @@ pub struct Config {
 }
 
 impl Config {
-    fn default_min_collection_job_retry_delay_secs() -> u64 { 600 }
+    fn default_min_collection_job_retry_delay_secs() -> u64 {
+        600
+    }
 
-    fn default_max_collection_job_retry_delay_secs() -> u64 { 3600 }
+    fn default_max_collection_job_retry_delay_secs() -> u64 {
+        3600
+    }
 
-    fn default_collection_job_retry_delay_exponential_factor() -> f64 { 1.25 }
+    fn default_collection_job_retry_delay_exponential_factor() -> f64 {
+        1.25
+    }
 }
 
 impl BinaryConfig for Config {

--- a/aggregator/src/binaries/collection_job_driver.rs
+++ b/aggregator/src/binaries/collection_job_driver.rs
@@ -35,6 +35,8 @@ pub async fn main_callback(ctx: BinaryContext<RealClock, Options, Config>) -> Re
         &ctx.meter,
         ctx.config.batch_aggregation_shard_count,
         Duration::from_secs(ctx.config.min_collection_job_retry_delay_secs),
+        Duration::from_secs(ctx.config.max_collection_job_retry_delay_secs),
+        ctx.config.collection_job_retry_delay_exponential_factor,
     ));
     let lease_duration =
         Duration::from_secs(ctx.config.job_driver_config.worker_lease_duration_secs);
@@ -104,11 +106,13 @@ impl BinaryOptions for Options {
 /// retry_max_elapsed_time_millis: 300000
 /// batch_aggregation_shard_count: 32
 /// min_collection_job_retry_delay_secs: 600
+/// max_collection_job_retry_delay_secs: 3600
+/// collection_job_retry_delay_exponential_factor: 1.25
 /// "#;
 ///
 /// let _decoded: Config = serde_yaml::from_str(yaml_config).unwrap();
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Config {
     #[serde(flatten)]
     pub common_config: CommonConfig,
@@ -122,7 +126,27 @@ pub struct Config {
 
     /// The minimum duration to wait, in seconds, before retrying a collection job that has been
     /// stepped but was not ready yet because not all included reports had finished aggregation.
+    #[serde(default = "Config::default_min_collection_job_retry_delay_secs")]
     pub min_collection_job_retry_delay_secs: u64,
+
+    /// The maximum duration to wait, in seconds, before retrying a collection job that has been
+    /// stepped but was not ready yet because not all included reports had finished aggregation.
+    #[serde(default = "Config::default_max_collection_job_retry_delay_secs")]
+    pub max_collection_job_retry_delay_secs: u64,
+
+    /// The exponential factor to use when computing a retry delay when retrying a collection job
+    /// that has been stepped but was not ready yet because not all included reports had finished
+    /// aggregation.
+    #[serde(default = "Config::default_collection_job_retry_delay_exponential_factor")]
+    pub collection_job_retry_delay_exponential_factor: f64,
+}
+
+impl Config {
+    fn default_min_collection_job_retry_delay_secs() -> u64 { 600 }
+
+    fn default_max_collection_job_retry_delay_secs() -> u64 { 3600 }
+
+    fn default_collection_job_retry_delay_exponential_factor() -> f64 { 1.25 }
 }
 
 impl BinaryConfig for Config {
@@ -176,6 +200,8 @@ mod tests {
             },
             batch_aggregation_shard_count: 32,
             min_collection_job_retry_delay_secs: 600,
+            max_collection_job_retry_delay_secs: 3600,
+            collection_job_retry_delay_exponential_factor: 1.25,
         })
     }
 

--- a/aggregator/tests/integration/graceful_shutdown.rs
+++ b/aggregator/tests/integration/graceful_shutdown.rs
@@ -376,6 +376,8 @@ async fn collection_job_driver_shutdown() {
         },
         batch_aggregation_shard_count: 32,
         min_collection_job_retry_delay_secs: 1,
+        max_collection_job_retry_delay_secs: 1,
+        collection_job_retry_delay_exponential_factor: 1.0,
     };
 
     graceful_shutdown("collection_job_driver", config).await;

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -691,6 +691,7 @@ pub struct AcquiredCollectionJob {
 
 impl AcquiredCollectionJob {
     /// Creates a new [`AcquiredCollectionJob`].
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         task_id: TaskId,
         collection_job_id: CollectionJobId,

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -686,6 +686,7 @@ pub struct AcquiredCollectionJob {
     time_precision: Duration,
     encoded_batch_identifier: Vec<u8>,
     encoded_aggregation_param: Vec<u8>,
+    step_attempts: u64,
 }
 
 impl AcquiredCollectionJob {
@@ -698,6 +699,7 @@ impl AcquiredCollectionJob {
         time_precision: Duration,
         encoded_batch_identifier: Vec<u8>,
         encoded_aggregation_param: Vec<u8>,
+        step_attempts: u64,
     ) -> Self {
         Self {
             task_id,
@@ -707,6 +709,7 @@ impl AcquiredCollectionJob {
             time_precision,
             encoded_batch_identifier,
             encoded_aggregation_param,
+            step_attempts,
         }
     }
 
@@ -744,6 +747,19 @@ impl AcquiredCollectionJob {
     /// bytes.
     pub fn encoded_aggregation_param(&self) -> &[u8] {
         &self.encoded_aggregation_param
+    }
+
+    /// Returns the number of times this collection job has been stepped without making progress.
+    pub fn step_attempts(&self) -> u64 {
+        self.step_attempts
+    }
+
+    #[cfg(feature = "test-util")]
+    pub fn with_step_attempts(self, step_attempts: u64) -> Self {
+        Self {
+            step_attempts,
+            ..self
+        }
     }
 }
 

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -3664,6 +3664,7 @@ async fn run_collection_job_acquire_test_case<Q: TestQueryTypeExt>(
                             Duration::from_hours(8).unwrap(),
                             c.batch_identifier.get_encoded().unwrap(),
                             c.agg_param.get_encoded().unwrap(),
+                            0,
                         ),
                         clock.now().as_naive_date_time().unwrap()
                             + chrono::Duration::try_seconds(100).unwrap(),
@@ -3775,10 +3776,14 @@ async fn time_interval_collection_job_acquire_release_happy_path(
 
                 let collection_jobs: Vec<_> = collection_job_leases
                     .iter()
-                    .map(|lease| (lease.leased().clone(), lease.lease_expiry_time()))
+                    .map(|lease| {
+                        (
+                            lease.leased().clone().with_step_attempts(1),
+                            lease.lease_expiry_time(),
+                        )
+                    })
                     .collect();
 
-                assert_eq!(reacquired_jobs.len(), 1);
                 assert_eq!(reacquired_jobs, collection_jobs);
 
                 Ok(reacquired_leases)
@@ -3851,10 +3856,9 @@ async fn time_interval_collection_job_acquire_release_happy_path(
                 .collect();
             let collection_jobs: Vec<_> = collection_job_leases
                 .iter()
-                .map(|lease| lease.leased().clone())
+                .map(|lease| lease.leased().clone().with_step_attempts(2))
                 .collect();
 
-            assert_eq!(reacquired_jobs.len(), 1);
             assert_eq!(reacquired_jobs, collection_jobs);
 
             Ok(())
@@ -3955,10 +3959,14 @@ async fn fixed_size_collection_job_acquire_release_happy_path(
 
                 let collection_jobs: Vec<_> = collection_job_leases
                     .iter()
-                    .map(|lease| (lease.leased().clone(), lease.lease_expiry_time()))
+                    .map(|lease| {
+                        (
+                            lease.leased().clone().with_step_attempts(1),
+                            lease.lease_expiry_time(),
+                        )
+                    })
                     .collect();
 
-                assert_eq!(reacquired_jobs.len(), 1);
                 assert_eq!(reacquired_jobs, collection_jobs);
 
                 Ok(reacquired_leases)
@@ -4023,10 +4031,9 @@ async fn fixed_size_collection_job_acquire_release_happy_path(
                 .collect();
             let collection_jobs: Vec<_> = collection_job_leases
                 .iter()
-                .map(|lease| lease.leased().clone())
+                .map(|lease| lease.leased().clone().with_step_attempts(2))
                 .collect();
 
-            assert_eq!(reacquired_jobs.len(), 1);
             assert_eq!(reacquired_jobs, collection_jobs);
 
             Ok(())
@@ -4232,6 +4239,7 @@ async fn collection_job_acquire_job_max(ephemeral_datastore: EphemeralDatastore)
                             Duration::from_hours(8).unwrap(),
                             c.batch_identifier.get_encoded().unwrap(),
                             c.agg_param.get_encoded().unwrap(),
+                            0,
                         ),
                         clock.now().as_naive_date_time().unwrap()
                             + chrono::Duration::try_seconds(100).unwrap(),

--- a/core/src/test_util/mod.rs
+++ b/core/src/test_util/mod.rs
@@ -233,7 +233,7 @@ pub fn run_vdaf<
 
 /// Encodes the given value to YAML, then decodes it again, and checks that the
 /// resulting value is equal to the given value.
-pub fn roundtrip_encoding<T: Serialize + DeserializeOwned + Debug + Eq>(value: T) {
+pub fn roundtrip_encoding<T: Serialize + DeserializeOwned + Debug + PartialEq>(value: T) {
     let encoded = serde_yaml::to_string(&value).unwrap();
     let decoded = serde_yaml::from_str(&encoded).unwrap();
     assert_eq!(value, decoded);

--- a/docs/samples/advanced_config/collection_job_driver.yaml
+++ b/docs/samples/advanced_config/collection_job_driver.yaml
@@ -109,3 +109,11 @@ batch_aggregation_shard_count: 32
 # The minimum duration to wait, in seconds, before retrying a collection job that has been stepped
 # but was not ready yet because not all included reports had finished aggregation.
 min_collection_job_retry_delay_secs: 600
+
+# The maximum duration to wait, in seconds, before retrying a collection job that has been stepped
+# but was not ready yet because not all included reports had finished aggregation.
+max_collection_job_retry_delay_secs: 3600
+
+# The exponential factor to use when computing a retry delay when retrying a collection job that has
+# been stepped but was not ready yet because not all included reports had finished aggregation.
+collection_job_retry_delay_exponential_factor: 1.25

--- a/docs/samples/basic_config/collection_job_driver.yaml
+++ b/docs/samples/basic_config/collection_job_driver.yaml
@@ -31,6 +31,3 @@ maximum_attempts_before_failure: 10
 # (required)
 batch_aggregation_shard_count: 32
 
-# The minimum duration to wait, in seconds, before retrying a collection job that has been stepped
-# but was not ready yet because not all included reports had finished aggregation.
-min_collection_job_retry_delay_secs: 600

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -217,6 +217,8 @@ impl JanusInProcess {
             },
             batch_aggregation_shard_count: 32,
             min_collection_job_retry_delay_secs: 1,
+            max_collection_job_retry_delay_secs: 1,
+            collection_job_retry_delay_exponential_factor: 1.0,
         };
 
         // Spawn each component.

--- a/interop_binaries/config/collection_job_driver.yaml
+++ b/interop_binaries/config/collection_job_driver.yaml
@@ -14,3 +14,5 @@ worker_lease_duration_secs: 10
 maximum_attempts_before_failure: 3
 batch_aggregation_shard_count: 32
 min_collection_job_retry_delay_secs: 1
+max_collection_job_retry_delay_secs: 1
+collection_job_retry_delay_exponential_factor: 1.0


### PR DESCRIPTION
This is controlled by a couple of new collection job driver config knobs, which determine the maximum delay between polling attempts & the exponential factor to use. No randomization factor is included as these delays are the _minimum_ delays possible before retry; thundering herd is not a risk because the collection job driver already controls how many collection jobs it tries to step at once.

Also, make min_collection_job_retry_delay optional (along with the new collection job driver configuration options).