### PR TITLE
Remove unused VDAF method parameters

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -972,7 +972,6 @@ mod tests {
         collections::{HashMap, HashSet},
         hash::Hash,
         iter,
-        ops::Deref,
         sync::Arc,
         time::Duration,
     };
@@ -1038,7 +1037,6 @@ mod tests {
         ds.run_unnamed_tx(|tx| {
             let leader_task = Arc::clone(&leader_task);
             let helper_task = Arc::clone(&helper_task);
-            let vdaf = Arc::clone(&vdaf);
             let leader_report = Arc::clone(&leader_report);
             let helper_report = Arc::clone(&helper_report);
 
@@ -1046,12 +1044,8 @@ mod tests {
                 tx.put_aggregator_task(&leader_task).await.unwrap();
                 tx.put_aggregator_task(&helper_task).await.unwrap();
 
-                tx.put_client_report(vdaf.as_ref(), &leader_report)
-                    .await
-                    .unwrap();
-                tx.put_client_report(&dummy::Vdaf::new(1), &helper_report)
-                    .await
-                    .unwrap();
+                tx.put_client_report(&leader_report).await.unwrap();
+                tx.put_client_report(&helper_report).await.unwrap();
                 Ok(())
             })
         })
@@ -1228,13 +1222,12 @@ mod tests {
 
         ds.run_unnamed_tx(|tx| {
             let task = Arc::clone(&task);
-            let vdaf = Arc::clone(&vdaf);
             let reports = Arc::clone(&reports);
 
             Box::pin(async move {
                 tx.put_aggregator_task(&task).await.unwrap();
                 for report in reports.iter() {
-                    tx.put_client_report(vdaf.as_ref(), report).await.unwrap();
+                    tx.put_client_report(report).await.unwrap();
                 }
                 Ok(())
             })
@@ -1416,14 +1409,11 @@ mod tests {
 
         ds.run_unnamed_tx(|tx| {
             let task = Arc::clone(&task);
-            let vdaf = Arc::clone(&vdaf);
             let first_report = Arc::clone(&first_report);
 
             Box::pin(async move {
                 tx.put_aggregator_task(&task).await.unwrap();
-                tx.put_client_report(vdaf.as_ref(), &first_report)
-                    .await
-                    .unwrap();
+                tx.put_client_report(&first_report).await.unwrap();
                 Ok(())
             })
         })
@@ -1487,13 +1477,10 @@ mod tests {
         job_creator
             .datastore
             .run_unnamed_tx(|tx| {
-                let vdaf = Arc::clone(&vdaf);
                 let second_report = Arc::clone(&second_report);
 
                 Box::pin(async move {
-                    tx.put_client_report(vdaf.as_ref(), &second_report)
-                        .await
-                        .unwrap();
+                    tx.put_client_report(&second_report).await.unwrap();
                     Ok(())
                 })
             })
@@ -1626,13 +1613,12 @@ mod tests {
 
         ds.run_unnamed_tx(|tx| {
             let task = Arc::clone(&task);
-            let vdaf = Arc::clone(&vdaf);
             let reports = Arc::clone(&reports);
 
             Box::pin(async move {
                 tx.put_aggregator_task(&task).await.unwrap();
                 for report in reports.iter() {
-                    tx.put_client_report(vdaf.as_ref(), report).await.unwrap();
+                    tx.put_client_report(report).await.unwrap();
                 }
                 tx.put_batch_aggregation(&BatchAggregation::<
                     VERIFY_KEY_LENGTH,
@@ -1814,13 +1800,12 @@ mod tests {
 
         ds.run_unnamed_tx(|tx| {
             let task = Arc::clone(&task);
-            let vdaf = Arc::clone(&vdaf);
             let reports = Arc::clone(&reports);
 
             Box::pin(async move {
                 tx.put_aggregator_task(&task).await.unwrap();
                 for report in reports.iter() {
-                    tx.put_client_report(vdaf.as_ref(), report).await.unwrap();
+                    tx.put_client_report(report).await.unwrap();
                 }
                 Ok(())
             })
@@ -2032,13 +2017,12 @@ mod tests {
 
         ds.run_unnamed_tx(|tx| {
             let task = Arc::clone(&task);
-            let vdaf = Arc::clone(&vdaf);
             let reports = Arc::clone(&reports);
 
             Box::pin(async move {
                 tx.put_aggregator_task(&task).await.unwrap();
                 for report in reports.iter() {
-                    tx.put_client_report(vdaf.as_ref(), report).await.unwrap();
+                    tx.put_client_report(report).await.unwrap();
                 }
                 Ok(())
             })
@@ -2202,13 +2186,12 @@ mod tests {
 
         ds.run_unnamed_tx(|tx| {
             let task = Arc::clone(&task);
-            let vdaf = Arc::clone(&vdaf);
             let reports = Arc::clone(&reports);
 
             Box::pin(async move {
                 tx.put_aggregator_task(&task).await.unwrap();
                 for report in reports.iter() {
-                    tx.put_client_report(vdaf.as_ref(), report).await.unwrap();
+                    tx.put_client_report(report).await.unwrap();
                 }
                 Ok(())
             })
@@ -2310,13 +2293,10 @@ mod tests {
         job_creator
             .datastore
             .run_unnamed_tx(|tx| {
-                let vdaf = Arc::clone(&vdaf);
                 let last_report = Arc::clone(&last_report);
 
                 Box::pin(async move {
-                    tx.put_client_report(vdaf.as_ref(), &last_report)
-                        .await
-                        .unwrap();
+                    tx.put_client_report(&last_report).await.unwrap();
                     Ok(())
                 })
             })
@@ -2470,13 +2450,12 @@ mod tests {
 
         ds.run_unnamed_tx(|tx| {
             let task = Arc::clone(&task);
-            let vdaf = Arc::clone(&vdaf);
             let reports = Arc::clone(&reports);
 
             Box::pin(async move {
                 tx.put_aggregator_task(&task).await.unwrap();
                 for report in reports.iter() {
-                    tx.put_client_report(vdaf.as_ref(), report).await.unwrap();
+                    tx.put_client_report(report).await.unwrap();
                 }
                 Ok(())
             })
@@ -2584,12 +2563,11 @@ mod tests {
         job_creator
             .datastore
             .run_unnamed_tx(|tx| {
-                let vdaf = Arc::clone(&vdaf);
                 let new_reports = Arc::clone(&new_reports);
 
                 Box::pin(async move {
                     for report in new_reports.iter() {
-                        tx.put_client_report(vdaf.as_ref(), report).await.unwrap();
+                        tx.put_client_report(report).await.unwrap();
                     }
                     Ok(())
                 })
@@ -2767,13 +2745,12 @@ mod tests {
 
         ds.run_unnamed_tx(|tx| {
             let task = Arc::clone(&task);
-            let vdaf = Arc::clone(&vdaf);
             let reports = Arc::clone(&reports);
 
             Box::pin(async move {
                 tx.put_aggregator_task(&task).await.unwrap();
                 for report in reports.iter() {
-                    tx.put_client_report(vdaf.as_ref(), report).await.unwrap();
+                    tx.put_client_report(report).await.unwrap();
                 }
                 Ok(())
             })
@@ -3060,13 +3037,12 @@ mod tests {
 
         ds.run_unnamed_tx(|tx| {
             let task = Arc::clone(&task);
-            let vdaf = Arc::clone(&vdaf);
             let reports = Arc::clone(&reports);
 
             Box::pin(async move {
                 tx.put_aggregator_task(&task).await.unwrap();
                 for report in reports.iter() {
-                    tx.put_client_report(vdaf.as_ref(), report).await.unwrap();
+                    tx.put_client_report(report).await.unwrap();
                 }
                 Ok(())
             })
@@ -3261,8 +3237,7 @@ mod tests {
         }
 
         ds.run_unnamed_tx(|tx| {
-            let (vdaf, task, batch_1_reports, batch_2_reports) = (
-                Arc::clone(&vdaf),
+            let (task, batch_1_reports, batch_2_reports) = (
                 Arc::clone(&task),
                 batch_1_reports.clone(),
                 batch_2_reports.clone(),
@@ -3270,10 +3245,10 @@ mod tests {
             Box::pin(async move {
                 tx.put_aggregator_task(&task).await.unwrap();
                 for report in batch_1_reports {
-                    tx.put_client_report(vdaf.deref(), &report).await.unwrap();
+                    tx.put_client_report(&report).await.unwrap();
                 }
                 for report in batch_2_reports {
-                    tx.put_client_report(vdaf.deref(), &report).await.unwrap();
+                    tx.put_client_report(&report).await.unwrap();
                 }
                 Ok(())
             })

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -1107,7 +1107,7 @@ mod tests {
         },
     };
     use rand::random;
-    use std::{borrow::Borrow, sync::Arc, time::Duration as StdDuration};
+    use std::{sync::Arc, time::Duration as StdDuration};
     use trillium_tokio::Stopper;
 
     #[tokio::test]
@@ -1165,15 +1165,14 @@ mod tests {
         let aggregation_job_id = random();
 
         ds.run_unnamed_tx(|tx| {
-            let (vdaf, task, report, aggregation_param) = (
-                vdaf.clone(),
+            let (task, report, aggregation_param) = (
                 leader_task.clone(),
                 report.clone(),
                 aggregation_param.clone(),
             );
             Box::pin(async move {
                 tx.put_aggregator_task(&task).await.unwrap();
-                tx.put_client_report(vdaf.borrow(), &report).await.unwrap();
+                tx.put_client_report(&report).await.unwrap();
                 tx.scrub_client_report(report.task_id(), report.metadata().id())
                     .await
                     .unwrap();
@@ -1455,15 +1454,14 @@ mod tests {
 
         let lease = ds
             .run_unnamed_tx(|tx| {
-                let vdaf = Arc::clone(&vdaf);
                 let task = leader_task.clone();
                 let report = report.clone();
                 let repeated_extension_report = repeated_extension_report.clone();
 
                 Box::pin(async move {
                     tx.put_aggregator_task(&task).await.unwrap();
-                    tx.put_client_report(vdaf.borrow(), &report).await.unwrap();
-                    tx.put_client_report(vdaf.borrow(), &repeated_extension_report)
+                    tx.put_client_report(&report).await.unwrap();
+                    tx.put_client_report(&repeated_extension_report)
                         .await
                         .unwrap();
                     tx.scrub_client_report(report.task_id(), report.metadata().id())
@@ -1777,15 +1775,14 @@ mod tests {
 
         let lease = ds
             .run_unnamed_tx(|tx| {
-                let (vdaf, task, report, aggregation_param) = (
-                    vdaf.clone(),
+                let (task, report, aggregation_param) = (
                     leader_task.clone(),
                     report.clone(),
                     aggregation_param.clone(),
                 );
                 Box::pin(async move {
                     tx.put_aggregator_task(&task).await.unwrap();
-                    tx.put_client_report(vdaf.borrow(), &report).await.unwrap();
+                    tx.put_client_report(&report).await.unwrap();
                     tx.scrub_client_report(report.task_id(), report.metadata().id())
                         .await
                         .unwrap();
@@ -2066,19 +2063,14 @@ mod tests {
 
         let lease = ds
             .run_unnamed_tx(|tx| {
-                let vdaf = Arc::clone(&vdaf);
                 let leader_task = leader_task.clone();
                 let gc_eligible_report = gc_eligible_report.clone();
                 let gc_ineligible_report = gc_ineligible_report.clone();
 
                 Box::pin(async move {
                     tx.put_aggregator_task(&leader_task).await.unwrap();
-                    tx.put_client_report(vdaf.borrow(), &gc_eligible_report)
-                        .await
-                        .unwrap();
-                    tx.put_client_report(vdaf.borrow(), &gc_ineligible_report)
-                        .await
-                        .unwrap();
+                    tx.put_client_report(&gc_eligible_report).await.unwrap();
+                    tx.put_client_report(&gc_ineligible_report).await.unwrap();
                     tx.scrub_client_report(
                         gc_eligible_report.task_id(),
                         gc_eligible_report.metadata().id(),
@@ -2409,10 +2401,10 @@ mod tests {
 
         let lease = ds
             .run_unnamed_tx(|tx| {
-                let (vdaf, task, report) = (vdaf.clone(), leader_task.clone(), report.clone());
+                let (task, report) = (leader_task.clone(), report.clone());
                 Box::pin(async move {
                     tx.put_aggregator_task(&task).await.unwrap();
-                    tx.put_client_report(vdaf.borrow(), &report).await.unwrap();
+                    tx.put_client_report(&report).await.unwrap();
                     tx.scrub_client_report(report.task_id(), report.metadata().id())
                         .await
                         .unwrap();
@@ -2687,15 +2679,14 @@ mod tests {
 
         let lease = ds
             .run_unnamed_tx(|tx| {
-                let (vdaf, task, report, aggregation_param) = (
-                    vdaf.clone(),
+                let (task, report, aggregation_param) = (
                     leader_task.clone(),
                     report.clone(),
                     aggregation_param.clone(),
                 );
                 Box::pin(async move {
                     tx.put_aggregator_task(&task).await.unwrap();
-                    tx.put_client_report(vdaf.borrow(), &report).await.unwrap();
+                    tx.put_client_report(&report).await.unwrap();
                     tx.scrub_client_report(report.task_id(), report.metadata().id())
                         .await
                         .unwrap();
@@ -2953,8 +2944,7 @@ mod tests {
 
         let lease = ds
             .run_unnamed_tx(|tx| {
-                let (vdaf, task, aggregation_param, report, transcript) = (
-                    vdaf.clone(),
+                let (task, aggregation_param, report, transcript) = (
                     leader_task.clone(),
                     aggregation_param.clone(),
                     report.clone(),
@@ -2962,7 +2952,7 @@ mod tests {
                 );
                 Box::pin(async move {
                     tx.put_aggregator_task(&task).await.unwrap();
-                    tx.put_client_report(vdaf.borrow(), &report).await.unwrap();
+                    tx.put_client_report(&report).await.unwrap();
                     tx.scrub_client_report(report.task_id(), report.metadata().id())
                         .await
                         .unwrap();
@@ -3306,8 +3296,7 @@ mod tests {
 
         let lease = ds
             .run_unnamed_tx(|tx| {
-                let (vdaf, task, report, aggregation_param, transcript) = (
-                    vdaf.clone(),
+                let (task, report, aggregation_param, transcript) = (
                     leader_task.clone(),
                     report.clone(),
                     aggregation_param.clone(),
@@ -3315,7 +3304,7 @@ mod tests {
                 );
                 Box::pin(async move {
                     tx.put_aggregator_task(&task).await.unwrap();
-                    tx.put_client_report(vdaf.borrow(), &report).await.unwrap();
+                    tx.put_client_report(&report).await.unwrap();
                     tx.scrub_client_report(report.task_id(), report.metadata().id())
                         .await
                         .unwrap();
@@ -3609,8 +3598,7 @@ mod tests {
 
         let lease = datastore
             .run_unnamed_tx(|tx| {
-                let (vdaf, task, report, aggregation_job, report_aggregation) = (
-                    vdaf.clone(),
+                let (task, report, aggregation_job, report_aggregation) = (
                     task.clone(),
                     report.clone(),
                     aggregation_job.clone(),
@@ -3618,7 +3606,7 @@ mod tests {
                 );
                 Box::pin(async move {
                     tx.put_aggregator_task(&task).await.unwrap();
-                    tx.put_client_report(vdaf.borrow(), &report).await.unwrap();
+                    tx.put_client_report(&report).await.unwrap();
                     tx.scrub_client_report(report.task_id(), report.metadata().id())
                         .await
                         .unwrap();
@@ -3862,13 +3850,12 @@ mod tests {
 
         // Set up fixtures in the database.
         ds.run_unnamed_tx(|tx| {
-            let vdaf = vdaf.clone();
             let task = leader_task.clone();
             let report = report.clone();
             Box::pin(async move {
                 tx.put_aggregator_task(&task).await.unwrap();
 
-                tx.put_client_report(&vdaf, &report).await.unwrap();
+                tx.put_client_report(&report).await.unwrap();
                 tx.scrub_client_report(report.task_id(), report.metadata().id())
                     .await
                     .unwrap();
@@ -4107,13 +4094,12 @@ mod tests {
 
         // Set up fixtures in the database.
         ds.run_unnamed_tx(|tx| {
-            let vdaf = vdaf.clone();
             let task = leader_task.clone();
             let report = report.clone();
             Box::pin(async move {
                 tx.put_aggregator_task(&task).await.unwrap();
 
-                tx.put_client_report(&vdaf, &report).await.unwrap();
+                tx.put_client_report(&report).await.unwrap();
                 tx.scrub_client_report(report.task_id(), report.metadata().id())
                     .await
                     .unwrap();

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -207,11 +207,14 @@ where
                                 }
                             }
                         },
-                        Q::get_batch_aggregation_job_count_for_collection_identifier(
+                        Q::get_batch_aggregation_job_count_for_collection_identifier::<
+                            SEED_SIZE,
+                            A,
+                            C,
+                        >(
                             tx,
                             lease.leased().task_id(),
                             lease.leased().time_precision(),
-                            vdaf.as_ref(),
                             &collection_identifier,
                             &aggregation_param,
                         ),
@@ -886,9 +889,7 @@ mod tests {
 
                     let report = LeaderStoredReport::new_dummy(*task.id(), report_timestamp);
 
-                    tx.put_client_report(&dummy::Vdaf::new(1), &report)
-                        .await
-                        .unwrap();
+                    tx.put_client_report(&report).await.unwrap();
                     tx.mark_report_aggregated(task.id(), report.metadata().id())
                         .await
                         .unwrap();
@@ -1029,9 +1030,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                    tx.put_client_report(&dummy::Vdaf::default(), &report)
-                        .await
-                        .unwrap();
+                    tx.put_client_report(&report).await.unwrap();
 
                     tx.put_report_aggregation(&ReportAggregation::<0, dummy::Vdaf>::new(
                         *task.id(),

--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -201,9 +201,7 @@ async fn setup_fixed_size_current_batch_collection_job_test_case(
 
                     for ord in 0..task.min_batch_size() + 1 {
                         let report = LeaderStoredReport::new_dummy(*task.id(), time);
-                        tx.put_client_report(&dummy::Vdaf::new(1), &report)
-                            .await
-                            .unwrap();
+                        tx.put_client_report(&report).await.unwrap();
 
                         tx.put_report_aggregation::<0, dummy::Vdaf>(&ReportAggregation::new(
                             *task.id(),

--- a/aggregator/src/aggregator/garbage_collector.rs
+++ b/aggregator/src/aggregator/garbage_collector.rs
@@ -214,7 +214,7 @@ mod tests {
         // Setup.
         let task = ds
             .run_unnamed_tx(|tx| {
-                let (clock, vdaf) = (clock.clone(), vdaf.clone());
+                let clock = clock.clone();
                 Box::pin(async move {
                     let task = TaskBuilder::new(
                         task::QueryType::TimeInterval,
@@ -229,7 +229,7 @@ mod tests {
                     // Client report artifacts.
                     let client_timestamp = clock.now().sub(&Duration::from_seconds(2)).unwrap();
                     let report = LeaderStoredReport::new_dummy(*task.id(), client_timestamp);
-                    tx.put_client_report(&vdaf, &report).await.unwrap();
+                    tx.put_client_report(&report).await.unwrap();
 
                     // Aggregation artifacts.
                     let aggregation_job_id = random();
@@ -537,7 +537,7 @@ mod tests {
         // Setup.
         let task = ds
             .run_unnamed_tx(|tx| {
-                let (clock, vdaf) = (clock.clone(), vdaf.clone());
+                let clock = clock.clone();
                 Box::pin(async move {
                     let task = TaskBuilder::new(
                         task::QueryType::FixedSize {
@@ -560,7 +560,7 @@ mod tests {
                         .sub(&Duration::from_seconds(2))
                         .unwrap();
                     let report = LeaderStoredReport::new_dummy(*task.id(), client_timestamp);
-                    tx.put_client_report(&vdaf, &report).await.unwrap();
+                    tx.put_client_report(&report).await.unwrap();
 
                     // Aggregation artifacts.
                     let batch_id = random();

--- a/aggregator/src/aggregator/report_writer.rs
+++ b/aggregator/src/aggregator/report_writer.rs
@@ -296,9 +296,7 @@ where
         // report at this stage.
         match Q::validate_uploaded_report(tx, self.vdaf.as_ref(), &self.report).await {
             Ok(_) => {
-                let result = tx
-                    .put_client_report::<SEED_SIZE, A>(&self.vdaf, &self.report)
-                    .await;
+                let result = tx.put_client_report::<SEED_SIZE, A>(&self.report).await;
                 match result {
                     Ok(_) => {
                         task_upload_counter.increment_report_success(self.report.task_id());

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -1589,7 +1589,6 @@ impl<C: Clock> Transaction<'_, C> {
     #[tracing::instrument(skip(self), err(level = Level::DEBUG))]
     pub async fn put_client_report<const SEED_SIZE: usize, A>(
         &self,
-        vdaf: &A,
         report: &LeaderStoredReport<SEED_SIZE, A>,
     ) -> Result<(), Error>
     where
@@ -3701,7 +3700,6 @@ impl<C: Clock> Transaction<'_, C> {
         A: vdaf::Aggregator<SEED_SIZE, 16>,
     >(
         &self,
-        vdaf: &A,
         task_id: &TaskId,
         batch_identifier: &Q::BatchIdentifier,
         aggregation_parameter: &A::AggregationParam,

--- a/aggregator_core/src/query_type.rs
+++ b/aggregator_core/src/query_type.rs
@@ -262,7 +262,6 @@ pub trait CollectableQueryType: AccumulableQueryType {
         tx: &Transaction<C>,
         task_id: &TaskId,
         time_precision: &Duration,
-        vdaf: &A,
         collection_identifier: &Self::BatchIdentifier,
         aggregation_param: &A::AggregationParam,
     ) -> Result<(u64, u64), datastore::Error>
@@ -281,7 +280,6 @@ pub trait CollectableQueryType: AccumulableQueryType {
 
                 async move {
                     tx.get_batch_aggregation_job_count_for_batch::<SEED_SIZE, Self, A>(
-                        vdaf,
                         &task_id,
                         &batch_identifier,
                         &aggregation_param,


### PR DESCRIPTION
This is a follow-up to #3004 that removes a couple more unused VDAF parameters. I found these by patching in a local modified copy of `tracing`, with an `instrument` attribute macro that just returned the provided item as-is.