### PR TITLE
Multi-collection for time interval tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3811,7 +3811,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.22.3",
- "rustls-pemfile 2.1.1",
+ "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "serde",
  "serde_json",

--- a/aggregator/src/aggregator/batch_creator.rs
+++ b/aggregator/src/aggregator/batch_creator.rs
@@ -402,6 +402,8 @@ where
         // because they have a write-after-read antidependency on the report shares.
         try_join!(
             try_join_all(
+                // TODO(#225): do not scrub reports if aggregation parameter is non-trivial, because
+                // we need to keep the input shares, etc. for future collections.
                 self.report_ids_to_scrub
                     .iter()
                     .map(|report_id| tx.scrub_client_report(&self.properties.task_id, report_id))
@@ -416,6 +418,9 @@ where
                     ))
             ),
             try_join_all(
+                // TODO(#225): do not mark reports we didn't aggregate under the current parameter
+                // as unaggregated, because they may have been aggregated under some other parameter
+                // previously.
                 unaggregated_report_ids
                     .iter()
                     .map(|report_id| tx

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -135,7 +135,7 @@ where
     ) -> Result<(), Error>
     where
         A: 'static,
-        A::AggregationParam: Send + Sync,
+        A::AggregationParam: Send + Sync + Encode,
         A::AggregateShare: 'static + Send + Sync,
         A::OutputShare: PartialEq + Eq + Send + Sync,
     {
@@ -189,6 +189,7 @@ where
                         {
                             let task_id = *lease.leased().task_id();
                             let collection_identifier = Arc::clone(&collection_identifier);
+                            let aggregation_param = Arc::clone(&aggregation_param);
 
                             async move {
                                 if let Some(collection_interval) =
@@ -197,6 +198,7 @@ where
                                     tx.interval_has_unaggregated_reports(
                                         &task_id,
                                         collection_interval,
+                                        aggregation_param.as_ref(),
                                     )
                                     .await
                                 } else {

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -233,6 +233,36 @@ where
     }
 
     #[cfg(feature = "test-util")]
+    pub fn run_vdaf_and_generate(
+        vdaf: &A,
+        task_id: TaskId,
+        timestamp: Time,
+        helper_hpke_config: &janus_messages::HpkeConfig,
+        aggregation_param: &A::AggregationParam,
+        measurement: &A::Measurement,
+    ) -> Self
+    where
+        A: vdaf::Client<16>,
+    {
+        let report_id = rand::random();
+        let verify_key = rand::random();
+        let transcript = janus_core::test_util::run_vdaf(
+            vdaf,
+            &verify_key,
+            aggregation_param,
+            &report_id,
+            measurement,
+        );
+        Self::generate(
+            task_id,
+            ReportMetadata::new(report_id, timestamp),
+            helper_hpke_config,
+            Vec::new(),
+            &transcript,
+        )
+    }
+
+    #[cfg(feature = "test-util")]
     pub fn generate(
         task_id: TaskId,
         report_metadata: ReportMetadata,

--- a/integration_tests/tests/integration/janus.rs
+++ b/integration_tests/tests/integration/janus.rs
@@ -413,8 +413,8 @@ async fn janus_in_process_one_round_with_agg_param_fixed_size() {
             dummy::AggregationParam(10),
             // TODO(#225): Querying a single batch multiple times doesn't work yet, failing with
             // "invalid number of reports (0)"
-            // dummy::AggregationParam(11),
-            // dummy::AggregationParam(12),
+            dummy::AggregationParam(11),
+            dummy::AggregationParam(12),
         ],
         (janus_pair.leader.port(), janus_pair.helper.port()),
         &ClientBackend::InProcess,
@@ -438,10 +438,8 @@ async fn janus_in_process_one_round_with_agg_param_time_interval() {
         &janus_pair.task_parameters,
         &[
             dummy::AggregationParam(10),
-            // TODO(#225): Querying a single batch multiple times doesn't work yet, failing with
-            // "invalid number of reports (0)"
-            // dummy::AggregationParam(11),
-            // dummy::AggregationParam(12),
+            dummy::AggregationParam(11),
+            dummy::AggregationParam(12),
         ],
         (janus_pair.leader.port(), janus_pair.helper.port()),
         &ClientBackend::InProcess,


### PR DESCRIPTION
Re-enables the `janus_in_process_one_round_with_agg_param_time_interval` integration test, and makes fixes necessary to get it passing.

 - `Transaction::get_unaggregated_client_report_ids_by_collect_for_task` is renamed to `get_aggregatable_reports_for_time_interval_task` to reflect that it doesn't (yet?) work for fixed size tasks, and that while the reports it returns can be aggregated, they aren't necessarily unaggregated.
 - The query in that method is modernized to use `self.task_info_for` and to set `updated_at`, `updated_by` when reports are marked as having started aggregation.
 - Added some notes and TODOs throughout aggregation job management to indicate where we should or should not be scrubbing reports. Report scrubbing is a valuable optimization for Prio-style VDAFs without multi-collection, but we need to keep input shares, etc., indefinitely in order to collect reports multiple times.
 - `Transaction::interval_has_unaggregated_reports` now considers the aggregation parameter and not just the `aggregation_started` column on `client_reports`. See comments inline for discussion of the fast and slow paths.

Part of #225