### PR TITLE
Fix unused import warning

### DIFF
--- a/integration_tests/tests/integration/in_cluster.rs
+++ b/integration_tests/tests/integration/in_cluster.rs
@@ -10,6 +10,7 @@ use divviup_client::{
     Client, DivviupClient, Histogram, HpkeConfig, NewAggregator, NewSharedAggregator, NewTask, Vdaf,
 };
 use janus_aggregator_core::task::{test_util::TaskBuilder, QueryType};
+#[cfg(feature = "ohttp")]
 use janus_client::OhttpConfig;
 use janus_collector::PrivateCollectorCredential;
 use janus_core::{


### PR DESCRIPTION
This fixes an unused import warning that's showing up in CI tests.