### PR TITLE
Add integration test for time-bucketed fixed size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,13 +1226,13 @@ dependencies = [
 
 [[package]]
 name = "divviup-client"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61f3b8ea9d2af56a3e7821f5eb07930688c97be58c431e4a6920d27b3893530"
+checksum = "ecacbabd66def525c90cb0e9c0d6665d59c10ff22d87bf3f3d58d17329e4986c"
 dependencies = [
  "base64 0.22.0",
  "email_address",
- "janus_messages 0.7.2",
+ "janus_messages 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "pad-adapter",
  "serde",
@@ -2649,24 +2649,6 @@ dependencies = [
 
 [[package]]
 name = "janus_messages"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "425b77ad31e0614c16041aa44c4014ebd4c67544d01135cece4f51c33b4adef2"
-dependencies = [
- "anyhow",
- "base64 0.22.0",
- "derivative",
- "hex",
- "num_enum",
- "prio",
- "rand",
- "serde",
- "thiserror",
- "url",
-]
-
-[[package]]
-name = "janus_messages"
 version = "0.7.5"
 dependencies = [
  "anyhow",
@@ -2679,6 +2661,24 @@ dependencies = [
  "rand",
  "serde",
  "serde_test",
+ "thiserror",
+ "url",
+]
+
+[[package]]
+name = "janus_messages"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd629c85e8ff09303b2bfccb15e7ae07adb716a998d9124b312f988afbd8b5b5"
+dependencies = [
+ "anyhow",
+ "base64 0.22.0",
+ "derivative",
+ "hex",
+ "num_enum",
+ "prio",
+ "rand",
+ "serde",
  "thiserror",
  "url",
 ]
@@ -5049,9 +5049,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -5070,9 +5070,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",


### PR DESCRIPTION
Supports https://github.com/divviup/divviup-api/issues/291.

Also updates divviup-client to 0.2.1 to get client support.

This is more or less a smoke test, since the actual time bucketing is not really exercised. I will leave that for a continuous load test. 