### PR TITLE
Improve client disconnect handling

### DIFF
--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -119,7 +119,7 @@ opentelemetry_sdk = { workspace = true, features = ["testing"] }
 prio = { workspace = true, features = ["multithreaded"] }
 rstest.workspace = true
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["test-util"] } # ensure this remains compatible with the non-dev dependency
+tokio = { workspace = true, features = ["net", "test-util"] } # ensure this remains compatible with the non-dev dependency
 trillium-testing.workspace = true
 trycmd = { workspace = true }
 wait-timeout = { workspace = true }

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -30,7 +30,7 @@ use std::{borrow::Cow, time::Duration as StdDuration};
 use std::{io::Cursor, sync::Arc};
 use tracing::warn;
 use trillium::{Conn, Handler, KnownHeaderName, Status};
-use trillium_api::{api, State};
+use trillium_api::{api, State, TryFromConn};
 use trillium_caching_headers::{CacheControlDirective, CachingHeadersExt as _};
 use trillium_opentelemetry::metrics;
 use trillium_router::{Router, RouterConnExt};
@@ -153,7 +153,7 @@ async fn run_error_handler(error: &Error, mut conn: Conn) -> Conn {
             &ProblemDocument::new_dap(DapProblemType::InvalidTask).with_task_id(task_id),
         ),
         Error::DifferentialPrivacy(_) => conn.with_status(Status::InternalServerError),
-        Error::ClientDisconnected => conn,
+        Error::ClientDisconnected => conn.with_status(Status::BadRequest),
     };
 
     if matches!(conn.status(), Some(status) if status.is_server_error()) {

--- a/aggregator/src/metrics.rs
+++ b/aggregator/src/metrics.rs
@@ -51,6 +51,8 @@ use {
 pub(crate) mod tokio_runtime;
 
 #[cfg(test)]
+pub(crate) mod test_util;
+#[cfg(test)]
 mod tests;
 
 /// Errors from initializing metrics provider, registry, and exporter.

--- a/aggregator/src/metrics/test_util.rs
+++ b/aggregator/src/metrics/test_util.rs
@@ -1,0 +1,66 @@
+use std::collections::HashMap;
+
+use opentelemetry::metrics::{Meter, MeterProvider};
+use opentelemetry_sdk::{
+    metrics::{data::Metric, PeriodicReader, SdkMeterProvider},
+    runtime,
+    testing::metrics::InMemoryMetricsExporter,
+};
+use tokio::task::spawn_blocking;
+
+#[derive(Clone)]
+pub(crate) struct InMemoryMetricsInfrastructure {
+    /// The in-memory metrics exporter
+    pub exporter: InMemoryMetricsExporter,
+    /// The meter provider.
+    pub meter_provider: SdkMeterProvider,
+    /// A meter, with the name "test".
+    pub meter: Meter,
+}
+
+impl InMemoryMetricsInfrastructure {
+    /// Create an [`InMemoryMetricsExporter`], then use it to create an [`SdkMeterProvider`] and
+    /// [`Meter`].
+    pub(crate) fn new() -> InMemoryMetricsInfrastructure {
+        let exporter = InMemoryMetricsExporter::default();
+        let reader = PeriodicReader::builder(exporter.clone(), runtime::Tokio).build();
+        let meter_provider = SdkMeterProvider::builder().with_reader(reader).build();
+        let meter = meter_provider.meter("test");
+        InMemoryMetricsInfrastructure {
+            exporter,
+            meter_provider,
+            meter,
+        }
+    }
+
+    /// Flush all pending metrics, and return data indexed by metric name. All resource and scope
+    /// information is ignored.
+    pub(crate) async fn collect(&self) -> HashMap<String, Metric> {
+        spawn_blocking({
+            let meter_provider = self.meter_provider.clone();
+            move || meter_provider.force_flush().unwrap()
+        })
+        .await
+        .unwrap();
+
+        // Discard resource and scope information, collect all metrics by name.
+        self.exporter
+            .get_finished_metrics()
+            .unwrap()
+            .into_iter()
+            .flat_map(|resource_metrics| resource_metrics.scope_metrics)
+            .flat_map(|scope_metrics| scope_metrics.metrics.into_iter())
+            .map(|metric| (metric.name.to_string(), metric))
+            .collect::<HashMap<_, _>>()
+    }
+
+    /// Shut down the periodic reader.
+    pub(crate) async fn shutdown(&self) {
+        spawn_blocking({
+            let meter_provider = self.meter_provider.clone();
+            move || meter_provider.shutdown().unwrap()
+        })
+        .await
+        .unwrap();
+    }
+}


### PR DESCRIPTION
This PR changes the status code we use for `Error::ClientDisconnected`, for the purposes of our metrics labels, and catches errors when reading request bodies, turning them into `Error::ClientDisconnected` or `Error::BadRequest`. A unit test is included, to send crafted incomplete requests, and check the resulting metrics.

Closes #2515.