### PR TITLE
Use tmpfs in database container

### DIFF
--- a/aggregator_core/src/datastore/test_util.rs
+++ b/aggregator_core/src/datastore/test_util.rs
@@ -24,7 +24,7 @@ use std::{
     thread::JoinHandle,
     time::Duration,
 };
-use testcontainers::{runners::AsyncRunner, ContainerRequest, ImageExt};
+use testcontainers::{core::Mount, runners::AsyncRunner, ContainerRequest, ImageExt};
 use tokio::{
     io::{AsyncBufRead, AsyncBufReadExt},
     join, spawn,
@@ -85,6 +85,7 @@ impl EphemeralDatabase {
                     // Start an instance of Postgres running in a container.
                     let db_container = ContainerRequest::from(Postgres::default())
                         .with_cmd(Self::postgres_configuration(&configuration))
+                        .with_mount(Mount::tmpfs_mount("/var/lib/postgresql/data"))
                         .start()
                         .await
                         .unwrap();


### PR DESCRIPTION
This mounts a tmpfs volume into test database containers, over where the Postgres data directory will be. Closes #3359. I saw the following runtime improvements locally.

Tests | Before | After
-------|-----------|-----------
All | 2m57s | 2m25s
`-p janus_aggregator --lib` | 82s | 68s
`-p janus_integration_tests --test integration` | 29s | 24s