### PR TITLE
Remove response_headers configuration option

### DIFF
--- a/aggregator/src/binaries/aggregator.rs
+++ b/aggregator/src/binaries/aggregator.rs
@@ -330,10 +330,6 @@ pub struct Config {
     #[serde(default, deserialize_with = "deserialize_aggregator_api")]
     pub aggregator_api: Option<AggregatorApi>,
 
-    /// This configuration option is no longer supported. It used to add headers to all HTTP
-    /// responses.
-    pub response_headers: Option<serde_yaml::Value>,
-
     /// Defines the maximum size of a batch of uploaded reports which will be written in a single
     /// transaction.
     pub max_upload_batch_size: usize,
@@ -398,11 +394,6 @@ fn default_tasks_per_tx() -> usize {
 
 impl Config {
     fn aggregator_config(&self, options: &Options) -> Result<aggregator::Config> {
-        if self.response_headers.is_some() {
-            return Err(anyhow!(
-                "the response_headers configuration option is no longer supported"
-            ));
-        }
         Ok(aggregator::Config {
             max_upload_batch_size: self.max_upload_batch_size,
             max_upload_batch_write_delay: Duration::from_millis(
@@ -518,7 +509,6 @@ mod tests {
                 health_check_listen_address: SocketAddr::from((Ipv4Addr::UNSPECIFIED, 8080)),
                 max_transaction_retries: default_max_transaction_retries(),
             },
-            response_headers: None,
             max_upload_batch_size: 100,
             max_upload_batch_write_delay_ms: 250,
             batch_aggregation_shard_count: 32,

--- a/aggregator/src/binary_utils.rs
+++ b/aggregator/src/binary_utils.rs
@@ -38,7 +38,7 @@ use tokio_postgres::NoTls;
 use tokio_postgres_rustls::MakeRustlsConnect;
 use tracing::{debug, info};
 use tracing_subscriber::EnvFilter;
-use trillium::{Handler, Headers, Info, Init, Status};
+use trillium::{Handler, Info, Init, Status};
 use trillium_api::{api, State};
 use trillium_head::Head;
 use trillium_router::Router;
@@ -474,7 +474,6 @@ pub fn setup_signal_handler(stopper: Stopper) -> Result<(), std::io::Error> {
 /// to wait until the server shuts down.
 pub async fn setup_server(
     listen_address: SocketAddr,
-    response_headers: Headers,
     stopper: Stopper,
     handler: impl Handler,
 ) -> anyhow::Result<(SocketAddr, impl Future<Output = ()> + 'static)> {
@@ -489,7 +488,7 @@ pub async fn setup_server(
         .with_host(&listen_address.ip().to_string())
         .with_stopper(stopper)
         .without_signals();
-    let handler = (init, response_headers, handler);
+    let handler = (init, handler);
 
     let task_handle = tokio::spawn(server_config.run_async(handler));
 

--- a/aggregator/tests/integration/graceful_shutdown.rs
+++ b/aggregator/tests/integration/graceful_shutdown.rs
@@ -271,7 +271,6 @@ async fn aggregator_shutdown() {
             path_prefix: None,
             public_dap_url: "https://public.dap.url".parse().unwrap(),
         }),
-        response_headers: None,
         max_upload_batch_size: 100,
         max_upload_batch_write_delay_ms: 250,
         batch_aggregation_shard_count: 32,

--- a/aggregator/tests/integration/graceful_shutdown.rs
+++ b/aggregator/tests/integration/graceful_shutdown.rs
@@ -271,7 +271,7 @@ async fn aggregator_shutdown() {
             path_prefix: None,
             public_dap_url: "https://public.dap.url".parse().unwrap(),
         }),
-        response_headers: Vec::new(),
+        response_headers: None,
         max_upload_batch_size: 100,
         max_upload_batch_write_delay_ms: 250,
         batch_aggregation_shard_count: 32,

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -160,7 +160,6 @@ impl JanusInProcess {
             garbage_collection: None,
             listen_address: (Ipv4Addr::LOCALHOST, 0).into(),
             aggregator_api: None,
-            response_headers: None,
             max_upload_batch_size: 100,
             max_upload_batch_write_delay_ms: 100,
             batch_aggregation_shard_count: 32,

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -160,7 +160,7 @@ impl JanusInProcess {
             garbage_collection: None,
             listen_address: (Ipv4Addr::LOCALHOST, 0).into(),
             aggregator_api: None,
-            response_headers: Vec::new(),
+            response_headers: None,
             max_upload_batch_size: 100,
             max_upload_batch_write_delay_ms: 100,
             batch_aggregation_shard_count: 32,


### PR DESCRIPTION
This removes the `response_headers` configuration option, leaving behind just enough to raise an error if it is specified in a configuration file. This was originally added as a workaround for limitations in ingress-gce, but we no longer need it, and haven't used it in a while. We did not mention this in the sample configuration files under the `docs` directory.

Part of the reason I'd like to get rid of this is that we used to have different config file sections that accepted HTTP headers as lists of name-value pairs (as done here) and as a YAML map (in the case of the now-removed OTLP metadata configuration option, which we dropped in favor of the exporter reading the `OTEL_EXPORTER_OTLP_HEADERS` environment variable). Dropping this configuration option will give us a fresh start when it comes to HTTP headers in configuration.