### PR TITLE
Integration test: use same time in all reports

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -34,7 +34,7 @@ jobs:
       id: default-input-values
       run: |
         DIVVIUP_TS_INTEROP_CONTAINER= ${{ inputs.divviup_ts_interop_container }}
-        echo "divviup_ts_interop_container=${DIVVIUP_TS_INTEROP_CONTAINER:-us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-ts/divviup_ts_interop_client:4e71c8b@sha256:61d1bf4cb731d0637b2c5489c45def0155ac22411c4e97607e6cff67cf135198}" >> $GITHUB_OUTPUT
+        echo "divviup_ts_interop_container=${DIVVIUP_TS_INTEROP_CONTAINER:-us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-ts/divviup_ts_interop_client:e2bd57d@sha256:ea32ec6d1e6522d4282b644e9885aeb30a0a92877f73e27424e9e00844b9a80c}" >> $GITHUB_OUTPUT
     - name: Get OS version
       id: os-version
       run: echo "release=$(lsb_release --release --short)" >> $GITHUB_OUTPUT

--- a/integration_tests/tests/integration/common.rs
+++ b/integration_tests/tests/integration/common.rs
@@ -204,12 +204,15 @@ where
 {
     // Submit some measurements, recording a timestamp before measurement upload to allow us to
     // determine the correct collect interval. (for time interval tasks)
-    let before_timestamp = RealClock::default().now();
+    let time = RealClock::default().now();
     for measurement in measurements.iter() {
-        client_implementation.upload(measurement).await.unwrap();
+        client_implementation
+            .upload(measurement, time)
+            .await
+            .unwrap();
     }
 
-    before_timestamp
+    time
 }
 
 pub async fn verify_aggregate_generic<V>(


### PR DESCRIPTION
This changes the integration tests to use the same timestamp in all uploaded reports. This removes one potential source of flakiness in the time-bucketed fixed size test, by keeping the reports from getting split into two time buckets.