### PR TITLE
Bump version to 0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,7 +1232,7 @@ checksum = "f61f3b8ea9d2af56a3e7821f5eb07930688c97be58c431e4a6920d27b3893530"
 dependencies = [
  "base64 0.22.0",
  "email_address",
- "janus_messages 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "janus_messages 0.7.2",
  "log",
  "pad-adapter",
  "serde",
@@ -2301,7 +2301,7 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "janus_aggregator"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2326,7 +2326,7 @@ dependencies = [
  "janus_aggregator_api",
  "janus_aggregator_core",
  "janus_core",
- "janus_messages 0.7.2",
+ "janus_messages 0.7.3",
  "k8s-openapi",
  "kube",
  "mockito",
@@ -2384,7 +2384,7 @@ dependencies = [
 
 [[package]]
 name = "janus_aggregator_api"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2394,7 +2394,7 @@ dependencies = [
  "futures",
  "janus_aggregator_core",
  "janus_core",
- "janus_messages 0.7.2",
+ "janus_messages 0.7.3",
  "opentelemetry",
  "querystring",
  "rand",
@@ -2416,7 +2416,7 @@ dependencies = [
 
 [[package]]
 name = "janus_aggregator_core"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2436,7 +2436,7 @@ dependencies = [
  "itertools 0.12.1",
  "janus_aggregator_core",
  "janus_core",
- "janus_messages 0.7.2",
+ "janus_messages 0.7.3",
  "k8s-openapi",
  "kube",
  "opentelemetry",
@@ -2470,7 +2470,7 @@ dependencies = [
 
 [[package]]
 name = "janus_client"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -2479,7 +2479,7 @@ dependencies = [
  "http 1.1.0",
  "itertools 0.12.1",
  "janus_core",
- "janus_messages 0.7.2",
+ "janus_messages 0.7.3",
  "mockito",
  "prio",
  "rand",
@@ -2494,7 +2494,7 @@ dependencies = [
 
 [[package]]
 name = "janus_collector"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -2506,7 +2506,7 @@ dependencies = [
  "hpke-dispatch",
  "janus_collector",
  "janus_core",
- "janus_messages 0.7.2",
+ "janus_messages 0.7.3",
  "mockito",
  "prio",
  "rand",
@@ -2522,7 +2522,7 @@ dependencies = [
 
 [[package]]
 name = "janus_core"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2539,7 +2539,7 @@ dependencies = [
  "http 1.1.0",
  "http-api-problem",
  "janus_core",
- "janus_messages 0.7.2",
+ "janus_messages 0.7.3",
  "k8s-openapi",
  "kube",
  "mockito",
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "janus_integration_tests"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2588,7 +2588,7 @@ dependencies = [
  "janus_collector",
  "janus_core",
  "janus_interop_binaries",
- "janus_messages 0.7.2",
+ "janus_messages 0.7.3",
  "k8s-openapi",
  "kube",
  "prio",
@@ -2608,7 +2608,7 @@ dependencies = [
 
 [[package]]
 name = "janus_interop_binaries"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "backoff",
@@ -2625,7 +2625,7 @@ dependencies = [
  "janus_collector",
  "janus_core",
  "janus_interop_binaries",
- "janus_messages 0.7.2",
+ "janus_messages 0.7.3",
  "prio",
  "rand",
  "regex",
@@ -2650,24 +2650,6 @@ dependencies = [
 [[package]]
 name = "janus_messages"
 version = "0.7.2"
-dependencies = [
- "anyhow",
- "assert_matches",
- "base64 0.22.0",
- "derivative",
- "hex",
- "num_enum",
- "prio",
- "rand",
- "serde",
- "serde_test",
- "thiserror",
- "url",
-]
-
-[[package]]
-name = "janus_messages"
-version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "425b77ad31e0614c16041aa44c4014ebd4c67544d01135cece4f51c33b4adef2"
 dependencies = [
@@ -2684,8 +2666,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "janus_messages"
+version = "0.7.3"
+dependencies = [
+ "anyhow",
+ "assert_matches",
+ "base64 0.22.0",
+ "derivative",
+ "hex",
+ "num_enum",
+ "prio",
+ "rand",
+ "serde",
+ "serde_test",
+ "thiserror",
+ "url",
+]
+
+[[package]]
 name = "janus_tools"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2696,7 +2696,7 @@ dependencies = [
  "fixed",
  "janus_collector",
  "janus_core",
- "janus_messages 0.7.2",
+ "janus_messages 0.7.3",
  "prio",
  "rand",
  "reqwest",
@@ -6323,7 +6323,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://divviup.org"
 license = "MPL-2.0"
 repository = "https://github.com/divviup/janus"
 rust-version = "1.73.0"
-version = "0.7.2"
+version = "0.7.3"
 
 [workspace.dependencies]
 anyhow = "1"


### PR DESCRIPTION
This bumps the version on the main branch. I plan to cut a release manually, in order to include a note about #2971.