### PR TITLE
aggregator_core: Allow dumping query plans to stdout

### DIFF
--- a/aggregator_core/README.md
+++ b/aggregator_core/README.md
@@ -9,8 +9,7 @@ It is not published to crates.io and should not be depended on directly by users
 ## PostgreSQL Logs
 
 During tests, you can have PostgreSQL dump its logs to stdout by setting
-`JANUS_TEST_DUMP_POSTGRESQL_LOGS`. The test database is set to log all query plans. You should only
-run this option with one test at a time, otherwise you might not get all the logs.
+`JANUS_TEST_DUMP_POSTGRESQL_LOGS`. The test database is set to log all query plans.
 
 Example:
 ```

--- a/aggregator_core/README.md
+++ b/aggregator_core/README.md
@@ -1,0 +1,18 @@
+# `aggregator_core`
+
+`aggregator_core` contains helper code for the `aggregator` crate. It mainly consists of data
+structures that are only pertinent to a DAP aggregator, and subroutines for talking to a PostgreSQL
+database.
+
+It is not published to crates.io and should not be depended on directly by users of Janus.
+
+## PostgreSQL Logs
+
+During tests, you can have PostgreSQL dump its logs to stdout by setting
+`JANUS_TEST_DUMP_POSTGRESQL_LOGS`. The test database is set to log all query plans. You should only
+run this option with one test at a time, otherwise you might not get all the logs.
+
+Example:
+```
+JANUS_TEST_DUMP_POSTGRESQL_LOGS= RUST_LOG=debug cargo test datastore::tests::roundtrip_task::case_1 -- --exact --nocapture
+```

--- a/aggregator_core/src/datastore/test_util.rs
+++ b/aggregator_core/src/datastore/test_util.rs
@@ -5,7 +5,6 @@ use crate::{
 use backoff::{future::retry, ExponentialBackoffBuilder};
 use chrono::NaiveDateTime;
 use deadpool_postgres::{Manager, Pool, Timeouts};
-use futures::{future::try_join_all, FutureExt, TryFutureExt};
 use janus_core::{
     test_util::testcontainers::Postgres,
     time::{Clock, MockClock, TimeExt},

--- a/aggregator_core/src/datastore/test_util.rs
+++ b/aggregator_core/src/datastore/test_util.rs
@@ -104,8 +104,7 @@ impl EphemeralDatabase {
     fn postgres_configuration<'a>(settings: &[&'a str]) -> Vec<&'a str> {
         settings
             .iter()
-            .map(|setting| ["-c", setting])
-            .flatten()
+            .flat_map(|setting| ["-c", setting])
             .collect::<Vec<_>>()
     }
 }


### PR DESCRIPTION
Makes it easier to inspect query plans while working locally. These query plans do have to be taken with a grain of salt, because they're always running against an empty database and with `enable_seqscan=false`, so they're not entirely representative.

We dump to stdout because the output from tracing is fairly incomprehensible, since each node of the query plan is on its own tracing event.