### PR TITLE
Log agg job init forbidden mutations.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2505,6 +2505,7 @@ dependencies = [
  "trillium-tokio",
  "trycmd",
  "url",
+ "uuid",
  "wait-timeout",
 ]
 

--- a/README.md
+++ b/README.md
@@ -96,8 +96,7 @@ Any other crates not mentioned have no stability guarantees whatsoever.
 
 ## Building
 
-To build Janus, ensure that you have [`cmake`](https://cmake.org/) installed and
-execute `cargo build`.
+To build Janus, execute `cargo build`.
 
 ### Container image
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ Any other crates not mentioned have no stability guarantees whatsoever.
 
 ## Building
 
-To build Janus, execute `cargo build`.
+To build Janus, ensure that you have [`cmake`](https://cmake.org/) installed and
+execute `cargo build`.
 
 ### Container image
 

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -109,6 +109,7 @@ trillium-router.workspace = true
 trillium-testing = { workspace = true, optional = true }
 trillium-tokio.workspace = true
 url.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
 janus_aggregator = { path = ".", features = ["fpvec_bounded_l2", "test-util"] }

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -33,7 +33,6 @@ test-util = [
     "janus_core/test-util",
     "janus_messages/test-util",
     "dep:assert_matches",
-    "dep:hex",
     "dep:testcontainers",
     "dep:trillium-testing",
 ]
@@ -54,7 +53,7 @@ derivative.workspace = true
 fixed = { workspace = true, optional = true }
 futures = { workspace = true }
 git-version = { workspace = true }
-hex = { workspace = true, features = ["serde"], optional = true }
+hex = { workspace = true, features = ["serde"] }
 http.workspace = true
 http-api-problem.workspace = true
 itertools.workspace = true

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -109,7 +109,7 @@ trillium-router.workspace = true
 trillium-testing = { workspace = true, optional = true }
 trillium-tokio.workspace = true
 url.workspace = true
-uuid.workspace = true
+uuid = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
 janus_aggregator = { path = ".", features = ["fpvec_bounded_l2", "test-util"] }

--- a/aggregator/src/binaries/aggregator.rs
+++ b/aggregator/src/binaries/aggregator.rs
@@ -309,6 +309,11 @@ pub struct Config {
     #[serde(default)]
     pub taskprov_config: TaskprovConfig,
 
+    /// Whether forbidden mutations of resources (e.g., re-using the same aggregation job ID but
+    /// with different reports in it) should be logged when detected.
+    #[serde(default)]
+    pub log_forbidden_mutations: bool,
+
     #[serde(default)]
     pub garbage_collection: Option<GarbageCollectorConfig>,
 
@@ -420,6 +425,7 @@ impl Config {
             task_cache_capacity: self
                 .task_cache_capacity
                 .unwrap_or(TASK_AGGREGATOR_CACHE_DEFAULT_CAPACITY),
+            log_forbidden_mutations: self.log_forbidden_mutations,
         })
     }
 }
@@ -526,6 +532,7 @@ mod tests {
             global_hpke_configs_refresh_interval: Some(42),
             task_cache_ttl_seconds: None,
             task_cache_capacity: None,
+            log_forbidden_mutations: true,
         })
     }
 

--- a/aggregator/src/binaries/aggregator.rs
+++ b/aggregator/src/binaries/aggregator.rs
@@ -23,6 +23,7 @@ use sec1::EcPrivateKey;
 use serde::{de, Deserialize, Deserializer, Serialize};
 use std::{
     future::{ready, Future},
+    path::PathBuf,
     pin::Pin,
 };
 use std::{iter::Iterator, net::SocketAddr, sync::Arc, time::Duration};
@@ -312,7 +313,7 @@ pub struct Config {
     /// Whether forbidden mutations of resources (e.g., re-using the same aggregation job ID but
     /// with different reports in it) should be logged when detected.
     #[serde(default)]
-    pub log_forbidden_mutations: bool,
+    pub log_forbidden_mutations: Option<PathBuf>,
 
     #[serde(default)]
     pub garbage_collection: Option<GarbageCollectorConfig>,
@@ -425,7 +426,7 @@ impl Config {
             task_cache_capacity: self
                 .task_cache_capacity
                 .unwrap_or(TASK_AGGREGATOR_CACHE_DEFAULT_CAPACITY),
-            log_forbidden_mutations: self.log_forbidden_mutations,
+            log_forbidden_mutations: self.log_forbidden_mutations.clone(),
         })
     }
 }
