### PR TITLE
Ephemeral database cleanup followup

### DIFF
--- a/aggregator_core/src/datastore/test_util.rs
+++ b/aggregator_core/src/datastore/test_util.rs
@@ -265,7 +265,7 @@ impl Drop for EphemeralDatastore {
         let db_name = self.db_name.clone();
         spawn(async move {
             if let Ok(conn) = pool.get().await {
-                let _ = conn.execute("DROP DATABASE $1", &[&db_name]).await;
+                let _ = conn.execute(&format!("DROP DATABASE {db_name}"), &[]).await;
             }
         });
     }


### PR DESCRIPTION
This is a follow-up to #3358, which was not actually deleting databases. First, we need to fix the SQL statement. The database name is an identifier, not a string, so we can't template it in as a parameter. This was producing the following error, which was being intentionally swallowed to handle container deletion races.

```
2024-08-09 19:41:26.520 UTC [30587] ERROR:  syntax error at or near "$1" at character 15
2024-08-09 19:41:26.520 UTC [30587] STATEMENT:  DROP DATABASE $1
```

Beyond that, we can't drop the database that the connection is using, so we have to spin up a fresh connection to the `postgres` database.

```
2024-08-09 19:52:39.758 UTC [843] ERROR:  cannot drop the currently open database
2024-08-09 19:52:39.758 UTC [843] STATEMENT:  DROP DATABASE janus_test_c71da38e6d7fe51b10f5c713d1130a0a
```

Lastly, dropping the database can take some time, and it will almost always happen near the end of a unit test. Thus, the Tokio runtime will be shutting down soon, which cancels the operation. This is fixed by spinning up a smaller runtime on its own thread, like we recently did for log forwarding. In this case, we don't need to block the `Drop` impl on the spawned operation, because we're just dropping the database for resource utilization reasons.