### PR TITLE
Upgrade trillium-prometheus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2592,7 +2592,7 @@ dependencies = [
  "trillium-macros 0.0.6",
  "trillium-opentelemetry",
  "trillium-prometheus",
- "trillium-router 0.4.1",
+ "trillium-router",
  "trillium-testing",
  "trillium-tokio",
  "trycmd",
@@ -2629,7 +2629,7 @@ dependencies = [
  "trillium",
  "trillium-api",
  "trillium-opentelemetry",
- "trillium-router 0.4.1",
+ "trillium-router",
  "trillium-testing",
  "url",
 ]
@@ -2684,7 +2684,7 @@ dependencies = [
  "tracing-log",
  "trillium",
  "trillium-macros 0.0.6",
- "trillium-router 0.4.1",
+ "trillium-router",
  "url",
 ]
 
@@ -2870,7 +2870,7 @@ dependencies = [
  "trillium",
  "trillium-api",
  "trillium-proxy",
- "trillium-router 0.4.1",
+ "trillium-router",
  "trillium-tokio",
  "url",
  "zstd",
@@ -6058,14 +6058,14 @@ dependencies = [
 
 [[package]]
 name = "trillium-prometheus"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50568433817ef994081242d1c62e672fec0c32165f431f47dc8bb58d2665c1a"
+checksum = "37f303a99a7a00c127cff63985b16d4d78c8ec9af17102a40debe80eb19a68e1"
 dependencies = [
  "prometheus",
  "tracing",
  "trillium",
- "trillium-router 0.3.6",
+ "trillium-router",
 ]
 
 [[package]]
@@ -6085,17 +6085,6 @@ dependencies = [
  "trillium-forwarding",
  "trillium-http",
  "url",
-]
-
-[[package]]
-name = "trillium-router"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71daa9c919d4b4a7afae1a846fa2e60aad712e5b924936751630a880a84e9659"
-dependencies = [
- "log",
- "routefinder",
- "trillium",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ trillium-caching-headers = "0.2.3"
 trillium-head = "0.2.3"
 trillium-macros = "0.0.6"
 trillium-opentelemetry = "0.9.0"
-trillium-prometheus = "0.1.0"
+trillium-prometheus = "0.2.0"
 trillium-proxy = { version = "0.5.5", default-features = false }
 trillium-router = "0.4.1"
 trillium-rustls = "0.8.1"


### PR DESCRIPTION
This upgrades trillium-prometheus to the new version I just published. This cleans up a duplicate version of trillium-router.