### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
 
 [[package]]
 name = "array-init"
@@ -493,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae74d9bd0a7530e8afd1770739ad34b36838829d6ad61818f9230f683f5ad77"
+checksum = "2f95446d919226d587817a7d21379e6eb099b97b45110a7f272a444ca5c54070"
 dependencies = [
  "aws-lc-sys",
  "mirai-annotations",
@@ -505,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e89b6941c2d1a7045538884d6e760ccfffdf8e1ffc2613d8efa74305e1f3752"
+checksum = "234314bd569802ec87011d653d6815c6d7b9ffb969e9fee5b8b20ef860e8dce9"
 dependencies = [
  "bindgen",
  "cc",
@@ -982,9 +982,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.16"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -992,9 +992,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.15"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1468,9 +1468,9 @@ dependencies = [
 
 [[package]]
 name = "divviup-client"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5316c5378832cca263e9aae9e8630008b99e49597ffcbb925b6ec1c779f7ad66"
+checksum = "3cbe97b8acfcc7e4006b5c4e8846a2dd84a815ebedbc7ca477817a29e0e2b30f"
 dependencies = [
  "base64 0.22.1",
  "email_address",
@@ -2365,7 +2365,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.6",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3137,9 +3137,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.94.0"
+version = "0.94.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65b8611df85a1a2eed6f47bd8bcca4e2b3dc14fbf83658efd01423ca9a13b72a"
+checksum = "8be507d4aad98648b68e0857909332e2ef791befd4fd7b0076662831575417ea"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -3148,9 +3148,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.94.0"
+version = "0.94.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93c5ee3e48ef9b8d8fdb40ddd935f8addc8a201397e3c7552edae7bc96bc0a78"
+checksum = "a153c7ec9f08a2008e27284c60f7b4dd4f493053868cbe919a0db639a68ee421"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3188,9 +3188,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.94.0"
+version = "0.94.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe6e24d4cc7e32576f363986dc3dfc13e8e90731bd7a467b67fc6c4bfbf8e95"
+checksum = "755a2f40ef78d317bde7829c7fc1f9d5b28b1233dfdebb0a9eeb7f738ba23bae"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -4688,9 +4688,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.12"
+version = "0.23.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
+checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4773,9 +4773,9 @@ checksum = "84e217e7fdc8466b5b35d30f8c0a30febd29173df4a3a0c2115d306b9c4117ad"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.6"
+version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4874,9 +4874,9 @@ checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
@@ -4893,9 +4893,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4904,9 +4904,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.127"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "itoa",
  "memchr",
@@ -5794,9 +5794,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
 dependencies = [
  "futures-core",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ cfg-if = "1.0.0"
 # (yet) need other default features.
 # https://docs.rs/chrono/latest/chrono/#duration
 chrono = { version = "0.4.38", default-features = false }
-clap = { version = "4.5.16", features = ["cargo", "derive", "env"] }
+clap = { version = "4.5.17", features = ["cargo", "derive", "env"] }
 console-subscriber = "0.2.0"
 deadpool = "0.12.1"
 deadpool-postgres = "0.13.2"
@@ -59,7 +59,7 @@ janus_core = { version = "0.7.33", path = "core" }
 janus_interop_binaries = { version = "0.7.33", path = "interop_binaries" }
 janus_messages = { version = "0.7.33", path = "messages" }
 k8s-openapi = { version = "0.22.0", features = ["v1_26"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
-kube = { version = "0.94.0", default-features = false, features = ["client", "rustls-tls"] }
+kube = { version = "0.94.1", default-features = false, features = ["client", "rustls-tls"] }
 mockito = "1.5.0"
 num_enum = "0.7.3"
 ohttp = { version = "0.5.1", default-features = false }
@@ -87,11 +87,11 @@ ring = "0.17.8"
 rstest = "0.18.2"
 rstest_reuse = "0.6.0"
 rustc_version = "0.4.1"
-rustls = "0.23.12"
+rustls = "0.23.13"
 rustls-pemfile = "2.1.3"
 sec1 = "0.7"
-serde = { version = "1.0.209", features = ["derive"] }
-serde_json = "1.0.127"
+serde = { version = "1.0.210", features = ["derive"] }
+serde_json = "1.0.128"
 serde_test = "1.0.177"
 serde_urlencoded = "0.7.1"
 serde_yaml = "0.9.34"
@@ -111,7 +111,7 @@ tracing-subscriber = "0.3"
 tokio = { version = "1.40", features = ["full", "tracing"] }
 tokio-postgres = "0.7.11"
 tokio-postgres-rustls = "0.12.0"
-tokio-stream = "0.1.15"
+tokio-stream = "0.1.16"
 trillium = "0.2.20"
 trillium-api = { version = "0.2.0-rc.12", default-features = false }
 trillium-caching-headers = "0.2.3"


### PR DESCRIPTION
Dependabot currently has a bug in its handling of Cargo workspaces, so it failed to create upgrade PRs. I ran a dry run using a previous version of the code in their local development environment, and it proposed these upgrades

- [anyhow 1.0.87](https://github.com/dtolnay/anyhow/releases/tag/1.0.87)
- [clap 4.5.17](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#4517---2024-09-04)
- divviup-client 0.4.6
- [kube 0.94.1](https://github.com/kube-rs/kube/releases/tag/0.94.1)
- [rustls 0.23.13](https://github.com/rustls/rustls/releases/tag/v%2F0.23.13)
- [serde 1.0.210](https://github.com/serde-rs/serde/releases/tag/v1.0.210)
- [serde_json 1.0.128](https://github.com/serde-rs/json/releases/tag/1.0.128)
- [tokio-stream 0.1.16](https://github.com/tokio-rs/tokio/blob/master/tokio-stream/CHANGELOG.md#0116-september-5th-2024)
