### PR TITLE
Fix `janus_client` build in docs.rs

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -37,6 +37,8 @@
 //! }
 //! ```
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 use backoff::ExponentialBackoff;
 #[cfg(feature = "ohttp")]
 use bhttp::{ControlData, Message, Mode};


### PR DESCRIPTION
`janus_client` 0.7.16 failed to build in docs.rs ([1]), because I forgot to add the appropriate `cfg_attr` to that crate, as we do in `janus_core` and `janus_collector`.

[1]: https://docs.rs/crate/janus_client/0.7.16/builds/1234824