### PR TITLE
Document more configuration options and fix errors

### DIFF
--- a/aggregator/src/binaries/janus_cli.rs
+++ b/aggregator/src/binaries/janus_cli.rs
@@ -1348,7 +1348,6 @@ mod tests {
   min_batch_size: 10
   time_precision: 300
   tolerable_clock_skew: 600
-  input_share_aad_public_share_length_prefix: false
   collector_hpke_config:
     id: 23
     kem_id: X25519HkdfSha256
@@ -1373,7 +1372,6 @@ mod tests {
   min_batch_size: 10
   time_precision: 300
   tolerable_clock_skew: 600
-  input_share_aad_public_share_length_prefix: false
   collector_hpke_config:
     id: 23
     kem_id: X25519HkdfSha256

--- a/aggregator/src/binaries/janus_cli.rs
+++ b/aggregator/src/binaries/janus_cli.rs
@@ -1381,7 +1381,7 @@ mod tests {
   aggregator_auth_token_hash:
     type: Bearer
     hash: MJOoBO_ysLEuG_lv2C37eEOf1Ngetsr-Ers0ZYj4vdQ
-  collector_auth_token:
+  collector_auth_token_hash:
   hpke_keys: []
 "#;
 

--- a/docs/samples/advanced_config/aggregation_job_creator.yaml
+++ b/docs/samples/advanced_config/aggregation_job_creator.yaml
@@ -20,6 +20,11 @@ database:
   # TLS will never be used. (optional)
   tls_trust_store_path: /path/to/file.pem
 
+# The maximum number of times a transaction can be retried. This is intended to
+# guard against bugs that induce infinite retries. It should be set to a
+# reasonably high limit to prevent legitimate work from being cancelled.
+max_transaction_retries: 1000
+
 # Socket address for /healthz and /traceconfigz HTTP requests. Defaults to 127.0.0.1:9001.
 health_check_listen_address: "0.0.0.0:8000"
 

--- a/docs/samples/advanced_config/aggregation_job_creator.yaml
+++ b/docs/samples/advanced_config/aggregation_job_creator.yaml
@@ -49,9 +49,6 @@ logging_config:
     otlp:
       # OTLP gRPC endpoint.
       endpoint: "https://example.com"
-      # gRPC metadata to send with OTLP requests. (optional)
-      metadata:
-        key: "value"
 
   # Flag to write tracing spans and events to JSON files. This is compatible
   # with Chrome's trace viewer, available at `chrome://tracing`, and
@@ -72,9 +69,6 @@ metrics_config:
   ##otlp:
   ##  # OTLP gRPC endpoint.
   ##  endpoint: "https://example.com/"
-  ##  # gRPC metadata to send with OTLP requests. (optional)
-  ##  metadata:
-  ##    key: "value"
 
   # Configuration for Tokio runtime metrics. (optional)
   tokio:

--- a/docs/samples/advanced_config/aggregation_job_creator.yaml
+++ b/docs/samples/advanced_config/aggregation_job_creator.yaml
@@ -5,7 +5,7 @@ database:
   url: "postgres://postgres:postgres@localhost:5432/postgres"
 
   # Timeout for new database connections. Defaults to 60 seconds.
-  connection_pool_timeout_secs: 60
+  connection_pool_timeouts_secs: 60
 
   # Maximum number of database connections. Defaults to CPUs * 4.
   connection_pool_max_size: 8
@@ -75,7 +75,7 @@ metrics_config:
     # Enable exporting metrics from the Tokio runtime. If this is true, the
     # binary must have been compiled with the flag `--cfg tokio_unstable`.
     # (optional)
-    enable: false
+    enabled: false
     # Enable a histogram of task poll times. This introduces some additional
     # overhead. (optional)
     enable_poll_time_histogram: false

--- a/docs/samples/advanced_config/aggregation_job_driver.yaml
+++ b/docs/samples/advanced_config/aggregation_job_driver.yaml
@@ -20,6 +20,11 @@ database:
   # TLS will never be used. (optional)
   tls_trust_store_path: /path/to/file.pem
 
+# The maximum number of times a transaction can be retried. This is intended to
+# guard against bugs that induce infinite retries. It should be set to a
+# reasonably high limit to prevent legitimate work from being cancelled.
+max_transaction_retries: 1000
+
 # Socket address for /healthz and /traceconfigz HTTP requests. Defaults to 127.0.0.1:9001.
 health_check_listen_address: "0.0.0.0:8000"
 
@@ -119,6 +124,18 @@ http_request_connection_timeout_secs: 10
 # https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.timeout for details.
 # (optional; defaults to 30 seconds)
 http_request_timeout_secs: 30
+
+# The initial interval, in milliseconds, to wait before retrying a retryable
+# HTTP request. (optional, default 1 second)
+retry_initial_interval_millis: 1000
+
+# The maximum interval, in milliseconds, to wait before retrying a retryable
+# HTTP request. (optional, default 30 seconds)
+retry_max_interval_millis: 30000
+
+# The maximum elapsed time, in milliseconds, to wait before giving up on
+# retrying a retryable HTTP request. (optional, default 5 minutes)
+retry_max_elapsed_time_millis: 300000
 
 # Number of sharded database records per batch aggregation. Must not be greater
 # than the equivalent setting in the collection job driver. (required)

--- a/docs/samples/advanced_config/aggregation_job_driver.yaml
+++ b/docs/samples/advanced_config/aggregation_job_driver.yaml
@@ -49,9 +49,6 @@ logging_config:
     otlp:
       # OTLP gRPC endpoint.
       endpoint: "https://example.com"
-      # gRPC metadata to send with OTLP requests. (optional)
-      metadata:
-        key: "value"
 
   # Flag to write tracing spans and events to JSON files. This is compatible
   # with Chrome's trace viewer, available at `chrome://tracing`, and
@@ -72,9 +69,6 @@ metrics_config:
   ##otlp:
   ##  # OTLP gRPC endpoint.
   ##  endpoint: "https://example.com/"
-  ##  # gRPC metadata to send with OTLP requests. (optional)
-  ##  metadata:
-  ##    key: "value"
 
   # Configuration for Tokio runtime metrics. (optional)
   tokio:

--- a/docs/samples/advanced_config/aggregation_job_driver.yaml
+++ b/docs/samples/advanced_config/aggregation_job_driver.yaml
@@ -5,7 +5,7 @@ database:
   url: "postgres://postgres:postgres@localhost:5432/postgres"
 
   # Timeout for new database connections. Defaults to 60 seconds.
-  connection_pool_timeout_secs: 60
+  connection_pool_timeouts_secs: 60
 
   # Maximum number of database connections. Defaults to CPUs * 4.
   connection_pool_max_size: 8
@@ -75,7 +75,7 @@ metrics_config:
     # Enable exporting metrics from the Tokio runtime. If this is true, the
     # binary must have been compiled with the flag `--cfg tokio_unstable`.
     # (optional)
-    enable: false
+    enabled: false
     # Enable a histogram of task poll times. This introduces some additional
     # overhead. (optional)
     enable_poll_time_histogram: false

--- a/docs/samples/advanced_config/aggregator.yaml
+++ b/docs/samples/advanced_config/aggregator.yaml
@@ -20,6 +20,11 @@ database:
   # TLS will never be used. (optional)
   tls_trust_store_path: /path/to/file.pem
 
+# The maximum number of times a transaction can be retried. This is intended to
+# guard against bugs that induce infinite retries. It should be set to a
+# reasonably high limit to prevent legitimate work from being cancelled.
+max_transaction_retries: 1000
+
 # Socket address for /healthz and /traceconfigz HTTP requests. Defaults to 127.0.0.1:9001.
 health_check_listen_address: "0.0.0.0:8000"
 
@@ -163,6 +168,14 @@ garbage_collection:
   # of the garbage collector.
   collection_limit: 50
 
+  # The maximum number of tasks to process together for GC in a single database
+  # transaction. (optional)
+  tasks_per_tx: 1
+
+  # The maximum number of concurrent database transactions to open at once while
+  # processing GC. Leaving this unset means there is no maximum. (optional)
+  concurrent_tx_limit: null
+
 # Configuration for key rotator. Allows running the key rotator as part of the aggregator process.
 # If omitted, you should run the key rotator as a separate cronjob.
 key_rotator:
@@ -190,3 +203,17 @@ key_rotator:
       - kem_id: P521HkdfSha512
         kdf_id: HkdfSha512
         aead_id: Aes256Gcm
+
+# Defines how often to refresh the global HPKE configs cache, in milliseconds.
+# This affects how often an aggregator becomes aware of key state changes.
+# (optional, defaults to 30 minutes)
+global_hpke_configs_refresh_interval: 1800000
+
+# Defines how long to cache tasks for, in seconds. This affects how soon the
+# aggregator becomes aware of task parameter changes. (optional, defaults to 10
+# minutes)
+task_cache_ttl_seconds: 600
+
+# Defines how many tasks can be cached. This affects how much memory the
+# aggregator might use to store cached tasks. (optional)
+task_cache_capacity: 10000

--- a/docs/samples/advanced_config/aggregator.yaml
+++ b/docs/samples/advanced_config/aggregator.yaml
@@ -49,9 +49,6 @@ logging_config:
     otlp:
       # OTLP gRPC endpoint.
       endpoint: "https://example.com"
-      # gRPC metadata to send with OTLP requests. (optional)
-      metadata:
-        key: "value"
 
   # Flag to write tracing spans and events to JSON files. This is compatible
   # with Chrome's trace viewer, available at `chrome://tracing`, and
@@ -72,9 +69,6 @@ metrics_config:
   ##otlp:
   ##  # OTLP gRPC endpoint.
   ##  endpoint: "https://example.com/"
-  ##  # gRPC metadata to send with OTLP requests. (optional)
-  ##  metadata:
-  ##    key: "value"
 
   # Configuration for Tokio runtime metrics. (optional)
   tokio:

--- a/docs/samples/advanced_config/aggregator.yaml
+++ b/docs/samples/advanced_config/aggregator.yaml
@@ -5,7 +5,7 @@ database:
   url: "postgres://postgres:postgres@localhost:5432/postgres"
 
   # Timeout for new database connections. Defaults to 60 seconds.
-  connection_pool_timeout_secs: 60
+  connection_pool_timeouts_secs: 60
 
   # Maximum number of database connections. Defaults to CPUs * 4.
   connection_pool_max_size: 8
@@ -75,7 +75,7 @@ metrics_config:
     # Enable exporting metrics from the Tokio runtime. If this is true, the
     # binary must have been compiled with the flag `--cfg tokio_unstable`.
     # (optional)
-    enable: false
+    enabled: false
     # Enable a histogram of task poll times. This introduces some additional
     # overhead. (optional)
     enable_poll_time_histogram: false
@@ -192,7 +192,7 @@ key_rotator:
 
     # The set of keys to manage, identified by ciphersuite. At least one is
     # required. Each entry represents a key with a particular ciphersuite.
-    ciphersuite:
+    ciphersuites:
       # Defaults to a key with these algorithms.
       - kem_id: P521HkdfSha512
         kdf_id: HkdfSha512

--- a/docs/samples/advanced_config/collection_job_driver.yaml
+++ b/docs/samples/advanced_config/collection_job_driver.yaml
@@ -49,9 +49,6 @@ logging_config:
     otlp:
       # OTLP gRPC endpoint.
       endpoint: "https://example.com"
-      # gRPC metadata to send with OTLP requests. (optional)
-      metadata:
-        key: "value"
 
   # Flag to write tracing spans and events to JSON files. This is compatible
   # with Chrome's trace viewer, available at `chrome://tracing`, and
@@ -72,9 +69,6 @@ metrics_config:
   ##otlp:
   ##  # OTLP gRPC endpoint.
   ##  endpoint: "https://example.com/"
-  ##  # gRPC metadata to send with OTLP requests. (optional)
-  ##  metadata:
-  ##    key: "value"
 
   # Configuration for Tokio runtime metrics. (optional)
   tokio:

--- a/docs/samples/advanced_config/collection_job_driver.yaml
+++ b/docs/samples/advanced_config/collection_job_driver.yaml
@@ -5,7 +5,7 @@ database:
   url: "postgres://postgres:postgres@localhost:5432/postgres"
 
   # Timeout for new database connections. Defaults to 60 seconds.
-  connection_pool_timeout_secs: 60
+  connection_pool_timeouts_secs: 60
 
   # Maximum number of database connections. Defaults to CPUs * 4.
   connection_pool_max_size: 8
@@ -75,7 +75,7 @@ metrics_config:
     # Enable exporting metrics from the Tokio runtime. If this is true, the
     # binary must have been compiled with the flag `--cfg tokio_unstable`.
     # (optional)
-    enable: false
+    enabled: false
     # Enable a histogram of task poll times. This introduces some additional
     # overhead. (optional)
     enable_poll_time_histogram: false

--- a/docs/samples/advanced_config/collection_job_driver.yaml
+++ b/docs/samples/advanced_config/collection_job_driver.yaml
@@ -20,6 +20,11 @@ database:
   # TLS will never be used. (optional)
   tls_trust_store_path: /path/to/file.pem
 
+# The maximum number of times a transaction can be retried. This is intended to
+# guard against bugs that induce infinite retries. It should be set to a
+# reasonably high limit to prevent legitimate work from being cancelled.
+max_transaction_retries: 1000
+
 # Socket address for /healthz and /traceconfigz HTTP requests. Defaults to 127.0.0.1:9001.
 health_check_listen_address: "0.0.0.0:8000"
 
@@ -119,6 +124,18 @@ http_request_connection_timeout_secs: 10
 # https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.timeout for details.
 # (optional; defaults to 30 seconds)
 http_request_timeout_secs: 30
+
+# The initial interval, in milliseconds, to wait before retrying a retryable
+# HTTP request. (optional, default 1 second)
+retry_initial_interval_millis: 1000
+
+# The maximum interval, in milliseconds, to wait before retrying a retryable
+# HTTP request. (optional, default 30 seconds)
+retry_max_interval_millis: 30000
+
+# The maximum elapsed time, in milliseconds, to wait before giving up on
+# retrying a retryable HTTP request. (optional, default 5 minutes)
+retry_max_elapsed_time_millis: 300000
 
 # Number of sharded database records per batch aggregation. Must not be less
 # than the equivalent setting in the aggregator and aggregation job driver.

--- a/docs/samples/advanced_config/garbage_collector.yaml
+++ b/docs/samples/advanced_config/garbage_collector.yaml
@@ -49,9 +49,6 @@ logging_config:
     otlp:
       # OTLP gRPC endpoint.
       endpoint: "https://example.com"
-      # gRPC metadata to send with OTLP requests. (optional)
-      metadata:
-        key: "value"
 
   # Flag to write tracing spans and events to JSON files. This is compatible
   # with Chrome's trace viewer, available at `chrome://tracing`, and
@@ -72,9 +69,6 @@ metrics_config:
   ##otlp:
   ##  # OTLP gRPC endpoint.
   ##  endpoint: "https://example.com/"
-  ##  # gRPC metadata to send with OTLP requests. (optional)
-  ##  metadata:
-  ##    key: "value"
 
   # Configuration for Tokio runtime metrics. (optional)
   tokio:

--- a/docs/samples/advanced_config/garbage_collector.yaml
+++ b/docs/samples/advanced_config/garbage_collector.yaml
@@ -5,7 +5,7 @@ database:
   url: "postgres://postgres:postgres@localhost:5432/postgres"
 
   # Timeout for new database connections. Defaults to 60 seconds.
-  connection_pool_timeout_secs: 60
+  connection_pool_timeouts_secs: 60
 
   # Maximum number of database connections. Defaults to CPUs * 4.
   connection_pool_max_size: 8
@@ -75,7 +75,7 @@ metrics_config:
     # Enable exporting metrics from the Tokio runtime. If this is true, the
     # binary must have been compiled with the flag `--cfg tokio_unstable`.
     # (optional)
-    enable: false
+    enabled: false
     # Enable a histogram of task poll times. This introduces some additional
     # overhead. (optional)
     enable_poll_time_histogram: false

--- a/docs/samples/advanced_config/garbage_collector.yaml
+++ b/docs/samples/advanced_config/garbage_collector.yaml
@@ -20,6 +20,11 @@ database:
   # TLS will never be used. (optional)
   tls_trust_store_path: /path/to/file.pem
 
+# The maximum number of times a transaction can be retried. This is intended to
+# guard against bugs that induce infinite retries. It should be set to a
+# reasonably high limit to prevent legitimate work from being cancelled.
+max_transaction_retries: 1000
+
 # Socket address for /healthz and /traceconfigz HTTP requests. Defaults to 127.0.0.1:9001.
 health_check_listen_address: "0.0.0.0:8000"
 
@@ -106,3 +111,11 @@ garbage_collection:
   # The maximum number of collection jobs (& related artifacts), per task, to delete in a single run
   # of the garbage collector.
   collection_limit: 50
+
+  # The maximum number of tasks to process together for GC in a single database
+  # transaction. (optional)
+  tasks_per_tx: 1
+
+  # The maximum number of concurrent database transactions to open at once while
+  # processing GC. Leaving this unset means there is no maximum. (optional)
+  concurrent_tx_limit: null

--- a/docs/samples/advanced_config/janus_cli.yaml
+++ b/docs/samples/advanced_config/janus_cli.yaml
@@ -49,9 +49,6 @@ logging_config:
     otlp:
       # OTLP gRPC endpoint.
       endpoint: "https://example.com"
-      # gRPC metadata to send with OTLP requests. (optional)
-      metadata:
-        key: "value"
 
   # Flag to write tracing spans and events to JSON files. This is compatible
   # with Chrome's trace viewer, available at `chrome://tracing`, and
@@ -72,9 +69,6 @@ metrics_config:
   ##otlp:
   ##  # OTLP gRPC endpoint.
   ##  endpoint: "https://example.com/"
-  ##  # gRPC metadata to send with OTLP requests. (optional)
-  ##  metadata:
-  ##    key: "value"
 
   # Configuration for Tokio runtime metrics. (optional)
   tokio:

--- a/docs/samples/advanced_config/janus_cli.yaml
+++ b/docs/samples/advanced_config/janus_cli.yaml
@@ -5,7 +5,7 @@ database:
   url: "postgres://postgres:postgres@localhost:5432/postgres"
 
   # Timeout for new database connections. Defaults to 60 seconds.
-  connection_pool_timeout_secs: 60
+  connection_pool_timeouts_secs: 60
 
   # Maximum number of database connections. Defaults to CPUs * 4.
   connection_pool_max_size: 8
@@ -75,7 +75,7 @@ metrics_config:
     # Enable exporting metrics from the Tokio runtime. If this is true, the
     # binary must have been compiled with the flag `--cfg tokio_unstable`.
     # (optional)
-    enable: false
+    enabled: false
     # Enable a histogram of task poll times. This introduces some additional
     # overhead. (optional)
     enable_poll_time_histogram: false

--- a/docs/samples/advanced_config/janus_cli.yaml
+++ b/docs/samples/advanced_config/janus_cli.yaml
@@ -20,6 +20,11 @@ database:
   # TLS will never be used. (optional)
   tls_trust_store_path: /path/to/file.pem
 
+# The maximum number of times a transaction can be retried. This is intended to
+# guard against bugs that induce infinite retries. It should be set to a
+# reasonably high limit to prevent legitimate work from being cancelled.
+max_transaction_retries: 1000
+
 # Socket address for /healthz HTTP requests. Defaults to 127.0.0.1:9001.
 health_check_listen_address: "0.0.0.0:8000"
 

--- a/docs/samples/advanced_config/key_rotator.yaml
+++ b/docs/samples/advanced_config/key_rotator.yaml
@@ -18,6 +18,11 @@ database:
   # TLS will never be used. (optional)
   tls_trust_store_path: /path/to/file.pem
 
+# The maximum number of times a transaction can be retried. This is intended to
+# guard against bugs that induce infinite retries. It should be set to a
+# reasonably high limit to prevent legitimate work from being cancelled.
+max_transaction_retries: 1000
+
 key_rotator:
   # Rotation policy for global HPKE keys.
   hpke:

--- a/docs/samples/advanced_config/key_rotator.yaml
+++ b/docs/samples/advanced_config/key_rotator.yaml
@@ -3,7 +3,7 @@ database:
   url: "postgres://postgres:postgres@localhost:5432/postgres"
 
   # Timeout for new database connections. Defaults to 60 seconds.
-  connection_pool_timeout_secs: 60
+  connection_pool_timeouts_secs: 60
 
   # Maximum number of database connections. Defaults to CPUs * 4.
   connection_pool_max_size: 8
@@ -40,7 +40,7 @@ key_rotator:
 
     # The set of keys to manage, identified by ciphersuite. At least one is
     # required. Each entry represents a key with a particular ciphersuite.
-    ciphersuite:
+    ciphersuites:
       # Defaults to a key with these algorithms.
       - kem_id: P521HkdfSha512
         kdf_id: HkdfSha512

--- a/docs/samples/tasks.yaml
+++ b/docs/samples/tasks.yaml
@@ -131,7 +131,7 @@
     hash: "MJOoBO_ysLEuG_lv2C37eEOf1Ngetsr-Ers0ZYj4vdQ"
   # Note that this task does not have a collector authentication token, since
   # it is a helper role task.
-  collector_auth_token:
+  collector_auth_token_hash:
   hpke_keys:
   - config:
       id: 37


### PR DESCRIPTION
This PR first adds documentation of more configuration parameters in our sample files. (I think `ignore_unknown_differential_privacy_mechanism` is the only one missing now) It also deletes two now-obsolete parameters (`input_share_aad_public_share_length_prefix` from a past spec compliance workaround and `metadata` under the OTLP exporters) and fixes parameters with incorrect names (either outdated or mistyped). I found the latter issues by hacking in `#[serde(deny_unknown_fields)]` everywhere.