### PR TITLE
Update VDAF preparation tracing spans

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -2031,7 +2031,7 @@ impl VdafOps {
                     // associated with the task and computes the first state transition. [...] If either
                     // step fails, then the aggregator MUST fail with error `vdaf-prep-error`. (§4.4.2.2)
                     let init_rslt = shares.and_then(|(public_share, input_share)| {
-                        trace_span!("VDAF preparation").in_scope(|| {
+                        trace_span!("VDAF preparation (helper initialization)").in_scope(|| {
                             vdaf.helper_initialized(
                                 verify_key.as_bytes(),
                                 &agg_param,

--- a/aggregator/src/aggregator/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/aggregation_job_continue.rs
@@ -131,7 +131,7 @@ impl VdafOps {
                     };
 
                     let (report_aggregation_state, prepare_step_result, output_share) =
-                        trace_span!("VDAF preparation")
+                        trace_span!("VDAF preparation (helper continuation)")
                             .in_scope(|| {
                                 // Continue with the incoming message.
                                 vdaf.helper_continued(

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -394,7 +394,7 @@ where
                         }
                     };
 
-                    match trace_span!("VDAF preparation").in_scope(|| {
+                    match trace_span!("VDAF preparation (leader initialization)").in_scope(|| {
                         vdaf.leader_initialized(
                             verify_key.as_bytes(),
                             aggregation_job.aggregation_parameter(),
@@ -557,8 +557,8 @@ where
         for report_aggregation in report_aggregations {
             if let ReportAggregationState::WaitingLeader { transition } = report_aggregation.state()
             {
-                let result =
-                    trace_span!("VDAF preparation").in_scope(|| transition.evaluate(vdaf.as_ref()));
+                let result = trace_span!("VDAF preparation (leader transition evaluation)")
+                    .in_scope(|| transition.evaluate(vdaf.as_ref()));
                 let (prep_state, message) = match result {
                     Ok((state, message)) => (state, message),
                     Err(error) => {
@@ -676,22 +676,23 @@ where
                 PrepareStepResult::Continue {
                     message: helper_prep_msg,
                 } => {
-                    let state_and_message = trace_span!("VDAF preparation").in_scope(|| {
-                        vdaf.leader_continued(
-                            stepped_aggregation.leader_state.clone(),
-                            aggregation_job.aggregation_parameter(),
-                            helper_prep_msg,
-                        )
-                        .map_err(|ping_pong_error| {
-                            handle_ping_pong_error(
-                                task.id(),
-                                Role::Leader,
-                                stepped_aggregation.report_aggregation.report_id(),
-                                ping_pong_error,
-                                &self.aggregate_step_failure_counter,
+                    let state_and_message = trace_span!("VDAF preparation (leader continuation)")
+                        .in_scope(|| {
+                            vdaf.leader_continued(
+                                stepped_aggregation.leader_state.clone(),
+                                aggregation_job.aggregation_parameter(),
+                                helper_prep_msg,
                             )
-                        })
-                    });
+                            .map_err(|ping_pong_error| {
+                                handle_ping_pong_error(
+                                    task.id(),
+                                    Role::Leader,
+                                    stepped_aggregation.report_aggregation.report_id(),
+                                    ping_pong_error,
+                                    &self.aggregate_step_failure_counter,
+                                )
+                            })
+                        });
 
                     match state_and_message {
                         Ok(PingPongContinuedValue::WithMessage { transition }) => {

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -557,7 +557,9 @@ where
         for report_aggregation in report_aggregations {
             if let ReportAggregationState::WaitingLeader { transition } = report_aggregation.state()
             {
-                let (prep_state, message) = match transition.evaluate(vdaf.as_ref()) {
+                let result =
+                    trace_span!("VDAF preparation").in_scope(|| transition.evaluate(vdaf.as_ref()));
+                let (prep_state, message) = match result {
                     Ok((state, message)) => (state, message),
                     Err(error) => {
                         let prepare_error = handle_ping_pong_error(
@@ -674,8 +676,8 @@ where
                 PrepareStepResult::Continue {
                     message: helper_prep_msg,
                 } => {
-                    let state_and_message = vdaf
-                        .leader_continued(
+                    let state_and_message = trace_span!("VDAF preparation").in_scope(|| {
+                        vdaf.leader_continued(
                             stepped_aggregation.leader_state.clone(),
                             aggregation_job.aggregation_parameter(),
                             helper_prep_msg,
@@ -688,7 +690,8 @@ where
                                 ping_pong_error,
                                 &self.aggregate_step_failure_counter,
                             )
-                        });
+                        })
+                    });
 
                     match state_and_message {
                         Ok(PingPongContinuedValue::WithMessage { transition }) => {


### PR DESCRIPTION
This adds a couple more tracing spans around VDAF preparation in the leader case of multi-round preparation, and renames all such spans so they have unique names.