### PR TITLE
Upgrade to opentelemetry-rust 0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3538,9 +3538,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "opentelemetry"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
+checksum = "1b69a91d4893e713e06f724597ad630f1fa76057a5e1026c0ca67054a9032a76"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3548,21 +3548,19 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "thiserror",
- "urlencoding",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb"
+checksum = "a94c69209c05319cdf7460c6d4c055ed102be242a0a6245835d7bc42c6ec7f54"
 dependencies = [
  "async-trait",
  "futures-core",
  "http 0.2.12",
  "opentelemetry",
  "opentelemetry-proto",
- "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "prost",
  "thiserror",
@@ -3572,9 +3570,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-prometheus"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bbcf6341cab7e2193e5843f0ac36c446a5b3fccb28747afaeda17996dcd02e"
+checksum = "5e1a24eafe47b693cb938f8505f240dc26c71db60df9aca376b4f857e9653ec7"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -3585,9 +3583,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
+checksum = "984806e6cf27f2b49282e2a05e288f30594f3dbc74eb7a6e99422bc48ed78162"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -3597,23 +3595,23 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
+checksum = "1869fb4bb9b35c5ba8a1e40c9b128a7b4c010d07091e864a29da19e4fe2ca4d7"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e90c7113be649e31e9a0f8b5ee24ed7a16923b322c3c5ab6367469c049d6b7e"
+checksum = "ae312d58eaa90a82d2e627fd86e075cf5230b3f11794e2ed74199ebbe572d4fd"
 dependencies = [
  "async-std",
  "async-trait",
- "crossbeam-channel",
  "futures-channel",
  "futures-executor",
  "futures-util",
  "glob",
+ "lazy_static",
  "once_cell",
  "opentelemetry",
  "ordered-float 4.2.0",
@@ -5949,9 +5947,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9be14ba1bbe4ab79e9229f7f89fab8d120b865859f10527f31c033e599d2284"
+checksum = "f68803492bf28ab40aeccaecc7021096bd256baf7ca77c3d425d89b35a7be4e4"
 dependencies = [
  "js-sys",
  "once_cell",
@@ -6137,9 +6135,9 @@ dependencies = [
 
 [[package]]
 name = "trillium-opentelemetry"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63429771124359b50235c641649a9d5532b5b137a2b8a2ee1447961ea0706698"
+checksum = "8340d1e32a42a09fe4b790e965683a126acf5d9a0bbca8fc3722031efdad7907"
 dependencies = [
  "opentelemetry",
  "trillium",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,11 +64,11 @@ kube = { version = "0.90.0", default-features = false, features = ["client", "ru
 mockito = "1.4.0"
 num_enum = "0.7.2"
 ohttp = { version = "0.5.1", default-features = false }
-opentelemetry = { version = "0.22", features = ["metrics"] }
-opentelemetry-otlp = "0.15"
-opentelemetry-prometheus = "0.15"
-opentelemetry_sdk = { version = "0.22", features = ["metrics"] }
-opentelemetry-semantic-conventions = "0.14"
+opentelemetry = { version = "0.23", features = ["metrics"] }
+opentelemetry-otlp = "0.16"
+opentelemetry-prometheus = "0.16"
+opentelemetry_sdk = { version = "0.23", features = ["metrics"] }
+opentelemetry-semantic-conventions = "0.15"
 pem = "3"
 postgres-protocol = "0.6.6"
 postgres-types = "0.2.6"
@@ -105,7 +105,7 @@ thiserror = "1.0"
 tracing = "0.1.40"
 tracing-chrome = "0.7.2"
 tracing-log = "0.2.0"
-tracing-opentelemetry = "0.23"
+tracing-opentelemetry = "0.24"
 tracing-stackdriver = "0.10.0"
 tracing-subscriber = "0.3"
 tokio = { version = "1.38", features = ["full", "tracing"] }
@@ -117,7 +117,7 @@ trillium-api = { version = "0.2.0-rc.11", default-features = false }
 trillium-caching-headers = "0.2.3"
 trillium-head = "0.2.2"
 trillium-macros = "0.0.6"
-trillium-opentelemetry = "0.7.0"
+trillium-opentelemetry = "0.8.0"
 trillium-prometheus = "0.1.0"
 trillium-proxy = { version = "0.5.4", default-features = false }
 trillium-router = "0.3.6"


### PR DESCRIPTION
This upgrades all OTel crates. Dependabot did not propose this for the main branch for some reason, it reports `update_not_possible` many times.