### PR TITLE
Upgrade trillium crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,7 +695,7 @@ version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -720,9 +720,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 dependencies = [
  "serde",
 ]
@@ -2711,7 +2711,7 @@ dependencies = [
  "trillium-macros 0.0.6",
  "trillium-opentelemetry",
  "trillium-prometheus",
- "trillium-router",
+ "trillium-router 0.4.1",
  "trillium-testing",
  "trillium-tokio",
  "trycmd",
@@ -2748,7 +2748,7 @@ dependencies = [
  "trillium",
  "trillium-api",
  "trillium-opentelemetry",
- "trillium-router",
+ "trillium-router 0.4.1",
  "trillium-testing",
  "url",
 ]
@@ -2803,7 +2803,7 @@ dependencies = [
  "tracing-log",
  "trillium",
  "trillium-macros 0.0.6",
- "trillium-router",
+ "trillium-router 0.4.1",
  "url",
 ]
 
@@ -2989,7 +2989,7 @@ dependencies = [
  "trillium",
  "trillium-api",
  "trillium-proxy",
- "trillium-router",
+ "trillium-router 0.4.1",
  "trillium-tokio",
  "url",
  "zstd",
@@ -3254,7 +3254,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "libc",
 ]
 
@@ -4391,7 +4391,7 @@ version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d86a7c4638d42c44551f4791a20e687dbb4c3de1f33c43dd71e355cd429def1"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -4567,6 +4567,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0971d3c8943a6267d6bd0d782fdc4afa7593e7381a92a3df950ff58897e066b5"
 dependencies = [
+ "memchr",
  "smartcow",
  "smartstring",
 ]
@@ -4679,7 +4680,7 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.14",
@@ -4746,9 +4747,9 @@ checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.3.0"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034f511ae2823d6a657925d5f7cf821d7458367ce0a54fbe743c471fdddd8111"
+checksum = "afbb878bdfdf63a336a5e63561b1835e7a8c91524f51621db870169eac84b490"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -4844,11 +4845,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.2"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -4858,9 +4859,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.1"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5365,7 +5366,7 @@ checksum = "64bb4714269afa44aef2755150a0fc19d756fb580a67db8885608cf02f47d06a"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "byteorder",
  "bytes",
  "crc",
@@ -5407,7 +5408,7 @@ checksum = "6fa91a732d854c5d7726349bb4bb879bb9478993ceb764247660aee25f67c2f8"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "byteorder",
  "crc",
  "dotenvy",
@@ -5955,7 +5956,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "base64 0.21.7",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "bytes",
  "http 1.1.0",
  "http-body 1.0.0",
@@ -6243,7 +6244,7 @@ dependencies = [
  "prometheus",
  "tracing",
  "trillium",
- "trillium-router",
+ "trillium-router 0.3.6",
 ]
 
 [[package]]
@@ -6277,10 +6278,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "trillium-rustls"
-version = "0.7.0"
+name = "trillium-router"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce4ebef1cbaa08a50768da511dabd44d772ca3487ad30360b51aec3c90165c3c"
+checksum = "6a7aed20d63101d7dcd165fd047141423009a7f4ccfc75db5b875312d8127dbe"
+dependencies = [
+ "log",
+ "routefinder",
+ "trillium",
+]
+
+[[package]]
+name = "trillium-rustls"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "371e6e906bfed11c2ebe85af747976805766ca5063a39e1329f9413c5543ef9e"
 dependencies = [
  "futures-rustls",
  "log",
@@ -6310,9 +6322,9 @@ dependencies = [
 
 [[package]]
 name = "trillium-testing"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccbf2cb1fe8f280ace56bb68ae3e6c969437d7b0c74386020c84d4790fe2ccf3"
+checksum = "4c6c5d4d9d6f6844131f166cbe4d779894f09f9b846945ab2024272bcd6e198c"
 dependencies = [
  "async-channel 2.2.0",
  "async-dup",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,9 +120,9 @@ trillium-macros = "0.0.6"
 trillium-opentelemetry = "0.9.0"
 trillium-prometheus = "0.1.0"
 trillium-proxy = { version = "0.5.5", default-features = false }
-trillium-router = "0.3.6"
-trillium-rustls = "0.7.0"
-trillium-testing = "0.6.1"
+trillium-router = "0.4.1"
+trillium-rustls = "0.8.1"
+trillium-testing = "0.7.0"
 trillium-tokio = "0.4.0"
 trycmd = "0.15.7"
 url = { version = "2.5.2", features = ["serde"] }


### PR DESCRIPTION
This upgrades three trillium crates that were stuck with "update not possible" in Dependabot.