### PR TITLE
Ignore opentelemetry-rust 0.25

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,17 @@ updates:
       - dependency-name: prio
         update-types:
           - version-update:semver-minor
+      # opentelemetry-rust has removed support for pull exporters, including
+      # opentelemetry-prometheus, and will add it back after the 1.0 release.
+      - dependency-name: opentelemetry
+        versions:
+        - "0.25"
+      - dependency-name: opentelemetry_sdk
+        versions:
+        - "0.25"
+      - dependency-name: opentelemetry-otlp
+        versions:
+        - "0.25"
     groups:
       serde:
         patterns:


### PR DESCRIPTION
This preemptively ignores the most recent OTel release in Dependabot, since Prometheus isn't supported for now.