### PR TITLE
Fix `janus_gc_deleted_batches_total`

### DIFF
--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -6125,6 +6125,23 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
             },
         );
         tx.put_batch_aggregation(&batch_aggregation).await.unwrap();
+        for ord in 1..8 {
+            let batch_aggregation = BatchAggregation::<0, Q, dummy::Vdaf>::new(
+                *task.id(),
+                batch_identifier.clone(),
+                dummy::AggregationParam(0),
+                ord,
+                client_timestamp_interval,
+                BatchAggregationState::Aggregating {
+                    aggregate_share: None,
+                    report_count: 0,
+                    checksum: ReportIdChecksum::default(),
+                    aggregation_jobs_created: 0,
+                    aggregation_jobs_terminated: 0,
+                },
+            );
+            tx.put_batch_aggregation(&batch_aggregation).await.unwrap();
+        }
 
         if task.role() == &Role::Leader {
             let collection_job = CollectionJob::<0, Q, dummy::Vdaf>::new(


### PR DESCRIPTION
This metric is currently increasing too fast, because it is counting the number of `batch_aggregations` rows deleted. I made the relevant test more robust by adding more `batch_aggregations` rows, and then changed the query to return the cardinality of the `batches_to_delete` CTE. Here's what the plan looks like, FWIW.

`postgres=> EXPLAIN WITH batches_to_delete AS (SELECT batch_identifier, aggregation_param FROM batch_aggregations WHERE task_id = 14 GROUP BY batch_identifier, aggregation_param HAVING MAX(UPPER(COALESCE(batch_interval, client_timestamp_interval))) < '2024-05-08 21:01:18.631912+00'::timestamp LIMIT 50), deleted_outstanding_batches AS (DELETE FROM outstanding_batches USING batches_to_delete WHERE task_id = 14 AND outstanding_batches.batch_id = batches_to_delete.batch_identifier), deleted_collection_jobs AS (DELETE FROM collection_jobs USING batches_to_delete WHERE task_id = 14 AND (LOWER(batch_interval) < '2024-05-08 21:01:18.631912+00'::timestamp OR (collection_jobs.batch_identifier = batches_to_delete.batch_identifier AND collection_jobs.aggregation_param = batches_to_delete.aggregation_param)) RETURNING 1), deleted_aggregate_share_jobs AS (DELETE FROM aggregate_share_jobs USING batches_to_delete WHERE task_id = 14 AND (LOWER(batch_interval) < '2024-05-08 21:01:18.631912+00'::timestamp OR (aggregate_share_jobs.batch_identifier = batches_to_delete.batch_identifier AND aggregate_share_jobs.aggregation_param = batches_to_delete.aggregation_param)) RETURNING 1), deleted_batch_aggregations AS (DELETE FROM batch_aggregations USING batches_to_delete WHERE task_id = 14 AND batch_aggregations.batch_identifier = batches_to_delete.batch_identifier AND batch_aggregations.aggregation_param = batches_to_delete.aggregation_param) SELECT COUNT(1) AS batch_count FROM batches_to_delete;`

```
 Aggregate  (cost=1071.07..1071.08 rows=1 width=8)
   CTE batches_to_delete
     ->  Limit  (cost=0.69..182.30 rows=50 width=34)
           ->  GroupAggregate  (cost=0.69..8906.69 rows=2452 width=34)
                 Group Key: batch_aggregations.batch_identifier, batch_aggregations.aggregation_param
                 Filter: (max(upper(COALESCE(batch_aggregations.batch_interval, batch_aggregations.client_timestamp_interval))) < '2024-05-08 21:01:18.631912'::timestamp without time zone)
                 ->  Index Scan using batch_aggregations_unique_task_id_batch_id_aggregation_param on batch_aggregations  (cost=0.69..8737.13 rows=7761 width=72)
                       Index Cond: (task_id = 14)
   CTE deleted_outstanding_batches
     ->  Delete on outstanding_batches  (cost=4.48..5.62 rows=0 width=0)
           ->  Hash Join  (cost=4.48..5.62 rows=1 width=62)
                 Hash Cond: (batches_to_delete_1.batch_identifier = outstanding_batches.batch_id)
                 ->  CTE Scan on batches_to_delete batches_to_delete_1  (cost=0.00..1.00 rows=50 width=88)
                 ->  Hash  (cost=4.45..4.45 rows=3 width=38)
                       ->  Bitmap Heap Scan on outstanding_batches  (cost=1.27..4.45 rows=3 width=38)
                             Recheck Cond: (task_id = 14)
                             ->  Bitmap Index Scan on outstanding_batches_unique_task_id_batch_id  (cost=0.00..1.27 rows=3 width=0)
                                   Index Cond: (task_id = 14)
   CTE deleted_collection_jobs
     ->  Delete on collection_jobs  (cost=0.14..4.36 rows=17 width=94)
           ->  Nested Loop  (cost=0.14..4.36 rows=17 width=94)
                 Join Filter: ((lower(collection_jobs.batch_interval) < '2024-05-08 21:01:18.631912'::timestamp without time zone) OR ((collection_jobs.batch_identifier = batches_to_delete_2.batch_identifier) AND (collection_jobs.aggregation_param = batches_to_delete_2.aggregation_param)))
                 ->  Index Scan using collection_jobs_task_id_batch_id on collection_jobs  (cost=0.14..2.36 rows=1 width=102)
                       Index Cond: (task_id = 14)
                 ->  CTE Scan on batches_to_delete batches_to_delete_2  (cost=0.00..1.00 rows=50 width=152)
   CTE deleted_aggregate_share_jobs
     ->  Delete on aggregate_share_jobs  (cost=0.56..730.42 rows=5383 width=94)
           ->  Nested Loop  (cost=0.56..730.42 rows=5383 width=94)
                 Join Filter: ((lower(aggregate_share_jobs.batch_interval) < '2024-05-08 21:01:18.631912'::timestamp without time zone) OR ((aggregate_share_jobs.batch_identifier = batches_to_delete_3.batch_identifier) AND (aggregate_share_jobs.aggregation_param = batches_to_delete_3.aggregation_param)))
                 ->  CTE Scan on batches_to_delete batches_to_delete_3  (cost=0.00..1.00 rows=50 width=152)
                 ->  Materialize  (cost=0.56..366.85 rows=323 width=72)
                       ->  Index Scan using aggregate_share_jobs_unique_task_id_batch_id_aggregation_param on aggregate_share_jobs  (cost=0.56..365.24 rows=323 width=72)
                             Index Cond: (task_id = 14)
   CTE deleted_batch_aggregations
     ->  Delete on batch_aggregations batch_aggregations_1  (cost=0.69..147.25 rows=0 width=0)
           ->  Nested Loop  (cost=0.69..147.25 rows=1 width=94)
                 ->  CTE Scan on batches_to_delete batches_to_delete_4  (cost=0.00..1.00 rows=50 width=152)
                 ->  Index Scan using batch_aggregations_unique_task_id_batch_id_aggregation_param on batch_aggregations batch_aggregations_1  (cost=0.69..2.92 rows=1 width=40)
                       Index Cond: ((task_id = 14) AND (batch_identifier = batches_to_delete_4.batch_identifier) AND (aggregation_param = batches_to_delete_4.aggregation_param))
   ->  CTE Scan on batches_to_delete  (cost=0.00..1.00 rows=50 width=0)
```