### PR TITLE
Reject unknown fields in configuration files

### DIFF
--- a/aggregator/src/aggregator/key_rotator.rs
+++ b/aggregator/src/aggregator/key_rotator.rs
@@ -60,6 +60,7 @@ pub struct KeyRotator<C: Clock> {
 
 /// Defines the ciphersuite and rotation policy of a global HPKE key.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct HpkeKeyRotatorConfig {
     /// How long key remains in [`HpkeKeyState::Pending`] before being moved to
     /// [`HpkeKeyState::Active`]. This should be greater than

--- a/aggregator/src/binaries/aggregation_job_creator.rs
+++ b/aggregator/src/binaries/aggregation_job_creator.rs
@@ -68,6 +68,7 @@ impl BinaryOptions for Options {
 /// ```
 // TODO(#3293): remove aliases during next breaking changes window.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     #[serde(flatten)]
     pub common_config: CommonConfig,

--- a/aggregator/src/binaries/aggregation_job_driver.rs
+++ b/aggregator/src/binaries/aggregation_job_driver.rs
@@ -108,6 +108,7 @@ impl BinaryOptions for Options {
 /// let _decoded: Config = serde_yaml::from_str(yaml_config).unwrap();
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     #[serde(flatten)]
     pub common_config: CommonConfig,

--- a/aggregator/src/binaries/aggregator.rs
+++ b/aggregator/src/binaries/aggregator.rs
@@ -330,6 +330,7 @@ where
 /// let _decoded: Config = serde_yaml::from_str(yaml_config).unwrap();
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     #[serde(flatten)]
     pub common_config: CommonConfig,
@@ -403,6 +404,7 @@ pub struct Config {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct KeyRotatorConfig {
     /// How frequently the key rotator is run, in seconds.
     pub frequency_s: u64,
@@ -416,6 +418,7 @@ fn default_task_counter_shard_count() -> u64 {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct GarbageCollectorConfig {
     /// How frequently garbage collection is run, in seconds.
     pub gc_frequency_s: u64,

--- a/aggregator/src/binaries/collection_job_driver.rs
+++ b/aggregator/src/binaries/collection_job_driver.rs
@@ -116,6 +116,7 @@ impl BinaryOptions for Options {
 /// ```
 // TODO(#3293): remove aliases during next breaking changes window.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     #[serde(flatten)]
     pub common_config: CommonConfig,

--- a/aggregator/src/binaries/garbage_collector.rs
+++ b/aggregator/src/binaries/garbage_collector.rs
@@ -97,6 +97,7 @@ impl BinaryOptions for Options {
 /// let _decoded: Config = serde_yaml::from_str(yaml_config).unwrap();
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     #[serde(flatten)]
     pub common_config: CommonConfig,

--- a/aggregator/src/binaries/janus_cli.rs
+++ b/aggregator/src/binaries/janus_cli.rs
@@ -682,6 +682,7 @@ impl KubernetesSecretOptions {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct ConfigFile {
     #[serde(flatten)]
     common_config: CommonConfig,

--- a/aggregator/src/binaries/key_rotator.rs
+++ b/aggregator/src/binaries/key_rotator.rs
@@ -60,6 +60,7 @@ impl BinaryOptions for Options {
 /// let _decoded: Config = serde_yaml::from_str(yaml_config).unwrap();
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     #[serde(flatten)]
     pub common_config: CommonConfig,
@@ -77,6 +78,7 @@ impl BinaryConfig for Config {
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct KeyRotatorConfig {
     #[serde(deserialize_with = "deserialize_hpke_key_rotator_config")]
     pub hpke: HpkeKeyRotatorConfig,

--- a/aggregator/src/config.rs
+++ b/aggregator/src/config.rs
@@ -28,6 +28,7 @@ use url::Url;
 /// let _decoded: CommonConfig = serde_yaml::from_str(yaml_config).unwrap();
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CommonConfig {
     /// The database configuration.
     pub database: DbConfig,
@@ -71,6 +72,7 @@ pub trait BinaryConfig: Debug + DeserializeOwned {
 /// Configuration for a Janus server using a database.
 #[derive(Clone, Derivative, PartialEq, Eq, Serialize, Deserialize)]
 #[derivative(Debug)]
+#[serde(deny_unknown_fields)]
 pub struct DbConfig {
     /// URL at which to connect to the database.
     #[derivative(Debug(format_with = "format_database_url"))]
@@ -133,6 +135,7 @@ fn format_database_url(url: &Url, fmt: &mut std::fmt::Formatter) -> Result<(), s
 ///
 /// [spec]: https://datatracker.ietf.org/doc/draft-wang-ppm-dap-taskprov/
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct TaskprovConfig {
     /// Whether to enable the extension or not. Enabling this changes the behavior
     /// of the aggregator consistent with the taskprov [specification][spec].
@@ -174,6 +177,7 @@ pub struct TaskprovConfig {
 /// ```
 // TODO(#3293): remove aliases during next breaking changes window.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct JobDriverConfig {
     /// The delay between checking for jobs ready to be stepped, in seconds. Applies only when
     /// there are no jobs to be stepped.

--- a/aggregator/src/metrics.rs
+++ b/aggregator/src/metrics.rs
@@ -68,6 +68,7 @@ pub enum Error {
 
 /// Configuration for collection/exporting of application-level metrics.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MetricsConfiguration {
     /// Configuration for OpenTelemetry metrics, with a choice of exporters.
     #[serde(default, with = "serde_yaml::with::singleton_map")]
@@ -80,7 +81,7 @@ pub struct MetricsConfiguration {
 
 /// Selection of an exporter for OpenTelemetry metrics.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(deny_unknown_fields, rename_all = "lowercase")]
 pub enum MetricsExporterConfiguration {
     Prometheus {
         host: Option<String>,
@@ -91,6 +92,7 @@ pub enum MetricsExporterConfiguration {
 
 /// Configuration options specific to the OpenTelemetry OTLP metrics exporter.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct OtlpExporterConfiguration {
     /// gRPC endpoint for OTLP exporter.
     pub endpoint: String,
@@ -98,6 +100,7 @@ pub struct OtlpExporterConfiguration {
 
 /// Configuration options for Tokio's (unstable) metrics feature.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TokioMetricsConfiguration {
     /// Enable collecting metrics from Tokio. The flag `--cfg tokio_unstable` must be passsed
     /// to the compiler if this is enabled.

--- a/aggregator/src/trace.rs
+++ b/aggregator/src/trace.rs
@@ -33,6 +33,7 @@ pub enum Error {
 
 /// Configuration for the tracing subscriber.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TraceConfiguration {
     /// If true, uses a [`tracing_subscriber::fmt::TestWriter`] to capture trace
     /// events when running tests
@@ -63,6 +64,7 @@ pub struct TraceConfiguration {
 
 /// Configuration related to tokio-console.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TokioConsoleConfiguration {
     /// If true, a tokio-console tracing subscriber is configured to monitor
     /// the async runtime, and listen for TCP connections. (Requires building
@@ -79,13 +81,14 @@ pub struct TokioConsoleConfiguration {
 
 /// Selection of an exporter for OpenTelemetry spans.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(deny_unknown_fields, rename_all = "lowercase")]
 pub enum OpenTelemetryTraceConfiguration {
     Otlp(OtlpTraceConfiguration),
 }
 
 /// Configuration options specific to the OpenTelemetry OTLP exporter.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct OtlpTraceConfiguration {
     /// gRPC endpoint for OTLP exporter.
     pub endpoint: String,

--- a/core/src/hpke.rs
+++ b/core/src/hpke.rs
@@ -266,6 +266,7 @@ impl HpkeKeypair {
 
 /// The algorithms used for each HPKE primitive.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[serde(deny_unknown_fields)]
 pub struct HpkeCiphersuite {
     kem_id: HpkeKemId,
     kdf_id: HpkeKdfId,


### PR DESCRIPTION
This changes all config-related deserialization routines to throw an error upon seeing unexpected fields, rather than ignoring them. This should be mentioned in the next release notes.