@@ -485,6 +486,7 @@ mod tests {
     };
     use std::{
         net::{IpAddr, Ipv4Addr, SocketAddr},
+        path::PathBuf,
         time::Duration,
     };
 
@@ -532,7 +534,7 @@ mod tests {
             global_hpke_configs_refresh_interval: Some(42),
             task_cache_ttl_seconds: None,
             task_cache_capacity: None,
-            log_forbidden_mutations: true,
+            log_forbidden_mutations: Some(PathBuf::from("/tmp/events")),
         })
     }
 

--- a/aggregator/src/diagnostic.rs
+++ b/aggregator/src/diagnostic.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Context;
 use derivative::Derivative;
-use janus_messages::{AggregationJobId, BatchId, ReportMetadata};
+use janus_messages::{AggregationJobId, ReportMetadata};
 use std::{fmt::Debug, fs::File, io::Write, path::Path, time::SystemTime};
 use uuid::Uuid;
 

--- a/aggregator/src/diagnostic.rs
+++ b/aggregator/src/diagnostic.rs
@@ -2,22 +2,30 @@
 
 use anyhow::Context;
 use derivative::Derivative;
-use janus_messages::{AggregationJobId, ReportMetadata};
-use std::{fmt::Debug, fs::File, io::Write, path::Path, time::SystemTime};
+use janus_messages::{AggregationJobId, ReportMetadata, TaskId};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::{fs::File, path::Path, time::SystemTime};
 use uuid::Uuid;
 
 /// Represents an illegal attempt to mutate an aggregation job.
-#[derive(Derivative, Clone)]
+#[derive(Derivative, Clone, Serialize, Deserialize)]
 #[derivative(Debug)]
 pub struct AggregationJobInitForbiddenMutationEvent {
+    /// The ID of the task.
+    #[serde(with = "serialize_task_id")]
+    pub task_id: TaskId,
+
     /// The ID of the aggregation job.
+    #[serde(with = "serialize_job_id")]
     pub aggregation_job_id: AggregationJobId,
 
     /// The SHA-256 of the request that created the aggregation job.
+    #[serde(with = "serialize_hash_option")]
     #[derivative(Debug(format_with = "fmt_hash_option"))]
     pub original_request_hash: Option<[u8; 32]>,
 
     /// The ordered report metadatas from the request that created the aggregation job.
+    #[serde(with = "serialize_metadata_vec")]
     pub original_report_metadatas: Vec<ReportMetadata>,
 
     /// The batch ID in the original request.
@@ -27,10 +35,12 @@ pub struct AggregationJobInitForbiddenMutationEvent {
     pub original_aggregation_parameter: Vec<u8>,
 
     /// The SHA-256 of the request that attempted to mutate the aggregation job.
+    #[serde(with = "serialize_hash_option")]
     #[derivative(Debug(format_with = "fmt_hash_option"))]
     pub mutating_request_hash: Option<[u8; 32]>,
 
     /// The ordered report metadatas from the request that attempted to mutate the aggregation job.
+    #[serde(with = "serialize_metadata_vec")]
     pub mutating_request_report_metadatas: Vec<ReportMetadata>,
 
     /// The batch ID of the mutating request.
@@ -47,31 +57,146 @@ fn fmt_hash_option(
     write!(f, "{:?}", v.map(hex::encode))
 }
 
+mod serialize_hash_option {
+    use super::*;
+
+    pub fn serialize<S: Serializer>(
+        value: &Option<[u8; 32]>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        match value {
+            Some(value) => serializer.serialize_some(&hex::encode(value)),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D>(_deserializer: D) -> Result<Option<[u8; 32]>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        todo!("can't deserialize yet")
+    }
+}
+
+mod serialize_task_id {
+    use super::*;
+
+    pub fn serialize<S: Serializer>(value: &TaskId, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&format!("{value:?}"))
+    }
+
+    pub fn deserialize<'de, D>(_deserializer: D) -> Result<TaskId, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        todo!("can't deserialize yet")
+    }
+}
+
+mod serialize_job_id {
+    use super::*;
+
+    pub fn serialize<S: Serializer>(
+        value: &AggregationJobId,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&format!("{value:?}"))
+    }
+
+    pub fn deserialize<'de, D>(_deserializer: D) -> Result<AggregationJobId, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        todo!("can't deserialize yet")
+    }
+}
+
+mod serialize_metadata_vec {
+    use super::*;
+
+    pub fn serialize<S: Serializer>(
+        value: &[ReportMetadata],
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        #[derive(Serialize)]
+        struct SerializableReportMetadata {
+            report_id: String,
+            time: String,
+        }
+
+        serializer.collect_seq(value.iter().map(|rm| SerializableReportMetadata {
+            report_id: format!("{:?}", rm.id()),
+            time: format!("{:?}", rm.time()),
+        }))
+    }
+
+    pub fn deserialize<'de, D>(_deserializer: D) -> Result<Vec<ReportMetadata>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        todo!("can't deserialize yet")
+    }
+}
+
+/// An event along with some metadata describing it.
+#[derive(Debug, Serialize, Deserialize)]
+struct Event<E> {
+    /// Unique identifier for the event.
+    id: Uuid,
+    /// Unix epoch time at which the event was recorded.
+    time: String,
+    /// Type of the event.
+    event_type: String,
+    /// Version of Janus that recorded the event.
+    janus_version: String,
+    /// The event itself.
+    event: E,
+}
+
 /// Write an event.
 ///
