### PR TITLE
Feature flag for requiring global HPKE keys

### DIFF
--- a/aggregator/src/aggregator/http_handlers/tests/hpke_config.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/hpke_config.rs
@@ -6,7 +6,7 @@ use crate::{
             HPKE_CONFIG_SIGNATURE_HEADER,
         },
         test_util::{hpke_config_signing_key, hpke_config_verification_key},
-        Config,
+        Aggregator, Config,
     },
     config::TaskprovConfig,
 };
@@ -375,4 +375,62 @@ async fn verify_and_decode_hpke_config_list(test_conn: &mut TestConn) -> HpkeCon
         .verify(&response_body, &signature)
         .unwrap();
     HpkeConfigList::get_decoded(&response_body).unwrap()
+}
+
+#[tokio::test]
+async fn require_global_hpke_keys() {
+    let (clock, _ephemeral_datastore, datastore, _) = setup_http_handler_test().await;
+
+    // Insert an HPKE config, i.e. start the application with a keypair already
+    // in the database.
+    let keypair = generate_test_hpke_config_and_private_key_with_id(1);
+    datastore
+        .run_unnamed_tx(|tx| {
+            let keypair = keypair.clone();
+            Box::pin(async move {
+                tx.put_global_hpke_keypair(&keypair).await.unwrap();
+                tx.set_global_hpke_keypair_state(keypair.config().id(), &HpkeKeyState::Active)
+                    .await
+                    .unwrap();
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
+
+    let cfg = Config {
+        require_global_hpke_keys: true,
+        hpke_config_signing_key: Some(hpke_config_signing_key()),
+        ..Default::default()
+    };
+
+    let aggregator = Arc::new(
+        Aggregator::new(
+            Arc::clone(&datastore),
+            clock.clone(),
+            TestRuntime::default(),
+            &noop_meter(),
+            cfg,
+        )
+        .await
+        .unwrap(),
+    );
+
+    let handler = aggregator_handler_with_aggregator(aggregator.clone(), &noop_meter())
+        .await
+        .unwrap();
+
+    let mut test_conn = get(&format!("/hpke_config?task_id={}", &random::<TaskId>()))
+        .run_async(&handler)
+        .await;
+    assert_eq!(test_conn.status(), Some(Status::Ok));
+    let hpke_config_list = verify_and_decode_hpke_config_list(&mut test_conn).await;
+    assert_eq!(hpke_config_list.hpke_configs(), &[keypair.config().clone()]);
+    check_hpke_config_is_usable(&hpke_config_list, &keypair);
+
+    let mut test_conn = get(&format!("/hpke_config")).run_async(&handler).await;
+    assert_eq!(test_conn.status(), Some(Status::Ok));
+    let hpke_config_list = verify_and_decode_hpke_config_list(&mut test_conn).await;
+    assert_eq!(hpke_config_list.hpke_configs(), &[keypair.config().clone()]);
+    check_hpke_config_is_usable(&hpke_config_list, &keypair);
 }

--- a/aggregator/src/aggregator/http_handlers/tests/hpke_config.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/hpke_config.rs
@@ -428,7 +428,7 @@ async fn require_global_hpke_keys() {
     assert_eq!(hpke_config_list.hpke_configs(), &[keypair.config().clone()]);
     check_hpke_config_is_usable(&hpke_config_list, &keypair);
 
-    let mut test_conn = get(&format!("/hpke_config")).run_async(&handler).await;
+    let mut test_conn = get("/hpke_config").run_async(&handler).await;
     assert_eq!(test_conn.status(), Some(Status::Ok));
     let hpke_config_list = verify_and_decode_hpke_config_list(&mut test_conn).await;
     assert_eq!(hpke_config_list.hpke_configs(), &[keypair.config().clone()]);

--- a/aggregator/src/aggregator/key_rotator.rs
+++ b/aggregator/src/aggregator/key_rotator.rs
@@ -83,6 +83,17 @@ pub struct HpkeKeyRotatorConfig {
     pub ciphersuites: HashSet<HpkeCiphersuite>,
 }
 
+impl Default for HpkeKeyRotatorConfig {
+    fn default() -> Self {
+        Self {
+            pending_duration: default_pending_duration(),
+            active_duration: default_active_duration(),
+            expired_duration: default_expired_duration(),
+            ciphersuites: default_hpke_ciphersuites(),
+        }
+    }
+}
+
 impl<C: Clock> KeyRotator<C> {
     pub fn new(datastore: Arc<Datastore<C>>, hpke: HpkeKeyRotatorConfig) -> Self {
         Self { datastore, hpke }

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -15,7 +15,7 @@ use janus_aggregator_core::{
     datastore::{
         models::{
             AggregateShareJob, AggregationJob, AggregationJobState, BatchAggregation,
-            BatchAggregationState, ReportAggregation, ReportAggregationState,
+            BatchAggregationState, HpkeKeyState, ReportAggregation, ReportAggregationState,
         },
         test_util::{ephemeral_datastore, EphemeralDatastore},
         Datastore,
@@ -138,6 +138,12 @@ where
                 let peer_aggregator = peer_aggregator.clone();
                 Box::pin(async move {
                     tx.put_global_hpke_keypair(&global_hpke_key).await.unwrap();
+                    tx.set_global_hpke_keypair_state(
+                        &global_hpke_key.config().id(),
+                        &HpkeKeyState::Active,
+                    )
+                    .await
+                    .unwrap();
                     tx.put_taskprov_peer_aggregator(&peer_aggregator)
                         .await
                         .unwrap();

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -139,7 +139,7 @@ where
                 Box::pin(async move {
                     tx.put_global_hpke_keypair(&global_hpke_key).await.unwrap();
                     tx.set_global_hpke_keypair_state(
-                        &global_hpke_key.config().id(),
+                        global_hpke_key.config().id(),
                         &HpkeKeyState::Active,
                     )
                     .await

--- a/aggregator/src/binaries/aggregator.rs
+++ b/aggregator/src/binaries/aggregator.rs
@@ -394,6 +394,11 @@ pub struct Config {
     /// [`TASK_AGGREGATOR_CACHE_DEFAULT_CAPACITY`]. You shouldn't normally have to specify this.
     #[serde(default)]
     pub task_cache_capacity: Option<u64>,
+
+    /// Experimental. Always advertise global HPKE keys instead of per-task HPKE keys. This will
+    /// become on by default in a future version of Janus.
+    #[serde(default)]
+    pub require_global_hpke_keys: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -467,6 +472,7 @@ impl Config {
                 .task_cache_capacity
                 .unwrap_or(TASK_AGGREGATOR_CACHE_DEFAULT_CAPACITY),
             log_forbidden_mutations: self.log_forbidden_mutations.clone(),
+            require_global_hpke_keys: self.require_global_hpke_keys.is_some_and(|r| r),
         })
     }
 }
@@ -598,6 +604,7 @@ mod tests {
             task_cache_ttl_seconds: None,
             task_cache_capacity: None,
             log_forbidden_mutations: Some(PathBuf::from("/tmp/events")),
+            require_global_hpke_keys: Some(true),
         })
     }
 

--- a/aggregator/src/binaries/aggregator.rs
+++ b/aggregator/src/binaries/aggregator.rs
@@ -398,7 +398,7 @@ pub struct Config {
     /// Experimental. Always advertise global HPKE keys instead of per-task HPKE keys. This will
     /// become on by default in a future version of Janus.
     #[serde(default)]
-    pub require_global_hpke_keys: Option<bool>,
+    pub require_global_hpke_keys: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -472,7 +472,7 @@ impl Config {
                 .task_cache_capacity
                 .unwrap_or(TASK_AGGREGATOR_CACHE_DEFAULT_CAPACITY),
             log_forbidden_mutations: self.log_forbidden_mutations.clone(),
-            require_global_hpke_keys: self.require_global_hpke_keys.is_some_and(|r| r),
+            require_global_hpke_keys: self.require_global_hpke_keys,
         })
     }
 }
@@ -604,7 +604,7 @@ mod tests {
             task_cache_ttl_seconds: None,
             task_cache_capacity: None,
             log_forbidden_mutations: Some(PathBuf::from("/tmp/events")),
-            require_global_hpke_keys: Some(true),
+            require_global_hpke_keys: true,
         })
     }
 

--- a/aggregator/src/binaries/key_rotator.rs
+++ b/aggregator/src/binaries/key_rotator.rs
@@ -76,7 +76,7 @@ impl BinaryConfig for Config {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct KeyRotatorConfig {
     #[serde(deserialize_with = "deserialize_hpke_key_rotator_config")]
     pub hpke: HpkeKeyRotatorConfig,

--- a/aggregator/tests/integration/graceful_shutdown.rs
+++ b/aggregator/tests/integration/graceful_shutdown.rs
@@ -315,7 +315,7 @@ async fn aggregator_shutdown() {
         task_cache_ttl_seconds: None,
         task_cache_capacity: None,
         log_forbidden_mutations: None,
-        require_global_hpke_keys: None,
+        require_global_hpke_keys: false,
     };
 
     graceful_shutdown("aggregator", config).await;

--- a/aggregator/tests/integration/graceful_shutdown.rs
+++ b/aggregator/tests/integration/graceful_shutdown.rs
@@ -315,6 +315,7 @@ async fn aggregator_shutdown() {
         task_cache_ttl_seconds: None,
         task_cache_capacity: None,
         log_forbidden_mutations: None,
+        require_global_hpke_keys: None,
     };
 
     graceful_shutdown("aggregator", config).await;

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -171,7 +171,7 @@ impl JanusInProcess {
             task_cache_ttl_seconds: None,
             task_cache_capacity: None,
             log_forbidden_mutations: None,
-            require_global_hpke_keys: None,
+            require_global_hpke_keys: false,
         };
         let aggregation_job_creator_options = AggregationJobCreatorOptions {
             common: common_binary_options.clone(),

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -171,6 +171,7 @@ impl JanusInProcess {
             task_cache_ttl_seconds: None,
             task_cache_capacity: None,
             log_forbidden_mutations: None,
+            require_global_hpke_keys: None,
         };
         let aggregation_job_creator_options = AggregationJobCreatorOptions {
             common: common_binary_options.clone(),

--- a/interop_binaries/config/janus_interop_aggregator.yaml
+++ b/interop_binaries/config/janus_interop_aggregator.yaml
@@ -13,3 +13,4 @@ logging_config:
   force_json_output: true
 listen_address: 0.0.0.0:8080
 aggregator_address: 127.0.0.1:8081
+require_global_hpke_keys: true

--- a/interop_binaries/config/key_rotator.yaml
+++ b/interop_binaries/config/key_rotator.yaml
@@ -1,0 +1,7 @@
+# This configuration file is used in the janus_interop_aggregator container
+# image.
+database:
+  url: postgres://postgres@127.0.0.1:5432/postgres
+  check_schema_version: false
+key_rotator:
+  hpke: {}

--- a/interop_binaries/config/supervisord.conf
+++ b/interop_binaries/config/supervisord.conf
@@ -46,6 +46,13 @@ environment=DATASTORE_KEYS=OSjfC8QVPATwO3uVJcAnTA
 stdout_logfile=/logs/collection_job_driver_stdout.log
 stderr_logfile=/logs/collection_job_driver_stderr.log
 
+[program:key_rotator]
+command=/usr/local/bin/janus_aggregator key_rotator --config-file /etc/janus/key_rotator.yaml
+autostart=false
+environment=DATASTORE_KEYS=OSjfC8QVPATwO3uVJcAnTA
+stdout_logfile=/logs/key_rotator_stdout.log
+stderr_logfile=/logs/key_rotator_stderr.log
+
 [program:postgres]
 command=/usr/local/bin/docker-entrypoint.sh postgres
 autostart=true

--- a/interop_binaries/setup.sh
+++ b/interop_binaries/setup.sh
@@ -8,3 +8,4 @@ sqlx migrate run --source /etc/janus/migrations --database-url postgres://postgr
 /usr/bin/supervisorctl -c /etc/janus/supervisord.conf start aggregation_job_creator
 /usr/bin/supervisorctl -c /etc/janus/supervisord.conf start aggregation_job_driver
 /usr/bin/supervisorctl -c /etc/janus/supervisord.conf start collection_job_driver
+/usr/bin/supervisorctl -c /etc/janus/supervisord.conf start key_rotator


### PR DESCRIPTION
Supports https://github.com/divviup/janus/issues/2147.

Introduces a feature flag `require_global_hpke_keys`. When this is enabled:
- The `GlobalHpkeKeypairCache` blocks and retries fetching keys until it gets a list containing at least one active key. This is a bootstrapping case--it allows for the key rotator to do initialization, whether it's running in-process or separately.
- The `/hpke_configs` endpoint unconditionally returns global keys, regardless of the `?task_id` parameter.

Draft, as it needs refactoring and more testing. Looking for feedback on whether the overall approach is sane.