### PR TITLE
Initialize rustls provider in integration tests

### DIFF
--- a/integration_tests/tests/integration/daphne.rs
+++ b/integration_tests/tests/integration/daphne.rs
@@ -1,4 +1,7 @@
-use crate::common::{build_test_task, submit_measurements_and_verify_aggregate, TestContext};
+use crate::{
+    common::{build_test_task, submit_measurements_and_verify_aggregate, TestContext},
+    initialize_rustls,
+};
 use janus_aggregator_core::task::{test_util::TaskBuilder, QueryType};
 use janus_core::{
     test_util::{install_test_trace_subscriber, testcontainers::container_client},
@@ -22,6 +25,7 @@ const VERSION_PATH: &str = "/v09/";
 async fn daphne_janus() {
     static TEST_NAME: &str = "daphne_janus";
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start servers.
     let network = generate_network_name();
@@ -73,6 +77,7 @@ async fn daphne_janus() {
 async fn janus_daphne() {
     static TEST_NAME: &str = "janus_daphne";
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start servers.
     let network = generate_network_name();
@@ -124,6 +129,7 @@ async fn janus_daphne() {
 async fn janus_in_process_daphne() {
     static TEST_NAME: &str = "janus_in_process_daphne";
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start servers.
     let network = generate_network_name();

--- a/integration_tests/tests/integration/divviup_ts.rs
+++ b/integration_tests/tests/integration/divviup_ts.rs
@@ -1,7 +1,10 @@
 #![cfg(feature = "testcontainer")]
 //! These tests check interoperation between the divviup-ts client and Janus aggregators.
 
-use crate::common::{build_test_task, submit_measurements_and_verify_aggregate, TestContext};
+use crate::{
+    common::{build_test_task, submit_measurements_and_verify_aggregate, TestContext},
+    initialize_rustls,
+};
 use janus_aggregator_core::task::{test_util::TaskBuilder, QueryType};
 use janus_core::{
     test_util::{install_test_trace_subscriber, testcontainers::container_client},
@@ -52,6 +55,7 @@ async fn run_divviup_ts_integration_test(
 #[ignore = "disabled until divviup-ts supports draft-ietf-ppm-dap-09"]
 async fn janus_divviup_ts_count() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     run_divviup_ts_integration_test(
         "janus_divviup_ts_count",
@@ -65,6 +69,7 @@ async fn janus_divviup_ts_count() {
 #[ignore = "disabled until divviup-ts supports draft-ietf-ppm-dap-09"]
 async fn janus_divviup_ts_sum() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     run_divviup_ts_integration_test(
         "janus_divviup_ts_sum",
@@ -78,6 +83,7 @@ async fn janus_divviup_ts_sum() {
 #[ignore = "disabled until divviup-ts supports draft-ietf-ppm-dap-09"]
 async fn janus_divviup_ts_histogram() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     run_divviup_ts_integration_test(
         "janus_divviup_ts_histogram",
@@ -94,6 +100,7 @@ async fn janus_divviup_ts_histogram() {
 #[ignore = "disabled until divviup-ts supports draft-ietf-ppm-dap-09"]
 async fn janus_divviup_ts_sumvec() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     run_divviup_ts_integration_test(
         "janus_divviup_ts_sumvec",

--- a/integration_tests/tests/integration/in_cluster.rs
+++ b/integration_tests/tests/integration/in_cluster.rs
@@ -1,6 +1,9 @@
 #![cfg(feature = "in-cluster")]
 
-use crate::common::{build_test_task, submit_measurements_and_verify_aggregate, TestContext};
+use crate::{
+    common::{build_test_task, submit_measurements_and_verify_aggregate, TestContext},
+    initialize_rustls,
+};
 use chrono::prelude::*;
 use clap::{CommandFactory, FromArgMatches, Parser};
 use divviup_client::{
@@ -471,6 +474,7 @@ impl InClusterJanus {
 #[tokio::test(flavor = "multi_thread")]
 async fn in_cluster_count() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start port forwards and set up task.
     let janus_pair =
@@ -489,6 +493,7 @@ async fn in_cluster_count() {
 #[tokio::test(flavor = "multi_thread")]
 async fn in_cluster_sum() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start port forwards and set up task.
     let janus_pair =
@@ -507,6 +512,7 @@ async fn in_cluster_sum() {
 #[tokio::test(flavor = "multi_thread")]
 async fn in_cluster_histogram() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start port forwards and set up task.
     let janus_pair = InClusterJanusPair::new(
@@ -531,6 +537,7 @@ async fn in_cluster_histogram() {
 #[tokio::test(flavor = "multi_thread")]
 async fn in_cluster_fixed_size() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start port forwards and set up task.
     let janus_pair = InClusterJanusPair::new(
@@ -555,6 +562,7 @@ async fn in_cluster_fixed_size() {
 #[cfg(feature = "in-cluster-rate-limits")]
 mod rate_limits {
     use super::InClusterJanusPair;
+    use crate::initialize_rustls;
     use assert_matches::assert_matches;
     use http::Method;
     use janus_aggregator_core::task::QueryType;
@@ -611,6 +619,7 @@ mod rate_limits {
         method: Method,
     ) {
         install_test_trace_subscriber();
+        initialize_rustls();
         let test_config = TestConfig::load();
 
         let janus_pair =

--- a/integration_tests/tests/integration/janus.rs
+++ b/integration_tests/tests/integration/janus.rs
@@ -1,6 +1,9 @@
-use crate::common::{
-    build_test_task, submit_measurements_and_verify_aggregate,
-    submit_measurements_and_verify_aggregate_varying_aggregation_parameter, TestContext,
+use crate::{
+    common::{
+        build_test_task, submit_measurements_and_verify_aggregate,
+        submit_measurements_and_verify_aggregate_varying_aggregation_parameter, TestContext,
+    },
+    initialize_rustls,
 };
 use janus_aggregator_core::task::{test_util::TaskBuilder, QueryType};
 #[cfg(feature = "testcontainer")]
@@ -107,6 +110,7 @@ impl JanusInProcessPair {
 async fn janus_janus_count() {
     static TEST_NAME: &str = "janus_janus_count";
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start servers.
     let container_client = container_client();
@@ -132,6 +136,7 @@ async fn janus_janus_count() {
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_in_process_count() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start servers.
     let janus_pair = JanusInProcessPair::new(TaskBuilder::new(
@@ -156,6 +161,7 @@ async fn janus_in_process_count() {
 async fn janus_janus_sum_16() {
     static TEST_NAME: &str = "janus_janus_sum_16";
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start servers.
     let container_client = container_client();
@@ -181,6 +187,7 @@ async fn janus_janus_sum_16() {
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_in_process_sum_16() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start servers.
     let janus_pair = JanusInProcessPair::new(TaskBuilder::new(
@@ -205,6 +212,7 @@ async fn janus_in_process_sum_16() {
 async fn janus_janus_histogram_4_buckets() {
     static TEST_NAME: &str = "janus_janus_histogram_4_buckets";
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start servers.
     let container_client = container_client();
@@ -233,6 +241,7 @@ async fn janus_janus_histogram_4_buckets() {
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_in_process_histogram_4_buckets() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start servers.
     let janus_pair = JanusInProcessPair::new(TaskBuilder::new(
@@ -260,6 +269,7 @@ async fn janus_in_process_histogram_4_buckets() {
 async fn janus_janus_fixed_size() {
     static TEST_NAME: &str = "janus_janus_fixed_size";
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start servers.
     let container_client = container_client();
@@ -288,6 +298,7 @@ async fn janus_janus_fixed_size() {
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_in_process_fixed_size() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start servers.
     let janus_pair = JanusInProcessPair::new(TaskBuilder::new(
@@ -315,6 +326,7 @@ async fn janus_in_process_fixed_size() {
 async fn janus_janus_sum_vec() {
     static TEST_NAME: &str = "janus_janus_sum_vec";
     install_test_trace_subscriber();
+    initialize_rustls();
 
     let container_client = container_client();
     let janus_pair = JanusContainerPair::new(
@@ -342,6 +354,7 @@ async fn janus_janus_sum_vec() {
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_in_process_sum_vec() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     let janus_pair = JanusInProcessPair::new(TaskBuilder::new(
         QueryType::TimeInterval,
@@ -367,6 +380,7 @@ async fn janus_in_process_sum_vec() {
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_in_process_customized_sum_vec() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     let janus_pair = JanusInProcessPair::new(TaskBuilder::new(
         QueryType::TimeInterval,
@@ -393,6 +407,7 @@ async fn janus_in_process_customized_sum_vec() {
 #[ignore = "fixed size with agg param not yet supported (#225)"]
 async fn janus_in_process_one_round_with_agg_param_fixed_size() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     let janus_pair = JanusInProcessPair::new(
         TaskBuilder::new(
@@ -426,6 +441,7 @@ async fn janus_in_process_one_round_with_agg_param_fixed_size() {
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_in_process_one_round_with_agg_param_time_interval() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     let janus_pair = JanusInProcessPair::new(
         TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake { rounds: 1 })

--- a/integration_tests/tests/integration/main.rs
+++ b/integration_tests/tests/integration/main.rs
@@ -3,3 +3,10 @@ mod daphne;
 mod divviup_ts;
 mod in_cluster;
 mod janus;
+
+fn initialize_rustls() {
+    // Choose aws-lc-rs as the default rustls crypto provider. This is what's currently enabled by
+    // the default Cargo feature. Specifying a default provider here prevents runtime errors if
+    // another dependency also enables the ring feature.
+    let _ = trillium_rustls::rustls::crypto::aws_lc_rs::default_provider().install_default();
+}


### PR DESCRIPTION
The in-cluster integration tests failed with Janus 0.7.2, because kube-client 0.90.0 both uses rustls 0.23, and enables the `aws-lc-rs` and `ring` features together. Thus, we need to set a default crypto provider before calling into `kube`. I went ahead and did so in all tests in `janus_integration_tests`.