### PR TITLE
Add Tokio runtime metrics

### DIFF
--- a/aggregator/src/main.rs
+++ b/aggregator/src/main.rs
@@ -48,37 +48,33 @@ enum Nested {
     JanusCli(janus_cli::CommandLineOptions),
 }
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
     let clock = RealClock::default();
     match Options::parse() {
         Options::Aggregator(options) | Options::Default(Nested::Aggregator(options)) => {
-            janus_main(options, clock, true, aggregator::main_callback).await
+            janus_main(options, clock, true, aggregator::main_callback)
         }
         Options::GarbageCollector(options)
         | Options::Default(Nested::GarbageCollector(options)) => {
-            janus_main(options, clock, false, garbage_collector::main_callback).await
+            janus_main(options, clock, false, garbage_collector::main_callback)
         }
         Options::AggregationJobCreator(options)
-        | Options::Default(Nested::AggregationJobCreator(options)) => {
-            janus_main(
-                options,
-                clock,
-                false,
-                aggregation_job_creator::main_callback,
-            )
-            .await
-        }
+        | Options::Default(Nested::AggregationJobCreator(options)) => janus_main(
+            options,
+            clock,
+            false,
+            aggregation_job_creator::main_callback,
+        ),
         Options::AggregationJobDriver(options)
         | Options::Default(Nested::AggregationJobDriver(options)) => {
-            janus_main(options, clock, true, aggregation_job_driver::main_callback).await
+            janus_main(options, clock, true, aggregation_job_driver::main_callback)
         }
         Options::CollectionJobDriver(options)
         | Options::Default(Nested::CollectionJobDriver(options)) => {
-            janus_main(options, clock, false, collection_job_driver::main_callback).await
+            janus_main(options, clock, false, collection_job_driver::main_callback)
         }
         Options::JanusCli(options) | Options::Default(Nested::JanusCli(options)) => {
-            janus_cli::run(options).await
+            janus_cli::run(options)
         }
     }
 }

--- a/aggregator/src/metrics.rs
+++ b/aggregator/src/metrics.rs
@@ -48,7 +48,7 @@ use {
 };
 
 #[cfg(tokio_unstable)]
-mod tokio_runtime;
+pub(crate) mod tokio_runtime;
 
 #[cfg(all(test, feature = "prometheus"))]
 mod tests;
@@ -127,7 +127,7 @@ pub struct TokioMetricsConfiguration {
 }
 
 /// Selects whether to use a linear scale or a logarithmic scale for a histogram.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum HistogramScale {
     /// Linear histogram scale. Each bucket will cover a range of the same width.

