### PR TITLE
Asynchronous aggregation jobs

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -2017,7 +2017,7 @@ impl VdafOps {
         Ok(None)
     }
 
-    async fn handle_get_aggregation_job_generic<const SEED_SIZE: usize, Q, A, C: Clock>(
+    async fn handle_get_aggregation_job_generic<const SEED_SIZE: usize, Q, A, C>(
         datastore: &Datastore<C>,
         vdaf: Arc<A>,
         task: Arc<AggregatorTask>,
@@ -2216,7 +2216,7 @@ impl VdafOps {
                                                     &vdaf,
                                                     prepare_init.report_share().public_share(),
                                                 );
-                                            if let Err(_) = public_share {
+                                            if public_share.is_err() {
                                                 state = ReportAggregationMetadataState::Failed {
                                                     prepare_error: PrepareError::InvalidMessage,
                                                 };

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -2296,19 +2296,13 @@ impl VdafOps {
                                         let task = Arc::clone(&task);
                                         let vdaf = Arc::clone(&vdaf);
                                         async move {
-                                            let public_share =
-                                                A::PublicShare::get_decoded_with_param(
-                                                    &vdaf,
-                                                    prepare_init.report_share().public_share(),
-                                                )?;
                                             let state = match tx
-                                                .put_helper_client_report(&HelperStoredReport::<
-                                                    SEED_SIZE,
-                                                    A,
-                                                >::new(
+                                                .put_helper_client_report(&HelperStoredReport::new(
                                                     *task.id(),
                                                     prepare_init.report_share().metadata().clone(),
-                                                    public_share,
+                                                    Vec::from(
+                                                        prepare_init.report_share().public_share(),
+                                                    ),
                                                     prepare_init
                                                         .report_share()
                                                         .encrypted_input_share()

--- a/aggregator/src/aggregator/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/aggregation_job_continue.rs
@@ -224,7 +224,7 @@ impl VdafOps {
                                         Role::Leader,
                                         prep_step.report_id(),
                                         error,
-                                        &metrics.aggregate_step_failure_counter,
+                                        Some(&metrics.aggregate_step_failure_counter),
                                     )
                                 })
                                 .unwrap_or_else(|prepare_error| {

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -375,7 +375,10 @@ where
 
                     // Check for repeated extensions.
                     let mut extension_types = HashSet::new();
+                    // TODO(inahga): evil unwrap due to doctoring StartLeader
                     if !leader_extensions
+                        .as_ref()
+                        .unwrap()
                         .iter()
                         .all(|extension| extension_types.insert(extension.extension_type()))
                     {
@@ -416,7 +419,8 @@ where
                             // DAP report ID is used as VDAF nonce
                             report_aggregation.report_id().as_ref(),
                             public_share,
-                            leader_input_share,
+                            // TODO(inahga): evil unwrap due to doctoring StartLeader
+                            &leader_input_share.as_ref().unwrap(),
                         )
                         .map_err(|ping_pong_error| {
                             handle_ping_pong_error(

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -27,7 +27,6 @@ use janus_aggregator_core::{
         Datastore,
     },
     task::{self, AggregatorTask, VerifyKey},
-    test_util::noop_meter,
 };
 use janus_core::{
     hpke::{self, HpkeApplicationInfo, Label},
@@ -456,7 +455,7 @@ where
                                 Role::Leader,
                                 report_aggregation.report_id(),
                                 ping_pong_error,
-                                &aggregate_step_failure_counter,
+                                Some(&aggregate_step_failure_counter),
                             )
                         })
                     }) {
@@ -921,7 +920,7 @@ where
                                                 Role::Helper,
                                                 report_aggregation.report_metadata().id(),
                                                 error,
-                                                &aggregate_step_failure_counter(&noop_meter()), // &self.aggregate_step_failure_counter,
+                                                None, // &self.aggregate_step_failure_counter,
                                             )
                                         })
                                     },
@@ -1121,7 +1120,7 @@ where
                                     Role::Leader,
                                     report_aggregation.report_id(),
                                     error,
-                                    &aggregate_step_failure_counter,
+                                    Some(&aggregate_step_failure_counter),
                                 );
                                 return ra_sender
                                     .send(WritableReportAggregation::new(
@@ -1312,7 +1311,7 @@ where
                                                 Role::Leader,
                                                 stepped_aggregation.report_aggregation.report_id(),
                                                 ping_pong_error,
-                                                &aggregate_step_failure_counter,
+                                                Some(&aggregate_step_failure_counter),
                                             )
                                         })
                                     });

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -503,6 +503,8 @@ where
                 prepare_inits,
             );
 
