### PR TITLE
Key rotator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,6 +1537,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2763,6 +2773,8 @@ dependencies = [
  "postgres-types",
  "prio",
  "prometheus",
+ "quickcheck",
+ "quickcheck_macros",
  "rand",
  "rayon",
  "regex",
@@ -2970,6 +2982,7 @@ dependencies = [
  "kube",
  "mockito",
  "prio",
+ "quickcheck",
  "rand",
  "regex",
  "reqwest",
@@ -4392,6 +4405,28 @@ dependencies = [
  "socket2 0.5.6",
  "tracing",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "env_logger",
+ "log",
+ "rand",
+]
+
+[[package]]
+name = "quickcheck_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b22a693222d716a9587786f37ac3f6b4faedb5b80c23914e7303ff5a1d8016e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,16 +1537,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4361,6 +4351,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9318ead08c799aad12a55a3e78b82e0b6167271ffd1f627b758891282f739187"
 
 [[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "rand",
+]
+
+[[package]]
+name = "quickcheck_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b22a693222d716a9587786f37ac3f6b4faedb5b80c23914e7303ff5a1d8016e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4371,7 +4381,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.9",
+ "rustls 0.23.10",
  "thiserror",
  "tokio",
  "tracing",
@@ -4387,7 +4397,7 @@ dependencies = [
  "rand",
  "ring",
  "rustc-hash",
- "rustls 0.23.9",
+ "rustls 0.23.10",
  "slab",
  "thiserror",
  "tinyvec",
@@ -4405,28 +4415,6 @@ dependencies = [
  "socket2 0.5.6",
  "tracing",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "quickcheck"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
-dependencies = [
- "env_logger",
- "log",
- "rand",
-]
-
-[[package]]
-name = "quickcheck_macros"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b22a693222d716a9587786f37ac3f6b4faedb5b80c23914e7303ff5a1d8016e9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -4603,7 +4591,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.9",
+ "rustls 0.23.10",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,8 @@ pretty_assertions = "1.4.0"
 prio = { version = "0.16.5", default-features = false, features = ["experimental"] }
 prometheus = "0.13.4"
 querystring = "1.1.0"
+quickcheck = "1.0.3"
+quickcheck_macros = "1.0.0"
 rand = "0.8"
 rayon = "1.10.0"
 reqwest = { version = "0.12.5", default-features = false, features = ["rustls-tls"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ pretty_assertions = "1.4.0"
 prio = { version = "0.16.5", default-features = false, features = ["experimental"] }
 prometheus = "0.13.4"
 querystring = "1.1.0"
-quickcheck = "1.0.3"
+quickcheck = { version = "1.0.3", default-features = false }
 quickcheck_macros = "1.0.0"
 rand = "0.8"
 rayon = "1.10.0"

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -115,8 +115,8 @@ janus_aggregator_core = { workspace = true, features = ["test-util"] }
 mockito = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
 prio = { workspace = true, features = ["multithreaded"] }
-quickcheck = "1.0.3"
-quickcheck_macros = "1.0.0"
+quickcheck = { workspace = true }
+quickcheck_macros = { workspace = true }
 rstest.workspace = true
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["net", "test-util"] } # ensure this remains compatible with the non-dev dependency

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -115,6 +115,8 @@ janus_aggregator_core = { workspace = true, features = ["test-util"] }
 mockito = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
 prio = { workspace = true, features = ["multithreaded"] }
+quickcheck = "1.0.3"
+quickcheck_macros = "1.0.0"
 rstest.workspace = true
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["net", "test-util"] } # ensure this remains compatible with the non-dev dependency

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -129,6 +129,7 @@ mod collection_job_tests;
 mod error;
 pub mod garbage_collector;
 pub mod http_handlers;
+pub mod key_rotator;
 pub mod problem_details;
 pub mod query_type;
 pub mod report_writer;

--- a/aggregator/src/aggregator/key_rotator.rs
+++ b/aggregator/src/aggregator/key_rotator.rs
@@ -60,17 +60,17 @@ pub struct HpkeKeyRotatorConfig {
     /// How long key remains in [`HpkeKeyState::Pending`] before being moved to
     /// [`HpkeKeyState::Active`]. This should be greater than
     /// [`AggregatorConfig::global_hpke_configs_refresh_interval`].
-    #[serde(rename = "pending_duration_secs", default = "default_pending_duration")]
+    #[serde(rename = "pending_duration_s", default = "default_pending_duration")]
     pub pending_duration: Duration,
 
     /// The time-to-live of the key. Once this is exceeded, the key is moved to
     /// [`HpkeKeyState::Expired`]. It is at operator discretion as to how long this should be.
-    #[serde(rename = "active_duration_secs", default = "default_active_duration")]
+    #[serde(rename = "active_duration_s", default = "default_active_duration")]
     pub active_duration: Duration,
 
     /// How long the key remains in [`HpkeKeyState::Expired`] before being deleted. This should
     /// be greater than the clients' HPKE key cache maximum age.
-    #[serde(rename = "expired_duration_secs", default = "default_expired_duration")]
+    #[serde(rename = "expired_duration_s", default = "default_expired_duration")]
     pub expired_duration: Duration,
 
     /// Set of keys to manage, identified by ciphersuite.

--- a/aggregator/src/aggregator/key_rotator.rs
+++ b/aggregator/src/aggregator/key_rotator.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashSet, sync::Arc};
 
 #[allow(unused_imports)]
-use crate::aggregator::Config as AggregatorConfig;
-use crate::cache::GlobalHpkeKeypairCache; // used in doccomment.
+use crate::aggregator::Config as AggregatorConfig; // used in doccomment.
+use crate::cache::GlobalHpkeKeypairCache;
 use anyhow::{anyhow, Error};
 use janus_aggregator_core::datastore::{
     models::{GlobalHpkeKeypair, HpkeKeyState},
@@ -65,12 +65,13 @@ pub struct HpkeKeyRotatorConfig {
     #[serde(default = "default_hpke_ciphersuite")]
     pub ciphersuite: HpkeCiphersuite,
 
-    /// Safely phase out this ciphersuite. This will immediately delete any pending keys and
-    /// expire any active keys. Expired keys are retained for at least [`Self::expired_duration`]
-    /// before being deleted.
+    /// Safely phase out this config. If set, on next run the key rotator will immediately delete
+    /// any pending keys and expire any active keys with the given [`Self::ciphersuite`]. Expired
+    /// keys are retained for at least [`Self::expired_duration`] before being deleted.
     ///
-    /// After [`Self::expired_duration`], this config can be removed entirely. It is not recommended
-    /// to remove key configurations without running the key rotator with `retire` first.
+    /// After the key rotator has run after [`Self::expired_duration`], this config can be removed
+    /// entirely. It is not recommended to remove key configs unless the key rotator has been run
+    /// after [`Self::expired_duration`] with `retire` set.
     ///
     /// There must be at least one non-retired config present with its key in the active state. If
     /// this is the only config and it is marked retired, the key rotator will refuse to run.

--- a/aggregator/src/aggregator/key_rotator.rs
+++ b/aggregator/src/aggregator/key_rotator.rs
@@ -404,7 +404,7 @@ impl<'a, C: Clock> HpkeKeypairs<'a, C> {
     }
 
     async fn write(self, tx: &Transaction<'_, C>) -> Result<(), DatastoreError> {
-        tx.rewrite_global_hpke_keypairs(&self.keypairs.values().cloned().collect::<Vec<_>>())
+        tx.update_global_hpke_keypairs(&self.keypairs.values().cloned().collect::<Vec<_>>())
             .await?;
 
         // Defensive assertion: Check our transaction snapshot for at least one active keypair in

--- a/aggregator/src/aggregator/key_rotator.rs
+++ b/aggregator/src/aggregator/key_rotator.rs
@@ -36,7 +36,7 @@ use tracing::{debug, info};
 #[derive(Debug)]
 pub struct KeyRotator<C: Clock> {
     datastore: Arc<Datastore<C>>,
-    hpke: Vec<HpkeKeyRotatorConfig>,
+    hpke: HpkeKeyRotatorConfig,
 }
 
 /// Defines the ciphersuite and rotation policy of a global HPKE key.
@@ -58,22 +58,9 @@ pub struct HpkeKeyRotatorConfig {
     #[serde(rename = "expired_duration_secs", default = "default_expired_duration")]
     pub expired_duration: Duration,
 
-    /// The ciphersuite of the key.
-    #[serde(default = "default_hpke_ciphersuite")]
-    pub ciphersuite: HpkeCiphersuite,
-
-    /// Safely phase out this config. If set, on next run the key rotator will immediately delete
-    /// any pending keys and expire any active keys with the given [`Self::ciphersuite`]. Expired
-    /// keys are retained for at least [`Self::expired_duration`] before being deleted.
-    ///
-    /// After the key rotator has run after [`Self::expired_duration`], this config can be removed
-    /// entirely. It is not recommended to remove key configs unless the key rotator has been run
-    /// after [`Self::expired_duration`] with `retire` set.
-    ///
-    /// There must be at least one non-retired config present with its key in the active state. If
-    /// this is the only config and it is marked retired, the key rotator will refuse to run.
-    #[serde(default)]
-    pub retire: bool,
+    /// Set of keys to manage, identified by ciphersuite.
+    #[serde(default = "default_hpke_ciphersuites")]
+    pub ciphersuites: HashSet<HpkeCiphersuite>,
 }
 
 /// Returns [`GlobalHpkeKeypairCache::DEFAULT_REFRESH_INTERVAL`] times 2, for safety margin.
@@ -92,16 +79,16 @@ fn default_expired_duration() -> Duration {
     Duration::from_seconds(60 * 60 * 24 * 7)
 }
 
-fn default_hpke_ciphersuite() -> HpkeCiphersuite {
-    HpkeCiphersuite::new(
+fn default_hpke_ciphersuites() -> HashSet<HpkeCiphersuite> {
+    HashSet::from([HpkeCiphersuite::new(
         HpkeKemId::X25519HkdfSha256,
         HpkeKdfId::HkdfSha256,
         HpkeAeadId::Aes128Gcm,
-    )
+    )])
 }
 
 impl<C: Clock> KeyRotator<C> {
-    pub fn new(datastore: Arc<Datastore<C>>, hpke: Vec<HpkeKeyRotatorConfig>) -> Self {
+    pub fn new(datastore: Arc<Datastore<C>>, hpke: HpkeKeyRotatorConfig) -> Self {
         Self { datastore, hpke }
     }
 
@@ -118,8 +105,8 @@ impl<C: Clock> KeyRotator<C> {
     pub async fn run(&self) -> Result<(), Error> {
         self.datastore
             .run_tx("global_hpke_key_rotator", |tx| {
-                let configs = self.hpke.clone();
-                Box::pin(async move { Self::run_hpke(tx, configs).await })
+                let config = self.hpke.clone();
+                Box::pin(async move { Self::run_hpke(tx, config).await })
             })
             .await
             .map_err(|err| err.into())
@@ -128,7 +115,7 @@ impl<C: Clock> KeyRotator<C> {
     #[tracing::instrument(err, skip(tx))]
     async fn run_hpke(
         tx: &Transaction<'_, C>,
-        configs: Vec<HpkeKeyRotatorConfig>,
+        config: HpkeKeyRotatorConfig,
     ) -> Result<(), DatastoreError> {
         // Take an ExclusiveLock on the table. This ensures that only one key rotator
         // replica writes to the table at a time and that each replica gets a consistent
@@ -142,8 +129,15 @@ impl<C: Clock> KeyRotator<C> {
         let current_keypairs = tx.get_global_hpke_keypairs().await?;
         debug!(?current_keypairs, "table state before running key rotator");
         let mut available_ids = Self::available_ids(&current_keypairs);
-        for config in &configs {
-            Self::run_hpke_for_config(tx, &current_keypairs, &mut available_ids, config).await?;
+        for ciphersuite in &config.ciphersuites {
+            Self::run_hpke_for_ciphersuite(
+                tx,
+                &config,
+                &current_keypairs,
+                &mut available_ids,
+                ciphersuite,
+            )
+            .await?;
         }
 
         // Defensive assertion: Check our transaction snapshot for at least one active keypair in
@@ -165,11 +159,12 @@ impl<C: Clock> KeyRotator<C> {
     }
 
     #[tracing::instrument(err, skip(tx, current_keypairs, available_ids))]
-    async fn run_hpke_for_config(
+    async fn run_hpke_for_ciphersuite(
         tx: &Transaction<'_, C>,
+        config: &HpkeKeyRotatorConfig,
         current_keypairs: &[GlobalHpkeKeypair],
         available_ids: &mut impl Iterator<Item = HpkeConfigId>,
-        config: &HpkeKeyRotatorConfig,
+        ciphersuite: &HpkeCiphersuite,
     ) -> Result<(), DatastoreError> {
         let clock = tx.clock();
 
@@ -177,33 +172,21 @@ impl<C: Clock> KeyRotator<C> {
             pending_keypairs,
             active_keypairs,
             expired_keypairs,
-        } = Self::partition_keypairs(current_keypairs, &config.ciphersuite);
+        } = Self::partition_keypairs(current_keypairs, &ciphersuite);
 
         let mut next_key = || {
             generate_hpke_config_and_private_key(
                 available_ids
                     .next()
                     .ok_or_else(|| DatastoreError::User(anyhow!("u8 space exhausted").into()))?,
-                config.ciphersuite.kem_id(),
-                config.ciphersuite.kdf_id(),
-                config.ciphersuite.aead_id(),
+                ciphersuite.kem_id(),
+                ciphersuite.kdf_id(),
+                ciphersuite.aead_id(),
             )
             .map_err(|e| DatastoreError::User(e.into()))
         };
 
-        if config.retire {
-            for pending_keypair in pending_keypairs {
-                // Janus replicas should have never advertised this keypair, so it should be safe
-                // to delete outright.
-                info!(id = ?pending_keypair.id(), "deleting pending keypair for retired ciphersuite");
-                tx.delete_global_hpke_keypair(pending_keypair.id()).await?;
-            }
-            for active_keypair in active_keypairs {
-                info!(id = ?active_keypair.id(), "expiring active keypair for retired ciphersuite");
-                tx.set_global_hpke_keypair_state(active_keypair.id(), &HpkeKeyState::Expired)
-                    .await?;
-            }
-        } else if active_keypairs.is_empty() && pending_keypairs.is_empty() {
+        if active_keypairs.is_empty() && pending_keypairs.is_empty() {
             // Bootstrapping case: there are no keys at all for this ciphersuite, so we need to
             // insert one.
             let new_keypair = next_key()?;
@@ -344,32 +327,24 @@ struct PartitionedKeypairs<'a> {
     expired_keypairs: Vec<&'a GlobalHpkeKeypair>,
 }
 
-/// Enforces that there's at least one [`HpkeKeyRotatorConfig`].
-pub fn deserialize_hpke_key_rotator_configs<'de, D>(
+/// Enforces that there's at least one [`HpkeCiphersuite`].
+pub fn deserialize_hpke_key_rotator_config<'de, D>(
     deserializer: D,
-) -> Result<Vec<HpkeKeyRotatorConfig>, D::Error>
+) -> Result<HpkeKeyRotatorConfig, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let configs: Vec<HpkeKeyRotatorConfig> = Deserialize::deserialize(deserializer)?;
-    let mut unique = HashSet::new();
-    if configs.is_empty() {
-        Err(de::Error::custom(
-            "must provide at least one hpke key rotator config",
-        ))
-    } else if !configs
-        .iter()
-        .all(|config| unique.insert(config.ciphersuite))
-    {
-        Err(de::Error::custom("each ciphersuite must be unique"))
+    let config: HpkeKeyRotatorConfig = Deserialize::deserialize(deserializer)?;
+    if config.ciphersuites.is_empty() {
+        Err(de::Error::custom("must provide at least one ciphersuite"))
     } else {
-        Ok(configs)
+        Ok(config)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{collections::HashSet, sync::Arc};
 
     use janus_aggregator_core::datastore::{
         models::{GlobalHpkeKeypair, HpkeKeyState},
@@ -411,25 +386,15 @@ mod tests {
             HpkeKdfId::HkdfSha512,
             HpkeAeadId::Aes256Gcm,
         );
-
+        let ciphersuites = HashSet::from([ciphersuite_0, ciphersuite_1]);
         let key_rotator = KeyRotator::new(
             ds.clone(),
-            Vec::from([
-                HpkeKeyRotatorConfig {
-                    pending_duration,
-                    active_duration,
-                    expired_duration,
-                    ciphersuite: ciphersuite_0,
-                    retire: false,
-                },
-                HpkeKeyRotatorConfig {
-                    pending_duration,
-                    active_duration,
-                    expired_duration,
-                    ciphersuite: ciphersuite_1,
-                    retire: false,
-                },
-            ]),
+            HpkeKeyRotatorConfig {
+                pending_duration,
+                active_duration,
+                expired_duration,
+                ciphersuites: ciphersuites.clone(),
+            },
         );
 
         // Checks that there's a keypair with the given state for each ciphersuite.
@@ -514,16 +479,15 @@ mod tests {
             HpkeKdfId::HkdfSha256,
             HpkeAeadId::Aes128Gcm,
         );
-
+        let ciphersuites = HashSet::from([ciphersuite_0]);
         let key_rotator = KeyRotator::new(
             ds.clone(),
-            Vec::from([HpkeKeyRotatorConfig {
+            HpkeKeyRotatorConfig {
                 pending_duration,
                 active_duration,
                 expired_duration,
-                ciphersuite: ciphersuite_0,
-                retire: false,
-            }]),
+                ciphersuites: ciphersuites.clone(),
+            },
         );
 
         // Run the key rotator for a while.
@@ -538,24 +502,15 @@ mod tests {
             HpkeKdfId::HkdfSha512,
             HpkeAeadId::Aes256Gcm,
         );
+        let ciphersuites = HashSet::from([ciphersuite_0, ciphersuite_1]);
         let key_rotator = KeyRotator::new(
             ds.clone(),
-            Vec::from([
-                HpkeKeyRotatorConfig {
-                    pending_duration,
-                    active_duration,
-                    expired_duration,
-                    ciphersuite: ciphersuite_0,
-                    retire: false,
-                },
-                HpkeKeyRotatorConfig {
-                    pending_duration,
-                    active_duration,
-                    expired_duration,
-                    ciphersuite: ciphersuite_1,
-                    retire: false,
-                },
-            ]),
+            HpkeKeyRotatorConfig {
+                pending_duration,
+                active_duration,
+                expired_duration,
+                ciphersuites: ciphersuites.clone(),
+            },
         );
 
         // Run the key rotator, we should insert a new pending key for the new ciphersuite.
@@ -609,16 +564,15 @@ mod tests {
             HpkeKdfId::HkdfSha256,
             HpkeAeadId::Aes128Gcm,
         );
-
+        let ciphersuites = HashSet::from([ciphersuite_0]);
         let key_rotator = KeyRotator::new(
             ds.clone(),
-            Vec::from([HpkeKeyRotatorConfig {
+            HpkeKeyRotatorConfig {
                 pending_duration,
                 active_duration,
                 expired_duration,
-                ciphersuite: ciphersuite_0,
-                retire: false,
-            }]),
+                ciphersuites: ciphersuites.clone(),
+            },
         );
 
         // Run the key rotator for a while, such that the current key is expired with one pending.
@@ -701,15 +655,15 @@ mod tests {
             HpkeAeadId::Aes128Gcm,
         );
 
+        let ciphersuites = HashSet::from([ciphersuite_0]);
         let key_rotator = KeyRotator::new(
             ds.clone(),
-            Vec::from([HpkeKeyRotatorConfig {
+            HpkeKeyRotatorConfig {
                 pending_duration,
                 active_duration,
                 expired_duration,
-                ciphersuite: ciphersuite_0,
-                retire: false,
-            }]),
+                ciphersuites: ciphersuites.clone(),
+            },
         );
 
         // Run the key rotator for a while.
@@ -761,153 +715,5 @@ mod tests {
             .filter(|keypair| keypair.state() == &HpkeKeyState::Active)
             .collect();
         assert_eq!(active_keypairs.len(), 1);
-    }
-
-    #[tokio::test]
-    async fn hpke_key_rotator_refuse_to_retire_only_one_key() {
-        install_test_trace_subscriber();
-        let clock = MockClock::default();
-        let ephemeral_datastore = ephemeral_datastore().await;
-        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
-
-        let pending_duration = Duration::from_seconds(60);
-        let active_duration = Duration::from_seconds(300);
-        let expired_duration = Duration::from_seconds(60);
-        let ciphersuite_0 = HpkeCiphersuite::new(
-            HpkeKemId::P256HkdfSha256,
-            HpkeKdfId::HkdfSha256,
-            HpkeAeadId::Aes128Gcm,
-        );
-
-        let key_rotator = KeyRotator::new(
-            ds.clone(),
-            Vec::from([HpkeKeyRotatorConfig {
-                pending_duration,
-                active_duration,
-                expired_duration,
-                ciphersuite: ciphersuite_0,
-                retire: true,
-            }]),
-        );
-
-        assert!(key_rotator.run().await.is_err());
-
-        let key_rotator = KeyRotator::new(
-            ds.clone(),
-            Vec::from([HpkeKeyRotatorConfig {
-                pending_duration,
-                active_duration,
-                expired_duration,
-                ciphersuite: ciphersuite_0,
-                retire: false,
-            }]),
-        );
-
-        for _ in 0..7 {
-            key_rotator.run().await.unwrap();
-            clock.advance(&Duration::from_seconds(30));
-        }
-
-        let key_rotator = KeyRotator::new(
-            ds.clone(),
-            Vec::from([HpkeKeyRotatorConfig {
-                pending_duration,
-                active_duration,
-                expired_duration,
-                ciphersuite: ciphersuite_0,
-                retire: true,
-            }]),
-        );
-
-        assert!(key_rotator.run().await.is_err());
-    }
-
-    #[tokio::test]
-    async fn hpke_key_rotator_retire() {
-        install_test_trace_subscriber();
-        let clock = MockClock::default();
-        let ephemeral_datastore = ephemeral_datastore().await;
-        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
-
-        let pending_duration = Duration::from_seconds(60);
-        let active_duration = Duration::from_seconds(300);
-        let expired_duration = Duration::from_seconds(120);
-        let ciphersuite_0 = HpkeCiphersuite::new(
-            HpkeKemId::P256HkdfSha256,
-            HpkeKdfId::HkdfSha256,
-            HpkeAeadId::Aes128Gcm,
-        );
-        let ciphersuite_1 = HpkeCiphersuite::new(
-            HpkeKemId::X25519HkdfSha256,
-            HpkeKdfId::HkdfSha512,
-            HpkeAeadId::Aes256Gcm,
-        );
-
-        let key_rotator = KeyRotator::new(
-            ds.clone(),
-            Vec::from([
-                HpkeKeyRotatorConfig {
-                    pending_duration,
-                    active_duration,
-                    expired_duration,
-                    ciphersuite: ciphersuite_0,
-                    retire: false,
-                },
-                HpkeKeyRotatorConfig {
-                    pending_duration,
-                    active_duration,
-                    expired_duration,
-                    ciphersuite: ciphersuite_1,
-                    retire: false,
-                },
-            ]),
-        );
-
-        // Run the key rotator for a while, such that the current key is expired with one pending.
-        for _ in 0..12 {
-            key_rotator.run().await.unwrap();
-            clock.advance(&Duration::from_seconds(30));
-        }
-        let keypairs = get_global_hpke_keypairs(&ds).await;
-        assert_eq!(keypairs.len(), 4);
-
-        // Retire ciphersuite_0.
-        let key_rotator = KeyRotator::new(
-            ds.clone(),
-            Vec::from([
-                HpkeKeyRotatorConfig {
-                    pending_duration,
-                    active_duration,
-                    expired_duration,
-                    ciphersuite: ciphersuite_0,
-                    retire: true,
-                },
-                HpkeKeyRotatorConfig {
-                    pending_duration,
-                    active_duration,
-                    expired_duration,
-                    ciphersuite: ciphersuite_1,
-                    retire: false,
-                },
-            ]),
-        );
-
-        key_rotator.run().await.unwrap();
-        let keypairs = get_global_hpke_keypairs(&ds).await;
-        let ciphersuite_0_keypairs: Vec<_> = keypairs
-            .iter()
-            .filter(|keypair| keypair.ciphersuite() == ciphersuite_0)
-            .collect();
-        assert_eq!(ciphersuite_0_keypairs.len(), 1);
-        assert!(ciphersuite_0_keypairs[0].state() == &HpkeKeyState::Expired);
-
-        clock.advance(&expired_duration.add(&Duration::from_seconds(1)).unwrap());
-        key_rotator.run().await.unwrap();
-        let keypairs = get_global_hpke_keypairs(&ds).await;
-        let ciphersuite_0_keypairs: Vec<_> = keypairs
-            .iter()
-            .filter(|keypair| keypair.ciphersuite() == ciphersuite_0)
-            .collect();
-        assert!(ciphersuite_0_keypairs.is_empty());
     }
 }

--- a/aggregator/src/aggregator/key_rotator.rs
+++ b/aggregator/src/aggregator/key_rotator.rs
@@ -1,0 +1,675 @@
+use std::sync::Arc;
+
+#[allow(unused_imports)]
+use crate::aggregator::Config as AggregatorConfig; // used in doccomment.
+use anyhow::{anyhow, Error};
+use janus_aggregator_core::datastore::{
+    models::{GlobalHpkeKeypair, HpkeKeyState},
+    Datastore, Error as DatastoreError, Transaction,
+};
+use janus_core::{
+    hpke::{generate_hpke_config_and_private_key, HpkeCiphersuite},
+    time::{Clock, TimeExt},
+};
+use janus_messages::{Duration, HpkeConfigId, Time};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, info};
+
+/// Handles key rotation for Janus, according to policies defined in the configuration.
+///
+/// # Global HPKE Keys
+///
+/// The key rotator can handle key rotation for global HPKE keys. The key rotator is tolerant of
+/// some manual operator changes to the `global_hpke_keys` table.
+///
+/// Operators _must not_ manually change the `created_at` or `updated_at` columns, as these are
+/// used for rotation decision-making.
+///
+/// It is strongly discouraged to:
+///   - Delete active or expired keypairs too early, as that would leave Janus unable to decrypt
+///     report shares using the keypair.
+///   - Promote pending keypairs too early or directly insert active keypairs, unless all Janus
+///     replicas are rebooted after the change.
+///
+/// Keypairs that are manually inserted are adopted by the key rotator and will have their lifecycle
+/// managed. The number of keypairs per ciphersuite will trend towards 1, i.e. 2 keys with the same
+/// ciphersuite will eventually be replaced with 1 key.
+#[derive(Debug)]
+pub struct KeyRotator<C: Clock> {
+    datastore: Arc<Datastore<C>>,
+    hpke: Vec<HpkeKeyRotatorConfig>,
+}
+
+/// Defines the ciphersuite and rotation policy of a global HPKE key.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HpkeKeyRotatorConfig {
+    /// How long key remains in [`HpkeKeyState::Pending`] before being moved to
+    /// [`HpkeKeyState::Active`]. This should be greater than
+    /// [`AggregatorConfig::global_hpke_configs_refresh_interval`].
+    pub pending_duration: Duration,
+
+    /// The time-to-live of the key. Once this is exceeded, the key is moved to
+    /// [`HpkeKeyState::Expired`]. It is at operator discretion as to how long this should be.
+    pub active_duration: Duration,
+
+    /// How long the key remains in [`HpkeKeyState::Expired`] before being deleted. This should
+    /// be greater than the clients' HPKE key cache maximum age.
+    pub expired_duration: Duration,
+
+    /// The ciphersuite of the key.
+    pub ciphersuite: HpkeCiphersuite,
+}
+
+impl<C: Clock> KeyRotator<C> {
+    pub fn new(datastore: Arc<Datastore<C>>, hpke: Vec<HpkeKeyRotatorConfig>) -> Self {
+        Self { datastore, hpke }
+    }
+
+    /// Runs the key rotator.
+    ///
+    /// # Errors
+    ///
+    /// Errors on general datastore errors.
+    ///
+    /// This is not permissive of [`HpkeConfigId`] space exhaustion, i.e. if there are more rows
+    /// than what fit into a `u8`, this process will error. To avoid this, keep the list of managed
+    /// ciphersuites small, and the expiration duration less than the key age.
+    #[tracing::instrument]
+    pub async fn run(&self) -> Result<(), Error> {
+        self.datastore
+            .run_tx("global_hpke_key_rotator", |tx| {
+                let configs = self.hpke.clone();
+                Box::pin(async move { Self::run_hpke(tx, configs).await })
+            })
+            .await
+            .map_err(|err| err.into())
+    }
+
+    #[tracing::instrument(skip(tx))]
+    async fn run_hpke(
+        tx: &Transaction<'_, C>,
+        configs: Vec<HpkeKeyRotatorConfig>,
+    ) -> Result<(), DatastoreError> {
+        // Take an ExclusiveLock on the table. This ensures that only one key rotator
+        // replica writes to the table at a time and that each replica gets a consistent
+        // view of the table state.
+        //
+        // ExclusiveLock does not conflict with the AccessShare lock taken by table
+        // reads, i.e. other aggregator replicas can continue to refresh their key
+        // caches without being blocked.
+        tx.lock_global_hpke_keypairs().await?;
+
+        let current_keypairs = tx.get_global_hpke_keypairs().await?;
+        debug!(?current_keypairs, "before");
+        let mut available_ids = Self::available_ids(&current_keypairs);
+        for config in &configs {
+            Self::run_hpke_for_config(tx, &current_keypairs, &mut available_ids, config).await?;
+        }
+
+        // Defensive assertion: Check our transaction snapshot for at least one active keypair in
+        // in the table. If one is absent, committing the transaction would leave Janus unstartable
+        // so we should rollback.
+        let current_keypairs = tx.get_global_hpke_keypairs().await?;
+        debug!(?current_keypairs, "after");
+        if current_keypairs
+            .iter()
+            .find(|keypair| keypair.state() == &HpkeKeyState::Active)
+            .is_none()
+        {
+            DatastoreError::User(anyhow!("unexpected state: no keypairs are active").into());
+        }
+
+        Ok(())
+    }
+
+    #[tracing::instrument(skip(tx, current_keypairs, available_ids))]
+    async fn run_hpke_for_config(
+        tx: &Transaction<'_, C>,
+        current_keypairs: &[GlobalHpkeKeypair],
+        available_ids: &mut impl Iterator<Item = HpkeConfigId>,
+        config: &HpkeKeyRotatorConfig,
+    ) -> Result<(), DatastoreError> {
+        let (pending_keypairs, active_keypairs, expired_keypairs) =
+            Self::partition_keypairs(&current_keypairs, &config.ciphersuite);
+        let mut next_key = || {
+            generate_hpke_config_and_private_key(
+                available_ids
+                    .next()
+                    .ok_or_else(|| DatastoreError::User(anyhow!("u8 space exhausted").into()))?,
+                config.ciphersuite.kem_id(),
+                config.ciphersuite.kdf_id(),
+                config.ciphersuite.aead_id(),
+            )
+            .map_err(|e| DatastoreError::User(e.into()))
+        };
+
+        if active_keypairs.is_empty() && pending_keypairs.is_empty() {
+            // Bootstrapping case: there are no keys at all for this ciphersuite, so we need to
+            // insert one.
+            let keypair = next_key()?;
+            info!(
+                id = ?keypair.config().id(),
+                "bootstrapping: inserting key for new ciphersuite"
+            );
+            tx.put_global_hpke_keypair(&keypair).await?;
+
+            // If there are zero keypairs reported by the database, it's likely beacuse we're
+            // in a brand new database, and this is the first execution of Janus. Initialize
+            // the table with active keys. Janus won't be ready until there's at least one
+            // active keypair in the database.
+            //
+            // Otherwise, the ciphersuite was likely added to the configuration and its key
+            // needs to go through the normal pending->active state change.
+            if current_keypairs.is_empty() {
+                info!(id = ?keypair.config().id(), "bootstrapping: moving new key to active state");
+                tx.set_global_hpke_keypair_state(keypair.config().id(), &HpkeKeyState::Active)
+                    .await?;
+            }
+        } else {
+            let to_be_expired_keypairs: Vec<_> = active_keypairs
+                .iter()
+                .filter(|keypair| {
+                    Self::duration_since(tx, keypair.updated_at()) > config.active_duration
+                })
+                .cloned()
+                .collect();
+
+            if to_be_expired_keypairs != active_keypairs {
+                for keypair in to_be_expired_keypairs {
+                    info!(id = ?keypair.id(), "allowing already active keypair to replace this one");
+                    tx.set_global_hpke_keypair_state(keypair.id(), &HpkeKeyState::Expired)
+                        .await?;
+                }
+            } else {
+                if pending_keypairs.is_empty() {
+                    let next = next_key()?;
+                    info!(id = ?next.config().id(), "inserting new pending key to replace expired one(s)");
+                    tx.put_global_hpke_keypair(&next).await?;
+                } else {
+                    let pending_key_is_ready = pending_keypairs
+                        .iter()
+                        .find(|keypair| {
+                            Self::duration_since(tx, keypair.updated_at()) > config.pending_duration
+                        })
+                        .is_some();
+                    if pending_key_is_ready {
+                        for keypair in to_be_expired_keypairs {
+                            info!(id = ?keypair.id(), "a pending key is ready, marking key expired");
+                            tx.set_global_hpke_keypair_state(keypair.id(), &HpkeKeyState::Expired)
+                                .await?;
+                        }
+                    }
+                }
+            }
+
+            // Promote any pending keypairs that are ready. We don't sweep them in the same loop
+            // as active keypairs, because it's possible for there to be a pending keypair
+            // without an active one.
+            for pending_keypair in pending_keypairs {
+                if Self::duration_since(tx, pending_keypair.updated_at()) > config.pending_duration
+                {
+                    info!(id = ?pending_keypair.id(), "pending key is ready, moving it to active");
+                    tx.set_global_hpke_keypair_state(pending_keypair.id(), &HpkeKeyState::Active)
+                        .await?;
+                }
+            }
+        }
+
+        // Sweep expired keypairs. Any keypairs that are old enough are deleted.
+        for keypair in &expired_keypairs {
+            if Self::duration_since(tx, keypair.updated_at()) > config.expired_duration {
+                info!(id = ?keypair.id(), "deleting expired keypair");
+                tx.delete_global_hpke_keypair(keypair.id()).await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn duration_since(tx: &Transaction<C>, time: &Time) -> Duration {
+        // Use saturating difference to account for time skew between key rotator runners. Since
+        // key rotators are synchronized by an exclusive lock on the table, it's possible that
+        // time skew between concurrently running replicas result in underflows.
+        tx.clock().now().saturating_difference(time)
+    }
+
+    fn partition_keypairs<'a>(
+        keypairs: &'a [GlobalHpkeKeypair],
+        ciphersuite: &HpkeCiphersuite,
+    ) -> (
+        Vec<&'a GlobalHpkeKeypair>,
+        Vec<&'a GlobalHpkeKeypair>,
+        Vec<&'a GlobalHpkeKeypair>,
+    ) {
+        let (mut pending, mut active, mut expired) = (Vec::new(), Vec::new(), Vec::new());
+        keypairs
+            .iter()
+            .filter(|keypair| &keypair.ciphersuite() == ciphersuite)
+            .for_each(|keypair| match keypair.state() {
+                HpkeKeyState::Pending => pending.push(keypair),
+                HpkeKeyState::Active => active.push(keypair),
+                HpkeKeyState::Expired => expired.push(keypair),
+            });
+        (pending, active, expired)
+    }
+
+    fn available_ids(current_keypairs: &[GlobalHpkeKeypair]) -> impl Iterator<Item = HpkeConfigId> {
+        let ids: Vec<_> = current_keypairs
+            .iter()
+            .map(|keypair| u8::from(*keypair.id()))
+            .collect();
+
+        // Try to cycle through the entire u8 space before going back to zero. This allows us a
+        // bigger window to quicky reject faulty old clients with an outdated HPKE config error,
+        // rather than attempting to decrypt them with the wrong key.
+        let newest_id = current_keypairs
+            .iter()
+            .max_by(|a, b| a.created_at().cmp(b.created_at()))
+            .map(|keypair| (*keypair.id()).into())
+            .unwrap_or(0);
+        (newest_id..=u8::MAX)
+            .chain(0..newest_id)
+            .filter_map(move |id| {
+                if !ids.contains(&id) {
+                    Some(HpkeConfigId::from(id))
+                } else {
+                    None
+                }
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use janus_aggregator_core::datastore::{
+        models::{GlobalHpkeKeypair, HpkeKeyState},
+        test_util::ephemeral_datastore,
+        Datastore,
+    };
+    use janus_core::{
+        hpke::{generate_hpke_config_and_private_key, HpkeCiphersuite},
+        test_util::install_test_trace_subscriber,
+        time::{Clock, DurationExt, MockClock},
+    };
+    use janus_messages::{Duration, HpkeAeadId, HpkeConfigId, HpkeKdfId, HpkeKemId};
+
+    use crate::aggregator::key_rotator::{HpkeKeyRotatorConfig, KeyRotator};
+
+    async fn get_global_hpke_keypairs<C: Clock>(ds: &Datastore<C>) -> Vec<GlobalHpkeKeypair> {
+        ds.run_unnamed_tx(|tx| Box::pin(async move { tx.get_global_hpke_keypairs().await }))
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn hpke_key_rotator() {
+        install_test_trace_subscriber();
+        let clock = MockClock::default();
+        let ephemeral_datastore = ephemeral_datastore().await;
+        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
+
+        let pending_duration = Duration::from_seconds(60);
+        let active_duration = Duration::from_seconds(300);
+        let expired_duration = Duration::from_seconds(120);
+        let ciphersuite_0 = HpkeCiphersuite::new(
+            HpkeKemId::P256HkdfSha256,
+            HpkeKdfId::HkdfSha256,
+            HpkeAeadId::Aes128Gcm,
+        );
+        let ciphersuite_1 = HpkeCiphersuite::new(
+            HpkeKemId::X25519HkdfSha256,
+            HpkeKdfId::HkdfSha512,
+            HpkeAeadId::Aes256Gcm,
+        );
+
+        let key_rotator = KeyRotator::new(
+            ds.clone(),
+            Vec::from([
+                HpkeKeyRotatorConfig {
+                    pending_duration,
+                    active_duration,
+                    expired_duration,
+                    ciphersuite: ciphersuite_0.clone(),
+                },
+                HpkeKeyRotatorConfig {
+                    pending_duration,
+                    active_duration,
+                    expired_duration,
+                    ciphersuite: ciphersuite_1.clone(),
+                },
+            ]),
+        );
+
+        // Checks that there's a keypair with the given state for each ciphersuite.
+        let ciphersuites = Vec::from([ciphersuite_0, ciphersuite_1]);
+        let assert_state = |keypairs: &[GlobalHpkeKeypair], state: HpkeKeyState| {
+            assert!(ciphersuites.iter().all(|ciphersuite| keypairs
+                .iter()
+                .find(|keypair| keypair.state() == &state && &keypair.ciphersuite() == ciphersuite)
+                .is_some()));
+        };
+
+        // First iteration: We should create active keys for each ciphersuite.
+        key_rotator.run().await.unwrap();
+        let keypairs = get_global_hpke_keypairs(&ds).await;
+        assert_eq!(keypairs.len(), 2);
+        assert_state(&keypairs, HpkeKeyState::Active);
+
+        // Advance the clock only a little, no action should be taken.
+        clock.advance(&Duration::from_seconds(1));
+        key_rotator.run().await.unwrap();
+        let keypairs = get_global_hpke_keypairs(&ds).await;
+        assert_eq!(keypairs.len(), 2);
+        assert_state(&keypairs, HpkeKeyState::Active);
+
+        // Run through several lifetimes.
+        for _ in 0..4 {
+            // Age out the keys. We should insert a couple of pending keys.
+            clock.advance(&active_duration.add(&Duration::from_seconds(1)).unwrap());
+            key_rotator.run().await.unwrap();
+            let keypairs = get_global_hpke_keypairs(&ds).await;
+            assert_eq!(keypairs.len(), 4);
+            assert_state(&keypairs, HpkeKeyState::Active);
+            assert_state(&keypairs, HpkeKeyState::Pending);
+
+            // Advance the clock only a little, no action should be taken.
+            clock.advance(&Duration::from_seconds(1));
+            key_rotator.run().await.unwrap();
+            let keypairs = get_global_hpke_keypairs(&ds).await;
+            assert_eq!(keypairs.len(), 4);
+            assert_state(&keypairs, HpkeKeyState::Active);
+            assert_state(&keypairs, HpkeKeyState::Pending);
+
+            // Move past the pending duration, we should promote the new keypairs to active and the
+            // old ones to expired.
+            clock.advance(&pending_duration.add(&Duration::from_seconds(1)).unwrap());
+            key_rotator.run().await.unwrap();
+            let keypairs = get_global_hpke_keypairs(&ds).await;
+            assert_eq!(keypairs.len(), 4);
+            assert_state(&keypairs, HpkeKeyState::Active);
+            assert_state(&keypairs, HpkeKeyState::Expired);
+
+            // Advance the clock only a little, no action should be taken.
+            clock.advance(&Duration::from_seconds(1));
+            key_rotator.run().await.unwrap();
+            let keypairs = get_global_hpke_keypairs(&ds).await;
+            assert_eq!(keypairs.len(), 4);
+            assert_state(&keypairs, HpkeKeyState::Active);
+            assert_state(&keypairs, HpkeKeyState::Expired);
+
+            // Move past the expiration duration, we should remove the old keys.
+            clock.advance(&expired_duration.add(&Duration::from_seconds(1)).unwrap());
+            key_rotator.run().await.unwrap();
+            let keypairs = get_global_hpke_keypairs(&ds).await;
+            assert_eq!(keypairs.len(), 2);
+            assert_state(&keypairs, HpkeKeyState::Active);
+        }
+    }
+
+    #[tokio::test]
+    async fn hpke_key_rotator_new_config() {
+        install_test_trace_subscriber();
+        let clock = MockClock::default();
+        let ephemeral_datastore = ephemeral_datastore().await;
+        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
+
+        let pending_duration = Duration::from_seconds(60);
+        let active_duration = Duration::from_seconds(300);
+        let expired_duration = Duration::from_seconds(60);
+        let ciphersuite_0 = HpkeCiphersuite::new(
+            HpkeKemId::P256HkdfSha256,
+            HpkeKdfId::HkdfSha256,
+            HpkeAeadId::Aes128Gcm,
+        );
+
+        let key_rotator = KeyRotator::new(
+            ds.clone(),
+            Vec::from([HpkeKeyRotatorConfig {
+                pending_duration,
+                active_duration,
+                expired_duration,
+                ciphersuite: ciphersuite_0.clone(),
+            }]),
+        );
+
+        // Run the key rotator for a while.
+        for _ in 0..18 {
+            key_rotator.run().await.unwrap();
+            clock.advance(&Duration::from_seconds(30));
+        }
+
+        // Add a new ciphersuite to the config.
+        let ciphersuite_1 = HpkeCiphersuite::new(
+            HpkeKemId::X25519HkdfSha256,
+            HpkeKdfId::HkdfSha512,
+            HpkeAeadId::Aes256Gcm,
+        );
+        let key_rotator = KeyRotator::new(
+            ds.clone(),
+            Vec::from([
+                HpkeKeyRotatorConfig {
+                    pending_duration,
+                    active_duration,
+                    expired_duration,
+                    ciphersuite: ciphersuite_0.clone(),
+                },
+                HpkeKeyRotatorConfig {
+                    pending_duration,
+                    active_duration,
+                    expired_duration,
+                    ciphersuite: ciphersuite_1.clone(),
+                },
+            ]),
+        );
+
+        // Run the key rotator, we should insert a new pending key for the new ciphersuite.
+        clock.advance(&Duration::from_seconds(1));
+        key_rotator.run().await.unwrap();
+        let keypairs = get_global_hpke_keypairs(&ds).await;
+        let keypairs: Vec<_> = keypairs
+            .iter()
+            .filter(|keypair| keypair.ciphersuite() == ciphersuite_1)
+            .collect();
+        assert_eq!(keypairs.len(), 1);
+        assert_eq!(keypairs[0].state(), &HpkeKeyState::Pending);
+
+        // Nothing should change.
+        clock.advance(&Duration::from_seconds(1));
+        key_rotator.run().await.unwrap();
+        let keypairs = get_global_hpke_keypairs(&ds).await;
+        let keypairs: Vec<_> = keypairs
+            .iter()
+            .filter(|keypair| keypair.ciphersuite() == ciphersuite_1)
+            .collect();
+        assert_eq!(keypairs.len(), 1);
+        assert_eq!(keypairs[0].state(), &HpkeKeyState::Pending);
+
+        // Move past the pending duration, we should promote the new keypair.
+        clock.advance(&pending_duration.add(&Duration::from_seconds(1)).unwrap());
+        key_rotator.run().await.unwrap();
+        let keypairs = get_global_hpke_keypairs(&ds).await;
+        let keypairs: Vec<_> = keypairs
+            .iter()
+            .filter(|keypair| keypair.ciphersuite() == ciphersuite_1)
+            .collect();
+        assert_eq!(keypairs.len(), 1);
+        assert_eq!(keypairs[0].state(), &HpkeKeyState::Active);
+    }
+
+    #[tokio::test]
+    async fn hpke_key_rotator_multiple_pending_keys() {
+        // While the key rotator only inserts pending keys one a at a time, it should respect if the
+        // operator has inserted a pending key themselves while one is in flight.
+        install_test_trace_subscriber();
+        let clock = MockClock::default();
+        let ephemeral_datastore = ephemeral_datastore().await;
+        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
+
+        let pending_duration = Duration::from_seconds(60);
+        let active_duration = Duration::from_seconds(300);
+        let expired_duration = Duration::from_seconds(60);
+        let ciphersuite_0 = HpkeCiphersuite::new(
+            HpkeKemId::P256HkdfSha256,
+            HpkeKdfId::HkdfSha256,
+            HpkeAeadId::Aes128Gcm,
+        );
+
+        let key_rotator = KeyRotator::new(
+            ds.clone(),
+            Vec::from([HpkeKeyRotatorConfig {
+                pending_duration,
+                active_duration,
+                expired_duration,
+                ciphersuite: ciphersuite_0.clone(),
+            }]),
+        );
+
+        // Run the key rotator for a while, such that the current key is expired with one pending.
+        for _ in 0..12 {
+            key_rotator.run().await.unwrap();
+            clock.advance(&Duration::from_seconds(30));
+        }
+        let keypairs = get_global_hpke_keypairs(&ds).await;
+        assert_eq!(keypairs.len(), 2);
+
+        // Operator inserts a new key in the pending state.
+        let id = HpkeConfigId::from(255);
+        ds.run_unnamed_tx(|tx| {
+            let ciphersuite_0 = ciphersuite_0.clone();
+            Box::pin(async move {
+                tx.put_global_hpke_keypair(
+                    &generate_hpke_config_and_private_key(
+                        id,
+                        ciphersuite_0.kem_id(),
+                        ciphersuite_0.kdf_id(),
+                        ciphersuite_0.aead_id(),
+                    )
+                    .unwrap(),
+                )
+                .await
+            })
+        })
+        .await
+        .unwrap();
+
+        key_rotator.run().await.unwrap();
+        let keypairs = get_global_hpke_keypairs(&ds).await;
+        assert_eq!(keypairs.len(), 3);
+        assert!(keypairs
+            .iter()
+            .find(|keypair| keypair.state() == &HpkeKeyState::Active)
+            .is_some());
+        let pending_keypairs: Vec<_> = keypairs
+            .iter()
+            .filter(|keypair| keypair.state() == &HpkeKeyState::Pending)
+            .collect();
+        assert_eq!(pending_keypairs.len(), 2);
+
+        // Move past the pending duration, we should promote both pending keypairs.
+        clock.advance(&pending_duration.add(&Duration::from_seconds(1)).unwrap());
+        key_rotator.run().await.unwrap();
+        let keypairs = get_global_hpke_keypairs(&ds).await;
+        let active_keypairs: Vec<_> = keypairs
+            .iter()
+            .filter(|keypair| keypair.state() == &HpkeKeyState::Active)
+            .collect();
+        assert_eq!(active_keypairs.len(), 2);
+        assert!(active_keypairs
+            .iter()
+            .find(|keypair| *keypair.id() == id)
+            .is_some());
+
+        // Step into the future, we should eventually replace both active keypairs with only one.
+        for _ in 0..30 {
+            key_rotator.run().await.unwrap();
+            clock.advance(&Duration::from_seconds(30));
+        }
+        let keypairs = get_global_hpke_keypairs(&ds).await;
+        let active_keypairs: Vec<_> = keypairs
+            .iter()
+            .filter(|keypair| keypair.state() == &HpkeKeyState::Active)
+            .collect();
+        assert_eq!(active_keypairs.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn hpke_key_rotator_multiple_active_keys() {
+        // If the operator inserts multiple active keys, we should replace them with only one key.
+        install_test_trace_subscriber();
+        let clock = MockClock::default();
+        let ephemeral_datastore = ephemeral_datastore().await;
+        let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
+
+        let pending_duration = Duration::from_seconds(60);
+        let active_duration = Duration::from_seconds(300);
+        let expired_duration = Duration::from_seconds(60);
+        let ciphersuite_0 = HpkeCiphersuite::new(
+            HpkeKemId::P256HkdfSha256,
+            HpkeKdfId::HkdfSha256,
+            HpkeAeadId::Aes128Gcm,
+        );
+
+        let key_rotator = KeyRotator::new(
+            ds.clone(),
+            Vec::from([HpkeKeyRotatorConfig {
+                pending_duration,
+                active_duration,
+                expired_duration,
+                ciphersuite: ciphersuite_0.clone(),
+            }]),
+        );
+
+        // Run the key rotator for a while.
+        for _ in 0..18 {
+            key_rotator.run().await.unwrap();
+            clock.advance(&Duration::from_seconds(30));
+        }
+
+        // Operator inserts a new key in the active state.
+        let id = HpkeConfigId::from(255);
+        ds.run_unnamed_tx(|tx| {
+            let ciphersuite_0 = ciphersuite_0.clone();
+            Box::pin(async move {
+                tx.put_global_hpke_keypair(
+                    &generate_hpke_config_and_private_key(
+                        id,
+                        ciphersuite_0.kem_id(),
+                        ciphersuite_0.kdf_id(),
+                        ciphersuite_0.aead_id(),
+                    )
+                    .unwrap(),
+                )
+                .await
+                .unwrap();
+                tx.set_global_hpke_keypair_state(&id, &HpkeKeyState::Active)
+                    .await
+                    .unwrap();
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
+
+        key_rotator.run().await.unwrap();
+        let keypairs = get_global_hpke_keypairs(&ds).await;
+        let active_keypairs: Vec<_> = keypairs
+            .iter()
+            .filter(|keypair| keypair.state() == &HpkeKeyState::Active)
+            .collect();
+        assert_eq!(active_keypairs.len(), 2);
+
+        // Step into the future, we should eventually replace both active keypairs with only one.
+        for _ in 0..30 {
+            key_rotator.run().await.unwrap();
+            clock.advance(&Duration::from_seconds(30));
+        }
+        let keypairs = dbg!(get_global_hpke_keypairs(&ds).await);
+        let active_keypairs: Vec<_> = keypairs
+            .iter()
+            .filter(|keypair| keypair.state() == &HpkeKeyState::Active)
+            .collect();
+        assert_eq!(active_keypairs.len(), 1);
+    }
+}

--- a/aggregator/src/aggregator/key_rotator.rs
+++ b/aggregator/src/aggregator/key_rotator.rs
@@ -449,22 +449,22 @@ where
 }
 
 /// Returns [`GlobalHpkeKeypairCache::DEFAULT_REFRESH_INTERVAL`] times 2, for safety margin.
-fn default_pending_duration() -> Duration {
+pub fn default_pending_duration() -> Duration {
     Duration::from_seconds(GlobalHpkeKeypairCache::DEFAULT_REFRESH_INTERVAL.as_secs() * 2)
 }
 
 /// 12 weeks. This is long enough not to be unnecessary churn, but short enough that misbehaving
 /// clients reveal themselves somewhat imminently.
-fn default_active_duration() -> Duration {
+pub fn default_active_duration() -> Duration {
     Duration::from_seconds(60 * 60 * 24 * 7 * 12)
 }
 
 /// 1 week.
-fn default_expired_duration() -> Duration {
+pub fn default_expired_duration() -> Duration {
     Duration::from_seconds(60 * 60 * 24 * 7)
 }
 
-fn default_hpke_ciphersuites() -> HashSet<HpkeCiphersuite> {
+pub fn default_hpke_ciphersuites() -> HashSet<HpkeCiphersuite> {
     HashSet::from([HpkeCiphersuite::new(
         HpkeKemId::X25519HkdfSha256,
         HpkeKdfId::HkdfSha256,

--- a/aggregator/src/aggregator/key_rotator.rs
+++ b/aggregator/src/aggregator/key_rotator.rs
@@ -512,6 +512,7 @@ mod tests {
     };
     use janus_messages::{Duration, HpkeAeadId, HpkeConfigId, HpkeKdfId, HpkeKemId, Time};
     use quickcheck::{Arbitrary, Gen, TestResult};
+    use quickcheck_macros::quickcheck;
 
     use crate::aggregator::key_rotator::{duration_since, HpkeKeyRotatorConfig, KeyRotator};
 

--- a/aggregator/src/binaries.rs
+++ b/aggregator/src/binaries.rs
@@ -4,3 +4,4 @@ pub mod aggregator;
 pub mod collection_job_driver;
 pub mod garbage_collector;
 pub mod janus_cli;
+pub mod key_rotator;

--- a/aggregator/src/binaries/key_rotator.rs
+++ b/aggregator/src/binaries/key_rotator.rs
@@ -79,7 +79,7 @@ impl BinaryConfig for Config {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct KeyRotatorConfig {
-    #[serde(default, deserialize_with = "deserialize_hpke_key_rotator_configs")]
+    #[serde(deserialize_with = "deserialize_hpke_key_rotator_configs")]
     pub hpke: Vec<HpkeKeyRotatorConfig>,
 }
 

--- a/aggregator/src/binaries/key_rotator.rs
+++ b/aggregator/src/binaries/key_rotator.rs
@@ -148,6 +148,40 @@ mod tests {
     }
 
     #[test]
+    fn reject_empty_config() {
+        assert!(serde_yaml::from_str::<Config>(
+            r#"---
+    database:
+        url: "postgres://postgres:postgres@localhost:5432/postgres"
+    key_rotator:
+        hpke: []
+    "#,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn reject_duplicate_ciphersuites() {
+        assert!(serde_yaml::from_str::<Config>(
+            r#"---
+    database:
+        url: "postgres://postgres:postgres@localhost:5432/postgres"
+    key_rotator:
+        hpke:
+            - ciphersuite:
+                kem_id: P521HkdfSha512
+                kdf_id: HkdfSha512
+                aead_id: Aes256Gcm
+            - ciphersuite:
+                kem_id: P521HkdfSha512
+                kdf_id: HkdfSha512
+                aead_id: Aes256Gcm
+    "#,
+        )
+        .is_err());
+    }
+
+    #[test]
     fn documentation_config_examples() {
         serde_yaml::from_str::<Config>(include_str!(
             "../../../docs/samples/basic_config/key_rotator.yaml"

--- a/aggregator/src/binaries/key_rotator.rs
+++ b/aggregator/src/binaries/key_rotator.rs
@@ -95,7 +95,10 @@ mod tests {
     use rand::random;
 
     use crate::{
-        aggregator::key_rotator::HpkeKeyRotatorConfig,
+        aggregator::key_rotator::{
+            default_active_duration, default_expired_duration, default_hpke_ciphersuites,
+            default_pending_duration, HpkeKeyRotatorConfig,
+        },
         config::{
             default_max_transaction_retries,
             test_util::{generate_db_config, generate_metrics_config, generate_trace_config},
@@ -103,7 +106,7 @@ mod tests {
         },
     };
 
-    use super::{Config, Options};
+    use super::{Config, KeyRotatorConfig, Options};
 
     #[test]
     fn verify_app() {
@@ -120,7 +123,7 @@ mod tests {
                 health_check_listen_address: SocketAddr::from((Ipv4Addr::UNSPECIFIED, 8080)),
                 max_transaction_retries: default_max_transaction_retries(),
             },
-            key_rotator: super::KeyRotatorConfig {
+            key_rotator: KeyRotatorConfig {
                 hpke: HpkeKeyRotatorConfig {
                     pending_duration: Duration::from_seconds(random()),
                     active_duration: Duration::from_seconds(random()),
@@ -140,6 +143,27 @@ mod tests {
                 },
             },
         });
+    }
+
+    #[test]
+    fn default_config() {
+        let config = serde_yaml::from_str::<KeyRotatorConfig>(
+            r#"---
+hpke: {}
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            config,
+            KeyRotatorConfig {
+                hpke: HpkeKeyRotatorConfig {
+                    pending_duration: default_pending_duration(),
+                    active_duration: default_active_duration(),
+                    expired_duration: default_expired_duration(),
+                    ciphersuites: default_hpke_ciphersuites(),
+                }
+            }
+        )
     }
 
     #[test]

--- a/aggregator/src/binaries/key_rotator.rs
+++ b/aggregator/src/binaries/key_rotator.rs
@@ -1,0 +1,177 @@
+use std::{sync::Arc, time::Duration};
+
+use anyhow::Result;
+use clap::Parser;
+use janus_aggregator_core::datastore::Datastore;
+use janus_core::{hpke::HpkeCiphersuite, time::RealClock};
+use opentelemetry::metrics::Meter;
+use serde::{Deserialize, Serialize};
+use tokio::time::interval;
+use tracing::error;
+use trillium_tokio::Stopper;
+
+use crate::{
+    aggregator::{garbage_collector::GarbageCollector, key_rotator::HpkeKeyRotatorConfig},
+    binary_utils::{BinaryContext, BinaryOptions, CommonBinaryOptions},
+    config::{BinaryConfig, CommonConfig},
+};
+
+use super::aggregator::GarbageCollectorConfig;
+
+pub async fn main_callback(ctx: BinaryContext<RealClock, Options, Config>) -> Result<()> {
+    let BinaryContext {
+        config,
+        datastore,
+        meter,
+        stopper,
+        ..
+    } = ctx;
+
+    let datastore = Arc::new(datastore);
+
+    run_key_rotator(datastore, config.key_rotator, meter, stopper).await;
+
+    Ok(())
+}
+
+pub(super) async fn run_key_rotator(
+    datastore: Arc<Datastore<RealClock>>,
+    config: KeyRotatorConfig,
+    meter: Meter,
+    stopper: Stopper,
+) {
+    // oneshot?
+
+    // let gc = GarbageCollector::new(
+    //     datastore,
+    //     &meter,
+    //     gc_config.report_limit,
+    //     gc_config.aggregation_limit,
+    //     gc_config.collection_limit,
+    //     gc_config.tasks_per_tx,
+    //     gc_config.concurrent_tx_limit,
+    // );
+    // let mut interval = interval(Duration::from_secs(gc_config.gc_frequency_s));
+    // while stopper.stop_future(interval.tick()).await.is_some() {
+    //     if let Err(err) = gc.run().await {
+    //         error!(?err, "GC error");
+    //     }
+    // }
+}
+
+#[derive(Debug, Default, Parser)]
+#[clap(
+    name = "key-rotator",
+    about = "Janus key rotator",
+    rename_all = "kebab-case",
+    version = env!("CARGO_PKG_VERSION"),
+)]
+pub struct Options {
+    #[clap(flatten)]
+    pub common: CommonBinaryOptions,
+}
+
+impl BinaryOptions for Options {
+    fn common_options(&self) -> &CommonBinaryOptions {
+        &self.common
+    }
+}
+
+/// Non-secret configuration options for a Janus key rotator, deserialized from YAML.
+///
+/// # Examples
+///
+/// ```
+/// # use janus_aggregator::binaries::garbage_collector::Config;
+/// let yaml_config = r#"
+/// ---
+/// database:
+///   url: "postgres://postgres:postgres@localhost:5432/postgres"
+/// logging_config: # logging_config is optional
+///   force_json_output: true
+/// garbage_collection:
+///   gc_frequency_s: 60
+///   report_limit: 5000
+///   aggregation_limit: 500
+///   collection_limit: 50
+/// "#;
+///
+/// let _decoded: Config = serde_yaml::from_str(yaml_config).unwrap();
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Config {
+    #[serde(flatten)]
+    pub common_config: CommonConfig,
+
+    pub key_rotator: KeyRotatorConfig,
+}
+
+impl BinaryConfig for Config {
+    fn common_config(&self) -> &CommonConfig {
+        &self.common_config
+    }
+
+    fn common_config_mut(&mut self) -> &mut CommonConfig {
+        &mut self.common_config
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KeyRotatorConfig {
+    /// How frequently key rotator is run, in seconds.
+    pub frequency_secs: Option<u64>,
+
+    pub hpke: HpkeKeyRotatorConfig,
+    // hpke options
+    // how long until pending->active
+    // how long until active->expired
+    // how long until expired->deleted
+    // ciphersuite to use (array)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{Ipv4Addr, SocketAddr};
+
+    use clap::CommandFactory;
+    use janus_core::test_util::roundtrip_encoding;
+
+    use crate::config::{
+        default_max_transaction_retries,
+        test_util::{generate_db_config, generate_metrics_config, generate_trace_config},
+        CommonConfig,
+    };
+
+    use super::{Config, Options};
+
+    #[test]
+    fn verify_app() {
+        Options::command().debug_assert();
+    }
+
+    // #[test]
+    // fn roundtrip_config() {
+    //     roundtrip_encoding(Config {
+    //         common_config: CommonConfig {
+    //             database: generate_db_config(),
+    //             logging_config: generate_trace_config(),
+    //             metrics_config: generate_metrics_config(),
+    //             health_check_listen_address: SocketAddr::from((Ipv4Addr::UNSPECIFIED, 8080)),
+    //             max_transaction_retries: default_max_transaction_retries(),
+    //         },
+    //         key_rotator: super::KeyRotatorConfig {},
+    //     });
+    // }
+
+    // #[test]
+    // fn documentation_config_examples() {
+    //     serde_yaml::from_str::<Config>(include_str!(
+    //         "../../../docs/samples/basic_config/key_rotator.yaml"
+    //     ))
+    //     .unwrap();
+    //     serde_yaml::from_str::<Config>(include_str!(
+    //         "../../../docs/samples/advanced_config/key_rotator.yaml"
+    //     ))
+    //     .unwrap();
+    // }
+}

--- a/aggregator/src/binaries/key_rotator.rs
+++ b/aggregator/src/binaries/key_rotator.rs
@@ -54,8 +54,7 @@ impl BinaryOptions for Options {
 /// logging_config: # logging_config is optional
 ///   force_json_output: true
 /// key_rotator:
-///   hpke:
-///     - {}
+///   hpke: {}
 /// "#;
 ///
 /// let _decoded: Config = serde_yaml::from_str(yaml_config).unwrap();

--- a/aggregator/src/lib.rs
+++ b/aggregator/src/lib.rs
@@ -12,6 +12,12 @@ pub mod diagnostic;
 pub mod metrics;
 pub mod trace;
 
+#[cfg(test)]
+extern crate quickcheck;
+#[cfg(test)]
+#[macro_use(quickcheck)]
+extern crate quickcheck_macros;
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 enum Operation {
     Put,

--- a/aggregator/src/lib.rs
+++ b/aggregator/src/lib.rs
@@ -12,12 +12,6 @@ pub mod diagnostic;
 pub mod metrics;
 pub mod trace;
 
-#[cfg(test)]
-extern crate quickcheck;
-#[cfg(test)]
-#[macro_use(quickcheck)]
-extern crate quickcheck_macros;
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 enum Operation {
     Put,

--- a/aggregator/src/main.rs
+++ b/aggregator/src/main.rs
@@ -2,7 +2,7 @@ use clap::{Parser, Subcommand};
 use janus_aggregator::{
     binaries::{
         aggregation_job_creator, aggregation_job_driver, aggregator, collection_job_driver,
-        garbage_collector, janus_cli,
+        garbage_collector, janus_cli, key_rotator,
     },
     binary_utils::janus_main,
 };
@@ -23,6 +23,8 @@ enum Options {
     CollectionJobDriver(collection_job_driver::Options),
     #[clap(name = "janus_cli")]
     JanusCli(janus_cli::CommandLineOptions),
+    #[clap(name = "key_rotator")]
+    KeyRotator(key_rotator::Options),
     #[clap(name = "janus_aggregator", subcommand)]
     Default(Nested),
 }
@@ -46,6 +48,8 @@ enum Nested {
     CollectionJobDriver(collection_job_driver::Options),
     #[clap(name = "janus_cli")]
     JanusCli(janus_cli::CommandLineOptions),
+    #[clap(name = "key_rotator")]
+    KeyRotator(key_rotator::Options),
 }
 
 fn main() -> anyhow::Result<()> {
@@ -75,6 +79,9 @@ fn main() -> anyhow::Result<()> {
         }
         Options::JanusCli(options) | Options::Default(Nested::JanusCli(options)) => {
             janus_cli::run(options)
+        }
+        Options::KeyRotator(options) | Options::Default(Nested::KeyRotator(options)) => {
+            janus_main(options, clock, false, key_rotator::main_callback)
         }
     }
 }

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -4968,6 +4968,61 @@ DELETE FROM global_hpke_keys WHERE config_id = $1",
     }
 
     #[tracing::instrument(skip(self), err(level = Level::DEBUG))]
+    pub async fn rewrite_global_hpke_keypairs(
+        &self,
+        keypairs: &[GlobalHpkeKeypair],
+    ) -> Result<(), Error> {
+        let stmt = self
+            .prepare_cached(
+                "-- clear_global_hpke_keypairs()
+DELETE FROM global_hpke_keys",
+            )
+            .await?;
+        self.execute(&stmt, &[]).await?;
+
+        try_join_all(keypairs.iter().map(|keypair| async move {
+            let hpke_config_id = u8::from(*keypair.id()) as i16;
+            let hpke_config = keypair.hpke_keypair().config().get_encoded()?;
+            let encrypted_hpke_private_key = self.crypter.encrypt(
+                "global_hpke_keys",
+                &u8::from(*keypair.id()).to_be_bytes(),
+                "private_key",
+                keypair.hpke_keypair().private_key().as_ref(),
+            )?;
+
+            let stmt = self
+                .prepare_cached(
+                    "-- clear_global_hpke_keypair()
+INSERT INTO global_hpke_keys
+    (config_id, config, private_key, state, last_state_change_at, created_at, updated_at, updated_by)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+                )
+                .await?;
+            let now = self.clock.now().as_naive_date_time()?;
+            check_insert(
+                self.execute(
+                    &stmt,
+                    &[
+                        /* config_id */ &hpke_config_id,
+                        /* config */ &hpke_config,
+                        /* private_key */ &encrypted_hpke_private_key,
+                        /* state */ keypair.state(),
+                        /* last_state_change_at */
+                        &keypair.last_state_change_at().as_naive_date_time()?,
+                        /* created_at */ &now,
+                        /* updated_at */ &now,
+                        /* updated_by */ &self.name,
+                    ],
+                )
+                .await?,
+            )
+        }))
+        .await?;
+
+        Ok(())
+    }
+
+    #[tracing::instrument(skip(self), err(level = Level::DEBUG))]
     pub async fn set_global_hpke_keypair_state(
         &self,
         config_id: &HpkeConfigId,

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -102,7 +102,7 @@ macro_rules! supported_schema_versions {
 // version is seen, [`Datastore::new`] fails.
 //
 // Note that the latest supported version must be first in the list.
-supported_schema_versions!(5, 4, 3);
+supported_schema_versions!(5);
 
 /// Datastore represents a datastore for Janus, with support for transactional reads and writes.
 /// In practice, Datastore instances are currently backed by a PostgreSQL database.
@@ -4903,7 +4903,7 @@ SELECT COUNT(1) AS batch_count FROM batches_to_delete",
         let stmt = self
             .prepare_cached(
                 "-- get_global_hpke_keypairs()
-SELECT config_id, config, private_key, state, created_at, updated_at FROM global_hpke_keys",
+SELECT config_id, config, private_key, state, last_state_change_at FROM global_hpke_keys",
             )
             .await?;
         let hpke_key_rows = self.query(&stmt, &[]).await?;
@@ -4923,7 +4923,7 @@ SELECT config_id, config, private_key, state, created_at, updated_at FROM global
         let stmt = self
             .prepare_cached(
                 "-- get_global_hpke_keypair()
-SELECT config_id, config, private_key, state, created_at, updated_at FROM global_hpke_keys
+SELECT config_id, config, private_key, state, last_state_change_at FROM global_hpke_keys
     WHERE config_id = $1",
             )
             .await?;
@@ -4947,8 +4947,7 @@ SELECT config_id, config, private_key, state, created_at, updated_at FROM global
         Ok(GlobalHpkeKeypair::new(
             HpkeKeypair::new(config, private_key),
             row.get("state"),
-            Time::from_naive_date_time(&row.get("created_at")),
-            Time::from_naive_date_time(&row.get("updated_at")),
+            Time::from_naive_date_time(&row.get("last_state_change_at")),
         ))
     }
 
@@ -4978,16 +4977,18 @@ DELETE FROM global_hpke_keys WHERE config_id = $1",
             .prepare_cached(
                 "-- set_global_hpke_keypair_state()
 UPDATE global_hpke_keys
-    SET state = $1, updated_at = $2, updated_by = $3
-    WHERE config_id = $4",
+    SET state = $1, last_state_change_at = $2, updated_at = $3, updated_by = $4
+    WHERE config_id = $5",
             )
             .await?;
+        let now = self.clock.now().as_naive_date_time()?;
         check_single_row_mutation(
             self.execute(
                 &stmt,
                 &[
                     /* state */ state,
-                    /* updated_at */ &self.clock.now().as_naive_date_time()?,
+                    /* last_state_change_at */ &now,
+                    /* updated_at */ &now,
                     /* updated_by */ &self.name,
                     /* config_id */ &(u8::from(*config_id) as i16),
                 ],
@@ -4996,7 +4997,7 @@ UPDATE global_hpke_keys
         )
     }
 
-    // Inserts a new global HPKE keypair and places it in the [`HpkeKeyState::Pending`] state.
+    /// Inserts a new global HPKE keypair and places it in the [`HpkeKeyState::Pending`] state.
     #[tracing::instrument(skip(self), err(level = Level::DEBUG))]
     pub async fn put_global_hpke_keypair(&self, hpke_keypair: &HpkeKeypair) -> Result<(), Error> {
         let hpke_config_id = u8::from(*hpke_keypair.config().id()) as i16;
@@ -5012,10 +5013,11 @@ UPDATE global_hpke_keys
             .prepare_cached(
                 "-- put_global_hpke_keypair()
 INSERT INTO global_hpke_keys
-    (config_id, config, private_key, created_at, updated_at, updated_by)
-    VALUES ($1, $2, $3, $4, $5, $6)",
+    (config_id, config, private_key, last_state_change_at, created_at, updated_at, updated_by)
+    VALUES ($1, $2, $3, $4, $5, $6, $7)",
             )
             .await?;
+        let now = self.clock.now().as_naive_date_time()?;
         check_insert(
             self.execute(
                 &stmt,
@@ -5023,8 +5025,9 @@ INSERT INTO global_hpke_keys
                     /* config_id */ &hpke_config_id,
                     /* config */ &hpke_config,
                     /* private_key */ &encrypted_hpke_private_key,
-                    /* created_at */ &self.clock.now().as_naive_date_time()?,
-                    /* updated_at */ &self.clock.now().as_naive_date_time()?,
+                    /* last_state_change_at */ &now,
+                    /* created_at */ &now,
+                    /* updated_at */ &now,
                     /* updated_by */ &self.name,
                 ],
             )

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -43,7 +43,7 @@ use prio::{
 use rand::random;
 use ring::aead::{self, LessSafeKey, AES_128_GCM};
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     convert::TryFrom,
     fmt::{Debug, Display},
     future::Future,
@@ -4967,57 +4967,71 @@ DELETE FROM global_hpke_keys WHERE config_id = $1",
         )
     }
 
+    /// Updates the entire `global_hpke_keys` table, by changing existing entries to match
+    // `keypairs`. Keys not in `keypairs` are removed.
     #[tracing::instrument(skip(self), err(level = Level::DEBUG))]
-    pub async fn rewrite_global_hpke_keypairs(
+    pub async fn update_global_hpke_keypairs(
         &self,
         keypairs: &[GlobalHpkeKeypair],
     ) -> Result<(), Error> {
-        let stmt = self
-            .prepare_cached(
-                "-- rewrite_global_hpke_keypairs()
-DELETE FROM global_hpke_keys",
-            )
-            .await?;
-        self.execute(&stmt, &[]).await?;
+        let current_keypairs_ids = self
+            .get_global_hpke_keypairs()
+            .await?
+            .into_iter()
+            .map(|keypair| *keypair.id())
+            .collect::<HashSet<_>>();
+        let update_keypairs_ids = keypairs.iter().map(|keypair| *keypair.id()).collect();
+        let to_delete: Vec<_> = current_keypairs_ids
+            .difference(&update_keypairs_ids)
+            .collect();
 
-        try_join_all(keypairs.iter().map(|keypair| async move {
-            let hpke_config_id = u8::from(*keypair.id()) as i16;
-            let hpke_config = keypair.hpke_keypair().config().get_encoded()?;
-            let encrypted_hpke_private_key = self.crypter.encrypt(
-                "global_hpke_keys",
-                &u8::from(*keypair.id()).to_be_bytes(),
-                "private_key",
-                keypair.hpke_keypair().private_key().as_ref(),
-            )?;
+        try_join!(
+            try_join_all(
+                to_delete
+                    .iter()
+                    .map(|id| async move { self.delete_global_hpke_keypair(id).await })
+            ),
+            try_join_all(keypairs.iter().map(|keypair| async move {
+                let hpke_config_id = u8::from(*keypair.id()) as i16;
+                let hpke_config = keypair.hpke_keypair().config().get_encoded()?;
+                let encrypted_hpke_private_key = self.crypter.encrypt(
+                    "global_hpke_keys",
+                    &u8::from(*keypair.id()).to_be_bytes(),
+                    "private_key",
+                    keypair.hpke_keypair().private_key().as_ref(),
+                )?;
 
-            let stmt = self
-                .prepare_cached(
-                    "-- rewrite_global_hpke_keypair()
+                let stmt = self
+                    .prepare_cached(
+                        "-- update_global_hpke_keypairs()
 INSERT INTO global_hpke_keys
-    (config_id, config, private_key, state, last_state_change_at, created_at, updated_at, updated_by)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+(config_id, config, private_key, state, last_state_change_at, created_at, updated_at, updated_by)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+ON CONFLICT (config_id) DO UPDATE
+    SET (state, last_state_change_at, updated_at, updated_by) = 
+        (excluded.state, excluded.last_state_change_at, excluded.updated_at, excluded.updated_by)",
+                    )
+                    .await?;
+                let now = self.clock.now().as_naive_date_time()?;
+                check_insert(
+                    self.execute(
+                        &stmt,
+                        &[
+                            /* config_id */ &hpke_config_id,
+                            /* config */ &hpke_config,
+                            /* private_key */ &encrypted_hpke_private_key,
+                            /* state */ keypair.state(),
+                            /* last_state_change_at */
+                            &keypair.last_state_change_at().as_naive_date_time()?,
+                            /* created_at */ &now,
+                            /* updated_at */ &now,
+                            /* updated_by */ &self.name,
+                        ],
+                    )
+                    .await?,
                 )
-                .await?;
-            let now = self.clock.now().as_naive_date_time()?;
-            check_insert(
-                self.execute(
-                    &stmt,
-                    &[
-                        /* config_id */ &hpke_config_id,
-                        /* config */ &hpke_config,
-                        /* private_key */ &encrypted_hpke_private_key,
-                        /* state */ keypair.state(),
-                        /* last_state_change_at */
-                        &keypair.last_state_change_at().as_naive_date_time()?,
-                        /* created_at */ &now,
-                        /* updated_at */ &now,
-                        /* updated_by */ &self.name,
-                    ],
-                )
-                .await?,
-            )
-        }))
-        .await?;
+            }))
+        )?;
 
         Ok(())
     }

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -102,7 +102,7 @@ macro_rules! supported_schema_versions {
 // version is seen, [`Datastore::new`] fails.
 //
 // Note that the latest supported version must be first in the list.
-supported_schema_versions!(5);
+supported_schema_versions!(6, 5);
 
 /// Datastore represents a datastore for Janus, with support for transactional reads and writes.
 /// In practice, Datastore instances are currently backed by a PostgreSQL database.

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -4974,7 +4974,7 @@ DELETE FROM global_hpke_keys WHERE config_id = $1",
     ) -> Result<(), Error> {
         let stmt = self
             .prepare_cached(
-                "-- clear_global_hpke_keypairs()
+                "-- rewrite_global_hpke_keypairs()
 DELETE FROM global_hpke_keys",
             )
             .await?;
@@ -4992,7 +4992,7 @@ DELETE FROM global_hpke_keys",
 
             let stmt = self
                 .prepare_cached(
-                    "-- clear_global_hpke_keypair()
+                    "-- rewrite_global_hpke_keypair()
 INSERT INTO global_hpke_keys
     (config_id, config, private_key, state, last_state_change_at, created_at, updated_at, updated_by)
     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -2203,22 +2203,19 @@ pub enum HpkeKeyState {
 pub struct GlobalHpkeKeypair {
     hpke_keypair: HpkeKeypair,
     state: HpkeKeyState,
-    created_at: Time,
-    updated_at: Time,
+    last_state_change_at: Time,
 }
 
 impl GlobalHpkeKeypair {
     pub(super) fn new(
         hpke_keypair: HpkeKeypair,
         state: HpkeKeyState,
-        created_at: Time,
-        updated_at: Time,
+        last_state_change_at: Time,
     ) -> Self {
         Self {
             hpke_keypair,
             state,
-            created_at,
-            updated_at,
+            last_state_change_at,
         }
     }
 
@@ -2230,12 +2227,8 @@ impl GlobalHpkeKeypair {
         &self.state
     }
 
-    pub fn created_at(&self) -> &Time {
-        &self.created_at
-    }
-
-    pub fn updated_at(&self) -> &Time {
-        &self.updated_at
+    pub fn last_state_change_at(&self) -> &Time {
+        &self.last_state_change_at
     }
 
     pub fn ciphersuite(&self) -> HpkeCiphersuite {

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -15,7 +15,7 @@ use janus_core::{
 use janus_messages::{
     query_type::{FixedSize, QueryType, TimeInterval},
     AggregationJobId, AggregationJobStep, BatchId, CollectionJobId, Duration, Extension,
-    HpkeCiphertext, HpkeConfig, HpkeConfigId, Interval, PrepareError, PrepareResp, Query, ReportId,
+    HpkeCiphertext, HpkeConfigId, Interval, PrepareError, PrepareResp, Query, ReportId,
     ReportIdChecksum, ReportMetadata, Role, TaskId, Time,
 };
 use postgres_protocol::types::{
@@ -303,7 +303,6 @@ where
 #[cfg(feature = "test-util")]
 impl LeaderStoredReport<0, prio::vdaf::dummy::Vdaf> {
     pub fn new_dummy(task_id: TaskId, when: Time) -> Self {
-        use janus_messages::HpkeConfigId;
         use rand::random;
 
         Self::new(

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -7200,10 +7200,11 @@ async fn roundtrip_global_hpke_keypair(ephemeral_datastore: EphemeralDatastore) 
                 assert_eq!(tx.get_global_hpke_keypairs().await.unwrap(), Vec::new());
                 tx.put_global_hpke_keypair(&keypair).await.unwrap();
 
+                let created_at = clock.now();
                 let expected_keypair = GlobalHpkeKeypair::new(
                     keypair.clone(),
                     HpkeKeyState::Pending,
-                    clock.now(),
+                    created_at,
                     clock.now(),
                 );
                 assert_eq!(
@@ -7231,7 +7232,7 @@ async fn roundtrip_global_hpke_keypair(ephemeral_datastore: EphemeralDatastore) 
                     GlobalHpkeKeypair::new(
                         keypair.clone(),
                         HpkeKeyState::Active,
-                        clock.now(),
+                        created_at,
                         clock.now(),
                     )
                 );
@@ -7248,7 +7249,7 @@ async fn roundtrip_global_hpke_keypair(ephemeral_datastore: EphemeralDatastore) 
                     GlobalHpkeKeypair::new(
                         keypair.clone(),
                         HpkeKeyState::Expired,
-                        clock.now(),
+                        created_at,
                         clock.now(),
                     )
                 );

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -7200,13 +7200,8 @@ async fn roundtrip_global_hpke_keypair(ephemeral_datastore: EphemeralDatastore) 
                 assert_eq!(tx.get_global_hpke_keypairs().await.unwrap(), Vec::new());
                 tx.put_global_hpke_keypair(&keypair).await.unwrap();
 
-                let created_at = clock.now();
-                let expected_keypair = GlobalHpkeKeypair::new(
-                    keypair.clone(),
-                    HpkeKeyState::Pending,
-                    created_at,
-                    clock.now(),
-                );
+                let expected_keypair =
+                    GlobalHpkeKeypair::new(keypair.clone(), HpkeKeyState::Pending, clock.now());
                 assert_eq!(
                     tx.get_global_hpke_keypairs().await.unwrap(),
                     Vec::from([expected_keypair.clone()])
@@ -7229,12 +7224,7 @@ async fn roundtrip_global_hpke_keypair(ephemeral_datastore: EphemeralDatastore) 
                         .await
                         .unwrap()
                         .unwrap(),
-                    GlobalHpkeKeypair::new(
-                        keypair.clone(),
-                        HpkeKeyState::Active,
-                        created_at,
-                        clock.now(),
-                    )
+                    GlobalHpkeKeypair::new(keypair.clone(), HpkeKeyState::Active, clock.now())
                 );
 
                 clock.advance(&Duration::from_seconds(100));
@@ -7246,12 +7236,7 @@ async fn roundtrip_global_hpke_keypair(ephemeral_datastore: EphemeralDatastore) 
                         .await
                         .unwrap()
                         .unwrap(),
-                    GlobalHpkeKeypair::new(
-                        keypair.clone(),
-                        HpkeKeyState::Expired,
-                        created_at,
-                        clock.now(),
-                    )
+                    GlobalHpkeKeypair::new(keypair.clone(), HpkeKeyState::Expired, clock.now())
                 );
 
                 Ok(())

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -7200,8 +7200,12 @@ async fn roundtrip_global_hpke_keypair(ephemeral_datastore: EphemeralDatastore) 
                 assert_eq!(tx.get_global_hpke_keypairs().await.unwrap(), Vec::new());
                 tx.put_global_hpke_keypair(&keypair).await.unwrap();
 
-                let expected_keypair =
-                    GlobalHpkeKeypair::new(keypair.clone(), HpkeKeyState::Pending, clock.now());
+                let expected_keypair = GlobalHpkeKeypair::new(
+                    keypair.clone(),
+                    HpkeKeyState::Pending,
+                    clock.now(),
+                    clock.now(),
+                );
                 assert_eq!(
                     tx.get_global_hpke_keypairs().await.unwrap(),
                     Vec::from([expected_keypair.clone()])
@@ -7224,7 +7228,12 @@ async fn roundtrip_global_hpke_keypair(ephemeral_datastore: EphemeralDatastore) 
                         .await
                         .unwrap()
                         .unwrap(),
-                    GlobalHpkeKeypair::new(keypair.clone(), HpkeKeyState::Active, clock.now(),)
+                    GlobalHpkeKeypair::new(
+                        keypair.clone(),
+                        HpkeKeyState::Active,
+                        clock.now(),
+                        clock.now(),
+                    )
                 );
 
                 clock.advance(&Duration::from_seconds(100));
@@ -7236,7 +7245,12 @@ async fn roundtrip_global_hpke_keypair(ephemeral_datastore: EphemeralDatastore) 
                         .await
                         .unwrap()
                         .unwrap(),
-                    GlobalHpkeKeypair::new(keypair.clone(), HpkeKeyState::Expired, clock.now(),)
+                    GlobalHpkeKeypair::new(
+                        keypair.clone(),
+                        HpkeKeyState::Expired,
+                        clock.now(),
+                        clock.now(),
+                    )
                 );
 
                 Ok(())

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -24,7 +24,6 @@ use assert_matches::assert_matches;
 use async_trait::async_trait;
 use chrono::NaiveDate;
 use futures::future::try_join_all;
-use itertools::Itertools as _;
 use janus_core::{
     hpke::{
         self, test_util::generate_test_hpke_config_and_private_key, HpkeApplicationInfo, Label,
@@ -7274,99 +7273,6 @@ async fn roundtrip_global_hpke_keypair(ephemeral_datastore: EphemeralDatastore) 
 
                 tx.check_timestamp_columns("global_hpke_keys", "test-put-keys", true)
                     .await;
-
-                Ok(())
-            })
-        })
-        .await
-        .unwrap();
-}
-
-#[rstest_reuse::apply(schema_versions_template)]
-#[tokio::test]
-async fn update_global_hpke_keypairs(ephemeral_datastore: EphemeralDatastore) {
-    install_test_trace_subscriber();
-    let datastore = ephemeral_datastore.datastore(MockClock::default()).await;
-    let clock = datastore.clock.clone();
-
-    datastore
-        .run_unnamed_tx(|tx| {
-            let clock = clock.clone();
-            Box::pin(async move {
-                let keypairs = Vec::from([
-                    GlobalHpkeKeypair::new(
-                        generate_test_hpke_config_and_private_key(),
-                        HpkeKeyState::Pending,
-                        clock.now(),
-                    ),
-                    GlobalHpkeKeypair::new(
-                        generate_test_hpke_config_and_private_key(),
-                        HpkeKeyState::Active,
-                        clock.now(),
-                    ),
-                ]);
-                tx.update_global_hpke_keypairs(&keypairs).await.unwrap();
-
-                let current_keypairs: Vec<_> = tx
-                    .get_global_hpke_keypairs()
-                    .await
-                    .unwrap()
-                    .into_iter()
-                    .sorted_by_key(|keypair| *keypair.id())
-                    .collect();
-                let expected_keypairs: Vec<_> = keypairs
-                    .iter()
-                    .cloned()
-                    .sorted_by_key(|keypair| *keypair.id())
-                    .collect();
-                assert_eq!(current_keypairs, expected_keypairs);
-
-                // No-op.
-                tx.update_global_hpke_keypairs(&keypairs).await.unwrap();
-                let current_keypairs: Vec<_> = tx
-                    .get_global_hpke_keypairs()
-                    .await
-                    .unwrap()
-                    .into_iter()
-                    .sorted_by_key(|keypair| *keypair.id())
-                    .collect();
-                let expected_keypairs: Vec<_> = keypairs
-                    .iter()
-                    .cloned()
-                    .sorted_by_key(|keypair| *keypair.id())
-                    .collect();
-                assert_eq!(current_keypairs, expected_keypairs);
-
-                let keypairs = Vec::from([
-                    // Move keypairs[0] to new state.
-                    GlobalHpkeKeypair::new(
-                        keypairs[0].hpke_keypair().clone(),
-                        HpkeKeyState::Active,
-                        clock.now(),
-                    ),
-                    // Introduce new keypair.
-                    GlobalHpkeKeypair::new(
-                        generate_test_hpke_config_and_private_key(),
-                        HpkeKeyState::Active,
-                        clock.now(),
-                    ),
-                    // keypairs[1] is deleted.
-                ]);
-                tx.update_global_hpke_keypairs(&keypairs).await.unwrap();
-
-                let current_keypairs: Vec<_> = tx
-                    .get_global_hpke_keypairs()
-                    .await
-                    .unwrap()
-                    .into_iter()
-                    .sorted_by_key(|keypair| *keypair.id())
-                    .collect();
-                let expected_keypairs: Vec<_> = keypairs
-                    .iter()
-                    .cloned()
-                    .sorted_by_key(|keypair| *keypair.id())
-                    .collect();
-                assert_eq!(current_keypairs, expected_keypairs);
 
                 Ok(())
             })

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,6 +18,7 @@ fpvec_bounded_l2 = ["dep:fixed", "prio/experimental"]
 test-util = [
     "dep:assert_matches",
     "dep:k8s-openapi",
+    "dep:quickcheck",
     "dep:serde_json",
     "dep:stopper",
     "dep:tempfile",
@@ -50,6 +51,7 @@ janus_messages.workspace = true
 k8s-openapi = { workspace = true, optional = true }
 kube = { workspace = true, optional = true, features = ["rustls-tls"] }
 prio = { workspace = true, default-features = true, features = ["experimental"] }
+quickcheck = { workspace = true, optional = true }
 rand.workspace = true
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }

--- a/core/src/hpke.rs
+++ b/core/src/hpke.rs
@@ -262,6 +262,46 @@ impl HpkeKeypair {
     }
 }
 
+/// The algorithms used for each HPKE primitive.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HpkeCiphersuite {
+    kem_id: HpkeKemId,
+    kdf_id: HpkeKdfId,
+    aead_id: HpkeAeadId,
+}
+
+impl HpkeCiphersuite {
+    pub fn new(kem_id: HpkeKemId, kdf_id: HpkeKdfId, aead_id: HpkeAeadId) -> Self {
+        Self {
+            kem_id,
+            kdf_id,
+            aead_id,
+        }
+    }
+
+    pub fn kem_id(&self) -> HpkeKemId {
+        self.kem_id
+    }
+
+    pub fn kdf_id(&self) -> HpkeKdfId {
+        self.kdf_id
+    }
+
+    pub fn aead_id(&self) -> HpkeAeadId {
+        self.aead_id
+    }
+}
+
+impl From<&HpkeConfig> for HpkeCiphersuite {
+    fn from(value: &HpkeConfig) -> Self {
+        Self {
+            kem_id: *value.kem_id(),
+            kdf_id: *value.kdf_id(),
+            aead_id: *value.aead_id(),
+        }
+    }
+}
+
 #[cfg(feature = "test-util")]
 #[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
 pub mod test_util {

--- a/core/src/hpke.rs
+++ b/core/src/hpke.rs
@@ -263,7 +263,7 @@ impl HpkeKeypair {
 }
 
 /// The algorithms used for each HPKE primitive.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct HpkeCiphersuite {
     kem_id: HpkeKemId,
     kdf_id: HpkeKdfId,

--- a/core/src/time.rs
+++ b/core/src/time.rs
@@ -199,6 +199,10 @@ pub trait TimeExt: Sized {
     /// Get the difference between the provided `other` and `self`. `self` must be after `other`.
     fn difference(&self, other: &Self) -> Result<Duration, Error>;
 
+    /// Get the difference between the provided `other` and `self` using saturating arithmetic. If
+    /// `self` is before `other`, the result is zero.
+    fn saturating_difference(&self, other: &Self) -> Duration;
+
     /// Returns true if this [`Time`] occurs after `time`.
     fn is_after(&self, time: &Time) -> bool;
 }
@@ -259,6 +263,13 @@ impl TimeExt for Time {
             .checked_sub(other.as_seconds_since_epoch())
             .map(Duration::from_seconds)
             .ok_or(Error::IllegalTimeArithmetic("operation would underflow"))
+    }
+
+    fn saturating_difference(&self, other: &Self) -> Duration {
+        Duration::from_seconds(
+            self.as_seconds_since_epoch()
+                .saturating_sub(other.as_seconds_since_epoch()),
+        )
     }
 
     fn is_after(&self, time: &Time) -> bool {

--- a/db/00000000000006_global_hpke_keys_last_state_change_at_drop_default.down.sql
+++ b/db/00000000000006_global_hpke_keys_last_state_change_at_drop_default.down.sql
@@ -1,2 +1,3 @@
 ALTER TABLE global_hpke_keys
-    ALTER COLUMN last_state_change_at SET DEFAULT '-infinity'::TIMESTAMP;
+    ALTER COLUMN last_state_change_at SET DEFAULT '-infinity'::TIMESTAMP,
+    ALTER COLUMN last_state_change_at DROP NOT NULL;

--- a/db/00000000000006_global_hpke_keys_last_state_change_at_drop_default.down.sql
+++ b/db/00000000000006_global_hpke_keys_last_state_change_at_drop_default.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE global_hpke_keys
+    ALTER COLUMN last_state_change_at SET DEFAULT '-infinity'::TIMESTAMP;

--- a/db/00000000000006_global_hpke_keys_last_state_change_at_drop_default.up.sql
+++ b/db/00000000000006_global_hpke_keys_last_state_change_at_drop_default.up.sql
@@ -1,1 +1,3 @@
-ALTER TABLE global_hpke_keys ALTER COLUMN last_state_change_at DROP DEFAULT;
+ALTER TABLE global_hpke_keys
+    ALTER COLUMN last_state_change_at DROP DEFAULT,
+    ALTER COLUMN last_state_change_at SET NOT NULL;

--- a/db/00000000000006_global_hpke_keys_last_state_change_at_drop_default.up.sql
+++ b/db/00000000000006_global_hpke_keys_last_state_change_at_drop_default.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE global_hpke_keys ALTER COLUMN last_state_change_at DROP DEFAULT;

--- a/docs/samples/advanced_config/key_rotator.yaml
+++ b/docs/samples/advanced_config/key_rotator.yaml
@@ -22,40 +22,21 @@ key_rotator:
   # Rotation policy for global HPKE keys. At least one is required. Each entry
   # represents a key with a particular ciphersuite.
   hpke:
-    - # How long the key remains pending before it's promoted to active. Should
-      # be greater than the global HPKE keypair cache refresh rate. Default to
-      # 1 hour.
-      pending_duration_secs: 3600
+    # How long keys remains pending before they're promoted to active. Should
+    # be greater than the global HPKE keypair cache refresh rate. Defaults to
+    # 1 hour.
+    pending_duration_secs: 3600
 
-      # The TTL of the key. Defaults to 4 weeks.
-      active_duration_secs: 2419200
+    # The TTL of keys. Defaults to 4 weeks.
+    active_duration_secs: 2419200
 
-      # How long the key can be expired before being deleted. Should be greater
-      # than how long clients cache HPKE keys. Defaults to 1 week.
-      expired_duration_secs: 604800
+    # How long keys can be expired before being deleted. Should be greater than
+    # how long clients cache HPKE keys. Defaults to 1 week.
+    expired_duration_secs: 604800
 
-      # The algorithms used by the key. Must be unique across different entries
-      # in the `hpke` array. Defaults to the values specified below.
-      ciphersuite:
-        kem_id: P521HkdfSha512
+    # The set of keys to manage, identified by ciphersuite.
+    ciphersuite:
+      # Defaults to a key with these algorithms.
+      - kem_id: P521HkdfSha512
         kdf_id: HkdfSha512
         aead_id: Aes256Gcm
-
-      # Safely phase out this config.
-      #
-      # If set, on next run the key rotator will immediately delete any pending
-      # keys and expire any keys with the given ciphersuite. Expired keys are
-      # retained for `expired_duration_secs` before being deleted.
-      #
-      # After the key rotator has run after `expired_duration_secs`, this config
-      # entry can be removed entirely. You should not remove this config unless
-      # the key rotator has been run after `expired_duration_secs` with
-      # `retire: true`.
-      #
-      # There must be at least one non-retired config present with its key
-      # in the active state (i.e. the key rotator has been run for longer
-      # than `pending_duration_secs` with a new key config). If this is the
-      # only key and it is marked retired, the key rotator will refuse to run.
-      #
-      # Defaults to false.
-      retire: false

--- a/docs/samples/advanced_config/key_rotator.yaml
+++ b/docs/samples/advanced_config/key_rotator.yaml
@@ -25,14 +25,14 @@ key_rotator:
     # How long keys remains pending before they're promoted to active. Should
     # be greater than the global HPKE keypair cache refresh rate. Defaults to
     # 1 hour.
-    pending_duration_secs: 3600
+    pending_duration_s: 3600
 
     # The TTL of keys. Defaults to 4 weeks.
-    active_duration_secs: 2419200
+    active_duration_s: 2419200
 
     # How long keys can be expired before being deleted. Should be greater than
     # how long clients cache HPKE keys. Defaults to 1 week.
-    expired_duration_secs: 604800
+    expired_duration_s: 604800
 
     # The set of keys to manage, identified by ciphersuite.
     ciphersuite:

--- a/docs/samples/advanced_config/key_rotator.yaml
+++ b/docs/samples/advanced_config/key_rotator.yaml
@@ -19,7 +19,8 @@ database:
   tls_trust_store_path: /path/to/file.pem
 
 key_rotator:
-  # Rotation policy for global HPKE keys. At least one is required.
+  # Rotation policy for global HPKE keys. At least one is required. Each entry
+  # represents a key with a particular ciphersuite.
   hpke:
     - # How long the key remains pending before it's promoted to active. Should
       # be greater than the global HPKE keypair cache refresh rate. Default to
@@ -34,13 +35,27 @@ key_rotator:
       expired_duration_secs: 604800
 
       # The algorithms used by the key. Must be unique across different entries
-      # in the `hpke` array.
+      # in the `hpke` array. Defaults to the values specified below.
       ciphersuite:
         kem_id: P521HkdfSha512
         kdf_id: HkdfSha512
         aead_id: Aes256Gcm
 
-      # Whether to phase out this key. Let the key rotator run for at least
-      # expired_duration_secs with `retire: true` before removing the key
-      # configuration.
+      # Safely phase out this config.
+      #
+      # If set, on next run the key rotator will immediately delete any pending
+      # keys and expire any keys with the given ciphersuite. Expired keys are
+      # retained for `expired_duration_secs` before being deleted.
+      #
+      # After the key rotator has run after `expired_duration_secs`, this config
+      # entry can be removed entirely. You should not remove this config unless
+      # the key rotator has been run after `expired_duration_secs` with
+      # `retire: true`.
+      #
+      # There must be at least one non-retired config present with its key
+      # in the active state (i.e. the key rotator has been run for longer
+      # than `pending_duration_secs` with a new key config). If this is the
+      # only key and it is marked retired, the key rotator will refuse to run.
+      #
+      # Defaults to false.
       retire: false

--- a/docs/samples/advanced_config/key_rotator.yaml
+++ b/docs/samples/advanced_config/key_rotator.yaml
@@ -2,26 +2,45 @@ database:
   # Database URL. (required)
   url: "postgres://postgres:postgres@localhost:5432/postgres"
 
+  # Timeout for new database connections. Defaults to 60 seconds.
+  connection_pool_timeout_secs: 60
+
+  # Maximum number of database connections. Defaults to CPUs * 4.
+  connection_pool_max_size: 8
+
+  # Flag to check if the database schema version is compatible upon startup.
+  # (optional, defaults to true)
+  check_schema_version: true
+
+  # Path to a PEM file with root certificates to trust for TLS database
+  # connections. If present, TLS may be used depending on the "sslmode"
+  # connection string parameter, and the server's support for TLS. If absent,
+  # TLS will never be used. (optional)
+  tls_trust_store_path: /path/to/file.pem
+
 key_rotator:
   # Rotation policy for global HPKE keys. At least one is required.
   hpke:
-    - # How long the key remains pending before it's promoted to active. Should be greater than
-      # the global HPKE keypair cache refresh rate. Default to 1 hour.
+    - # How long the key remains pending before it's promoted to active. Should
+      # be greater than the global HPKE keypair cache refresh rate. Default to
+      # 1 hour.
       pending_duration_secs: 3600
 
       # The TTL of the key. Defaults to 4 weeks.
       active_duration_secs: 2419200
 
-      # How long the key can be expired before being deleted. Should be greater than how long
-      # clients cache HPKE keys. Defaults to 1 week.
+      # How long the key can be expired before being deleted. Should be greater
+      # than how long clients cache HPKE keys. Defaults to 1 week.
       expired_duration_secs: 604800
 
-      # The algorithms used by the key. Must be unique across different entries in the `hpke` array.
+      # The algorithms used by the key. Must be unique across different entries
+      # in the `hpke` array.
       ciphersuite:
         kem_id: P521HkdfSha512
         kdf_id: HkdfSha512
         aead_id: Aes256Gcm
 
-      # Whether to phase out this key. Let the key rotator run for at least expired_duration_secs
-      # with `retire: true` before removing the key configuration.
+      # Whether to phase out this key. Let the key rotator run for at least
+      # expired_duration_secs with `retire: true` before removing the key
+      # configuration.
       retire: false

--- a/docs/samples/advanced_config/key_rotator.yaml
+++ b/docs/samples/advanced_config/key_rotator.yaml
@@ -1,0 +1,27 @@
+database:
+  # Database URL. (required)
+  url: "postgres://postgres:postgres@localhost:5432/postgres"
+
+key_rotator:
+  # Rotation policy for global HPKE keys. At least one is required.
+  hpke:
+    - # How long the key remains pending before it's promoted to active. Should be greater than
+      # the global HPKE keypair cache refresh rate. Default to 1 hour.
+      pending_duration_secs: 3600
+
+      # The TTL of the key. Defaults to 4 weeks.
+      active_duration_secs: 2419200
+
+      # How long the key can be expired before being deleted. Should be greater than how long
+      # clients cache HPKE keys. Defaults to 1 week.
+      expired_duration_secs: 604800
+
+      # The algorithms used by the key. Must be unique across different entries in the `hpke` array.
+      ciphersuite:
+        kem_id: P521HkdfSha512
+        kdf_id: HkdfSha512
+        aead_id: Aes256Gcm
+
+      # Whether to phase out this key. Let the key rotator run for at least expired_duration_secs
+      # with `retire: true` before removing the key configuration.
+      retire: false

--- a/docs/samples/advanced_config/key_rotator.yaml
+++ b/docs/samples/advanced_config/key_rotator.yaml
@@ -19,8 +19,7 @@ database:
   tls_trust_store_path: /path/to/file.pem
 
 key_rotator:
-  # Rotation policy for global HPKE keys. At least one is required. Each entry
-  # represents a key with a particular ciphersuite.
+  # Rotation policy for global HPKE keys.
   hpke:
     # How long keys remains pending before they're promoted to active. Should
     # be greater than the global HPKE keypair cache refresh rate. Defaults to
@@ -34,7 +33,8 @@ key_rotator:
     # how long clients cache HPKE keys. Defaults to 1 week.
     expired_duration_s: 604800
 
-    # The set of keys to manage, identified by ciphersuite.
+    # The set of keys to manage, identified by ciphersuite. At least one is
+    # required. Each entry represents a key with a particular ciphersuite.
     ciphersuite:
       # Defaults to a key with these algorithms.
       - kem_id: P521HkdfSha512

--- a/docs/samples/advanced_config/key_rotator.yaml
+++ b/docs/samples/advanced_config/key_rotator.yaml
@@ -26,7 +26,7 @@ key_rotator:
     # 1 hour.
     pending_duration_s: 3600
 
-    # The TTL of keys. Defaults to 4 weeks.
+    # The TTL of keys. Defaults to 12 weeks.
     active_duration_s: 2419200
 
     # How long keys can be expired before being deleted. Should be greater than

--- a/docs/samples/basic_config/key_rotator.yaml
+++ b/docs/samples/basic_config/key_rotator.yaml
@@ -1,0 +1,9 @@
+database:
+  # Database URL. (required)
+  url: "postgres://postgres:postgres@localhost:5432/postgres"
+
+key_rotator:
+  # Rotation policy for global HPKE keys. At least one is required.
+  hpke:
+    # A default key that rotates every 4 weeks.
+    - {}

--- a/docs/samples/basic_config/key_rotator.yaml
+++ b/docs/samples/basic_config/key_rotator.yaml
@@ -3,7 +3,5 @@ database:
   url: "postgres://postgres:postgres@localhost:5432/postgres"
 
 key_rotator:
-  # Rotation policy for global HPKE keys. At least one is required.
-  hpke:
-    # A default key that rotates every 4 weeks.
-    - {}
+  # Rotation policy for global HPKE keys
+  hpke: {}

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -763,7 +763,7 @@ impl<'de> Deserialize<'de> for TaskId {
 
 /// DAP protocol message representing an HPKE key encapsulation mechanism.
 #[derive(
-    Clone, Copy, Debug, PartialEq, Eq, FromPrimitive, IntoPrimitive, Serialize, Deserialize,
+    Clone, Copy, Debug, PartialEq, Eq, FromPrimitive, IntoPrimitive, Serialize, Deserialize, Hash,
 )]
 #[repr(u16)]
 #[non_exhaustive]
@@ -802,7 +802,7 @@ impl Decode for HpkeKemId {
 
 /// DAP protocol message representing an HPKE key derivation function.
 #[derive(
-    Clone, Copy, Debug, PartialEq, Eq, FromPrimitive, IntoPrimitive, Serialize, Deserialize,
+    Clone, Copy, Debug, PartialEq, Eq, FromPrimitive, IntoPrimitive, Serialize, Deserialize, Hash,
 )]
 #[repr(u16)]
 #[non_exhaustive]
@@ -837,7 +837,7 @@ impl Decode for HpkeKdfId {
 
 /// DAP protocol message representing an HPKE AEAD.
 #[derive(
-    Clone, Copy, Debug, PartialEq, Eq, FromPrimitive, IntoPrimitive, Serialize, Deserialize,
+    Clone, Copy, Debug, PartialEq, Eq, FromPrimitive, IntoPrimitive, Serialize, Deserialize, Hash,
 )]
 #[repr(u16)]
 #[non_exhaustive]


### PR DESCRIPTION
Supports https://github.com/divviup/janus/issues/2147.

Introduces the `key_rotator`, which is a utility for managing the lifecycle of global HPKE keys. It will bootstrap keys, and rotate them according to the rotation policy in the config.

Keys are unique by their HPKE ciphersuite. For each ciphersuite, a key is run through the pending->active->expired->deleted lifecycle. It is permissive of some manual operator changes, e.g. if a manual key rotation needs to be executed through janus_cli or the aggregator API.

In this iteration, it runs as a standalone binary for use in a cronjob. It is suitable for deployment in our environments, including taskprov ones. A future PR will add support for BYOH deployments by letting the `aggregator` process run the key rotator.