### PR TITLE
Check report count in simulation tests

### DIFF
--- a/integration_tests/tests/integration/simulation/run.rs
+++ b/integration_tests/tests/integration/simulation/run.rs
@@ -609,6 +609,11 @@ fn check_aggregate_results_valid<Q: janus_messages::query_type::QueryType>(
             );
             return false;
         }
+        let sum = collection.aggregate_result().iter().sum::<u128>();
+        if sum != u128::from(collection.report_count()) {
+            error!(?collection, "bad report count");
+            return false;
+        }
     }
     true
 }


### PR DESCRIPTION
This adds a check to the simulation tests that the report count in collection results is consistent with the aggregate result. This leverages the "bad client" implementation to confirm that we correctly exclude invalid report shares from "report_count".