### PR TITLE
Update trillium-opentelemetry to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5633,13 +5633,13 @@ dependencies = [
 
 [[package]]
 name = "trillium-opentelemetry"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2624a8daa27fa4882a88258e447c9b95f1aa8292285bcef9101f751dd9940d"
+checksum = "63429771124359b50235c641649a9d5532b5b137a2b8a2ee1447961ea0706698"
 dependencies = [
  "opentelemetry",
  "trillium",
- "trillium-macros 0.0.5",
+ "trillium-macros 0.0.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ trillium-api = { version = "0.2.0-rc.11", default-features = false }
 trillium-caching-headers = "0.2.3"
 trillium-head = "0.2.2"
 trillium-macros = "0.0.6"
-trillium-opentelemetry = "0.6.0"
+trillium-opentelemetry = "0.7.0"
 trillium-prometheus = "0.1.0"
 trillium-proxy = { version = "0.5.4", default-features = false }
 trillium-router = "0.3.6"


### PR DESCRIPTION
Dependabot is failing to update this and reporting `update_not_possible`. The main change in 0.7.0 for our purposes is that the server.address and server.port metric attributes are now opt-in. We should keep them off because these attributes are populated from request headers, and Janus is expected to be a public-facing HTTP server. (currently we get a lot of junk values for server.address)