### PR TITLE
Return HTTP 401 Unauthorized for authorization errors.

### DIFF
--- a/aggregator/src/aggregator/aggregate_init_tests.rs
+++ b/aggregator/src/aggregator/aggregate_init_tests.rs
@@ -389,7 +389,7 @@ async fn aggregation_job_init_malformed_authorization_header(#[case] header_valu
     .run_async(&test_case.handler)
     .await;
 
-    assert_eq!(response.status(), Some(Status::Unauthorized));
+    assert_eq!(response.status(), Some(Status::Forbidden));
 }
 
 #[tokio::test]

--- a/aggregator/src/aggregator/aggregate_init_tests.rs
+++ b/aggregator/src/aggregator/aggregate_init_tests.rs
@@ -389,7 +389,7 @@ async fn aggregation_job_init_malformed_authorization_header(#[case] header_valu
     .run_async(&test_case.handler)
     .await;
 
-    assert_eq!(response.status(), Some(Status::BadRequest));
+    assert_eq!(response.status(), Some(Status::Unauthorized));
 }
 
 #[tokio::test]

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
@@ -152,7 +152,7 @@ async fn aggregate_wrong_agg_auth_token() {
 
         let mut test_conn = test_conn.run_async(&handler).await;
 
-        let want_status = u16::from(Status::Unauthorized);
+        let want_status = u16::from(Status::Forbidden);
         assert_eq!(
             take_problem_details(&mut test_conn).await,
             json!({

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
@@ -152,7 +152,7 @@ async fn aggregate_wrong_agg_auth_token() {
 
         let mut test_conn = test_conn.run_async(&handler).await;
 
-        let want_status = 400;
+        let want_status = u16::from(Status::Unauthorized);
         assert_eq!(
             take_problem_details(&mut test_conn).await,
             json!({

--- a/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
@@ -197,7 +197,7 @@ async fn collection_job_put_request_unauthenticated() {
         .put_collection_job_with_auth_token(&collection_job_id, &req, Some(&random()))
         .await;
 
-    let want_status = u16::from(Status::Unauthorized);
+    let want_status = u16::from(Status::Forbidden);
     assert_eq!(
         take_problem_details(&mut test_conn).await,
         json!({
@@ -218,7 +218,7 @@ async fn collection_job_put_request_unauthenticated() {
         )
         .await;
 
-    let want_status = u16::from(Status::Unauthorized);
+    let want_status = u16::from(Status::Forbidden);
     assert_eq!(
         take_problem_details(&mut test_conn).await,
         json!({
@@ -235,7 +235,7 @@ async fn collection_job_put_request_unauthenticated() {
         .put_collection_job_with_auth_token(&collection_job_id, &req, None)
         .await;
 
-    let want_status = u16::from(Status::Unauthorized);
+    let want_status = u16::from(Status::Forbidden);
     assert_eq!(
         take_problem_details(&mut test_conn).await,
         json!({
@@ -275,7 +275,7 @@ async fn collection_job_post_request_unauthenticated_collection_jobs() {
         .post_collection_job_with_auth_token(&collection_job_id, Some(&random()))
         .await;
 
-    let want_status = u16::from(Status::Unauthorized);
+    let want_status = u16::from(Status::Forbidden);
     assert_eq!(
         take_problem_details(&mut test_conn).await,
         json!({
@@ -295,7 +295,7 @@ async fn collection_job_post_request_unauthenticated_collection_jobs() {
         )
         .await;
 
-    let want_status = u16::from(Status::Unauthorized);
+    let want_status = u16::from(Status::Forbidden);
     assert_eq!(
         take_problem_details(&mut test_conn).await,
         json!({
@@ -312,7 +312,7 @@ async fn collection_job_post_request_unauthenticated_collection_jobs() {
         .post_collection_job_with_auth_token(&collection_job_id, None)
         .await;
 
-    let want_status = u16::from(Status::Unauthorized);
+    let want_status = u16::from(Status::Forbidden);
     assert_eq!(
         take_problem_details(&mut test_conn).await,
         json!({

--- a/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
@@ -299,7 +299,7 @@ async fn collection_job_post_request_unauthenticated_collection_jobs() {
     assert_eq!(
         take_problem_details(&mut test_conn).await,
         json!({
-            "status": want_status as u16,
+            "status": want_status,
             "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
             "title": "The request's authorization is not valid.",
             "taskid": format!("{}", test_case.task.id()),
@@ -316,7 +316,7 @@ async fn collection_job_post_request_unauthenticated_collection_jobs() {
     assert_eq!(
         take_problem_details(&mut test_conn).await,
         json!({
-            "status": want_status as u16,
+            "status": want_status,
             "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
             "title": "The request's authorization is not valid.",
             "taskid": format!("{}", test_case.task.id()),

--- a/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
@@ -197,11 +197,11 @@ async fn collection_job_put_request_unauthenticated() {
         .put_collection_job_with_auth_token(&collection_job_id, &req, Some(&random()))
         .await;
 
-    let want_status = Status::BadRequest;
+    let want_status = u16::from(Status::Unauthorized);
     assert_eq!(
         take_problem_details(&mut test_conn).await,
         json!({
-            "status": want_status as u16,
+            "status": want_status,
             "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
             "title": "The request's authorization is not valid.",
             "taskid": format!("{}", test_case.task.id()),
@@ -218,11 +218,11 @@ async fn collection_job_put_request_unauthenticated() {
         )
         .await;
 
-    let want_status = Status::BadRequest;
+    let want_status = u16::from(Status::Unauthorized);
     assert_eq!(
         take_problem_details(&mut test_conn).await,
         json!({
-            "status": want_status as u16,
+            "status": want_status,
             "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
             "title": "The request's authorization is not valid.",
             "taskid": format!("{}", test_case.task.id()),
@@ -235,11 +235,11 @@ async fn collection_job_put_request_unauthenticated() {
         .put_collection_job_with_auth_token(&collection_job_id, &req, None)
         .await;
 
-    let want_status = Status::BadRequest;
+    let want_status = u16::from(Status::Unauthorized);
     assert_eq!(
         take_problem_details(&mut test_conn).await,
         json!({
-            "status": want_status as u16,
+            "status": want_status,
             "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
             "title": "The request's authorization is not valid.",
             "taskid": format!("{}", test_case.task.id()),
@@ -275,11 +275,11 @@ async fn collection_job_post_request_unauthenticated_collection_jobs() {
         .post_collection_job_with_auth_token(&collection_job_id, Some(&random()))
         .await;
 
-    let want_status = Status::BadRequest;
+    let want_status = u16::from(Status::Unauthorized);
     assert_eq!(
         take_problem_details(&mut test_conn).await,
         json!({
-            "status": want_status as u16,
+            "status": want_status,
             "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
             "title": "The request's authorization is not valid.",
             "taskid": format!("{}", test_case.task.id()),
@@ -295,7 +295,7 @@ async fn collection_job_post_request_unauthenticated_collection_jobs() {
         )
         .await;
 
-    let want_status = Status::BadRequest;
+    let want_status = u16::from(Status::Unauthorized);
     assert_eq!(
         take_problem_details(&mut test_conn).await,
         json!({
@@ -312,7 +312,7 @@ async fn collection_job_post_request_unauthenticated_collection_jobs() {
         .post_collection_job_with_auth_token(&collection_job_id, None)
         .await;
 
-    let want_status = Status::BadRequest;
+    let want_status = u16::from(Status::Unauthorized);
     assert_eq!(
         take_problem_details(&mut test_conn).await,
         json!({

--- a/aggregator/src/aggregator/problem_details.rs
+++ b/aggregator/src/aggregator/problem_details.rs
@@ -16,10 +16,10 @@ impl DapProblemTypeExt for DapProblemType {
         match self {
             // The HTTPS request authentication section does not specify that an authorization
             // failure is an "abort" of the protocol, and thus we can use a non-400 error code.
-            // Therefore, we choose to use 401 Unauthorized.
+            // Therefore, we choose to use 403 Forbidden.
             //
             // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-09.html#section-3.1
-            DapProblemType::UnauthorizedRequest => Status::Unauthorized,
+            DapProblemType::UnauthorizedRequest => Status::Forbidden,
 
             // Per the Errors section of the protocol, error responses corresponding to an "abort"
             // in the protocol should use HTTP status code 400 Bad Request unless explicitly

--- a/aggregator/src/aggregator/problem_details.rs
+++ b/aggregator/src/aggregator/problem_details.rs
@@ -13,10 +13,21 @@ impl DapProblemTypeExt for DapProblemType {
     /// Returns the HTTP status code that should be used in responses whose body is a problem
     /// document of this type.
     fn http_status(&self) -> Status {
-        // Per the errors section of the protocol, error responses should use HTTP status code 400
-        // Bad Request unless explicitly specified otherwise.
-        // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-07.html#section-3.2-7
-        Status::BadRequest
+        match self {
+            // The HTTPS request authentication section does not specify that an authorization
+            // failure is an "abort" of the protocol, and thus we can use a non-400 error code.
+            // Therefore, we choose to use 401 Unauthorized.
+            //
+            // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-09.html#section-3.1
+            DapProblemType::UnauthorizedRequest => Status::Unauthorized,
+
+            // Per the Errors section of the protocol, error responses corresponding to an "abort"
+            // in the protocol should use HTTP status code 400 Bad Request unless explicitly
+            // specified otherwise.
+            //
+            // https://www.ietf.org/archive/id/draft-ietf-ppm-dap-09.html#section-3.2
+            _ => Status::BadRequest,
+        }
     }
 }
 

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -316,11 +316,11 @@ async fn taskprov_aggregate_init() {
         .with_request_body(request.get_encoded().unwrap())
         .run_async(&test.handler)
         .await;
-        assert_eq!(test_conn.status(), Some(Status::Unauthorized), "{}", name);
+        assert_eq!(test_conn.status(), Some(Status::Forbidden), "{}", name);
         assert_eq!(
             take_problem_details(&mut test_conn).await,
             json!({
-                "status": u16::from(Status::Unauthorized),
+                "status": u16::from(Status::Forbidden),
                 "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
                 "title": "The request's authorization is not valid.",
                 "taskid": format!("{}", test.task_id),
@@ -971,11 +971,11 @@ async fn taskprov_aggregate_continue() {
     .with_request_body(request.get_encoded().unwrap())
     .run_async(&test.handler)
     .await;
-    assert_eq!(test_conn.status(), Some(Status::Unauthorized));
+    assert_eq!(test_conn.status(), Some(Status::Forbidden));
     assert_eq!(
         take_problem_details(&mut test_conn).await,
         json!({
-            "status": u16::from(Status::Unauthorized),
+            "status": u16::from(Status::Forbidden),
             "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
             "title": "The request's authorization is not valid.",
             "taskid": format!("{}", test.task_id),
@@ -1083,11 +1083,11 @@ async fn taskprov_aggregate_share() {
         .with_request_body(request.get_encoded().unwrap())
         .run_async(&test.handler)
         .await;
-    assert_eq!(test_conn.status(), Some(Status::Unauthorized));
+    assert_eq!(test_conn.status(), Some(Status::Forbidden));
     assert_eq!(
         take_problem_details(&mut test_conn).await,
         json!({
-            "status": u16::from(Status::Unauthorized),
+            "status": u16::from(Status::Forbidden),
             "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
             "title": "The request's authorization is not valid.",
             "taskid": format!("{}", test.task_id),

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -316,11 +316,11 @@ async fn taskprov_aggregate_init() {
         .with_request_body(request.get_encoded().unwrap())
         .run_async(&test.handler)
         .await;
-        assert_eq!(test_conn.status(), Some(Status::BadRequest), "{}", name);
+        assert_eq!(test_conn.status(), Some(Status::Unauthorized), "{}", name);
         assert_eq!(
             take_problem_details(&mut test_conn).await,
             json!({
-                "status": Status::BadRequest as u16,
+                "status": u16::from(Status::Unauthorized),
                 "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
                 "title": "The request's authorization is not valid.",
                 "taskid": format!("{}", test.task_id),
@@ -971,11 +971,11 @@ async fn taskprov_aggregate_continue() {
     .with_request_body(request.get_encoded().unwrap())
     .run_async(&test.handler)
     .await;
-    assert_eq!(test_conn.status(), Some(Status::BadRequest));
+    assert_eq!(test_conn.status(), Some(Status::Unauthorized));
     assert_eq!(
         take_problem_details(&mut test_conn).await,
         json!({
-            "status": Status::BadRequest as u16,
+            "status": u16::from(Status::Unauthorized),
             "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
             "title": "The request's authorization is not valid.",
             "taskid": format!("{}", test.task_id),
@@ -1083,11 +1083,11 @@ async fn taskprov_aggregate_share() {
         .with_request_body(request.get_encoded().unwrap())
         .run_async(&test.handler)
         .await;
-    assert_eq!(test_conn.status(), Some(Status::BadRequest));
+    assert_eq!(test_conn.status(), Some(Status::Unauthorized));
     assert_eq!(
         take_problem_details(&mut test_conn).await,
         json!({
-            "status": Status::BadRequest as u16,
+            "status": u16::from(Status::Unauthorized),
             "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
             "title": "The request's authorization is not valid.",
             "taskid": format!("{}", test.task_id),


### PR DESCRIPTION
Previously, we were returning 400 Bad Request, likely based on the following text from the DAP specification:

> This document uses the verbs "abort" and "alert with [some error message]" to describe how protocol participants react to various error conditions. This implies HTTP status code 400 Bad Request unless explicitly specified otherwise.

...but the authorization section of the spec does not list an authorization error as an "abort", and 401 Unauthorized is a much more common response code for authorization errors.