### PR TITLE
Helper agg init: check for repeated request before VDAF computations.

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1872,17 +1872,29 @@ impl VdafOps {
                 .map_err(Error::MessageDecode)?,
         );
 
-        if let Some(response) = datastore.run_tx("aggregate_init_idempotecy_check", |tx| {
-            let vdaf = vdaf.clone();
-            let task = Arc::clone(&task);
-            let aggregation_job_id = *aggregation_job_id;
-            let req = Arc::clone(&req);
-            let log_forbidden_mutations = log_forbidden_mutations.clone();
+        if let Some(response) = datastore
+            .run_tx("aggregate_init_idempotecy_check", |tx| {
+                let vdaf = vdaf.clone();
+                let task = Arc::clone(&task);
+                let aggregation_job_id = *aggregation_job_id;
+                let req = Arc::clone(&req);
+                let log_forbidden_mutations = log_forbidden_mutations.clone();
 
-            Box::pin(async move {
-                Self::check_aggregate_init_idempotency(tx, vdaf.as_ref(), task.id(), &aggregation_job_id, &req, request_hash, log_forbidden_mutations).await
+                Box::pin(async move {
+                    Self::check_aggregate_init_idempotency(
+                        tx,
+                        vdaf.as_ref(),
+                        task.id(),
+                        &aggregation_job_id,
+                        &req,
+                        request_hash,
+                        log_forbidden_mutations,
+                    )
+                    .await
+                })
             })
-        }).await? {
+            .await?
+        {
             return Ok(response);
         }
 

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1872,6 +1872,8 @@ impl VdafOps {
                 .map_err(Error::MessageDecode)?,
         );
 
+        // Check if this is a repeated request, and if it is the same as before, send
+        // the same response as last time.
         if let Some(response) = datastore
             .run_tx("aggregate_init_idempotecy_check", |tx| {
                 let vdaf = vdaf.clone();
@@ -2319,7 +2321,8 @@ impl VdafOps {
 
                 Box::pin(async move {
                     // Check if this is a repeated request, and if it is the same as before, send
-                    // the same response as last time.
+                    // the same response as last time. We check again to avoid the possibility of
+                    // races.
                     if let Some(response) = Self::check_aggregate_init_idempotency(
                         tx,
                         vdaf.as_ref(),


### PR DESCRIPTION
This will considerably reduce the computational cost of repeated requests, at the cost of an additional (read-only) DB transaction per aggregation initialization.