### PR TITLE
Ignore range of opentelemetry-rust versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,13 +16,13 @@ updates:
       # opentelemetry-prometheus, and will add it back after the 1.0 release.
       - dependency-name: opentelemetry
         versions:
-        - "0.25"
+        - ">= 0.25, < 1.0"
       - dependency-name: opentelemetry_sdk
         versions:
-        - "0.25"
+        - ">= 0.25, < 1.0"
       - dependency-name: opentelemetry-otlp
         versions:
-        - "0.25"
+        - ">= 0.25, < 1.0"
     groups:
       serde:
         patterns:


### PR DESCRIPTION
The OpenTelemetry Rust crates are releasing on a more frequent cadence on the road to 1.0. This PR ignores this week's release, and future pre-1.0 releases.