### PR TITLE
Fix warning in Dockerfile.sqlx

### DIFF
--- a/Dockerfile.sqlx
+++ b/Dockerfile.sqlx
@@ -1,4 +1,4 @@
-FROM rust:1.79.0-alpine as builder
+FROM rust:1.79.0-alpine AS builder
 ENV CARGO_INCREMENTAL=0
 ARG SQLX_VERSION
 RUN apk add libc-dev


### PR DESCRIPTION
This fixes the following warning I saw while building.

 > WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)