### PR TITLE
Change integration test name arguments

### DIFF
--- a/integration_tests/tests/integration/in_cluster.rs
+++ b/integration_tests/tests/integration/in_cluster.rs
@@ -528,7 +528,7 @@ async fn in_cluster_count_ohttp() {
 
     // Run the behavioral test.
     submit_measurements_and_verify_aggregate(
-        "in_cluster_count",
+        "in_cluster_count_ohttp",
         &janus_pair.task_parameters,
         (janus_pair.leader.port(), janus_pair.helper.port()),
         &ClientBackend::InProcess,

--- a/integration_tests/tests/integration/janus.rs
+++ b/integration_tests/tests/integration/janus.rs
@@ -401,7 +401,7 @@ async fn janus_in_process_one_round_with_agg_param_fixed_size() {
     .await;
 
     submit_measurements_and_verify_aggregate_varying_aggregation_parameter(
-        "janus_in_process_one_round_with_agg_param",
+        "janus_in_process_one_round_with_agg_param_fixed_size",
         &janus_pair.task_parameters,
         &[
             dummy::AggregationParam(10),
@@ -429,7 +429,7 @@ async fn janus_in_process_one_round_with_agg_param_time_interval() {
     .await;
 
     submit_measurements_and_verify_aggregate_varying_aggregation_parameter(
-        "janus_in_process_one_round_with_agg_param",
+        "janus_in_process_one_round_with_agg_param_time_interval",
         &janus_pair.task_parameters,
         &[
             dummy::AggregationParam(10),


### PR DESCRIPTION
This changes some string literals so that each integration test gets its own directory when logs are saved.