### PR TITLE
Set default rustls crypto provider, 0.6 backport

### DIFF
--- a/integration_tests/tests/integration/daphne.rs
+++ b/integration_tests/tests/integration/daphne.rs
@@ -1,4 +1,7 @@
-use crate::common::{submit_measurements_and_verify_aggregate, test_task_builder};
+use crate::{
+    common::{submit_measurements_and_verify_aggregate, test_task_builder},
+    initialize_rustls,
+};
 use janus_aggregator_core::task::QueryType;
 use janus_core::{test_util::install_test_trace_subscriber, vdaf::VdafInstance};
 #[cfg(feature = "testcontainer")]
@@ -17,6 +20,7 @@ use std::time::Duration;
 async fn daphne_janus() {
     static TEST_NAME: &str = "daphne_janus";
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start servers.
     let network = generate_network_name();
@@ -58,6 +62,7 @@ async fn daphne_janus() {
 async fn janus_daphne() {
     static TEST_NAME: &str = "janus_daphne";
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start servers.
     let network = generate_network_name();
@@ -99,6 +104,7 @@ async fn janus_daphne() {
 async fn janus_in_process_daphne() {
     static TEST_NAME: &str = "janus_in_process_daphne";
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start servers.
     let network = generate_network_name();

--- a/integration_tests/tests/integration/divviup_ts.rs
+++ b/integration_tests/tests/integration/divviup_ts.rs
@@ -1,7 +1,10 @@
 #![cfg(feature = "testcontainer")]
 //! These tests check interoperation between the divviup-ts client and Janus aggregators.
 
-use crate::common::{submit_measurements_and_verify_aggregate, test_task_builder};
+use crate::{
+    common::{submit_measurements_and_verify_aggregate, test_task_builder},
+    initialize_rustls,
+};
 use janus_aggregator_core::task::QueryType;
 use janus_core::{test_util::install_test_trace_subscriber, vdaf::VdafInstance};
 use janus_integration_tests::{
@@ -40,6 +43,7 @@ async fn run_divviup_ts_integration_test(test_name: &str, vdaf: VdafInstance) {
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_divviup_ts_count() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     run_divviup_ts_integration_test("janus_divviup_ts_count", VdafInstance::Prio3Count).await;
 }
@@ -47,6 +51,7 @@ async fn janus_divviup_ts_count() {
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_divviup_ts_sum() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     run_divviup_ts_integration_test("janus_divviup_ts_sum", VdafInstance::Prio3Sum { bits: 8 })
         .await;
@@ -55,6 +60,7 @@ async fn janus_divviup_ts_sum() {
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_divviup_ts_histogram() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     run_divviup_ts_integration_test(
         "janus_divviup_ts_histogram",
@@ -69,6 +75,7 @@ async fn janus_divviup_ts_histogram() {
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_divviup_ts_sumvec() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     run_divviup_ts_integration_test(
         "janus_divviup_ts_sumvec",

--- a/integration_tests/tests/integration/in_cluster.rs
+++ b/integration_tests/tests/integration/in_cluster.rs
@@ -1,7 +1,10 @@
 #![cfg(feature = "in-cluster")]
 
-use crate::common::{
-    submit_measurements_and_verify_aggregate, test_task_builder, test_task_builder_remote,
+use crate::{
+    common::{
+        submit_measurements_and_verify_aggregate, test_task_builder, test_task_builder_remote,
+    },
+    initialize_rustls,
 };
 use chrono::prelude::*;
 use clap::{CommandFactory, FromArgMatches, Parser};
@@ -487,6 +490,7 @@ impl InClusterJanus {
 #[tokio::test(flavor = "multi_thread")]
 async fn in_cluster_count() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start port forwards and set up task.
     let janus_pair =
@@ -505,6 +509,7 @@ async fn in_cluster_count() {
 #[tokio::test(flavor = "multi_thread")]
 async fn in_cluster_sum() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start port forwards and set up task.
     let janus_pair =
@@ -523,6 +528,7 @@ async fn in_cluster_sum() {
 #[tokio::test(flavor = "multi_thread")]
 async fn in_cluster_histogram() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start port forwards and set up task.
     let janus_pair = InClusterJanusPair::new(
@@ -547,6 +553,7 @@ async fn in_cluster_histogram() {
 #[tokio::test(flavor = "multi_thread")]
 async fn in_cluster_fixed_size() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start port forwards and set up task.
     let janus_pair = InClusterJanusPair::new(
@@ -571,6 +578,7 @@ async fn in_cluster_fixed_size() {
 #[cfg(feature = "in-cluster-rate-limits")]
 mod rate_limits {
     use super::InClusterJanusPair;
+    use crate::initialize_rustls;
     use assert_matches::assert_matches;
     use http::Method;
     use janus_aggregator_core::task::QueryType;
@@ -627,6 +635,7 @@ mod rate_limits {
         method: Method,
     ) {
         install_test_trace_subscriber();
+        initialize_rustls();
         let test_config = TestConfig::load();
 
         let janus_pair =

--- a/integration_tests/tests/integration/janus.rs
+++ b/integration_tests/tests/integration/janus.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "testcontainer")]
 use crate::common::test_task_builder;
-use crate::common::{submit_measurements_and_verify_aggregate, test_task_builder_host};
+use crate::{
+    common::{submit_measurements_and_verify_aggregate, test_task_builder_host},
+    initialize_rustls,
+};
 use janus_aggregator_core::task::QueryType;
 use janus_core::{test_util::install_test_trace_subscriber, vdaf::VdafInstance};
 #[cfg(feature = "testcontainer")]
@@ -98,6 +101,7 @@ impl JanusInProcessPair {
 async fn janus_janus_count() {
     static TEST_NAME: &str = "janus_janus_count";
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start servers.
     let janus_pair =
@@ -117,6 +121,7 @@ async fn janus_janus_count() {
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_in_process_count() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start servers.
     let janus_pair =
@@ -138,6 +143,7 @@ async fn janus_in_process_count() {
 async fn janus_janus_sum_16() {
     static TEST_NAME: &str = "janus_janus_sum_16";
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start servers.
     let janus_pair = JanusContainerPair::new(
@@ -161,6 +167,7 @@ async fn janus_janus_sum_16() {
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_in_process_sum_16() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start servers.
     let janus_pair =
@@ -182,6 +189,7 @@ async fn janus_in_process_sum_16() {
 async fn janus_janus_histogram_4_buckets() {
     static TEST_NAME: &str = "janus_janus_histogram_4_buckets";
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start servers.
     let janus_pair = JanusContainerPair::new(
@@ -208,6 +216,7 @@ async fn janus_janus_histogram_4_buckets() {
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_in_process_histogram_4_buckets() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start servers.
     let janus_pair = JanusInProcessPair::new(
@@ -235,6 +244,7 @@ async fn janus_in_process_histogram_4_buckets() {
 async fn janus_janus_fixed_size() {
     static TEST_NAME: &str = "janus_janus_fixed_size";
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start servers.
     let janus_pair = JanusContainerPair::new(
@@ -261,6 +271,7 @@ async fn janus_janus_fixed_size() {
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_in_process_fixed_size() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // Start servers.
     let janus_pair = JanusInProcessPair::new(
@@ -288,6 +299,7 @@ async fn janus_in_process_fixed_size() {
 async fn janus_janus_sum_vec() {
     static TEST_NAME: &str = "janus_janus_sum_vec";
     install_test_trace_subscriber();
+    initialize_rustls();
 
     let janus_pair = JanusContainerPair::new(
         TEST_NAME,
@@ -313,6 +325,7 @@ async fn janus_janus_sum_vec() {
 #[tokio::test(flavor = "multi_thread")]
 async fn janus_in_process_sum_vec() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     let janus_pair = JanusInProcessPair::new(
         VdafInstance::Prio3SumVec {

--- a/integration_tests/tests/integration/main.rs
+++ b/integration_tests/tests/integration/main.rs
@@ -3,3 +3,10 @@ mod daphne;
 mod divviup_ts;
 mod in_cluster;
 mod janus;
+
+fn initialize_rustls() {
+    // Choose aws-lc-rs as the default rustls crypto provider. This is what's currently enabled by
+    // the default Cargo feature. Specifying a default provider here prevents runtime errors if
+    // another dependency also enables the ring feature.
+    let _ = trillium_rustls::rustls::crypto::aws_lc_rs::default_provider().install_default();
+}


### PR DESCRIPTION
This PR sets the default rustls crypto provider at various entry points. This is a backport of parts of #2973, #3063, and #3082. This should unblock #3241.