### PR TITLE
fix: Count batch size via batch_aggregations rather than report_aggregations

### DIFF
--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -4600,7 +4600,7 @@ WITH report_aggregations_count AS (
     AND report_aggregations.state in ('START', 'WAITING')
 ),
 batch_aggregation_count AS (
-    SELECT SUM(report_count) as count FROM batch_aggregations
+    SELECT SUM(report_count) AS count FROM batch_aggregations
     WHERE batch_aggregations.task_id = $1
     AND batch_aggregations.batch_identifier = $2
 )

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -4591,7 +4591,7 @@ WHERE task_id = $1
             .prepare_cached(
                 "-- read_batch_size()
 WITH report_aggregations_count AS (
-    SELECT COUNT(*) as count FROM report_aggregations
+    SELECT COUNT(*) AS count FROM report_aggregations
     JOIN aggregation_jobs
         ON report_aggregations.aggregation_job_id = aggregation_jobs.id
     WHERE aggregation_jobs.task_id = $1

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -5176,7 +5176,10 @@ async fn roundtrip_outstanding_batch(ephemeral_datastore: EphemeralDatastore) {
                         .unwrap(),
                     BatchAggregationState::Aggregating {
                         aggregate_share: Some(dummy::AggregateShare(0)),
-                        report_count: 0,
+                        // Let report_count be 1 without an accompanying report_aggregation in a
+                        // terminal state. This captures the case where a FINISHED report_aggregation
+                        // was garbage collected and no longer exists in the database.
+                        report_count: 1,
                         checksum: ReportIdChecksum::default(),
                         aggregation_jobs_created: 4,
                         aggregation_jobs_terminated: 1,
@@ -5429,7 +5432,7 @@ async fn roundtrip_outstanding_batch(ephemeral_datastore: EphemeralDatastore) {
         Vec::from([OutstandingBatch::new(
             task_id_2,
             batch_id_2,
-            RangeInclusive::new(0, 1)
+            RangeInclusive::new(1, 2)
         )])
     );
     assert_eq!(outstanding_batches_task_2_after_mark, Vec::new());

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -5176,7 +5176,7 @@ async fn roundtrip_outstanding_batch(ephemeral_datastore: EphemeralDatastore) {
                         .unwrap(),
                     BatchAggregationState::Aggregating {
                         aggregate_share: Some(dummy::AggregateShare(0)),
-                        report_count: 1,
+                        report_count: 0,
                         checksum: ReportIdChecksum::default(),
                         aggregation_jobs_created: 4,
                         aggregation_jobs_terminated: 1,


### PR DESCRIPTION
Fixes #3323.

Track the number of FINISHED report_aggregations from `batch_aggregations.report_count`. This allows us to account for GC, since `batch_aggregations` are not sensitive to GC.

I don't think this is racy. The only possible race I can think of: If an aggregation job is in flight, there must be an accompanying report_aggregations row, as generated by the job creator. That row will be captured in `max_size`. Anyone else have thoughts?

This passes the regression test in https://github.com/divviup/janus/pull/3324.