### PR TITLE
Use rayon VDAF in client, not aggregator/collector

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ postgres-protocol = "0.6.6"
 postgres-types = "0.2.6"
 # Disable default features so that individual workspace crates can choose to
 # re-enable them
-prio = { version = "0.16.2", default-features = false, features = ["multithreaded", "experimental"] }
+prio = { version = "0.16.2", default-features = false, features = ["experimental"] }
 prometheus = "0.13.3"
 querystring = "1.1.0"
 rand = "0.8"

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -52,6 +52,7 @@ use janus_messages::{
     PrepareStepResult, ReportIdChecksum, ReportShare, Role, TaskId, Time,
 };
 use prio::{
+    flp::gadgets::ParallelSumMultithreaded,
     idpf::IdpfInput,
     vdaf::{
         poplar1::{Poplar1, Poplar1AggregationParam},
@@ -1266,7 +1267,10 @@ async fn end_to_end_poplar1() {
 
 #[tokio::test]
 async fn end_to_end_sumvec_hmac() {
-    let vdaf = new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128(2, 8, 12, 14).unwrap();
+    let vdaf = new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128::<
+        ParallelSumMultithreaded<_, _>,
+    >(2, 8, 12, 14)
+    .unwrap();
     let vdaf_config = VdafConfig::new(
         DpConfig::new(DpMechanism::None),
         VdafType::Prio3SumVecField64MultiproofHmacSha256Aes128 {

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -1145,7 +1145,7 @@ mod tests {
     async fn successful_collect_prio3_fixedpoint_boundedl2_vec_sum() {
         install_test_trace_subscriber();
         let mut server = mockito::Server::new_async().await;
-        let vdaf = Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, 3).unwrap();
+        let vdaf = Prio3::new_fixedpoint_boundedl2_vec_sum(2, 3).unwrap();
         let fp32_4_inv = fixed!(0.25: I1F31);
         let fp32_8_inv = fixed!(0.125: I1F31);
         let fp32_16_inv = fixed!(0.0625: I1F31);

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -49,9 +49,7 @@ http-api-problem.workspace = true
 janus_messages.workspace = true
 k8s-openapi = { workspace = true, optional = true }
 kube = { workspace = true, optional = true, features = ["rustls-tls"] }
-prio = { workspace = true, default-features = true, features = [
-    "experimental",
-] }
+prio = { workspace = true, default-features = true, features = ["experimental"] }
 rand.workspace = true
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -49,7 +49,9 @@ http-api-problem.workspace = true
 janus_messages.workspace = true
 k8s-openapi = { workspace = true, optional = true }
 kube = { workspace = true, optional = true, features = ["rustls-tls"] }
-prio = { workspace = true, default-features = true, features = ["multithreaded", "experimental"] }
+prio = { workspace = true, default-features = true, features = [
+    "experimental",
+] }
 rand.workspace = true
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }

--- a/core/src/dp.rs
+++ b/core/src/dp.rs
@@ -3,7 +3,7 @@ use derivative::Derivative;
 use fixed::traits::Fixed;
 #[cfg(feature = "fpvec_bounded_l2")]
 use prio::flp::{
-    gadgets::{ParallelSumGadget, PolyEval},
+    gadgets::PolyEval,
     types::fixedpoint_l2::{compatible_float::CompatibleFloat, FixedPointBoundedL2VecSum},
 };
 #[cfg(feature = "test-util")]
@@ -15,7 +15,7 @@ use prio::{
     },
     field::{Field128, Field64},
     flp::{
-        gadgets::{Mul, ParallelSum, ParallelSumMultithreaded},
+        gadgets::{Mul, ParallelSumGadget},
         TypeWithNoise,
     },
     vdaf::{xof::XofTurboShake128, AggregatorWithNoise},
@@ -85,8 +85,9 @@ impl TypeWithNoise<NoDifferentialPrivacy> for prio::flp::types::Count<Field64> {
     }
 }
 
-impl TypeWithNoise<NoDifferentialPrivacy>
-    for prio::flp::types::Histogram<Field128, ParallelSum<Field128, Mul<Field128>>>
+impl<PS> TypeWithNoise<NoDifferentialPrivacy> for prio::flp::types::Histogram<Field128, PS>
+where
+    PS: ParallelSumGadget<Field128, Mul<Field128>> + Eq + 'static,
 {
     fn add_noise_to_result(
         &self,
@@ -98,8 +99,9 @@ impl TypeWithNoise<NoDifferentialPrivacy>
     }
 }
 
-impl TypeWithNoise<NoDifferentialPrivacy>
-    for prio::flp::types::SumVec<Field128, ParallelSumMultithreaded<Field128, Mul<Field128>>>
+impl<PS> TypeWithNoise<NoDifferentialPrivacy> for prio::flp::types::SumVec<Field128, PS>
+where
+    PS: ParallelSumGadget<Field128, Mul<Field128>> + Eq + 'static,
 {
     fn add_noise_to_result(
         &self,
@@ -111,8 +113,9 @@ impl TypeWithNoise<NoDifferentialPrivacy>
     }
 }
 
-impl TypeWithNoise<NoDifferentialPrivacy>
-    for prio::flp::types::SumVec<Field64, ParallelSum<Field64, Mul<Field64>>>
+impl<PS> TypeWithNoise<NoDifferentialPrivacy> for prio::flp::types::SumVec<Field64, PS>
+where
+    PS: ParallelSumGadget<Field64, Mul<Field64>> + Eq + 'static,
 {
     fn add_noise_to_result(
         &self,

--- a/integration_tests/src/client.rs
+++ b/integration_tests/src/client.rs
@@ -7,9 +7,11 @@ use janus_interop_binaries::{get_rust_log_level, ContainerLogsDropGuard};
 use janus_messages::{Duration, TaskId};
 use prio::{
     codec::Encode,
+    field::Field64,
+    flp::gadgets::{Mul, ParallelSumGadget},
     vdaf::{
         self, dummy,
-        prio3::{Prio3Count, Prio3Histogram, Prio3Sum, Prio3SumVecMultithreaded},
+        prio3::{Prio3Count, Prio3HistogramMultithreaded, Prio3Sum, Prio3SumVecMultithreaded},
     },
 };
 use rand::random;
@@ -36,7 +38,7 @@ impl InteropClientEncoding for Prio3Sum {
     }
 }
 
-impl InteropClientEncoding for Prio3Histogram {
+impl InteropClientEncoding for Prio3HistogramMultithreaded {
     fn json_encode_measurement(&self, measurement: &Self::Measurement) -> Value {
         Value::String(format!("{measurement}"))
     }
@@ -53,7 +55,10 @@ impl InteropClientEncoding for Prio3SumVecMultithreaded {
     }
 }
 
-impl InteropClientEncoding for Prio3SumVecField64MultiproofHmacSha256Aes128 {
+impl<PS> InteropClientEncoding for Prio3SumVecField64MultiproofHmacSha256Aes128<PS>
+where
+    PS: ParallelSumGadget<Field64, Mul<Field64>> + Eq + 'static,
+{
     fn json_encode_measurement(&self, measurement: &Self::Measurement) -> Value {
         Value::Array(
             measurement

--- a/interop_binaries/Cargo.toml
+++ b/interop_binaries/Cargo.toml
@@ -32,7 +32,7 @@ janus_client.workspace = true
 janus_collector.workspace = true
 janus_core.workspace = true
 janus_messages.workspace = true
-prio.workspace = true
+prio = { workspace = true, features = ["multithreaded"] }
 rand.workspace = true
 regex = { workspace = true, optional = true }
 reqwest.workspace = true

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -20,7 +20,7 @@ hex = { workspace = true }
 num_enum = { workspace = true }
 # Make sure not to enable default-features on prio, as we want clients to be
 # able to get message definitions without pulling in prio/crypto-dependencies
-prio = { workspace = true, features = ["multithreaded", "experimental"] }
+prio = { workspace = true, features = ["experimental"] }
 rand.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -20,7 +20,7 @@ use janus_messages::{
     Query, TaskId, Time,
 };
 #[cfg(feature = "fpvec_bounded_l2")]
-use prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded;
+use prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSum;
 use prio::{
     codec::Decode,
     vdaf::{self, prio3::Prio3, Vdaf},
@@ -504,16 +504,16 @@ macro_rules! options_vdaf_dispatch {
             }
             #[cfg(feature = "fpvec_bounded_l2")]
             (VdafType::FixedPoint16BitBoundedL2VecSum, Some(length), None) => {
-                let $vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI16<U15>> =
-                    Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length)
+                let $vdaf: Prio3FixedPointBoundedL2VecSum<FixedI16<U15>> =
+                    Prio3::new_fixedpoint_boundedl2_vec_sum(2, length)
                         .map_err(|err| Error::Anyhow(err.into()))?;
                 let body = $body;
                 body
             }
             #[cfg(feature = "fpvec_bounded_l2")]
             (VdafType::FixedPoint32BitBoundedL2VecSum, Some(length), None) => {
-                let $vdaf: Prio3FixedPointBoundedL2VecSumMultithreaded<FixedI32<U31>> =
-                    Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(2, length)
+                let $vdaf: Prio3FixedPointBoundedL2VecSum<FixedI32<U31>> =
+                    Prio3::new_fixedpoint_boundedl2_vec_sum(2, length)
                         .map_err(|err| Error::Anyhow(err.into()))?;
                 let body = $body;
                 body


### PR DESCRIPTION
This closes #2956. I changed the aggregator and collector to use `ParallelSum` throughout, because it doesn't matter there. (The multithreading feature only affects the gadget's `call_poly()` method, which is only used during proof generation when sharding) I changed some client callers in integration tests and the interop containers to use `ParallelSumMultithreaded`, because those can be sped up. I also made a few impl blocks generic over `ParallelSumGadget`.