### PR TITLE
Initialize default rustls provider in another test

### DIFF
--- a/aggregator/src/binaries/janus_cli.rs
+++ b/aggregator/src/binaries/janus_cli.rs
@@ -784,6 +784,7 @@ mod tests {
 
     #[tokio::test]
     async fn options_datastore_keys() {
+        initialize_rustls();
         // Prep: create a Kubernetes cluster and put a secret in it
         let k8s_cluster = kubernetes::EphemeralCluster::create();
         let kube_client = k8s_cluster.cluster().client().await.into();


### PR DESCRIPTION
This initializes the default rustls provider in another unit test. I ran into one such issue in #3063 when running one unit test in isolation. To find this missing initialization, I exhaustively ran all tests each in their own process, with the following Python script. (I pivoted from Bash once I realized I needed a directory from each JSON object as well as a compiled executable)

```python
#!/usr/bin/env python3
import json
import os.path
import subprocess

cargo_output = subprocess.check_output([
    "cargo",
    "test",
    "--all-targets",
    "--no-run",
    "--message-format=json",
])
for cargo_line in cargo_output.decode("utf-8").splitlines():
    message = json.loads(cargo_line)
    if message["reason"] != "compiler-artifact":
        continue
    if not message["profile"]:
        continue
    if not message["profile"]["test"]:
        continue
    directory = os.path.dirname(message["manifest_path"])
    executable = message["executable"]

    list_output = subprocess.check_output([
        executable,
        "--list",
        "--format=terse",
    ])
    for line in list_output.decode("utf-8").splitlines():
        if not line.endswith(": test"):
            continue
        test_name = line.removesuffix(": test")
        print(executable, test_name)
        subprocess.check_call(
            [
                executable,
                test_name,
                "--exact",
            ],
            cwd=directory,
        )
```