### PR TITLE
tests: allow more client connections in test DB

### DIFF
--- a/aggregator_core/src/datastore/test_util.rs
+++ b/aggregator_core/src/datastore/test_util.rs
@@ -50,7 +50,13 @@ impl EphemeralDatabase {
 
     async fn start() -> Self {
         // Start an instance of Postgres running in a container.
-        let db_container = RunnableImage::from(Postgres::default()).start().await;
+        let db_container = RunnableImage::from(Postgres::default())
+            .with_args(Vec::from([
+                "-c".to_string(),
+                "max_connections=200".to_string(),
+            ]))
+            .start()
+            .await;
         const POSTGRES_DEFAULT_PORT: u16 = 5432;
         let port_number = db_container.get_host_port_ipv4(POSTGRES_DEFAULT_PORT).await;
         trace!("Postgres container is up with port {port_number}");


### PR DESCRIPTION
On my machine I get intermittent errors like
```
---- binaries::janus_cli::tests::set_global_hpke_key_state stdout ----
thread 'binaries::janus_cli::tests::set_global_hpke_key_state' panicked at /home/inahga/Projects/janus/aggregator_core/src/datastore/test_util.rs:269:78:
called `Result::unwrap()` on an `Err` value: Database(PgDatabaseError { severity: Fatal, code: "53300", message: "sorry, too many clients already", detail: None, hint: None, position: None, where: None, schema: None, table: None, column: None, data_type: None, constraint: None, file: Some("proc.c"), line: Some(357), routine: Some("InitProcess") })
```
when running tests. Bump the number of connections allowed in the test DB.