### PR TITLE
Fix warnings in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN cargo build --release -p janus_aggregator --features=prometheus,otlp
 FROM alpine:3.20.1 AS final
 ARG BINARY=aggregator
 ARG GIT_REVISION=unknown
-LABEL revision ${GIT_REVISION}
+LABEL revision=${GIT_REVISION}
 COPY --from=builder /src/target/release/janus_aggregator /janus_aggregator
 RUN ln -s /janus_aggregator /aggregator && \
     ln -s /janus_aggregator /garbage_collector && \

--- a/Dockerfile.sqlx
+++ b/Dockerfile.sqlx
@@ -9,8 +9,8 @@ RUN cargo install sqlx-cli \
 FROM alpine:3.20.1
 ARG SQLX_VERSION=unknown
 ARG GIT_REVISION=unknown
-LABEL revision ${GIT_REVISION}
-LABEL sqlx_version ${SQLX_VERSION}
+LABEL revision=${GIT_REVISION}
+LABEL sqlx_version=${SQLX_VERSION}
 COPY --from=builder /usr/local/cargo/bin/sqlx /sqlx
 COPY db /migrations
 ENTRYPOINT ["/sqlx"]


### PR DESCRIPTION
This fixes the following warning message.

>  - LegacyKeyValueFormat: "LABEL key=value" should be used instead of legacy "LABEL key value" format