### PR TITLE
Backpressure by bounded request queueing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2811,6 +2811,7 @@ dependencies = [
  "trillium-api",
  "trillium-caching-headers",
  "trillium-head",
+ "trillium-macros 0.0.6",
  "trillium-opentelemetry",
  "trillium-prometheus",
  "trillium-router",

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -100,6 +100,7 @@ trillium.workspace = true
 trillium-api.workspace = true
 trillium-caching-headers.workspace = true
 trillium-head.workspace = true
+trillium-macros = "0.0.6"
 trillium-opentelemetry.workspace = true
 trillium-prometheus = { workspace = true, optional = true }
 trillium-router.workspace = true

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -134,7 +134,6 @@ pub mod http_handlers;
 pub mod key_rotator;
 pub mod problem_details;
 pub mod query_type;
-mod queue;
 pub mod report_writer;
 #[cfg(test)]
 mod taskprov_tests;
@@ -143,6 +142,10 @@ mod taskprov_tests;
 pub mod test_util;
 #[cfg(test)]
 mod upload_tests;
+
+// TODO(#3181): reallow dead code once there's a production code path that uses this code.
+#[allow(dead_code)]
+mod queue;
 
 /// Aggregator implements a DAP aggregator.
 pub struct Aggregator<C: Clock> {

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -134,6 +134,7 @@ pub mod http_handlers;
 pub mod key_rotator;
 pub mod problem_details;
 pub mod query_type;
+mod queue;
 pub mod report_writer;
 #[cfg(test)]
 mod taskprov_tests;

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -134,6 +134,7 @@ pub mod http_handlers;
 pub mod key_rotator;
 pub mod problem_details;
 pub mod query_type;
+mod queue;
 pub mod report_writer;
 #[cfg(test)]
 mod taskprov_tests;
@@ -142,10 +143,6 @@ mod taskprov_tests;
 pub mod test_util;
 #[cfg(test)]
 mod upload_tests;
-
-// TODO(#3181): reallow dead code once there's a production code path that uses this code.
-#[allow(dead_code)]
-mod queue;
 
 /// Aggregator implements a DAP aggregator.
 pub struct Aggregator<C: Clock> {

--- a/aggregator/src/aggregator/aggregate_init_tests.rs
+++ b/aggregator/src/aggregator/aggregate_init_tests.rs
@@ -1,7 +1,7 @@
 use crate::aggregator::{
     http_handlers::{
-        aggregator_handler,
         test_util::{decode_response_body, take_problem_details},
+        AggregatorHandlerBuilder,
     },
     test_util::generate_helper_report_share,
     Config,
@@ -257,7 +257,7 @@ async fn setup_aggregate_init_test_without_sending_request<
     datastore.put_aggregator_task(&helper_task).await.unwrap();
     let keypair = datastore.put_global_hpke_key().await.unwrap();
 
-    let handler = aggregator_handler(
+    let handler = AggregatorHandlerBuilder::new(
         Arc::clone(&datastore),
         clock.clone(),
         TestRuntime::default(),
@@ -265,6 +265,8 @@ async fn setup_aggregate_init_test_without_sending_request<
         Config::default(),
     )
     .await
+    .unwrap()
+    .build()
     .unwrap();
 
     let prepare_init_generator = PrepareInitGenerator::new(

--- a/aggregator/src/aggregator/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/aggregation_job_continue.rs
@@ -400,8 +400,8 @@ mod tests {
             post_aggregation_job_expecting_status,
         },
         http_handlers::{
-            aggregator_handler,
             test_util::{take_problem_details, HttpHandlerTest},
+            AggregatorHandlerBuilder,
         },
         test_util::default_aggregator_config,
     };
@@ -555,7 +555,7 @@ mod tests {
         );
 
         // Create aggregator handler.
-        let handler = aggregator_handler(
+        let handler = AggregatorHandlerBuilder::new(
             Arc::clone(&datastore),
             clock,
             TestRuntime::default(),
@@ -563,6 +563,8 @@ mod tests {
             default_aggregator_config(),
         )
         .await
+        .unwrap()
+        .build()
         .unwrap();
 
         AggregationJobContinueTestCase {

--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -1,8 +1,5 @@
 use crate::aggregator::{
-    http_handlers::{
-        aggregator_handler,
-        test_util::{decode_response_body, take_problem_details},
-    },
+    http_handlers::test_util::{decode_response_body, take_problem_details},
     test_util::BATCH_AGGREGATION_SHARD_COUNT,
     Config,
 };
@@ -47,6 +44,8 @@ use trillium_testing::{
     prelude::{post, put},
     TestConn,
 };
+
+use super::http_handlers::AggregatorHandlerBuilder;
 
 pub(crate) struct CollectionJobTestCase {
     pub(super) task: Task,
@@ -268,7 +267,7 @@ pub(crate) async fn setup_collection_job_test_case(
     datastore.put_aggregator_task(&role_task).await.unwrap();
     datastore.put_global_hpke_key().await.unwrap();
 
-    let handler = aggregator_handler(
+    let handler = AggregatorHandlerBuilder::new(
         Arc::clone(&datastore),
         clock.clone(),
         TestRuntime::default(),
@@ -279,6 +278,8 @@ pub(crate) async fn setup_collection_job_test_case(
         },
     )
     .await
+    .unwrap()
+    .build()
     .unwrap();
 
     CollectionJobTestCase {

--- a/aggregator/src/aggregator/error.rs
+++ b/aggregator/src/aggregator/error.rs
@@ -145,6 +145,8 @@ pub enum Error {
     DifferentialPrivacy(VdafError),
     #[error("client disconnected")]
     ClientDisconnected,
+    #[error("too many requests")]
+    TooManyRequests,
 }
 
 /// A newtype around `Arc<Error>`. This is needed to host a customized implementation of
@@ -312,6 +314,7 @@ impl Error {
             Error::InvalidTask(_, _) => "invalid_task",
             Error::DifferentialPrivacy(_) => "differential_privacy",
             Error::ClientDisconnected => "client_disconnected",
+            Error::TooManyRequests => "too_many_requests",
         }
     }
 }

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -169,7 +169,7 @@ async fn run_error_handler(error: &Error, mut conn: Conn) -> Conn {
     };
 
     if matches!(conn.status(), Some(status) if status.is_server_error()) {
-        warn!(error_code, ?error, "Error handling endpoint");
+        // warn!(error_code, ?error, "Error handling endpoint");
     }
 
     conn

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -169,7 +169,7 @@ async fn run_error_handler(error: &Error, mut conn: Conn) -> Conn {
     };
 
     if matches!(conn.status(), Some(status) if status.is_server_error()) {
-        // warn!(error_code, ?error, "Error handling endpoint");
+        warn!(error_code, ?error, "Error handling endpoint");
     }
 
     conn

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -159,7 +159,7 @@ async fn run_error_handler(error: &Error, mut conn: Conn) -> Conn {
             &ProblemDocument::new(
                 "https://docs.divviup.org/references/janus-errors#too-many-requests",
                 "The server is currently overloaded.",
-                Status::ServiceUnavailable,
+                Status::TooManyRequests,
             )
             .with_detail(concat!(
                 "The server is currently servicing too many requests, please try the request ",

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -169,7 +169,7 @@ async fn run_error_handler(error: &Error, mut conn: Conn) -> Conn {
     };
 
     if matches!(conn.status(), Some(status) if status.is_server_error()) {
-        warn!(error_code, ?error, "Error handling endpoint");
+        // warn!(error_code, ?error, "Error handling endpoint");
     }
 
     conn
@@ -312,7 +312,7 @@ async fn aggregator_handler_with_aggregator<C: Clock>(
     aggregator: Arc<Aggregator<C>>,
     meter: &Meter,
 ) -> Result<impl Handler, Error> {
-    let queue = Arc::new(LIFORequestQueue::new(2, 8)?);
+    let queue = Arc::new(LIFORequestQueue::new(2, 8, meter)?);
     Ok((
         State(aggregator),
         metrics(meter)

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
@@ -2,8 +2,8 @@ use crate::aggregator::{
     aggregate_init_tests::{put_aggregation_job, PrepareInitGenerator},
     empty_batch_aggregations,
     http_handlers::{
-        aggregator_handler,
         test_util::{decode_response_body, take_problem_details, HttpHandlerTest},
+        AggregatorHandlerBuilder,
     },
     test_util::{
         assert_task_aggregation_counter, default_aggregator_config, generate_helper_report_share,
@@ -768,7 +768,7 @@ async fn aggregate_init_with_reports_encrypted_by_task_specific_key() {
     }
 
     // Create new handler _after_ the keys have been inserted so that they come pre-cached.
-    let handler = aggregator_handler(
+    let handler = AggregatorHandlerBuilder::new(
         datastore.clone(),
         clock.clone(),
         TestRuntime::default(),
@@ -776,6 +776,8 @@ async fn aggregate_init_with_reports_encrypted_by_task_specific_key() {
         default_aggregator_config(),
     )
     .await
+    .unwrap()
+    .build()
     .unwrap();
 
     let (prepare_init, transcript) = prep_init_generator.next(&0);

--- a/aggregator/src/aggregator/http_handlers/tests/report.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/report.rs
@@ -2,8 +2,8 @@ use crate::{
     aggregator::{
         error::ReportRejectionReason,
         http_handlers::{
-            aggregator_handler,
             test_util::{take_problem_details, HttpHandlerTest},
+            AggregatorHandlerBuilder,
         },
         test_util::{create_report, create_report_custom, default_aggregator_config},
     },
@@ -416,7 +416,7 @@ async fn upload_handler_error_fanout() {
         .await;
     let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
     let hpke_keypair = datastore.put_global_hpke_key().await.unwrap();
-    let handler = aggregator_handler(
+    let handler = AggregatorHandlerBuilder::new(
         datastore.clone(),
         clock.clone(),
         TestRuntime::default(),
@@ -424,6 +424,8 @@ async fn upload_handler_error_fanout() {
         default_aggregator_config(),
     )
     .await
+    .unwrap()
+    .build()
     .unwrap();
 
     const REPORT_EXPIRY_AGE: u64 = 1_000_000;
@@ -527,7 +529,7 @@ async fn upload_client_early_disconnect() {
     let ephemeral_datastore = ephemeral_datastore().await;
     let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
     let hpke_keypair = datastore.put_global_hpke_key().await.unwrap();
-    let handler = aggregator_handler(
+    let handler = AggregatorHandlerBuilder::new(
         datastore.clone(),
         clock.clone(),
         TestRuntime::default(),
@@ -535,6 +537,8 @@ async fn upload_client_early_disconnect() {
         default_aggregator_config(),
     )
     .await
+    .unwrap()
+    .build()
     .unwrap();
 
     let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Prio3Count).build();

--- a/aggregator/src/aggregator/queue.rs
+++ b/aggregator/src/aggregator/queue.rs
@@ -1,0 +1,568 @@
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc, Mutex as StdMutex,
+};
+
+use tokio::{
+    sync::{
+        mpsc,
+        oneshot::{self},
+        Notify, OwnedSemaphorePermit, Semaphore,
+    },
+    task::JoinHandle,
+};
+use tracing::warn;
+use trillium::{Conn, Handler};
+use trillium_macros::Handler;
+
+use super::Error;
+
+type Stack = Arc<StdMutex<Vec<Dispatcher>>>;
+
+/// A queue that services requests in a LIFO manner, i.e. the most recent request is serviced first.
+/// It bounds the total number of waiting requests, and the number of requests that can be run
+/// concurrently. This is useful for adding backpressure and preventing the process from being
+/// overwhelmed.
+///
+/// See https://encore.dev/blog/queueing for a rationale of LIFO request queuing.
+///
+/// Note the actual execution order of requests is not perfectly LIFO if the concurrency is >1,
+/// because the order that request futures are scheduled and executed in is essentially
+/// non-deterministic.
+#[derive(Debug)]
+pub struct LIFORequestQueue {
+    /// Maximum size of the queue.
+    depth: usize,
+
+    /// LIFO data structure.
+    stack: Stack,
+
+    /// Notifies the dispatch task to wake up when a new ticket arrives in an empty stack.
+    notifier: Arc<Notify>,
+
+    /// Controls concurrency of requests.
+    _semaphore: Arc<Semaphore>,
+
+    /// Alerts tickets when they're ready.
+    dispatcher: JoinHandle<()>,
+
+    /// Generates unique ticket IDs, used to identify tickets in the queue.
+    id_generator: TicketIdGenerator,
+
+    /// Receives notifications when a request has given up on waiting in the queue.
+    cancel_tx: mpsc::UnboundedSender<TicketId>,
+
+    /// Services cancel notifications by directly removing cancelled tickets from the queue. This
+    /// prevents cancelled tickets from taking up space in the queue and starving new requests.
+    canceller: JoinHandle<()>,
+}
+
+impl LIFORequestQueue {
+    /// Creates a new [`Self`].
+    ///
+    /// `concurrency` and `depth` must be greater than 0, and `depth` must be greater than or
+    /// equal to `concurrency`.
+    pub fn new(concurrency: usize, depth: usize) -> Result<Self, Error> {
+        if concurrency < 1 {
+            return Err(Error::InvalidConfiguration(
+                "concurrency must be greater than 0",
+            ));
+        } else if depth < 1 {
+            return Err(Error::InvalidConfiguration(
+                "depth must be greater than zero",
+            ));
+        } else if concurrency > depth {
+            // We enforce this property otherwise it leads to strange intermittent behavior, i.e.
+            // rejecting requests due to the queue being full even though there's sufficient
+            // concurrency slots open.
+            return Err(Error::InvalidConfiguration(
+                "depth must be greater than or equal to concurrency",
+            ));
+        }
+
+        let stack: Stack = Default::default();
+        let notifier = Arc::new(Notify::new());
+        let (cancel_tx, cancel_rx) = mpsc::unbounded_channel();
+        let semaphore = Arc::new(Semaphore::new(concurrency));
+        let dispatcher = Self::dispatcher(
+            Arc::clone(&stack),
+            Arc::clone(&notifier),
+            Arc::clone(&semaphore),
+        );
+        let canceller = Self::canceller(Arc::clone(&stack), cancel_rx);
+        let id_generator = Default::default();
+        Ok(Self {
+            depth,
+            stack,
+            notifier,
+            _semaphore: semaphore,
+            dispatcher,
+            id_generator,
+            cancel_tx,
+            canceller,
+        })
+    }
+
+    fn dispatcher(
+        stack: Stack,
+        notifier: Arc<Notify>,
+        semaphore: Arc<Semaphore>,
+    ) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            loop {
+                let semaphore = Arc::clone(&semaphore);
+
+                // Unwrap safety: the semaphore is never dropped.
+                let permit = semaphore.acquire_owned().await.unwrap();
+                let dispatcher = {
+                    // Unwrap safety: mutex poisoning
+                    let mut stack = stack.lock().unwrap();
+                    stack.pop()
+                };
+                match dispatcher {
+                    Some(mut dispatcher) => {
+                        dispatcher.send(permit);
+                    }
+                    None => {
+                        // The queue is empty. Sleep here until we're notified that there's another
+                        // ticket available to work on.
+                        notifier.notified().await;
+                    }
+                }
+            }
+        })
+    }
+
+    fn canceller(stack: Stack, mut cancel_rx: mpsc::UnboundedReceiver<TicketId>) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            while let Some(cancellation) = cancel_rx.recv().await {
+                // Unwrap safety: mutex poisoning.
+                let mut stack = stack.lock().unwrap();
+
+                // For a Vec, this is worst case O(n) per cancelled request. We anticipate the
+                // queue depth will be small, so cache locality should keep this relatively
+                // performant.
+                stack.retain(|dispatcher| dispatcher.id != cancellation);
+            }
+        })
+    }
+
+    fn acquire(&self) -> Result<Ticket, Error> {
+        // Unwrap safety: mutex poisoning.
+        let mut stack = self.stack.lock().unwrap();
+        if stack.len() < self.depth {
+            let (permit_tx, permit_rx) = oneshot::channel();
+            let id = self.id_generator.next();
+            let dispatcher = Dispatcher {
+                id,
+                permit_tx: Some(permit_tx),
+            };
+            let ticket = Ticket {
+                id,
+                permit_rx: Some(permit_rx),
+                completed: false,
+                cancel_tx: self.cancel_tx.clone(),
+            };
+
+            stack.push(dispatcher);
+            self.notifier.notify_waiters();
+            Ok(ticket)
+        } else {
+            Err(Error::TooManyRequests)
+        }
+    }
+
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        // Unwrap safety: mutex poisoning.
+        let stack = self.stack.lock().unwrap();
+        stack.len()
+    }
+
+    #[cfg(test)]
+    pub fn available_permits(&self) -> usize {
+        self._semaphore.available_permits()
+    }
+}
+
+impl Drop for LIFORequestQueue {
+    fn drop(&mut self) {
+        self.dispatcher.abort();
+        self.canceller.abort();
+    }
+}
+
+/// Identifies a ticket in the queue.
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+struct TicketId(usize);
+
+/// Simple generator for unique ticket numbers. Ticket numbers are unique as long as there aren't
+/// more than [`usize`] entries in the queue, at which point you've run out of memory.
+#[derive(Debug, Default)]
+struct TicketIdGenerator(AtomicUsize);
+
+impl TicketIdGenerator {
+    fn next(&self) -> TicketId {
+        let ret = self.0.load(Ordering::Relaxed);
+        self.0.store(ret.wrapping_add(1), Ordering::Relaxed);
+        TicketId(ret)
+    }
+}
+
+/// Dispatcher-side ticket which is used to signal when the ticket is ready. Corresponds 1:1 with a
+/// [`Ticket`].
+#[derive(Debug)]
+struct Dispatcher {
+    /// Identifies the ticket in the queue.
+    id: TicketId,
+
+    /// Signals the [`Ticket`] holder that it may proceed.
+    permit_tx: Option<oneshot::Sender<OwnedSemaphorePermit>>,
+}
+
+impl Dispatcher {
+    fn send(&mut self, permit: OwnedSemaphorePermit) {
+        // Unwrap safety: we should only send once on this channel.
+        let _ = self
+            .permit_tx
+            .take()
+            .unwrap()
+            .send(permit)
+            .map_err(|_| warn!("failed to dispatch, request cancelled?"));
+    }
+}
+
+/// Handler-side ticket which is used to get in the queue.
+#[derive(Debug)]
+struct Ticket {
+    id: TicketId,
+    permit_rx: Option<oneshot::Receiver<OwnedSemaphorePermit>>,
+    completed: bool,
+    cancel_tx: mpsc::UnboundedSender<TicketId>,
+}
+
+impl Ticket {
+    /// Waits for the ticket to be called. Returns an [`OwnedSemaphorePermit`] which should be
+    /// dropped to signal that the request is done.
+    async fn wait(&mut self) -> OwnedSemaphorePermit {
+        // Unwrap safety: wait() should only be called once.
+        // TODO(inahga): fix unwrap
+        let ret = self.permit_rx.take().unwrap().await.unwrap();
+        self.completed = true;
+        ret
+    }
+}
+
+impl Drop for Ticket {
+    fn drop(&mut self) {
+        if !self.completed {
+            let _ = self
+                .cancel_tx
+                .send(self.id)
+                .map_err(|err| warn!("failed to send cancellation message: {:?}", err));
+        }
+    }
+}
+
+/// A handler that queues requests in a LIFO manner, according to the parameters set in a
+/// [`LIFORequestQueue`].
+///
+/// Multiple request handlers can share a queue, by cloning the [`Arc`] that wraps the queue.
+#[derive(Handler)]
+pub struct LIFOQueueHandler<H> {
+    #[handler(except = [run])]
+    handler: H,
+    queue: Arc<LIFORequestQueue>,
+}
+
+impl<H: Handler> LIFOQueueHandler<H> {
+    pub fn new(queue: Arc<LIFORequestQueue>, handler: H) -> Self {
+        Self { handler, queue }
+    }
+
+    async fn run(&self, mut conn: Conn) -> Conn {
+        match self.queue.acquire() {
+            Ok(mut ticket) => match conn.cancel_on_disconnect(ticket.wait()).await {
+                Some(_permit) => self.handler.run(conn).await,
+                None => Error::ClientDisconnected.run(conn).await,
+            },
+            Err(full) => full.run(conn).await,
+        }
+    }
+}
+
+/// Convenience function for wrapping a handler with a [`LIFOQueueHandler`].
+pub fn queued_lifo<H: Handler>(queue: Arc<LIFORequestQueue>, handler: H) -> impl Handler {
+    LIFOQueueHandler::new(queue, handler)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+        time::Duration,
+    };
+
+    use async_trait::async_trait;
+    use backoff::{future::retry, ExponentialBackoff};
+    use futures::future::join_all;
+    use janus_core::test_util::install_test_trace_subscriber;
+    use quickcheck::Arbitrary;
+    use quickcheck_macros::quickcheck;
+    use tokio::{
+        runtime::{Builder as RuntimeBuilder, Runtime},
+        sync::Semaphore,
+        task::{yield_now, JoinHandle},
+    };
+    use tracing::debug;
+    use trillium::{Handler, Status};
+    use trillium_testing::{assert_ok, assert_status, methods::get};
+
+    use crate::aggregator::queue::{queued_lifo, LIFORequestQueue};
+
+    struct HangingHandler {
+        unhang: Arc<Semaphore>,
+    }
+
+    #[async_trait]
+    impl Handler for HangingHandler {
+        async fn run(&self, conn: trillium::Conn) -> trillium::Conn {
+            let _ = self.unhang.acquire().await;
+            conn.ok("hello")
+        }
+    }
+
+    async fn fill_queue(
+        queue: Arc<LIFORequestQueue>,
+        handler: Arc<impl Handler>,
+        concurrency: usize,
+        depth: usize,
+    ) -> Vec<JoinHandle<()>> {
+        let mut requests = Vec::new();
+        for _ in 0..(concurrency + depth) {
+            let handler = Arc::clone(&handler);
+            requests.push(tokio::spawn({
+                async move {
+                    let backoff = ExponentialBackoff {
+                        initial_interval: Duration::from_nanos(1),
+                        max_interval: Duration::from_nanos(30),
+                        multiplier: 2.0,
+                        ..Default::default()
+                    };
+                    retry(backoff, || {
+                        let handler = Arc::clone(&handler);
+                        async move {
+                            let request = get("/").run_async(&handler).await;
+                            if request.status().unwrap() == Status::Ok {
+                                Ok(())
+                            } else {
+                                Err(backoff::Error::transient(()))
+                            }
+                        }
+                    })
+                    .await
+                    .unwrap();
+                }
+            }));
+        }
+
+        // Wait until all semaphore permits are exhausted and the queue is full, indicating full
+        // saturation.
+        while queue.len() < depth || queue.available_permits() > 0 {
+            yield_now().await;
+        }
+
+        requests
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    struct Parameters {
+        /// In the making of this code, some bugs were uncovered by running on a different runtime
+        /// flavor. Test both runtime flavors.
+        runtime_flavor: RuntimeFlavor,
+        depth: usize,
+        concurrency: usize,
+    }
+
+    impl Arbitrary for Parameters {
+        fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+            let concurrency = u8::arbitrary(g) as usize + 1;
+            let depth = concurrency + u8::arbitrary(g) as usize;
+            Self {
+                runtime_flavor: if bool::arbitrary(g) {
+                    RuntimeFlavor::CurrentThread
+                } else {
+                    RuntimeFlavor::MultiThread
+                },
+                depth,
+                concurrency,
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum RuntimeFlavor {
+        CurrentThread,
+        MultiThread,
+    }
+
+    impl RuntimeFlavor {
+        fn build(&self) -> Runtime {
+            match self {
+                RuntimeFlavor::CurrentThread => RuntimeBuilder::new_current_thread(),
+                RuntimeFlavor::MultiThread => RuntimeBuilder::new_multi_thread(),
+            }
+            .enable_all()
+            .build()
+            .unwrap()
+        }
+    }
+
+    // #[tokio::test]
+    // async fn lifo_cancel_on_disconnect() {}
+
+    #[quickcheck]
+    fn quickcheck_lifo_concurrency(parameters: Parameters, requests: u16) {
+        install_test_trace_subscriber();
+        debug!(?parameters, "quickcheck_lifo_concurrency parameters");
+        let Parameters {
+            runtime_flavor,
+            depth,
+            concurrency,
+        } = parameters;
+
+        struct ConcurrencyAssertingHandler {
+            max_concurrency: usize,
+            concurrency: AtomicUsize,
+        }
+
+        #[async_trait]
+        impl Handler for ConcurrencyAssertingHandler {
+            async fn run(&self, conn: trillium::Conn) -> trillium::Conn {
+                let concurrency = self.concurrency.fetch_add(1, Ordering::Relaxed);
+
+                // Somewhat arbitrary yield points, to give the dispatcher a chance to signal
+                // another concurring future. This is mostly pertinent if we're running the test on
+                // a current_thread runtime. Otherwise, without await points, on a current_thread
+                // runtime, this function won't yield.
+                yield_now().await;
+                assert!(concurrency < self.max_concurrency);
+
+                let conn = conn.ok("hello");
+
+                yield_now().await;
+                assert!(concurrency < self.max_concurrency);
+
+                self.concurrency.fetch_sub(1, Ordering::Relaxed);
+                conn
+            }
+        }
+
+        runtime_flavor.build().block_on(async move {
+            let queue = Arc::new(LIFORequestQueue::new(concurrency, depth).unwrap());
+            let handler = Arc::new(queued_lifo(
+                Arc::clone(&queue),
+                ConcurrencyAssertingHandler {
+                    concurrency: Default::default(),
+                    max_concurrency: concurrency,
+                },
+            ));
+
+            join_all((0..requests).map(|_| {
+                let handler = Arc::clone(&handler);
+                async move {
+                    get("/").run_async(&handler).await;
+                }
+            }))
+            .await;
+        });
+    }
+
+    #[quickcheck]
+    fn quickcheck_lifo_cancel(parameters: Parameters) {
+        install_test_trace_subscriber();
+        debug!(?parameters, "quickcheck_lifo_cancel parameters");
+        let Parameters {
+            runtime_flavor,
+            depth,
+            concurrency,
+        } = parameters;
+
+        runtime_flavor.build().block_on(async move {
+            let unhang = Arc::new(Semaphore::new(0));
+            let queue = Arc::new(LIFORequestQueue::new(concurrency, depth).unwrap());
+            let handler = Arc::new(queued_lifo(
+                Arc::clone(&queue),
+                HangingHandler {
+                    unhang: Arc::clone(&unhang),
+                },
+            ));
+
+            let requests =
+                fill_queue(Arc::clone(&queue), Arc::clone(&handler), concurrency, depth).await;
+
+            // Abort all outstanding requests.
+            requests.iter().for_each(|request| request.abort());
+
+            // Wait until the queue is empty.
+            while queue.len() > 0 {
+                yield_now().await;
+            }
+
+            unhang.close();
+            let request = get("/").run_async(&handler).await;
+            assert_ok!(request);
+
+            for handle in requests {
+                // These handles will return a JoinError, but we're moreso interested to see if
+                // they've all terminated.
+                let _ = handle.await;
+            }
+        });
+    }
+
+    #[quickcheck]
+    fn quickcheck_lifo_full(parameters: Parameters) {
+        install_test_trace_subscriber();
+        debug!(?parameters, "quickcheck_lifo_full parameters");
+        let Parameters {
+            runtime_flavor,
+            depth,
+            concurrency,
+        } = parameters;
+
+        runtime_flavor.build().block_on(async move {
+            let unhang = Arc::new(Semaphore::new(0));
+            let queue = Arc::new(LIFORequestQueue::new(concurrency, depth).unwrap());
+            let handler = Arc::new(queued_lifo(
+                Arc::clone(&queue),
+                HangingHandler {
+                    unhang: Arc::clone(&unhang),
+                },
+            ));
+
+            let requests =
+                fill_queue(Arc::clone(&queue), Arc::clone(&handler), concurrency, depth).await;
+
+            let request = get("/").run_async(&handler).await;
+            assert_status!(request, Status::ServiceUnavailable);
+
+            unhang.close();
+
+            // Let the dispatcher get a turn on the scheduler.
+            while queue.len() == depth {
+                yield_now().await;
+            }
+
+            let request = get("/").run_async(&handler).await;
+            assert_ok!(request);
+
+            for handle in requests {
+                handle.await.unwrap();
+            }
+        });
+    }
+}

--- a/aggregator/src/aggregator/queue.rs
+++ b/aggregator/src/aggregator/queue.rs
@@ -358,13 +358,11 @@ mod tests {
         meter_prefix: &str,
         condition: impl Fn(usize) -> bool,
     ) {
-        loop {
-            let metric = get_outstanding_requests_gauge(&metrics, meter_prefix).await;
-            if let Some(metric) = metric {
-                if condition(metric) {
-                    return;
-                }
-            }
+        while get_outstanding_requests_gauge(metrics, meter_prefix)
+            .await
+            .map(|metric| !condition(metric))
+            .unwrap_or(true)
+        {
             // Nominal sleep to prevent this loop from being too tight.
             sleep(Duration::from_millis(3)).await;
         }

--- a/aggregator/src/aggregator/queue.rs
+++ b/aggregator/src/aggregator/queue.rs
@@ -230,8 +230,6 @@ impl PermitTx {
     }
 }
 
-type PermitRx = oneshot::Receiver<Result<OwnedSemaphorePermit, Error>>;
-
 /// A handler that queues requests in a LIFO manner, according to the parameters set in a
 /// [`LIFORequestQueue`].
 ///
@@ -649,7 +647,7 @@ mod tests {
 
                 debug!("sending request, should fail");
                 let request = get("/").run_async(&handler).await;
-                assert_status!(request, Status::ServiceUnavailable);
+                assert_status!(request, Status::TooManyRequests);
 
                 debug!("draining the queue");
                 while get_outstanding_requests_gauge(&metrics, meter_prefix).await > Some(0) {

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -1,10 +1,7 @@
 use crate::{
     aggregator::{
         aggregate_init_tests::PrepareInitGenerator,
-        http_handlers::{
-            aggregator_handler,
-            test_util::{decode_response_body, take_problem_details},
-        },
+        http_handlers::test_util::{decode_response_body, take_problem_details},
         Config,
     },
     config::TaskprovConfig,
@@ -67,6 +64,8 @@ use trillium_testing::{
     prelude::{post, put},
 };
 use url::Url;
+
+use super::http_handlers::AggregatorHandlerBuilder;
 
 type TestVdaf = Poplar1<XofTurboShake128, 16>;
 
@@ -150,7 +149,7 @@ where
             .await
             .unwrap();
 
-        let handler = aggregator_handler(
+        let handler = AggregatorHandlerBuilder::new(
             Arc::clone(&datastore),
             clock.clone(),
             TestRuntime::default(),
@@ -164,6 +163,8 @@ where
             },
         )
         .await
+        .unwrap()
+        .build()
         .unwrap();
 
         let time_precision = Duration::from_seconds(1);

--- a/aggregator/src/binaries/aggregator.rs
+++ b/aggregator/src/binaries/aggregator.rs
@@ -1,7 +1,7 @@
 use crate::{
     aggregator::{
         self,
-        http_handlers::aggregator_handler,
+        http_handlers::{AggregatorHandlerBuilder, HelperAggregationRequestQueue},
         key_rotator::{deserialize_hpke_key_rotator_config, HpkeKeyRotatorConfig, KeyRotator},
     },
     binaries::garbage_collector::run_garbage_collector,
@@ -90,17 +90,19 @@ async fn run_aggregator(
         })
     };
 
-    let mut handlers = (
-        aggregator_handler(
-            Arc::clone(&datastore),
-            clock,
-            TokioRuntime,
-            &meter,
-            config.aggregator_config(&options)?,
-        )
-        .await?,
-        None,
-    );
+    let mut aggregator_handler = AggregatorHandlerBuilder::new(
+        Arc::clone(&datastore),
+        clock,
+        TokioRuntime,
+        &meter,
+        config.aggregator_config(&options)?,
+    )
+    .await?;
+    if let Some(harq) = config.helper_aggregation_request_queue {
+        aggregator_handler = aggregator_handler.with_helper_aggregation_request_queue(harq);
+    }
+
+    let mut handlers = (aggregator_handler.build()?, None);
 
     let garbage_collector_handle = {
         let datastore = Arc::clone(&datastore);
@@ -401,6 +403,10 @@ pub struct Config {
     /// become on by default in a future version of Janus.
     #[serde(default)]
     pub require_global_hpke_keys: bool,
+
+    /// Experimental. Queue aggregate init and continue requests with a LIFO strategy.
+    #[serde(default)]
+    pub helper_aggregation_request_queue: Option<HelperAggregationRequestQueue>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -609,6 +615,7 @@ mod tests {
             task_cache_capacity: None,
             log_forbidden_mutations: Some(PathBuf::from("/tmp/events")),
             require_global_hpke_keys: true,
+            helper_aggregation_request_queue: None,
         })
     }
 

--- a/aggregator/src/metrics/tests/prometheus.rs
+++ b/aggregator/src/metrics/tests/prometheus.rs
@@ -1,5 +1,5 @@
 use crate::{
-    aggregator::{http_handlers::aggregator_handler, test_util::default_aggregator_config},
+    aggregator::{http_handlers::AggregatorHandlerBuilder, test_util::default_aggregator_config},
     metrics::{build_opentelemetry_prometheus_meter_provider, prometheus_metrics_server},
 };
 use http::StatusCode;
@@ -83,7 +83,7 @@ async fn http_metrics() {
     let clock = MockClock::default();
     let ephemeral_datastore = ephemeral_datastore().await;
     let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
-    let handler = aggregator_handler(
+    let handler = AggregatorHandlerBuilder::new(
         datastore.clone(),
         clock.clone(),
         TestRuntime::default(),
@@ -91,6 +91,8 @@ async fn http_metrics() {
         default_aggregator_config(),
     )
     .await
+    .unwrap()
+    .build()
     .unwrap();
 
     get("/hpke_config").run_async(&handler).await;

--- a/aggregator/tests/integration/graceful_shutdown.rs
+++ b/aggregator/tests/integration/graceful_shutdown.rs
@@ -316,6 +316,7 @@ async fn aggregator_shutdown() {
         task_cache_capacity: None,
         log_forbidden_mutations: None,
         require_global_hpke_keys: false,
+        helper_aggregation_request_queue: None,
     };
 
     graceful_shutdown("aggregator", config).await;

--- a/docs/samples/advanced_config/aggregator.yaml
+++ b/docs/samples/advanced_config/aggregator.yaml
@@ -219,5 +219,5 @@ helper_aggregation_request_queue:
   concurrency: 1
   # The maximum number of requests that can be left waiting in the queue for
   # a concurrency slot to become available. Excess requests are rejected with
-  # HTTP status 503 Unavailable.
+  # HTTP status 429 Too Many Requests.
   depth: 24

--- a/docs/samples/advanced_config/aggregator.yaml
+++ b/docs/samples/advanced_config/aggregator.yaml
@@ -211,3 +211,13 @@ task_cache_ttl_s: 600
 # Defines how many tasks can be cached. This affects how much memory the
 # aggregator might use to store cached tasks. (optional)
 task_cache_capacity: 10000
+
+# Queue aggregate init and continue requests with a LIFO strategy. (optional;
+# experimental, not stable between Janus releases)
+helper_aggregation_request_queue:
+  # The number of requests that can be processed concurrently.
+  concurrency: 1
+  # The maximum number of requests that can be left waiting in the queue for
+  # a concurrency slot to become available. Excess requests are rejected with
+  # HTTP status 503 Unavailable.
+  depth: 24

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -175,6 +175,7 @@ impl JanusInProcess {
             task_cache_capacity: None,
             log_forbidden_mutations: None,
             require_global_hpke_keys: true,
+            helper_aggregation_request_queue: None,
         };
         let aggregation_job_creator_options = AggregationJobCreatorOptions {
             common: common_binary_options.clone(),

--- a/integration_tests/tests/integration/simulation/bad_client.rs
+++ b/integration_tests/tests/integration/simulation/bad_client.rs
@@ -2,7 +2,7 @@ use std::{net::Ipv4Addr, sync::Arc};
 
 use assert_matches::assert_matches;
 use http::header::CONTENT_TYPE;
-use janus_aggregator::aggregator::http_handlers::aggregator_handler;
+use janus_aggregator::aggregator::http_handlers::AggregatorHandlerBuilder;
 use janus_aggregator_core::{
     datastore::{models::HpkeKeyState, test_util::ephemeral_datastore},
     task::test_util::{Task, TaskBuilder},
@@ -389,14 +389,17 @@ async fn bad_client_report_validity() {
         .await
         .unwrap();
 
-    let handler = aggregator_handler(
+    let handler = AggregatorHandlerBuilder::new(
         Arc::clone(&datastore),
         clock,
         TestRuntime::default(),
         &noop_meter(),
         Default::default(),
     )
-    .await;
+    .await
+    .unwrap()
+    .build()
+    .unwrap();
     let stopper = Stopper::new();
     let server_handle = trillium_tokio::config()
         .with_stopper(stopper.clone())

--- a/integration_tests/tests/integration/simulation/setup.rs
+++ b/integration_tests/tests/integration/simulation/setup.rs
@@ -13,7 +13,7 @@ use janus_aggregator::{
         aggregation_job_driver::AggregationJobDriver,
         collection_job_driver::{CollectionJobDriver, RetryStrategy},
         garbage_collector::GarbageCollector,
-        http_handlers::aggregator_handler,
+        http_handlers::AggregatorHandlerBuilder,
         key_rotator::KeyRotator,
         Config as AggregatorConfig,
     },
@@ -89,7 +89,7 @@ impl SimulationAggregator {
             require_global_hpke_keys: false,
         };
 
-        let aggregator_handler = aggregator_handler(
+        let aggregator_handler = AggregatorHandlerBuilder::new(
             Arc::clone(&datastore),
             state.clock.clone(),
             report_writer_runtime,
@@ -97,6 +97,8 @@ impl SimulationAggregator {
             aggregator_config,
         )
         .await
+        .unwrap()
+        .build()
         .unwrap();
 
         let inspect_handler = InspectHandler::new(aggregator_handler);


### PR DESCRIPTION
Supports https://github.com/divviup/janus/issues/3181.

Introduces functionality for LIFO queueing certain request handlers. This is done independently of the request handlers themselves, i.e. any handler could be queued by wrapping them in a `queued_lifo()` function.

This code is not plumbed through anything production, yet, to keep this PR small. I will do so in a future PR. See tests for the expected usage of the code.