### PR TITLE
Disable incremental compilation in small profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,8 +138,9 @@ incremental = false
 [profile.small]
 # We define a profile intended to minimize the eventual binary size, while still allowing for
 # relatively fast compilation. It is intended for use in size-constrained testing scenarios, e.g.
-# building a binary artifact that ends up embedded in another binary.
+# minimizing cache usage in CI.
 inherits = "dev"
-opt-level = "z"   # Optimize for size.
-debug = false     # Do not generate debug info.
-strip = true      # Strip symbols from binary.
+opt-level = "z"     # Optimize for size.
+debug = false       # Do not generate debug info.
+strip = true        # Strip symbols from binary.
+incremental = false # This is only used in `docker build`, so incremental compilation won't help.


### PR DESCRIPTION
I noticed that the "ci" profile disables incremental compilation, while the "small" profile does not. Since we only use "small" from inside `docker build`, disabling incremental compilation should be an easy win in terms of layer cache usage.

After this change, the two profiles only differ in their `opt-level` and `strip` settings. It may make sense to unify these profiles, but I'd want to measure build times and layer sizes first.