### PR TITLE
Replace generate_* functions with methods of HpkeKeypair

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -3456,10 +3456,7 @@ mod tests {
         test_util::noop_meter,
     };
     use janus_core::{
-        hpke::{
-            self, test_util::generate_test_hpke_config_and_private_key_with_id,
-            HpkeApplicationInfo, HpkeKeypair, Label,
-        },
+        hpke::{self, HpkeApplicationInfo, HpkeKeypair, Label},
         test_util::{
             install_test_trace_subscriber,
             runtime::{TestRuntime, TestRuntimeManager},
@@ -3966,11 +3963,10 @@ mod tests {
         let leader_task = task.leader_view().unwrap();
 
         // Same ID as the task to test having both keys to choose from.
-        let global_hpke_keypair_same_id = generate_test_hpke_config_and_private_key_with_id(
-            (*leader_task.current_hpke_key().config().id()).into(),
-        );
+        let global_hpke_keypair_same_id =
+            HpkeKeypair::test_with_id((*leader_task.current_hpke_key().config().id()).into());
         // Different ID to test misses on the task key.
-        let global_hpke_keypair_different_id = generate_test_hpke_config_and_private_key_with_id(
+        let global_hpke_keypair_different_id = HpkeKeypair::test_with_id(
             (0..)
                 .map(HpkeConfigId::from)
                 .find(|id| !leader_task.hpke_keys().contains_key(id))
@@ -4158,9 +4154,7 @@ mod tests {
             &task,
             clock.now(),
             random(),
-            &generate_test_hpke_config_and_private_key_with_id(
-                (*task.current_hpke_key().config().id()).into(),
-            ),
+            &HpkeKeypair::test_with_id((*task.current_hpke_key().config().id()).into()),
         );
 
         // Try to upload the report, verify that we get the expected error.

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -923,7 +923,7 @@ mod tests {
         test_util::noop_meter,
     };
     use janus_core::{
-        hpke::test_util::generate_test_hpke_config_and_private_key,
+        hpke::HpkeKeypair,
         test_util::{install_test_trace_subscriber, run_vdaf},
         time::{Clock, DurationExt, IntervalExt, MockClock, TimeExt},
         vdaf::{VdafInstance, VERIFY_KEY_LENGTH},
@@ -978,7 +978,7 @@ mod tests {
         let batch_identifier =
             TimeInterval::to_batch_identifier(&leader_task, &(), &report_time).unwrap();
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
-        let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
+        let helper_hpke_keypair = HpkeKeypair::test();
         let leader_report_metadata = ReportMetadata::new(random(), report_time);
         let leader_transcript = run_vdaf(
             vdaf.as_ref(),
@@ -1160,7 +1160,7 @@ mod tests {
         // batches shouldn't have any aggregation jobs in common since we can fill our aggregation
         // jobs without overlap.
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
-        let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
+        let helper_hpke_keypair = HpkeKeypair::test();
 
         let first_report_time = clock.now();
         let second_report_time = clock.now().add(task.time_precision()).unwrap();
@@ -1345,7 +1345,7 @@ mod tests {
         let report_time = clock.now();
         let batch_identifier = TimeInterval::to_batch_identifier(&task, &(), &report_time).unwrap();
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
-        let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
+        let helper_hpke_keypair = HpkeKeypair::test();
 
         let first_report_metadata = ReportMetadata::new(random(), report_time);
         let first_transcript = run_vdaf(
@@ -1555,7 +1555,7 @@ mod tests {
         // Create a min-size batch.
         let report_time = clock.now();
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
-        let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
+        let helper_hpke_keypair = HpkeKeypair::test();
         let batch_identifier = TimeInterval::to_batch_identifier(&task, &(), &report_time).unwrap();
         let reports: Arc<Vec<_>> = Arc::new(
             iter::repeat_with(|| {
@@ -1742,7 +1742,7 @@ mod tests {
         // containing these reports.
         let report_time = clock.now();
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
-        let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
+        let helper_hpke_keypair = HpkeKeypair::test();
         let reports: Arc<Vec<_>> = Arc::new(
             iter::repeat_with(|| {
                 let report_metadata = ReportMetadata::new(random(), report_time);
@@ -1964,7 +1964,7 @@ mod tests {
         // the reports should remain "unaggregated".
         let report_time = clock.now();
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
-        let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
+        let helper_hpke_keypair = HpkeKeypair::test();
         let reports: Arc<Vec<_>> = Arc::new(
             iter::repeat_with(|| {
                 let report_metadata = ReportMetadata::new(random(), report_time);
@@ -2128,7 +2128,7 @@ mod tests {
         // of reports for the second batch.
         let report_time = clock.now();
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
-        let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
+        let helper_hpke_keypair = HpkeKeypair::test();
         let reports: Arc<Vec<_>> = Arc::new(
             iter::repeat_with(|| {
                 let report_metadata = ReportMetadata::new(random(), report_time);
@@ -2392,7 +2392,7 @@ mod tests {
         // job with the remainder of the reports.
         let report_time = clock.now();
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
-        let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
+        let helper_hpke_keypair = HpkeKeypair::test();
         let reports: Arc<Vec<_>> = Arc::new(
             iter::repeat_with(|| {
                 let report_metadata = ReportMetadata::new(random(), report_time);
@@ -2665,7 +2665,7 @@ mod tests {
         let report_time_1 = clock.now().sub(&batch_time_window_size).unwrap();
         let report_time_2 = clock.now();
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
-        let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
+        let helper_hpke_keypair = HpkeKeypair::test();
 
         let mut reports = Vec::new();
         reports.extend(
@@ -2979,7 +2979,7 @@ mod tests {
         // aggregation jobs to be created containing all these reports, but only two batches.
         let report_time = clock.now();
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
-        let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
+        let helper_hpke_keypair = HpkeKeypair::test();
         let reports: Arc<Vec<_>> = Arc::new(
             iter::repeat_with(|| {
                 let report_metadata = ReportMetadata::new(random(), report_time);

--- a/aggregator/src/aggregator/aggregation_job_driver/tests.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver/tests.rs
@@ -23,7 +23,7 @@ use janus_aggregator_core::{
     test_util::noop_meter,
 };
 use janus_core::{
-    hpke::test_util::generate_test_hpke_config_and_private_key,
+    hpke::HpkeKeypair,
     report_id::ReportIdChecksumExt,
     retries::test_util::LimitedRetryer,
     test_util::{install_test_trace_subscriber, run_vdaf, runtime::TestRuntimeManager},
@@ -97,7 +97,7 @@ async fn aggregation_job_driver() {
     );
 
     let agg_auth_token = task.aggregator_auth_token().clone();
-    let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
+    let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
         report_metadata,
@@ -375,7 +375,7 @@ async fn step_time_interval_aggregation_job_init_single_step() {
     );
 
     let agg_auth_token = task.aggregator_auth_token();
-    let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
+    let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
         report_metadata,
@@ -704,7 +704,7 @@ async fn step_time_interval_aggregation_job_init_two_steps() {
     );
 
     let agg_auth_token = task.aggregator_auth_token();
-    let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
+    let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
         report_metadata,
@@ -983,7 +983,7 @@ async fn step_time_interval_aggregation_job_init_partially_garbage_collected() {
     );
 
     let agg_auth_token = task.aggregator_auth_token();
-    let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
+    let helper_hpke_keypair = HpkeKeypair::test();
     let gc_eligible_report = LeaderStoredReport::generate(
         *task.id(),
         gc_eligible_report_metadata,
@@ -1325,7 +1325,7 @@ async fn step_fixed_size_aggregation_job_init_single_step() {
     );
 
     let agg_auth_token = task.aggregator_auth_token();
-    let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
+    let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
         report_metadata,
@@ -1608,7 +1608,7 @@ async fn step_fixed_size_aggregation_job_init_two_steps() {
     );
 
     let agg_auth_token = task.aggregator_auth_token();
-    let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
+    let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
         report_metadata,
@@ -1872,7 +1872,7 @@ async fn step_time_interval_aggregation_job_continue() {
     );
 
     let agg_auth_token = task.aggregator_auth_token();
-    let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
+    let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
         report_metadata,
@@ -2207,7 +2207,7 @@ async fn step_fixed_size_aggregation_job_continue() {
     );
 
     let agg_auth_token = task.aggregator_auth_token();
-    let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
+    let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
         report_metadata,
@@ -2501,7 +2501,7 @@ async fn setup_cancel_aggregation_job_test() -> CancelAggregationJobTestCase {
         &false,
     );
 
-    let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
+    let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
         report_metadata,
@@ -2750,7 +2750,7 @@ async fn abandon_failing_aggregation_job_with_retryable_error() {
     let aggregation_job_id = random();
     let verify_key: VerifyKey<VERIFY_KEY_LENGTH> = task.vdaf_verify_key().unwrap();
 
-    let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
+    let helper_hpke_keypair = HpkeKeypair::test();
 
     let vdaf = Prio3::new_count(2).unwrap();
     let time = clock
@@ -2991,7 +2991,7 @@ async fn abandon_failing_aggregation_job_with_fatal_error() {
     let aggregation_job_id = random();
     let verify_key: VerifyKey<VERIFY_KEY_LENGTH> = task.vdaf_verify_key().unwrap();
 
-    let helper_hpke_keypair = generate_test_hpke_config_and_private_key();
+    let helper_hpke_keypair = HpkeKeypair::test();
 
     let vdaf = Prio3::new_count(2).unwrap();
     let time = clock

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
@@ -20,10 +20,7 @@ use janus_aggregator_core::{
 };
 use janus_core::{
     auth_tokens::AuthenticationToken,
-    hpke::test_util::{
-        generate_test_hpke_config_and_private_key,
-        generate_test_hpke_config_and_private_key_with_id,
-    },
+    hpke::HpkeKeypair,
     report_id::ReportIdChecksumExt,
     test_util::{run_vdaf, runtime::TestRuntime},
     time::{Clock, MockClock, TimeExt},
@@ -242,7 +239,7 @@ async fn aggregate_init() {
     let (prepare_init_3, transcript_3) = prep_init_generator.next(&measurement);
 
     let wrong_hpke_config = loop {
-        let hpke_config = generate_test_hpke_config_and_private_key().config().clone();
+        let hpke_config = HpkeKeypair::test().config().clone();
         if helper_task.hpke_keys().contains_key(hpke_config.id()) {
             continue;
         }
@@ -703,11 +700,10 @@ async fn aggregate_init_with_reports_encrypted_by_global_key() {
 
     // Insert some global HPKE keys.
     // Same ID as the task to test having both keys to choose from.
-    let global_hpke_keypair_same_id = generate_test_hpke_config_and_private_key_with_id(
-        (*helper_task.current_hpke_key().config().id()).into(),
-    );
+    let global_hpke_keypair_same_id =
+        HpkeKeypair::test_with_id((*helper_task.current_hpke_key().config().id()).into());
     // Different ID to test misses on the task key.
-    let global_hpke_keypair_different_id = generate_test_hpke_config_and_private_key_with_id(
+    let global_hpke_keypair_different_id = HpkeKeypair::test_with_id(
         (0..)
             .map(HpkeConfigId::from)
             .find(|id| !helper_task.hpke_keys().contains_key(id))

--- a/aggregator/src/aggregator/http_handlers/tests/hpke_config.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/hpke_config.rs
@@ -17,10 +17,7 @@ use janus_aggregator_core::{
     test_util::noop_meter,
 };
 use janus_core::{
-    hpke::{
-        self, test_util::generate_test_hpke_config_and_private_key_with_id, HpkeApplicationInfo,
-        HpkeKeypair, Label,
-    },
+    hpke::{self, HpkeApplicationInfo, HpkeKeypair, Label},
     test_util::runtime::TestRuntime,
     vdaf::VdafInstance,
 };
@@ -99,7 +96,7 @@ async fn global_hpke_config() {
 
     // Insert an HPKE config, i.e. start the application with a keypair already
     // in the database.
-    let first_hpke_keypair = generate_test_hpke_config_and_private_key_with_id(1);
+    let first_hpke_keypair = HpkeKeypair::test_with_id(1);
     datastore
         .run_unnamed_tx(|tx| {
             let keypair = first_hpke_keypair.clone();
@@ -148,7 +145,7 @@ async fn global_hpke_config() {
     check_hpke_config_is_usable(&hpke_config_list, &first_hpke_keypair);
 
     // Insert an inactive HPKE config.
-    let second_hpke_keypair = generate_test_hpke_config_and_private_key_with_id(2);
+    let second_hpke_keypair = HpkeKeypair::test_with_id(2);
     datastore
         .run_unnamed_tx(|tx| {
             let keypair = second_hpke_keypair.clone();
@@ -239,7 +236,7 @@ async fn global_hpke_config_with_taskprov() {
 
     // Insert an HPKE config, i.e. start the application with a keypair already
     // in the database.
-    let first_hpke_keypair = generate_test_hpke_config_and_private_key_with_id(1);
+    let first_hpke_keypair = HpkeKeypair::test_with_id(1);
     datastore
         .run_unnamed_tx(|tx| {
             let keypair = first_hpke_keypair.clone();
@@ -383,7 +380,7 @@ async fn require_global_hpke_keys() {
 
     // Insert an HPKE config, i.e. start the application with a keypair already
     // in the database.
-    let keypair = generate_test_hpke_config_and_private_key_with_id(1);
+    let keypair = HpkeKeypair::test_with_id(1);
     datastore
         .run_unnamed_tx(|tx| {
             let keypair = keypair.clone();

--- a/aggregator/src/aggregator/http_handlers/tests/report.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/report.rs
@@ -16,10 +16,7 @@ use janus_aggregator_core::{
     test_util::noop_meter,
 };
 use janus_core::{
-    hpke::{
-        self, test_util::generate_test_hpke_config_and_private_key_with_id, HpkeApplicationInfo,
-        Label,
-    },
+    hpke::{self, HpkeApplicationInfo, HpkeKeypair, Label},
     test_util::{install_test_trace_subscriber, runtime::TestRuntime},
     time::{Clock, DurationExt, MockClock, TimeExt},
     vdaf::VdafInstance,
@@ -263,9 +260,7 @@ async fn upload_handler() {
         clock.now(),
         *accepted_report_id,
         // Encrypt report with some arbitrary key that has the same ID as an existing one.
-        &generate_test_hpke_config_and_private_key_with_id(
-            (*leader_task.current_hpke_key().config().id()).into(),
-        ),
+        &HpkeKeypair::test_with_id((*leader_task.current_hpke_key().config().id()).into()),
     );
     let mut test_conn = put(task.report_upload_uri().unwrap().path())
         .with_request_header(KnownHeaderName::ContentType, Report::MEDIA_TYPE)

--- a/aggregator/src/aggregator/key_rotator.rs
+++ b/aggregator/src/aggregator/key_rotator.rs
@@ -14,7 +14,7 @@ use janus_aggregator_core::datastore::{
     Datastore, Error as DatastoreError, Transaction,
 };
 use janus_core::{
-    hpke::{generate_hpke_config_and_private_key, HpkeCiphersuite},
+    hpke::{HpkeCiphersuite, HpkeKeypair},
     time::{Clock, TimeExt},
 };
 use janus_messages::{Duration, HpkeAeadId, HpkeConfigId, HpkeKdfId, HpkeKemId, Time};
@@ -341,7 +341,7 @@ impl<'a, C: Clock> HpkeKeyRotator<'a, C> {
                     let id = self.available_ids.next().ok_or_else(|| {
                         DatastoreError::User(anyhow!("global HPKE key ID space exhausted").into())
                     })?;
-                    let keypair = generate_hpke_config_and_private_key(
+                    let keypair = HpkeKeypair::generate(
                         id,
                         ciphersuite.kem_id(),
                         ciphersuite.kdf_id(),
@@ -514,10 +514,7 @@ mod tests {
         Datastore,
     };
     use janus_core::{
-        hpke::{
-            test_util::generate_test_hpke_config_and_private_key_with_id_and_ciphersuite,
-            HpkeCiphersuite,
-        },
+        hpke::{HpkeCiphersuite, HpkeKeypair},
         test_util::install_test_trace_subscriber,
         time::{Clock, DurationExt, MockClock},
     };
@@ -657,10 +654,7 @@ mod tests {
                     (
                         HpkeConfigId::from(id),
                         GlobalHpkeKeypair::new(
-                            generate_test_hpke_config_and_private_key_with_id_and_ciphersuite(
-                                id,
-                                HpkeCiphersuite::arbitrary(g),
-                            ),
+                            HpkeKeypair::test_with_ciphersuite(id, HpkeCiphersuite::arbitrary(g)),
                             *g.choose(&[
                                 HpkeKeyState::Pending,
                                 HpkeKeyState::Active,

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -28,10 +28,7 @@ use janus_aggregator_core::{
     test_util::noop_meter,
 };
 use janus_core::{
-    hpke::{
-        self, test_util::generate_test_hpke_config_and_private_key, HpkeApplicationInfo,
-        HpkeKeypair, Label,
-    },
+    hpke::{self, HpkeApplicationInfo, HpkeKeypair, Label},
     report_id::ReportIdChecksumExt,
     taskprov::TASKPROV_HEADER,
     test_util::{install_test_trace_subscriber, runtime::TestRuntime, VdafTranscript},
@@ -124,8 +121,8 @@ where
         let ephemeral_datastore = ephemeral_datastore().await;
         let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
 
-        let global_hpke_key = generate_test_hpke_config_and_private_key();
-        let collector_hpke_keypair = generate_test_hpke_config_and_private_key();
+        let global_hpke_key = HpkeKeypair::test();
+        let collector_hpke_keypair = HpkeKeypair::test();
         let peer_aggregator = PeerAggregatorBuilder::new()
             .with_endpoint(url::Url::parse("https://leader.example.com/").unwrap())
             .with_role(Role::Leader)

--- a/aggregator/src/binaries/janus_cli.rs
+++ b/aggregator/src/binaries/janus_cli.rs
@@ -16,7 +16,7 @@ use janus_aggregator_core::{
 use janus_core::{
     auth_tokens::AuthenticationToken,
     cli::{AeadAlgorithm, KdfAlgorithm, KemAlgorithm},
-    hpke::generate_hpke_config_and_private_key,
+    hpke::HpkeKeypair,
     time::{Clock, RealClock},
 };
 use janus_messages::{
@@ -355,7 +355,7 @@ async fn generate_global_hpke_key<C: Clock>(
     aead: HpkeAeadId,
     hpke_config_out_file: Option<&Path>,
 ) -> Result<()> {
-    let hpke_keypair = Arc::new(generate_hpke_config_and_private_key(id, kem, kdf, aead)?);
+    let hpke_keypair = Arc::new(HpkeKeypair::generate(id, kem, kdf, aead)?);
 
     if !dry_run {
         datastore
@@ -756,7 +756,7 @@ mod tests {
     };
     use janus_core::{
         auth_tokens::AuthenticationToken,
-        hpke::generate_hpke_config_and_private_key,
+        hpke::HpkeKeypair,
         test_util::{kubernetes, roundtrip_encoding},
         time::RealClock,
         vdaf::VdafInstance,
@@ -964,7 +964,7 @@ mod tests {
         ds.run_unnamed_tx(|tx| {
             Box::pin(async move {
                 tx.put_global_hpke_keypair(
-                    &generate_hpke_config_and_private_key(
+                    &HpkeKeypair::generate(
                         id,
                         HpkeKemId::P256HkdfSha256,
                         HpkeKdfId::HkdfSha256,
@@ -1012,7 +1012,7 @@ mod tests {
         ds.run_unnamed_tx(|tx| {
             Box::pin(async move {
                 tx.put_global_hpke_keypair(
-                    &generate_hpke_config_and_private_key(
+                    &HpkeKeypair::generate(
                         id,
                         HpkeKemId::P256HkdfSha256,
                         HpkeKdfId::HkdfSha256,
@@ -1092,7 +1092,7 @@ mod tests {
         let peer_endpoint = "https://example.com".try_into().unwrap();
         let role = Role::Leader;
         let verify_key_init = random();
-        let collector_hpke_config = generate_hpke_config_and_private_key(
+        let collector_hpke_config = HpkeKeypair::generate(
             HpkeConfigId::from(96),
             HpkeKemId::P256HkdfSha256,
             HpkeKdfId::HkdfSha256,
@@ -1160,7 +1160,7 @@ mod tests {
             &"https://example.com".try_into().unwrap(),
             Role::Leader,
             random(),
-            &generate_hpke_config_and_private_key(
+            &HpkeKeypair::generate(
                 HpkeConfigId::from(96),
                 HpkeKemId::P256HkdfSha256,
                 HpkeKdfId::HkdfSha256,

--- a/aggregator/src/cache.rs
+++ b/aggregator/src/cache.rs
@@ -325,7 +325,7 @@ mod tests {
         task::{test_util::TaskBuilder, QueryType},
     };
     use janus_core::{
-        hpke::test_util::generate_test_hpke_config_and_private_key,
+        hpke::HpkeKeypair,
         test_util::{install_test_trace_subscriber, runtime::TestRuntime},
         time::MockClock,
         vdaf::VdafInstance,
@@ -361,7 +361,7 @@ mod tests {
 
         // Insert a new active key in the foreground, after a short wait.
         sleep(Duration::from_secs(1)).await;
-        let keypair = generate_test_hpke_config_and_private_key();
+        let keypair = HpkeKeypair::test();
         datastore
             .run_unnamed_tx(|tx| {
                 let keypair = keypair.clone();

--- a/aggregator_api/src/routes.rs
+++ b/aggregator_api/src/routes.rs
@@ -14,9 +14,7 @@ use janus_aggregator_core::{
     taskprov::PeerAggregator,
     SecretBytes,
 };
-use janus_core::{
-    auth_tokens::AuthenticationTokenHash, hpke::generate_hpke_config_and_private_key, time::Clock,
-};
+use janus_core::{auth_tokens::AuthenticationTokenHash, hpke::HpkeKeypair, time::Clock};
 use janus_messages::HpkeConfigId;
 use janus_messages::{
     query_type::Code as SupportedQueryType, Duration, HpkeAeadId, HpkeKdfId, HpkeKemId, Role,
@@ -168,7 +166,7 @@ pub(super) async fn post_task<C: Clock>(
             Duration::from_seconds(60), // 1 minute,
             // hpke_keys
             // Unwrap safety: we always use a supported KEM.
-            [generate_hpke_config_and_private_key(
+            [HpkeKeypair::generate(
                 random(),
                 HpkeKemId::X25519HkdfSha256,
                 HpkeKdfId::HkdfSha256,
@@ -341,7 +339,7 @@ pub(super) async fn put_global_hpke_config<C: Clock>(
                 Error::Conflict("All possible IDs for global HPKE key have been taken".to_string())
             })?,
     );
-    let keypair = generate_hpke_config_and_private_key(
+    let keypair = HpkeKeypair::generate(
         config_id,
         req.kem_id.unwrap_or(HpkeKemId::X25519HkdfSha256),
         req.kdf_id.unwrap_or(HpkeKdfId::HkdfSha256),

--- a/aggregator_api/src/tests.rs
+++ b/aggregator_api/src/tests.rs
@@ -23,14 +23,7 @@ use janus_aggregator_core::{
 };
 use janus_core::{
     auth_tokens::{AuthenticationToken, AuthenticationTokenHash},
-    hpke::{
-        generate_hpke_config_and_private_key,
-        test_util::{
-            generate_test_hpke_config_and_private_key,
-            generate_test_hpke_config_and_private_key_with_id,
-        },
-        HpkeKeypair, HpkePrivateKey,
-    },
+    hpke::{HpkeKeypair, HpkePrivateKey},
     test_util::install_test_trace_subscriber,
     time::MockClock,
     vdaf::VdafInstance,
@@ -201,15 +194,7 @@ async fn post_task_bad_role() {
         task_expiration: Some(Time::from_seconds_since_epoch(12345)),
         min_batch_size: 223,
         time_precision: Duration::from_seconds(62),
-        collector_hpke_config: generate_hpke_config_and_private_key(
-            random(),
-            HpkeKemId::X25519HkdfSha256,
-            HpkeKdfId::HkdfSha256,
-            HpkeAeadId::Aes128Gcm,
-        )
-        .unwrap()
-        .config()
-        .clone(),
+        collector_hpke_config: HpkeKeypair::test().config().clone(),
         aggregator_auth_token: Some(aggregator_auth_token),
         collector_auth_token_hash: Some(AuthenticationTokenHash::from(&random())),
     };
@@ -243,15 +228,7 @@ async fn post_task_unauthorized() {
         task_expiration: Some(Time::from_seconds_since_epoch(12345)),
         min_batch_size: 223,
         time_precision: Duration::from_seconds(62),
-        collector_hpke_config: generate_hpke_config_and_private_key(
-            random(),
-            HpkeKemId::X25519HkdfSha256,
-            HpkeKdfId::HkdfSha256,
-            HpkeAeadId::Aes128Gcm,
-        )
-        .unwrap()
-        .config()
-        .clone(),
+        collector_hpke_config: HpkeKeypair::test().config().clone(),
         aggregator_auth_token: Some(aggregator_auth_token),
         collector_auth_token_hash: Some(AuthenticationTokenHash::from(&random())),
     };
@@ -286,15 +263,7 @@ async fn post_task_helper_no_optional_fields() {
         task_expiration: Some(Time::from_seconds_since_epoch(12345)),
         min_batch_size: 223,
         time_precision: Duration::from_seconds(62),
-        collector_hpke_config: generate_hpke_config_and_private_key(
-            random(),
-            HpkeKemId::X25519HkdfSha256,
-            HpkeKdfId::HkdfSha256,
-            HpkeAeadId::Aes128Gcm,
-        )
-        .unwrap()
-        .config()
-        .clone(),
+        collector_hpke_config: HpkeKeypair::test().config().clone(),
         aggregator_auth_token: None,
         collector_auth_token_hash: None,
     };
@@ -376,15 +345,7 @@ async fn post_task_helper_with_aggregator_auth_token() {
         task_expiration: Some(Time::from_seconds_since_epoch(12345)),
         min_batch_size: 223,
         time_precision: Duration::from_seconds(62),
-        collector_hpke_config: generate_hpke_config_and_private_key(
-            random(),
-            HpkeKemId::X25519HkdfSha256,
-            HpkeKdfId::HkdfSha256,
-            HpkeAeadId::Aes128Gcm,
-        )
-        .unwrap()
-        .config()
-        .clone(),
+        collector_hpke_config: HpkeKeypair::test().config().clone(),
         aggregator_auth_token: Some(aggregator_auth_token),
         collector_auth_token_hash: None,
     };
@@ -420,15 +381,7 @@ async fn post_task_idempotence() {
         task_expiration: Some(Time::from_seconds_since_epoch(12345)),
         min_batch_size: 223,
         time_precision: Duration::from_seconds(62),
-        collector_hpke_config: generate_hpke_config_and_private_key(
-            random(),
-            HpkeKemId::X25519HkdfSha256,
-            HpkeKdfId::HkdfSha256,
-            HpkeAeadId::Aes128Gcm,
-        )
-        .unwrap()
-        .config()
-        .clone(),
+        collector_hpke_config: HpkeKeypair::test().config().clone(),
         aggregator_auth_token: Some(aggregator_auth_token.clone()),
 
         collector_auth_token_hash: Some(AuthenticationTokenHash::from(&random())),
@@ -503,15 +456,7 @@ async fn post_task_leader_all_optional_fields() {
         task_expiration: Some(Time::from_seconds_since_epoch(12345)),
         min_batch_size: 223,
         time_precision: Duration::from_seconds(62),
-        collector_hpke_config: generate_hpke_config_and_private_key(
-            random(),
-            HpkeKemId::X25519HkdfSha256,
-            HpkeKdfId::HkdfSha256,
-            HpkeAeadId::Aes128Gcm,
-        )
-        .unwrap()
-        .config()
-        .clone(),
+        collector_hpke_config: HpkeKeypair::test().config().clone(),
         aggregator_auth_token: Some(aggregator_auth_token.clone()),
         collector_auth_token_hash: Some(collector_auth_token_hash.clone()),
     };
@@ -591,15 +536,7 @@ async fn post_task_leader_no_aggregator_auth_token() {
         task_expiration: Some(Time::from_seconds_since_epoch(12345)),
         min_batch_size: 223,
         time_precision: Duration::from_seconds(62),
-        collector_hpke_config: generate_hpke_config_and_private_key(
-            random(),
-            HpkeKemId::X25519HkdfSha256,
-            HpkeKdfId::HkdfSha256,
-            HpkeAeadId::Aes128Gcm,
-        )
-        .unwrap()
-        .config()
-        .clone(),
+        collector_hpke_config: HpkeKeypair::test().config().clone(),
         aggregator_auth_token: None,
         collector_auth_token_hash: Some(AuthenticationTokenHash::from(&random())),
     };
@@ -967,8 +904,8 @@ async fn get_global_hpke_configs() {
     assert_eq!(resp, vec![]);
 
     let keypair1_id = random();
-    let keypair1 = generate_test_hpke_config_and_private_key_with_id(keypair1_id);
-    let keypair2 = generate_hpke_config_and_private_key(
+    let keypair1 = HpkeKeypair::test_with_id(keypair1_id);
+    let keypair2 = HpkeKeypair::generate(
         HpkeConfigId::from(keypair1_id.wrapping_add(1)),
         HpkeKemId::P256HkdfSha256,
         HpkeKdfId::HkdfSha384,
@@ -1069,8 +1006,8 @@ async fn get_global_hpke_config() {
     );
 
     let keypair1_id = random();
-    let keypair1 = generate_test_hpke_config_and_private_key_with_id(keypair1_id);
-    let keypair2 = generate_hpke_config_and_private_key(
+    let keypair1 = HpkeKeypair::test_with_id(keypair1_id);
+    let keypair2 = HpkeKeypair::generate(
         HpkeConfigId::from(keypair1_id.wrapping_add(1)),
         HpkeKemId::P256HkdfSha256,
         HpkeKdfId::HkdfSha384,
@@ -1266,7 +1203,7 @@ async fn patch_global_hpke_config() {
         "",
     );
 
-    let keypair = generate_test_hpke_config_and_private_key();
+    let keypair = HpkeKeypair::test();
     ds.run_unnamed_tx(|tx| {
         let keypair = keypair.clone();
         Box::pin(async move { tx.put_global_hpke_keypair(&keypair).await })
@@ -1337,7 +1274,7 @@ async fn delete_global_hpke_config() {
         "",
     );
 
-    let keypair = generate_test_hpke_config_and_private_key();
+    let keypair = HpkeKeypair::test();
     ds.run_unnamed_tx(|tx| {
         let keypair = keypair.clone();
         Box::pin(async move { tx.put_global_hpke_keypair(&keypair).await })

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -25,9 +25,7 @@ use async_trait::async_trait;
 use chrono::NaiveDate;
 use futures::future::try_join_all;
 use janus_core::{
-    hpke::{
-        self, test_util::generate_test_hpke_config_and_private_key, HpkeApplicationInfo, Label,
-    },
+    hpke::{self, HpkeApplicationInfo, Label},
     test_util::{install_test_trace_subscriber, run_vdaf},
     time::{Clock, DurationExt, IntervalExt, MockClock, TimeExt},
     vdaf::{VdafInstance, VERIFY_KEY_LENGTH},
@@ -7187,10 +7185,12 @@ SELECT (lower(interval) = '2021-10-05 00:00:00' AND
 #[rstest_reuse::apply(schema_versions_template)]
 #[tokio::test]
 async fn roundtrip_global_hpke_keypair(ephemeral_datastore: EphemeralDatastore) {
+    use janus_core::hpke::HpkeKeypair;
+
     install_test_trace_subscriber();
     let datastore = ephemeral_datastore.datastore(MockClock::default()).await;
     let clock = datastore.clock.clone();
-    let keypair = generate_test_hpke_config_and_private_key();
+    let keypair = HpkeKeypair::test();
 
     datastore
         .run_tx("test-put-keys", |tx| {

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -5,7 +5,7 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use derivative::Derivative;
 use janus_core::{
     auth_tokens::{AuthenticationToken, AuthenticationTokenHash},
-    hpke::{generate_hpke_config_and_private_key, HpkeKeypair},
+    hpke::HpkeKeypair,
     time::TimeExt,
     vdaf::VdafInstance,
 };
@@ -665,7 +665,7 @@ impl SerializedAggregatorTask {
 
         if self.hpke_keys.is_empty() {
             // Unwrap safety: we always use a supported KEM.
-            let hpke_keypair = generate_hpke_config_and_private_key(
+            let hpke_keypair = HpkeKeypair::generate(
                 random(),
                 HpkeKemId::X25519HkdfSha256,
                 HpkeKdfId::HkdfSha256,
@@ -787,13 +787,7 @@ pub mod test_util {
     use derivative::Derivative;
     use janus_core::{
         auth_tokens::{AuthenticationToken, AuthenticationTokenHash},
-        hpke::{
-            test_util::{
-                generate_test_hpke_config_and_private_key,
-                generate_test_hpke_config_and_private_key_with_id,
-            },
-            HpkeKeypair,
-        },
+        hpke::HpkeKeypair,
         time::DurationExt,
         url_ensure_trailing_slash,
         vdaf::VdafInstance,
@@ -1088,14 +1082,8 @@ pub mod test_util {
         pub fn new(query_type: QueryType, vdaf: VdafInstance) -> Self {
             let task_id = random();
 
-            let leader_hpke_keypairs = [
-                generate_test_hpke_config_and_private_key(),
-                generate_test_hpke_config_and_private_key_with_id(1),
-            ];
-            let helper_hpke_keypairs = [
-                generate_test_hpke_config_and_private_key(),
-                generate_test_hpke_config_and_private_key_with_id(1),
-            ];
+            let leader_hpke_keypairs = [HpkeKeypair::test(), HpkeKeypair::test_with_id(1)];
+            let helper_hpke_keypairs = [HpkeKeypair::test(), HpkeKeypair::test_with_id(1)];
 
             let vdaf_verify_key = SecretBytes::new(
                 thread_rng()
@@ -1117,7 +1105,7 @@ pub mod test_util {
                 0,
                 Duration::from_hours(8).unwrap(),
                 Duration::from_minutes(10).unwrap(),
-                /* Collector HPKE keypair */ generate_test_hpke_config_and_private_key(),
+                /* Collector HPKE keypair */ HpkeKeypair::test(),
                 /* Aggregator auth token */ random(),
                 /* Collector auth token */ random(),
                 leader_hpke_keypairs,

--- a/aggregator_core/src/taskprov.rs
+++ b/aggregator_core/src/taskprov.rs
@@ -275,10 +275,7 @@ impl KeyType for VdafVerifyKeyLength {
 #[cfg(feature = "test-util")]
 #[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
 pub mod test_util {
-    use janus_core::{
-        auth_tokens::AuthenticationToken,
-        hpke::test_util::generate_test_hpke_config_and_private_key,
-    };
+    use janus_core::{auth_tokens::AuthenticationToken, hpke::HpkeKeypair};
     use janus_messages::{Duration, HpkeConfig, Role};
     use rand::random;
     use url::Url;
@@ -294,7 +291,7 @@ pub mod test_util {
                 Url::parse("https://example.com").unwrap(),
                 Role::Leader,
                 random(),
-                generate_test_hpke_config_and_private_key().config().clone(),
+                HpkeKeypair::test().config().clone(),
                 None,
                 Duration::from_seconds(1),
                 Vec::from([random()]),

--- a/client/src/tests/mod.rs
+++ b/client/src/tests/mod.rs
@@ -3,8 +3,7 @@ use assert_matches::assert_matches;
 use hex_literal::hex;
 use http::{header::CONTENT_TYPE, StatusCode};
 use janus_core::{
-    hpke::test_util::generate_test_hpke_config_and_private_key,
-    retries::test_util::test_http_request_exponential_backoff,
+    hpke::HpkeKeypair, retries::test_util::test_http_request_exponential_backoff,
     test_util::install_test_trace_subscriber,
 };
 use janus_messages::{Duration, HpkeConfigList, Report, Role, Time};
@@ -28,8 +27,8 @@ async fn setup_client<V: vdaf::Client<16>>(server: &mockito::Server, vdaf: V) ->
         vdaf,
     )
     .with_backoff(test_http_request_exponential_backoff())
-    .with_leader_hpke_config(generate_test_hpke_config_and_private_key().config().clone())
-    .with_helper_hpke_config(generate_test_hpke_config_and_private_key().config().clone())
+    .with_leader_hpke_config(HpkeKeypair::test().config().clone())
+    .with_helper_hpke_config(HpkeKeypair::test().config().clone())
     .build()
     .await
     .unwrap()
@@ -168,8 +167,8 @@ async fn upload_bad_time_precision() {
         Duration::from_seconds(0),
         Prio3::new_count(2).unwrap(),
     )
-    .with_leader_hpke_config(generate_test_hpke_config_and_private_key().config().clone())
-    .with_helper_hpke_config(generate_test_hpke_config_and_private_key().config().clone())
+    .with_leader_hpke_config(HpkeKeypair::test().config().clone())
+    .with_helper_hpke_config(HpkeKeypair::test().config().clone())
     .build()
     .await
     .unwrap();
@@ -227,7 +226,7 @@ async fn aggregator_hpke() {
     );
     client_parameters.http_request_retry_parameters = test_http_request_exponential_backoff();
 
-    let keypair = generate_test_hpke_config_and_private_key();
+    let keypair = HpkeKeypair::test();
     let hpke_config_list = HpkeConfigList::new(Vec::from([keypair.config().clone()]));
     let mock = server
         .mock(
@@ -284,7 +283,7 @@ async fn unsupported_hpke_algorithms() {
         "4141414141414141" // Contents of HpkePublicKey
     );
 
-    let good_hpke_config = generate_test_hpke_config_and_private_key().config().clone();
+    let good_hpke_config = HpkeKeypair::test().config().clone();
     let encoded_good_hpke_config = good_hpke_config.get_encoded().unwrap();
 
     let mut encoded_hpke_config_list = Vec::new();

--- a/client/src/tests/ohttp.rs
+++ b/client/src/tests/ohttp.rs
@@ -8,7 +8,7 @@ use assert_matches::assert_matches;
 use bhttp::{Message, Mode, StatusCode};
 use http::header::{ACCEPT, CONTENT_TYPE};
 use janus_core::{
-    hpke::test_util::generate_test_hpke_config_and_private_key, http::HttpErrorResponse,
+    hpke::HpkeKeypair, http::HttpErrorResponse,
     retries::test_util::test_http_request_exponential_backoff,
     test_util::install_test_trace_subscriber,
 };
@@ -38,8 +38,8 @@ async fn build_client(server: &mockito::ServerGuard) -> Result<Client<Prio3Count
         Prio3::new_count(2).unwrap(),
     )
     .with_backoff(test_http_request_exponential_backoff())
-    .with_leader_hpke_config(generate_test_hpke_config_and_private_key().config().clone())
-    .with_helper_hpke_config(generate_test_hpke_config_and_private_key().config().clone())
+    .with_leader_hpke_config(HpkeKeypair::test().config().clone())
+    .with_helper_hpke_config(HpkeKeypair::test().config().clone())
     .with_ohttp_config(OhttpConfig {
         key_configs: keys_endpoint,
         relay,

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -754,9 +754,7 @@ mod tests {
     use fixed_macro::fixed;
     use janus_core::{
         auth_tokens::AuthenticationToken,
-        hpke::{
-            self, test_util::generate_test_hpke_config_and_private_key, HpkeApplicationInfo, Label,
-        },
+        hpke::{self, HpkeApplicationInfo, HpkeKeypair, Label},
         retries::test_util::test_http_request_exponential_backoff,
         test_util::{install_test_trace_subscriber, run_vdaf, VdafTranscript},
     };
@@ -782,7 +780,7 @@ mod tests {
 
     fn setup_collector<V: vdaf::Collector>(server: &mut mockito::Server, vdaf: V) -> Collector<V> {
         let server_url = Url::parse(&server.url()).unwrap();
-        let hpke_keypair = generate_test_hpke_config_and_private_key();
+        let hpke_keypair = HpkeKeypair::test();
         Collector::builder(
             random(),
             server_url,
@@ -876,7 +874,7 @@ mod tests {
 
     #[test]
     fn leader_endpoint_end_in_slash() {
-        let hpke_keypair = generate_test_hpke_config_and_private_key();
+        let hpke_keypair = HpkeKeypair::test();
         let collector = Collector::new(
             random(),
             "http://example.com/dap".parse().unwrap(),
@@ -1296,7 +1294,7 @@ mod tests {
         let vdaf = Prio3::new_count(2).unwrap();
         let transcript = run_vdaf(&vdaf, &random(), &(), &random(), &true);
         let server_url = Url::parse(&server.url()).unwrap();
-        let hpke_keypair = generate_test_hpke_config_and_private_key();
+        let hpke_keypair = HpkeKeypair::test();
         let collector = Collector::builder(
             random(),
             server_url,

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -3,10 +3,7 @@ use derivative::Derivative;
 use janus_aggregator_core::task::{test_util::Task, QueryType};
 #[cfg(feature = "fpvec_bounded_l2")]
 use janus_core::vdaf::{vdaf_dp_strategies, Prio3FixedPointBoundedL2VecSumBitSize};
-use janus_core::{
-    hpke::{generate_hpke_config_and_private_key, HpkeKeypair},
-    vdaf::VdafInstance,
-};
+use janus_core::{hpke::HpkeKeypair, vdaf::VdafInstance};
 use janus_messages::{
     query_type::{FixedSize, QueryType as _, TimeInterval},
     HpkeAeadId, HpkeConfigId, HpkeKdfId, HpkeKemId, Role, TaskId, Time,
@@ -379,7 +376,7 @@ impl HpkeConfigRegistry {
             .entry(id)
             .or_insert_with(|| {
                 // Unwrap safety: we always use a supported KEM.
-                generate_hpke_config_and_private_key(
+                HpkeKeypair::generate(
                     id,
                     // These algorithms should be broadly compatible with other DAP implementations, since they
                     // are required by section 6 of draft-ietf-ppm-dap-02.

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -730,7 +730,7 @@ mod tests {
     use janus_collector::PrivateCollectorCredential;
     use janus_core::{
         auth_tokens::{BearerToken, DapAuthToken},
-        hpke::test_util::generate_test_hpke_config_and_private_key,
+        hpke::HpkeKeypair,
     };
     use janus_messages::{BatchId, TaskId};
     use prio::codec::Encode;
@@ -757,7 +757,7 @@ mod tests {
 
     #[tokio::test]
     async fn argument_handling() {
-        let hpke_keypair = generate_test_hpke_config_and_private_key();
+        let hpke_keypair = HpkeKeypair::test();
         let encoded_hpke_config =
             URL_SAFE_NO_PAD.encode(hpke_keypair.config().get_encoded().unwrap());
         let encoded_private_key = URL_SAFE_NO_PAD.encode(hpke_keypair.private_key().as_ref());
@@ -994,7 +994,7 @@ mod tests {
 
         let leader = Url::parse("https://example.com/dap/").unwrap();
 
-        let hpke_keypair = generate_test_hpke_config_and_private_key();
+        let hpke_keypair = HpkeKeypair::test();
         let encoded_hpke_config =
             URL_SAFE_NO_PAD.encode(hpke_keypair.config().get_encoded().unwrap());
         let encoded_private_key = URL_SAFE_NO_PAD.encode(hpke_keypair.private_key().as_ref());
@@ -1193,7 +1193,7 @@ mod tests {
         let task_id: TaskId = random();
         let task_id_encoded = URL_SAFE_NO_PAD.encode(task_id.get_encoded().unwrap());
 
-        let hpke_keypair = generate_test_hpke_config_and_private_key();
+        let hpke_keypair = HpkeKeypair::test();
         let encoded_hpke_config =
             URL_SAFE_NO_PAD.encode(hpke_keypair.config().get_encoded().unwrap());
         let encoded_private_key = URL_SAFE_NO_PAD.encode(hpke_keypair.private_key().as_ref());
@@ -1383,7 +1383,7 @@ mod tests {
         let task_id: TaskId = random();
         let task_id_encoded = URL_SAFE_NO_PAD.encode(task_id.get_encoded().unwrap());
         let leader = Url::parse("https://example.com/dap/").unwrap();
-        let hpke_keypair = generate_test_hpke_config_and_private_key();
+        let hpke_keypair = HpkeKeypair::test();
         let encoded_hpke_config =
             URL_SAFE_NO_PAD.encode(hpke_keypair.config().get_encoded().unwrap());
         let encoded_private_key = URL_SAFE_NO_PAD.encode(hpke_keypair.private_key().as_ref());
@@ -1450,7 +1450,7 @@ mod tests {
 
     #[test]
     fn subcommand_new_job_arguments() {
-        let hpke_keypair = generate_test_hpke_config_and_private_key();
+        let hpke_keypair = HpkeKeypair::test();
         let encoded_hpke_config =
             URL_SAFE_NO_PAD.encode(hpke_keypair.config().get_encoded().unwrap());
         let encoded_private_key = URL_SAFE_NO_PAD.encode(hpke_keypair.private_key().as_ref());
@@ -1537,7 +1537,7 @@ mod tests {
 
     #[test]
     fn subcommand_poll_job_arguments() {
-        let hpke_keypair = generate_test_hpke_config_and_private_key();
+        let hpke_keypair = HpkeKeypair::test();
         let encoded_hpke_config =
             URL_SAFE_NO_PAD.encode(hpke_keypair.config().get_encoded().unwrap());
         let encoded_private_key = URL_SAFE_NO_PAD.encode(hpke_keypair.private_key().as_ref());

--- a/tools/src/bin/hpke_keygen.rs
+++ b/tools/src/bin/hpke_keygen.rs
@@ -3,7 +3,7 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use clap::Parser;
 use janus_core::{
     cli::{AeadAlgorithm, KdfAlgorithm, KemAlgorithm},
-    hpke::generate_hpke_config_and_private_key,
+    hpke::HpkeKeypair,
 };
 use janus_messages::HpkeConfigId;
 use prio::codec::Encode;
@@ -14,7 +14,7 @@ fn main() -> Result<()> {
     let options = Options::parse();
 
     let id = HpkeConfigId::from(options.id);
-    let keypair = generate_hpke_config_and_private_key(
+    let keypair = HpkeKeypair::generate(
         id,
         options.kem.into(),
         options.kdf.into(),


### PR DESCRIPTION
Small refactor. `generate_test_hpke_config_and_private_key_with_id_and_ciphersuite()` is a pretty incredible name, so let's shorten that up by making these functions methods on `HpkeKeypair`.

A lot of ways this could be cleaned up, e.g. builder pattern, `impl Distribution`, but this seemed the most straightforward win to me.