### PR TITLE
Implement cancellation on disconnect, & parallelize Helper aggregation computations.

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -90,6 +90,7 @@ use prio::{
         xof::XofTurboShake128,
     },
 };
+use rayon::iter::{IndexedParallelIterator as _, IntoParallelRefIterator as _, ParallelIterator};
 use reqwest::Client;
 use ring::{
     digest::{digest, SHA256},
@@ -97,20 +98,15 @@ use ring::{
     signature::{EcdsaKeyPair, Signature},
 };
 use std::{
-    any::Any,
     collections::{HashMap, HashSet},
     fmt::Debug,
     hash::Hash,
-    panic::{catch_unwind, resume_unwind, AssertUnwindSafe},
     path::PathBuf,
     sync::{Arc, Mutex as SyncMutex},
     time::{Duration as StdDuration, Instant},
 };
-use tokio::{
-    sync::oneshot::{self, error::RecvError},
-    try_join,
-};
-use tracing::{debug, info, info_span, trace_span, warn, Level, Span};
+use tokio::try_join;
+use tracing::{debug, info, trace_span, warn, Level};
 use url::Url;
 
 #[cfg(test)]
@@ -1900,10 +1896,8 @@ impl VdafOps {
             return Ok(response);
         }
 
-        let agg_param = Arc::new(
-            A::AggregationParam::get_decoded(req.aggregation_parameter())
-                .map_err(Error::MessageDecode)?,
-        );
+        let agg_param = A::AggregationParam::get_decoded(req.aggregation_parameter())
+            .map_err(Error::MessageDecode)?;
 
         let report_deadline = clock
             .now()
@@ -1922,358 +1916,318 @@ impl VdafOps {
             }
         }
 
