### PR TITLE
Update kube

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2009,12 +2009,29 @@ dependencies = [
  "http 1.1.0",
  "hyper 1.2.0",
  "hyper-util",
- "log",
  "rustls 0.22.3",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736f15a50e749d033164c56c09783b6102c4ff8da79ad77dbddbbaea0f8567f7"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.2.0",
+ "hyper-util",
+ "log",
+ "rustls 0.23.4",
  "rustls-native-certs 0.7.0",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.0",
  "tower-service",
 ]
 
@@ -2648,9 +2665,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.89.0"
+version = "0.90.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92cd10d00ad38b2f72a5223cd8f2827968466a5d32ae89672d2b0df06488c499"
+checksum = "65bfada4e00dac93a7b94e454ae4cde04ff8786645ac1b98f31352272e2682b5"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -2659,9 +2676,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.89.0"
+version = "0.90.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b4ee4e409c9afb4e38a30802875acb108902387a41346bbc2fd8610df5f729"
+checksum = "e0708306b5c0085f249f5e3d2d56a9bbfe0cbbf4fd4eb9ed4bbba542ba7649a7"
 dependencies = [
  "base64 0.22.0",
  "bytes",
@@ -2673,16 +2690,15 @@ dependencies = [
  "http-body 1.0.0",
  "http-body-util",
  "hyper 1.2.0",
- "hyper-rustls",
+ "hyper-rustls 0.27.0",
  "hyper-timeout 0.5.1",
  "hyper-util",
  "jsonpath-rust",
  "k8s-openapi",
  "kube-core",
  "pem",
- "pin-project",
  "rand",
- "rustls 0.22.3",
+ "rustls 0.23.4",
  "rustls-pemfile 2.1.2",
  "secrecy",
  "serde",
@@ -2699,15 +2715,14 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.89.0"
+version = "0.90.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beab9186726ed0c2420ff8a37b02f26dc62b3c33330ac60d0cc7605e1a6f6678"
+checksum = "7845bcc3e0f422df4d9049570baedd9bc1942f0504594e393e72fe24092559cf"
 dependencies = [
  "chrono",
  "form_urlencoded",
  "http 1.1.0",
  "k8s-openapi",
- "once_cell",
  "serde",
  "serde_json",
  "thiserror",
@@ -3785,7 +3800,7 @@ dependencies = [
  "http-body 1.0.0",
  "http-body-util",
  "hyper 1.2.0",
- "hyper-rustls",
+ "hyper-rustls 0.26.0",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -3802,7 +3817,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.25.0",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3994,6 +4009,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
 dependencies = [
  "log",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c4d6d8ad9f2492485e13453acbb291dd08f64441b6609c491f1c2cd2c6b4fe1"
+dependencies = [
+ "log",
+ "once_cell",
  "ring 0.17.8",
  "rustls-pki-types",
  "rustls-webpki 0.102.2",
@@ -5013,7 +5043,7 @@ dependencies = [
  "rustls 0.22.3",
  "tokio",
  "tokio-postgres",
- "tokio-rustls",
+ "tokio-rustls 0.25.0",
  "x509-certificate",
 ]
 
@@ -5024,6 +5054,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
  "rustls 0.22.3",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls 0.23.4",
  "rustls-pki-types",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ janus_integration_tests = { version = "0.7.2", path = "integration_tests" }
 janus_interop_binaries = { version = "0.7.2", path = "interop_binaries" }
 janus_messages = { version = "0.7.2", path = "messages" }
 k8s-openapi = { version = "0.21.0", features = ["v1_26"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
-kube = { version = "0.89.0", default-features = false, features = ["client", "rustls-tls"] }
+kube = { version = "0.90.0", default-features = false, features = ["client", "rustls-tls"] }
 mockito = "1.4.0"
 num_enum = "0.7.2"
 opentelemetry = { version = "0.22", features = ["metrics"] }


### PR DESCRIPTION
This updates kube to 0.90.0.

Dependabot is still reporting `update_not_possible` for this package unfortunately:

```
Starting update group for 'kube'
Checking if k8s-openapi 0.21.1 needs updating
Ignored versions:
  < 1, > 0.13.1 - from @dependabot ignore command
Filtered out 9 ignored versions
Latest version is 0.13.1
No update needed for k8s-openapi 0.21.1
Checking if kube 0.89.0 needs updating
Latest version is 0.90.0
Requirements to unlock update_not_possible
Requirements update strategy bump_versions
No update possible for kube 0.89.0
Nothing to update for Dependency Group: 'kube'
```