+            // TODO(inahga): poll the helper here
+
             let resp_bytes = send_request_to_helper(
                 &self.http_client,
                 self.backoff.clone(),
@@ -693,6 +695,8 @@ where
 
         // Construct request, send it to the helper, and process the response.
         let request = AggregationJobContinueReq::new(aggregation_job.step(), prepare_continues);
+
+        // TODO(inahga): poll the helper here
 
         let resp_bytes = send_request_to_helper(
             &self.http_client,

--- a/aggregator/src/aggregator/aggregation_job_writer.rs
+++ b/aggregator/src/aggregator/aggregation_job_writer.rs
@@ -902,7 +902,7 @@ where
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct WritableReportAggregation<const SEED_SIZE: usize, A>
 where
     A: vdaf::Aggregator<SEED_SIZE, 16>,

--- a/aggregator/src/aggregator/error.rs
+++ b/aggregator/src/aggregator/error.rs
@@ -373,7 +373,7 @@ pub(crate) fn handle_ping_pong_error(
     role: Role,
     report_id: &ReportId,
     ping_pong_error: PingPongError,
-    aggregate_step_failure_counter: &Counter<u64>,
+    aggregate_step_failure_counter: Option<&Counter<u64>>,
 ) -> PrepareError {
     let peer_role = match role {
         Role::Leader => Role::Helper,
@@ -426,7 +426,9 @@ pub(crate) fn handle_ping_pong_error(
         error_desc,
     );
 
-    aggregate_step_failure_counter.add(1, &[KeyValue::new("type", value)]);
+    if let Some(aggregate_step_failure_counter) = aggregate_step_failure_counter {
+        aggregate_step_failure_counter.add(1, &[KeyValue::new("type", value)]);
+    }
 
     // Per DAP, any occurrence of state Rejected() from a ping-pong routime is translated to
     // VdafPrepError

--- a/aggregator/src/aggregator/error.rs
+++ b/aggregator/src/aggregator/error.rs
@@ -63,6 +63,8 @@ pub enum Error {
     /// An attempt was made to act on a known but deleted aggregation job.
     #[error("task {0}: deleted aggregation job: {1}")]
     DeletedAggregationJob(TaskId, AggregationJobId),
+    #[error("task {0}: abandoned aggregation job: {1}")]
+    AbandonedAggregationJob(TaskId, AggregationJobId),
     /// An attempt was made to act on an unknown collection job.
     #[error("unrecognized collection job: {0}")]
     UnrecognizedCollectionJob(TaskId, CollectionJobId),
@@ -287,6 +289,7 @@ impl Error {
             Error::UnrecognizedTask(_) => "unrecognized_task",
             Error::MissingTaskId => "missing_task_id",
             Error::UnrecognizedAggregationJob(_, _) => "unrecognized_aggregation_job",
+            Error::AbandonedAggregationJob(_, _) => "abandoned_aggregation_job",
             Error::DeletedAggregationJob(_, _) => "deleted_aggregation_job",
             Error::DeletedCollectionJob(_, _) => "deleted_collection_job",
             Error::AbandonedCollectionJob(_, _) => "abandoned_collection_job",

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -848,6 +848,7 @@ pub mod test_util {
         pub datastore: Arc<Datastore<MockClock>>,
         pub handler: Box<dyn Handler>,
         pub hpke_keypair: HpkeKeypair,
+        // TODO(inahga): create aggregation job driver
     }
 
     impl HttpHandlerTest {
@@ -882,6 +883,8 @@ pub mod test_util {
             )
             .await
             .unwrap();
+
+            // TODO(inahga): create aggregation job driver
 
             Self {
                 clock,

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
@@ -479,18 +479,31 @@ async fn aggregate_init() {
                         .get_aggregation_jobs_for_task::<0, TimeInterval, dummy::Vdaf>(task.id())
                         .await
                         .unwrap());
+                    // dbg!(tx
+                    //     .get_batch_aggregations_for_task::<0, TimeInterval, _>(&vdaf, task.id())
+                    //     .await
+                    //     .unwrap());
+                    // dbg!(tx.get_report_metadatas_for_task(task.id()).await.unwrap());
+
                     dbg!(tx
-                        .get_batch_aggregations_for_task::<0, TimeInterval, _>(&vdaf, task.id())
+                        .get_report_aggregations_for_aggregation_job(
+                            &vdaf,
+                            &janus_messages::Role::Helper,
+                            task.id(),
+                            &aggregation_job_id
+                        )
                         .await
                         .unwrap());
-                    dbg!(tx.get_report_metadatas_for_task(task.id()).await.unwrap());
                     Ok(())
                 })
             })
             .await
             .unwrap();
 
-        assert_eq!(test_conn.status(), Some(Status::Ok));
+        assert_eq!(test_conn.status(), Some(Status::Created));
+
+        // poll aggregation job
+
         assert_headers!(
             &test_conn,
             "content-type" => (AggregationJobResp::MEDIA_TYPE)

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
@@ -38,6 +38,8 @@ use janus_messages::{
 use prio::{codec::Encode, vdaf::dummy};
 use rand::random;
 use serde_json::json;
+use std::time::Duration as StdDuration;
+use tokio::time::sleep;
 use trillium::{KnownHeaderName, Status};
 use trillium_testing::{assert_headers, prelude::put, TestConn};
 
@@ -503,6 +505,8 @@ async fn aggregate_init() {
         assert_eq!(test_conn.status(), Some(Status::Created));
 
         // poll aggregation job
+
+        sleep(StdDuration::from_secs(5)).await;
 
         assert_headers!(
             &test_conn,

--- a/aggregator/src/cache.rs
+++ b/aggregator/src/cache.rs
@@ -192,7 +192,7 @@ impl Drop for GlobalHpkeKeypairCache {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct GlobalHpkeKeypairCacheView {
     // We use a std::sync::Mutex in this cache because we won't hold locks across
     // `.await` boundaries. StdMutex is lighter weight than `tokio::sync::Mutex`.

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -322,32 +322,26 @@ impl LeaderStoredReport<0, prio::vdaf::dummy::Vdaf> {
 
 #[derive(Clone, Derivative)]
 #[derivative(Debug)]
-pub struct HelperStoredReport<const SEED_SIZE: usize, A>
-where
-    A: vdaf::Aggregator<SEED_SIZE, 16>,
-{
+pub struct HelperStoredReport {
     task_id: TaskId,
     metadata: ReportMetadata,
     #[derivative(Debug = "ignore")]
-    public_share: A::PublicShare,
+    encoded_public_share: Vec<u8>,
     #[derivative(Debug = "ignore")]
     helper_encrypted_input_share: HpkeCiphertext,
 }
 
-impl<const SEED_SIZE: usize, A> HelperStoredReport<SEED_SIZE, A>
-where
-    A: vdaf::Aggregator<SEED_SIZE, 16>,
-{
+impl HelperStoredReport {
     pub fn new(
         task_id: TaskId,
         metadata: ReportMetadata,
-        public_share: A::PublicShare,
+        encoded_public_share: Vec<u8>,
         helper_encrypted_input_share: HpkeCiphertext,
     ) -> Self {
         Self {
             task_id,
             metadata,
-            public_share,
+            encoded_public_share,
             helper_encrypted_input_share,
         }
     }
@@ -360,8 +354,8 @@ where
         &self.metadata
     }
 
-    pub fn public_share(&self) -> &A::PublicShare {
-        &self.public_share
+    pub fn encoded_public_share(&self) -> &[u8] {
+        self.encoded_public_share.as_ref()
     }
 
     pub fn helper_encrypted_input_share(&self) -> &HpkeCiphertext {
@@ -369,27 +363,16 @@ where
     }
 }
 
-impl<const SEED_SIZE: usize, A> PartialEq for HelperStoredReport<SEED_SIZE, A>
-where
-    A: vdaf::Aggregator<SEED_SIZE, 16>,
-    A::InputShare: PartialEq,
-    A::PublicShare: PartialEq,
-{
+impl PartialEq for HelperStoredReport {
     fn eq(&self, other: &Self) -> bool {
         self.task_id == other.task_id
             && self.metadata == other.metadata
-            && self.public_share == other.public_share
+            && self.encoded_public_share == other.encoded_public_share
             && self.helper_encrypted_input_share == other.helper_encrypted_input_share
     }
 }
 
-impl<const SEED_SIZE: usize, A> Eq for HelperStoredReport<SEED_SIZE, A>
-where
-    A: vdaf::Aggregator<SEED_SIZE, 16>,
-    A::InputShare: Eq,
-    A::PublicShare: PartialEq,
-{
-}
+impl Eq for HelperStoredReport {}
 
 /// AggregatorRole corresponds to the `AGGREGATOR_ROLE` enum in the schema.
 #[derive(Clone, Debug, ToSql, FromSql)]

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -320,6 +320,77 @@ impl LeaderStoredReport<0, prio::vdaf::dummy::Vdaf> {
     }
 }
 
+#[derive(Clone, Derivative)]
+#[derivative(Debug)]
+pub struct HelperStoredReport<const SEED_SIZE: usize, A>
+where
+    A: vdaf::Aggregator<SEED_SIZE, 16>,
+{
+    task_id: TaskId,
+    metadata: ReportMetadata,
+    #[derivative(Debug = "ignore")]
+    public_share: A::PublicShare,
+    #[derivative(Debug = "ignore")]
+    helper_encrypted_input_share: HpkeCiphertext,
+}
+
+impl<const SEED_SIZE: usize, A> HelperStoredReport<SEED_SIZE, A>
+where
+    A: vdaf::Aggregator<SEED_SIZE, 16>,
+{
+    pub fn new(
+        task_id: TaskId,
+        metadata: ReportMetadata,
+        public_share: A::PublicShare,
+        helper_encrypted_input_share: HpkeCiphertext,
+    ) -> Self {
+        Self {
+            task_id,
+            metadata,
+            public_share,
+            helper_encrypted_input_share,
+        }
+    }
+
+    pub fn task_id(&self) -> &TaskId {
+        &self.task_id
+    }
+
+    pub fn metadata(&self) -> &ReportMetadata {
+        &self.metadata
+    }
+
+    pub fn public_share(&self) -> &A::PublicShare {
+        &self.public_share
+    }
+
+    pub fn helper_encrypted_input_share(&self) -> &HpkeCiphertext {
+        &self.helper_encrypted_input_share
+    }
+}
+
+impl<const SEED_SIZE: usize, A> PartialEq for HelperStoredReport<SEED_SIZE, A>
+where
+    A: vdaf::Aggregator<SEED_SIZE, 16>,
+    A::InputShare: PartialEq,
+    A::PublicShare: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.task_id == other.task_id
+            && self.metadata == other.metadata
+            && self.public_share == other.public_share
+            && self.helper_encrypted_input_share == other.helper_encrypted_input_share
+    }
+}
+
+impl<const SEED_SIZE: usize, A> Eq for HelperStoredReport<SEED_SIZE, A>
+where
+    A: vdaf::Aggregator<SEED_SIZE, 16>,
+    A::InputShare: Eq,
+    A::PublicShare: PartialEq,
+{
+}
+
 /// AggregatorRole corresponds to the `AGGREGATOR_ROLE` enum in the schema.
 #[derive(Clone, Debug, ToSql, FromSql)]
 #[postgres(name = "aggregator_role")]

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -2285,11 +2285,11 @@ async fn roundtrip_report_aggregation(ephemeral_datastore: EphemeralDatastore) {
             Role::Leader,
             ReportAggregationState::StartLeader {
                 public_share: vdaf_transcript.public_share.clone(),
-                leader_extensions: Vec::from([
+                leader_extensions: Some(Vec::from([
                     Extension::new(ExtensionType::Tbd, Vec::from("extension_data_0")),
                     Extension::new(ExtensionType::Tbd, Vec::from("extension_data_1")),
-                ]),
-                leader_input_share: vdaf_transcript.leader_input_share.clone(),
+                ])),
+                leader_input_share: Some(vdaf_transcript.leader_input_share.clone()),
                 helper_encrypted_input_share: HpkeCiphertext::new(
                     HpkeConfigId::from(13),
                     Vec::from("encapsulated_context"),
@@ -2653,8 +2653,8 @@ async fn get_report_aggregations_for_aggregation_job(ephemeral_datastore: Epheme
                 for (ord, state) in [
                     ReportAggregationState::StartLeader {
                         public_share: vdaf_transcript.public_share.clone(),
-                        leader_extensions: Vec::new(),
-                        leader_input_share: vdaf_transcript.leader_input_share.clone(),
+                        leader_extensions: Some(Vec::new()),
+                        leader_input_share: Some(vdaf_transcript.leader_input_share.clone()),
                         helper_encrypted_input_share: HpkeCiphertext::new(
                             HpkeConfigId::from(13),
                             Vec::from("encapsulated_context"),
@@ -2848,8 +2848,10 @@ async fn create_report_aggregation_from_client_reports_table(
                     None,
                     ReportAggregationState::<16, Poplar1<XofTurboShake128, 16>>::StartLeader {
                         public_share: leader_stored_report.public_share().clone(),
-                        leader_extensions: leader_stored_report.leader_extensions().to_owned(),
-                        leader_input_share: leader_stored_report.leader_input_share().clone(),
+                        leader_extensions: Some(
+                            leader_stored_report.leader_extensions().to_owned(),
+                        ),
+                        leader_input_share: Some(leader_stored_report.leader_input_share().clone()),
                         helper_encrypted_input_share: leader_stored_report
                             .helper_encrypted_input_share()
                             .clone(),

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -1922,6 +1922,7 @@ async fn aggregation_job_acquire_release(ephemeral_datastore: EphemeralDatastore
                     agg_job_id,
                     task::QueryType::TimeInterval,
                     VdafInstance::Prio3Count,
+                    Vec::new(),
                 ),
                 want_expiry_time,
             )
@@ -2044,6 +2045,7 @@ async fn aggregation_job_acquire_release(ephemeral_datastore: EphemeralDatastore
                     job_id,
                     task::QueryType::TimeInterval,
                     VdafInstance::Prio3Count,
+                    Vec::new(),
                 ),
                 want_expiry_time,
             )
@@ -2295,6 +2297,7 @@ async fn roundtrip_report_aggregation(ephemeral_datastore: EphemeralDatastore) {
                     Vec::from("encapsulated_context"),
                     Vec::from("payload"),
                 ),
+                message: None,
             },
         ),
         (
@@ -2660,6 +2663,7 @@ async fn get_report_aggregations_for_aggregation_job(ephemeral_datastore: Epheme
                             Vec::from("encapsulated_context"),
                             Vec::from("payload"),
                         ),
+                        message: None,
                     },
                     ReportAggregationState::WaitingHelper {
                         prepare_state: vdaf_transcript.helper_prepare_transitions[0]
@@ -2855,6 +2859,7 @@ async fn create_report_aggregation_from_client_reports_table(
                         helper_encrypted_input_share: leader_stored_report
                             .helper_encrypted_input_share()
                             .clone(),
+                        message: None,
                     },
                 )]))
             })

--- a/core/src/hpke.rs
+++ b/core/src/hpke.rs
@@ -90,7 +90,7 @@ impl HpkeApplicationInfo {
 /// An HPKE private key, serialized using the `SerializePrivateKey` function as
 /// described in RFC 9180, §4 and §7.1.2.
 // TODO(#230): refactor HpkePrivateKey to simplify usage
-#[derive(Clone, Derivative, PartialEq, Eq)]
+#[derive(Clone, Derivative, PartialEq, Eq, PartialOrd, Ord)]
 #[derivative(Debug)]
 pub struct HpkePrivateKey(#[derivative(Debug = "ignore")] Vec<u8>);
 
@@ -210,7 +210,7 @@ pub fn open(
 }
 
 /// An HPKE configuration and its corresponding private key.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord)]
 pub struct HpkeKeypair {
     config: HpkeConfig,
     private_key: HpkePrivateKey, // uses unpadded base64url

--- a/db/00000000000001_initial_schema.up.sql
+++ b/db/00000000000001_initial_schema.up.sql
@@ -266,6 +266,7 @@ CREATE TABLE report_aggregations(
     leader_extensions             BYTEA,  -- encoded sequence of Extension messages from Leader input share (opaque DAP messages)
     leader_input_share            BYTEA,  -- encoded leader input share (opaque VDAF message)
     helper_encrypted_input_share  BYTEA,  -- encoded HPKE ciphertext of helper input share (opaque DAP message)
+    message                       BYTEA,  -- optional encoded ping pong message (opaque VDAF message)
 
     -- Additional data for state WaitingLeader.
     leader_prep_transition  BYTEA,  -- the current VDAF prepare transition (opaque VDAF message)

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -763,7 +763,18 @@ impl<'de> Deserialize<'de> for TaskId {
 
 /// DAP protocol message representing an HPKE key encapsulation mechanism.
 #[derive(
-    Clone, Copy, Debug, PartialEq, Eq, FromPrimitive, IntoPrimitive, Serialize, Deserialize, Hash,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    FromPrimitive,
+    IntoPrimitive,
+    Serialize,
+    Deserialize,
+    Hash,
+    PartialOrd,
+    Ord,
 )]
 #[repr(u16)]
 #[non_exhaustive]
@@ -802,7 +813,18 @@ impl Decode for HpkeKemId {
 
 /// DAP protocol message representing an HPKE key derivation function.
 #[derive(
-    Clone, Copy, Debug, PartialEq, Eq, FromPrimitive, IntoPrimitive, Serialize, Deserialize, Hash,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    FromPrimitive,
+    IntoPrimitive,
+    Serialize,
+    Deserialize,
+    Hash,
+    PartialOrd,
+    Ord,
 )]
 #[repr(u16)]
 #[non_exhaustive]
@@ -837,7 +859,18 @@ impl Decode for HpkeKdfId {
 
 /// DAP protocol message representing an HPKE AEAD.
 #[derive(
-    Clone, Copy, Debug, PartialEq, Eq, FromPrimitive, IntoPrimitive, Serialize, Deserialize, Hash,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    FromPrimitive,
+    IntoPrimitive,
+    Serialize,
+    Deserialize,
+    Hash,
+    PartialOrd,
+    Ord,
 )]
 #[repr(u16)]
 #[non_exhaustive]
@@ -1027,7 +1060,7 @@ impl Decode for HpkeCiphertext {
 
 /// DAP protocol message representing an HPKE public key.
 // TODO(#230): refactor HpkePublicKey & HpkeConfig to simplify usage
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct HpkePublicKey(Vec<u8>);
 
 impl From<Vec<u8>> for HpkePublicKey {
@@ -1123,7 +1156,7 @@ impl<'de> Deserialize<'de> for HpkePublicKey {
 }
 
 /// DAP protocol message representing an HPKE config.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord)]
 pub struct HpkeConfig {
     id: HpkeConfigId,
     kem_id: HpkeKemId,


### PR DESCRIPTION
Proof of concept of https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/564, only supports single round VDAFs for now.

Rather brutal hacks take place here, rather this is illustrative of the work we'd need to do to adopt this proposal, and lets us experiment with it in load tests.

Note it only passes the `aggregator::http_handlers::tests::aggregation_job_init::aggregate_init` since I haven't plumbed through the polling logic to the remaining tests.