### PR TITLE
Update trillium-opentelemetry to 0.7.0, 0.5 backport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4952,13 +4952,13 @@ dependencies = [
 
 [[package]]
 name = "trillium-opentelemetry"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2624a8daa27fa4882a88258e447c9b95f1aa8292285bcef9101f751dd9940d"
+checksum = "63429771124359b50235c641649a9d5532b5b137a2b8a2ee1447961ea0706698"
 dependencies = [
  "opentelemetry",
  "trillium",
- "trillium-macros 0.0.5",
+ "trillium-macros 0.0.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ trillium = "0.2.19"
 trillium-api = { version = "0.2.0-rc.11", default-features = false }
 trillium-caching-headers = "0.2.3"
 trillium-head = "0.2.2"
-trillium-opentelemetry = "0.6.0"
+trillium-opentelemetry = "0.7.0"
 trillium-router = "0.3.6"
 trillium-testing = "0.6.1"
 trillium-tokio = "0.4.0"


### PR DESCRIPTION
Backport of #3059.