### PR TITLE
Accept repeated, duplicate Authorization headers as one.

### DIFF
--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -8,7 +8,7 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use janus_aggregator_core::{datastore::Datastore, instrumented};
 use janus_core::{
     auth_tokens::{AuthenticationToken, DAP_AUTH_HEADER},
-    http::extract_bearer_token,
+    http::{extract_bearer_token, HeadersExt as _},
     taskprov::TASKPROV_HEADER,
     time::Clock,
     Runtime,
@@ -686,7 +686,7 @@ fn parse_auth_token(task_id: &TaskId, conn: &Conn) -> Result<Option<Authenticati
     }
 
     conn.request_headers()
-        .get(DAP_AUTH_HEADER)
+        .get_coalescing_duplicates(DAP_AUTH_HEADER) // TODO(#3163): get_coalescing_duplicates -> get
         .map(|value| {
             AuthenticationToken::new_dap_auth_token_from_bytes(value.as_ref())
                 .map_err(|e| Error::BadRequest(format!("bad DAP-Auth-Token header: {e}")))

--- a/core/src/http.rs
+++ b/core/src/http.rs
@@ -6,7 +6,7 @@ use janus_messages::problem_type::DapProblemType;
 use reqwest::{header::CONTENT_TYPE, Response};
 use std::fmt::{self, Display, Formatter};
 use tracing::warn;
-use trillium::{Conn, HeaderValue};
+use trillium::{Conn, HeaderName, HeaderValue, Headers};
 
 /// This captures an HTTP status code and parsed problem details document from an HTTP response.
 #[derive(Debug)]
@@ -108,7 +108,7 @@ impl Display for HttpErrorResponse {
 pub fn extract_bearer_token(conn: &Conn) -> Result<Option<AuthenticationToken>, anyhow::Error> {
     if let Some(authorization) = conn
         .request_headers()
-        .get("authorization")
+        .get_coalescing_duplicates("authorization") // TODO(#3163): get_coalescing_duplicates -> get
         .map(HeaderValue::to_string)
     {
         let (auth_scheme, token) = authorization
@@ -125,6 +125,28 @@ pub fn extract_bearer_token(conn: &Conn) -> Result<Option<AuthenticationToken>, 
     }
 
     Ok(None)
+}
+
+pub trait HeadersExt {
+    fn get_coalescing_duplicates<'a>(
+        &self,
+        name: impl Into<HeaderName<'a>>,
+    ) -> Option<&HeaderValue>;
+}
+
+impl HeadersExt for Headers {
+    fn get_coalescing_duplicates<'a>(
+        &self,
+        name: impl Into<HeaderName<'a>>,
+    ) -> Option<&HeaderValue> {
+        self.get_values(name).and_then(|header_values| {
+            header_values
+                .iter()
+                .map(Option::Some)
+                .reduce(|l, r| if l == r { l } else { None })
+                .flatten()
+        })
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This is not to the RFC, but we are observing this behavior in a deployment.