-/// The [`std::fmt::Debug`] representation of `event` will be written to a file named
-/// `<event_type>-<timestamp>-<ID>-<version>`, where `event_type` is the provided argument,
+/// The JSON representation of `event` will be written to a file named
+/// `<event_type>-<timestamp>-<ID>-<version>.json`, where `event_type` is the provided argument,
 /// `timestamp` is the time at which the event was recorded, `ID` is a UUIDv4 and `version` is the
-/// version of Janus that generated the event.
-pub fn write_event<P: AsRef<Path>>(
+/// version of Janus that generated the event. The JSON document will also contain this metadata in
+/// a structured form.
+pub async fn write_event<P: AsRef<Path>, S: Serialize + Send + Sync + 'static>(
     event_storage: P,
     event_type: &'static str,
-    event: Box<dyn Debug>,
+    event: S,
 ) -> Result<Uuid, anyhow::Error> {
-    let now = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .context("failed to get current time")?;
+    let now = format!(
+        "{:?}",
+        SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .context("failed to get current time")?
+    );
     let event_id = Uuid::new_v4();
-    let version = env!("CARGO_PKG_VERSION");
+    let janus_version = env!("CARGO_PKG_VERSION");
 
-    let mut f = File::create(
-        event_storage
-            .as_ref()
-            .join(format!("{event_type}-{now:?}-{event_id}-{version}")),
-    )
-    .context("failed to open file to write event")?;
+    let event_with_metadata = Event {
+        id: event_id,
+        time: now.clone(),
+        event_type: event_type.to_string(),
+        janus_version: janus_version.to_string(),
+        event,
+    };
 
-    write!(&mut f, "{event:#?}").context("failed to write event")?;
+    let event_storage_path = event_storage.as_ref().join(format!(
+        "{event_type}-{now}-{event_id}-{janus_version}.json"
+    ));
+
+    tokio::task::spawn_blocking(move || -> Result<(), anyhow::Error> {
+        let mut f =
+            File::create(event_storage_path).context("failed to open file to write event")?;
+
+        serde_json::to_writer(&mut f, &event_with_metadata).context("failed to write event")?;
+
+        f.sync_all().context("failed to sync file contents")?;
+
+        Ok(())
+    })
+    .await??;
 
     Ok(event_id)
 }
@@ -79,41 +204,45 @@ pub fn write_event<P: AsRef<Path>>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs::{read, read_dir};
+    use std::{fs::read_dir, io::BufReader};
     use tempfile::tempdir;
 
