### PR TITLE
Upgrade itertools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2629,6 +2629,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2655,7 +2664,7 @@ dependencies = [
  "hex",
  "http 1.1.0",
  "http-api-problem",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "janus_aggregator",
  "janus_aggregator_api",
  "janus_aggregator_core",
@@ -2772,7 +2781,7 @@ dependencies = [
  "hex",
  "http 1.1.0",
  "http-api-problem",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "janus_aggregator_core",
  "janus_core",
  "janus_messages 0.7.33",
@@ -2817,7 +2826,7 @@ dependencies = [
  "derivative",
  "hex-literal",
  "http 1.1.0",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "janus_core",
  "janus_messages 0.7.33",
  "mockito",
@@ -2924,7 +2933,7 @@ dependencies = [
  "futures",
  "hex",
  "http 1.1.0",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "janus_aggregator",
  "janus_aggregator_core",
  "janus_client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ hex-literal = "0.4.1"
 hpke-dispatch = "0.6.0"
 http = "1.1"
 http-api-problem = "0.58.0"
-itertools = "0.12"
+itertools = "0.13"
 janus_aggregator = { version = "0.7.33", path = "aggregator" }
 janus_aggregator_api = { version = "0.7.33", path = "aggregator_api" }
 janus_aggregator_core = { version = "0.7.33", path = "aggregator_core" }

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -599,7 +599,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                         // We have to place `reports_by_batch` in this block, as some of its
                         // internal types are not Send/Sync & thus cannot be held across an await
                         // point.
-                        let reports_by_batch = reports.into_iter().group_by(|report_metadata| {
+                        let reports_by_batch = reports.into_iter().chunk_by(|report_metadata| {
                             // Unwrap safety: task.time_precision() is nonzero, so
                             // `to_batch_interval_start` will never return an error.
                             report_metadata

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -1621,7 +1621,7 @@ where
     });
     batch_aggregations
         .into_iter()
-        .group_by(|ba| {
+        .chunk_by(|ba| {
             (
                 *ba.task_id(),
                 ba.batch_identifier().clone(),


### PR DESCRIPTION
This upgrades itertools, which was stuck with "update not possible" in Dependabot. Note that `group_by()` has been deprecated, in favor of the renamed `chunk_by()`.