### PR TITLE
Update Tokio runtime metrics

### DIFF
--- a/aggregator/src/metrics/tokio_runtime.rs
+++ b/aggregator/src/metrics/tokio_runtime.rs
@@ -127,6 +127,7 @@ impl MetricProducer for TokioRuntimeMetrics {
         let num_blocking_threads = self.runtime_metrics.num_blocking_threads();
         let num_alive_tasks = self.runtime_metrics.num_alive_tasks();
         let num_idle_blocking_threads = self.runtime_metrics.num_idle_blocking_threads();
+        let spawned_task_count = self.runtime_metrics.spawned_tasks_count();
         let remote_schedule_count = self.runtime_metrics.remote_schedule_count();
         let budget_forced_yield_count = self.runtime_metrics.budget_forced_yield_count();
         let injection_queue_depth = self.runtime_metrics.injection_queue_depth();
@@ -227,6 +228,22 @@ impl MetricProducer for TokioRuntimeMetrics {
                         value: u64::try_from(num_idle_blocking_threads).unwrap_or(u64::MAX),
                         exemplars: Vec::new(),
                     }]),
+                }),
+            },
+            Metric {
+                name: "tokio.task.spawned".into(),
+                description: "Total number of tasks spawned in the runtime".into(),
+                unit: "{task}".into(),
+                data: Box::new(Sum::<u64> {
+                    data_points: Vec::from([DataPoint {
+                        attributes: Vec::new(),
+                        start_time: Some(self.start_time),
+                        time: Some(now),
+                        value: spawned_task_count,
+                        exemplars: Vec::new(),
+                    }]),
+                    temporality: Temporality::Cumulative,
+                    is_monotonic: true,
                 }),
             },
             Metric {

--- a/aggregator/src/metrics/tokio_runtime.rs
+++ b/aggregator/src/metrics/tokio_runtime.rs
@@ -28,7 +28,7 @@ pub(crate) fn configure_runtime(
     if config.enable_poll_time_histogram {
         runtime_builder.enable_metrics_poll_count_histogram();
         runtime_builder.metrics_poll_count_histogram_scale(config.poll_time_histogram_scale.into());
-        if let Some(resolution) = config.poll_time_histogram_resolution_microseconds {
+        if let Some(resolution) = config.poll_time_histogram_resolution_us {
             let resolution = Duration::from_micros(resolution);
             runtime_builder.metrics_poll_count_histogram_resolution(resolution);
         }

--- a/aggregator/src/metrics/tokio_runtime.rs
+++ b/aggregator/src/metrics/tokio_runtime.rs
@@ -125,7 +125,7 @@ impl MetricProducer for TokioRuntimeMetrics {
         let now = SystemTime::now();
 
         let num_blocking_threads = self.runtime_metrics.num_blocking_threads();
-        let active_tasks_count = self.runtime_metrics.active_tasks_count();
+        let num_alive_tasks = self.runtime_metrics.num_alive_tasks();
         let num_idle_blocking_threads = self.runtime_metrics.num_idle_blocking_threads();
         let remote_schedule_count = self.runtime_metrics.remote_schedule_count();
         let budget_forced_yield_count = self.runtime_metrics.budget_forced_yield_count();
@@ -201,15 +201,15 @@ impl MetricProducer for TokioRuntimeMetrics {
                 }),
             },
             Metric {
-                name: "tokio.task.active.count".into(),
-                description: "Number of active tasks in the runtime".into(),
+                name: "tokio.task.alive.count".into(),
+                description: "Number of alive tasks in the runtime".into(),
                 unit: "{task}".into(),
                 data: Box::new(Gauge::<u64> {
                     data_points: Vec::from([DataPoint {
                         attributes: Vec::new(),
                         start_time: Some(self.start_time),
                         time: Some(now),
-                        value: u64::try_from(active_tasks_count).unwrap_or(u64::MAX),
+                        value: u64::try_from(num_alive_tasks).unwrap_or(u64::MAX),
                         exemplars: Vec::new(),
                     }]),
                 }),


### PR DESCRIPTION
This updates the exporter for Tokio runtime metrics for various external changes. The latest version of Tokio renamed one method and added three, I added `spawned_tasks_count()` but skipped the thread ID and "park/unpark count".