### PR TITLE
Do not treat user errors as DB errors.

### DIFF
--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -263,7 +263,7 @@ impl<C: Clock> Datastore<C> {
                         "retry"
                     }
                 }
-                (Ok(_), _) => "success",
+                (Ok(_), _) | (Err(Error::User(_)), _) => "success",
                 (Err(Error::Db(_)), _) | (Err(Error::Pool(_)), _) => "error_db",
                 (Err(_), _) => "error_other",
             };


### PR DESCRIPTION
Previously, a datastore::Error::User would have been added to our metrics as an "error_other". But returning a user error from a database transaction is, from the POV of the database code, a perfectly successful way to terminate a transaction. So we treat these errors as a success.