### PR TITLE
Task cache invalidation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
 dependencies = [
  "concurrent-queue",
- "event-listener 5.2.0",
+ "event-listener 5.3.0",
  "event-listener-strategy 0.5.0",
  "futures-core",
  "pin-project-lite",
@@ -1371,9 +1371,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5fb89194fa3cad959b833185b3063ba881dbfc7030680b314250779fb4cc91"
+checksum = "6d9944b8ca13534cdfb2800775f8dd4902ff3fc75a50101466decadfdf322a24"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1396,7 +1396,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291"
 dependencies = [
- "event-listener 5.2.0",
+ "event-listener 5.3.0",
  "pin-project-lite",
 ]
 
@@ -2330,6 +2330,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "mockito",
+ "moka",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-prometheus",
@@ -3025,6 +3026,30 @@ dependencies = [
  "serde_urlencoded",
  "similar",
  "tokio",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e0d88686dc561d743b40de8269b26eaf0dc58781bde087b0984646602021d08"
+dependencies = [
+ "async-lock 3.3.0",
+ "async-trait",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "event-listener 5.3.0",
+ "futures-util",
+ "once_cell",
+ "parking_lot",
+ "quanta",
+ "rustc_version",
+ "smallvec",
+ "tagptr",
+ "thiserror",
+ "triomphe",
+ "uuid",
 ]
 
 [[package]]
@@ -3781,6 +3806,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
+name = "quanta"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "querystring"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3835,6 +3875,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d86a7c4638d42c44551f4791a20e687dbb4c3de1f33c43dd71e355cd429def1"
+dependencies = [
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -4914,7 +4963,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66c82d03d16a1e591756e978782ce4bc4300f83048b57d44c5600dafa7337019"
 dependencies = [
- "event-listener 5.2.0",
+ "event-listener 5.3.0",
  "futures-lite 2.3.0",
  "pin-project-lite",
 ]
@@ -4981,6 +5030,12 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tap"
@@ -5738,6 +5793,12 @@ dependencies = [
  "trillium-macros 0.0.5",
  "trillium-server-common",
 ]
+
+[[package]]
+name = "triomphe"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859eb650cfee7434994602c3a68b25d77ad9e68c8a6cd491616ef86661382eb3"
 
 [[package]]
 name = "try-lock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,6 @@ janus_aggregator_core = { version = "0.7.5", path = "aggregator_core" }
 janus_client = { version = "0.7.5", path = "client" }
 janus_collector = { version = "0.7.5", path = "collector" }
 janus_core = { version = "0.7.5", path = "core" }
-janus_integration_tests = { version = "0.7.5", path = "integration_tests" }
 janus_interop_binaries = { version = "0.7.5", path = "interop_binaries" }
 janus_messages = { version = "0.7.5", path = "messages" }
 k8s-openapi = { version = "0.21.0", features = ["v1_26"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -64,6 +64,7 @@ janus_core.workspace = true
 janus_messages.workspace = true
 k8s-openapi.workspace = true
 kube.workspace = true
+moka = { version = "0.12.7", features = ["future"] }
 opentelemetry.workspace = true
 opentelemetry-otlp = { workspace = true, features = ["metrics"], optional = true }
 opentelemetry-prometheus = { workspace = true, optional = true }

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -242,7 +242,10 @@ impl<C: Clock> Aggregator<C> {
                 cfg.max_upload_batch_size,
                 cfg.max_upload_batch_write_delay,
             ),
-            cfg.taskprov_config.enabled,
+            // If we're in taskprov mode, we can never cache None entries for tasks, since aggregators
+            // could insert tasks at any time and expect them to be available across all aggregator
+            // replicas.
+            !cfg.taskprov_config.enabled,
             cfg.task_cache_ttl,
         );
 

--- a/aggregator/src/aggregator/report_writer.rs
+++ b/aggregator/src/aggregator/report_writer.rs
@@ -36,6 +36,7 @@ type ResultSender = oneshot::Sender<Result<(), Arc<Error>>>;
 type ReportWriteBatcherSender<C> = mpsc::Sender<(ReportResult<C>, Option<ResultSender>)>;
 type ReportWriteBatcherReceiver<C> = mpsc::Receiver<(ReportResult<C>, Option<ResultSender>)>;
 
+#[derive(Debug)]
 pub struct ReportWriteBatcher<C> {
     report_tx: ReportWriteBatcherSender<C>,
 }

--- a/aggregator/src/cache.rs
+++ b/aggregator/src/cache.rs
@@ -256,6 +256,7 @@ impl<C: Clock> TaskAggregatorCache<C> {
         // task.
         let task_aggregator = {
             let mut entry = entry.lock().await;
+
             if entry.is_none() {
                 *entry = Some(
                     self.datastore
@@ -269,13 +270,14 @@ impl<C: Clock> TaskAggregatorCache<C> {
                         .map(Arc::new),
                 );
             }
-            // Unwrap safety: we've ensured that the entry is initialized in the previous if statement.
-            entry.as_ref().unwrap().clone()
-        };
 
-        if !self.cache_none && task_aggregator.is_none() {
-            self.cache.invalidate(task_id).await;
-        }
+            // Unwrap safety: we've ensured that the entry is initialized in the previous if statement.
+            let task_aggregator = entry.as_ref().unwrap();
+            if !self.cache_none && task_aggregator.is_none() {
+                self.cache.invalidate(task_id).await;
+            }
+            task_aggregator.clone()
+        };
 
         Ok(task_aggregator)
     }

--- a/aggregator/src/cache.rs
+++ b/aggregator/src/cache.rs
@@ -377,7 +377,7 @@ mod tests {
         let ephemeral_datastore = ephemeral_datastore().await;
         let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
 
-        let ttl = Duration::from_secs(1);
+        let ttl = Duration::from_millis(500);
         let task_aggregators = TaskAggregatorCache::new(
             Arc::clone(&datastore),
             ReportWriteBatcher::new(
@@ -407,7 +407,7 @@ mod tests {
 
         // Unfortunately, because moka doesn't provide any facility for a fake clock, we have to resort
         // to sleeps to test TTL functionality.
-        sleep(Duration::from_secs(2)).await;
+        sleep(Duration::from_secs(1)).await;
 
         // Now we should see it.
         let task_aggregator = task_aggregators.get(task.id()).await.unwrap().unwrap();
@@ -435,7 +435,7 @@ mod tests {
             task.task_expiration()
         );
 
-        sleep(Duration::from_secs(2)).await;
+        sleep(Duration::from_secs(1)).await;
 
         let task_aggregator = task_aggregators.get(task.id()).await.unwrap().unwrap();
         assert_eq!(

--- a/aggregator/tests/integration/graceful_shutdown.rs
+++ b/aggregator/tests/integration/graceful_shutdown.rs
@@ -284,6 +284,7 @@ async fn aggregator_shutdown() {
         batch_aggregation_shard_count: 32,
         task_counter_shard_count: 64,
         global_hpke_configs_refresh_interval: None,
+        task_cache_ttl_seconds: None,
     };
 
     graceful_shutdown("aggregator", config).await;

--- a/aggregator/tests/integration/graceful_shutdown.rs
+++ b/aggregator/tests/integration/graceful_shutdown.rs
@@ -285,6 +285,7 @@ async fn aggregator_shutdown() {
         task_counter_shard_count: 64,
         global_hpke_configs_refresh_interval: None,
         task_cache_ttl_seconds: None,
+        task_cache_capacity: None,
     };
 
     graceful_shutdown("aggregator", config).await;

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -5409,7 +5409,9 @@ impl<C: Clock> Transaction<'_, C> {
         )
     }
 
-    /// Helper function to look up (cached) information about a given task.
+    /// Helper function to look up (cached) information about a given task. The cache is retained
+    /// indefinitely. It is assumed that the parameters stored in a [`TaskInfo`] are never changed
+    /// so this should be fine.
     async fn task_info_for(&self, task_id: &TaskId) -> Result<Option<TaskInfo>, Error> {
         // We fetch the task's primary key & task-level information in a separate query. This will
         // allow the query planner to make more accurate row count estimates, by comparing concrete

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -82,8 +82,9 @@ impl TryFrom<&taskprov::Query> for QueryType {
 
 /// A verification key for a VDAF, with a fixed length. It must be kept secret from clients to
 /// maintain robustness, and it must be shared between aggregators.
-#[derive(Debug, Clone, Copy)]
-pub struct VerifyKey<const SEED_SIZE: usize>([u8; SEED_SIZE]);
+#[derive(Derivative, Clone, Copy)]
+#[derivative(Debug)]
+pub struct VerifyKey<const SEED_SIZE: usize>(#[derivative(Debug = "ignore")] [u8; SEED_SIZE]);
 
 impl<const SEED_SIZE: usize> VerifyKey<SEED_SIZE> {
     pub fn new(array: [u8; SEED_SIZE]) -> VerifyKey<SEED_SIZE> {

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -82,7 +82,7 @@ impl TryFrom<&taskprov::Query> for QueryType {
 
 /// A verification key for a VDAF, with a fixed length. It must be kept secret from clients to
 /// maintain robustness, and it must be shared between aggregators.
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct VerifyKey<const SEED_SIZE: usize>([u8; SEED_SIZE]);
 
 impl<const SEED_SIZE: usize> VerifyKey<SEED_SIZE> {

--- a/core/src/time.rs
+++ b/core/src/time.rs
@@ -193,9 +193,6 @@ pub trait TimeExt: Sized {
     /// Add the provided duration to this time.
     fn add(&self, duration: &Duration) -> Result<Self, Error>;
 
-    /// Add the provided duration to this time, saturating at the upper bound of u64.
-    fn saturating_add(&self, duration: &Duration) -> Self;
-
     /// Subtract the provided duration from this time.
     fn sub(&self, duration: &Duration) -> Result<Self, Error>;
 
@@ -248,13 +245,6 @@ impl TimeExt for Time {
             .checked_add(duration.as_seconds())
             .map(Self::from_seconds_since_epoch)
             .ok_or(Error::IllegalTimeArithmetic("operation would overflow"))
-    }
-
-    fn saturating_add(&self, duration: &Duration) -> Self {
-        Self::from_seconds_since_epoch(
-            self.as_seconds_since_epoch()
-                .saturating_add(duration.as_seconds()),
-        )
     }
 
     fn sub(&self, duration: &Duration) -> Result<Self, Error> {

--- a/core/src/time.rs
+++ b/core/src/time.rs
@@ -193,6 +193,9 @@ pub trait TimeExt: Sized {
     /// Add the provided duration to this time.
     fn add(&self, duration: &Duration) -> Result<Self, Error>;
 
+    /// Add the provided duration to this time, saturating at the upper bound of u64.
+    fn saturating_add(&self, duration: &Duration) -> Self;
+
     /// Subtract the provided duration from this time.
     fn sub(&self, duration: &Duration) -> Result<Self, Error>;
 
@@ -245,6 +248,13 @@ impl TimeExt for Time {
             .checked_add(duration.as_seconds())
             .map(Self::from_seconds_since_epoch)
             .ok_or(Error::IllegalTimeArithmetic("operation would overflow"))
+    }
+
+    fn saturating_add(&self, duration: &Duration) -> Self {
+        Self::from_seconds_since_epoch(
+            self.as_seconds_since_epoch()
+                .saturating_add(duration.as_seconds()),
+        )
     }
 
     fn sub(&self, duration: &Duration) -> Result<Self, Error> {

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -165,6 +165,7 @@ impl JanusInProcess {
             batch_aggregation_shard_count: 32,
             task_counter_shard_count: 64,
             global_hpke_configs_refresh_interval: None,
+            task_cache_ttl_seconds: None,
         };
         let aggregation_job_creator_options = AggregationJobCreatorOptions {
             common: common_binary_options.clone(),

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -166,6 +166,7 @@ impl JanusInProcess {
             task_counter_shard_count: 64,
             global_hpke_configs_refresh_interval: None,
             task_cache_ttl_seconds: None,
+            task_cache_capacity: None,
         };
         let aggregation_job_creator_options = AggregationJobCreatorOptions {
             common: common_binary_options.clone(),


### PR DESCRIPTION
Supports https://github.com/divviup/divviup-api/issues/862. Closes https://github.com/divviup/janus/issues/238.

This attaches a lifetime to entries in a TaskAggregatorCache, and uses that lifetime to evaluate whether to use the entry or not. I've also added an optimization for the non-taskprov use-case where we are allowed to cache None results for some time. Please review this code and its tests carefully, since it's somewhat complex.