### PR TITLE
Fully plumb through cache TTL config

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -253,7 +253,7 @@ impl<C: Clock> Aggregator<C> {
             // replicas.
             !cfg.taskprov_config.enabled,
             cfg.task_cache_capacity,
-            StdDuration::from_secs(1),
+            cfg.task_cache_ttl,
         );
 
         let upload_decrypt_failure_counter = meter


### PR DESCRIPTION
This was left as a placeholder during testing, instead of plumbing through the config. Fixes an issue where the task cache refreshes too often.