### PR TITLE
Implement cancellation on disconnect.

### DIFF
--- a/aggregator/src/aggregator/error.rs
+++ b/aggregator/src/aggregator/error.rs
@@ -143,6 +143,8 @@ pub enum Error {
     /// An error occurred when trying to ensure differential privacy.
     #[error("differential privacy error: {0}")]
     DifferentialPrivacy(VdafError),
+    #[error("client disconnected")]
+    ClientDisconnected,
 }
 
 /// A newtype around `Arc<Error>`. This is needed to host a customized implementation of
@@ -309,6 +311,7 @@ impl Error {
             Error::BadRequest(_) => "bad_request",
             Error::InvalidTask(_, _) => "invalid_task",
             Error::DifferentialPrivacy(_) => "differential_privacy",
+            Error::ClientDisconnected => "client_disconnected",
         }
     }
 }


### PR DESCRIPTION
This will be very helpful when we have requests which timeout, which is presented to Janus as a client disconnect. Otherwise, we would continue processing the request until it is complete.

Update Helper aggregation methods, which use rayon to parallelize processing, to respect cancellation. Specifically, the `receiver` will be dropped, causing the producer's `sender` to return a SendError, which will cause `try_for_each_with` to stop processing.