-        let prep_closure = {
-            let parent_span = Span::current();
-            let global_hpke_keypairs = global_hpke_keypairs.view();
-            let vdaf = Arc::clone(&vdaf);
-            let task = Arc::clone(&task);
-            let metrics = metrics.clone();
-            let req = Arc::clone(&req);
-            let aggregation_job_id = *aggregation_job_id;
-            let verify_key = *verify_key;
-            let agg_param = Arc::clone(&agg_param);
-            move || -> Result<Vec<ReportShareData<SEED_SIZE, A>>, Error> {
-                let span = info_span!(
-                    parent: parent_span,
-                    "handle_aggregate_init_generic threadpool task"
+        // We validate that each prepare_init can be represented by a `u64` ord value here, so that
+        // inside the parallel iterator we can unwrap. A conversion failure here will fail the
+        // entire aggregation. However, this is desirable: this can only happen if we receive too
+        // many report shares in an aggregation job for us to store, which is a whole-aggregation
+        // problem rather than a per-report problem. (separately, this would require more than
+        // u64::MAX report shares in a single aggregation job, which is practically impossible.)
+        u64::try_from(req.prepare_inits().len())?;
+
+        let mut report_share_data = Vec::new();
+        req
+            .prepare_inits()
+            .par_iter()
+            .enumerate()
+            .map(|(ord, prepare_init)| {
+                // If decryption fails, then the aggregator MUST fail with error `hpke-decrypt-error`. (§4.4.2.2)
+                let global_hpke_keypair = global_hpke_keypairs.keypair(
+                    prepare_init
+                        .report_share()
+                        .encrypted_input_share()
+                        .config_id(),
                 );
-                let _entered = span.enter();
 
-                // Decrypt shares & prepare initialization states. (§4.4.4.1)
-                let mut report_share_data = Vec::new();
-                for (ord, prepare_init) in req.prepare_inits().iter().enumerate() {
-                    // If decryption fails, then the aggregator MUST fail with error `hpke-decrypt-error`. (§4.4.2.2)
-                    let global_hpke_keypair = global_hpke_keypairs.keypair(
-                        prepare_init
-                            .report_share()
-                            .encrypted_input_share()
-                            .config_id(),
+                let task_hpke_keypair = task.hpke_keys().get(
+                    prepare_init
+                        .report_share()
+                        .encrypted_input_share()
+                        .config_id(),
+                );
+
+                let check_keypairs = if task_hpke_keypair.is_none()
+                    && global_hpke_keypair.is_none()
+                {
+                    debug!(
+                        config_id = %prepare_init.report_share().encrypted_input_share().config_id(),
+                        "Helper encrypted input share references unknown HPKE config ID"
                     );
+                    metrics
+                        .aggregate_step_failure_counter
+                        .add(1, &[KeyValue::new("type", "unknown_hpke_config_id")]);
+                    Err(PrepareError::HpkeUnknownConfigId)
+                } else {
+                    Ok(())
+                };
 
-                    let task_hpke_keypair = task.hpke_keys().get(
-                        prepare_init
-                            .report_share()
-                            .encrypted_input_share()
-                            .config_id(),
-                    );
-
-                    let check_keypairs = if task_hpke_keypair.is_none()
-                        && global_hpke_keypair.is_none()
-                    {
+                let input_share_aad = check_keypairs.and_then(|_| {
+                    InputShareAad::new(
+                        *task.id(),
+                        prepare_init.report_share().metadata().clone(),
+                        prepare_init.report_share().public_share().to_vec(),
+                    )
+                    .get_encoded()
+                    .map_err(|err| {
                         debug!(
-                            config_id = %prepare_init.report_share().encrypted_input_share().config_id(),
-                            "Helper encrypted input share references unknown HPKE config ID"
+                            task_id = %task.id(),
+                            metadata = ?prepare_init.report_share().metadata(),
+                            ?err,
+                            "Couldn't encode input share AAD"
+                        );
+                        metrics.aggregate_step_failure_counter.add(
+                            1,
+                            &[KeyValue::new("type", "input_share_aad_encode_failure")],
+                        );
+                        // HpkeDecryptError isn't strictly accurate, but given that this
+                        // fallible encoding is part of the HPKE decryption process, I think
+                        // this is as close as we can get to a meaningful error signal.
+                        PrepareError::HpkeDecryptError
+                    })
+                });
+
+                let plaintext = input_share_aad.and_then(|input_share_aad| {
+                    let try_hpke_open = |hpke_keypair| {
+                        hpke::open(
+                            hpke_keypair,
+                            &HpkeApplicationInfo::new(
+                                &Label::InputShare,
+                                &Role::Client,
+                                &Role::Helper,
+                            ),
+                            prepare_init.report_share().encrypted_input_share(),
+                            &input_share_aad,
+                        )
+                    };
+
+                    match (task_hpke_keypair, global_hpke_keypair) {
+                        (None, None) => unreachable!("already checked this condition"),
+                        (None, Some(global_hpke_keypair)) => {
+                            try_hpke_open(&global_hpke_keypair)
+                        }
+                        (Some(task_hpke_keypair), None) => try_hpke_open(task_hpke_keypair),
+                        (Some(task_hpke_keypair), Some(global_hpke_keypair)) => {
+                            try_hpke_open(task_hpke_keypair).or_else(|error| match error {
+                                // Only attempt second trial if _decryption_ fails, and not some
+                                // error in server-side HPKE configuration.
+                                hpke::Error::Hpke(_) => try_hpke_open(&global_hpke_keypair),
+                                error => Err(error),
+                            })
+                        }
+                    }
+                    .map_err(|error| {
+                        debug!(
+                            task_id = %task.id(),
+                            metadata = ?prepare_init.report_share().metadata(),
+                            ?error,
+                            "Couldn't decrypt helper's report share"
                         );
                         metrics
                             .aggregate_step_failure_counter
-                            .add(1, &[KeyValue::new("type", "unknown_hpke_config_id")]);
-                        Err(PrepareError::HpkeUnknownConfigId)
-                    } else {
-                        Ok(())
-                    };
+                            .add(1, &[KeyValue::new("type", "decrypt_failure")]);
+                        PrepareError::HpkeDecryptError
+                    })
+                });
 
-                    let input_share_aad = check_keypairs.and_then(|_| {
-                        InputShareAad::new(
-                            *task.id(),
-                            prepare_init.report_share().metadata().clone(),
-                            prepare_init.report_share().public_share().to_vec(),
-                        )
-                        .get_encoded()
-                        .map_err(|err| {
+                let plaintext_input_share = plaintext.and_then(|plaintext| {
+                    let plaintext_input_share = PlaintextInputShare::get_decoded(&plaintext)
+                        .map_err(|error| {
                             debug!(
                                 task_id = %task.id(),
                                 metadata = ?prepare_init.report_share().metadata(),
-                                ?err,
-                                "Couldn't encode input share AAD"
+                                ?error, "Couldn't decode helper's plaintext input share",
                             );
                             metrics.aggregate_step_failure_counter.add(
                                 1,
-                                &[KeyValue::new("type", "input_share_aad_encode_failure")],
+                                &[KeyValue::new(
+                                    "type",
+                                    "plaintext_input_share_decode_failure",
+                                )],
                             );
-                            // HpkeDecryptError isn't strictly accurate, but given that this
-                            // fallible encoding is part of the HPKE decryption process, I think
-                            // this is as close as we can get to a meaningful error signal.
-                            PrepareError::HpkeDecryptError
-                        })
-                    });
-
-                    let plaintext = input_share_aad.and_then(|input_share_aad| {
-                        let try_hpke_open = |hpke_keypair| {
-                            hpke::open(
-                                hpke_keypair,
-                                &HpkeApplicationInfo::new(
-                                    &Label::InputShare,
-                                    &Role::Client,
-                                    &Role::Helper,
-                                ),
-                                prepare_init.report_share().encrypted_input_share(),
-                                &input_share_aad,
-                            )
-                        };
-
-                        match (task_hpke_keypair, global_hpke_keypair) {
-                            (None, None) => unreachable!("already checked this condition"),
-                            (None, Some(global_hpke_keypair)) => {
-                                try_hpke_open(&global_hpke_keypair)
-                            }
-                            (Some(task_hpke_keypair), None) => try_hpke_open(task_hpke_keypair),
-                            (Some(task_hpke_keypair), Some(global_hpke_keypair)) => {
-                                try_hpke_open(task_hpke_keypair).or_else(|error| match error {
-                                    // Only attempt second trial if _decryption_ fails, and not some
-                                    // error in server-side HPKE configuration.
-                                    hpke::Error::Hpke(_) => try_hpke_open(&global_hpke_keypair),
-                                    error => Err(error),
-                                })
-                            }
-                        }
-                        .map_err(|error| {
-                            debug!(
-                                task_id = %task.id(),
-                                metadata = ?prepare_init.report_share().metadata(),
-                                ?error,
-                                "Couldn't decrypt helper's report share"
-                            );
-                            metrics
-                                .aggregate_step_failure_counter
-                                .add(1, &[KeyValue::new("type", "decrypt_failure")]);
-                            PrepareError::HpkeDecryptError
-                        })
-                    });
-
-                    let plaintext_input_share = plaintext.and_then(|plaintext| {
-                        let plaintext_input_share = PlaintextInputShare::get_decoded(&plaintext)
-                            .map_err(|error| {
-                                debug!(
-                                    task_id = %task.id(),
-                                    metadata = ?prepare_init.report_share().metadata(),
-                                    ?error, "Couldn't decode helper's plaintext input share",
-                                );
-                                metrics.aggregate_step_failure_counter.add(
-                                    1,
-                                    &[KeyValue::new(
-                                        "type",
-                                        "plaintext_input_share_decode_failure",
-                                    )],
-                                );
-                                PrepareError::InvalidMessage
-                            })?;
-
-                        // Build map of extension type to extension data, checking for duplicates.
-                        let mut extensions = HashMap::new();
-                        if !plaintext_input_share.extensions().iter().all(|extension| {
-                            extensions
-                                .insert(*extension.extension_type(), extension.extension_data())
-                                .is_none()
-                        }) {
-                            debug!(
-                                task_id = %task.id(),
-                                metadata = ?prepare_init.report_share().metadata(),
-                                "Received report share with duplicate extensions",
-                            );
-                            metrics
-                                .aggregate_step_failure_counter
-                                .add(1, &[KeyValue::new("type", "duplicate_extension")]);
-                            return Err(PrepareError::InvalidMessage);
-                        }
-
-                        if require_taskprov_extension {
-                            let valid_taskprov_extension_present = extensions
-                                .get(&ExtensionType::Taskprov)
-                                .map(|data| data.is_empty())
-                                .unwrap_or(false);
-                            if !valid_taskprov_extension_present {
-                                debug!(
-                                    task_id = %task.id(),
-                                    metadata = ?prepare_init.report_share().metadata(),
-                                    "Taskprov task received report with missing or malformed \
-                                    taskprov extension",
-                                );
-                                metrics.aggregate_step_failure_counter.add(
-                                    1,
-                                    &[KeyValue::new(
-                                        "type",
-                                        "missing_or_malformed_taskprov_extension",
-                                    )],
-                                );
-                                return Err(PrepareError::InvalidMessage);
-                            }
-                        } else if extensions.contains_key(&ExtensionType::Taskprov) {
-                            // taskprov not enabled, but the taskprov extension is present.
-                            debug!(
-                                task_id = %task.id(),
-                                metadata = ?prepare_init.report_share().metadata(),
-                                "Non-taskprov task received report with unexpected taskprov \
-                                extension",
-                            );
-                            metrics
-                                .aggregate_step_failure_counter
-                                .add(1, &[KeyValue::new("type", "unexpected_taskprov_extension")]);
-                            return Err(PrepareError::InvalidMessage);
-                        }
-
-                        Ok(plaintext_input_share)
-                    });
-
-                    let input_share = plaintext_input_share.and_then(|plaintext_input_share| {
-                        A::InputShare::get_decoded_with_param(
-                            &(&vdaf, Role::Helper.index().unwrap()),
-                            plaintext_input_share.payload(),
-                        )
-                        .map_err(|error| {
-                            debug!(
-                                task_id = %task.id(),
-                                metadata = ?prepare_init.report_share().metadata(),
-                                ?error, "Couldn't decode helper's input share",
-                            );
-                            metrics
-                                .aggregate_step_failure_counter
-                                .add(1, &[KeyValue::new("type", "input_share_decode_failure")]);
                             PrepareError::InvalidMessage
-                        })
-                    });
+                        })?;
 
-                    let public_share = A::PublicShare::get_decoded_with_param(
-                        &vdaf,
-                        prepare_init.report_share().public_share(),
+                    // Build map of extension type to extension data, checking for duplicates.
+                    let mut extensions = HashMap::new();
+                    if !plaintext_input_share.extensions().iter().all(|extension| {
+                        extensions
+                            .insert(*extension.extension_type(), extension.extension_data())
+                            .is_none()
+                    }) {
+                        debug!(
+                            task_id = %task.id(),
+                            metadata = ?prepare_init.report_share().metadata(),
+                            "Received report share with duplicate extensions",
+                        );
+                        metrics
+                            .aggregate_step_failure_counter
+                            .add(1, &[KeyValue::new("type", "duplicate_extension")]);
+                        return Err(PrepareError::InvalidMessage);
+                    }
+
+                    if require_taskprov_extension {
+                        let valid_taskprov_extension_present = extensions
+                            .get(&ExtensionType::Taskprov)
+                            .map(|data| data.is_empty())
+                            .unwrap_or(false);
+                        if !valid_taskprov_extension_present {
+                            debug!(
+                                task_id = %task.id(),
+                                metadata = ?prepare_init.report_share().metadata(),
+                                "Taskprov task received report with missing or malformed \
+                                taskprov extension",
+                            );
+                            metrics.aggregate_step_failure_counter.add(
+                                1,
+                                &[KeyValue::new(
+                                    "type",
+                                    "missing_or_malformed_taskprov_extension",
+                                )],
+                            );
+                            return Err(PrepareError::InvalidMessage);
+                        }
+                    } else if extensions.contains_key(&ExtensionType::Taskprov) {
+                        // taskprov not enabled, but the taskprov extension is present.
+                        debug!(
+                            task_id = %task.id(),
+                            metadata = ?prepare_init.report_share().metadata(),
+                            "Non-taskprov task received report with unexpected taskprov \
+                            extension",
+                        );
+                        metrics
+                            .aggregate_step_failure_counter
+                            .add(1, &[KeyValue::new("type", "unexpected_taskprov_extension")]);
+                        return Err(PrepareError::InvalidMessage);
+                    }
+
+                    Ok(plaintext_input_share)
+                });
+
+                let input_share = plaintext_input_share.and_then(|plaintext_input_share| {
+                    A::InputShare::get_decoded_with_param(
+                        &(&vdaf, Role::Helper.index().unwrap()),
+                        plaintext_input_share.payload(),
                     )
                     .map_err(|error| {
                         debug!(
                             task_id = %task.id(),
                             metadata = ?prepare_init.report_share().metadata(),
-                            ?error, "Couldn't decode public share",
+                            ?error, "Couldn't decode helper's input share",
                         );
                         metrics
                             .aggregate_step_failure_counter
-                            .add(1, &[KeyValue::new("type", "public_share_decode_failure")]);
+                            .add(1, &[KeyValue::new("type", "input_share_decode_failure")]);
                         PrepareError::InvalidMessage
-                    });
+                    })
+                });
 
-                    let shares =
-                        input_share.and_then(|input_share| Ok((public_share?, input_share)));
+                let public_share = A::PublicShare::get_decoded_with_param(
+                    &vdaf,
+                    prepare_init.report_share().public_share(),
+                )
+                .map_err(|error| {
+                    debug!(
+                        task_id = %task.id(),
+                        metadata = ?prepare_init.report_share().metadata(),
+                        ?error, "Couldn't decode public share",
+                    );
+                    metrics
+                        .aggregate_step_failure_counter
+                        .add(1, &[KeyValue::new("type", "public_share_decode_failure")]);
+                    PrepareError::InvalidMessage
+                });
 
-                    // Reject reports from too far in the future.
-                    let shares = shares.and_then(|shares| {
-                        if prepare_init
-                            .report_share()
-                            .metadata()
-                            .time()
-                            .is_after(&report_deadline)
-                        {
-                            return Err(PrepareError::ReportTooEarly);
-                        }
-                        Ok(shares)
-                    });
+                let shares =
+                    input_share.and_then(|input_share| Ok((public_share?, input_share)));
 
-                    // Next, the aggregator runs the preparation-state initialization algorithm for the VDAF
-                    // associated with the task and computes the first state transition. [...] If either
-                    // step fails, then the aggregator MUST fail with error `vdaf-prep-error`. (§4.4.2.2)
-                    let init_rslt = shares.and_then(|(public_share, input_share)| {
-                        trace_span!("VDAF preparation (helper initialization)").in_scope(|| {
-                            vdaf.helper_initialized(
-                                verify_key.as_bytes(),
-                                &agg_param,
-                                /* report ID is used as VDAF nonce */
-                                prepare_init.report_share().metadata().id().as_ref(),
-                                &public_share,
-                                &input_share,
-                                prepare_init.message(),
+                // Reject reports from too far in the future.
+                let shares = shares.and_then(|shares| {
+                    if prepare_init
+                        .report_share()
+                        .metadata()
+                        .time()
+                        .is_after(&report_deadline)
+                    {
+                        return Err(PrepareError::ReportTooEarly);
+                    }
+                    Ok(shares)
+                });
+
+                // Next, the aggregator runs the preparation-state initialization algorithm for the VDAF
+                // associated with the task and computes the first state transition. [...] If either
+                // step fails, then the aggregator MUST fail with error `vdaf-prep-error`. (§4.4.2.2)
+                let init_rslt = shares.and_then(|(public_share, input_share)| {
+                    trace_span!("VDAF preparation (helper initialization)").in_scope(|| {
+                        vdaf.helper_initialized(
+                            verify_key.as_bytes(),
+                            &agg_param,
+                            /* report ID is used as VDAF nonce */
+                            prepare_init.report_share().metadata().id().as_ref(),
+                            &public_share,
+                            &input_share,
+                            prepare_init.message(),
+                        )
+                        .and_then(|transition| transition.evaluate(&vdaf))
+                        .map_err(|error| {
+                            handle_ping_pong_error(
+                                task.id(),
+                                Role::Helper,
+                                prepare_init.report_share().metadata().id(),
+                                error,
+                                &metrics.aggregate_step_failure_counter,
                             )
-                            .and_then(|transition| transition.evaluate(&vdaf))
-                            .map_err(|error| {
-                                handle_ping_pong_error(
-                                    task.id(),
-                                    Role::Helper,
-                                    prepare_init.report_share().metadata().id(),
-                                    error,
-                                    &metrics.aggregate_step_failure_counter,
-                                )
-                            })
                         })
-                    });
+                    })
+                });
 
-                    let (report_aggregation_state, prepare_step_result, output_share) =
-                        match init_rslt {
-                            Ok((PingPongState::Continued(prepare_state), outgoing_message)) => {
-                                // Helper is not finished. Await the next message from the Leader to advance to
-                                // the next step.
-                                (
-                                    ReportAggregationState::WaitingHelper { prepare_state },
-                                    PrepareStepResult::Continue {
-                                        message: outgoing_message,
-                                    },
-                                    None,
-                                )
-                            }
-                            Ok((PingPongState::Finished(output_share), outgoing_message)) => (
-                                ReportAggregationState::Finished,
+                let (report_aggregation_state, prepare_step_result, output_share) =
+                    match init_rslt {
+                        Ok((PingPongState::Continued(prepare_state), outgoing_message)) => {
+                            // Helper is not finished. Await the next message from the Leader to advance to
+                            // the next step.
+                            (
+                                ReportAggregationState::WaitingHelper { prepare_state },
                                 PrepareStepResult::Continue {
                                     message: outgoing_message,
                                 },
-                                Some(output_share),
-                            ),
-                            Err(prepare_error) => (
-                                ReportAggregationState::Failed { prepare_error },
-                                PrepareStepResult::Reject(prepare_error),
                                 None,
-                            ),
-                        };
-
-                    report_share_data.push(ReportShareData {
-                        report_share: prepare_init.report_share().clone(),
-                        report_aggregation: WritableReportAggregation::new(
-                            ReportAggregation::<SEED_SIZE, A>::new(
-                                *task.id(),
-                                aggregation_job_id,
-                                *prepare_init.report_share().metadata().id(),
-                                *prepare_init.report_share().metadata().time(),
-                                // A conversion failure here will fail the entire aggregation.
-                                // However, this is desirable: this can only happen if we receive
-                                // too many report shares in an aggregation job for us to store,
-                                // which is a whole-aggregation problem rather than a per-report
-                                // problem. (separately, this would require more than u64::MAX
-                                // report shares in a single aggregation job, which is practically
-                                // impossible.)
-                                ord.try_into()?,
-                                Some(PrepareResp::new(
-                                    *prepare_init.report_share().metadata().id(),
-                                    prepare_step_result,
-                                )),
-                                report_aggregation_state,
-                            ),
-                            output_share,
+                            )
+                        }
+                        Ok((PingPongState::Finished(output_share), outgoing_message)) => (
+                            ReportAggregationState::Finished,
+                            PrepareStepResult::Continue {
+                                message: outgoing_message,
+                            },
+                            Some(output_share),
                         ),
-                    });
-                }
-                Ok(report_share_data)
-            }
-        };
-        let (sender, receiver) = oneshot::channel();
-        rayon::spawn(|| {
-            // Do nothing if the result cannot be sent back. This would happen if the initiating
-            // future is cancelled.
-            //
-            // We need to catch panics here because rayon's default threadpool panic handler will
-            // abort, and it would be preferable to propagate the panic in the original future to
-            // avoid behavior changes.
-            //
-            // Using `AssertUnwindSafe` is OK here, because the only interior mutability we make use
-            // of is OTel instruments, which can't be put into inconsistent states merely by
-            // incrementing counters, and the global HPKE keypair cache, which we only read from.
-            // Using `AssertUnwindSafe` is easier than adding infectious `UnwindSafe` trait bounds
-            // to various VDAF associated types throughout the codebase.
-            let _ = sender.send(catch_unwind(AssertUnwindSafe(prep_closure)));
-        });
-        let report_share_data = receiver
-            .await
-            .map_err(|_recv_error: RecvError| {
-                Error::Internal("threadpool failed to send VDAF preparation result".into())
-            })?
-            .unwrap_or_else(|panic_cause: Box<dyn Any + Send>| {
-                resume_unwind(panic_cause);
-            })?;
+                        Err(prepare_error) => (
+                            ReportAggregationState::Failed { prepare_error },
+                            PrepareStepResult::Reject(prepare_error),
+                            None,
+                        ),
+                    };
 
-        // TODO: Use Arc::unwrap_or_clone() once the MSRV is at least 1.76.0.
-        let agg_param = Arc::try_unwrap(agg_param).unwrap_or_else(|arc| arc.as_ref().clone());
+                ReportShareData {
+                    report_share: prepare_init.report_share().clone(),
+                    report_aggregation: WritableReportAggregation::new(
+                        ReportAggregation::<SEED_SIZE, A>::new(
+                            *task.id(),
+                            *aggregation_job_id,
+                            *prepare_init.report_share().metadata().id(),
+                            *prepare_init.report_share().metadata().time(),
+                            // Unwrap safety: we checked that all ordinal values are representable
+                            // as a u64 before entering the parallel iterator.
+                            ord.try_into().unwrap(),
+                            Some(PrepareResp::new(
+                                *prepare_init.report_share().metadata().id(),
+                                prepare_step_result,
+                            )),
+                            report_aggregation_state,
+                        ),
+                        output_share,
+                    ),
+                }
+            })
+            .collect_into_vec(&mut report_share_data);
 
         // Store data to datastore.
         let min_client_timestamp = req

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -101,11 +101,12 @@ use std::{
     collections::{HashMap, HashSet},
     fmt::Debug,
     hash::Hash,
+    panic,
     path::PathBuf,
     sync::{Arc, Mutex as SyncMutex},
     time::{Duration as StdDuration, Instant},
 };
-use tokio::try_join;
+use tokio::{sync::mpsc, try_join};
 use tracing::{debug, info, trace_span, warn, Level};
 use url::Url;
 
@@ -1896,8 +1897,10 @@ impl VdafOps {
             return Ok(response);
         }
 
-        let agg_param = A::AggregationParam::get_decoded(req.aggregation_parameter())
-            .map_err(Error::MessageDecode)?;
+        let agg_param = Arc::new(
+            A::AggregationParam::get_decoded(req.aggregation_parameter())
+                .map_err(Error::MessageDecode)?,
+        );
 
         let report_deadline = clock
             .now()
@@ -1916,6 +1919,8 @@ impl VdafOps {
             }
         }
 
+        // Compute the next aggregation step.
+        //
         // We validate that each prepare_init can be represented by a `u64` ord value here, so that
         // inside the parallel iterator we can unwrap. A conversion failure here will fail the
         // entire aggregation. However, this is desirable: this can only happen if we receive too
@@ -1924,310 +1929,339 @@ impl VdafOps {
         // u64::MAX report shares in a single aggregation job, which is practically impossible.)
         u64::try_from(req.prepare_inits().len())?;
 
-        let mut report_share_data = Vec::new();
-        req
-            .prepare_inits()
-            .par_iter()
-            .enumerate()
-            .map(|(ord, prepare_init)| {
-                // If decryption fails, then the aggregator MUST fail with error `hpke-decrypt-error`. (§4.4.2.2)
-                let global_hpke_keypair = global_hpke_keypairs.keypair(
-                    prepare_init
-                        .report_share()
-                        .encrypted_input_share()
-                        .config_id(),
-                );
+        let (sender, mut receiver) = mpsc::unbounded_channel();
+        let producer_task = tokio::task::spawn_blocking({
+            let global_hpke_keypairs = global_hpke_keypairs.view();
+            let vdaf = Arc::clone(&vdaf);
+            let task = Arc::clone(&task);
+            let metrics = metrics.clone();
+            let req = Arc::clone(&req);
+            let aggregation_job_id = *aggregation_job_id;
+            let verify_key = *verify_key;
+            let agg_param = Arc::clone(&agg_param);
 
-                let task_hpke_keypair = task.hpke_keys().get(
-                    prepare_init
-                        .report_share()
-                        .encrypted_input_share()
-                        .config_id(),
-                );
-
-                let check_keypairs = if task_hpke_keypair.is_none()
-                    && global_hpke_keypair.is_none()
-                {
-                    debug!(
-                        config_id = %prepare_init.report_share().encrypted_input_share().config_id(),
-                        "Helper encrypted input share references unknown HPKE config ID"
-                    );
-                    metrics
-                        .aggregate_step_failure_counter
-                        .add(1, &[KeyValue::new("type", "unknown_hpke_config_id")]);
-                    Err(PrepareError::HpkeUnknownConfigId)
-                } else {
-                    Ok(())
-                };
-
-                let input_share_aad = check_keypairs.and_then(|_| {
-                    InputShareAad::new(
-                        *task.id(),
-                        prepare_init.report_share().metadata().clone(),
-                        prepare_init.report_share().public_share().to_vec(),
-                    )
-                    .get_encoded()
-                    .map_err(|err| {
-                        debug!(
-                            task_id = %task.id(),
-                            metadata = ?prepare_init.report_share().metadata(),
-                            ?err,
-                            "Couldn't encode input share AAD"
+            move || {
+                req
+                    .prepare_inits()
+                    .par_iter()
+                    .enumerate()
+                    .try_for_each_with(sender, |sender, (ord, prepare_init)| {
+                        // If decryption fails, then the aggregator MUST fail with error `hpke-decrypt-error`. (§4.4.2.2)
+                        let global_hpke_keypair = global_hpke_keypairs.keypair(
+                            prepare_init
+                                .report_share()
+                                .encrypted_input_share()
+                                .config_id(),
                         );
-                        metrics.aggregate_step_failure_counter.add(
-                            1,
-                            &[KeyValue::new("type", "input_share_aad_encode_failure")],
+
+                        let task_hpke_keypair = task.hpke_keys().get(
+                            prepare_init
+                                .report_share()
+                                .encrypted_input_share()
+                                .config_id(),
                         );
-                        // HpkeDecryptError isn't strictly accurate, but given that this
-                        // fallible encoding is part of the HPKE decryption process, I think
-                        // this is as close as we can get to a meaningful error signal.
-                        PrepareError::HpkeDecryptError
-                    })
-                });
 
-                let plaintext = input_share_aad.and_then(|input_share_aad| {
-                    let try_hpke_open = |hpke_keypair| {
-                        hpke::open(
-                            hpke_keypair,
-                            &HpkeApplicationInfo::new(
-                                &Label::InputShare,
-                                &Role::Client,
-                                &Role::Helper,
-                            ),
-                            prepare_init.report_share().encrypted_input_share(),
-                            &input_share_aad,
-                        )
-                    };
-
-                    match (task_hpke_keypair, global_hpke_keypair) {
-                        (None, None) => unreachable!("already checked this condition"),
-                        (None, Some(global_hpke_keypair)) => {
-                            try_hpke_open(&global_hpke_keypair)
-                        }
-                        (Some(task_hpke_keypair), None) => try_hpke_open(task_hpke_keypair),
-                        (Some(task_hpke_keypair), Some(global_hpke_keypair)) => {
-                            try_hpke_open(task_hpke_keypair).or_else(|error| match error {
-                                // Only attempt second trial if _decryption_ fails, and not some
-                                // error in server-side HPKE configuration.
-                                hpke::Error::Hpke(_) => try_hpke_open(&global_hpke_keypair),
-                                error => Err(error),
-                            })
-                        }
-                    }
-                    .map_err(|error| {
-                        debug!(
-                            task_id = %task.id(),
-                            metadata = ?prepare_init.report_share().metadata(),
-                            ?error,
-                            "Couldn't decrypt helper's report share"
-                        );
-                        metrics
-                            .aggregate_step_failure_counter
-                            .add(1, &[KeyValue::new("type", "decrypt_failure")]);
-                        PrepareError::HpkeDecryptError
-                    })
-                });
-
-                let plaintext_input_share = plaintext.and_then(|plaintext| {
-                    let plaintext_input_share = PlaintextInputShare::get_decoded(&plaintext)
-                        .map_err(|error| {
+                        let check_keypairs = if task_hpke_keypair.is_none()
+                            && global_hpke_keypair.is_none()
+                        {
                             debug!(
-                                task_id = %task.id(),
-                                metadata = ?prepare_init.report_share().metadata(),
-                                ?error, "Couldn't decode helper's plaintext input share",
+                                config_id = %prepare_init.report_share().encrypted_input_share().config_id(),
+                                "Helper encrypted input share references unknown HPKE config ID"
                             );
-                            metrics.aggregate_step_failure_counter.add(
-                                1,
-                                &[KeyValue::new(
-                                    "type",
-                                    "plaintext_input_share_decode_failure",
-                                )],
-                            );
-                            PrepareError::InvalidMessage
-                        })?;
+                            metrics
+                                .aggregate_step_failure_counter
+                                .add(1, &[KeyValue::new("type", "unknown_hpke_config_id")]);
+                            Err(PrepareError::HpkeUnknownConfigId)
+                        } else {
+                            Ok(())
+                        };
 
-                    // Build map of extension type to extension data, checking for duplicates.
-                    let mut extensions = HashMap::new();
-                    if !plaintext_input_share.extensions().iter().all(|extension| {
-                        extensions
-                            .insert(*extension.extension_type(), extension.extension_data())
-                            .is_none()
-                    }) {
-                        debug!(
-                            task_id = %task.id(),
-                            metadata = ?prepare_init.report_share().metadata(),
-                            "Received report share with duplicate extensions",
-                        );
-                        metrics
-                            .aggregate_step_failure_counter
-                            .add(1, &[KeyValue::new("type", "duplicate_extension")]);
-                        return Err(PrepareError::InvalidMessage);
-                    }
-
-                    if require_taskprov_extension {
-                        let valid_taskprov_extension_present = extensions
-                            .get(&ExtensionType::Taskprov)
-                            .map(|data| data.is_empty())
-                            .unwrap_or(false);
-                        if !valid_taskprov_extension_present {
-                            debug!(
-                                task_id = %task.id(),
-                                metadata = ?prepare_init.report_share().metadata(),
-                                "Taskprov task received report with missing or malformed \
-                                taskprov extension",
-                            );
-                            metrics.aggregate_step_failure_counter.add(
-                                1,
-                                &[KeyValue::new(
-                                    "type",
-                                    "missing_or_malformed_taskprov_extension",
-                                )],
-                            );
-                            return Err(PrepareError::InvalidMessage);
-                        }
-                    } else if extensions.contains_key(&ExtensionType::Taskprov) {
-                        // taskprov not enabled, but the taskprov extension is present.
-                        debug!(
-                            task_id = %task.id(),
-                            metadata = ?prepare_init.report_share().metadata(),
-                            "Non-taskprov task received report with unexpected taskprov \
-                            extension",
-                        );
-                        metrics
-                            .aggregate_step_failure_counter
-                            .add(1, &[KeyValue::new("type", "unexpected_taskprov_extension")]);
-                        return Err(PrepareError::InvalidMessage);
-                    }
-
-                    Ok(plaintext_input_share)
-                });
-
-                let input_share = plaintext_input_share.and_then(|plaintext_input_share| {
-                    A::InputShare::get_decoded_with_param(
-                        &(&vdaf, Role::Helper.index().unwrap()),
-                        plaintext_input_share.payload(),
-                    )
-                    .map_err(|error| {
-                        debug!(
-                            task_id = %task.id(),
-                            metadata = ?prepare_init.report_share().metadata(),
-                            ?error, "Couldn't decode helper's input share",
-                        );
-                        metrics
-                            .aggregate_step_failure_counter
-                            .add(1, &[KeyValue::new("type", "input_share_decode_failure")]);
-                        PrepareError::InvalidMessage
-                    })
-                });
-
-                let public_share = A::PublicShare::get_decoded_with_param(
-                    &vdaf,
-                    prepare_init.report_share().public_share(),
-                )
-                .map_err(|error| {
-                    debug!(
-                        task_id = %task.id(),
-                        metadata = ?prepare_init.report_share().metadata(),
-                        ?error, "Couldn't decode public share",
-                    );
-                    metrics
-                        .aggregate_step_failure_counter
-                        .add(1, &[KeyValue::new("type", "public_share_decode_failure")]);
-                    PrepareError::InvalidMessage
-                });
-
-                let shares =
-                    input_share.and_then(|input_share| Ok((public_share?, input_share)));
-
-                // Reject reports from too far in the future.
-                let shares = shares.and_then(|shares| {
-                    if prepare_init
-                        .report_share()
-                        .metadata()
-                        .time()
-                        .is_after(&report_deadline)
-                    {
-                        return Err(PrepareError::ReportTooEarly);
-                    }
-                    Ok(shares)
-                });
-
-                // Next, the aggregator runs the preparation-state initialization algorithm for the VDAF
-                // associated with the task and computes the first state transition. [...] If either
-                // step fails, then the aggregator MUST fail with error `vdaf-prep-error`. (§4.4.2.2)
-                let init_rslt = shares.and_then(|(public_share, input_share)| {
-                    trace_span!("VDAF preparation (helper initialization)").in_scope(|| {
-                        vdaf.helper_initialized(
-                            verify_key.as_bytes(),
-                            &agg_param,
-                            /* report ID is used as VDAF nonce */
-                            prepare_init.report_share().metadata().id().as_ref(),
-                            &public_share,
-                            &input_share,
-                            prepare_init.message(),
-                        )
-                        .and_then(|transition| transition.evaluate(&vdaf))
-                        .map_err(|error| {
-                            handle_ping_pong_error(
-                                task.id(),
-                                Role::Helper,
-                                prepare_init.report_share().metadata().id(),
-                                error,
-                                &metrics.aggregate_step_failure_counter,
+                        let input_share_aad = check_keypairs.and_then(|_| {
+                            InputShareAad::new(
+                                *task.id(),
+                                prepare_init.report_share().metadata().clone(),
+                                prepare_init.report_share().public_share().to_vec(),
                             )
+                            .get_encoded()
+                            .map_err(|err| {
+                                debug!(
+                                    task_id = %task.id(),
+                                    metadata = ?prepare_init.report_share().metadata(),
+                                    ?err,
+                                    "Couldn't encode input share AAD"
+                                );
+                                metrics.aggregate_step_failure_counter.add(
+                                    1,
+                                    &[KeyValue::new("type", "input_share_aad_encode_failure")],
+                                );
+                                // HpkeDecryptError isn't strictly accurate, but given that this
+                                // fallible encoding is part of the HPKE decryption process, I think
+                                // this is as close as we can get to a meaningful error signal.
+                                PrepareError::HpkeDecryptError
+                            })
+                        });
+
+                        let plaintext = input_share_aad.and_then(|input_share_aad| {
+                            let try_hpke_open = |hpke_keypair| {
+                                hpke::open(
+                                    hpke_keypair,
+                                    &HpkeApplicationInfo::new(
+                                        &Label::InputShare,
+                                        &Role::Client,
+                                        &Role::Helper,
+                                    ),
+                                    prepare_init.report_share().encrypted_input_share(),
+                                    &input_share_aad,
+                                )
+                            };
+
+                            match (task_hpke_keypair, global_hpke_keypair) {
+                                (None, None) => unreachable!("already checked this condition"),
+                                (None, Some(global_hpke_keypair)) => {
+                                    try_hpke_open(&global_hpke_keypair)
+                                }
+                                (Some(task_hpke_keypair), None) => try_hpke_open(task_hpke_keypair),
+                                (Some(task_hpke_keypair), Some(global_hpke_keypair)) => {
+                                    try_hpke_open(task_hpke_keypair).or_else(|error| match error {
+                                        // Only attempt second trial if _decryption_ fails, and not some
+                                        // error in server-side HPKE configuration.
+                                        hpke::Error::Hpke(_) => try_hpke_open(&global_hpke_keypair),
+                                        error => Err(error),
+                                    })
+                                }
+                            }
+                            .map_err(|error| {
+                                debug!(
+                                    task_id = %task.id(),
+                                    metadata = ?prepare_init.report_share().metadata(),
+                                    ?error,
+                                    "Couldn't decrypt helper's report share"
+                                );
+                                metrics
+                                    .aggregate_step_failure_counter
+                                    .add(1, &[KeyValue::new("type", "decrypt_failure")]);
+                                PrepareError::HpkeDecryptError
+                            })
+                        });
+
+                        let plaintext_input_share = plaintext.and_then(|plaintext| {
+                            let plaintext_input_share = PlaintextInputShare::get_decoded(&plaintext)
+                                .map_err(|error| {
+                                    debug!(
+                                        task_id = %task.id(),
+                                        metadata = ?prepare_init.report_share().metadata(),
+                                        ?error, "Couldn't decode helper's plaintext input share",
+                                    );
+                                    metrics.aggregate_step_failure_counter.add(
+                                        1,
+                                        &[KeyValue::new(
+                                            "type",
+                                            "plaintext_input_share_decode_failure",
+                                        )],
+                                    );
+                                    PrepareError::InvalidMessage
+                                })?;
+
+                            // Build map of extension type to extension data, checking for duplicates.
+                            let mut extensions = HashMap::new();
+                            if !plaintext_input_share.extensions().iter().all(|extension| {
+                                extensions
+                                    .insert(*extension.extension_type(), extension.extension_data())
+                                    .is_none()
+                            }) {
+                                debug!(
+                                    task_id = %task.id(),
+                                    metadata = ?prepare_init.report_share().metadata(),
+                                    "Received report share with duplicate extensions",
+                                );
+                                metrics
+                                    .aggregate_step_failure_counter
+                                    .add(1, &[KeyValue::new("type", "duplicate_extension")]);
+                                return Err(PrepareError::InvalidMessage);
+                            }
+
+                            if require_taskprov_extension {
+                                let valid_taskprov_extension_present = extensions
+                                    .get(&ExtensionType::Taskprov)
+                                    .map(|data| data.is_empty())
+                                    .unwrap_or(false);
+                                if !valid_taskprov_extension_present {
+                                    debug!(
+                                        task_id = %task.id(),
+                                        metadata = ?prepare_init.report_share().metadata(),
+                                        "Taskprov task received report with missing or malformed \
+                                        taskprov extension",
+                                    );
+                                    metrics.aggregate_step_failure_counter.add(
+                                        1,
+                                        &[KeyValue::new(
+                                            "type",
+                                            "missing_or_malformed_taskprov_extension",
+                                        )],
+                                    );
+                                    return Err(PrepareError::InvalidMessage);
+                                }
+                            } else if extensions.contains_key(&ExtensionType::Taskprov) {
+                                // taskprov not enabled, but the taskprov extension is present.
+                                debug!(
+                                    task_id = %task.id(),
+                                    metadata = ?prepare_init.report_share().metadata(),
+                                    "Non-taskprov task received report with unexpected taskprov \
+                                    extension",
+                                );
+                                metrics
+                                    .aggregate_step_failure_counter
+                                    .add(1, &[KeyValue::new("type", "unexpected_taskprov_extension")]);
+                                return Err(PrepareError::InvalidMessage);
+                            }
+
+                            Ok(plaintext_input_share)
+                        });
+
+                        let input_share = plaintext_input_share.and_then(|plaintext_input_share| {
+                            A::InputShare::get_decoded_with_param(
+                                &(&vdaf, Role::Helper.index().unwrap()),
+                                plaintext_input_share.payload(),
+                            )
+                            .map_err(|error| {
+                                debug!(
+                                    task_id = %task.id(),
+                                    metadata = ?prepare_init.report_share().metadata(),
+                                    ?error, "Couldn't decode helper's input share",
+                                );
+                                metrics
+                                    .aggregate_step_failure_counter
+                                    .add(1, &[KeyValue::new("type", "input_share_decode_failure")]);
+                                PrepareError::InvalidMessage
+                            })
+                        });
+
+                        let public_share = A::PublicShare::get_decoded_with_param(
+                            &vdaf,
+                            prepare_init.report_share().public_share(),
+                        )
+                        .map_err(|error| {
+                            debug!(
+                                task_id = %task.id(),
+                                metadata = ?prepare_init.report_share().metadata(),
+                                ?error, "Couldn't decode public share",
+                            );
+                            metrics
+                                .aggregate_step_failure_counter
+                                .add(1, &[KeyValue::new("type", "public_share_decode_failure")]);
+                            PrepareError::InvalidMessage
+                        });
+
+                        let shares =
+                            input_share.and_then(|input_share| Ok((public_share?, input_share)));
+
+                        // Reject reports from too far in the future.
+                        let shares = shares.and_then(|shares| {
+                            if prepare_init
+                                .report_share()
+                                .metadata()
+                                .time()
+                                .is_after(&report_deadline)
+                            {
+                                return Err(PrepareError::ReportTooEarly);
+                            }
+                            Ok(shares)
+                        });
+
+                        // Next, the aggregator runs the preparation-state initialization algorithm for the VDAF
+                        // associated with the task and computes the first state transition. [...] If either
+                        // step fails, then the aggregator MUST fail with error `vdaf-prep-error`. (§4.4.2.2)
+                        let init_rslt = shares.and_then(|(public_share, input_share)| {
+                            trace_span!("VDAF preparation (helper initialization)").in_scope(|| {
+                                vdaf.helper_initialized(
+                                    verify_key.as_bytes(),
+                                    &agg_param,
+                                    /* report ID is used as VDAF nonce */
+                                    prepare_init.report_share().metadata().id().as_ref(),
+                                    &public_share,
+                                    &input_share,
+                                    prepare_init.message(),
+                                )
+                                .and_then(|transition| transition.evaluate(&vdaf))
+                                .map_err(|error| {
+                                    handle_ping_pong_error(
+                                        task.id(),
+                                        Role::Helper,
+                                        prepare_init.report_share().metadata().id(),
+                                        error,
+                                        &metrics.aggregate_step_failure_counter,
+                                    )
+                                })
+                            })
+                        });
+
+                        let (report_aggregation_state, prepare_step_result, output_share) =
+                            match init_rslt {
+                                Ok((PingPongState::Continued(prepare_state), outgoing_message)) => {
+                                    // Helper is not finished. Await the next message from the Leader to advance to
+                                    // the next step.
+                                    (
+                                        ReportAggregationState::WaitingHelper { prepare_state },
+                                        PrepareStepResult::Continue {
+                                            message: outgoing_message,
+                                        },
+                                        None,
+                                    )
+                                }
+                                Ok((PingPongState::Finished(output_share), outgoing_message)) => (
+                                    ReportAggregationState::Finished,
+                                    PrepareStepResult::Continue {
+                                        message: outgoing_message,
+                                    },
+                                    Some(output_share),
+                                ),
+                                Err(prepare_error) => (
+                                    ReportAggregationState::Failed { prepare_error },
+                                    PrepareStepResult::Reject(prepare_error),
+                                    None,
+                                ),
+                            };
+
+                        sender.send(ReportShareData {
+                            report_share: prepare_init.report_share().clone(),
+                            report_aggregation: WritableReportAggregation::new(
+                                ReportAggregation::<SEED_SIZE, A>::new(
+                                    *task.id(),
+                                    aggregation_job_id,
+                                    *prepare_init.report_share().metadata().id(),
+                                    *prepare_init.report_share().metadata().time(),
+                                    // Unwrap safety: we checked that all ordinal values are representable
+                                    // as a u64 before entering the parallel iterator.
+                                    ord.try_into().unwrap(),
+                                    Some(PrepareResp::new(
+                                        *prepare_init.report_share().metadata().id(),
+                                        prepare_step_result,
+                                    )),
+                                    report_aggregation_state,
+                                ),
+                                output_share,
+                            ),
                         })
                     })
-                });
+            }
+        });
 
-                let (report_aggregation_state, prepare_step_result, output_share) =
-                    match init_rslt {
-                        Ok((PingPongState::Continued(prepare_state), outgoing_message)) => {
-                            // Helper is not finished. Await the next message from the Leader to advance to
-                            // the next step.
-                            (
-                                ReportAggregationState::WaitingHelper { prepare_state },
-                                PrepareStepResult::Continue {
-                                    message: outgoing_message,
-                                },
-                                None,
-                            )
-                        }
-                        Ok((PingPongState::Finished(output_share), outgoing_message)) => (
-                            ReportAggregationState::Finished,
-                            PrepareStepResult::Continue {
-                                message: outgoing_message,
-                            },
-                            Some(output_share),
-                        ),
-                        Err(prepare_error) => (
-                            ReportAggregationState::Failed { prepare_error },
-                            PrepareStepResult::Reject(prepare_error),
-                            None,
-                        ),
-                    };
+        let mut report_share_data = Vec::with_capacity(req.prepare_inits().len());
+        while receiver.recv_many(&mut report_share_data, usize::MAX).await > 0 {}
 
-                ReportShareData {
-                    report_share: prepare_init.report_share().clone(),
-                    report_aggregation: WritableReportAggregation::new(
-                        ReportAggregation::<SEED_SIZE, A>::new(
-                            *task.id(),
-                            *aggregation_job_id,
-                            *prepare_init.report_share().metadata().id(),
-                            *prepare_init.report_share().metadata().time(),
-                            // Unwrap safety: we checked that all ordinal values are representable
-                            // as a u64 before entering the parallel iterator.
-                            ord.try_into().unwrap(),
-                            Some(PrepareResp::new(
-                                *prepare_init.report_share().metadata().id(),
-                                prepare_step_result,
-                            )),
-                            report_aggregation_state,
-                        ),
-                        output_share,
-                    ),
-                }
-            })
-            .collect_into_vec(&mut report_share_data);
+        // Await the producer task to resume any panics that may have occurred, and to ensure we can
+        // unwrap the aggregation parameter's Arc in a few lines. The only other errors that can
+        // occur are: a `JoinError` indicating cancellation, which is impossible because we do not
+        // cancel the task; and a `SendError`, which can only happen if this future is cancelled (in
+        // which case we will not run this code at all).
+        let _ = producer_task.await.map_err(|join_error| {
+            if let Ok(reason) = join_error.try_into_panic() {
+                panic::resume_unwind(reason);
+            }
+        });
+
+        // TODO: Use Arc::unwrap_or_clone() once the MSRV is at least 1.76.0.
+        let agg_param = Arc::try_unwrap(agg_param).unwrap_or_else(|arc| arc.as_ref().clone());
 
         // Store data to datastore.
         let min_client_timestamp = req

--- a/aggregator/src/aggregator/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/aggregation_job_continue.rs
@@ -24,13 +24,9 @@ use prio::{
     topology::ping_pong::{PingPongContinuedValue, PingPongState, PingPongTopology},
     vdaf,
 };
-use std::{
-    any::Any,
-    panic::{catch_unwind, resume_unwind, AssertUnwindSafe},
-    sync::Arc,
-};
-use tokio::sync::oneshot::{self, error::RecvError};
-use tracing::{info_span, trace_span, Span};
+use rayon::iter::{IntoParallelIterator as _, ParallelExtend as _, ParallelIterator as _};
+use std::sync::Arc;
+use tracing::trace_span;
 
 impl VdafOps {
     /// Step the helper's aggregation job to the next step using the step `n` ping pong state in
@@ -59,87 +55,102 @@ impl VdafOps {
     {
         let request_step = req.step();
 
-        let prep_closure = {
-            let parent_span = Span::current();
-            let task_id = *task.id();
-            let vdaf = Arc::clone(&vdaf);
-            let aggregation_parameter = aggregation_job.aggregation_parameter().clone();
-            let metrics = metrics.clone();
-            move || {
-                let span = info_span!(parent: parent_span, "step_aggregation_job threadpool task");
-                let _entered = span.enter();
+        // Match preparation step received from leader to stored report aggregation, and extract
+        // the stored preparation step.
+        let mut prep_steps_and_ras = Vec::new();
+        let mut report_aggregations_iter = report_aggregations.iter();
+        let mut report_aggregations_to_write = Vec::new();
 
-                // Handle each transition in the request.
-                let mut report_aggregations_iter = report_aggregations.into_iter();
-                let mut report_aggregations_to_write = Vec::new();
-                for prep_step in req.prepare_steps() {
-                    // Match preparation step received from leader to stored report aggregation, and extract
-                    // the stored preparation step.
-                    let report_aggregation = loop {
-                        let report_agg = report_aggregations_iter.next().ok_or_else(|| {
-                            datastore::Error::User(
-                                Error::InvalidMessage(
-                                    Some(task_id),
-                                    "leader sent unexpected, duplicate, or out-of-order prepare \
-                                    steps",
-                                )
-                                .into(),
+        for prep_step in req.prepare_steps() {
+            let report_aggregation = loop {
+                let report_agg = report_aggregations_iter.next().ok_or_else(|| {
+                    datastore::Error::User(
+                        Error::InvalidMessage(
+                            Some(*task.id()),
+                            "leader sent unexpected, duplicate, or out-of-order prepare steps",
+                        )
+                        .into(),
+                    )
+                })?;
+                if report_agg.report_id() != prep_step.report_id() {
+                    // This report was omitted by the leader because of a prior failure. Note that
+                    // the report was dropped (if it's not already in an error state) and continue.
+                    if matches!(
+                        report_agg.state(),
+                        ReportAggregationState::WaitingHelper { .. }
+                    ) {
+                        report_aggregations_to_write.push(WritableReportAggregation::new(
+                            report_agg
+                                .clone()
+                                .with_state(ReportAggregationState::Failed {
+                                    prepare_error: PrepareError::ReportDropped,
+                                })
+                                .with_last_prep_resp(None),
+                            None,
+                        ));
+                    }
+                    continue;
+                }
+                break report_agg;
+            };
+
+            let prep_state = match report_aggregation.state() {
+                ReportAggregationState::WaitingHelper { prepare_state } => prepare_state,
+                ReportAggregationState::WaitingLeader { .. } => {
+                    return Err(datastore::Error::User(
+                        Error::Internal(
+                            "helper encountered unexpected ReportAggregationState::WaitingLeader"
+                                .to_string(),
+                        )
+                        .into(),
+                    ))
+                }
+                _ => {
+                    return Err(datastore::Error::User(
+                        Error::InvalidMessage(
+                            Some(*task.id()),
+                            "leader sent prepare step for non-WAITING report aggregation",
+                        )
+                        .into(),
+                    ));
+                }
+            };
+
+            prep_steps_and_ras.push((prep_step, report_aggregation, prep_state));
+        }
+
+        for report_aggregation in report_aggregations_iter {
+            // This report was omitted by the leader because of a prior failure. Note that
+            // the report was dropped (if it's not already in an error state) and continue.
+            if matches!(
+                report_aggregation.state(),
+                ReportAggregationState::WaitingHelper { .. }
+            ) {
+                report_aggregations_to_write.push(WritableReportAggregation::new(
+                    report_aggregation
+                        .clone()
+                        .with_state(ReportAggregationState::Failed {
+                            prepare_error: PrepareError::ReportDropped,
+                        })
+                        .with_last_prep_resp(None),
+                    None,
+                ));
+            }
+        }
+
+        report_aggregations_to_write.par_extend(prep_steps_and_ras.into_par_iter().map(
+            |(prep_step, report_aggregation, prep_state)| {
+                let (report_aggregation_state, prepare_step_result, output_share) =
+                    trace_span!("VDAF preparation (helper continuation)")
+                        .in_scope(|| {
+                            // Continue with the incoming message.
+                            vdaf.helper_continued(
+                                PingPongState::Continued(prep_state.clone()),
+                                aggregation_job.aggregation_parameter(),
+                                prep_step.message(),
                             )
-                        })?;
-                        if report_agg.report_id() != prep_step.report_id() {
-                            // This report was omitted by the leader because of a prior failure. Note that
-                            // the report was dropped (if it's not already in an error state) and continue.
-                            if matches!(
-                                report_agg.state(),
-                                ReportAggregationState::WaitingHelper { .. }
-                            ) {
-                                report_aggregations_to_write.push(WritableReportAggregation::new(
-                                    report_agg
-                                        .with_state(ReportAggregationState::Failed {
-                                            prepare_error: PrepareError::ReportDropped,
-                                        })
-                                        .with_last_prep_resp(None),
-                                    None,
-                                ));
-                            }
-                            continue;
-                        }
-                        break report_agg;
-                    };
-
-                    let prep_state = match report_aggregation.state() {
-                        ReportAggregationState::WaitingHelper { prepare_state } => prepare_state,
-                        ReportAggregationState::WaitingLeader { .. } => {
-                            return Err(datastore::Error::User(
-                                Error::Internal(
-                                    "helper encountered unexpected \
-                                    ReportAggregationState::WaitingLeader"
-                                        .to_string(),
-                                )
-                                .into(),
-                            ))
-                        }
-                        _ => {
-                            return Err(datastore::Error::User(
-                                Error::InvalidMessage(
-                                    Some(task_id),
-                                    "leader sent prepare step for non-WAITING report aggregation",
-                                )
-                                .into(),
-                            ));
-                        }
-                    };
-
-                    let (report_aggregation_state, prepare_step_result, output_share) =
-                        trace_span!("VDAF preparation (helper continuation)")
-                            .in_scope(|| {
-                                // Continue with the incoming message.
-                                vdaf.helper_continued(
-                                    PingPongState::Continued(prep_state.clone()),
-                                    &aggregation_parameter,
-                                    prep_step.message(),
-                                )
-                                .and_then(|continued_value| match continued_value {
+                            .and_then(|continued_value| {
+                                match continued_value {
                                     PingPongContinuedValue::WithMessage { transition } => {
                                         let (new_state, message) =
                                             transition.evaluate(vdaf.as_ref())?;
@@ -175,80 +186,38 @@ impl VdafOps {
                                             Some(output_share),
                                         ))
                                     }
-                                })
+                                }
                             })
-                            .map_err(|error| {
-                                handle_ping_pong_error(
-                                    &task_id,
-                                    Role::Leader,
-                                    prep_step.report_id(),
-                                    error,
-                                    &metrics.aggregate_step_failure_counter,
-                                )
-                            })
-                            .unwrap_or_else(|prepare_error| {
-                                (
-                                    ReportAggregationState::Failed { prepare_error },
-                                    PrepareStepResult::Reject(prepare_error),
-                                    None,
-                                )
-                            });
+                        })
+                        .map_err(|error| {
+                            handle_ping_pong_error(
+                                task.id(),
+                                Role::Leader,
+                                prep_step.report_id(),
+                                error,
+                                &metrics.aggregate_step_failure_counter,
+                            )
+                        })
+                        .unwrap_or_else(|prepare_error| {
+                            (
+                                ReportAggregationState::Failed { prepare_error },
+                                PrepareStepResult::Reject(prepare_error),
+                                None,
+                            )
+                        });
 
-                    report_aggregations_to_write.push(WritableReportAggregation::new(
-                        report_aggregation
-                            .with_state(report_aggregation_state)
-                            .with_last_prep_resp(Some(PrepareResp::new(
-                                *prep_step.report_id(),
-                                prepare_step_result,
-                            ))),
-                        output_share,
-                    ));
-                }
-
-                for report_aggregation in report_aggregations_iter {
-                    // This report was omitted by the leader because of a prior failure. Note that
-                    // the report was dropped (if it's not already in an error state) and continue.
-                    if matches!(
-                        report_aggregation.state(),
-                        ReportAggregationState::WaitingHelper { .. }
-                    ) {
-                        report_aggregations_to_write.push(WritableReportAggregation::new(
-                            report_aggregation
-                                .with_state(ReportAggregationState::Failed {
-                                    prepare_error: PrepareError::ReportDropped,
-                                })
-                                .with_last_prep_resp(None),
-                            None,
-                        ));
-                    }
-                }
-                Ok(report_aggregations_to_write)
-            }
-        };
-        let (sender, receiver) = oneshot::channel();
-        rayon::spawn(|| {
-            // Do nothing if the result cannot be sent back. This would happen if the initiating
-            // future is cancelled.
-            //
-            // We need to catch panics here because rayon's default threadpool panic handler will
-            // abort, and it would be preferable to propagate the panic in the original future to
-            // avoid behavior changes.
-            //
-            // Using `AssertUnwindSafe` is OK here, because the only interior mutability we make use
-            // of is OTel instruments, and those can't be put into inconsistent states merely by
-            // incrementing counters. Using `AssertUnwindSafe` is easier than adding infectious
-            // `UnwindSafe` trait bounds to various VDAF associated types throughout the codebase.
-            let _ = sender.send(catch_unwind(AssertUnwindSafe(prep_closure)));
-        });
-        let report_aggregations_to_write = receiver
-            .await
-            .map_err(|_recv_error: RecvError| {
-                datastore::Error::User(
-                    Error::Internal("threadpool failed to send VDAF preparation result".into())
-                        .into(),
+                WritableReportAggregation::new(
+                    report_aggregation
+                        .clone()
+                        .with_state(report_aggregation_state)
+                        .with_last_prep_resp(Some(PrepareResp::new(
+                            *prep_step.report_id(),
+                            prepare_step_result,
+                        ))),
+                    output_share,
                 )
-            })?
-            .unwrap_or_else(|panic_cause: Box<dyn Any + Send>| resume_unwind(panic_cause))?;
+            },
+        ));
 
         // Write accumulated aggregation values back to the datastore; this will mark any reports
         // that can't be aggregated because the batch is collected with error BatchCollected.

--- a/aggregator/src/aggregator/error.rs
+++ b/aggregator/src/aggregator/error.rs
@@ -143,6 +143,8 @@ pub enum Error {
     /// An error occurred when trying to ensure differential privacy.
     #[error("differential privacy error: {0}")]
     DifferentialPrivacy(VdafError),
+    #[error("client disconnected")]
+    ClientDisconnected,
 }
 
 /// A newtype around `Arc<Error>`. This is needed to host a customized implementation of
@@ -309,6 +311,7 @@ impl Error {
             Error::BadRequest(_) => "bad_request",
             Error::InvalidTask(_, _) => "invalid_task",
             Error::DifferentialPrivacy(_) => "differential_privacy",
+            Error::ClientDisconnected => "client_disconnected",
         }
     }
 }


### PR DESCRIPTION
This will be very helpful when we have requests which timeout, which is presented to Janus as a client disconnect. Otherwise, we would continue processing the request until it is complete.

Previously, we used a rayon threadpool for aggregation computations, but the computations within the handling of a single aggregation job were still serialized. Now, we use a parallel iterator for handling each report share in turn, allowing the VDAF evaluations to be performed in parallel. The Helper methods are also updated such that the parallel computations respect cancellation. Specifically, the `receiver` will be dropped on cancellation, causing the producer threads' `sender` to return a `SendError` when they attempt to send, which will cause `try_for_each_with` to stop processing, which will cause the producer thread to terminate.

Also, remove the (unstated!) requirement in aggregation_job_writer than report aggregations be provided in order. This eases parallelization of the aggregation job continuation logic.