--- a/aggregator/src/metrics/tests.rs
+++ b/aggregator/src/metrics/tests.rs
@@ -20,7 +20,8 @@ use trillium_testing::prelude::get;
 #[tokio::test]
 async fn prometheus_metrics_pull() {
     let registry = Registry::new();
-    let meter_provider = build_opentelemetry_prometheus_meter_provider(registry.clone()).unwrap();
+    let meter_provider =
+        build_opentelemetry_prometheus_meter_provider(registry.clone(), None).unwrap();
     let (join_handle, port) = prometheus_metrics_server(registry, Ipv4Addr::LOCALHOST.into(), 0)
         .await
         .unwrap();
@@ -75,7 +76,8 @@ async fn http_metrics() {
     install_test_trace_subscriber();
 
     let registry = Registry::new();
-    let meter_provider = build_opentelemetry_prometheus_meter_provider(registry.clone()).unwrap();
+    let meter_provider =
+        build_opentelemetry_prometheus_meter_provider(registry.clone(), None).unwrap();
     let meter = meter_provider.meter("tests");
 
     let clock = MockClock::default();

--- a/aggregator/src/metrics/tokio_runtime.rs
+++ b/aggregator/src/metrics/tokio_runtime.rs
@@ -1,12 +1,31 @@
-use tokio::runtime::HistogramScale;
+use std::time::Duration;
 
-use crate::metrics::HistogramScale as ConfigHistogramScale;
+use tokio::runtime::{self, HistogramScale};
+
+use crate::metrics::{HistogramScale as ConfigHistogramScale, TokioMetricsConfiguration};
 
 impl From<ConfigHistogramScale> for HistogramScale {
     fn from(value: ConfigHistogramScale) -> Self {
         match value {
             ConfigHistogramScale::Linear => HistogramScale::Linear,
             ConfigHistogramScale::Log => HistogramScale::Log,
+        }
+    }
+}
+
+pub(crate) fn configure_runtime(
+    runtime_builder: &mut runtime::Builder,
+    config: &TokioMetricsConfiguration,
+) {
+    if config.enable_poll_time_histogram {
+        runtime_builder.enable_metrics_poll_count_histogram();
+        runtime_builder.metrics_poll_count_histogram_scale(config.poll_time_histogram_scale.into());
+        if let Some(resolution) = config.poll_time_histogram_resolution_microseconds {
+            let resolution = Duration::from_micros(resolution);
+            runtime_builder.metrics_poll_count_histogram_resolution(resolution);
+        }
+        if let Some(buckets) = config.poll_time_histogram_buckets {
+            runtime_builder.metrics_poll_count_histogram_buckets(buckets);
         }
     }
 }

--- a/aggregator/src/metrics/tokio_runtime.rs
+++ b/aggregator/src/metrics/tokio_runtime.rs
@@ -1,0 +1,12 @@
+use tokio::runtime::HistogramScale;
+
+use crate::metrics::HistogramScale as ConfigHistogramScale;
+
+impl From<ConfigHistogramScale> for HistogramScale {
+    fn from(value: ConfigHistogramScale) -> Self {
+        match value {
+            ConfigHistogramScale::Linear => HistogramScale::Linear,
+            ConfigHistogramScale::Log => HistogramScale::Log,
+        }
+    }
+}

--- a/aggregator/src/metrics/tokio_runtime.rs
+++ b/aggregator/src/metrics/tokio_runtime.rs
@@ -1,6 +1,20 @@
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
-use tokio::runtime::{self, HistogramScale};
+use derivative::Derivative;
+use opentelemetry::{
+    metrics::{MetricsError, Unit},
+    InstrumentationLibrary, KeyValue,
+};
+use opentelemetry_sdk::{
+    metrics::{
+        data::{
+            DataPoint, Gauge, Histogram, HistogramDataPoint, Metric, ScopeMetrics, Sum, Temporality,
+        },
+        reader::MetricProducer,
+    },
+    AttributeSet,
+};
+use tokio::runtime::{self, HistogramScale, RuntimeMetrics};
 
 use crate::metrics::{HistogramScale as ConfigHistogramScale, TokioMetricsConfiguration};
 
@@ -27,5 +41,485 @@ pub(crate) fn configure_runtime(
         if let Some(buckets) = config.poll_time_histogram_buckets {
             runtime_builder.metrics_poll_count_histogram_buckets(buckets);
         }
+    }
+}
+
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub(super) struct TokioRuntimeMetrics {
+    runtime_metrics: RuntimeMetrics,
+    #[derivative(Debug = "ignore")]
+    scope: InstrumentationLibrary,
+    #[derivative(Debug = "ignore")]
+    start_time: SystemTime,
+    num_workers: usize,
+    poll_count_histogram_num_buckets: usize,
+    poll_count_histogram_bucket_bounds: Vec<f64>,
+    #[derivative(Debug = "ignore")]
+    attributes_local: AttributeSet,
+    #[derivative(Debug = "ignore")]
+    attributes_local_overflow: AttributeSet,
+    #[derivative(Debug = "ignore")]
+    attributes_remote: AttributeSet,
+    #[derivative(Debug = "ignore")]
+    attributes_local_queue_worker: Vec<AttributeSet>,
+    attributes_injection_queue: AttributeSet,
+    attributes_blocking_queue: AttributeSet,
+}
+
+impl TokioRuntimeMetrics {
+    pub(super) fn new(runtime_metrics: RuntimeMetrics) -> Self {
+        let scope = InstrumentationLibrary::new(
+            "tokio-runtime-metrics",
+            None::<&'static str>,
+            None::<&'static str>,
+            None,
+        );
+
+        let start_time = SystemTime::now();
+
+        let num_workers = runtime_metrics.num_workers();
+        let poll_count_histogram_enabled = runtime_metrics.poll_count_histogram_enabled();
+        let poll_count_histogram_num_buckets = runtime_metrics.poll_count_histogram_num_buckets();
+        let all_but_last_bucket = if poll_count_histogram_enabled {
+            0..poll_count_histogram_num_buckets - 1
+        } else {
+            0..0
+        };
+        let poll_count_histogram_bucket_bounds = all_but_last_bucket
+            .map(|bucket| {
+                runtime_metrics
+                    .poll_count_histogram_bucket_range(bucket)
+                    .end
+                    .as_secs_f64()
+            })
+            .collect();
+
+        let attributes_local = AttributeSet::from([KeyValue::new("queue", "local")].as_slice());
+        let attributes_local_overflow =
+            AttributeSet::from([KeyValue::new("queue", "local_overflow")].as_slice());
+        let attributes_remote = AttributeSet::from([KeyValue::new("queue", "remote")].as_slice());
+        let attributes_local_queue_worker = (0..num_workers)
+            .map(|i| {
+                AttributeSet::from(
+                    [
+                        KeyValue::new("queue", "local"),
+                        KeyValue::new("worker", i64::try_from(i).unwrap()),
+                    ]
+                    .as_slice(),
+                )
+            })
+            .collect();
+        let attributes_injection_queue =
+            AttributeSet::from([KeyValue::new("queue", "injection")].as_slice());
+        let attributes_blocking_queue =
+            AttributeSet::from([KeyValue::new("queue", "blocking")].as_slice());
+
+        Self {
+            runtime_metrics,
+            scope,
+            start_time,
+            num_workers,
+            poll_count_histogram_num_buckets,
+            poll_count_histogram_bucket_bounds,
+            attributes_local,
+            attributes_local_overflow,
+            attributes_remote,
+            attributes_local_queue_worker,
+            attributes_injection_queue,
+            attributes_blocking_queue,
+        }
+    }
+}
+
+impl MetricProducer for TokioRuntimeMetrics {
+    fn produce(&self) -> Result<ScopeMetrics, MetricsError> {
+        let now = SystemTime::now();
+
+        let num_blocking_threads = self.runtime_metrics.num_blocking_threads();
+        let active_tasks_count = self.runtime_metrics.active_tasks_count();
+        let num_idle_blocking_threads = self.runtime_metrics.num_idle_blocking_threads();
+        let remote_schedule_count = self.runtime_metrics.remote_schedule_count();
+        let budget_forced_yield_count = self.runtime_metrics.budget_forced_yield_count();
+        let injection_queue_depth = self.runtime_metrics.injection_queue_depth();
+        let blocking_queue_depth = self.runtime_metrics.blocking_queue_depth();
+        let io_driver_fd_registered_count = self.runtime_metrics.io_driver_fd_registered_count();
+        let io_driver_fd_deregistered_count =
+            self.runtime_metrics.io_driver_fd_deregistered_count();
+        let io_driver_ready_count = self.runtime_metrics.io_driver_ready_count();
+
+        let mut park_count = 0;
+        let mut noop_count = 0;
+        let mut steal_count = 0;
+        let mut steal_operations = 0;
+        let mut poll_count = 0;
+        let mut total_busy_duration = Duration::from_secs(0);
+        let mut local_schedule_count = 0;
+        let mut overflow_count = 0;
+        let mut local_queue_depth = vec![0; self.num_workers];
+        let mut poll_count_histogram_bucket_count = vec![0; self.poll_count_histogram_num_buckets];
+        let mut worker_mean_poll_time_sum = Duration::from_secs(0);
+        for (worker, worker_local_queue_depth) in local_queue_depth.iter_mut().enumerate() {
+            park_count += self.runtime_metrics.worker_park_count(worker);
+            noop_count += self.runtime_metrics.worker_noop_count(worker);
+            steal_count += self.runtime_metrics.worker_steal_count(worker);
+            steal_operations += self.runtime_metrics.worker_steal_operations(worker);
+            poll_count += self.runtime_metrics.worker_poll_count(worker);
+            total_busy_duration += self.runtime_metrics.worker_total_busy_duration(worker);
+            local_schedule_count += self.runtime_metrics.worker_local_schedule_count(worker);
+            overflow_count += self.runtime_metrics.worker_overflow_count(worker);
+
+            *worker_local_queue_depth = self.runtime_metrics.worker_local_queue_depth(worker);
+
+            for (bucket, out) in poll_count_histogram_bucket_count.iter_mut().enumerate() {
+                *out += self
+                    .runtime_metrics
+                    .poll_count_histogram_bucket_count(worker, bucket);
+            }
+
+            worker_mean_poll_time_sum += self.runtime_metrics.worker_mean_poll_time(worker);
+        }
+        let mean_poll_time = worker_mean_poll_time_sum / u32::try_from(self.num_workers).unwrap();
+
+        let metrics = Vec::from([
+            Metric {
+                name: "tokio.thread.worker.count".into(),
+                description: "Number of runtime worker threads".into(),
+                unit: Unit::new("{thread}"),
+                data: Box::new(Gauge::<u64> {
+                    data_points: Vec::from([DataPoint {
+                        attributes: AttributeSet::default(),
+                        start_time: Some(self.start_time),
+                        time: Some(now),
+                        value: u64::try_from(self.num_workers).unwrap_or(u64::MAX),
+                        exemplars: Vec::new(),
+                    }]),
+                }),
+            },
+            Metric {
+                name: "tokio.thread.blocking.count".into(),
+                description: "Number of additional threads spawned by the runtime for blocking \
+                              operations"
+                    .into(),
+                unit: Unit::new("{thread}"),
+                data: Box::new(Gauge::<u64> {
+                    data_points: Vec::from([DataPoint {
+                        attributes: AttributeSet::default(),
+                        start_time: Some(self.start_time),
+                        time: Some(now),
+                        value: u64::try_from(num_blocking_threads).unwrap_or(u64::MAX),
+                        exemplars: Vec::new(),
+                    }]),
+                }),
+            },
+            Metric {
+                name: "tokio.task.active.count".into(),
+                description: "Number of active tasks in the runtime".into(),
+                unit: Unit::new("{task}"),
+                data: Box::new(Gauge::<u64> {
+                    data_points: Vec::from([DataPoint {
+                        attributes: AttributeSet::default(),
+                        start_time: Some(self.start_time),
+                        time: Some(now),
+                        value: u64::try_from(active_tasks_count).unwrap_or(u64::MAX),
+                        exemplars: Vec::new(),
+                    }]),
+                }),
+            },
+            Metric {
+                name: "tokio.thread.blocking.idle.count".into(),
+                description: "Number of additional threads for blocking operations which are idle"
+                    .into(),
+                unit: Unit::new("{thread}"),
+                data: Box::new(Gauge::<u64> {
+                    data_points: Vec::from([DataPoint {
+                        attributes: AttributeSet::default(),
+                        start_time: Some(self.start_time),
+                        time: Some(now),
+                        value: u64::try_from(num_idle_blocking_threads).unwrap_or(u64::MAX),
+                        exemplars: Vec::new(),
+                    }]),
+                }),
+            },
+            Metric {
+                name: "tokio.task.scheduled".into(),
+                description: "Number of tasks scheduled, either to the thread's own local queue, \
+                              from a worker thread to the injection queue due to overflow, or \
+                              from a remote thread to the injection queue"
+                    .into(),
+                unit: Unit::new("{task}"),
+                data: Box::new(Sum::<u64> {
+                    data_points: Vec::from([
+                        DataPoint {
+                            attributes: self.attributes_local.clone(),
+                            start_time: Some(self.start_time),
+                            time: Some(now),
+                            value: local_schedule_count,
+                            exemplars: Vec::new(),
+                        },
+                        DataPoint {
+                            attributes: self.attributes_local_overflow.clone(),
+                            start_time: Some(self.start_time),
+                            time: Some(now),
+                            value: overflow_count,
+                            exemplars: Vec::new(),
+                        },
+                        DataPoint {
+                            attributes: self.attributes_remote.clone(),
+                            start_time: Some(self.start_time),
+                            time: Some(now),
+                            value: remote_schedule_count,
+                            exemplars: Vec::new(),
+                        },
+                    ]),
+                    temporality: Temporality::Cumulative,
+                    is_monotonic: true,
+                }),
+            },
+            Metric {
+                name: "tokio.task.budget_forced_yield".into(),
+                description: "Number of times tasks have been forced to yield because their task \
+                              budget was exhausted"
+                    .into(),
+                unit: Unit::new(""),
+                data: Box::new(Sum::<u64> {
+                    data_points: Vec::from([DataPoint {
+                        attributes: AttributeSet::default(),
+                        start_time: Some(self.start_time),
+                        time: Some(now),
+                        value: budget_forced_yield_count,
+                        exemplars: Vec::new(),
+                    }]),
+                    temporality: Temporality::Cumulative,
+                    is_monotonic: true,
+                }),
+            },
+            Metric {
+                name: "tokio.park".into(),
+                description: "Total number of times worker threads have parked".into(),
+                unit: Unit::new(""),
+                data: Box::new(Sum::<u64> {
+                    data_points: Vec::from([DataPoint {
+                        attributes: AttributeSet::default(),
+                        start_time: Some(self.start_time),
+                        time: Some(now),
+                        value: park_count,
+                        exemplars: Vec::new(),
+                    }]),
+                    temporality: Temporality::Cumulative,
+                    is_monotonic: true,
+                }),
+            },
+            Metric {
+                name: "tokio.noop".into(),
+                description: "Total number of times worker threads unparked and parked again \
+                              without doing any work"
+                    .into(),
+                unit: Unit::new(""),
+                data: Box::new(Sum::<u64> {
+                    data_points: Vec::from([DataPoint {
+                        attributes: AttributeSet::default(),
+                        start_time: Some(self.start_time),
+                        time: Some(now),
+                        value: noop_count,
+                        exemplars: Vec::new(),
+                    }]),
+                    temporality: Temporality::Cumulative,
+                    is_monotonic: true,
+                }),
+            },
+            Metric {
+                name: "tokio.task.stolen".into(),
+                description: "Total number of tasks stolen between worker threads".into(),
+                unit: Unit::new("{task}"),
+                data: Box::new(Sum::<u64> {
+                    data_points: Vec::from([DataPoint {
+                        attributes: AttributeSet::default(),
+                        start_time: Some(self.start_time),
+                        time: Some(now),
+                        value: steal_count,
+                        exemplars: Vec::new(),
+                    }]),
+                    temporality: Temporality::Cumulative,
+                    is_monotonic: true,
+                }),
+            },
+            Metric {
+                name: "tokio.steals".into(),
+                description: "Number of times worker threads successfully stole one or more tasks"
+                    .into(),
+                unit: Unit::new("{operation}"),
+                data: Box::new(Sum::<u64> {
+                    data_points: Vec::from([DataPoint {
+                        attributes: AttributeSet::default(),
+                        start_time: Some(self.start_time),
+                        time: Some(now),
+                        value: steal_operations,
+                        exemplars: Vec::new(),
+                    }]),
+                    temporality: Temporality::Cumulative,
+                    is_monotonic: true,
+                }),
+            },
+            Metric {
+                name: "tokio.thread.worker.busy.time".into(),
+                description: "Total amount of time that all worker threads have been busy".into(),
+                unit: Unit::new("s"),
+                data: Box::new(Sum::<f64> {
+                    data_points: Vec::from([DataPoint {
+                        attributes: AttributeSet::default(),
+                        start_time: Some(self.start_time),
+                        time: Some(now),
+                        value: total_busy_duration.as_secs_f64(),
+                        exemplars: Vec::new(),
+                    }]),
+                    temporality: Temporality::Cumulative,
+                    is_monotonic: true,
+                }),
+            },
+            Metric {
+                name: "tokio.queue.depth".into(),
+                description: "Number of tasks currently in the runtime's injection queue, \
+                              blocking thread pool queue, or a worker's local queue"
+                    .into(),
+                unit: Unit::new("{task}"),
+                data: Box::new(Gauge::<u64> {
+                    data_points: {
+                        let mut data_points = Vec::with_capacity(self.num_workers + 2);
+                        data_points.extend(
+                            local_queue_depth
+                                .into_iter()
+                                .zip(self.attributes_local_queue_worker.iter())
+                                .map(|(worker_local_queue_depth, attributes)| DataPoint {
+                                    attributes: attributes.clone(),
+                                    start_time: Some(self.start_time),
+                                    time: Some(now),
+                                    value: u64::try_from(worker_local_queue_depth)
+                                        .unwrap_or(u64::MAX),
+                                    exemplars: Vec::new(),
+                                }),
+                        );
+                        data_points.push(DataPoint {
+                            attributes: self.attributes_injection_queue.clone(),
+                            start_time: Some(self.start_time),
+                            time: Some(now),
+                            value: u64::try_from(injection_queue_depth).unwrap_or(u64::MAX),
+                            exemplars: Vec::new(),
+                        });
+                        data_points.push(DataPoint {
+                            attributes: self.attributes_blocking_queue.clone(),
+                            start_time: Some(self.start_time),
+                            time: Some(now),
+                            value: u64::try_from(blocking_queue_depth).unwrap_or(u64::MAX),
+                            exemplars: Vec::new(),
+                        });
+                        data_points
+                    },
+                }),
+            },
+            Metric {
+                name: "tokio.task.poll.time".into(),
+                description: "Histogram of task poll times".into(),
+                unit: Unit::new("s"),
+                data: Box::new(Histogram::<f64> {
+                    data_points: Vec::from([HistogramDataPoint {
+                        attributes: AttributeSet::default(),
+                        start_time: self.start_time,
+                        time: now,
+                        count: poll_count,
+                        bounds: self.poll_count_histogram_bucket_bounds.clone(),
+                        bucket_counts: poll_count_histogram_bucket_count,
+                        min: Some(f64::NAN),
+                        max: Some(f64::NAN),
+                        sum: f64::NAN,
+                        exemplars: Vec::new(),
+                    }]),
+                    temporality: Temporality::Cumulative,
+                }),
+            },
+            Metric {
+                name: "tokio.task.poll.time.average".into(),
+                description: "Exponentially weighted moving average of task poll times".into(),
+                unit: Unit::new("s"),
+                data: Box::new(Gauge::<f64> {
+                    data_points: Vec::from([DataPoint {
+                        attributes: AttributeSet::default(),
+                        start_time: Some(self.start_time),
+                        time: Some(now),
+                        value: mean_poll_time.as_secs_f64(),
+                        exemplars: Vec::new(),
+                    }]),
+                }),
+            },
+            Metric {
+                name: "tokio.io.fd.count".into(),
+                description: "Number of file descriptors currently registered with the I/O driver"
+                    .into(),
+                unit: Unit::new("{fd}"),
+                data: Box::new(Gauge::<u64> {
+                    data_points: Vec::from([DataPoint {
+                        attributes: AttributeSet::default(),
+                        start_time: Some(self.start_time),
+                        time: Some(now),
+                        value: io_driver_fd_registered_count
+                            .saturating_sub(io_driver_fd_deregistered_count),
+                        exemplars: Vec::new(),
+                    }]),
+                }),
+            },
+            Metric {
+                name: "tokio.io.fd.registered".into(),
+                description: "Total number of file descriptors registered by the I/O driver".into(),
+                unit: Unit::new("{fd}"),
+                data: Box::new(Sum::<u64> {
+                    data_points: Vec::from([DataPoint {
+                        attributes: AttributeSet::default(),
+                        start_time: Some(self.start_time),
+                        time: Some(now),
+                        value: io_driver_fd_registered_count,
+                        exemplars: Vec::new(),
+                    }]),
+                    temporality: Temporality::Cumulative,
+                    is_monotonic: true,
+                }),
+            },
+            Metric {
+                name: "tokio.io.fd.deregistered".into(),
+                description: "Total number of file descriptors deregistered by the I/O driver"
+                    .into(),
+                unit: Unit::new("{fd}"),
+                data: Box::new(Sum::<u64> {
+                    data_points: Vec::from([DataPoint {
+                        attributes: AttributeSet::default(),
+                        start_time: Some(self.start_time),
+                        time: Some(now),
+                        value: io_driver_fd_deregistered_count,
+                        exemplars: Vec::new(),
+                    }]),
+                    temporality: Temporality::Cumulative,
+                    is_monotonic: true,
+                }),
+            },
+            Metric {
+                name: "tokio.io.ready_events".into(),
+                description: "Number of ready events processed by the I/O driver".into(),
+                unit: Unit::new("{event}"),
+                data: Box::new(Sum::<u64> {
+                    data_points: Vec::from([DataPoint {
+                        attributes: AttributeSet::default(),
+                        start_time: Some(self.start_time),
+                        time: Some(now),
+                        value: io_driver_ready_count,
+                        exemplars: Vec::new(),
+                    }]),
+                    temporality: Temporality::Cumulative,
+                    is_monotonic: true,
+                }),
+            },
+        ]);
+        Ok(ScopeMetrics {
+            scope: self.scope.clone(),
+            metrics,
+        })
     }
 }

--- a/docs/samples/advanced_config/aggregation_job_creator.yaml
+++ b/docs/samples/advanced_config/aggregation_job_creator.yaml
@@ -71,6 +71,25 @@ metrics_config:
   ##  metadata:
   ##    key: "value"
 
+  # Configuration for Tokio runtime metrics. (optional)
+  tokio:
+    # Enable exporting metrics from the Tokio runtime. If this is true, the
+    # binary must have been compiled with the flag `--cfg tokio_unstable`.
+    # (optional)
+    enable: false
+    # Enable a histogram of task poll times. This introduces some additional
+    # overhead. (optional)
+    enable_poll_time_histogram: false
+    # Selects whether to use a `"linear"` scale or a logarithmic (`"log"`) scale
+    # for the poll time histogram. Defaults to `"linear"`. (optional)
+    poll_time_histogram_scale: linear
+    # Sets the poll time histogram's resolution. Defaults to 100 microseconds.
+    # (optional)
+    poll_time_histogram_resolution_microseconds: 100
+    # Sets the number of buckets in the poll time histogram. Defaults to 10.
+    # (optional)
+    poll_time_histogram_buckets: 10
+
 # Aggregation job creator-specific parameters:
 
 # Number of sharded database records per batch aggregation. Must not be greater

--- a/docs/samples/advanced_config/aggregation_job_driver.yaml
+++ b/docs/samples/advanced_config/aggregation_job_driver.yaml
@@ -71,6 +71,25 @@ metrics_config:
   ##  metadata:
   ##    key: "value"
 
+  # Configuration for Tokio runtime metrics. (optional)
+  tokio:
+    # Enable exporting metrics from the Tokio runtime. If this is true, the
+    # binary must have been compiled with the flag `--cfg tokio_unstable`.
+    # (optional)
+    enable: false
+    # Enable a histogram of task poll times. This introduces some additional
+    # overhead. (optional)
+    enable_poll_time_histogram: false
+    # Selects whether to use a `"linear"` scale or a logarithmic (`"log"`) scale
+    # for the poll time histogram. Defaults to `"linear"`. (optional)
+    poll_time_histogram_scale: linear
+    # Sets the poll time histogram's resolution. Defaults to 100 microseconds.
+    # (optional)
+    poll_time_histogram_resolution_microseconds: 100
+    # Sets the number of buckets in the poll time histogram. Defaults to 10.
+    # (optional)
+    poll_time_histogram_buckets: 10
+
 # Aggregation job driver-related parameters:
 
 # Maximum interval on which to acquire incomplete aggregation jobs. (required)

--- a/docs/samples/advanced_config/aggregator.yaml
+++ b/docs/samples/advanced_config/aggregator.yaml
@@ -71,6 +71,25 @@ metrics_config:
   ##  metadata:
   ##    key: "value"
 
+  # Configuration for Tokio runtime metrics. (optional)
+  tokio:
+    # Enable exporting metrics from the Tokio runtime. If this is true, the
+    # binary must have been compiled with the flag `--cfg tokio_unstable`.
+    # (optional)
+    enable: false
+    # Enable a histogram of task poll times. This introduces some additional
+    # overhead. (optional)
+    enable_poll_time_histogram: false
+    # Selects whether to use a `"linear"` scale or a logarithmic (`"log"`) scale
+    # for the poll time histogram. Defaults to `"linear"`. (optional)
+    poll_time_histogram_scale: linear
+    # Sets the poll time histogram's resolution. Defaults to 100 microseconds.
+    # (optional)
+    poll_time_histogram_resolution_microseconds: 100
+    # Sets the number of buckets in the poll time histogram. Defaults to 10.
+    # (optional)
+    poll_time_histogram_buckets: 10
+
 # Aggregator-specific parameters:
 
 # Socket address for DAP requests. (required)

--- a/docs/samples/advanced_config/collection_job_driver.yaml
+++ b/docs/samples/advanced_config/collection_job_driver.yaml
@@ -71,6 +71,25 @@ metrics_config:
   ##  metadata:
   ##    key: "value"
 
+  # Configuration for Tokio runtime metrics. (optional)
+  tokio:
+    # Enable exporting metrics from the Tokio runtime. If this is true, the
+    # binary must have been compiled with the flag `--cfg tokio_unstable`.
+    # (optional)
+    enable: false
+    # Enable a histogram of task poll times. This introduces some additional
+    # overhead. (optional)
+    enable_poll_time_histogram: false
+    # Selects whether to use a `"linear"` scale or a logarithmic (`"log"`) scale
+    # for the poll time histogram. Defaults to `"linear"`. (optional)
+    poll_time_histogram_scale: linear
+    # Sets the poll time histogram's resolution. Defaults to 100 microseconds.
+    # (optional)
+    poll_time_histogram_resolution_microseconds: 100
+    # Sets the number of buckets in the poll time histogram. Defaults to 10.
+    # (optional)
+    poll_time_histogram_buckets: 10
+
 # Collection job driver-related parameters:
 
 # Maximum interval on which to acquire incomplete collection jobs. (required)

--- a/docs/samples/advanced_config/garbage_collector.yaml
+++ b/docs/samples/advanced_config/garbage_collector.yaml
@@ -71,6 +71,25 @@ metrics_config:
   ##  metadata:
   ##    key: "value"
 
+  # Configuration for Tokio runtime metrics. (optional)
+  tokio:
+    # Enable exporting metrics from the Tokio runtime. If this is true, the
+    # binary must have been compiled with the flag `--cfg tokio_unstable`.
+    # (optional)
+    enable: false
+    # Enable a histogram of task poll times. This introduces some additional
+    # overhead. (optional)
+    enable_poll_time_histogram: false
+    # Selects whether to use a `"linear"` scale or a logarithmic (`"log"`) scale
+    # for the poll time histogram. Defaults to `"linear"`. (optional)
+    poll_time_histogram_scale: linear
+    # Sets the poll time histogram's resolution. Defaults to 100 microseconds.
+    # (optional)
+    poll_time_histogram_resolution_microseconds: 100
+    # Sets the number of buckets in the poll time histogram. Defaults to 10.
+    # (optional)
+    poll_time_histogram_buckets: 10
+
 # Garbage collector-specific parameters:
 garbage_collection:
   # How frequently to collect garbage, in seconds.

--- a/docs/samples/advanced_config/janus_cli.yaml
+++ b/docs/samples/advanced_config/janus_cli.yaml
@@ -70,3 +70,22 @@ metrics_config:
   ##  # gRPC metadata to send with OTLP requests. (optional)
   ##  metadata:
   ##    key: "value"
+
+  # Configuration for Tokio runtime metrics. (optional)
+  tokio:
+    # Enable exporting metrics from the Tokio runtime. If this is true, the
+    # binary must have been compiled with the flag `--cfg tokio_unstable`.
+    # (optional)
+    enable: false
+    # Enable a histogram of task poll times. This introduces some additional
+    # overhead. (optional)
+    enable_poll_time_histogram: false
+    # Selects whether to use a `"linear"` scale or a logarithmic (`"log"`) scale
+    # for the poll time histogram. Defaults to `"linear"`. (optional)
+    poll_time_histogram_scale: linear
+    # Sets the poll time histogram's resolution. Defaults to 100 microseconds.
+    # (optional)
+    poll_time_histogram_resolution_microseconds: 100
+    # Sets the number of buckets in the poll time histogram. Defaults to 10.
+    # (optional)
+    poll_time_histogram_buckets: 10

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -145,7 +145,10 @@ impl JanusInProcess {
                 tls_trust_store_path: None,
             },
             logging_config,
-            metrics_config: MetricsConfiguration { exporter: None },
+            metrics_config: MetricsConfiguration {
+                exporter: None,
+                tokio: None,
+            },
             health_check_listen_address: (Ipv4Addr::LOCALHOST, 0).into(),
             max_transaction_retries: default_max_transaction_retries(),
         };

