### PR TITLE
Fix unused opentelemetry-semantic-conventions dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2625,7 +2625,6 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-prometheus",
- "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "pem",
  "postgres-protocol",
@@ -3599,12 +3598,6 @@ dependencies = [
  "prost",
  "tonic 0.11.0",
 ]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1869fb4bb9b35c5ba8a1e40c9b128a7b4c010d07091e864a29da19e4fe2ca4d7"
 
 [[package]]
 name = "opentelemetry_sdk"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,6 @@ opentelemetry = { version = "0.23", features = ["metrics"] }
 opentelemetry-otlp = "0.16"
 opentelemetry-prometheus = "0.16"
 opentelemetry_sdk = { version = "0.23", features = ["metrics"] }
-opentelemetry-semantic-conventions = "0.15"
 pem = "3"
 postgres-protocol = "0.6.6"
 postgres-types = "0.2.6"

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -18,7 +18,6 @@ fpvec_bounded_l2 = ["dep:fixed", "janus_core/fpvec_bounded_l2"]
 tokio-console = ["dep:console-subscriber"]
 otlp = [
     "dep:opentelemetry-otlp",
-    "dep:opentelemetry-semantic-conventions",
     "dep:opentelemetry_sdk",
     "dep:tracing-opentelemetry",
 ]
@@ -67,7 +66,6 @@ moka = { version = "0.12.7", features = ["future"] }
 opentelemetry.workspace = true
 opentelemetry-otlp = { workspace = true, features = ["metrics"], optional = true }
 opentelemetry-prometheus = { workspace = true, optional = true }
-opentelemetry-semantic-conventions = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, features = ["rt-tokio"], optional = true }
 pem.workspace = true
 postgres-protocol = { workspace = true }


### PR DESCRIPTION
Closes #3209. We stopped using this directly almost a year ago, when we stopped setting the `service.name` resource attribute explicitly in the code, and instead let an SDK resource provider read it from an environment variable. Since then, this crate has been pulled in transitively by `opentelemetry-otlp`, but that stopped depending on it in `opentelemetry-otlp 0.16.0`.