### PR TITLE
Fix rate limit integration test to accept any client error

### DIFF
--- a/integration_tests/tests/integration/in_cluster.rs
+++ b/integration_tests/tests/integration/in_cluster.rs
@@ -707,7 +707,7 @@ mod rate_limits {
             let (retry_after, status) = handle.await.unwrap();
             // Every request this test send should get rejected due to a missing body if it gets
             // past the rate limiter.
-            if status == StatusCode::BAD_REQUEST {
+            if status.is_client_error() {
                 assert!(retry_after.is_none());
                 acceptable_status_count += 1
             } else if status == StatusCode::TOO_MANY_REQUESTS {


### PR DESCRIPTION
We changed the return code to 403 in https://github.com/divviup/janus/pull/3162, but this test was hard-coded to look for 400.