### PR TITLE
Upgrade deadpool-postgres

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,10 +1366,11 @@ dependencies = [
 
 [[package]]
 name = "deadpool-postgres"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19be9da496d60d03ec3ab45d960d80a3afb285b787394b83614a79942f467e7f"
+checksum = "1ab8a4ea925ce79678034870834602a2980f4b88c09e97feb266496dbb4493d2"
 dependencies = [
+ "async-trait",
  "deadpool",
  "getrandom",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ chrono = { version = "0.4.38", default-features = false }
 clap = { version = "4.5.16", features = ["cargo", "derive", "env"] }
 console-subscriber = "0.2.0"
 deadpool = "0.12.1"
-deadpool-postgres = "0.13.2"
+deadpool-postgres = "0.14.0"
 derivative = "2.2.0"
 divviup-client = "0.4"
 fixed = "1.27"


### PR DESCRIPTION
This upgrades deadpool-postgres, which was stuck with "update not possible" in Dependabot.