### PR TITLE
Task aggregator cache: remove redundant reads on concurrent requests.

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -720,6 +720,8 @@ impl<C: Clock> Aggregator<C> {
         //
         // TODO(#238): once cache eviction is implemented, we can likely remove this step. We only
         // need to do this to avoid trivial DoS via a requestor spraying many nonexistent task IDs.
+        // However, we need to consider the taskprov case, where an aggregator can add a task and
+        // expect it to be immediately visible.
         if task_aggregator.is_none() {
             // Unwrap safety: mutex poisoning.
             let mut task_aggs = self.task_aggregators.lock().unwrap();


### PR DESCRIPTION
Previously, if multiple requestors concurrently retrieved the same task from the task aggregator cache, we would query the DB for the task for each requestor.

Now, we use an additional layer of per-task locking so that, in the concurrent-requestor scenario, one requestor will read the task from the DB, and the remaining requestors will wait on that requestor's value.