### PR TITLE
Update HTTP verbs for DAP-13.

### DIFF
--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -361,7 +361,7 @@ where
                 "hpke_config",
                 hpke_config_cors_preflight,
             )
-            .put("tasks/:task_id/reports", instrumented(api(upload::<C>)))
+            .post("tasks/:task_id/reports", instrumented(api(upload::<C>)))
             .with_route(
                 trillium::Method::Options,
                 "tasks/:task_id/reports",
@@ -397,9 +397,9 @@ where
                 COLLECTION_JOB_ROUTE,
                 instrumented(api(collection_jobs_put::<C>)),
             )
-            .post(
+            .get(
                 COLLECTION_JOB_ROUTE,
-                instrumented(api(collection_jobs_post::<C>)),
+                instrumented(api(collection_jobs_get::<C>)),
             )
             .delete(
                 COLLECTION_JOB_ROUTE,
@@ -491,7 +491,7 @@ async fn hpke_config_cors_preflight(mut conn: Conn) -> Conn {
     conn
 }
 
-/// API handler for the "/tasks/.../reports" PUT endpoint.
+/// API handler for the "/tasks/.../reports" POST endpoint.
 async fn upload<C: Clock>(
     conn: &mut Conn,
     (State(aggregator), BodyBytes(body)): (State<Arc<Aggregator<C>>>, BodyBytes),
@@ -517,12 +517,12 @@ async fn upload<C: Clock>(
 /// Handler for CORS preflight requests to "/tasks/.../reports".
 async fn upload_cors_preflight(mut conn: Conn) -> Conn {
     conn.response_headers_mut()
-        .insert(KnownHeaderName::Allow, "PUT");
+        .insert(KnownHeaderName::Allow, "POST");
     if let Some(origin) = conn.request_headers().get(KnownHeaderName::Origin) {
         let origin = origin.clone();
         let request_headers = conn.response_headers_mut();
         request_headers.insert(KnownHeaderName::AccessControlAllowOrigin, origin);
-        request_headers.insert(KnownHeaderName::AccessControlAllowMethods, "PUT");
+        request_headers.insert(KnownHeaderName::AccessControlAllowMethods, "POST");
         request_headers.insert(KnownHeaderName::AccessControlAllowHeaders, "content-type");
         request_headers.insert(
             KnownHeaderName::AccessControlMaxAge,
@@ -629,8 +629,8 @@ async fn collection_jobs_put<C: Clock>(
     Ok(Status::Created)
 }
 
-/// API handler for the "/tasks/.../collection_jobs/..." POST endpoint.
-async fn collection_jobs_post<C: Clock>(
+/// API handler for the "/tasks/.../collection_jobs/..." GET endpoint.
+async fn collection_jobs_get<C: Clock>(
     conn: &mut Conn,
     State(aggregator): State<Arc<Aggregator<C>>>,
 ) -> Result<(), Error> {

--- a/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
@@ -24,7 +24,7 @@ use serde_json::json;
 use trillium::{KnownHeaderName, Status};
 use trillium_testing::{
     assert_headers,
-    prelude::{delete, post, put},
+    prelude::{delete, get, put},
 };
 
 #[tokio::test]
@@ -288,7 +288,7 @@ async fn collection_job_post_request_unauthenticated_collection_jobs() {
 
     // Incorrect authentication token.
     let mut test_conn = test_case
-        .post_collection_job_with_auth_token(&collection_job_id, Some(&random()))
+        .get_collection_job_with_auth_token(&collection_job_id, Some(&random()))
         .await;
 
     let want_status = u16::from(Status::Forbidden);
@@ -305,7 +305,7 @@ async fn collection_job_post_request_unauthenticated_collection_jobs() {
 
     // Aggregator authentication token.
     let mut test_conn = test_case
-        .post_collection_job_with_auth_token(
+        .get_collection_job_with_auth_token(
             &collection_job_id,
             Some(test_case.task.aggregator_auth_token()),
         )
@@ -325,7 +325,7 @@ async fn collection_job_post_request_unauthenticated_collection_jobs() {
 
     // Missing authentication token.
     let mut test_conn = test_case
-        .post_collection_job_with_auth_token(&collection_job_id, None)
+        .get_collection_job_with_auth_token(&collection_job_id, None)
         .await;
 
     let want_status = u16::from(Status::Forbidden);
@@ -398,7 +398,7 @@ async fn collection_job_success_time_interval() {
 
     assert_eq!(test_conn.status(), Some(Status::Created));
 
-    let test_conn = test_case.post_collection_job(&collection_job_id).await;
+    let test_conn = test_case.get_collection_job(&collection_job_id).await;
     assert_eq!(test_conn.status(), Some(Status::Accepted));
 
     // Update the collection job with the aggregate shares and some aggregation jobs. collection
@@ -452,7 +452,7 @@ async fn collection_job_success_time_interval() {
         .await
         .unwrap();
 
-    let mut test_conn = test_case.post_collection_job(&collection_job_id).await;
+    let mut test_conn = test_case.get_collection_job(&collection_job_id).await;
 
     assert_eq!(test_conn.status(), Some(Status::Ok));
     assert_headers!(
@@ -502,7 +502,7 @@ async fn collection_job_success_time_interval() {
 }
 
 #[tokio::test]
-async fn collection_job_post_request_no_such_collection_job() {
+async fn collection_job_get_request_no_such_collection_job() {
     let test_case = setup_collection_job_test_case(Role::Leader, QueryType::TimeInterval).await;
     test_case
         .setup_time_interval_batch(Time::from_seconds_since_epoch(0))
@@ -514,7 +514,7 @@ async fn collection_job_post_request_no_such_collection_job() {
         .task
         .collector_auth_token()
         .request_authentication();
-    let test_conn = post(format!(
+    let test_conn = get(format!(
         "/tasks/{}/collection_jobs/{no_such_collection_job_id}",
         test_case.task.id()
     ))
@@ -659,6 +659,6 @@ async fn delete_collection_job() {
     assert_eq!(test_conn.status(), Some(Status::NoContent));
 
     // Get the job again
-    let test_conn = test_case.post_collection_job(&collection_job_id).await;
+    let test_conn = test_case.get_collection_job(&collection_job_id).await;
     assert_eq!(test_conn.status(), Some(Status::NoContent));
 }

--- a/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
@@ -262,7 +262,7 @@ async fn collection_job_put_request_unauthenticated() {
 }
 
 #[tokio::test]
-async fn collection_job_post_request_unauthenticated_collection_jobs() {
+async fn collection_job_get_request_unauthenticated_collection_jobs() {
     let test_case = setup_collection_job_test_case(Role::Leader, QueryType::TimeInterval).await;
     test_case
         .setup_time_interval_batch(Time::from_seconds_since_epoch(0))

--- a/aggregator/src/aggregator/http_handlers/tests/report.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/report.rs
@@ -36,7 +36,7 @@ use tokio::{
     time::{sleep, timeout},
 };
 use trillium::{KnownHeaderName, Status};
-use trillium_testing::{assert_headers, prelude::put, TestConn};
+use trillium_testing::{assert_headers, prelude::post, TestConn};
 use trillium_tokio::Stopper;
 
 #[tokio::test]
@@ -86,7 +86,7 @@ async fn upload_handler() {
 
     // Upload a report. Do this twice to prove that PUT is idempotent.
     for _ in 0..2 {
-        let mut test_conn = put(task.report_upload_uri().unwrap().path())
+        let mut test_conn = post(task.report_upload_uri().unwrap().path())
             .with_request_header(KnownHeaderName::ContentType, Report::MEDIA_TYPE)
             .with_request_body(report.get_encoded().unwrap())
             .run_async(&handler)
@@ -105,7 +105,7 @@ async fn upload_handler() {
         *accepted_report_id,
         &hpke_keypair,
     );
-    let mut test_conn = put(task.report_upload_uri().unwrap().path())
+    let mut test_conn = post(task.report_upload_uri().unwrap().path())
         .with_request_header(KnownHeaderName::ContentType, Report::MEDIA_TYPE)
         .with_request_body(duplicate_id_report.get_encoded().unwrap())
         .run_async(&handler)
@@ -127,7 +127,7 @@ async fn upload_handler() {
         report.leader_encrypted_input_share().clone(),
         report.helper_encrypted_input_share().clone(),
     );
-    let mut test_conn = put(task.report_upload_uri().unwrap().path())
+    let mut test_conn = post(task.report_upload_uri().unwrap().path())
         .with_request_header(KnownHeaderName::ContentType, Report::MEDIA_TYPE)
         .with_request_body(gc_eligible_report.get_encoded().unwrap())
         .run_async(&handler)
@@ -161,7 +161,7 @@ async fn upload_handler() {
         ),
         report.helper_encrypted_input_share().clone(),
     );
-    let mut test_conn = put(task.report_upload_uri().unwrap().path())
+    let mut test_conn = post(task.report_upload_uri().unwrap().path())
         .with_request_header(KnownHeaderName::ContentType, Report::MEDIA_TYPE)
         .with_request_body(bad_report.get_encoded().unwrap())
         .run_async(&handler)
@@ -189,7 +189,7 @@ async fn upload_handler() {
         report.leader_encrypted_input_share().clone(),
         report.helper_encrypted_input_share().clone(),
     );
-    let mut test_conn = put(task.report_upload_uri().unwrap().path())
+    let mut test_conn = post(task.report_upload_uri().unwrap().path())
         .with_request_header(KnownHeaderName::ContentType, Report::MEDIA_TYPE)
         .with_request_body(bad_report.get_encoded().unwrap())
         .run_async(&handler)
@@ -218,7 +218,7 @@ async fn upload_handler() {
         &hpke_keypair,
         clock.now().add(&Duration::from_seconds(120)).unwrap(),
     );
-    let mut test_conn = put(task_expire_soon.report_upload_uri().unwrap().path())
+    let mut test_conn = post(task_expire_soon.report_upload_uri().unwrap().path())
         .with_request_header(KnownHeaderName::ContentType, Report::MEDIA_TYPE)
         .with_request_body(report_2.get_encoded().unwrap())
         .run_async(&handler)
@@ -246,7 +246,7 @@ async fn upload_handler() {
             .helper_encrypted_input_share()
             .clone(),
     );
-    let mut test_conn = put(task.report_upload_uri().unwrap().path())
+    let mut test_conn = post(task.report_upload_uri().unwrap().path())
         .with_request_header(KnownHeaderName::ContentType, Report::MEDIA_TYPE)
         .with_request_body(bad_public_share_report.get_encoded().unwrap())
         .run_async(&handler)
@@ -269,7 +269,7 @@ async fn upload_handler() {
         // Encrypt report with some arbitrary key that has the same ID as an existing one.
         &HpkeKeypair::test_with_id((*hpke_keypair.config().id()).into()),
     );
-    let mut test_conn = put(task.report_upload_uri().unwrap().path())
+    let mut test_conn = post(task.report_upload_uri().unwrap().path())
         .with_request_header(KnownHeaderName::ContentType, Report::MEDIA_TYPE)
         .with_request_body(undecryptable_report.get_encoded().unwrap())
         .run_async(&handler)
@@ -309,7 +309,7 @@ async fn upload_handler() {
             .helper_encrypted_input_share()
             .clone(),
     );
-    let mut test_conn = put(task.report_upload_uri().unwrap().path())
+    let mut test_conn = post(task.report_upload_uri().unwrap().path())
         .with_request_header(KnownHeaderName::ContentType, Report::MEDIA_TYPE)
         .with_request_body(bad_leader_input_share_report.get_encoded().unwrap())
         .run_async(&handler)
@@ -331,7 +331,7 @@ async fn upload_handler() {
         (),
     )
     .with_request_header(KnownHeaderName::Origin, "https://example.com/")
-    .with_request_header(KnownHeaderName::AccessControlRequestMethod, "PUT")
+    .with_request_header(KnownHeaderName::AccessControlRequestMethod, "POST")
     .with_request_header(KnownHeaderName::AccessControlRequestHeaders, "content-type")
     .run_async(&handler)
     .await;
@@ -339,13 +339,13 @@ async fn upload_handler() {
     assert_headers!(
         &test_conn,
         "access-control-allow-origin" => "https://example.com/",
-        "access-control-allow-methods"=> "PUT",
+        "access-control-allow-methods"=> "POST",
         "access-control-allow-headers" => "content-type",
         "access-control-max-age"=> "86400",
     );
 
     // Check for appropriate CORS headers in response to the main request.
-    let test_conn = put(task.report_upload_uri().unwrap().path())
+    let test_conn = post(task.report_upload_uri().unwrap().path())
         .with_request_header(KnownHeaderName::Origin, "https://example.com/")
         .with_request_header(KnownHeaderName::ContentType, Report::MEDIA_TYPE)
         .with_request_body(report.get_encoded().unwrap())
@@ -375,7 +375,7 @@ async fn upload_handler_helper() {
     datastore.put_aggregator_task(&helper_task).await.unwrap();
     let report = create_report(&helper_task, &hpke_keypair, clock.now());
 
-    let mut test_conn = put(task.report_upload_uri().unwrap().path())
+    let mut test_conn = post(task.report_upload_uri().unwrap().path())
         .with_request_header(KnownHeaderName::ContentType, Report::MEDIA_TYPE)
         .with_request_body(report.get_encoded().unwrap())
         .run_async(&handler)
@@ -455,7 +455,7 @@ async fn upload_handler_error_fanout() {
     // Upload one report and wait for it to finish, to prepopulate the aggregator's task cache.
     let report: Report = create_report(&leader_task, &hpke_keypair, clock.now());
     let response = client
-        .put(url.clone())
+        .post(url.clone())
         .header("Content-Type", Report::MEDIA_TYPE)
         .body(report.get_encoded().unwrap())
         .send()
@@ -498,7 +498,7 @@ async fn upload_handler_error_fanout() {
                 async move {
                     let report = create_report(&leader_task, &hpke_keypair, clock.now());
                     let response = client
-                        .put(url)
+                        .post(url)
                         .header("Content-Type", Report::MEDIA_TYPE)
                         .body(report.get_encoded().unwrap())
                         .send()
@@ -563,7 +563,7 @@ async fn upload_client_early_disconnect() {
     // Client sends report, using Content-Length, and waits for one byte of response.
     let mut client_socket = TcpStream::connect(local_addr).await.unwrap();
     let request_line_and_headers = format!(
-        "PUT /tasks/{task_id}/reports HTTP/1.1\r\n\
+        "POST /tasks/{task_id}/reports HTTP/1.1\r\n\
         Content-Type: application/dap-report\r\n\
         Content-Length: {}\r\n\r\n",
         encoded_report_1.len(),
@@ -586,7 +586,7 @@ async fn upload_client_early_disconnect() {
     // Client disconnects before sending the entire request body, using Content-Length.
     let mut client_socket = TcpStream::connect(local_addr).await.unwrap();
     let request_line_and_headers = format!(
-        "PUT /tasks/{task_id}/reports HTTP/1.1\r\n\
+        "POST /tasks/{task_id}/reports HTTP/1.1\r\n\
         Content-Type: application/dap-report\r\n\
         Content-Length: 1000\r\n\r\n"
     );
@@ -601,7 +601,7 @@ async fn upload_client_early_disconnect() {
     // Client sends report, using chunked transfer encoding, and waits for one byte of response.
     let mut client_socket = TcpStream::connect(local_addr).await.unwrap();
     let request_line_and_headers = format!(
-        "PUT /tasks/{task_id}/reports HTTP/1.1\r\n\
+        "POST /tasks/{task_id}/reports HTTP/1.1\r\n\
         Content-Type: application/dap-report\r\n\
         Transfer-Encoding: chunked\r\n\r\n"
     );
@@ -630,7 +630,7 @@ async fn upload_client_early_disconnect() {
     // encoding.
     let mut client_socket = TcpStream::connect(local_addr).await.unwrap();
     let request_line_and_headers = format!(
-        "PUT /tasks/{task_id}/reports HTTP/1.1\r\n\
+        "POST /tasks/{task_id}/reports HTTP/1.1\r\n\
         Content-Type: application/dap-report\r\n\
         Transfer-Encoding: chunked\r\n\r\n"
     );

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -699,7 +699,7 @@ impl<V: vdaf::Client<16>> Client<V> {
             self.parameters.http_request_retry_parameters.clone(),
             || async {
                 self.http_client
-                    .put(upload_endpoint.clone())
+                    .post(upload_endpoint.clone())
                     .header(CONTENT_TYPE, Report::MEDIA_TYPE)
                     .body(request_body.to_vec())
                     .send()
@@ -728,7 +728,7 @@ impl<V: vdaf::Client<16>> Client<V> {
 
         // Construct a Message representing the upload request...
         let mut message = Message::request(
-            "PUT".into(),
+            "POST".into(),
             upload_endpoint.scheme().into(),
             upload_endpoint.authority().into(),
             upload_endpoint.path().into(),

--- a/client/src/tests/mod.rs
+++ b/client/src/tests/mod.rs
@@ -61,7 +61,7 @@ async fn upload_prio3_count() {
 
     let mocked_upload = server
         .mock(
-            "PUT",
+            "POST",
             format!("/tasks/{}/reports", client.parameters.task_id).as_str(),
         )
         .match_header(CONTENT_TYPE.as_str(), Report::MEDIA_TYPE)
@@ -96,7 +96,7 @@ async fn upload_prio3_http_status_code() {
 
     let mocked_upload = server
         .mock(
-            "PUT",
+            "POST",
             format!("/tasks/{}/reports", client.parameters.task_id).as_str(),
         )
         .match_header(CONTENT_TYPE.as_str(), Report::MEDIA_TYPE)
@@ -123,7 +123,7 @@ async fn upload_problem_details() {
 
     let mocked_upload = server
         .mock(
-            "PUT",
+            "POST",
             format!("/tasks/{}/reports", client.parameters.task_id).as_str(),
         )
         .match_header(CONTENT_TYPE.as_str(), Report::MEDIA_TYPE)

--- a/client/src/tests/ohttp.rs
+++ b/client/src/tests/ohttp.rs
@@ -97,7 +97,7 @@ async fn successful_upload() {
                     .control()
                     .method()
                     .map(|a| String::from_utf8(a.to_vec()).unwrap()),
-                Some("PUT".to_string()),
+                Some("POST".to_string()),
             );
             assert_eq!(
                 bin_request

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -538,7 +538,7 @@ impl<V: vdaf::Collector> Collector<V> {
             retry_http_request(self.http_request_retry_parameters.clone(), || async {
                 let (auth_header, auth_value) = self.authentication.request_authentication();
                 self.http_client
-                    .post(collection_job_url.clone())
+                    .get(collection_job_url.clone())
                     // reqwest does not send Content-Length for requests with empty bodies. Some
                     // HTTP servers require this anyway, so explicitly set it.
                     .header(CONTENT_LENGTH, 0)
@@ -965,19 +965,19 @@ mod tests {
             collector.task_id, job.collection_job_id
         );
         let mocked_collect_error = server
-            .mock("POST", collection_job_path.as_str())
+            .mock("GET", collection_job_path.as_str())
             .with_status(500)
             .expect(1)
             .create_async()
             .await;
         let mocked_collect_accepted = server
-            .mock("POST", collection_job_path.as_str())
+            .mock("GET", collection_job_path.as_str())
             .with_status(202)
             .expect(2)
             .create_async()
             .await;
         let mocked_collect_complete = server
-            .mock("POST", collection_job_path.as_str())
+            .mock("GET", collection_job_path.as_str())
             .match_header(auth_header, auth_value.as_str())
             .with_status(200)
             .with_header(
@@ -1051,7 +1051,7 @@ mod tests {
             collector.task_id, job.collection_job_id
         );
         let mocked_collect_complete = server
-            .mock("POST", collection_job_path.as_str())
+            .mock("GET", collection_job_path.as_str())
             .with_status(200)
             .with_header(
                 CONTENT_TYPE.as_str(),
@@ -1120,7 +1120,7 @@ mod tests {
             collector.task_id, job.collection_job_id
         );
         let mocked_collect_complete = server
-            .mock("POST", collection_job_path.as_str())
+            .mock("GET", collection_job_path.as_str())
             .with_status(200)
             .with_header(
                 CONTENT_TYPE.as_str(),
@@ -1198,7 +1198,7 @@ mod tests {
             collector.task_id, job.collection_job_id
         );
         let mocked_collect_complete = server
-            .mock("POST", collection_job_path.as_str())
+            .mock("GET", collection_job_path.as_str())
             .with_status(200)
             .with_header(
                 CONTENT_TYPE.as_str(),
@@ -1268,7 +1268,7 @@ mod tests {
             collector.task_id, job.collection_job_id
         );
         let mocked_collect_complete = server
-            .mock("POST", collection_job_path.as_str())
+            .mock("GET", collection_job_path.as_str())
             .with_status(200)
             .with_header(
                 CONTENT_TYPE.as_str(),
@@ -1350,7 +1350,7 @@ mod tests {
             collector.task_id, job.collection_job_id
         );
         let mocked_collect_complete = server
-            .mock("POST", collection_job_path.as_str())
+            .mock("GET", collection_job_path.as_str())
             .match_header(AUTHORIZATION.as_str(), "Bearer AAAAAAAAAAAAAAAA")
             .with_status(200)
             .with_header(
@@ -1489,7 +1489,7 @@ mod tests {
             .create_async()
             .await;
         let mock_collection_job_server_error = server
-            .mock("POST", matcher)
+            .mock("GET", matcher)
             .with_status(500)
             .expect_at_least(1)
             .create_async()
@@ -1518,7 +1518,7 @@ mod tests {
             collector.task_id, job.collection_job_id
         );
         let mock_collection_job_server_error_details = server
-            .mock("POST", collection_job_path.as_str())
+            .mock("GET", collection_job_path.as_str())
             .with_status(500)
             .with_header("Content-Type", "application/problem+json")
             .with_body("{\"type\": \"http://example.com/test_server_error\"}")
@@ -1538,7 +1538,7 @@ mod tests {
             .await;
 
         let mock_collection_job_bad_request = server
-            .mock("POST", collection_job_path.as_str())
+            .mock("GET", collection_job_path.as_str())
             .with_status(400)
             .with_header("Content-Type", "application/problem+json")
             .with_body(concat!(
@@ -1561,7 +1561,7 @@ mod tests {
         mock_collection_job_bad_request.assert_async().await;
 
         let mock_collection_job_bad_message_bytes = server
-            .mock("POST", collection_job_path.as_str())
+            .mock("GET", collection_job_path.as_str())
             .with_status(200)
             .with_header(
                 CONTENT_TYPE.as_str(),
@@ -1578,7 +1578,7 @@ mod tests {
         mock_collection_job_bad_message_bytes.assert_async().await;
 
         let mock_collection_job_bad_ciphertext = server
-            .mock("POST", collection_job_path.as_str())
+            .mock("GET", collection_job_path.as_str())
             .with_status(200)
             .with_header(
                 CONTENT_TYPE.as_str(),
@@ -1637,7 +1637,7 @@ mod tests {
             .unwrap(),
         );
         let mock_collection_job_bad_shares = server
-            .mock("POST", collection_job_path.as_str())
+            .mock("GET", collection_job_path.as_str())
             .with_status(200)
             .with_header(
                 CONTENT_TYPE.as_str(),
@@ -1680,7 +1680,7 @@ mod tests {
             .unwrap(),
         );
         let mock_collection_job_wrong_length = server
-            .mock("POST", collection_job_path.as_str())
+            .mock("GET", collection_job_path.as_str())
             .with_status(200)
             .with_header(
                 CONTENT_TYPE.as_str(),
@@ -1697,7 +1697,7 @@ mod tests {
         mock_collection_job_wrong_length.assert_async().await;
 
         let mock_collection_job_always_fail = server
-            .mock("POST", collection_job_path.as_str())
+            .mock("GET", collection_job_path.as_str())
             .with_status(500)
             .expect_at_least(3)
             .create_async()
@@ -1744,7 +1744,7 @@ mod tests {
             collector.task_id, job.collection_job_id
         );
         let mock_collect_poll_no_retry_after = server
-            .mock("POST", collection_job_path.as_str())
+            .mock("GET", collection_job_path.as_str())
             .with_status(202)
             .expect(1)
             .create_async()
@@ -1756,7 +1756,7 @@ mod tests {
         mock_collect_poll_no_retry_after.assert_async().await;
 
         let mock_collect_poll_retry_after_60s = server
-            .mock("POST", collection_job_path.as_str())
+            .mock("GET", collection_job_path.as_str())
             .with_status(202)
             .with_header("Retry-After", "60")
             .expect(1)
@@ -1769,7 +1769,7 @@ mod tests {
         mock_collect_poll_retry_after_60s.assert_async().await;
 
         let mock_collect_poll_retry_after_date_time = server
-            .mock("POST", collection_job_path.as_str())
+            .mock("GET", collection_job_path.as_str())
             .with_status(202)
             .with_header("Retry-After", "Wed, 21 Oct 2015 07:28:00 GMT")
             .expect(1)
@@ -1813,14 +1813,14 @@ mod tests {
         );
 
         let mock_collect_poll_retry_after_1s = server
-            .mock("POST", collection_job_path.as_str())
+            .mock("GET", collection_job_path.as_str())
             .with_status(202)
             .with_header("Retry-After", "1")
             .expect(1)
             .create_async()
             .await;
         let mock_collect_poll_retry_after_10s = server
-            .mock("POST", collection_job_path.as_str())
+            .mock("GET", collection_job_path.as_str())
             .with_status(202)
             .with_header("Retry-After", "10")
             .expect(1)
@@ -1837,21 +1837,21 @@ mod tests {
             Utc::now() + chrono::Duration::from_std(std::time::Duration::from_secs(1)).unwrap();
         let near_future_formatted = near_future.format("%a, %d %b %Y %H:%M:%S GMT").to_string();
         let mock_collect_poll_retry_after_near_future = server
-            .mock("POST", collection_job_path.as_str())
+            .mock("GET", collection_job_path.as_str())
             .with_status(202)
             .with_header("Retry-After", &near_future_formatted)
             .expect(1)
             .create_async()
             .await;
         let mock_collect_poll_retry_after_past = server
-            .mock("POST", collection_job_path.as_str())
+            .mock("GET", collection_job_path.as_str())
             .with_status(202)
             .with_header("Retry-After", "Mon, 01 Jan 1900 00:00:00 GMT")
             .expect(1)
             .create_async()
             .await;
         let mock_collect_poll_retry_after_far_future = server
-            .mock("POST", collection_job_path.as_str())
+            .mock("GET", collection_job_path.as_str())
             .with_status(202)
             .with_header("Retry-After", "Wed, 01 Jan 3000 00:00:00 GMT")
             .expect(1)
@@ -1875,7 +1875,7 @@ mod tests {
         collector.collect_poll_wait_parameters.initial_interval =
             std::time::Duration::from_millis(10);
         let mock_collect_poll_no_retry_after = server
-            .mock("POST", collection_job_path.as_str())
+            .mock("GET", collection_job_path.as_str())
             .with_status(202)
             .expect_at_least(1)
             .create_async()
@@ -1985,20 +1985,20 @@ mod tests {
             collector.task_id, job.collection_job_id
         );
         let mocked_collect_error = server
-            .mock("POST", collection_job_path.as_str())
+            .mock("GET", collection_job_path.as_str())
             .with_status(500)
             .expect(1)
             .create_async()
             .await;
         let mocked_collect_accepted = server
-            .mock("POST", collection_job_path.as_str())
+            .mock("GET", collection_job_path.as_str())
             .match_header(CONTENT_LENGTH.as_str(), "0")
             .with_status(202)
             .expect(2)
             .create_async()
             .await;
         let mocked_collect_complete = server
-            .mock("POST", collection_job_path.as_str())
+            .mock("GET", collection_job_path.as_str())
             .match_header(auth_header, auth_value.as_str())
             .match_header(CONTENT_LENGTH.as_str(), "0")
             .with_status(200)

--- a/integration_tests/tests/integration/daphne.rs
+++ b/integration_tests/tests/integration/daphne.rs
@@ -102,7 +102,7 @@ async fn janus_daphne() {
 /// This test places Janus in the leader role and Daphne in the helper role. Janus is run
 /// in-process, while Daphne is run in Docker.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "Daphne does not currently support DAP-07 (issue #1669)"]
+#[ignore = "Daphne does not currently support DAP-13"]
 async fn janus_in_process_daphne() {
     static TEST_NAME: &str = "janus_in_process_daphne";
     install_test_trace_subscriber();

--- a/integration_tests/tests/integration/divviup_ts.rs
+++ b/integration_tests/tests/integration/divviup_ts.rs
@@ -44,6 +44,7 @@ async fn run_divviup_ts_integration_test(test_name: &str, vdaf: VdafInstance) {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "divviup-ts does not expose a DAP-13-compatible image (issue #3479)"]
 async fn janus_divviup_ts_count() {
     install_test_trace_subscriber();
     initialize_rustls();
@@ -52,6 +53,7 @@ async fn janus_divviup_ts_count() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "divviup-ts does not expose a DAP-13-compatible image (issue #3479)"]
 async fn janus_divviup_ts_sum() {
     install_test_trace_subscriber();
     initialize_rustls();
@@ -61,6 +63,7 @@ async fn janus_divviup_ts_sum() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "divviup-ts does not expose a DAP-13-compatible image (issue #3479)"]
 async fn janus_divviup_ts_histogram() {
     install_test_trace_subscriber();
     initialize_rustls();
@@ -77,6 +80,7 @@ async fn janus_divviup_ts_histogram() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "divviup-ts does not expose a DAP-13-compatible image (issue #3479)"]
 async fn janus_divviup_ts_sumvec() {
     install_test_trace_subscriber();
     initialize_rustls();

--- a/integration_tests/tests/integration/simulation/bad_client.rs
+++ b/integration_tests/tests/integration/simulation/bad_client.rs
@@ -312,7 +312,7 @@ async fn upload_report(
         .unwrap();
     retry_http_request(http_request_exponential_backoff(), || async {
         http_client
-            .put(url.clone())
+            .post(url.clone())
             .header(CONTENT_TYPE, Report::MEDIA_TYPE)
             .body(report.get_encoded().unwrap())
             .send()


### PR DESCRIPTION
Specifically:
* Use POST rather than PUT for report uploads.
* Use GET rather than POST for collection job polling.