### PR TITLE
Update cargo-deny config

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -136,7 +136,7 @@ jobs:
     - name: cargo-deny
       uses: EmbarkStudios/cargo-deny-action@v1.6.2
       with:
-        command: check bans
+        command: check bans sources -A unmatched-organization
 
   janus_docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -136,7 +136,7 @@ jobs:
     - name: cargo-deny
       uses: EmbarkStudios/cargo-deny-action@v1.6.2
       with:
-        command: check bans sources -A unmatched-organization
+        command: check bans licenses sources -A unmatched-organization
 
   janus_docker:
     runs-on: ubuntu-latest

--- a/deny.toml
+++ b/deny.toml
@@ -3,6 +3,7 @@ targets = [
     { triple = "x86_64-unknown-linux-gnu" },
     { triple = "x86_64-unknown-linux-musl" },
 ]
+all-features = true
 
 [bans]
 multiple-versions = "allow"

--- a/deny.toml
+++ b/deny.toml
@@ -5,6 +5,9 @@ targets = [
 ]
 all-features = true
 
+[advisories]
+version = 2
+
 [bans]
 multiple-versions = "allow"
 deny = [

--- a/deny.toml
+++ b/deny.toml
@@ -11,3 +11,9 @@ deny = [
     { name = "tracing", deny-multiple-versions = true },
     { name = "opentelemetry", deny-multiple-versions = true },
 ]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+required-git-spec = "rev"
+allow-org = { github = ["divviup"] }

--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,4 @@
+[graph]
 targets = [
     { triple = "x86_64-unknown-linux-gnu" },
     { triple = "x86_64-unknown-linux-musl" },
@@ -9,8 +10,3 @@ deny = [
     { name = "tracing", deny-multiple-versions = true },
     { name = "opentelemetry", deny-multiple-versions = true },
 ]
-
-[licenses]
-copyleft = "allow"
-default = "allow"
-unlicensed = "allow"

--- a/deny.toml
+++ b/deny.toml
@@ -17,3 +17,23 @@ unknown-registry = "deny"
 unknown-git = "deny"
 required-git-spec = "rev"
 allow-org = { github = ["divviup"] }
+
+[licenses]
+version = 2
+allow = [
+    "MPL-2.0",
+    "MIT",
+    "Apache-2.0",
+    "BSL-1.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-DFS-2016",
+    "OpenSSL",
+    "Unlicense",
+]
+
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]


### PR DESCRIPTION
This addresses some warnings from `cargo-deny` about deprecations in the config file format, and enables some new checks. I enabled the `sources` check, which will exclude any non-crates.io registries, and codified our practice of occasionally using pinned git commits from our other repositories. I enabled the `licenses` check, and allowed all licenses of software we currently use, primarily to raise a flag if we add a dependency on a crate lacking clear license terms.