### PR TITLE
tests: Use HttpHandlerTest struct instead of returning tuple

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/aggregation_job_continue.rs
@@ -398,7 +398,7 @@ mod tests {
         },
         http_handlers::{
             aggregator_handler,
-            test_util::{setup_http_handler_test, take_problem_details},
+            test_util::{take_problem_details, HttpHandlerTest},
         },
         test_util::default_aggregator_config,
     };
@@ -608,7 +608,12 @@ mod tests {
 
     #[tokio::test]
     async fn leader_rejects_aggregation_job_post() {
-        let (_, _ephemeral_datastore, datastore, handler) = setup_http_handler_test().await;
+        let HttpHandlerTest {
+            ephemeral_datastore: _ephemeral_datastore,
+            datastore,
+            handler,
+            ..
+        } = HttpHandlerTest::new().await;
 
         let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Prio3Count).build();
         datastore
@@ -634,7 +639,12 @@ mod tests {
 
     #[tokio::test]
     async fn leader_rejects_aggregation_job_delete() {
-        let (_, _ephemeral_datastore, datastore, handler) = setup_http_handler_test().await;
+        let HttpHandlerTest {
+            ephemeral_datastore: _ephemeral_datastore,
+            datastore,
+            handler,
+            ..
+        } = HttpHandlerTest::new().await;
 
         let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Prio3Count).build();
         datastore

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -847,28 +847,4 @@ pub mod test_util {
             }
         }
     }
-
-    pub async fn setup_http_handler_test() -> (
-        MockClock,
-        EphemeralDatastore,
-        Arc<Datastore<MockClock>>,
-        impl Handler,
-    ) {
-        install_test_trace_subscriber();
-        let clock = MockClock::default();
-        let ephemeral_datastore = ephemeral_datastore().await;
-        let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
-        datastore.put_global_hpke_key().await.unwrap();
-        let handler = aggregator_handler(
-            datastore.clone(),
-            clock.clone(),
-            TestRuntime::default(),
-            &noop_meter(),
-            default_aggregator_config(),
-        )
-        .await
-        .unwrap();
-
-        (clock, ephemeral_datastore, datastore, handler)
-    }
 }

--- a/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
@@ -1,8 +1,6 @@
 use crate::aggregator::{
     error::BatchMismatch,
-    http_handlers::test_util::{
-        decode_response_body, setup_http_handler_test, take_problem_details,
-    },
+    http_handlers::test_util::{decode_response_body, take_problem_details, HttpHandlerTest},
 };
 use assert_matches::assert_matches;
 use futures::future::try_join_all;
