### PR TITLE
Add ":latest" tag fallback in Daphne module

### DIFF
--- a/integration_tests/src/daphne.rs
+++ b/integration_tests/src/daphne.rs
@@ -38,7 +38,9 @@ impl<'a> Daphne<'a> {
             ),
             Role::Collector | Role::Client => unreachable!(),
         };
-        let (image_name, image_tag) = image_name_and_tag.rsplit_once(':').unwrap();
+        let (image_name, image_tag) = image_name_and_tag
+            .rsplit_once(':')
+            .unwrap_or((image_name_and_tag, "latest"));
 
         // Start the Daphne test container running.
         let (port, daphne_container) = if start_container {


### PR DESCRIPTION
This adds a fallback to use the `latest` tag when a container image is specified without a tag in the Daphne integration test module. The two other places where we parse image names already do the same thing.