### PR TITLE
Ignore const_is_empty lint

### DIFF
--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -35,6 +35,11 @@ use trillium_api::ApiConnExt;
 use url::Url;
 
 #[cfg(feature = "testcontainer")]
+// Consts in this module are derived from `include_bytes!()`. If the target file is empty at
+// lint-time, they'll be empty, so this lint does us no good. This lint is only on Rust >1.79, so
+// we have to ignore unknown lints for MSRVs.
+#[allow(unknown_lints)]
+#[allow(clippy::const_is_empty)]
 pub mod testcontainer;
 
 pub mod status {


### PR DESCRIPTION
This lint does us no good, since `INTEROP_CLIENT_IMAGE_BYTES` et. al. are defined as
```rust
const INTEROP_AGGREGATOR_IMAGE_BYTES: &[u8] =
    include_bytes!(concat!(env!("OUT_DIR"), "/interop_aggregator.tar.zst"));
```
so if that file is absent at linting time, it will flag.