@@ -52,7 +50,12 @@ pub(crate) async fn post_aggregate_share_request<Q: query_type::QueryType>(
 
 #[tokio::test]
 async fn aggregate_share_request_to_leader() {
-    let (_, _ephemeral_datastore, datastore, handler) = setup_http_handler_test().await;
+    let HttpHandlerTest {
+        ephemeral_datastore: _ephemeral_datastore,
+        datastore,
+        handler,
+        ..
+    } = HttpHandlerTest::new().await;
 
     // Prepare parameters.
     let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake { rounds: 1 }).build();
@@ -84,7 +87,13 @@ async fn aggregate_share_request_to_leader() {
 
 #[tokio::test]
 async fn aggregate_share_request_invalid_batch_interval() {
-    let (clock, _ephemeral_datastore, datastore, handler) = setup_http_handler_test().await;
+    let HttpHandlerTest {
+        clock,
+        ephemeral_datastore: _ephemeral_datastore,
+        datastore,
+        handler,
+        ..
+    } = HttpHandlerTest::new().await;
 
     // Prepare parameters.
     const REPORT_EXPIRY_AGE: Duration = Duration::from_seconds(3600);
@@ -143,7 +152,12 @@ async fn aggregate_share_request_invalid_batch_interval() {
 
 #[tokio::test]
 async fn aggregate_share_request() {
-    let (_, _ephemeral_datastore, datastore, handler) = setup_http_handler_test().await;
+    let HttpHandlerTest {
+        ephemeral_datastore: _ephemeral_datastore,
+        datastore,
+        handler,
+        ..
+    } = HttpHandlerTest::new().await;
 
     let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake { rounds: 1 })
         .with_max_batch_query_count(1)

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_continue.rs
@@ -3,7 +3,7 @@ use crate::aggregator::{
         post_aggregation_job_and_decode, post_aggregation_job_expecting_error,
     },
     empty_batch_aggregations,
-    http_handlers::test_util::{setup_http_handler_test, HttpHandlerTest},
+    http_handlers::test_util::HttpHandlerTest,
     test_util::{generate_helper_report_share, BATCH_AGGREGATION_SHARD_COUNT},
 };
 use futures::future::try_join_all;
@@ -1056,7 +1056,12 @@ async fn aggregate_continue_accumulate_batch_aggregation() {
 
 #[tokio::test]
 async fn aggregate_continue_leader_sends_non_continue_or_finish_transition() {
-    let (_, _ephemeral_datastore, datastore, handler) = setup_http_handler_test().await;
+    let HttpHandlerTest {
+        ephemeral_datastore: _ephemeral_datastore,
+        datastore,
+        handler,
+        ..
+    } = HttpHandlerTest::new().await;
 
     // Prepare parameters.
     let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Poplar1 { bits: 1 }).build();
@@ -1341,7 +1346,12 @@ async fn aggregate_continue_prep_step_fails() {
 
 #[tokio::test]
 async fn aggregate_continue_unexpected_transition() {
-    let (_, _ephemeral_datastore, datastore, handler) = setup_http_handler_test().await;
+    let HttpHandlerTest {
+        ephemeral_datastore: _ephemeral_datastore,
+        datastore,
+        handler,
+        ..
+    } = HttpHandlerTest::new().await;
 
     // Prepare parameters.
     let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Poplar1 { bits: 1 }).build();
@@ -1452,7 +1462,12 @@ async fn aggregate_continue_unexpected_transition() {
 
 #[tokio::test]
 async fn aggregate_continue_out_of_order_transition() {
-    let (_, _ephemeral_datastore, datastore, handler) = setup_http_handler_test().await;
+    let HttpHandlerTest {
+        ephemeral_datastore: _ephemeral_datastore,
+        datastore,
+        handler,
+        ..
+    } = HttpHandlerTest::new().await;
 
     // Prepare parameters.
     let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Poplar1 { bits: 1 }).build();
@@ -1622,7 +1637,12 @@ async fn aggregate_continue_out_of_order_transition() {
 
 #[tokio::test]
 async fn aggregate_continue_for_non_waiting_aggregation() {
-    let (_, _ephemeral_datastore, datastore, handler) = setup_http_handler_test().await;
+    let HttpHandlerTest {
+        ephemeral_datastore: _ephemeral_datastore,
+        datastore,
+        handler,
+        ..
+    } = HttpHandlerTest::new().await;
 
     // Prepare parameters.
     let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake { rounds: 1 }).build();

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
@@ -3,9 +3,7 @@ use crate::aggregator::{
     empty_batch_aggregations,
     http_handlers::{
         aggregator_handler,
-        test_util::{
-            decode_response_body, setup_http_handler_test, take_problem_details, HttpHandlerTest,
-        },
+        test_util::{decode_response_body, take_problem_details, HttpHandlerTest},
     },
     test_util::{
         default_aggregator_config, generate_helper_report_share,
@@ -48,7 +46,12 @@ use trillium_testing::{assert_headers, prelude::put, TestConn};
 
 #[tokio::test]
 async fn aggregate_leader() {
-    let (_, _ephemeral_datastore, datastore, handler) = setup_http_handler_test().await;
+    let HttpHandlerTest {
+        ephemeral_datastore: _ephemeral_datastore,
+        datastore,
+        handler,
+        ..
+    } = HttpHandlerTest::new().await;
 
     let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Prio3Count).build();
     datastore
@@ -111,7 +114,12 @@ async fn aggregate_leader() {
 
 #[tokio::test]
 async fn aggregate_wrong_agg_auth_token() {
-    let (_, _ephemeral_datastore, datastore, handler) = setup_http_handler_test().await;
+    let HttpHandlerTest {
+        ephemeral_datastore: _ephemeral_datastore,
+        datastore,
+        handler,
+        ..
+    } = HttpHandlerTest::new().await;
 
     let dap_auth_token = AuthenticationToken::DapAuth(random());
 

--- a/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
@@ -1,8 +1,6 @@
 use crate::aggregator::{
     collection_job_tests::setup_collection_job_test_case,
-    http_handlers::test_util::{
-        decode_response_body, setup_http_handler_test, take_problem_details,
-    },
+    http_handlers::test_util::{decode_response_body, take_problem_details, HttpHandlerTest},
 };
 use janus_aggregator_core::{
     datastore::models::{
@@ -132,7 +130,12 @@ async fn collection_job_put_request_invalid_aggregation_parameter() {
 
 #[tokio::test]
 async fn collection_job_put_request_invalid_batch_size() {
-    let (_, _ephemeral_datastore, datastore, handler) = setup_http_handler_test().await;
+    let HttpHandlerTest {
+        ephemeral_datastore: _ephemeral_datastore,
+        datastore,
+        handler,
+        ..
+    } = HttpHandlerTest::new().await;
 
     // Prepare parameters.
     let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Fake { rounds: 1 })

--- a/aggregator/src/aggregator/http_handlers/tests/hpke_config.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/hpke_config.rs
@@ -2,7 +2,7 @@ use crate::{
     aggregator::{
         http_handlers::{
             aggregator_handler, aggregator_handler_with_aggregator,
-            test_util::{setup_http_handler_test, take_problem_details, take_response_body},
+            test_util::{take_problem_details, take_response_body, HttpHandlerTest},
             HPKE_CONFIG_SIGNATURE_HEADER,
         },
         test_util::{
@@ -109,7 +109,12 @@ async fn task_specific_hpke_config() {
 
 #[tokio::test]
 async fn global_hpke_config() {
-    let (clock, _ephemeral_datastore, datastore, _) = setup_http_handler_test().await;
+    let HttpHandlerTest {
+        clock,
+        ephemeral_datastore: _ephemeral_datastore,
+        datastore,
+        ..
+    } = HttpHandlerTest::new().await;
 
     // Retrieve the global keypair from the test fixture.
     let first_hpke_keypair = datastore
@@ -244,7 +249,12 @@ async fn global_hpke_config() {
 
 #[tokio::test]
 async fn global_hpke_config_with_taskprov() {
-    let (clock, _ephemeral_datastore, datastore, _) = setup_http_handler_test().await;
+    let HttpHandlerTest {
+        clock,
+        ephemeral_datastore: _ephemeral_datastore,
+        datastore,
+        ..
+    } = HttpHandlerTest::new().await;
 
     // Retrieve the global keypair from the test fixture.
     let first_hpke_keypair = datastore
@@ -327,7 +337,12 @@ fn check_hpke_config_is_usable(hpke_config_list: &HpkeConfigList, hpke_keypair: 
 
 #[tokio::test]
 async fn hpke_config_cors_headers() {
-    let (_, _ephemeral_datastore, datastore, handler) = setup_http_handler_test().await;
+    let HttpHandlerTest {
+        ephemeral_datastore: _ephemeral_datastore,
+        datastore,
+        handler,
+        ..
+    } = HttpHandlerTest::new().await;
 
     let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Prio3Count)
         .build()
@@ -383,7 +398,12 @@ async fn verify_and_decode_hpke_config_list(test_conn: &mut TestConn) -> HpkeCon
 
 #[tokio::test]
 async fn require_global_hpke_keys() {
-    let (clock, _ephemeral_datastore, datastore, _) = setup_http_handler_test().await;
+    let HttpHandlerTest {
+        clock,
+        ephemeral_datastore: _ephemeral_datastore,
+        datastore,
+        ..
+    } = HttpHandlerTest::new().await;
 
     // Retrieve the global keypair from the test fixture.
     let keypair = datastore

--- a/aggregator/src/aggregator/upload_tests.rs
+++ b/aggregator/src/aggregator/upload_tests.rs
@@ -55,6 +55,8 @@ impl UploadTest {
     where
         R: Runtime + Send + Sync + 'static,
     {
+        install_test_trace_subscriber();
+
         let clock = MockClock::default();
         let vdaf = Prio3Count::new_count(2).unwrap();
         let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Prio3Count).build();
@@ -90,8 +92,6 @@ impl UploadTest {
 
 #[tokio::test]
 async fn upload() {
-    install_test_trace_subscriber();
-
     let UploadTest {
         vdaf,
         aggregator,
@@ -174,8 +174,6 @@ async fn upload() {
 
 #[tokio::test]
 async fn upload_batch() {
-    install_test_trace_subscriber();
-
     const BATCH_SIZE: usize = 100;
     let UploadTest {
         vdaf,
@@ -239,8 +237,6 @@ async fn upload_batch() {
 
 #[tokio::test]
 async fn upload_wrong_hpke_config_id() {
-    install_test_trace_subscriber();
-
     let mut runtime_manager = TestRuntimeManager::new();
     let UploadTest {
         aggregator,
@@ -310,8 +306,6 @@ async fn upload_wrong_hpke_config_id() {
 
 #[tokio::test]
 async fn upload_report_in_the_future_boundary_condition() {
-    install_test_trace_subscriber();
-
     let UploadTest {
         vdaf,
         aggregator,
@@ -359,7 +353,6 @@ async fn upload_report_in_the_future_boundary_condition() {
 
 #[tokio::test]
 async fn upload_report_in_the_future_past_clock_skew() {
-    install_test_trace_subscriber();
     let mut runtime_manager = TestRuntimeManager::new();
     let UploadTest {
         aggregator,
@@ -416,8 +409,6 @@ async fn upload_report_in_the_future_past_clock_skew() {
 
 #[tokio::test]
 async fn upload_report_for_collected_batch() {
-    install_test_trace_subscriber();
-
     let mut runtime_manager = TestRuntimeManager::new();
     let UploadTest {
         aggregator,
@@ -499,8 +490,6 @@ async fn upload_report_for_collected_batch() {
 
 #[tokio::test]
 async fn upload_report_encrypted_with_task_specific_key() {
-    install_test_trace_subscriber();
-
     let UploadTest {
         vdaf,
         aggregator,
@@ -563,7 +552,6 @@ async fn upload_report_encrypted_with_task_specific_key() {
 
 #[tokio::test]
 async fn upload_report_task_expired() {
-    install_test_trace_subscriber();
     let mut runtime_manager = TestRuntimeManager::new();
     let UploadTest {
         aggregator,
@@ -624,7 +612,6 @@ async fn upload_report_task_expired() {
 
 #[tokio::test]
 async fn upload_report_report_expired() {
-    install_test_trace_subscriber();
     let mut runtime_manager = TestRuntimeManager::new();
     let UploadTest {
         aggregator,
@@ -686,7 +673,6 @@ async fn upload_report_report_expired() {
 
 #[tokio::test]
 async fn upload_report_faulty_encryption() {
-    install_test_trace_subscriber();
     let mut runtime_manager = TestRuntimeManager::new();
     let UploadTest {
         aggregator,
@@ -747,7 +733,6 @@ async fn upload_report_faulty_encryption() {
 
 #[tokio::test]
 async fn upload_report_public_share_decode_failure() {
-    install_test_trace_subscriber();
     let mut runtime_manager = TestRuntimeManager::new();
     let UploadTest {
         aggregator,
@@ -809,7 +794,6 @@ async fn upload_report_public_share_decode_failure() {
 
 #[tokio::test]
 async fn upload_report_leader_input_share_decode_failure() {
-    install_test_trace_subscriber();
     let mut runtime_manager = TestRuntimeManager::new();
     let UploadTest {
         aggregator,


### PR DESCRIPTION
Redo of https://github.com/divviup/janus/pull/3286. I merged it into https://github.com/divviup/janus/pull/3284 but accidentally clobbered it when I rebased on it on main (i.e. this code never actually made it into main).