### PR TITLE
Improve efficiency of collection-artifact GC.

### DIFF
--- a/db/00000000000004_batch_aggregation_gc.down.sql
+++ b/db/00000000000004_batch_aggregation_gc.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX batch_aggregations_gc_time;

--- a/db/00000000000004_batch_aggregation_gc.up.sql
+++ b/db/00000000000004_batch_aggregation_gc.up.sql
@@ -1,0 +1,2 @@
+-- Used to identify batch aggregations which can be garbage collected.
+CREATE INDEX batch_aggregations_gc_time ON batch_aggregations(task_id, UPPER(COALESCE(batch_interval, client_timestamp_interval)));


### PR DESCRIPTION
Previously, we would need to scan the batch_aggregations table to fulfill batches_to_delete, which was especially painful if there were not enough batches to delete because we would have to scan the entire table to determine that.

Now, we do a quick first pass to determine candidate batches to delete, with the aid of a new index.