### PR TITLE
Stop accepting repeated, duplicate Authorization headers.

### DIFF
--- a/aggregator/src/aggregator/aggregate_init_tests.rs
+++ b/aggregator/src/aggregator/aggregate_init_tests.rs
@@ -309,32 +309,10 @@ pub(crate) async fn put_aggregation_job<Q: query_type::QueryType>(
     aggregation_job: &AggregationJobInitializeReq<Q>,
     handler: &impl Handler,
 ) -> TestConn {
-    put_aggregation_job_with_auth_header_count(
-        task,
-        aggregation_job_id,
-        aggregation_job,
-        handler,
-        1,
-    )
-    .await
-}
-
-pub(crate) async fn put_aggregation_job_with_auth_header_count<Q: query_type::QueryType>(
-    task: &Task,
-    aggregation_job_id: &AggregationJobId,
-    aggregation_job: &AggregationJobInitializeReq<Q>,
-    handler: &impl Handler,
-    auth_header_count: usize,
-) -> TestConn {
     let (header, value) = task.aggregator_auth_token().request_authentication();
 
-    let mut test_conn = put(task.aggregation_job_uri(aggregation_job_id).unwrap().path());
-
-    for _ in 0..auth_header_count {
-        test_conn = test_conn.with_request_header(header, value.clone());
-    }
-
-    test_conn
+    put(task.aggregation_job_uri(aggregation_job_id).unwrap().path())
+        .with_request_header(header, value)
         .with_request_header(
             KnownHeaderName::ContentType,
             AggregationJobInitializeReq::<Q>::MEDIA_TYPE,

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -8,7 +8,7 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use janus_aggregator_core::{datastore::Datastore, instrumented};
 use janus_core::{
     auth_tokens::{AuthenticationToken, DAP_AUTH_HEADER},
-    http::{extract_bearer_token, HeadersExt as _},
+    http::extract_bearer_token,
     taskprov::TASKPROV_HEADER,
     time::Clock,
     Runtime,
@@ -686,7 +686,7 @@ fn parse_auth_token(task_id: &TaskId, conn: &Conn) -> Result<Option<Authenticati
     }
 
     conn.request_headers()
-        .get_coalescing_duplicates(DAP_AUTH_HEADER) // TODO(#3163): get_coalescing_duplicates -> get
+        .get(DAP_AUTH_HEADER)
         .map(|value| {
             AuthenticationToken::new_dap_auth_token_from_bytes(value.as_ref())
                 .map_err(|e| Error::BadRequest(format!("bad DAP-Auth-Token header: {e}")))

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
@@ -1,7 +1,5 @@
 use crate::aggregator::{
-    aggregate_init_tests::{
-        put_aggregation_job, put_aggregation_job_with_auth_header_count, PrepareInitGenerator,
-    },
+    aggregate_init_tests::{put_aggregation_job, PrepareInitGenerator},
     empty_batch_aggregations,
     http_handlers::{
         aggregator_handler,
@@ -448,15 +446,9 @@ async fn aggregate_init() {
 
     // Send request, parse response. Do this twice to prove that the request is idempotent.
     let aggregation_job_id: AggregationJobId = random();
-    for auth_header_count in 1..=2 {
-        let mut test_conn = put_aggregation_job_with_auth_header_count(
-            &task,
-            &aggregation_job_id,
-            &request,
-            &handler,
-            auth_header_count,
-        )
-        .await;
+    for _ in 0..2 {
+        let mut test_conn =
+            put_aggregation_job(&task, &aggregation_job_id, &request, &handler).await;
         assert_eq!(test_conn.status(), Some(Status::Ok));
         assert_headers!(
             &test_conn,


### PR DESCRIPTION
The issue that led to us accepting this behavior has been fixed. Given that this behavior is not RFC-compliant, we remove it from Janus.