### PR TITLE
Remove unused parameter from `Transaction` method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3811,7 +3811,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.22.3",
- "rustls-pemfile 2.1.1",
+ "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "serde",
  "serde_json",

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -592,7 +592,6 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                     // Find some unaggregated client reports.
                     let mut reports = tx
                         .get_unaggregated_client_reports_for_task(
-                            vdaf.as_ref(),
                             task.id(),
                             aggregation_job_creation_report_window,
                         )
@@ -899,7 +898,6 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                     // Find unaggregated client reports.
                     let unaggregated_reports = tx
                         .get_unaggregated_client_reports_for_task(
-                            vdaf.as_ref(),
                             task.id(),
                             aggregation_job_creation_report_window,
                         )
@@ -2113,11 +2111,10 @@ mod tests {
             .datastore
             .run_unnamed_tx(|tx| {
                 let task = Arc::clone(&task);
-                let vdaf = Arc::clone(&vdaf);
 
                 Box::pin(async move {
                     let report_ids = tx
-                        .get_unaggregated_client_reports_for_task(vdaf.as_ref(), task.id(), 5000)
+                        .get_unaggregated_client_reports_for_task(task.id(), 5000)
                         .await
                         .unwrap()
                         .into_iter()

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -1251,19 +1251,11 @@ impl<C: Clock> Transaction<'_, C> {
     /// VDAFs that do have a different aggregation parameter,
     /// `get_unaggregated_client_report_ids_by_collect_for_task` should be used instead.
     #[tracing::instrument(skip(self), err(level = Level::DEBUG))]
-    pub async fn get_unaggregated_client_reports_for_task<
-        const SEED_SIZE: usize,
-        A: vdaf::Aggregator<SEED_SIZE, 16>,
-    >(
+    pub async fn get_unaggregated_client_reports_for_task(
         &self,
-        vdaf: &A,
         task_id: &TaskId,
         limit: usize,
-    ) -> Result<Vec<ReportMetadata>, Error>
-    where
-        A::InputShare: PartialEq,
-        A::PublicShare: PartialEq,
-    {
+    ) -> Result<Vec<ReportMetadata>, Error> {
         let task_info = match self.task_info_for(task_id).await? {
             Some(task_info) => task_info,
             None => return Ok(Vec::new()),

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -725,10 +725,7 @@ async fn get_unaggregated_client_reports_for_task(ephemeral_datastore: Ephemeral
                     .unwrap());
 
                 Ok(tx
-                    .get_unaggregated_client_reports_for_task(
-                        task.id(),
-                        5000,
-                    )
+                    .get_unaggregated_client_reports_for_task(task.id(), 5000)
                     .await
                     .unwrap())
             })
@@ -757,10 +754,7 @@ async fn get_unaggregated_client_reports_for_task(ephemeral_datastore: Ephemeral
                     .unwrap());
 
                 Ok(tx
-                    .get_unaggregated_client_reports_for_task(
-                        task.id(),
-                        5000,
-                    )
+                    .get_unaggregated_client_reports_for_task(task.id(), 5000)
                     .await
                     .unwrap())
             })
@@ -793,10 +787,7 @@ async fn get_unaggregated_client_reports_for_task(ephemeral_datastore: Ephemeral
                     .unwrap());
 
                 Ok(tx
-                    .get_unaggregated_client_reports_for_task(
-                        task.id(),
-                        5000,
-                    )
+                    .get_unaggregated_client_reports_for_task(task.id(), 5000)
                     .await
                     .unwrap())
             })

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -726,7 +726,6 @@ async fn get_unaggregated_client_reports_for_task(ephemeral_datastore: Ephemeral
 
                 Ok(tx
                     .get_unaggregated_client_reports_for_task(
-                        &dummy::Vdaf::default(),
                         task.id(),
                         5000,
                     )
@@ -759,7 +758,6 @@ async fn get_unaggregated_client_reports_for_task(ephemeral_datastore: Ephemeral
 
                 Ok(tx
                     .get_unaggregated_client_reports_for_task(
-                        &dummy::Vdaf::default(),
                         task.id(),
                         5000,
                     )
@@ -796,7 +794,6 @@ async fn get_unaggregated_client_reports_for_task(ephemeral_datastore: Ephemeral
 
                 Ok(tx
                     .get_unaggregated_client_reports_for_task(
-                        &dummy::Vdaf::default(),
                         task.id(),
                         5000,
                     )


### PR DESCRIPTION
`Transaction::get_unaggregated_client_reports_for_task` took a `vdaf: &A` parameter that isn't actually used. Deleting that lets us remove some generics and trait bounds from the method, which probably emits less code. Curiously, this didn't trip any unused parameter warnings. I think this is because we put a `tracing::instrument` annotation on the method, which must generate code that uses that parameter.