### PR TITLE
Use ci profile in interop containers

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -181,7 +181,7 @@ jobs:
       with:
         files: docker-bake.hcl
         workdir: .
-        targets: interop_binaries_small
+        targets: interop_binaries_ci
 
   rustsec_advisories:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,8 +137,7 @@ incremental = false
 
 [profile.small]
 # We define a profile intended to minimize the eventual binary size, while still allowing for
-# relatively fast compilation. It is intended for use in size-constrained testing scenarios, e.g.
-# building a binary artifact that ends up embedded in another binary.
+# relatively fast compilation. It is intended for use in size-constrained testing scenarios.
 inherits = "dev"
 opt-level = "z"   # Optimize for size.
 debug = false     # Do not generate debug info.

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -70,6 +70,14 @@ group "interop_binaries_small" {
   ]
 }
 
+group "interop_binaries_ci" {
+  targets = [
+    "janus_interop_client_ci",
+    "janus_interop_aggregator_ci",
+    "janus_interop_collector_ci",
+  ]
+}
+
 target "janus_aggregator" {
   args = {
     GIT_REVISION = "${GIT_REVISION}"
@@ -280,10 +288,6 @@ target "janus_interop_collector_release" {
   ]
 }
 
-# These targets should match the `docker build` commands run in the
-# janus_interop_binaries build script. They are run separately in CI for
-# caching purposes.
-
 target "janus_interop_client_small" {
   args = {
     PROFILE = "small"
@@ -319,6 +323,45 @@ target "janus_interop_collector_small" {
     "type=gha,scope=main-interop-small",
     "type=gha,scope=${GITHUB_BASE_REF}-interop-small",
     "type=gha,scope=${GITHUB_REF_NAME}-interop-small",
+  ]
+  dockerfile = "Dockerfile.interop"
+}
+
+target "janus_interop_client_ci" {
+  args = {
+    PROFILE = "ci"
+    BINARY  = "janus_interop_client"
+  }
+  cache-from = [
+    "type=gha,scope=main-interop-ci",
+    "type=gha,scope=${GITHUB_BASE_REF}-interop-ci",
+    "type=gha,scope=${GITHUB_REF_NAME}-interop-ci",
+  ]
+  dockerfile = "Dockerfile.interop"
+}
+
+target "janus_interop_aggregator_ci" {
+  args = {
+    PROFILE = "ci"
+  }
+  cache-from = [
+    "type=gha,scope=main-interop-ci",
+    "type=gha,scope=${GITHUB_BASE_REF}-interop-ci",
+    "type=gha,scope=${GITHUB_REF_NAME}-interop-ci",
+  ]
+  cache-to   = ["type=gha,scope=${GITHUB_REF_NAME}-interop-ci,mode=max,ignore-error=true"]
+  dockerfile = "Dockerfile.interop_aggregator"
+}
+
+target "janus_interop_collector_ci" {
+  args = {
+    PROFILE = "ci"
+    BINARY  = "janus_interop_collector"
+  }
+  cache-from = [
+    "type=gha,scope=main-interop-ci",
+    "type=gha,scope=${GITHUB_BASE_REF}-interop-ci",
+    "type=gha,scope=${GITHUB_REF_NAME}-interop-ci",
   ]
   dockerfile = "Dockerfile.interop"
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -88,7 +88,7 @@ fn build_container_images() -> Result<ContainerImages> {
         .args([
             "buildx",
             "bake",
-            "interop_binaries_small",
+            "interop_binaries_ci",
             "--load",
             "--metadata-file",
         ])
@@ -103,18 +103,18 @@ fn build_container_images() -> Result<ContainerImages> {
     let metadata: HashMap<String, DockerBakeTargetMetadata> = serde_json::from_reader(file)?;
 
     let client = metadata
-        .get("janus_interop_client_small")
-        .context("missing metadata for janus_interop_client_small")?
+        .get("janus_interop_client_ci")
+        .context("missing metadata for janus_interop_client_ci")?
         .digest
         .clone();
     let aggregator = metadata
-        .get("janus_interop_aggregator_small")
-        .context("missing metadata for janus_interop_aggregator_small")?
+        .get("janus_interop_aggregator_ci")
+        .context("missing metadata for janus_interop_aggregator_ci")?
         .digest
         .clone();
     let collector = metadata
-        .get("janus_interop_collector_small")
-        .context("missing metadata for janus_interop_collector_small")?
+        .get("janus_interop_collector_ci")
+        .context("missing metadata for janus_interop_collector_ci")?
         .digest
         .clone();
 


### PR DESCRIPTION
This changes the profile we use to compile interop containers in tests, from `small` to `ci`. This results in an increase in layer sizes, and thus cache usage, and a huge speedup in compile time. I think this effect is primarily attributable to changing `opt-level` from `"z"` to `0`.

The total size of all Docker stages increased from 5397MiB to 5724MiB. The two chief contributors are the `builder-aggregator` and `final` stages from `Dockerfile.interop_aggregator`, which grew by 158MiB and 136MiB. The relative increase in the `final` stages of both Dockerfiles is large, at 41% and 141%, but note that the size of the final stage doesn't have a big impact anymore, since we are no longer embedding it in later compilations.

Locally, compilation time for the various layers improved by 2x to 6x, depending. The time to compile the aggregator, including both `cargo chef cook` and `cargo build`, went from 18 minutes to 3 minutes. I'm thus expecting a big improvement in CI times.