### PR TITLE
Feature flag for queuing of expensive helper requests

### DIFF
--- a/aggregator/src/aggregator/aggregate_init_tests.rs
+++ b/aggregator/src/aggregator/aggregate_init_tests.rs
@@ -1,8 +1,5 @@
 use crate::aggregator::{
-    http_handlers::{
-        aggregator_handler,
-        test_util::{decode_response_body, take_problem_details},
-    },
+    http_handlers::test_util::{decode_response_body, take_problem_details},
     test_util::generate_helper_report_share,
     Config,
 };
@@ -42,6 +39,8 @@ use serde_json::json;
 use std::sync::Arc;
 use trillium::{Handler, KnownHeaderName, Status};
 use trillium_testing::{prelude::put, TestConn};
+
+use super::http_handlers::AggregatorHandlerBuilder;
 
 #[derive(Clone)]
 pub(super) struct PrepareInitGenerator<const VERIFY_KEY_SIZE: usize, V>
@@ -257,7 +256,7 @@ async fn setup_aggregate_init_test_without_sending_request<
     datastore.put_aggregator_task(&helper_task).await.unwrap();
     let keypair = datastore.put_global_hpke_key().await.unwrap();
 
-    let handler = aggregator_handler(
+    let handler = AggregatorHandlerBuilder::new(
         Arc::clone(&datastore),
         clock.clone(),
         TestRuntime::default(),
@@ -265,6 +264,8 @@ async fn setup_aggregate_init_test_without_sending_request<
         Config::default(),
     )
     .await
+    .unwrap()
+    .build()
     .unwrap();
 
     let prepare_init_generator = PrepareInitGenerator::new(

--- a/aggregator/src/aggregator/aggregate_init_tests.rs
+++ b/aggregator/src/aggregator/aggregate_init_tests.rs
@@ -1,5 +1,8 @@
 use crate::aggregator::{
-    http_handlers::test_util::{decode_response_body, take_problem_details},
+    http_handlers::{
+        test_util::{decode_response_body, take_problem_details},
+        AggregatorHandlerBuilder,
+    },
     test_util::generate_helper_report_share,
     Config,
 };
@@ -39,8 +42,6 @@ use serde_json::json;
 use std::sync::Arc;
 use trillium::{Handler, KnownHeaderName, Status};
 use trillium_testing::{prelude::put, TestConn};
-
-use super::http_handlers::AggregatorHandlerBuilder;
 
 #[derive(Clone)]
 pub(super) struct PrepareInitGenerator<const VERIFY_KEY_SIZE: usize, V>

--- a/aggregator/src/aggregator/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/aggregation_job_continue.rs
@@ -400,8 +400,8 @@ mod tests {
             post_aggregation_job_expecting_status,
         },
         http_handlers::{
-            aggregator_handler,
             test_util::{take_problem_details, HttpHandlerTest},
+            AggregatorHandlerBuilder,
         },
         test_util::default_aggregator_config,
     };
@@ -555,7 +555,7 @@ mod tests {
         );
 
         // Create aggregator handler.
-        let handler = aggregator_handler(
+        let handler = AggregatorHandlerBuilder::new(
             Arc::clone(&datastore),
             clock,
             TestRuntime::default(),
@@ -563,6 +563,8 @@ mod tests {
             default_aggregator_config(),
         )
         .await
+        .unwrap()
+        .build()
         .unwrap();
 
         AggregationJobContinueTestCase {

--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -1,8 +1,5 @@
 use crate::aggregator::{
-    http_handlers::{
-        aggregator_handler,
-        test_util::{decode_response_body, take_problem_details},
-    },
+    http_handlers::test_util::{decode_response_body, take_problem_details},
     test_util::BATCH_AGGREGATION_SHARD_COUNT,
     Config,
 };
@@ -47,6 +44,8 @@ use trillium_testing::{
     prelude::{post, put},
     TestConn,
 };
+
+use super::http_handlers::AggregatorHandlerBuilder;
 
 pub(crate) struct CollectionJobTestCase {
     pub(super) task: Task,
@@ -268,7 +267,7 @@ pub(crate) async fn setup_collection_job_test_case(
     datastore.put_aggregator_task(&role_task).await.unwrap();
     datastore.put_global_hpke_key().await.unwrap();
 
-    let handler = aggregator_handler(
+    let handler = AggregatorHandlerBuilder::new(
         Arc::clone(&datastore),
         clock.clone(),
         TestRuntime::default(),
@@ -279,6 +278,8 @@ pub(crate) async fn setup_collection_job_test_case(
         },
     )
     .await
+    .unwrap()
+    .build()
     .unwrap();
 
     CollectionJobTestCase {

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -1,5 +1,6 @@
 use super::{
     error::{ArcError, ReportRejectionReason},
+    queue::{queued_lifo, LIFORequestQueue},
     Aggregator, Config, Error,
 };
 use crate::aggregator::problem_details::{ProblemDetailsConnExt, ProblemDocument};
@@ -25,7 +26,7 @@ use opentelemetry::{
 };
 use prio::codec::Encode;
 use ring::digest::{digest, SHA256};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, time::Duration as StdDuration};
 use std::{io::Cursor, sync::Arc};
 use tracing::warn;
@@ -291,38 +292,65 @@ pub(crate) static AGGREGATION_JOB_ROUTE: &str =
 pub(crate) static COLLECTION_JOB_ROUTE: &str = "tasks/:task_id/collection_jobs/:collection_job_id";
 pub(crate) static AGGREGATE_SHARES_ROUTE: &str = "tasks/:task_id/aggregate_shares";
 
-/// Constructs a Trillium handler for the aggregator.
-pub async fn aggregator_handler<C, R>(
-    datastore: Arc<Datastore<C>>,
-    clock: C,
-    runtime: R,
-    meter: &Meter,
-    cfg: Config,
-) -> Result<impl Handler, Error>
-where
-    C: Clock,
-    R: Runtime + Send + Sync + 'static,
-{
-    let aggregator = Arc::new(Aggregator::new(datastore, clock, runtime, meter, cfg).await?);
-    aggregator_handler_with_aggregator(aggregator, meter).await
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HelperRequestQueue {
+    pub depth: usize,
+    pub concurrency: u32,
 }
 
-async fn aggregator_handler_with_aggregator<C: Clock>(
+pub struct AggregatorHandlerBuilder<'a, C>
+where
+    C: Clock,
+{
     aggregator: Arc<Aggregator<C>>,
-    meter: &Meter,
-) -> Result<impl Handler, Error> {
-    Ok((
-        State(aggregator),
-        metrics(meter)
-            .with_route(|conn| {
-                conn.route()
-                    .map(|route_spec| Cow::Owned(route_spec.to_string()))
+    meter: &'a Meter,
+    helper_request_queue: Option<HelperRequestQueue>,
+}
+
+impl<'a, C> AggregatorHandlerBuilder<'a, C>
+where
+    C: Clock,
+{
+    pub async fn new<R>(
+        datastore: Arc<Datastore<C>>,
+        clock: C,
+        runtime: R,
+        meter: &'a Meter,
+        cfg: Config,
+    ) -> Result<Self, Error>
+    where
+        R: Runtime + Send + Sync + 'static,
+    {
+        let aggregator = Arc::new(Aggregator::new(datastore, clock, runtime, meter, cfg).await?);
+        Ok(Self::from_aggregator(aggregator, meter))
+    }
+
+    pub fn from_aggregator(aggregator: Arc<Aggregator<C>>, meter: &'a Meter) -> Self {
+        Self {
+            aggregator,
+            meter,
+            helper_request_queue: None,
+        }
+    }
+
+    pub fn with_helper_request_queue(self, hrq: HelperRequestQueue) -> Self {
+        Self {
+            helper_request_queue: Some(hrq),
+            ..self
+        }
+    }
+
+    pub fn build(self) -> Result<impl Handler, Error> {
+        let helper_queue = self
+            .helper_request_queue
+            .map(|HelperRequestQueue { depth, concurrency }| {
+                LIFORequestQueue::new(concurrency, depth, self.meter, "janus_helper")
             })
-            .with_error_type(|conn| {
-                conn.state::<ErrorCode>()
-                    .map(|error_code| Cow::Borrowed(error_code.0))
-            }),
-        Router::new()
+            .transpose()?
+            .map(Arc::new);
+
+        let router = Router::new()
             .without_options_handling()
             .get("hpke_config", instrumented(api(hpke_config::<C>)))
             .with_route(
@@ -338,11 +366,25 @@ async fn aggregator_handler_with_aggregator<C: Clock>(
             )
             .put(
                 AGGREGATION_JOB_ROUTE,
-                instrumented(api(aggregation_jobs_put::<C>)),
+                instrumented(if let Some(ref queue) = helper_queue {
+                    Box::new(queued_lifo(
+                        Arc::clone(queue),
+                        api(aggregation_jobs_put::<C>),
+                    )) as Box<dyn Handler>
+                } else {
+                    Box::new(api(aggregation_jobs_put::<C>)) as Box<dyn Handler>
+                }),
             )
             .post(
                 AGGREGATION_JOB_ROUTE,
-                instrumented(api(aggregation_jobs_post::<C>)),
+                instrumented(if let Some(ref queue) = helper_queue {
+                    Box::new(queued_lifo(
+                        Arc::clone(queue),
+                        api(aggregation_jobs_post::<C>),
+                    )) as Box<dyn Handler>
+                } else {
+                    Box::new(api(aggregation_jobs_post::<C>)) as Box<dyn Handler>
+                }),
             )
             .delete(
                 AGGREGATION_JOB_ROUTE,
@@ -363,9 +405,23 @@ async fn aggregator_handler_with_aggregator<C: Clock>(
             .post(
                 AGGREGATE_SHARES_ROUTE,
                 instrumented(api(aggregate_shares::<C>)),
-            ),
-        StatusCounter::new(meter),
-    ))
+            );
+
+        Ok((
+            State(self.aggregator),
+            metrics(self.meter)
+                .with_route(|conn| {
+                    conn.route()
+                        .map(|route_spec| Cow::Owned(route_spec.to_string()))
+                })
+                .with_error_type(|conn| {
+                    conn.state::<ErrorCode>()
+                        .map(|error_code| Cow::Borrowed(error_code.0))
+                }),
+            router,
+            StatusCounter::new(self.meter),
+        ))
+    }
 }
 
 /// Deserialization helper struct to extract a "task_id" parameter from a query string.
@@ -766,7 +822,6 @@ impl TryFromConn for BodyBytes {
 #[cfg(feature = "test-util")]
 #[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
 pub mod test_util {
-    use super::aggregator_handler;
     use crate::aggregator::test_util::default_aggregator_config;
     use janus_aggregator_core::{
         datastore::{
@@ -785,6 +840,8 @@ pub mod test_util {
     use std::sync::Arc;
     use trillium::Handler;
     use trillium_testing::{assert_headers, TestConn};
+
+    use super::AggregatorHandlerBuilder;
 
     pub async fn take_response_body(test_conn: &mut TestConn) -> Vec<u8> {
         test_conn
@@ -839,7 +896,7 @@ pub mod test_util {
                 .await
                 .unwrap();
 
-            let handler = aggregator_handler(
+            let handler = AggregatorHandlerBuilder::new(
                 datastore.clone(),
                 clock.clone(),
                 TestRuntime::default(),
@@ -847,6 +904,13 @@ pub mod test_util {
                 default_aggregator_config(),
             )
             .await
+            .unwrap()
+            // Shake out any bugs with helper request queuing.
+            .with_helper_request_queue(super::HelperRequestQueue {
+                depth: 16,
+                concurrency: 2,
+            })
+            .build()
             .unwrap();
 
             Self {

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
@@ -2,8 +2,8 @@ use crate::aggregator::{
     aggregate_init_tests::{put_aggregation_job, PrepareInitGenerator},
     empty_batch_aggregations,
     http_handlers::{
-        aggregator_handler,
         test_util::{decode_response_body, take_problem_details, HttpHandlerTest},
+        AggregatorHandlerBuilder,
     },
     test_util::{
         assert_task_aggregation_counter, default_aggregator_config, generate_helper_report_share,
@@ -768,7 +768,7 @@ async fn aggregate_init_with_reports_encrypted_by_task_specific_key() {
     }
 
     // Create new handler _after_ the keys have been inserted so that they come pre-cached.
-    let handler = aggregator_handler(
+    let handler = AggregatorHandlerBuilder::new(
         datastore.clone(),
         clock.clone(),
         TestRuntime::default(),
@@ -776,6 +776,8 @@ async fn aggregate_init_with_reports_encrypted_by_task_specific_key() {
         default_aggregator_config(),
     )
     .await
+    .unwrap()
+    .build()
     .unwrap();
 
     let (prepare_init, transcript) = prep_init_generator.next(&0);

--- a/aggregator/src/aggregator/http_handlers/tests/report.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/report.rs
@@ -2,8 +2,8 @@ use crate::{
     aggregator::{
         error::ReportRejectionReason,
         http_handlers::{
-            aggregator_handler,
             test_util::{take_problem_details, HttpHandlerTest},
+            AggregatorHandlerBuilder,
         },
         test_util::{create_report, create_report_custom, default_aggregator_config},
     },
@@ -416,7 +416,7 @@ async fn upload_handler_error_fanout() {
         .await;
     let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
     let hpke_keypair = datastore.put_global_hpke_key().await.unwrap();
-    let handler = aggregator_handler(
+    let handler = AggregatorHandlerBuilder::new(
         datastore.clone(),
         clock.clone(),
         TestRuntime::default(),
@@ -424,6 +424,8 @@ async fn upload_handler_error_fanout() {
         default_aggregator_config(),
     )
     .await
+    .unwrap()
+    .build()
     .unwrap();
 
     const REPORT_EXPIRY_AGE: u64 = 1_000_000;
@@ -527,7 +529,7 @@ async fn upload_client_early_disconnect() {
     let ephemeral_datastore = ephemeral_datastore().await;
     let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
     let hpke_keypair = datastore.put_global_hpke_key().await.unwrap();
-    let handler = aggregator_handler(
+    let handler = AggregatorHandlerBuilder::new(
         datastore.clone(),
         clock.clone(),
         TestRuntime::default(),
@@ -535,6 +537,8 @@ async fn upload_client_early_disconnect() {
         default_aggregator_config(),
     )
     .await
+    .unwrap()
+    .build()
     .unwrap();
 
     let task = TaskBuilder::new(QueryType::TimeInterval, VdafInstance::Prio3Count).build();

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -1,10 +1,7 @@
 use crate::{
     aggregator::{
         aggregate_init_tests::PrepareInitGenerator,
-        http_handlers::{
-            aggregator_handler,
-            test_util::{decode_response_body, take_problem_details},
-        },
+        http_handlers::test_util::{decode_response_body, take_problem_details},
         Config,
     },
     config::TaskprovConfig,
@@ -67,6 +64,8 @@ use trillium_testing::{
     prelude::{post, put},
 };
 use url::Url;
+
+use super::http_handlers::AggregatorHandlerBuilder;
 
 type TestVdaf = Poplar1<XofTurboShake128, 16>;
 
@@ -150,7 +149,7 @@ where
             .await
             .unwrap();
 
-        let handler = aggregator_handler(
+        let handler = AggregatorHandlerBuilder::new(
             Arc::clone(&datastore),
             clock.clone(),
             TestRuntime::default(),
@@ -164,6 +163,8 @@ where
             },
         )
         .await
+        .unwrap()
+        .build()
         .unwrap();
 
         let time_precision = Duration::from_seconds(1);

--- a/aggregator/src/binaries/aggregator.rs
+++ b/aggregator/src/binaries/aggregator.rs
@@ -1,7 +1,7 @@
 use crate::{
     aggregator::{
         self,
-        http_handlers::{AggregatorHandlerBuilder, HelperRequestQueue},
+        http_handlers::{AggregatorHandlerBuilder, HelperAggregationRequestQueue},
         key_rotator::{deserialize_hpke_key_rotator_config, HpkeKeyRotatorConfig, KeyRotator},
     },
     binaries::garbage_collector::run_garbage_collector,
@@ -98,8 +98,8 @@ async fn run_aggregator(
         config.aggregator_config(&options)?,
     )
     .await?;
-    if let Some(hrq) = config.helper_request_queue {
-        aggregator_handler = aggregator_handler.with_helper_request_queue(hrq);
+    if let Some(harq) = config.helper_aggregation_request_queue {
+        aggregator_handler = aggregator_handler.with_helper_aggregation_request_queue(harq);
     }
 
     let mut handlers = (aggregator_handler.build()?, None);
@@ -406,7 +406,7 @@ pub struct Config {
 
     /// Experimental. Queue aggregate init and continue requests with a LIFO strategy.
     #[serde(default)]
-    pub helper_request_queue: Option<HelperRequestQueue>,
+    pub helper_aggregation_request_queue: Option<HelperAggregationRequestQueue>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -615,7 +615,7 @@ mod tests {
             task_cache_capacity: None,
             log_forbidden_mutations: Some(PathBuf::from("/tmp/events")),
             require_global_hpke_keys: true,
-            helper_request_queue: None,
+            helper_aggregation_request_queue: None,
         })
     }
 

--- a/aggregator/src/binaries/aggregator.rs
+++ b/aggregator/src/binaries/aggregator.rs
@@ -1,7 +1,7 @@
 use crate::{
     aggregator::{
         self,
-        http_handlers::aggregator_handler,
+        http_handlers::{AggregatorHandlerBuilder, HelperRequestQueue},
         key_rotator::{deserialize_hpke_key_rotator_config, HpkeKeyRotatorConfig, KeyRotator},
     },
     binaries::garbage_collector::run_garbage_collector,
@@ -90,17 +90,19 @@ async fn run_aggregator(
         })
     };
 
-    let mut handlers = (
-        aggregator_handler(
-            Arc::clone(&datastore),
-            clock,
-            TokioRuntime,
-            &meter,
-            config.aggregator_config(&options)?,
-        )
-        .await?,
-        None,
-    );
+    let mut aggregator_handler = AggregatorHandlerBuilder::new(
+        Arc::clone(&datastore),
+        clock,
+        TokioRuntime,
+        &meter,
+        config.aggregator_config(&options)?,
+    )
+    .await?;
+    if let Some(hrq) = config.helper_request_queue {
+        aggregator_handler = aggregator_handler.with_helper_request_queue(hrq);
+    }
+
+    let mut handlers = (aggregator_handler.build()?, None);
 
     let garbage_collector_handle = {
         let datastore = Arc::clone(&datastore);
@@ -401,6 +403,10 @@ pub struct Config {
     /// become on by default in a future version of Janus.
     #[serde(default)]
     pub require_global_hpke_keys: bool,
+
+    /// Experimental. Queue aggregate init and continue requests with a LIFO strategy.
+    #[serde(default)]
+    pub helper_request_queue: Option<HelperRequestQueue>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -609,6 +615,7 @@ mod tests {
             task_cache_capacity: None,
             log_forbidden_mutations: Some(PathBuf::from("/tmp/events")),
             require_global_hpke_keys: true,
+            helper_request_queue: None,
         })
     }
 

--- a/aggregator/src/metrics/tests/prometheus.rs
+++ b/aggregator/src/metrics/tests/prometheus.rs
@@ -1,5 +1,5 @@
 use crate::{
-    aggregator::{http_handlers::aggregator_handler, test_util::default_aggregator_config},
+    aggregator::{http_handlers::AggregatorHandlerBuilder, test_util::default_aggregator_config},
     metrics::{build_opentelemetry_prometheus_meter_provider, prometheus_metrics_server},
 };
 use http::StatusCode;
@@ -83,7 +83,7 @@ async fn http_metrics() {
     let clock = MockClock::default();
     let ephemeral_datastore = ephemeral_datastore().await;
     let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
-    let handler = aggregator_handler(
+    let handler = AggregatorHandlerBuilder::new(
         datastore.clone(),
         clock.clone(),
         TestRuntime::default(),
@@ -91,6 +91,8 @@ async fn http_metrics() {
         default_aggregator_config(),
     )
     .await
+    .unwrap()
+    .build()
     .unwrap();
 
     get("/hpke_config").run_async(&handler).await;

--- a/aggregator/tests/integration/graceful_shutdown.rs
+++ b/aggregator/tests/integration/graceful_shutdown.rs
@@ -316,7 +316,7 @@ async fn aggregator_shutdown() {
         task_cache_capacity: None,
         log_forbidden_mutations: None,
         require_global_hpke_keys: false,
-        helper_request_queue: None,
+        helper_aggregation_request_queue: None,
     };
 
     graceful_shutdown("aggregator", config).await;

--- a/aggregator/tests/integration/graceful_shutdown.rs
+++ b/aggregator/tests/integration/graceful_shutdown.rs
@@ -316,6 +316,7 @@ async fn aggregator_shutdown() {
         task_cache_capacity: None,
         log_forbidden_mutations: None,
         require_global_hpke_keys: false,
+        helper_request_queue: None,
     };
 
     graceful_shutdown("aggregator", config).await;

--- a/docs/samples/advanced_config/aggregator.yaml
+++ b/docs/samples/advanced_config/aggregator.yaml
@@ -213,11 +213,11 @@ task_cache_ttl_s: 600
 task_cache_capacity: 10000
 
 # Queue aggregate init and continue requests with a LIFO strategy. (optional;
-# experimental, may be removed or changed in minor releases)
-helper_request_queue:
+# experimental, not stable between Janus releases)
+helper_aggregation_request_queue:
   # The number of requests that can be processed concurrently.
   concurrency: 1
   # The maximum number of requests that can be left waiting in the queue for
   # a concurrency slot to become available. Excess requests are rejected with
-  # HTTP status 503 Unavailable. (optional)
+  # HTTP status 503 Unavailable.
   depth: 24

--- a/docs/samples/advanced_config/aggregator.yaml
+++ b/docs/samples/advanced_config/aggregator.yaml
@@ -211,3 +211,13 @@ task_cache_ttl_s: 600
 # Defines how many tasks can be cached. This affects how much memory the
 # aggregator might use to store cached tasks. (optional)
 task_cache_capacity: 10000
+
+# Queue aggregate init and continue requests with a LIFO strategy. (optional;
+# experimental, may be removed or changed in minor releases)
+helper_request_queue:
+  # The number of requests that can be processed concurrently.
+  concurrency: 1
+  # The maximum number of requests that can be left waiting in the queue for
+  # a concurrency slot to become available. Excess requests are rejected with
+  # HTTP status 503 Unavailable. (optional)
+  depth: 24

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -175,7 +175,7 @@ impl JanusInProcess {
             task_cache_capacity: None,
             log_forbidden_mutations: None,
             require_global_hpke_keys: true,
-            helper_request_queue: None,
+            helper_aggregation_request_queue: None,
         };
         let aggregation_job_creator_options = AggregationJobCreatorOptions {
             common: common_binary_options.clone(),

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -175,6 +175,7 @@ impl JanusInProcess {
             task_cache_capacity: None,
             log_forbidden_mutations: None,
             require_global_hpke_keys: true,
+            helper_request_queue: None,
         };
         let aggregation_job_creator_options = AggregationJobCreatorOptions {
             common: common_binary_options.clone(),

--- a/integration_tests/tests/integration/simulation/setup.rs
+++ b/integration_tests/tests/integration/simulation/setup.rs
@@ -12,7 +12,7 @@ use janus_aggregator::{
         aggregation_job_driver::AggregationJobDriver,
         collection_job_driver::{CollectionJobDriver, RetryStrategy},
         garbage_collector::GarbageCollector,
-        http_handlers::aggregator_handler,
+        http_handlers::AggregatorHandlerBuilder,
         key_rotator::KeyRotator,
         Config as AggregatorConfig,
     },
@@ -87,7 +87,7 @@ impl SimulationAggregator {
             require_global_hpke_keys: false,
         };
 
-        let aggregator_handler = aggregator_handler(
+        let aggregator_handler = AggregatorHandlerBuilder::new(
             Arc::clone(&datastore),
             state.clock.clone(),
             report_writer_runtime,
@@ -95,6 +95,8 @@ impl SimulationAggregator {
             aggregator_config,
         )
         .await
+        .unwrap()
+        .build()
         .unwrap();
 
         let inspect_handler = InspectHandler::new(aggregator_handler);


### PR DESCRIPTION
Stacked on https://github.com/divviup/janus/pull/3369. Supports https://github.com/divviup/janus/issues/3181.

I attached a shared queue to the aggregate init and continue handlers, and plumbed through configuration to a flag `helper_request_queue`. These are our most expensive handlers. Queuing them allows servicing of `/hpke_configs` even if the server is overloaded.

I refactored the `aggregator_handler*` functions into a rough builder pattern.

