### PR TITLE
`integration_tests`: OHTTP report uploads

### DIFF
--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace = true
 in-cluster = ["dep:k8s-openapi", "dep:kube"]
 testcontainer = ["janus_interop_binaries/testcontainer"]
 in-cluster-rate-limits = []
+ohttp = []
 
 [dependencies]
 anyhow.workspace = true
@@ -25,7 +26,7 @@ http.workspace = true
 itertools.workspace = true
 janus_aggregator = { workspace = true, features = ["test-util"] }
 janus_aggregator_core = { workspace = true, features = ["test-util"] }
-janus_client.workspace = true
+janus_client = { workspace = true, features = ["ohttp"] }
 janus_collector.workspace = true
 janus_core = { workspace = true, features = ["test-util"] }
 janus_interop_binaries = { workspace = true, features = ["test-util"] }

--- a/integration_tests/src/client.rs
+++ b/integration_tests/src/client.rs
@@ -262,14 +262,19 @@ where
         let (leader_aggregator_endpoint, helper_aggregator_endpoint) = task_parameters
             .endpoint_fragments
             .endpoints_for_host_client(leader_port, helper_port);
-        let client = Client::new(
+        let mut builder = Client::builder(
             task_parameters.task_id,
             leader_aggregator_endpoint,
             helper_aggregator_endpoint,
             task_parameters.time_precision,
             vdaf,
-        )
-        .await?;
+        );
+
+        if let Some(ohttp_config) = &task_parameters.endpoint_fragments.ohttp_config {
+            builder = builder.with_ohttp_config(ohttp_config.clone());
+        }
+
+        let client = builder.build().await?;
         Ok(ClientImplementation::InProcess { client })
     }
 

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -1,6 +1,7 @@
 //! This crate contains functionality useful for Janus integration tests.
 
 use janus_aggregator_core::task::QueryType;
+use janus_client::OhttpConfig;
 use janus_collector::AuthenticationToken;
 use janus_core::{hpke::HpkeKeypair, vdaf::VdafInstance};
 use janus_messages::{Duration, TaskId};
@@ -98,6 +99,7 @@ impl AggregatorEndpointFragments {
 pub struct EndpointFragments {
     pub leader: AggregatorEndpointFragments,
     pub helper: AggregatorEndpointFragments,
+    pub ohttp_config: Option<OhttpConfig>,
 }
 
 impl EndpointFragments {

--- a/integration_tests/tests/integration/common.rs
+++ b/integration_tests/tests/integration/common.rs
@@ -60,6 +60,7 @@ pub fn build_test_task(
                         host: format!("helper-{endpoint_random_value}"),
                         path: "/".to_string(),
                     },
+                    ohttp_config: None,
                 },
             )
         }
@@ -73,6 +74,7 @@ pub fn build_test_task(
                 helper: AggregatorEndpointFragments::Localhost {
                     path: "/".to_string(),
                 },
+                ohttp_config: None,
             },
         ),
         #[cfg(feature = "in-cluster")]
@@ -86,6 +88,7 @@ pub fn build_test_task(
                 helper: AggregatorEndpointFragments::Remote {
                     url: task_builder.helper_aggregator_endpoint().clone(),
                 },
+                ohttp_config: None,
             },
         ),
     };


### PR DESCRIPTION
Add an integration test which configures its `janus_client::Client`s to upload over OHTTP. The OHTTP key configs and gateway are assumed to be adjacent to the leader's DAP API. The test only runs if feature `ohttp` is enabled.