### PR TITLE
Add validation that min_batch_size is nonzero

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_driver/tests.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver/tests.rs
@@ -54,6 +54,7 @@ use prio::{
 };
 use rand::random;
 use std::{sync::Arc, time::Duration as StdDuration};
+use tokio::time::timeout;
 use trillium_tokio::Stopper;
 
 #[tokio::test]
@@ -255,7 +256,12 @@ async fn aggregation_job_driver() {
 
     tracing::info!("awaiting stepper tasks");
     // Wait for all of the aggregation job stepper tasks to complete.
-    runtime_manager.wait_for_completed_tasks("stepper", 2).await;
+    timeout(
+        StdDuration::from_secs(30),
+        runtime_manager.wait_for_completed_tasks("stepper", 2),
+    )
+    .await
+    .unwrap();
     // Stop the aggregation job driver.
     stopper.stop();
     // Wait for the aggregation job driver task to complete.

--- a/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
@@ -3,9 +3,7 @@ use crate::aggregator::{
     http_handlers::test_util::{decode_response_body, take_problem_details, HttpHandlerTest},
 };
 use janus_aggregator_core::{
-    datastore::models::{
-        BatchAggregation, BatchAggregationState, CollectionJob, CollectionJobState,
-    },
+    datastore::models::{CollectionJob, CollectionJobState},
     query_type::AccumulableQueryType,
     task::{test_util::TaskBuilder, QueryType},
 };
@@ -15,7 +13,7 @@ use janus_core::{
 };
 use janus_messages::{
     query_type::TimeInterval, AggregateShareAad, BatchSelector, Collection, CollectionJobId,
-    CollectionReq, Duration, Interval, Query, ReportIdChecksum, Role, Time,
+    CollectionReq, Duration, Interval, Query, Role, Time,
 };
 use prio::{
     codec::{Decode, Encode},
@@ -32,6 +30,9 @@ use trillium_testing::{
 #[tokio::test]
 async fn collection_job_put_request_to_helper() {
     let test_case = setup_collection_job_test_case(Role::Helper, QueryType::TimeInterval).await;
+    test_case
+        .setup_time_interval_batch(Time::from_seconds_since_epoch(0))
+        .await;
 
     let collection_job_id: CollectionJobId = random();
     let request = CollectionReq::new(
@@ -64,6 +65,9 @@ async fn collection_job_put_request_to_helper() {
 #[tokio::test]
 async fn collection_job_put_request_invalid_batch_interval() {
     let test_case = setup_collection_job_test_case(Role::Leader, QueryType::TimeInterval).await;
+    test_case
+        .setup_time_interval_batch(Time::from_seconds_since_epoch(0))
+        .await;
 
     let collection_job_id: CollectionJobId = random();
     let request = CollectionReq::new(
@@ -97,6 +101,9 @@ async fn collection_job_put_request_invalid_batch_interval() {
 #[tokio::test]
 async fn collection_job_put_request_invalid_aggregation_parameter() {
     let test_case = setup_collection_job_test_case(Role::Leader, QueryType::TimeInterval).await;
+    test_case
+        .setup_time_interval_batch(Time::from_seconds_since_epoch(0))
+        .await;
 
     let collection_job_id: CollectionJobId = random();
     let request = CollectionReq::new(
@@ -183,6 +190,9 @@ async fn collection_job_put_request_invalid_batch_size() {
 #[tokio::test]
 async fn collection_job_put_request_unauthenticated() {
     let test_case = setup_collection_job_test_case(Role::Leader, QueryType::TimeInterval).await;
+    test_case
+        .setup_time_interval_batch(Time::from_seconds_since_epoch(0))
+        .await;
 
     let batch_interval = Interval::new(
         Time::from_seconds_since_epoch(0),
@@ -254,6 +264,9 @@ async fn collection_job_put_request_unauthenticated() {
 #[tokio::test]
 async fn collection_job_post_request_unauthenticated_collection_jobs() {
     let test_case = setup_collection_job_test_case(Role::Leader, QueryType::TimeInterval).await;
+    test_case
+        .setup_time_interval_batch(Time::from_seconds_since_epoch(0))
+        .await;
 
     let batch_interval = Interval::new(
         Time::from_seconds_since_epoch(0),
@@ -331,6 +344,9 @@ async fn collection_job_post_request_unauthenticated_collection_jobs() {
 #[tokio::test]
 async fn collection_job_success_time_interval() {
     let test_case = setup_collection_job_test_case(Role::Leader, QueryType::TimeInterval).await;
+    test_case
+        .setup_time_interval_batch(Time::from_seconds_since_epoch(0))
+        .await;
 
     let batch_interval = TimeInterval::to_batch_identifier(
         &test_case.task.leader_view().unwrap(),
@@ -488,6 +504,9 @@ async fn collection_job_success_time_interval() {
 #[tokio::test]
 async fn collection_job_post_request_no_such_collection_job() {
     let test_case = setup_collection_job_test_case(Role::Leader, QueryType::TimeInterval).await;
+    test_case
+        .setup_time_interval_batch(Time::from_seconds_since_epoch(0))
+        .await;
 
     let no_such_collection_job_id: CollectionJobId = random();
 
@@ -508,37 +527,9 @@ async fn collection_job_post_request_no_such_collection_job() {
 #[tokio::test]
 async fn collection_job_put_request_batch_queried_too_many_times() {
     let test_case = setup_collection_job_test_case(Role::Leader, QueryType::TimeInterval).await;
-    let interval = Interval::new(
-        Time::from_seconds_since_epoch(0),
-        *test_case.task.time_precision(),
-    )
-    .unwrap();
-
-    test_case
-        .datastore
-        .run_unnamed_tx(|tx| {
-            let task = test_case.task.clone();
-            Box::pin(async move {
-                tx.put_batch_aggregation(&BatchAggregation::<0, TimeInterval, dummy::Vdaf>::new(
-                    *task.id(),
-                    Interval::new(Time::from_seconds_since_epoch(0), *task.time_precision())
-                        .unwrap(),
-                    dummy::AggregationParam(0),
-                    0,
-                    interval,
-                    BatchAggregationState::Aggregating {
-                        aggregate_share: Some(dummy::AggregateShare(0)),
-                        report_count: 10,
-                        checksum: ReportIdChecksum::get_decoded(&[2; 32]).unwrap(),
-                        aggregation_jobs_created: 1,
-                        aggregation_jobs_terminated: 1,
-                    },
-                ))
-                .await
-            })
-        })
-        .await
-        .unwrap();
+    let interval = test_case
+        .setup_time_interval_batch(Time::from_seconds_since_epoch(0))
+        .await;
 
     // Sending this request will consume a query for [0, time_precision).
     let request = CollectionReq::new(
@@ -574,36 +565,9 @@ async fn collection_job_put_request_batch_queried_too_many_times() {
 #[tokio::test]
 async fn collection_job_put_request_batch_overlap() {
     let test_case = setup_collection_job_test_case(Role::Leader, QueryType::TimeInterval).await;
-    let interval = Interval::new(
-        Time::from_seconds_since_epoch(0),
-        *test_case.task.time_precision(),
-    )
-    .unwrap();
-
-    test_case
-        .datastore
-        .run_unnamed_tx(|tx| {
-            let task = test_case.task.clone();
-            Box::pin(async move {
-                tx.put_batch_aggregation(&BatchAggregation::<0, TimeInterval, dummy::Vdaf>::new(
-                    *task.id(),
-                    interval,
-                    dummy::AggregationParam(0),
-                    0,
-                    interval,
-                    BatchAggregationState::Aggregating {
-                        aggregate_share: Some(dummy::AggregateShare(0)),
-                        report_count: 10,
-                        checksum: ReportIdChecksum::get_decoded(&[2; 32]).unwrap(),
-                        aggregation_jobs_created: 1,
-                        aggregation_jobs_terminated: 1,
-                    },
-                ))
-                .await
-            })
-        })
-        .await
-        .unwrap();
+    let interval = test_case
+        .setup_time_interval_batch(Time::from_seconds_since_epoch(0))
+        .await;
 
     // Sending this request will consume a query for [0, 2 * time_precision).
     let request = CollectionReq::new(
@@ -645,11 +609,9 @@ async fn collection_job_put_request_batch_overlap() {
 #[tokio::test]
 async fn delete_collection_job() {
     let test_case = setup_collection_job_test_case(Role::Leader, QueryType::TimeInterval).await;
-    let batch_interval = Interval::new(
-        Time::from_seconds_since_epoch(0),
-        *test_case.task.time_precision(),
-    )
-    .unwrap();
+    let batch_interval = test_case
+        .setup_time_interval_batch(Time::from_seconds_since_epoch(0))
+        .await;
 
     let collection_job_id: CollectionJobId = random();
 

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -155,6 +155,10 @@ impl CommonTaskParameters {
         time_precision: Duration,
         tolerable_clock_skew: Duration,
     ) -> Result<Self, Error> {
+        if min_batch_size == 0 {
+            return Err(Error::InvalidParameter("min_batch_size"));
+        }
+
         if let QueryType::FixedSize {
             max_batch_size: Some(max_batch_size),
             ..
@@ -1102,7 +1106,7 @@ pub mod test_util {
                 1,
                 None,
                 None,
-                0,
+                1,
                 Duration::from_hours(8).unwrap(),
                 Duration::from_minutes(10).unwrap(),
                 /* Collector HPKE keypair */ HpkeKeypair::test(),


### PR DESCRIPTION
This adds a validation that `min_batch_size` is not zero. Without this, we can wind up taking this code path in the collection job driver: https://github.com/divviup/janus/blob/3258350fabbd6b1be8ad48637d7fbdd381893742/aggregator/src/aggregator/aggregate_share.rs#L98-L101

The following simulation test input reproduces this, based on an automatically-generated input.

```rust
Input {
    is_fixed_size: true,
    config: Config {
        time_precision: Duration::from_seconds(3600),
        min_batch_size: 0,
        max_batch_size: Some(255),
        batch_time_window_size: None,
        report_expiry_age: None,
        min_aggregation_job_size: 1,
        max_aggregation_job_size: 76,
    },
    ops: Vec::from([
        Op::Upload {
            report_time: Time::from_seconds_since_epoch(1700000903),
            count: 13,
        },
        Op::AggregationJobCreator,
        Op::AggregationJobDriverResponseError,
        Op::AdvanceTime {
            amount: Duration::from_seconds(27041),
        },
        Op::AggregationJobDriverResponseError,
        Op::AdvanceTime {
            amount: Duration::from_seconds(8541),
        },
        Op::CollectorStart {
            collection_job_id: random(),
            query: Query::FixedSizeCurrentBatch,
        },
        Op::AggregationJobDriverResponseError,
        Op::CollectionJobDriverResponseError,
    ]),
}
```

This looks like a variant of the test case showing that abandoning an aggregation job leads to a batch mismatch, but the collection job driver encounters this error before sending an aggregate share request. Instead, collection jobs with 0 aggregated reports can get picked up once the aggregation job is abandoned, and then they tick up their error counter.