### PR TITLE
aggregation_job_creator: mark filled outstanding batches.

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -1871,7 +1871,9 @@ mod tests {
 
                     Box::pin(async move {
                         Ok((
-                            tx.get_outstanding_batches(task.id(), &None).await.unwrap(),
+                            tx.get_unfilled_outstanding_batches(task.id(), &None)
+                                .await
+                                .unwrap(),
                             read_and_verify_aggregate_info_for_task::<
                                 VERIFY_KEY_LENGTH,
                                 FixedSize,
@@ -2087,7 +2089,9 @@ mod tests {
 
                     Box::pin(async move {
                         Ok((
-                            tx.get_outstanding_batches(task.id(), &None).await.unwrap(),
+                            tx.get_unfilled_outstanding_batches(task.id(), &None)
+                                .await
+                                .unwrap(),
                             read_and_verify_aggregate_info_for_task::<
                                 VERIFY_KEY_LENGTH,
                                 FixedSize,
@@ -2256,7 +2260,9 @@ mod tests {
 
                     Box::pin(async move {
                         Ok((
-                            tx.get_outstanding_batches(task.id(), &None).await.unwrap(),
+                            tx.get_unfilled_outstanding_batches(task.id(), &None)
+                                .await
+                                .unwrap(),
                             read_and_verify_aggregate_info_for_task::<
                                 VERIFY_KEY_LENGTH,
                                 FixedSize,
@@ -2353,7 +2359,9 @@ mod tests {
 
                     Box::pin(async move {
                         Ok((
-                            tx.get_outstanding_batches(task.id(), &None).await.unwrap(),
+                            tx.get_unfilled_outstanding_batches(task.id(), &None)
+                                .await
+                                .unwrap(),
                             read_and_verify_aggregate_info_for_task::<
                                 VERIFY_KEY_LENGTH,
                                 FixedSize,
@@ -2520,7 +2528,9 @@ mod tests {
 
                     Box::pin(async move {
                         Ok((
-                            tx.get_outstanding_batches(task.id(), &None).await.unwrap(),
+                            tx.get_unfilled_outstanding_batches(task.id(), &None)
+                                .await
+                                .unwrap(),
                             read_and_verify_aggregate_info_for_task::<
                                 VERIFY_KEY_LENGTH,
                                 FixedSize,
@@ -2623,7 +2633,9 @@ mod tests {
 
                     Box::pin(async move {
                         Ok((
-                            tx.get_outstanding_batches(task.id(), &None).await.unwrap(),
+                            tx.get_unfilled_outstanding_batches(task.id(), &None)
+                                .await
+                                .unwrap(),
                             read_and_verify_aggregate_info_for_task::<
                                 VERIFY_KEY_LENGTH,
                                 FixedSize,
@@ -2823,12 +2835,18 @@ mod tests {
 
                     Box::pin(async move {
                         Ok((
-                            tx.get_outstanding_batches(task.id(), &Some(time_bucket_start_1))
-                                .await
-                                .unwrap(),
-                            tx.get_outstanding_batches(task.id(), &Some(time_bucket_start_2))
-                                .await
-                                .unwrap(),
+                            tx.get_unfilled_outstanding_batches(
+                                task.id(),
+                                &Some(time_bucket_start_1),
+                            )
+                            .await
+                            .unwrap(),
+                            tx.get_unfilled_outstanding_batches(
+                                task.id(),
+                                &Some(time_bucket_start_2),
+                            )
+                            .await
+                            .unwrap(),
                             read_and_verify_aggregate_info_for_task::<
                                 VERIFY_KEY_LENGTH,
                                 FixedSize,
@@ -3100,7 +3118,9 @@ mod tests {
 
                     Box::pin(async move {
                         Ok((
-                            tx.get_outstanding_batches(task.id(), &None).await.unwrap(),
+                            tx.get_unfilled_outstanding_batches(task.id(), &None)
+                                .await
+                                .unwrap(),
                             read_and_verify_aggregate_info_for_task::<
                                 VERIFY_KEY_LENGTH,
                                 FixedSize,

--- a/aggregator/src/aggregator/garbage_collector.rs
+++ b/aggregator/src/aggregator/garbage_collector.rs
@@ -670,7 +670,7 @@ mod tests {
                     .unwrap()
                     .is_empty());
                 assert!(tx
-                    .get_outstanding_batches(task.id(), &None)
+                    .get_unfilled_outstanding_batches(task.id(), &None)
                     .await
                     .unwrap()
                     .is_empty());

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -4601,7 +4601,7 @@ impl<C: Clock> Transaction<'_, C> {
     /// Retrieves an outstanding batch for the given task with at least the given number of
     /// successfully-aggregated reports, removing it from the datastore.
     #[tracing::instrument(skip(self), err(level = Level::DEBUG))]
-    pub async fn acquire_filled_outstanding_batch(
+    pub async fn acquire_outstanding_batch_with_report_count(
         &self,
         task_id: &TaskId,
         min_report_count: u64,

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -102,7 +102,7 @@ macro_rules! supported_schema_versions {
 // version is seen, [`Datastore::new`] fails.
 //
 // Note that the latest supported version must be first in the list.
-supported_schema_versions!(3, 2);
+supported_schema_versions!(3);
 
 /// Datastore represents a datastore for Janus, with support for transactional reads and writes.
 /// In practice, Datastore instances are currently backed by a PostgreSQL database.
@@ -4465,9 +4465,10 @@ impl<C: Clock> Transaction<'_, C> {
         )
     }
 
-    /// Retrieves all [`OutstandingBatch`]es for a given task and time bucket, if applicable.
+    /// Retrieves all [`OutstandingBatch`]es for a given task and (if applicable) time bucket which
+    /// have not yet been marked filled.
     #[tracing::instrument(skip(self), err(level = Level::DEBUG))]
-    pub async fn get_outstanding_batches(
+    pub async fn get_unfilled_outstanding_batches(
         &self,
         task_id: &TaskId,
         time_bucket_start: &Option<Time>,
@@ -4493,6 +4494,7 @@ impl<C: Clock> Transaction<'_, C> {
                     SELECT batch_id FROM outstanding_batches
                     WHERE task_id = $1
                       AND time_bucket_start = $2
+                      AND state = 'FILLING'
                       AND EXISTS(SELECT 1 FROM non_gc_batches
                                  WHERE batch_identifier = outstanding_batches.batch_id)",
                 )
@@ -4523,6 +4525,7 @@ impl<C: Clock> Transaction<'_, C> {
                     SELECT batch_id FROM outstanding_batches
                     WHERE task_id = $1
                       AND time_bucket_start IS NULL
+                      AND state = 'FILLING'
                       AND EXISTS(SELECT 1 FROM non_gc_batches
                                  WHERE batch_identifier = outstanding_batches.batch_id)",
                 )
@@ -4645,6 +4648,50 @@ impl<C: Clock> Transaction<'_, C> {
         .await?
         .map(|row| Ok(BatchId::get_decoded(row.get("batch_id"))?))
         .transpose()
+    }
+
+    /// Marks a given outstanding batch as filled, such that it will no longer be considered when
+    /// assigning aggregation jobs to batches.
+    #[tracing::instrument(skip(self), err(level = Level::DEBUG))]
+    pub async fn mark_outstanding_batch_filled(
+        &self,
+        task_id: &TaskId,
+        batch_id: &BatchId,
+    ) -> Result<(), Error> {
+        let task_info = match self.task_info_for(task_id).await? {
+            Some(task_info) => task_info,
+            None => return Err(Error::MutationTargetNotFound),
+        };
+        let now = self.clock.now().as_naive_date_time()?;
+
+        let stmt = self
+            .prepare_cached(
+                "WITH non_gc_batches AS (
+                    SELECT batch_identifier
+                    FROM batch_aggregations
+                    WHERE task_id = $1
+                    AND batch_identifier = $2
+                    GROUP BY batch_identifier
+                    HAVING MAX(UPPER(client_timestamp_interval)) >= $3
+                )
+                UPDATE outstanding_batches
+                SET state = 'FILLED'
+                WHERE task_id = $1
+                AND batch_id = $2
+                AND EXISTS(SELECT 1 FROM non_gc_batches WHERE batch_identifier = $2)",
+            )
+            .await?;
+        check_single_row_mutation(
+            self.execute(
+                &stmt,
+                &[
+                    /* task_id */ &task_info.pkey,
+                    /* batch_id */ batch_id.as_ref(),
+                    /* threshold */ &task_info.report_expiry_threshold(&now)?,
+                ],
+            )
+            .await?,
+        )
     }
 
     /// Deletes old client reports for a given task, that is, client reports whose timestamp is

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -5558,15 +5558,15 @@ async fn roundtrip_outstanding_batch(ephemeral_datastore: EphemeralDatastore) {
                     .unwrap();
 
                 let outstanding_batch_1 = tx
-                    .acquire_filled_outstanding_batch(&task_id_1, 3)
+                    .acquire_outstanding_batch_with_report_count(&task_id_1, 3)
                     .await
                     .unwrap();
                 let outstanding_batch_2 = tx
-                    .acquire_filled_outstanding_batch(&task_id_1, 2)
+                    .acquire_outstanding_batch_with_report_count(&task_id_1, 2)
                     .await
                     .unwrap();
                 let outstanding_batch_3 = tx
-                    .acquire_filled_outstanding_batch(&task_id_1, 1)
+                    .acquire_outstanding_batch_with_report_count(&task_id_1, 1)
                     .await
                     .unwrap();
 

--- a/aggregator_core/src/query_type.rs
+++ b/aggregator_core/src/query_type.rs
@@ -405,7 +405,7 @@ impl CollectableQueryType for FixedSize {
         match query.fixed_size_query() {
             FixedSizeQuery::ByBatchId { batch_id } => Ok(Some(*batch_id)),
             FixedSizeQuery::CurrentBatch => {
-                tx.acquire_filled_outstanding_batch(task.id(), task.min_batch_size())
+                tx.acquire_outstanding_batch_with_report_count(task.id(), task.min_batch_size())
                     .await
             }
         }


### PR DESCRIPTION
These marked batches will no longer be considered when generating aggregation jobs in the future; this is a performance optimization which will be especially impactful when there are many outstanding_batches, which might occur if the collector falls behind in collection.