-    #[test]
-    fn write_two_events() {
+    #[tokio::test]
+    async fn write_two_events() {
         let tempdir = tempdir().unwrap();
 
-        let first_event = "something happened 1";
-        let first_event_id = write_event(&tempdir, "test-event", Box::new(first_event)).unwrap();
-        let second_event = "something happened 2";
-        let second_event_id = write_event(&tempdir, "test-event", Box::new(second_event)).unwrap();
+        let first_event_id = write_event(&tempdir, "test-event", 1).await.unwrap();
+        let second_event_id = write_event(&tempdir, "test-event", 2).await.unwrap();
 
-        let entries: Vec<_> = read_dir(&tempdir).unwrap().collect();
+        let entries: Vec<_> = read_dir(&tempdir).unwrap().map(|r| r.unwrap()).collect();
         assert_eq!(entries.len(), 2);
 
         let mut saw_first_event = false;
         let mut saw_second_event = false;
 
         for entry in entries {
-            let event_path = entry.as_ref().unwrap().path();
+            let event_path = entry.path();
             let filename = event_path.file_name().unwrap().to_str().unwrap();
 
             assert!(filename.starts_with("test-event"));
-            assert!(filename.ends_with(env!("CARGO_PKG_VERSION")));
+            assert!(filename.ends_with(&format!("{}.json", env!("CARGO_PKG_VERSION"))));
 
-            let file_contents = read(&event_path).unwrap();
+            let event: Event<u32> =
+                serde_json::from_reader(BufReader::new(File::open(&event_path).unwrap())).unwrap();
 
-            if file_contents == b"\"something happened 1\"" {
+            assert_eq!(event.event_type, "test-event");
+            assert_eq!(event.janus_version, env!("CARGO_PKG_VERSION"));
+
+            if event.id == first_event_id {
                 assert!(filename.contains(&first_event_id.to_string()));
+                assert_eq!(event.event, 1);
                 saw_first_event = true
-            } else if file_contents == b"\"something happened 2\"" {
+            } else if event.id == second_event_id {
                 assert!(filename.contains(&second_event_id.to_string()));
+                assert_eq!(event.event, 2);
                 saw_second_event = true
             } else {
-                panic!("saw unexpected event {file_contents:?}");
+                panic!("saw unexpected event {event:?}");
             }
         }
 

--- a/aggregator/src/diagnostic.rs
+++ b/aggregator/src/diagnostic.rs
@@ -1,0 +1,123 @@
+//! Writing diagnostic files to disk.
+
+use anyhow::Context;
+use derivative::Derivative;
+use janus_messages::{AggregationJobId, BatchId, ReportMetadata};
+use std::{fmt::Debug, fs::File, io::Write, path::Path, time::SystemTime};
+use uuid::Uuid;
+
+/// Represents an illegal attempt to mutate an aggregation job.
+#[derive(Derivative, Clone)]
+#[derivative(Debug)]
+pub struct AggregationJobInitForbiddenMutationEvent {
+    /// The ID of the aggregation job.
+    pub aggregation_job_id: AggregationJobId,
+
+    /// The SHA-256 of the request that created the aggregation job.
+    #[derivative(Debug(format_with = "fmt_hash_option"))]
+    pub original_request_hash: Option<[u8; 32]>,
+
+    /// The ordered report metadatas from the request that created the aggregation job.
+    pub original_report_metadatas: Vec<ReportMetadata>,
+
+    /// The batch ID in the original request.
+    pub original_batch_id: String,
+
+    /// The aggregation param in the original request.
+    pub original_aggregation_parameter: Vec<u8>,
+
+    /// The SHA-256 of the request that attempted to mutate the aggregation job.
+    #[derivative(Debug(format_with = "fmt_hash_option"))]
+    pub mutating_request_hash: Option<[u8; 32]>,
+
+    /// The ordered report metadatas from the request that attempted to mutate the aggregation job.
+    pub mutating_request_report_metadatas: Vec<ReportMetadata>,
+
+    /// The batch ID of the mutating request.
+    pub mutating_request_batch_id: String,
+
+    /// The aggregation param in the mutating request.
+    pub mutating_request_aggregation_parameter: Vec<u8>,
+}
+
+fn fmt_hash_option(
+    v: &Option<[u8; 32]>,
+    f: &mut std::fmt::Formatter,
+) -> Result<(), std::fmt::Error> {
+    write!(f, "{:?}", v.map(hex::encode))
+}
+
+/// Write an event.
+///
+/// The [`std::fmt::Debug`] representation of `event` will be written to a file named
+/// `<event_type>-<timestamp>-<ID>-<version>`, where `event_type` is the provided argument,
+/// `timestamp` is the time at which the event was recorded, `ID` is a UUIDv4 and `version` is the
+/// version of Janus that generated the event.
+pub fn write_event<P: AsRef<Path>>(
+    event_storage: P,
+    event_type: &'static str,
+    event: Box<dyn Debug>,
+) -> Result<Uuid, anyhow::Error> {
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .context("failed to get current time")?;
+    let event_id = Uuid::new_v4();
+    let version = env!("CARGO_PKG_VERSION");
+
+    let mut f = File::create(
+        event_storage
+            .as_ref()
+            .join(format!("{event_type}-{now:?}-{event_id}-{version}")),
+    )
+    .context("failed to open file to write event")?;
+
+    write!(&mut f, "{event:#?}").context("failed to write event")?;
+
+    Ok(event_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::{read, read_dir};
+    use tempfile::tempdir;
+
+    #[test]
+    fn write_two_events() {
+        let tempdir = tempdir().unwrap();
+
+        let first_event = "something happened 1";
+        let first_event_id = write_event(&tempdir, "test-event", Box::new(first_event)).unwrap();
+        let second_event = "something happened 2";
+        let second_event_id = write_event(&tempdir, "test-event", Box::new(second_event)).unwrap();
+
+        let entries: Vec<_> = read_dir(&tempdir).unwrap().collect();
+        assert_eq!(entries.len(), 2);
+
+        let mut saw_first_event = false;
+        let mut saw_second_event = false;
+
+        for entry in entries {
+            let event_path = entry.as_ref().unwrap().path();
+            let filename = event_path.file_name().unwrap().to_str().unwrap();
+
+            assert!(filename.starts_with("test-event"));
+            assert!(filename.ends_with(env!("CARGO_PKG_VERSION")));
+
+            let file_contents = read(&event_path).unwrap();
+
+            if file_contents == b"\"something happened 1\"" {
+                assert!(filename.contains(&first_event_id.to_string()));
+                saw_first_event = true
+            } else if file_contents == b"\"something happened 2\"" {
+                assert!(filename.contains(&second_event_id.to_string()));
+                saw_second_event = true
+            } else {
+                panic!("saw unexpected event {file_contents:?}");
+            }
+        }
+
+        assert!(saw_first_event);
+        assert!(saw_second_event);
+    }
+}

--- a/aggregator/src/lib.rs
+++ b/aggregator/src/lib.rs
@@ -8,6 +8,7 @@ pub mod binaries;
 pub mod binary_utils;
 pub mod cache;
 pub mod config;
+pub mod diagnostic;
 pub mod metrics;
 pub mod trace;
 

--- a/aggregator/tests/integration/graceful_shutdown.rs
+++ b/aggregator/tests/integration/graceful_shutdown.rs
@@ -286,6 +286,7 @@ async fn aggregator_shutdown() {
         global_hpke_configs_refresh_interval: None,
         task_cache_ttl_seconds: None,
         task_cache_capacity: None,
+        log_forbidden_mutations: false,
     };
 
     graceful_shutdown("aggregator", config).await;

--- a/aggregator/tests/integration/graceful_shutdown.rs
+++ b/aggregator/tests/integration/graceful_shutdown.rs
@@ -286,7 +286,7 @@ async fn aggregator_shutdown() {
         global_hpke_configs_refresh_interval: None,
         task_cache_ttl_seconds: None,
         task_cache_capacity: None,
-        log_forbidden_mutations: false,
+        log_forbidden_mutations: None,
     };
 
     graceful_shutdown("aggregator", config).await;

--- a/docs/samples/advanced_config/aggregator.yaml
+++ b/docs/samples/advanced_config/aggregator.yaml
@@ -144,7 +144,7 @@ taskprov_config:
 # promises.
 #
 # Optional; the default is not to log events.
-log_forbidden_mutations:
+log_forbidden_mutations: "/tmp/event-storage"
 
 # Configuration for garbage collection. If omitted, old data is never deleted. (optional)
 garbage_collection:

--- a/docs/samples/advanced_config/aggregator.yaml
+++ b/docs/samples/advanced_config/aggregator.yaml
@@ -130,16 +130,18 @@ taskprov_config:
   # Whether to enable the taskprov extension. Defaults to false.
   enabled: false
 
-# Whether forbidden mutations should be logged. In DAP, it's permitted to retry HTTP requests like
+# Where forbidden mutations should be logged. In DAP, it's permitted to retry HTTP requests like
 # aggregation job creation/initialization, but it's not legal to mutate the resource, for example by
 # changing which reports are included in an aggregation job. Janus always rejects such forbidden
 # mutations. If this option is enabled, then it will log the hash of the request that created the
 # resource, the hash of the incoming request that attempted to mutate it, and the list of report
-# metadatas in both. Janus does not unconditionally log this information because retrieving the
-# report metadata for the existing request is expensive.
+# metadatas in both, into a file created under the path provided here.
 #
-# Optional; the default is false.
-log_forbidden_mutations: false
+# Janus does not unconditionally log this information because retrieving the report metadata for the
+# existing request is expensive and the resulting event is large.
+#
+# Optional; the default is not to log events.
+log_forbidden_mutations:
 
 # Configuration for garbage collection. If omitted, old data is never deleted. (optional)
 garbage_collection:

--- a/docs/samples/advanced_config/aggregator.yaml
+++ b/docs/samples/advanced_config/aggregator.yaml
@@ -140,6 +140,9 @@ taskprov_config:
 # Janus does not unconditionally log this information because retrieving the report metadata for the
 # existing request is expensive and the resulting event is large.
 #
+# This option is not stable and not subject to Janus' typical API and configuration stability
+# promises.
+#
 # Optional; the default is not to log events.
 log_forbidden_mutations:
 

--- a/docs/samples/advanced_config/aggregator.yaml
+++ b/docs/samples/advanced_config/aggregator.yaml
@@ -130,6 +130,17 @@ taskprov_config:
   # Whether to enable the taskprov extension. Defaults to false.
   enabled: false
 
+# Whether forbidden mutations should be logged. In DAP, it's permitted to retry HTTP requests like
+# aggregation job creation/initialization, but it's not legal to mutate the resource, for example by
+# changing which reports are included in an aggregation job. Janus always rejects such forbidden
+# mutations. If this option is enabled, then it will log the hash of the request that created the
+# resource, the hash of the incoming request that attempted to mutate it, and the list of report
+# metadatas in both. Janus does not unconditionally log this information because retrieving the
+# report metadata for the existing request is expensive.
+#
+# Optional; the default is false.
+log_forbidden_mutations: false
+
 # Configuration for garbage collection. If omitted, old data is never deleted. (optional)
 garbage_collection:
   # How frequently to collect garbage, in seconds.

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -169,7 +169,7 @@ impl JanusInProcess {
             global_hpke_configs_refresh_interval: None,
             task_cache_ttl_seconds: None,
             task_cache_capacity: None,
-            log_forbidden_mutations: false,
+            log_forbidden_mutations: None,
         };
         let aggregation_job_creator_options = AggregationJobCreatorOptions {
             common: common_binary_options.clone(),

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -169,6 +169,7 @@ impl JanusInProcess {
             global_hpke_configs_refresh_interval: None,
             task_cache_ttl_seconds: None,
             task_cache_capacity: None,
+            log_forbidden_mutations: false,
         };
         let aggregation_job_creator_options = AggregationJobCreatorOptions {
             common: common_binary_options.clone(),


### PR DESCRIPTION
When we detect that an aggregation job ID is being re-used, we check that the incoming request matches whatever request we previously saw, and reject it with `Error::ForbiddenMutation`, which is rendered as HTTP 409 Conflict.

We now record an event when this occurs for aggregation job initialization. The event contains the expected request hash, the incoming request's hash and the list of `ReportMetadata`s for both.

Because the resulting event object is quite large, it gets written to a file, created under the directory specified in the `log_forbidden_mutations` option.

~The event is logged in a new span `aggregation_job_init_forbidden_mutation_span` at the DEBUG level. This event will be logged if a suitable filter is set up. For example, running Janus with `RUST_LOG=debug` or a `RUST_LOG` environment variable containing this string will do the trick:~

~`janus_aggregator::aggregator[aggregation_job_init_forbidden_mutation_span]=debug`~

Logging the forbidden mutation is expensive because it requires fetching all the `report_aggregations` rows for the existing aggregation job, so this is gated on the `log_forbidden_mutations` option.

Note that there are also cases in aggregation job continuation and collection job creation where we check for resource mutation and return 409 Conflict. This commit only logs on the aggregation job init path because that's what we're trying to debug right now.