--- a/interop_binaries/src/bin/janus_interop.rs
+++ b/interop_binaries/src/bin/janus_interop.rs
@@ -30,15 +30,12 @@ enum Nested {
     Collector(janus_interop_collector::Options),
 }
 
-#[tokio::main]
-async fn main() -> Result<(), anyhow::Error> {
+fn main() -> Result<(), anyhow::Error> {
     match Options::parse() {
-        Options::Client(options) | Options::Default(Nested::Client(options)) => options.run().await,
+        Options::Client(options) | Options::Default(Nested::Client(options)) => options.run(),
         Options::Aggregator(options) | Options::Default(Nested::Aggregator(options)) => {
-            options.run().await
+            options.run()
         }
-        Options::Collector(options) | Options::Default(Nested::Collector(options)) => {
-            options.run().await
-        }
+        Options::Collector(options) | Options::Default(Nested::Collector(options)) => options.run(),
     }
 }

--- a/interop_binaries/src/commands/janus_interop_aggregator.rs
+++ b/interop_binaries/src/commands/janus_interop_aggregator.rs
@@ -253,7 +253,7 @@ impl BinaryConfig for Config {
 }
 
 impl Options {
-    pub async fn run(self) -> anyhow::Result<()> {
+    pub fn run(self) -> anyhow::Result<()> {
         janus_main::<_, _, Config, _, _>(self, RealClock::default(), true, |ctx| async move {
             let datastore = Arc::new(ctx.datastore);
 
@@ -275,7 +275,6 @@ impl Options {
 
             Ok(())
         })
-        .await
     }
 }
 

--- a/interop_binaries/src/commands/janus_interop_client.rs
+++ b/interop_binaries/src/commands/janus_interop_client.rs
@@ -229,13 +229,12 @@ pub struct Options {
 }
 
 impl Options {
-    pub async fn run(self) -> anyhow::Result<()> {
+    pub fn run(self) -> anyhow::Result<()> {
         install_tracing_subscriber()?;
         trillium_tokio::config()
             .with_host(&Ipv4Addr::UNSPECIFIED.to_string())
             .with_port(self.port)
-            .run_async(handler()?)
-            .await;
+            .run(handler()?);
         Ok(())
     }
 }

--- a/interop_binaries/src/commands/janus_interop_collector.rs
+++ b/interop_binaries/src/commands/janus_interop_collector.rs
@@ -838,13 +838,12 @@ pub struct Options {
 }
 
 impl Options {
-    pub async fn run(self) -> anyhow::Result<()> {
+    pub fn run(self) -> anyhow::Result<()> {
         install_tracing_subscriber()?;
         trillium_tokio::config()
             .with_host(&Ipv4Addr::UNSPECIFIED.to_string())
             .with_port(self.port)
-            .run_async(handler()?)
-            .await;
+            .run(handler()?);
         Ok(())
     }
 }


### PR DESCRIPTION
This implements #2968. I've held off on changing the build configuration of our Dockerfiles yet, pending review and discussion. Here's sample output from the new metrics.

```
# HELP tokio_io_fd_count Number of file descriptors currently registered with the I/O driver
# TYPE tokio_io_fd_count gauge
tokio_io_fd_count{otel_scope_name="tokio-runtime-metrics"} 7
# HELP tokio_io_fd_deregistered_total Total number of file descriptors deregistered by the I/O driver
# TYPE tokio_io_fd_deregistered_total counter
tokio_io_fd_deregistered_total{otel_scope_name="tokio-runtime-metrics"} 0
# HELP tokio_io_fd_registered_total Total number of file descriptors registered by the I/O driver
# TYPE tokio_io_fd_registered_total counter
tokio_io_fd_registered_total{otel_scope_name="tokio-runtime-metrics"} 7
# HELP tokio_io_ready_events_total Number of ready events processed by the I/O driver
# TYPE tokio_io_ready_events_total counter
tokio_io_ready_events_total{otel_scope_name="tokio-runtime-metrics"} 30
# HELP tokio_noop_total Total number of times worker threads unparked and parked again without doing any work
# TYPE tokio_noop_total counter
tokio_noop_total{otel_scope_name="tokio-runtime-metrics"} 37
# HELP tokio_park_total Total number of times worker threads have parked
# TYPE tokio_park_total counter
tokio_park_total{otel_scope_name="tokio-runtime-metrics"} 89
# HELP tokio_queue_depth Number of tasks currently in the runtime's injection queue, blocking thread pool queue, or a worker's local queue
# TYPE tokio_queue_depth gauge
tokio_queue_depth{queue="blocking",otel_scope_name="tokio-runtime-metrics"} 0
tokio_queue_depth{queue="injection",otel_scope_name="tokio-runtime-metrics"} 0
tokio_queue_depth{queue="local",worker="0",otel_scope_name="tokio-runtime-metrics"} 0
tokio_queue_depth{queue="local",worker="1",otel_scope_name="tokio-runtime-metrics"} 0
tokio_queue_depth{queue="local",worker="2",otel_scope_name="tokio-runtime-metrics"} 0
tokio_queue_depth{queue="local",worker="3",otel_scope_name="tokio-runtime-metrics"} 0
tokio_queue_depth{queue="local",worker="4",otel_scope_name="tokio-runtime-metrics"} 0
tokio_queue_depth{queue="local",worker="5",otel_scope_name="tokio-runtime-metrics"} 0
tokio_queue_depth{queue="local",worker="6",otel_scope_name="tokio-runtime-metrics"} 0
tokio_queue_depth{queue="local",worker="7",otel_scope_name="tokio-runtime-metrics"} 0
# HELP tokio_steals_total Number of times worker threads successfully stole one or more tasks
# TYPE tokio_steals_total counter
tokio_steals_total{otel_scope_name="tokio-runtime-metrics"} 0
# HELP tokio_task_active_count Number of active tasks in the runtime
# TYPE tokio_task_active_count gauge
tokio_task_active_count{otel_scope_name="tokio-runtime-metrics"} 8
# HELP tokio_task_budget_forced_yield_total Number of times tasks have been forced to yield because their task budget was exhausted
# TYPE tokio_task_budget_forced_yield_total counter
tokio_task_budget_forced_yield_total{otel_scope_name="tokio-runtime-metrics"} 0
# HELP tokio_task_poll_time_average_seconds Exponentially weighted moving average of task poll times
# TYPE tokio_task_poll_time_average_seconds gauge
tokio_task_poll_time_average_seconds{otel_scope_name="tokio-runtime-metrics"} 0.000012563
# HELP tokio_task_poll_time_seconds Histogram of task poll times
# TYPE tokio_task_poll_time_seconds histogram
tokio_task_poll_time_seconds_bucket{otel_scope_name="tokio-runtime-metrics",le="0.0001"} 49
tokio_task_poll_time_seconds_bucket{otel_scope_name="tokio-runtime-metrics",le="0.0002"} 51
tokio_task_poll_time_seconds_bucket{otel_scope_name="tokio-runtime-metrics",le="0.0003"} 52
tokio_task_poll_time_seconds_bucket{otel_scope_name="tokio-runtime-metrics",le="0.0004"} 52
tokio_task_poll_time_seconds_bucket{otel_scope_name="tokio-runtime-metrics",le="0.0005"} 52
tokio_task_poll_time_seconds_bucket{otel_scope_name="tokio-runtime-metrics",le="0.0006"} 52
tokio_task_poll_time_seconds_bucket{otel_scope_name="tokio-runtime-metrics",le="0.0007"} 52
tokio_task_poll_time_seconds_bucket{otel_scope_name="tokio-runtime-metrics",le="0.0008"} 52
tokio_task_poll_time_seconds_bucket{otel_scope_name="tokio-runtime-metrics",le="0.0009"} 52
tokio_task_poll_time_seconds_bucket{otel_scope_name="tokio-runtime-metrics",le="+Inf"} 52
tokio_task_poll_time_seconds_sum{otel_scope_name="tokio-runtime-metrics"} NaN
tokio_task_poll_time_seconds_count{otel_scope_name="tokio-runtime-metrics"} 52
# HELP tokio_task_scheduled_total Number of tasks scheduled, either to the thread's own local queue, from a worker thread to the injection queue due to overflow, or from a remote thread to the injection queue
# TYPE tokio_task_scheduled_total counter
tokio_task_scheduled_total{queue="local",otel_scope_name="tokio-runtime-metrics"} 27
tokio_task_scheduled_total{queue="local_overflow",otel_scope_name="tokio-runtime-metrics"} 0
tokio_task_scheduled_total{queue="remote",otel_scope_name="tokio-runtime-metrics"} 29
# HELP tokio_task_stolen_total Total number of tasks stolen between worker threads
# TYPE tokio_task_stolen_total counter
tokio_task_stolen_total{otel_scope_name="tokio-runtime-metrics"} 0
# HELP tokio_thread_blocking_count Number of additional threads spawned by the runtime for blocking operations
# TYPE tokio_thread_blocking_count gauge
tokio_thread_blocking_count{otel_scope_name="tokio-runtime-metrics"} 9
# HELP tokio_thread_blocking_idle_count Number of additional threads for blocking operations which are idle
# TYPE tokio_thread_blocking_idle_count gauge
tokio_thread_blocking_idle_count{otel_scope_name="tokio-runtime-metrics"} 1
# HELP tokio_thread_worker_busy_time_seconds_total Total amount of time that all worker threads have been busy
# TYPE tokio_thread_worker_busy_time_seconds_total counter
tokio_thread_worker_busy_time_seconds_total{otel_scope_name="tokio-runtime-metrics"} 0.001783787
# HELP tokio_thread_worker_count Number of runtime worker threads
# TYPE tokio_thread_worker_count gauge
tokio_thread_worker_count{otel_scope_name="tokio-runtime-metrics"} 8
```