### PR TITLE
Upgrade testcontainers to 0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,12 +666,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "bollard-stubs"
-version = "1.42.0-rc.3"
+name = "bollard"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed59b5c00048f48d7af971b71f800fdf23e858844a6f9e4d32ca72e9399e7864"
+checksum = "0aed08d3adb6ebe0eff737115056652670ae290f177759aac19c30456135f94c"
+dependencies = [
+ "base64 0.22.0",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "home",
+ "http 1.1.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-named-pipe",
+ "hyper-rustls 0.26.0",
+ "hyper-util",
+ "hyperlocal-next",
+ "log",
+ "pin-project-lite",
+ "rustls 0.22.4",
+ "rustls-native-certs",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.44.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709d9aa1c37abb89d40f19f5d0ad6f0d88cb1581264e571c9350fc5bb89cf1c5"
 dependencies = [
  "serde",
+ "serde_repr",
  "serde_with",
 ]
 
@@ -1078,9 +1118,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.4"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1088,27 +1128,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.13.4"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 1.0.109",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.13.4"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1231,6 +1271,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "divviup-client"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,6 +1361,70 @@ checksum = "e2153bd83ebc09db15bcbdc3e2194d901804952e3dc96967e1cd3b0c5c32d112"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "encoding"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+dependencies = [
+ "encoding-index-japanese",
+ "encoding-index-korean",
+ "encoding-index-simpchinese",
+ "encoding-index-singlebyte",
+ "encoding-index-tradchinese",
+]
+
+[[package]]
+name = "encoding-index-japanese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-korean"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-simpchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-singlebyte"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-tradchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding_index_tests"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 
 [[package]]
 name = "encoding_rs"
@@ -2107,6 +2232,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper 1.2.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2116,7 +2256,9 @@ dependencies = [
  "http 1.1.0",
  "hyper 1.2.0",
  "hyper-util",
+ "log",
  "rustls 0.22.4",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
@@ -2188,6 +2330,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyperlocal-next"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf569d43fa9848e510358c07b80f4adf34084ddc28c6a4a651ee8474c070dcc"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2234,6 +2391,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -2244,6 +2402,7 @@ checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
+ "serde",
 ]
 
 [[package]]
@@ -2720,6 +2879,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "java-properties"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1904d8654a1ef51034d02d5a9411b50bf91bea15b0ab644ae179d1325976263"
+dependencies = [
+ "encoding",
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "jni"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2904,6 +3074,16 @@ name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.5.0",
+ "libc",
+]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -3312,6 +3492,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3387,6 +3573,31 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "parse-display"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06af5f9333eb47bd9ba8462d612e37a8328a5cb80b13f0af4de4c3b89f52dee5"
+dependencies = [
+ "parse-display-derive",
+ "regex",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc9252f259500ee570c75adcc4e317fa6f57a1e47747d622e0bf838002a7b790"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax 0.8.2",
+ "structmeta",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -3933,6 +4144,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4426,6 +4648,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-java-properties"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ad00b6835632ee448fec1af7c6f8b42efacfa85a393a931427bfae33221a44"
+dependencies = [
+ "encoding",
+ "java-properties",
+ "serde",
+]
+
+[[package]]
 name = "serde-value"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4468,6 +4701,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4499,24 +4743,32 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.14.0"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
 dependencies = [
+ "base64 0.22.0",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.2.6",
  "serde",
+ "serde_derive",
+ "serde_json",
  "serde_with_macros",
+ "time",
 ]
 
 [[package]]
 name = "serde_with_macros"
-version = "1.5.2"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -5015,6 +5267,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn 2.0.55",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5074,19 +5349,24 @@ dependencies = [
 
 [[package]]
 name = "testcontainers"
-version = "0.15.0"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d2931d7f521af5bae989f716c3fa43a6af9af7ec7a5e21b59ae40878cec00"
+checksum = "09f8819a48f576d6a893c574d48cc191eda23a46f4bc395159ba1d9ee33894a3"
 dependencies = [
+ "async-trait",
+ "bollard",
  "bollard-stubs",
+ "dirs",
  "futures",
- "hex",
- "hmac",
  "log",
- "rand",
+ "parse-display",
  "serde",
+ "serde-java-properties",
  "serde_json",
- "sha2",
+ "serde_with",
+ "tokio",
+ "tokio-util",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ signal-hook-tokio = "0.3.1"
 sqlx = "0.7.4"
 stopper = "0.2.7"
 tempfile = "3.10.1"
-testcontainers = "0.15.0"
+testcontainers = { version = "0.16.3", features = ["blocking"] }
 thiserror = "1.0"
 tracing = "0.1.40"
 tracing-chrome = "0.7.2"

--- a/aggregator_core/src/datastore/test_util.rs
+++ b/aggregator_core/src/datastore/test_util.rs
@@ -23,7 +23,7 @@ use std::{
     thread::{self, JoinHandle},
     time::Duration,
 };
-use testcontainers::RunnableImage;
+use testcontainers::{runners::SyncRunner, RunnableImage};
 use tokio::sync::{oneshot, Mutex};
 use tokio_postgres::{connect, Config, NoTls};
 use tracing::trace;
@@ -57,8 +57,7 @@ impl EphemeralDatabase {
             let shutdown_barrier = Arc::clone(&shutdown_barrier);
             move || {
                 // Start an instance of Postgres running in a container.
-                let container_client = testcontainers::clients::Cli::default();
-                let db_container = container_client.run(RunnableImage::from(Postgres::default()));
+                let db_container = RunnableImage::from(Postgres::default()).start();
                 const POSTGRES_DEFAULT_PORT: u16 = 5432;
                 let port_number = db_container.get_host_port_ipv4(POSTGRES_DEFAULT_PORT);
                 trace!("Postgres container is up with port {port_number}");

--- a/core/src/test_util/testcontainers.rs
+++ b/core/src/test_util/testcontainers.rs
@@ -1,23 +1,7 @@
 //! Testing functionality that interacts with the testcontainers library.
 
-use std::{
-    collections::HashMap,
-    process::Command,
-    sync::{Arc, Mutex, Weak},
-};
-use testcontainers::{clients::Cli, core::WaitFor, Image};
-
-/// Returns a container client, possibly shared with other callers to this function.
-pub fn container_client() -> Arc<Cli> {
-    static CONTAINER_CLIENT_MU: Mutex<Weak<Cli>> = Mutex::new(Weak::new());
-
-    let mut container_client = CONTAINER_CLIENT_MU.lock().unwrap();
-    container_client.upgrade().unwrap_or_else(|| {
-        let client = Arc::new(Cli::default());
-        *container_client = Arc::downgrade(&client);
-        client
-    })
-}
+use std::{collections::HashMap, process::Command};
+use testcontainers::{core::WaitFor, Image};
 
 /// A [`testcontainers::Image`] that provides a Postgres server.
 #[derive(Debug)]

--- a/integration_tests/src/client.rs
+++ b/integration_tests/src/client.rs
@@ -17,7 +17,7 @@ use prio::{
 use rand::random;
 use serde_json::{json, Value};
 use std::env;
-use testcontainers::{clients::Cli, core::WaitFor, Image, RunnableImage};
+use testcontainers::{core::WaitFor, runners::AsyncRunner, Image, RunnableImage};
 use url::Url;
 
 /// Extension trait to encode measurements for VDAFs as JSON objects, according to
@@ -182,7 +182,6 @@ pub enum ClientBackend<'a> {
     /// Uploads reports by starting a containerized client implementation, and sending it requests
     /// using draft-dcook-ppm-dap-interop-test-design.
     Container {
-        container_client: &'a Cli,
         container_image: InteropClient,
         network: &'a str,
     },
@@ -195,7 +194,7 @@ impl<'a> ClientBackend<'a> {
         task_parameters: &TaskParameters,
         (leader_port, helper_port): (u16, u16),
         vdaf: V,
-    ) -> anyhow::Result<ClientImplementation<'a, V>>
+    ) -> anyhow::Result<ClientImplementation<V>>
     where
         V: vdaf::Client<16> + InteropClientEncoding,
     {
@@ -208,26 +207,25 @@ impl<'a> ClientBackend<'a> {
             .await
             .map_err(Into::into),
             ClientBackend::Container {
-                container_client,
                 container_image,
                 network,
             } => Ok(ClientImplementation::new_container(
                 test_name,
-                container_client,
                 container_image.clone(),
                 network,
                 task_parameters,
                 vdaf,
-            )),
+            )
+            .await),
         }
     }
 }
 
-pub struct ContainerClientImplementation<'d, V>
+pub struct ContainerClientImplementation<V>
 where
     V: vdaf::Client<16>,
 {
-    _container: ContainerLogsDropGuard<'d, InteropClient>,
+    _container: ContainerLogsDropGuard<InteropClient>,
     leader: Url,
     helper: Url,
     task_id: TaskId,
@@ -240,15 +238,15 @@ where
 
 /// A DAP client implementation, specialized to work with a particular VDAF. See also
 /// [`ClientBackend`].
-pub enum ClientImplementation<'d, V>
+pub enum ClientImplementation<V>
 where
     V: vdaf::Client<16>,
 {
     InProcess { client: Client<V> },
-    Container(Box<ContainerClientImplementation<'d, V>>),
+    Container(Box<ContainerClientImplementation<V>>),
 }
 
-impl<'d, V> ClientImplementation<'d, V>
+impl<V> ClientImplementation<V>
 where
     V: vdaf::Client<16> + InteropClientEncoding,
 {
@@ -256,7 +254,7 @@ where
         task_parameters: &TaskParameters,
         (leader_port, helper_port): (u16, u16),
         vdaf: V,
-    ) -> Result<ClientImplementation<'static, V>, janus_client::Error> {
+    ) -> Result<ClientImplementation<V>, janus_client::Error> {
         let (leader_aggregator_endpoint, helper_aggregator_endpoint) = task_parameters
             .endpoint_fragments
             .endpoints_for_host_client(leader_port, helper_port);
@@ -271,9 +269,8 @@ where
         Ok(ClientImplementation::InProcess { client })
     }
 
-    pub fn new_container(
+    pub async fn new_container(
         test_name: &str,
-        container_client: &'d Cli,
         container_image: InteropClient,
         network: &str,
         task_parameters: &TaskParameters,
@@ -283,14 +280,14 @@ where
         let client_container_name = format!("client-{random_part}");
         let container = ContainerLogsDropGuard::new_janus(
             test_name,
-            container_client.run(
-                RunnableImage::from(container_image)
-                    .with_network(network)
-                    .with_env_var(get_rust_log_level())
-                    .with_container_name(client_container_name),
-            ),
+            RunnableImage::from(container_image)
+                .with_network(network)
+                .with_env_var(get_rust_log_level())
+                .with_container_name(client_container_name)
+                .start()
+                .await,
         );
-        let host_port = container.get_host_port_ipv4(8080);
+        let host_port = container.get_host_port_ipv4(8080).await;
         let http_client = reqwest::Client::new();
         let (leader_aggregator_endpoint, helper_aggregator_endpoint) = task_parameters
             .endpoint_fragments

--- a/integration_tests/tests/integration/common.rs
+++ b/integration_tests/tests/integration/common.rs
@@ -173,7 +173,7 @@ pub async fn submit_measurements_and_verify_aggregate_generic<V>(
     leader_port: u16,
     vdaf: V,
     test_case: &AggregationTestCase<V>,
-    client_implementation: &ClientImplementation<'_, V>,
+    client_implementation: &ClientImplementation<V>,
 ) where
     V: vdaf::Client<16> + vdaf::Collector + InteropClientEncoding,
     V::AggregateResult: PartialEq,
@@ -193,7 +193,7 @@ pub async fn submit_measurements_and_verify_aggregate_generic<V>(
 
 pub async fn submit_measurements_generic<V>(
     measurements: &[V::Measurement],
-    client_implementation: &ClientImplementation<'_, V>,
+    client_implementation: &ClientImplementation<V>,
 ) -> Time
 where
     V: vdaf::Client<16> + vdaf::Collector + InteropClientEncoding,

--- a/integration_tests/tests/integration/daphne.rs
+++ b/integration_tests/tests/integration/daphne.rs
@@ -3,10 +3,7 @@ use crate::{
     initialize_rustls,
 };
 use janus_aggregator_core::task::{test_util::TaskBuilder, QueryType};
-use janus_core::{
-    test_util::{install_test_trace_subscriber, testcontainers::container_client},
-    vdaf::VdafInstance,
-};
+use janus_core::{test_util::install_test_trace_subscriber, vdaf::VdafInstance};
 #[cfg(feature = "testcontainer")]
 use janus_integration_tests::janus::JanusContainer;
 use janus_integration_tests::{
@@ -47,18 +44,8 @@ async fn daphne_janus() {
         .with_leader_aggregator_endpoint(leader_aggregator_endpoint)
         .build();
 
-    let container_client = container_client();
-    let leader = Daphne::new(
-        TEST_NAME,
-        &container_client,
-        &network,
-        &task,
-        Role::Leader,
-        true,
-    )
-    .await;
-    let helper =
-        JanusContainer::new(TEST_NAME, &container_client, &network, &task, Role::Helper).await;
+    let leader = Daphne::new(TEST_NAME, &network, &task, Role::Leader, true).await;
+    let helper = JanusContainer::new(TEST_NAME, &network, &task, Role::Helper).await;
 
     // Run the behavioral test.
     submit_measurements_and_verify_aggregate(
@@ -99,18 +86,8 @@ async fn janus_daphne() {
         .with_helper_aggregator_endpoint(helper_aggregator_endpoint)
         .build();
 
-    let container_client = container_client();
-    let leader =
-        JanusContainer::new(TEST_NAME, &container_client, &network, &task, Role::Leader).await;
-    let helper = Daphne::new(
-        TEST_NAME,
-        &container_client,
-        &network,
-        &task,
-        Role::Helper,
-        true,
-    )
-    .await;
+    let leader = JanusContainer::new(TEST_NAME, &network, &task, Role::Leader).await;
+    let helper = Daphne::new(TEST_NAME, &network, &task, Role::Helper, true).await;
 
     // Run the behavioral test.
     submit_measurements_and_verify_aggregate(
@@ -133,7 +110,6 @@ async fn janus_in_process_daphne() {
 
     // Start servers.
     let network = generate_network_name();
-    let container_client = container_client();
     let (mut task_parameters, mut task_builder) = build_test_task(
         TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Prio3Count),
         TestContext::VirtualNetwork,
@@ -149,7 +125,6 @@ async fn janus_in_process_daphne() {
         .set_path(VERSION_PATH.to_owned());
     let helper = Daphne::new(
         TEST_NAME,
-        &container_client,
         &network,
         &task_builder.clone().build(),
         Role::Helper,

--- a/integration_tests/tests/integration/janus.rs
+++ b/integration_tests/tests/integration/janus.rs
@@ -6,8 +6,6 @@ use crate::{
     initialize_rustls,
 };
 use janus_aggregator_core::task::{test_util::TaskBuilder, QueryType};
-#[cfg(feature = "testcontainer")]
-use janus_core::test_util::testcontainers::container_client;
 use janus_core::{test_util::install_test_trace_subscriber, vdaf::VdafInstance};
 #[cfg(feature = "testcontainer")]
 use janus_integration_tests::janus::JanusContainer;
@@ -17,32 +15,29 @@ use janus_interop_binaries::test_util::generate_network_name;
 use janus_messages::Role;
 use prio::vdaf::dummy;
 use std::time::Duration;
-#[cfg(feature = "testcontainer")]
-use testcontainers::clients::Cli;
 
 /// A pair of Janus instances, running in containers, against which integration tests may be run.
 #[cfg(feature = "testcontainer")]
-struct JanusContainerPair<'a> {
+struct JanusContainerPair {
     /// Task parameters needed by the client and collector, for the task configured in both Janus
     /// aggregators.
     task_parameters: TaskParameters,
 
     /// Handle to the leader's resources, which are released on drop.
-    leader: JanusContainer<'a>,
+    leader: JanusContainer,
     /// Handle to the helper's resources, which are released on drop.
-    helper: JanusContainer<'a>,
+    helper: JanusContainer,
 }
 
 #[cfg(feature = "testcontainer")]
-impl<'a> JanusContainerPair<'a> {
+impl JanusContainerPair {
     /// Set up a new pair of containerized Janus test instances, and set up a new task in each using
     /// the given VDAF and query type.
     pub async fn new(
         test_name: &str,
-        container_client: &'a Cli,
         vdaf: VdafInstance,
         query_type: QueryType,
-    ) -> JanusContainerPair<'a> {
+    ) -> JanusContainerPair {
         let (task_parameters, task_builder) = build_test_task(
             TaskBuilder::new(query_type, vdaf),
             TestContext::VirtualNetwork,
@@ -52,10 +47,8 @@ impl<'a> JanusContainerPair<'a> {
         let task = task_builder.build();
 
         let network = generate_network_name();
-        let leader =
-            JanusContainer::new(test_name, container_client, &network, &task, Role::Leader).await;
-        let helper =
-            JanusContainer::new(test_name, container_client, &network, &task, Role::Helper).await;
+        let leader = JanusContainer::new(test_name, &network, &task, Role::Leader).await;
+        let helper = JanusContainer::new(test_name, &network, &task, Role::Helper).await;
 
         Self {
             task_parameters,
@@ -113,14 +106,8 @@ async fn janus_janus_count() {
     initialize_rustls();
 
     // Start servers.
-    let container_client = container_client();
-    let janus_pair = JanusContainerPair::new(
-        TEST_NAME,
-        &container_client,
-        VdafInstance::Prio3Count,
-        QueryType::TimeInterval,
-    )
-    .await;
+    let janus_pair =
+        JanusContainerPair::new(TEST_NAME, VdafInstance::Prio3Count, QueryType::TimeInterval).await;
 
     // Run the behavioral test.
     submit_measurements_and_verify_aggregate(
@@ -164,10 +151,8 @@ async fn janus_janus_sum_16() {
     initialize_rustls();
 
     // Start servers.
-    let container_client = container_client();
     let janus_pair = JanusContainerPair::new(
         TEST_NAME,
-        &container_client,
         VdafInstance::Prio3Sum { bits: 16 },
         QueryType::TimeInterval,
     )
@@ -215,10 +200,8 @@ async fn janus_janus_histogram_4_buckets() {
     initialize_rustls();
 
     // Start servers.
-    let container_client = container_client();
     let janus_pair = JanusContainerPair::new(
         TEST_NAME,
-        &container_client,
         VdafInstance::Prio3Histogram {
             length: 4,
             chunk_length: 2,
@@ -272,10 +255,8 @@ async fn janus_janus_fixed_size() {
     initialize_rustls();
 
     // Start servers.
-    let container_client = container_client();
     let janus_pair = JanusContainerPair::new(
         TEST_NAME,
-        &container_client,
         VdafInstance::Prio3Count,
         QueryType::FixedSize {
             max_batch_size: Some(50),
@@ -328,10 +309,8 @@ async fn janus_janus_sum_vec() {
     install_test_trace_subscriber();
     initialize_rustls();
 
-    let container_client = container_client();
     let janus_pair = JanusContainerPair::new(
         TEST_NAME,
-        &container_client,
         VdafInstance::Prio3SumVec {
             bits: 16,
             length: 15,

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -27,7 +27,7 @@ use std::{
     str::FromStr,
     sync::Arc,
 };
-use testcontainers::{Container, Image};
+use testcontainers::{ContainerAsync, Image};
 use tokio::sync::Mutex;
 use tracing_log::LogTracer;
 use tracing_subscriber::{prelude::*, EnvFilter, Registry};
@@ -416,9 +416,9 @@ struct ContainerInspectEntry {
     name: String,
 }
 
-pub struct ContainerLogsDropGuard<'d, I: Image> {
+pub struct ContainerLogsDropGuard<I: Image> {
     test_name: String,
-    container: Container<'d, I>,
+    container: ContainerAsync<I>,
     source: ContainerLogsSource,
 }
 
@@ -429,12 +429,12 @@ pub enum ContainerLogsSource {
     Path(String),
 }
 
-impl<'d, I: Image> ContainerLogsDropGuard<'d, I> {
+impl<I: Image> ContainerLogsDropGuard<I> {
     pub fn new(
         test_name: &str,
-        container: Container<'d, I>,
+        container: ContainerAsync<I>,
         source: ContainerLogsSource,
-    ) -> ContainerLogsDropGuard<'d, I> {
+    ) -> ContainerLogsDropGuard<I> {
         ContainerLogsDropGuard {
             test_name: test_name.into(),
             container,
@@ -442,10 +442,7 @@ impl<'d, I: Image> ContainerLogsDropGuard<'d, I> {
         }
     }
 
-    pub fn new_janus(
-        test_name: &str,
-        container: Container<'d, I>,
-    ) -> ContainerLogsDropGuard<'d, I> {
+    pub fn new_janus(test_name: &str, container: ContainerAsync<I>) -> ContainerLogsDropGuard<I> {
         ContainerLogsDropGuard {
             test_name: test_name.into(),
             container,
@@ -454,7 +451,7 @@ impl<'d, I: Image> ContainerLogsDropGuard<'d, I> {
     }
 }
 
-impl<'d, I: Image> Drop for ContainerLogsDropGuard<'d, I> {
+impl<I: Image> Drop for ContainerLogsDropGuard<I> {
     fn drop(&mut self) {
         // The unwraps in this code block would induce a double panic, but we accept this risk
         // since it happens only in test code. This is also our main method of debugging
@@ -510,8 +507,8 @@ impl<'d, I: Image> Drop for ContainerLogsDropGuard<'d, I> {
     }
 }
 
-impl<'d, I: Image> Deref for ContainerLogsDropGuard<'d, I> {
-    type Target = Container<'d, I>;
+impl<I: Image> Deref for ContainerLogsDropGuard<I> {
+    type Target = ContainerAsync<I>;
 
     fn deref(&self) -> &Self::Target {
         &self.container


### PR DESCRIPTION
Testcontainers-rs published a big refactor over the weekend, this PR updates to adapt to the API changes. The biggest changes are that testcontainer clients are no longer part of the API surface, and the library now takes care of lazily instantiating them, plus the non-async client now wraps the HTTP-based client in a new Tokio runtime, rather than shelling out to Docker's CLI. We have to switch to the async API in several places where we are already running inside a Tokio runtime.