### PR TITLE
Re-enable divviup-ts integration tests

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -34,7 +34,7 @@ jobs:
       id: default-input-values
       run: |
         DIVVIUP_TS_INTEROP_CONTAINER= ${{ inputs.divviup_ts_interop_container }}
-        echo "divviup_ts_interop_container=${DIVVIUP_TS_INTEROP_CONTAINER:-us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-ts/divviup_ts_interop_client:dap-draft-07@sha256:3c7ee0bc6e82bd24c8502b7630ac3ff6eb9c87c91498d5765cff0403683231cc}" >> $GITHUB_OUTPUT
+        echo "divviup_ts_interop_container=${DIVVIUP_TS_INTEROP_CONTAINER:-us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-ts/divviup_ts_interop_client:4e71c8b@sha256:61d1bf4cb731d0637b2c5489c45def0155ac22411c4e97607e6cff67cf135198}" >> $GITHUB_OUTPUT
     - name: Get OS version
       id: os-version
       run: echo "release=$(lsb_release --release --short)" >> $GITHUB_OUTPUT

--- a/integration_tests/src/client.rs
+++ b/integration_tests/src/client.rs
@@ -151,8 +151,8 @@ impl InteropClient {
                 name: "us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-ts/\
                        divviup_ts_interop_client"
                     .to_string(),
-                tag: "dap-draft-07@sha256:\
-                      3c7ee0bc6e82bd24c8502b7630ac3ff6eb9c87c91498d5765cff0403683231cc"
+                tag: "4e71c8b@sha256:\
+                      61d1bf4cb731d0637b2c5489c45def0155ac22411c4e97607e6cff67cf135198"
                     .to_string(),
             }
         }

--- a/integration_tests/src/client.rs
+++ b/integration_tests/src/client.rs
@@ -28,7 +28,11 @@ pub trait InteropClientEncoding: vdaf::Client<16> {
 
 impl InteropClientEncoding for Prio3Count {
     fn json_encode_measurement(&self, measurement: &Self::Measurement) -> Value {
-        Value::String(format!("{measurement}"))
+        if *measurement {
+            Value::String("0".into())
+        } else {
+            Value::String("1".into())
+        }
     }
 }
 

--- a/integration_tests/tests/integration/divviup_ts.rs
+++ b/integration_tests/tests/integration/divviup_ts.rs
@@ -41,7 +41,6 @@ async fn run_divviup_ts_integration_test(test_name: &str, vdaf: VdafInstance) {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "disabled until divviup-ts supports draft-ietf-ppm-dap-09"]
 async fn janus_divviup_ts_count() {
     install_test_trace_subscriber();
     initialize_rustls();
@@ -50,7 +49,6 @@ async fn janus_divviup_ts_count() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "disabled until divviup-ts supports draft-ietf-ppm-dap-09"]
 async fn janus_divviup_ts_sum() {
     install_test_trace_subscriber();
     initialize_rustls();
@@ -60,7 +58,6 @@ async fn janus_divviup_ts_sum() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "disabled until divviup-ts supports draft-ietf-ppm-dap-09"]
 async fn janus_divviup_ts_histogram() {
     install_test_trace_subscriber();
     initialize_rustls();
@@ -76,7 +73,6 @@ async fn janus_divviup_ts_histogram() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "disabled until divviup-ts supports draft-ietf-ppm-dap-09"]
 async fn janus_divviup_ts_sumvec() {
     install_test_trace_subscriber();
     initialize_rustls();


### PR DESCRIPTION
The integration tests need a small fix in how they handle Prio3Count. Due to how the generics work out, we are currently relying on `<bool As Display>`, when we should be sending `"0"` or `"1"`. See https://divergentdave.github.io/draft-dcook-ppm-dap-interop-test-design/draft-dcook-ppm-dap-interop-test-design.html#table-3.

> Error: measurement is not a valid base 10 integer (was 'true')