### PR TITLE
Retry on leader -> helper client errors

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -28,7 +28,11 @@ use janus_aggregator_core::{
     },
     task::{self, AggregatorTask, VerifyKey},
 };
-use janus_core::{retries::is_retryable_http_status, time::Clock, vdaf_dispatch};
+use janus_core::{
+    retries::{is_retryable_http_client_error, is_retryable_http_status},
+    time::Clock,
+    vdaf_dispatch,
+};
 use janus_messages::{
     query_type::{FixedSize, TimeInterval},
     AggregationJobContinueReq, AggregationJobInitializeReq, AggregationJobResp,
@@ -1187,6 +1191,7 @@ where
             Error::Http(http_error_response) => {
                 is_retryable_http_status(http_error_response.status())
             }
+            Error::HttpClient(error) => is_retryable_http_client_error(error),
             Error::Datastore(error) => match error {
                 datastore::Error::Db(_) | datastore::Error::Pool(_) => true,
                 datastore::Error::User(error) => match error.downcast_ref::<Error>() {

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -18,7 +18,11 @@ use janus_aggregator_core::{
     },
     task,
 };
-use janus_core::{retries::is_retryable_http_status, time::Clock, vdaf_dispatch};
+use janus_core::{
+    retries::{is_retryable_http_client_error, is_retryable_http_status},
+    time::Clock,
+    vdaf_dispatch,
+};
 use janus_messages::{
     query_type::{FixedSize, QueryType, TimeInterval},
     AggregateShare, AggregateShareReq, BatchSelector,
@@ -631,6 +635,7 @@ where
             Error::Http(http_error_response) => {
                 is_retryable_http_status(http_error_response.status())
             }
+            Error::HttpClient(error) => is_retryable_http_client_error(error),
             Error::Datastore(error) => match error {
                 datastore::Error::Db(_) | datastore::Error::Pool(_) => true,
                 datastore::Error::User(error) => match error.downcast_ref::<Error>() {

--- a/core/src/retries.rs
+++ b/core/src/retries.rs
@@ -207,6 +207,10 @@ pub fn is_retryable_http_status(status: StatusCode) -> bool {
         || status == StatusCode::TOO_MANY_REQUESTS
 }
 
+pub fn is_retryable_http_client_error(error: &reqwest::Error) -> bool {
+    error.is_timeout() || error.is_connect() || error.is_request() || error.is_body()
+}
+
 #[cfg(feature = "test-util")]
 #[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
 pub mod test_util {


### PR DESCRIPTION
Transient HTTP Client errors were causing an aggregation/collection job to immediately be abandoned. Extend `is_retryable_error()` to cover client errors. See https://docs.rs/reqwest/latest/reqwest/struct.Error.html for the list of error kinds.