### PR TITLE
Add Unicode license V3 to allow-list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -32,6 +32,7 @@ allow = [
     "BSD-3-Clause",
     "ISC",
     "Unicode-DFS-2016",
+    "Unicode-3.0",
     "OpenSSL",
     "Unlicense",
     "CC0-1.0",


### PR DESCRIPTION
ISRG counsel has reviewed the license
(https://opensource.org/license/unicode-license-v3) and deemed it "harmless", so allow it in our `cargo deny` config. This will unblock `url` updates (#3214, #3223).