### PR TITLE
CI: Enable unprivileged user namespaces

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -30,6 +30,8 @@ jobs:
       CARGO_TERM_COLOR: always
       RUSTFLAGS: "-D warnings"
     steps:
+    - name: 'Workaround for issue #3178'
+      run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
     - name: Set default input values
       id: default-input-values
       run: |


### PR DESCRIPTION
This adds a workaround for #3178 to CI. The GitHub Actions workers are now using Ubuntu 24.04 as well. This workaround can be removed once the tests are rewritten to be part of `cargo xtask test-docker`.