### PR TITLE
Add check-cfg directive to build script

### DIFF
--- a/aggregator/build.rs
+++ b/aggregator/build.rs
@@ -4,4 +4,5 @@ fn main() {
     let rustc_semver = version().expect("could not parse rustc version");
     println!("cargo:rustc-env=RUSTC_SEMVER={rustc_semver}");
     println!("cargo:rerun-if-env-changed=RUSTC");
+    println!("cargo:rustc-check-cfg=cfg(tokio_unstable)");
 }


### PR DESCRIPTION
This adds a directive to build.rs telling the compiler to expect the `tokio_unstable` config flag. This prevents a warning in nightly currently.