### PR TITLE
Fix flaky tests

### DIFF
--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
@@ -265,6 +265,9 @@ async fn aggregate_init() {
         if helper_task.hpke_keys().contains_key(hpke_config.id()) {
             continue;
         }
+        if hpke_keypair.config().id() == hpke_config.id() {
+            continue;
+        }
         break hpke_config;
     };
 

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
@@ -13,12 +13,9 @@ use crate::aggregator::{
 use assert_matches::assert_matches;
 use futures::future::try_join_all;
 use janus_aggregator_core::{
-    datastore::{
-        self,
-        models::{
-            AggregationJob, AggregationJobState, BatchAggregation, BatchAggregationState,
-            ReportAggregation, ReportAggregationState,
-        },
+    datastore::models::{
+        AggregationJob, AggregationJobState, BatchAggregation, BatchAggregationState,
+        ReportAggregation, ReportAggregationState,
     },
     task::{test_util::TaskBuilder, QueryType, VerifyKey},
     test_util::noop_meter,
@@ -720,6 +717,7 @@ async fn aggregate_init_with_reports_encrypted_by_task_specific_key() {
         clock,
         ephemeral_datastore: _ephemeral_datastore,
         datastore,
+        hpke_keypair,
         ..
     } = HttpHandlerTest::new().await;
 
@@ -737,28 +735,23 @@ async fn aggregate_init_with_reports_encrypted_by_task_specific_key() {
         aggregation_param,
     );
 
-    // Same ID as the task to test having both keys to choose from.
-    let global_hpke_keypair_same_id =
-        HpkeKeypair::test_with_id((*helper_task.current_hpke_key().config().id()).into());
-    datastore
-        .run_unnamed_tx(|tx| {
-            let global_hpke_keypair_same_id = global_hpke_keypair_same_id.clone();
-            Box::pin(async move {
-                // Leave these in the PENDING state--they should still be decryptable.
-                match tx
-                    .put_global_hpke_keypair(&global_hpke_keypair_same_id)
-                    .await
-                {
-                    // Prevent test flakes in case a colliding key is already in the datastore.
-                    // The test context code randomly generates an ID so there's a chance for
-                    // collision.
-                    Ok(_) | Err(datastore::Error::MutationTargetAlreadyExists) => Ok(()),
-                    Err(err) => Err(err),
-                }
+    // Same ID as the task to test having both keys to choose from. (skip if there is already a
+    // global keypair with the same ID set up by the fixture)
+    if helper_task.current_hpke_key().config().id() != hpke_keypair.config().id() {
+        let global_hpke_keypair_same_id =
+            HpkeKeypair::test_with_id((*helper_task.current_hpke_key().config().id()).into());
+        datastore
+            .run_unnamed_tx(|tx| {
+                let global_hpke_keypair_same_id = global_hpke_keypair_same_id.clone();
+                Box::pin(async move {
+                    // Leave these in the PENDING state--they should still be decryptable.
+                    tx.put_global_hpke_keypair(&global_hpke_keypair_same_id)
+                        .await
+                })
             })
-        })
-        .await
-        .unwrap();
+            .await
+            .unwrap();
+    }
 
     // Create new handler _after_ the keys have been inserted so that they come pre-cached.
     let handler = aggregator_handler(

--- a/aggregator/src/aggregator/upload_tests.rs
+++ b/aggregator/src/aggregator/upload_tests.rs
@@ -254,9 +254,11 @@ async fn upload_wrong_hpke_config_id() {
     let leader_task = task.leader_view().unwrap();
     let report = create_report(&leader_task, &hpke_keypair, clock.now());
 
+    let mut hpke_keys = leader_task.hpke_keys().clone();
+    hpke_keys.insert(*hpke_keypair.config().id(), hpke_keypair);
     let unused_hpke_config_id = (0..)
         .map(HpkeConfigId::from)
-        .find(|id| !leader_task.hpke_keys().contains_key(id))
+        .find(|id| !hpke_keys.contains_key(id))
         .unwrap();
 
     let report = Report::new(

--- a/aggregator/src/aggregator/upload_tests.rs
+++ b/aggregator/src/aggregator/upload_tests.rs
@@ -7,7 +7,6 @@ use assert_matches::assert_matches;
 use futures::future::try_join_all;
 use janus_aggregator_core::{
     datastore::{
-        self,
         models::{CollectionJob, CollectionJobState, TaskUploadCounter},
         test_util::{ephemeral_datastore, EphemeralDatastore},
         Datastore,
@@ -499,6 +498,7 @@ async fn upload_report_encrypted_with_task_specific_key() {
         task,
         datastore,
         ephemeral_datastore: _ephemeral_datastore,
+        hpke_keypair,
         ..
     } = UploadTest::new(Config {
         max_upload_batch_size: 1000,
@@ -509,30 +509,24 @@ async fn upload_report_encrypted_with_task_specific_key() {
     let leader_task = task.leader_view().unwrap();
 
     // Insert a global keypair with the same ID as the task to test having both keys to choose
-    // from.
-    let global_hpke_keypair_same_id =
-        HpkeKeypair::test_with_id((*leader_task.current_hpke_key().config().id()).into());
+    // from. (skip if there is already a global keypair with the same ID set up by the fixture)
+    if leader_task.current_hpke_key().config().id() != hpke_keypair.config().id() {
+        let global_hpke_keypair_same_id =
+            HpkeKeypair::test_with_id((*leader_task.current_hpke_key().config().id()).into());
 
-    datastore
-        .run_unnamed_tx(|tx| {
-            let global_hpke_keypair_same_id = global_hpke_keypair_same_id.clone();
-            Box::pin(async move {
-                // Leave these in the PENDING state--they should still be decryptable.
-                match tx
-                    .put_global_hpke_keypair(&global_hpke_keypair_same_id)
-                    .await
-                {
-                    // Prevent test flakes in case a colliding key is already in the datastore.
-                    // The test context code randomly generates an ID so there's a chance for
-                    // collision.
-                    Ok(_) | Err(datastore::Error::MutationTargetAlreadyExists) => Ok(()),
-                    Err(err) => Err(err),
-                }
+        datastore
+            .run_unnamed_tx(|tx| {
+                let global_hpke_keypair_same_id = global_hpke_keypair_same_id.clone();
+                Box::pin(async move {
+                    // Leave these in the PENDING state--they should still be decryptable.
+                    tx.put_global_hpke_keypair(&global_hpke_keypair_same_id)
+                        .await
+                })
             })
-        })
-        .await
-        .unwrap();
-    aggregator.refresh_caches().await.unwrap();
+            .await
+            .unwrap();
+        aggregator.refresh_caches().await.unwrap();
+    }
 
     let report = create_report(&leader_task, leader_task.current_hpke_key(), clock.now());
     aggregator

--- a/aggregator/src/cache.rs
+++ b/aggregator/src/cache.rs
@@ -432,11 +432,12 @@ mod tests {
             .await
             .unwrap();
 
-        // That change shouldn't be reflected yet because we've cached the previous task.
+        // At this point, the above change may or may not be reflected yet, because we've cached the
+        // previous task.
         let task_aggregator = task_aggregators.get(task.id()).await.unwrap().unwrap();
-        assert_eq!(
-            task_aggregator.task.task_expiration(),
-            task.task_expiration()
+        assert!(
+            (task_aggregator.task.task_expiration() == task.task_expiration())
+                || (task_aggregator.task.task_expiration() == Some(&new_expiration))
         );
 
         // Unfortunately, because moka doesn't provide any facility for a fake clock, we have to resort
@@ -482,9 +483,6 @@ mod tests {
         // A wild task appears!
         datastore.put_aggregator_task(&task).await.unwrap();
 
-        // We shouldn't see the new task yet.
-        assert!(task_aggregators.get(task.id()).await.unwrap().is_none());
-
         // Unfortunately, because moka doesn't provide any facility for a fake clock, we have to resort
         // to sleeps to test TTL functionality.
         sleep(Duration::from_secs(1)).await;
@@ -508,11 +506,12 @@ mod tests {
             .await
             .unwrap();
 
-        // That change shouldn't be reflected yet because we've cached the previous run.
+        // At this point, the above change may or may not be reflected yet because we've cached the
+        // previous value.
         let task_aggregator = task_aggregators.get(task.id()).await.unwrap().unwrap();
-        assert_eq!(
-            task_aggregator.task.task_expiration(),
-            task.task_expiration()
+        assert!(
+            (task_aggregator.task.task_expiration() == task.task_expiration())
+                || (task_aggregator.task.task_expiration() == Some(&new_expiration))
         );
 
         sleep(Duration::from_secs(1)).await;


### PR DESCRIPTION
This fixes some flaky tests I found. Common themes:

- Some more tests that assume an HPKE config ID is unused needed to be updated to take the initial global HPKE key into account.
- `put_global_hpke_keypair()` does not return `MutationTargetAlreadyExists`, so we can't try to insert a keypair and suppress errors, but we can compare config IDs up front in tests.
- Some of the checks in task cache tests are racy, and they are more likely to fail under high CPU load. I removed or changed these, so we no longer require that the cache reflect a stale value immediately after changing the database. (since sometimes "immediately" comes too late)