### PR TITLE
DB migration for key rotator

### DIFF
--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -102,7 +102,7 @@ macro_rules! supported_schema_versions {
 // version is seen, [`Datastore::new`] fails.
 //
 // Note that the latest supported version must be first in the list.
-supported_schema_versions!(4, 3);
+supported_schema_versions!(5, 4, 3);
 
 /// Datastore represents a datastore for Janus, with support for transactional reads and writes.
 /// In practice, Datastore instances are currently backed by a PostgreSQL database.

--- a/db/00000000000005_global_hpke_keys_last_state_change_at.down.sql
+++ b/db/00000000000005_global_hpke_keys_last_state_change_at.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE global_hpke_keys DROP COLUMN last_state_change_at;

--- a/db/00000000000005_global_hpke_keys_last_state_change_at.up.sql
+++ b/db/00000000000005_global_hpke_keys_last_state_change_at.up.sql
@@ -1,0 +1,11 @@
+-- When the key state was last changed. Used for key rotation logic.
+ALTER TABLE global_hpke_keys
+    ADD COLUMN last_state_change_at TIMESTAMP NOT NULL DEFAULT '-infinity'::TIMESTAMP;
+
+-- Backfill new column using updated_at. Older Janus versions aren't aware of
+-- this column, so state change operations on this table won't update the new
+-- column. However, this is an infrequently used table that is only manually
+-- modified (at the time of writing), so the risk of corruption due to this is
+-- low. In the worst case, the key rotator service will induce a rotation of
+-- any keys with `-infinity`.
+UPDATE global_hpke_keys SET last_state_change_at = updated_at;


### PR DESCRIPTION
Supports https://github.com/divviup/janus/issues/2147.

It's generally risky to directly add a NOT NULL column with our usual migration workflow, because older versions of Janus missing application code won't know about the new column.

Work around this by using an intermediate `-infinity` default for the column. This works because `global_hpke_keys` is not frequently used at the moment, so the window of time where someone can insert or modify rows on the old Janus version is low. Even if they do, the worst case is that the key rotator induces an early rotation of the key.

This migration blocks readers while it's applied. However, readers run in a background task to refresh their cache of this table, so it's not a big deal if they're blocked for longer.