### PR TITLE
Remove max_batch_size parameter from leader-selected tasks.

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -399,39 +399,36 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
 
             (
                 task::BatchMode::LeaderSelected {
-                    max_batch_size,
                     batch_time_window_size,
                 },
                 VdafInstance::Prio3Count,
             ) => {
-                let vdaf = Arc::new(Prio3::new_count(2)?);
-                let max_batch_size = *max_batch_size;
+                let vdaf: Arc<
+                    Prio3<prio::flp::types::Count<Field64>, vdaf::xof::XofTurboShake128, 16>,
+                > = Arc::new(Prio3::new_count(2)?);
                 let batch_time_window_size = *batch_time_window_size;
                 self.create_aggregation_jobs_for_leader_selected_task_no_param::<
                     VERIFY_KEY_LENGTH,
                     Prio3Count,
-                >(task, vdaf, max_batch_size, batch_time_window_size).await
+                >(task, vdaf, batch_time_window_size).await
             }
 
             (
                 task::BatchMode::LeaderSelected {
-                    max_batch_size,
                     batch_time_window_size,
                 },
                 VdafInstance::Prio3Sum { bits },
             ) => {
                 let vdaf = Arc::new(Prio3::new_sum(2, *bits)?);
-                let max_batch_size = *max_batch_size;
                 let batch_time_window_size = *batch_time_window_size;
                 self.create_aggregation_jobs_for_leader_selected_task_no_param::<
                     VERIFY_KEY_LENGTH,
                     Prio3Sum,
-                >(task, vdaf, max_batch_size, batch_time_window_size).await
+                >(task, vdaf, batch_time_window_size).await
             }
 
             (
                 task::BatchMode::LeaderSelected {
-                    max_batch_size,
                     batch_time_window_size,
                 },
                 VdafInstance::Prio3SumVec {
@@ -442,17 +439,15 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                 },
             ) => {
                 let vdaf = Arc::new(Prio3::new_sum_vec(2, *bits, *length, *chunk_length)?);
-                let max_batch_size = *max_batch_size;
                 let batch_time_window_size = *batch_time_window_size;
                 self.create_aggregation_jobs_for_leader_selected_task_no_param::<
                     VERIFY_KEY_LENGTH,
                     Prio3SumVec,
-                >(task, vdaf, max_batch_size, batch_time_window_size).await
+                >(task, vdaf, batch_time_window_size).await
             }
 
             (
                 task::BatchMode::LeaderSelected {
-                    max_batch_size,
                     batch_time_window_size,
                 },
                 VdafInstance::Prio3SumVecField64MultiproofHmacSha256Aes128 {
@@ -466,17 +461,15 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                 let vdaf = Arc::new(new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128::<
                     ParallelSum<Field64, Mul<Field64>>,
                 >(*proofs, *bits, *length, *chunk_length)?);
-                let max_batch_size = *max_batch_size;
                 let batch_time_window_size = *batch_time_window_size;
                 self.create_aggregation_jobs_for_leader_selected_task_no_param::<
                     VERIFY_KEY_LENGTH_HMACSHA256_AES128,
                     Prio3SumVecField64MultiproofHmacSha256Aes128<_>,
-                >(task, vdaf, max_batch_size, batch_time_window_size).await
+                >(task, vdaf, batch_time_window_size).await
             }
 
             (
                 task::BatchMode::LeaderSelected {
-                    max_batch_size,
                     batch_time_window_size,
                 },
                 VdafInstance::Prio3Histogram {
@@ -486,18 +479,16 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                 },
             ) => {
                 let vdaf = Arc::new(Prio3::new_histogram(2, *length, *chunk_length)?);
-                let max_batch_size = *max_batch_size;
                 let batch_time_window_size = *batch_time_window_size;
                 self.create_aggregation_jobs_for_leader_selected_task_no_param::<
                     VERIFY_KEY_LENGTH,
                     Prio3Histogram,
-                >(task, vdaf, max_batch_size, batch_time_window_size).await
+                >(task, vdaf, batch_time_window_size).await
             }
 
             #[cfg(feature = "fpvec_bounded_l2")]
             (
                 task::BatchMode::LeaderSelected {
-                    max_batch_size,
                     batch_time_window_size,
                 },
                 VdafInstance::Prio3FixedPointBoundedL2VecSum {
@@ -506,7 +497,6 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                     length,
                 },
             ) => {
-                let max_batch_size = *max_batch_size;
                 let batch_time_window_size = *batch_time_window_size;
 
                 match bitsize {
@@ -516,7 +506,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                         self.create_aggregation_jobs_for_leader_selected_task_no_param::<
                                 VERIFY_KEY_LENGTH,
                             Prio3FixedPointBoundedL2VecSum<FixedI16<U15>>,
-                            >(task, vdaf, max_batch_size, batch_time_window_size).await
+                            >(task, vdaf, batch_time_window_size).await
                     }
                     janus_core::vdaf::Prio3FixedPointBoundedL2VecSumBitSize::BitSize32 => {
                         let vdaf: Arc<Prio3FixedPointBoundedL2VecSum<FixedI32<U31>>> =
@@ -524,7 +514,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                         self.create_aggregation_jobs_for_leader_selected_task_no_param::<
                                 VERIFY_KEY_LENGTH,
                             Prio3FixedPointBoundedL2VecSum<FixedI32<U31>>,
-                            >(task, vdaf, max_batch_size, batch_time_window_size).await
+                            >(task, vdaf, batch_time_window_size).await
                     }
                 }
             }
@@ -532,7 +522,6 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
             #[cfg(feature = "test-util")]
             (
                 task::BatchMode::LeaderSelected {
-                    max_batch_size: _max_batch_size,
                     batch_time_window_size: _batch_time_window_size,
                 },
                 VdafInstance::Fake { rounds },
@@ -849,7 +838,6 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
         self: Arc<Self>,
         task: Arc<AggregatorTask>,
         vdaf: Arc<A>,
-        task_max_batch_size: Option<u64>,
         task_batch_time_window_size: Option<janus_messages::Duration>,
     ) -> anyhow::Result<bool>
     where
@@ -862,10 +850,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
         A::PublicShare: Send + Sync + PartialEq,
         A::OutputShare: Send + Sync,
     {
-        let (task_min_batch_size, task_max_batch_size) = (
-            usize::try_from(task.min_batch_size())?,
-            task_max_batch_size.map(usize::try_from).transpose()?,
-        );
+        let task_min_batch_size = usize::try_from(task.min_batch_size())?;
         Ok(self
             .datastore
             .run_tx("aggregation_job_creator_fixed_no_param", |tx| {
@@ -895,7 +880,6 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                         this.max_aggregation_job_size,
                         *task.id(),
                         task_min_batch_size,
-                        task_max_batch_size,
                         task_batch_time_window_size,
                         &mut aggregation_job_writer,
                     );
@@ -1732,12 +1716,10 @@ mod tests {
         const MIN_AGGREGATION_JOB_SIZE: usize = 50;
         const MAX_AGGREGATION_JOB_SIZE: usize = 60;
         const MIN_BATCH_SIZE: usize = 200;
-        const MAX_BATCH_SIZE: usize = 300;
 
         let task = Arc::new(
             TaskBuilder::new(
                 TaskBatchMode::LeaderSelected {
-                    max_batch_size: Some(MAX_BATCH_SIZE as u64),
                     batch_time_window_size: None,
                 },
                 VdafInstance::Prio3Count,
@@ -1748,8 +1730,8 @@ mod tests {
             .unwrap(),
         );
 
-        // Create MIN_BATCH_SIZE + MAX_BATCH_SIZE reports. We expect aggregation jobs to be created
-        // containing these reports.
+        // Create 2 * MIN_BATCH_SIZE reports. We expect aggregation jobs to be created containing
+        // these reports.
         let report_time = clock.now();
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
         let helper_hpke_keypair = HpkeKeypair::test();
@@ -1771,7 +1753,7 @@ mod tests {
                     &transcript,
                 )
             })
-            .take(MIN_BATCH_SIZE + MAX_BATCH_SIZE)
+            .take(2 * MIN_BATCH_SIZE)
             .collect(),
         );
 
@@ -1855,26 +1837,15 @@ mod tests {
 
         // Verify outstanding batches.
         let mut total_max_size = 0;
-        let mut min_size_batch_id = None;
-        let mut max_size_batch_id = None;
+        let mut seen_batch_ids = HashSet::new();
         for outstanding_batch in &outstanding_batches {
             assert_eq!(outstanding_batch.size().start(), &0);
-            assert!(&MIN_BATCH_SIZE <= outstanding_batch.size().end());
-            assert!(outstanding_batch.size().end() <= &MAX_BATCH_SIZE);
+            assert!(&MIN_BATCH_SIZE == outstanding_batch.size().end());
             total_max_size += *outstanding_batch.size().end();
-
-            if outstanding_batch.size().end() == &MIN_BATCH_SIZE {
-                min_size_batch_id = Some(*outstanding_batch.id());
-            }
-            if outstanding_batch.size().end() == &MAX_BATCH_SIZE {
-                max_size_batch_id = Some(*outstanding_batch.id());
-            }
+            assert!(!seen_batch_ids.contains(outstanding_batch.id()));
+            seen_batch_ids.insert(*outstanding_batch.id());
         }
         assert_eq!(total_max_size, report_ids.len());
-        let batch_ids: HashSet<_> = outstanding_batches
-            .iter()
-            .map(|outstanding_batch| *outstanding_batch.id())
-            .collect();
 
         // Verify aggregation jobs.
         let mut seen_report_ids = HashSet::new();
@@ -1884,7 +1855,7 @@ mod tests {
             assert_eq!(agg_job.step(), AggregationJobStep::from(0));
 
             // Every batch corresponds to one of the outstanding batches.
-            assert!(batch_ids.contains(agg_job.batch_id()));
+            assert!(seen_batch_ids.contains(agg_job.batch_id()));
 
             // At most one aggregation job per batch will be smaller than the normal minimum
             // aggregation job size.
@@ -1903,39 +1874,28 @@ mod tests {
             }
         }
 
-        // Every client report was added to some aggregation job.
+        // Every report was added to some aggregation job.
         assert_eq!(report_ids, seen_report_ids);
 
-        let mut want_batch_aggregations = Vec::from([
-            BatchAggregation::new(
-                *task.id(),
-                max_size_batch_id.unwrap(),
-                (),
-                0,
-                Interval::from_time(&report_time).unwrap(),
-                BatchAggregationState::Aggregating {
-                    aggregate_share: None,
-                    report_count: 0,
-                    checksum: ReportIdChecksum::default(),
-                    aggregation_jobs_created: 5,
-                    aggregation_jobs_terminated: 0,
-                },
-            ),
-            BatchAggregation::new(
-                *task.id(),
-                min_size_batch_id.unwrap(),
-                (),
-                0,
-                Interval::from_time(&report_time).unwrap(),
-                BatchAggregationState::Aggregating {
-                    aggregate_share: None,
-                    report_count: 0,
-                    checksum: ReportIdChecksum::default(),
-                    aggregation_jobs_created: 4,
-                    aggregation_jobs_terminated: 0,
-                },
-            ),
-        ]);
+        let mut want_batch_aggregations: Vec<_> = seen_batch_ids
+            .iter()
+            .map(|batch_id| {
+                BatchAggregation::new(
+                    *task.id(),
+                    *batch_id,
+                    (),
+                    0,
+                    Interval::from_time(&report_time).unwrap(),
+                    BatchAggregationState::Aggregating {
+                        aggregate_share: None,
+                        report_count: 0,
+                        checksum: ReportIdChecksum::default(),
+                        aggregation_jobs_created: 4,
+                        aggregation_jobs_terminated: 0,
+                    },
+                )
+            })
+            .collect();
         want_batch_aggregations.sort_by_key(|ba| *ba.batch_id());
 
         assert_eq!(batch_aggregations, want_batch_aggregations);
@@ -1953,12 +1913,10 @@ mod tests {
         const MIN_AGGREGATION_JOB_SIZE: usize = 50;
         const MAX_AGGREGATION_JOB_SIZE: usize = 60;
         const MIN_BATCH_SIZE: usize = 200;
-        const MAX_BATCH_SIZE: usize = 300;
 
         let task = Arc::new(
             TaskBuilder::new(
                 TaskBatchMode::LeaderSelected {
-                    max_batch_size: Some(MAX_BATCH_SIZE as u64),
                     batch_time_window_size: None,
                 },
                 VdafInstance::Prio3Count,
@@ -2116,12 +2074,10 @@ mod tests {
         const MIN_AGGREGATION_JOB_SIZE: usize = 50;
         const MAX_AGGREGATION_JOB_SIZE: usize = 60;
         const MIN_BATCH_SIZE: usize = 200;
-        const MAX_BATCH_SIZE: usize = 300;
 
         let task = Arc::new(
             TaskBuilder::new(
                 TaskBatchMode::LeaderSelected {
-                    max_batch_size: Some(MAX_BATCH_SIZE as u64),
                     batch_time_window_size: None,
                 },
                 VdafInstance::Prio3Count,
@@ -2155,7 +2111,7 @@ mod tests {
                     &transcript,
                 )
             })
-            .take(MAX_BATCH_SIZE + MIN_BATCH_SIZE - 1)
+            .take(2 * MIN_BATCH_SIZE - 1)
             .collect(),
         );
 
@@ -2243,13 +2199,13 @@ mod tests {
             .map(|outstanding_batch| *outstanding_batch.size().end())
             .collect::<Vec<_>>();
         outstanding_batch_sizes.sort();
-        assert_eq!(outstanding_batch_sizes, [180, MAX_BATCH_SIZE]);
+        assert_eq!(outstanding_batch_sizes, [180, MIN_BATCH_SIZE]);
         let mut agg_job_sizes = agg_jobs
             .iter()
             .map(|(_agg_job, report_ids)| report_ids.len())
             .collect::<Vec<_>>();
         agg_job_sizes.sort();
-        assert_eq!(agg_job_sizes, [60, 60, 60, 60, 60, 60, 60, 60]);
+        assert_eq!(agg_job_sizes, [20, 60, 60, 60, 60, 60, 60]);
 
         // Add one more report.
         let last_report_metadata = ReportMetadata::new(random(), report_time);
@@ -2342,13 +2298,13 @@ mod tests {
             .map(|outstanding_batch| *outstanding_batch.size().end())
             .collect::<Vec<_>>();
         outstanding_batch_sizes.sort();
-        assert_eq!(outstanding_batch_sizes, [MIN_BATCH_SIZE, MAX_BATCH_SIZE]);
+        assert_eq!(outstanding_batch_sizes, [MIN_BATCH_SIZE, MIN_BATCH_SIZE]);
         let mut agg_job_sizes = agg_jobs
             .iter()
             .map(|(_agg_job, report_ids)| report_ids.len())
             .collect::<Vec<_>>();
         agg_job_sizes.sort();
-        assert_eq!(agg_job_sizes, [20, 60, 60, 60, 60, 60, 60, 60, 60]);
+        assert_eq!(agg_job_sizes, [20, 20, 60, 60, 60, 60, 60, 60]);
 
         // Verify consistency of batches and aggregation jobs.
         let mut seen_report_ids = HashSet::new();
@@ -2378,12 +2334,10 @@ mod tests {
         const MIN_AGGREGATION_JOB_SIZE: usize = 50;
         const MAX_AGGREGATION_JOB_SIZE: usize = 60;
         const MIN_BATCH_SIZE: usize = 200;
-        const MAX_BATCH_SIZE: usize = 300;
 
         let task = Arc::new(
             TaskBuilder::new(
                 TaskBatchMode::LeaderSelected {
-                    max_batch_size: Some(MAX_BATCH_SIZE as u64),
                     batch_time_window_size: None,
                 },
                 VdafInstance::Prio3Count,
@@ -2417,7 +2371,7 @@ mod tests {
                     &transcript,
                 )
             })
-            .take(MAX_BATCH_SIZE + MIN_AGGREGATION_JOB_SIZE + 5)
+            .take(MIN_BATCH_SIZE + MIN_AGGREGATION_JOB_SIZE + 5)
             .collect(),
         );
 
@@ -2505,13 +2459,13 @@ mod tests {
             .map(|outstanding_batch| *outstanding_batch.size().end())
             .collect::<Vec<_>>();
         outstanding_batch_sizes.sort();
-        assert_eq!(outstanding_batch_sizes, [55, MAX_BATCH_SIZE]);
+        assert_eq!(outstanding_batch_sizes, [55, MIN_BATCH_SIZE]);
         let mut agg_job_sizes = agg_jobs
             .iter()
             .map(|(_agg_job, report_ids)| report_ids.len())
             .collect::<Vec<_>>();
         agg_job_sizes.sort();
-        assert_eq!(agg_job_sizes, [55, 60, 60, 60, 60, 60]);
+        assert_eq!(agg_job_sizes, [20, 55, 60, 60, 60]);
 
         // Add more reports, enough to allow creating a second intermediate-sized aggregation job in
         // the existing outstanding batch.
@@ -2612,13 +2566,13 @@ mod tests {
             .map(|outstanding_batch| *outstanding_batch.size().end())
             .collect::<Vec<_>>();
         outstanding_batch_sizes.sort();
-        assert_eq!(outstanding_batch_sizes, [110, MAX_BATCH_SIZE]);
+        assert_eq!(outstanding_batch_sizes, [110, MIN_BATCH_SIZE]);
         let mut agg_job_sizes = agg_jobs
             .iter()
             .map(|(_agg_job, report_ids)| report_ids.len())
             .collect::<Vec<_>>();
         agg_job_sizes.sort();
-        assert_eq!(agg_job_sizes, [55, 55, 60, 60, 60, 60, 60]);
+        assert_eq!(agg_job_sizes, [20, 55, 55, 60, 60, 60]);
 
         // Verify consistency of batches and aggregation jobs.
         let mut seen_report_ids = HashSet::new();
@@ -2648,13 +2602,11 @@ mod tests {
         const MIN_AGGREGATION_JOB_SIZE: usize = 50;
         const MAX_AGGREGATION_JOB_SIZE: usize = 60;
         const MIN_BATCH_SIZE: usize = 200;
-        const MAX_BATCH_SIZE: usize = 300;
         let batch_time_window_size = janus_messages::Duration::from_hours(24).unwrap();
 
         let task = Arc::new(
             TaskBuilder::new(
                 TaskBatchMode::LeaderSelected {
-                    max_batch_size: Some(MAX_BATCH_SIZE as u64),
                     batch_time_window_size: Some(batch_time_window_size),
                 },
                 VdafInstance::Prio3Count,
@@ -2665,7 +2617,7 @@ mod tests {
             .unwrap(),
         );
 
-        // Create MIN_BATCH_SIZE + MAX_BATCH_SIZE reports in two different time buckets.
+        // Create 2 * MIN_BATCH_SIZE reports in two different time buckets.
         let report_time_1 = clock.now().sub(&batch_time_window_size).unwrap();
         let report_time_2 = clock.now();
         let vdaf = Arc::new(Prio3::new_count(2).unwrap());
@@ -2690,7 +2642,7 @@ mod tests {
                     &transcript,
                 )
             })
-            .take(MIN_BATCH_SIZE + MAX_BATCH_SIZE),
+            .take(2 * MIN_BATCH_SIZE),
         );
         reports.extend(
             iter::repeat_with(|| {
@@ -2710,7 +2662,7 @@ mod tests {
                     &transcript,
                 )
             })
-            .take(MIN_BATCH_SIZE + MAX_BATCH_SIZE),
+            .take(2 * MIN_BATCH_SIZE),
         );
         let reports = Arc::new(reports);
 
@@ -2810,26 +2762,8 @@ mod tests {
             assert_eq!(outstanding_batches.len(), 2);
             for outstanding_batch in outstanding_batches {
                 assert_eq!(outstanding_batch.size().start(), &0);
-                assert!(outstanding_batch.size().end() >= &MIN_BATCH_SIZE);
-                assert!(outstanding_batch.size().end() <= &MAX_BATCH_SIZE);
+                assert_eq!(outstanding_batch.size().end(), &MIN_BATCH_SIZE);
             }
-            let total_max_size: usize = outstanding_batches
-                .iter()
-                .map(|outstanding_batch| outstanding_batch.size().end())
-                .sum();
-            assert_eq!(total_max_size, report_ids.len() / 2);
-            let smallest_batch_size = outstanding_batches
-                .iter()
-                .map(|outstanding_batch| outstanding_batch.size().end())
-                .min()
-                .unwrap();
-            assert_eq!(smallest_batch_size, &MIN_BATCH_SIZE);
-            let largest_batch_size = outstanding_batches
-                .iter()
-                .map(|outstanding_batch| outstanding_batch.size().end())
-                .max()
-                .unwrap();
-            assert_eq!(largest_batch_size, &MAX_BATCH_SIZE);
         }
         let batch_ids: HashSet<_> = [&outstanding_batches_bucket_1, &outstanding_batches_bucket_2]
             .into_iter()
@@ -2862,269 +2796,33 @@ mod tests {
         // Every client report was added to some aggregation job.
         assert_eq!(report_ids, seen_report_ids);
 
-        let bucket_1_small_batch_id = *outstanding_batches_bucket_1
+        let mut want_batch_aggregations: Vec<_> = outstanding_batches_bucket_1
             .iter()
-            .find(|outstanding_batch| outstanding_batch.size().end() == &MIN_BATCH_SIZE)
-            .unwrap()
-            .id();
-        let bucket_1_large_batch_id = *outstanding_batches_bucket_1
-            .iter()
-            .find(|outstanding_batch| outstanding_batch.size().end() == &MAX_BATCH_SIZE)
-            .unwrap()
-            .id();
-        let bucket_2_small_batch_id = *outstanding_batches_bucket_2
-            .iter()
-            .find(|outstanding_batch| outstanding_batch.size().end() == &MIN_BATCH_SIZE)
-            .unwrap()
-            .id();
-        let bucket_2_large_batch_id = *outstanding_batches_bucket_2
-            .iter()
-            .find(|outstanding_batch| outstanding_batch.size().end() == &MAX_BATCH_SIZE)
-            .unwrap()
-            .id();
-
-        let mut want_batch_aggregations = Vec::from([
-            BatchAggregation::new(
-                *task.id(),
-                bucket_1_large_batch_id,
-                (),
-                0,
-                Interval::from_time(&report_time_1).unwrap(),
-                BatchAggregationState::Aggregating {
-                    aggregate_share: None,
-                    report_count: 0,
-                    checksum: ReportIdChecksum::default(),
-                    aggregation_jobs_created: 5,
-                    aggregation_jobs_terminated: 0,
-                },
-            ),
-            BatchAggregation::new(
-                *task.id(),
-                bucket_1_small_batch_id,
-                (),
-                0,
-                Interval::from_time(&report_time_1).unwrap(),
-                BatchAggregationState::Aggregating {
-                    aggregate_share: None,
-                    report_count: 0,
-                    checksum: ReportIdChecksum::default(),
-                    aggregation_jobs_created: 4,
-                    aggregation_jobs_terminated: 0,
-                },
-            ),
-            BatchAggregation::new(
-                *task.id(),
-                bucket_2_large_batch_id,
-                (),
-                0,
-                Interval::from_time(&report_time_2).unwrap(),
-                BatchAggregationState::Aggregating {
-                    aggregate_share: None,
-                    report_count: 0,
-                    checksum: ReportIdChecksum::default(),
-                    aggregation_jobs_created: 5,
-                    aggregation_jobs_terminated: 0,
-                },
-            ),
-            BatchAggregation::new(
-                *task.id(),
-                bucket_2_small_batch_id,
-                (),
-                0,
-                Interval::from_time(&report_time_2).unwrap(),
-                BatchAggregationState::Aggregating {
-                    aggregate_share: None,
-                    report_count: 0,
-                    checksum: ReportIdChecksum::default(),
-                    aggregation_jobs_created: 4,
-                    aggregation_jobs_terminated: 0,
-                },
-            ),
-        ]);
-        want_batch_aggregations.sort_by_key(|ba| *ba.batch_id());
-
-        assert_eq!(batch_aggregations, want_batch_aggregations);
-    }
-
-    #[tokio::test]
-    async fn create_aggregation_jobs_for_leader_selected_task_no_max_batch_size() {
-        // Setup.
-        install_test_trace_subscriber();
-        let clock: MockClock = MockClock::default();
-        let ephemeral_datastore = ephemeral_datastore().await;
-        let ds = ephemeral_datastore.datastore(clock.clone()).await;
-
-        const MIN_AGGREGATION_JOB_SIZE: usize = 50;
-        const MAX_AGGREGATION_JOB_SIZE: usize = 60;
-        const MIN_BATCH_SIZE: usize = 200;
-
-        let task = Arc::new(
-            TaskBuilder::new(
-                TaskBatchMode::LeaderSelected {
-                    max_batch_size: None,
-                    batch_time_window_size: None,
-                },
-                VdafInstance::Prio3Count,
+            .zip(iter::repeat(report_time_1))
+            .chain(
+                outstanding_batches_bucket_2
+                    .iter()
+                    .zip(iter::repeat(report_time_2)),
             )
-            .with_min_batch_size(MIN_BATCH_SIZE as u64)
-            .build()
-            .leader_view()
-            .unwrap(),
-        );
-
-        // Create MIN_BATCH_SIZE + MIN_BATCH_SIZE + MIN_AGGREGATION_JOB_SIZE reports. We expect
-        // aggregation jobs to be created containing all these reports, but only two batches.
-        let report_time = clock.now();
-        let vdaf = Arc::new(Prio3::new_count(2).unwrap());
-        let helper_hpke_keypair = HpkeKeypair::test();
-        let reports: Arc<Vec<_>> = Arc::new(
-            iter::repeat_with(|| {
-                let report_metadata = ReportMetadata::new(random(), report_time);
-                let transcript = run_vdaf(
-                    vdaf.as_ref(),
-                    task.vdaf_verify_key().unwrap().as_bytes(),
-                    &(),
-                    report_metadata.id(),
-                    &false,
-                );
-                LeaderStoredReport::generate(
+            .map(|(outstanding_batch, report_time)| {
+                BatchAggregation::new(
                     *task.id(),
-                    report_metadata,
-                    helper_hpke_keypair.config(),
-                    Vec::new(),
-                    &transcript,
+                    *outstanding_batch.id(),
+                    (),
+                    0,
+                    Interval::from_time(&report_time).unwrap(),
+                    BatchAggregationState::Aggregating {
+                        aggregate_share: None,
+                        report_count: 0,
+                        checksum: ReportIdChecksum::default(),
+                        aggregation_jobs_created: 4,
+                        aggregation_jobs_terminated: 0,
+                    },
                 )
             })
-            .take(MIN_BATCH_SIZE + MIN_BATCH_SIZE + MIN_AGGREGATION_JOB_SIZE)
-            .collect(),
-        );
-
-        let report_ids: HashSet<ReportId> = reports
-            .iter()
-            .map(|report| *report.metadata().id())
             .collect();
-
-        ds.run_unnamed_tx(|tx| {
-            let task = Arc::clone(&task);
-            let reports = Arc::clone(&reports);
-
-            Box::pin(async move {
-                tx.put_aggregator_task(&task).await.unwrap();
-                for report in reports.iter() {
-                    tx.put_client_report(report).await.unwrap();
-                }
-                Ok(())
-            })
-        })
-        .await
-        .unwrap();
-
-        // Run.
-        let job_creator = Arc::new(AggregationJobCreator::new(
-            Arc::new(ds),
-            noop_meter(),
-            BATCH_AGGREGATION_SHARD_COUNT,
-            Duration::from_secs(3600),
-            Duration::from_secs(1),
-            MIN_AGGREGATION_JOB_SIZE,
-            MAX_AGGREGATION_JOB_SIZE,
-            5000,
-        ));
-        Arc::clone(&job_creator)
-            .create_aggregation_jobs_for_task(Arc::clone(&task))
-            .await
-            .unwrap();
-
-        // Verify.
-        let want_ra_states: Arc<HashMap<_, _>> = Arc::new(
-            reports
-                .iter()
-                .map(|report| {
-                    (
-                        (*report.metadata().id(), ()),
-                        report
-                            .as_start_leader_report_aggregation(random(), 0)
-                            .state()
-                            .clone(),
-                    )
-                })
-                .collect(),
-        );
-        let (outstanding_batches, (agg_jobs, _)) = job_creator
-            .datastore
-            .run_unnamed_tx(|tx| {
-                let task = Arc::clone(&task);
-                let vdaf = Arc::clone(&vdaf);
-                let want_ra_states = Arc::clone(&want_ra_states);
-
-                Box::pin(async move {
-                    Ok((
-                        tx.get_unfilled_outstanding_batches(task.id(), &None)
-                            .await
-                            .unwrap(),
-                        read_and_verify_aggregate_info_for_task::<
-                            VERIFY_KEY_LENGTH,
-                            LeaderSelected,
-                            _,
-                            _,
-                        >(
-                            tx, vdaf.as_ref(), task.id(), want_ra_states.as_ref()
-                        )
-                        .await,
-                    ))
-                })
-            })
-            .await
-            .unwrap();
-
-        // Verify outstanding batches.
-        let mut total_max_size = 0;
-        for outstanding_batch in &outstanding_batches {
-            assert_eq!(outstanding_batch.size().start(), &0);
-            assert!(
-                outstanding_batch.size().end() == &MIN_BATCH_SIZE
-                    || outstanding_batch.size().end() == &MIN_AGGREGATION_JOB_SIZE
-            );
-            total_max_size += *outstanding_batch.size().end();
-        }
-        assert_eq!(
-            total_max_size,
-            2 * MIN_BATCH_SIZE + MIN_AGGREGATION_JOB_SIZE
-        );
-        let batch_ids: HashSet<_> = outstanding_batches
-            .iter()
-            .map(|outstanding_batch| *outstanding_batch.id())
-            .collect();
-
-        // Verify aggregation jobs.
-        let mut seen_report_ids = HashSet::new();
-        let mut batches_with_small_agg_jobs = HashSet::new();
-        for (agg_job, report_aggs) in agg_jobs {
-            // Aggregation jobs are created in step 0.
-            assert_eq!(agg_job.step(), AggregationJobStep::from(0));
-
-            // Every batch corresponds to one of the outstanding batches.
-            assert!(batch_ids.contains(agg_job.batch_id()));
-
-            // At most one aggregation job per batch will be smaller than the normal minimum
-            // aggregation job size.
-            if report_aggs.len() < MIN_AGGREGATION_JOB_SIZE {
-                assert!(!batches_with_small_agg_jobs.contains(agg_job.batch_id()));
-                batches_with_small_agg_jobs.insert(*agg_job.batch_id());
-            }
-
-            // The aggregation job is at most MAX_AGGREGATION_JOB_SIZE in size.
-            assert!(report_aggs.len() <= MAX_AGGREGATION_JOB_SIZE);
-
-            // Report IDs are not repeated across or inside aggregation jobs.
-            for ra in report_aggs {
-                assert!(!seen_report_ids.contains(ra.report_id()));
-                seen_report_ids.insert(*ra.report_id());
-            }
-        }
-
-        // Every client report was added to some aggregation job.
-        assert_eq!(report_ids, seen_report_ids);
+        want_batch_aggregations.sort_by_key(|ba| *ba.batch_id());
+        assert_eq!(batch_aggregations, want_batch_aggregations);
     }
 
     #[tokio::test]

--- a/aggregator/src/aggregator/aggregation_job_driver/tests.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver/tests.rs
@@ -1294,7 +1294,6 @@ async fn step_leader_selected_aggregation_job_init_single_step() {
 
     let task = TaskBuilder::new(
         BatchMode::LeaderSelected {
-            max_batch_size: Some(10),
             batch_time_window_size: None,
         },
         VdafInstance::Prio3Count,
@@ -1580,7 +1579,6 @@ async fn step_leader_selected_aggregation_job_init_two_steps() {
 
     let task = TaskBuilder::new(
         BatchMode::LeaderSelected {
-            max_batch_size: Some(10),
             batch_time_window_size: None,
         },
         VdafInstance::Fake { rounds: 2 },
@@ -2154,7 +2152,6 @@ async fn step_leader_selected_aggregation_job_continue() {
 
     let task = TaskBuilder::new(
         BatchMode::LeaderSelected {
-            max_batch_size: Some(10),
             batch_time_window_size: None,
         },
         VdafInstance::Fake { rounds: 2 },

--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -296,7 +296,6 @@ async fn setup_leader_selected_current_batch_collection_job_test_case(
     let test_case = setup_collection_job_test_case(
         Role::Leader,
         BatchMode::LeaderSelected {
-            max_batch_size: Some(10),
             batch_time_window_size: None,
         },
     )

--- a/aggregator/src/aggregator/garbage_collector.rs
+++ b/aggregator/src/aggregator/garbage_collector.rs
@@ -541,7 +541,6 @@ mod tests {
                 Box::pin(async move {
                     let task = TaskBuilder::new(
                         task::BatchMode::LeaderSelected {
-                            max_batch_size: Some(10),
                             batch_time_window_size: None,
                         },
                         VdafInstance::Fake { rounds: 1 },
@@ -710,7 +709,6 @@ mod tests {
                 Box::pin(async move {
                     let task = TaskBuilder::new(
                         task::BatchMode::LeaderSelected {
-                            max_batch_size: Some(10),
                             batch_time_window_size: None,
                         },
                         VdafInstance::Fake { rounds: 1 },

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
@@ -624,7 +624,6 @@ async fn aggregate_init_batch_already_collected() {
 
     let task = TaskBuilder::new(
         BatchMode::LeaderSelected {
-            max_batch_size: Some(100),
             batch_time_window_size: None,
         },
         VdafInstance::Fake { rounds: 1 },

--- a/aggregator/src/aggregator/http_handlers/tests/helper_e2e.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/helper_e2e.rs
@@ -35,7 +35,6 @@ async fn helper_aggregation_report_share_replay() {
 
     let task = TaskBuilder::new(
         BatchMode::LeaderSelected {
-            max_batch_size: None,
             batch_time_window_size: None,
         },
         VdafInstance::Fake { rounds: 1 },

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -157,7 +157,6 @@ where
 
         let time_precision = Duration::from_seconds(1);
         let min_batch_size = 1;
-        let max_batch_size = 1;
         let task_expiration = clock.now().add(&Duration::from_hours(24).unwrap()).unwrap();
         let task_config = TaskConfig::new(
             Vec::from("foobar".as_bytes()),
@@ -166,7 +165,7 @@ where
             QueryConfig::new(
                 time_precision,
                 min_batch_size,
-                TaskprovQuery::LeaderSelected { max_batch_size },
+                TaskprovQuery::LeaderSelected,
             ),
             task_expiration,
             vdaf_config,
@@ -181,7 +180,6 @@ where
 
         let task = TaskBuilder::new(
             BatchMode::LeaderSelected {
-                max_batch_size: Some(max_batch_size as u64),
                 batch_time_window_size: None,
             },
             vdaf_instance,
@@ -649,9 +647,7 @@ async fn taskprov_opt_out_mismatched_task_id() {
         QueryConfig::new(
             Duration::from_seconds(1),
             100,
-            TaskprovQuery::LeaderSelected {
-                max_batch_size: 100,
-            },
+            TaskprovQuery::LeaderSelected,
         ),
         task_expiration,
         VdafConfig::new(
@@ -728,9 +724,7 @@ async fn taskprov_opt_out_peer_aggregator_wrong_role() {
         QueryConfig::new(
             Duration::from_seconds(1),
             100,
-            TaskprovQuery::LeaderSelected {
-                max_batch_size: 100,
-            },
+            TaskprovQuery::LeaderSelected,
         ),
         task_expiration,
         VdafConfig::new(
@@ -808,9 +802,7 @@ async fn taskprov_opt_out_peer_aggregator_does_not_exist() {
         QueryConfig::new(
             Duration::from_seconds(1),
             100,
-            TaskprovQuery::LeaderSelected {
-                max_batch_size: 100,
-            },
+            TaskprovQuery::LeaderSelected,
         ),
         task_expiration,
         VdafConfig::new(

--- a/aggregator/src/binaries/janus_cli.rs
+++ b/aggregator/src/binaries/janus_cli.rs
@@ -1289,7 +1289,6 @@ mod tests {
         // Construct a "new" task with a previously existing ID.
         let replacement_task = TaskBuilder::new(
             BatchMode::LeaderSelected {
-                max_batch_size: Some(100),
                 batch_time_window_size: None,
             },
             VdafInstance::Prio3SumVec {

--- a/aggregator_api/src/tests.rs
+++ b/aggregator_api/src/tests.rs
@@ -1647,7 +1647,6 @@ fn post_task_req_serialization() {
         &PostTaskReq {
             peer_aggregator_endpoint: "https://example.com/".parse().unwrap(),
             batch_mode: BatchMode::LeaderSelected {
-                max_batch_size: Some(999),
                 batch_time_window_size: None,
             },
             vdaf: VdafInstance::Prio3SumVec {
@@ -1682,11 +1681,8 @@ fn post_task_req_serialization() {
             Token::StructVariant {
                 name: "BatchMode",
                 variant: "LeaderSelected",
-                len: 2,
+                len: 1,
             },
-            Token::Str("max_batch_size"),
-            Token::Some,
-            Token::U64(999),
             Token::Str("batch_time_window_size"),
             Token::None,
             Token::StructVariantEnd,
@@ -1766,7 +1762,6 @@ fn post_task_req_serialization() {
         &PostTaskReq {
             peer_aggregator_endpoint: "https://example.com/".parse().unwrap(),
             batch_mode: BatchMode::LeaderSelected {
-                max_batch_size: Some(999),
                 batch_time_window_size: None,
             },
             vdaf: VdafInstance::Prio3SumVec {
@@ -1805,11 +1800,8 @@ fn post_task_req_serialization() {
             Token::StructVariant {
                 name: "BatchMode",
                 variant: "LeaderSelected",
-                len: 2,
+                len: 1,
             },
-            Token::Str("max_batch_size"),
-            Token::Some,
-            Token::U64(999),
             Token::Str("batch_time_window_size"),
             Token::None,
             Token::StructVariantEnd,
@@ -1917,7 +1909,6 @@ fn task_resp_serialization() {
         TaskId::from([0u8; 32]),
         "https://helper.com/".parse().unwrap(),
         BatchMode::LeaderSelected {
-            max_batch_size: Some(999),
             batch_time_window_size: None,
         },
         VdafInstance::Prio3SumVec {
@@ -1976,11 +1967,8 @@ fn task_resp_serialization() {
             Token::StructVariant {
                 name: "BatchMode",
                 variant: "LeaderSelected",
-                len: 2,
+                len: 1,
             },
-            Token::Str("max_batch_size"),
-            Token::Some,
-            Token::U64(999),
             Token::Str("batch_time_window_size"),
             Token::None,
             Token::StructVariantEnd,

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -1290,7 +1290,6 @@ async fn count_client_reports_for_batch_id(ephemeral_datastore: EphemeralDatasto
 
     let task = TaskBuilder::new(
         task::BatchMode::LeaderSelected {
-            max_batch_size: Some(10),
             batch_time_window_size: None,
         },
         VdafInstance::Fake { rounds: 1 },
@@ -1301,7 +1300,6 @@ async fn count_client_reports_for_batch_id(ephemeral_datastore: EphemeralDatasto
     .unwrap();
     let unrelated_task = TaskBuilder::new(
         task::BatchMode::LeaderSelected {
-            max_batch_size: None,
             batch_time_window_size: None,
         },
         VdafInstance::Fake { rounds: 1 },
@@ -1548,7 +1546,6 @@ async fn roundtrip_aggregation_job(ephemeral_datastore: EphemeralDatastore) {
     // serialization/deserialization roundtrip of the batch_identifier & aggregation_param.
     let task = TaskBuilder::new(
         task::BatchMode::LeaderSelected {
-            max_batch_size: Some(10),
             batch_time_window_size: None,
         },
         VdafInstance::Fake { rounds: 1 },
@@ -2157,7 +2154,6 @@ async fn get_aggregation_jobs_for_task(ephemeral_datastore: EphemeralDatastore) 
     // serialization/deserialization roundtrip of the batch_identifier & aggregation_param.
     let task = TaskBuilder::new(
         task::BatchMode::LeaderSelected {
-            max_batch_size: None,
             batch_time_window_size: None,
         },
         VdafInstance::Fake { rounds: 1 },
@@ -2213,7 +2209,6 @@ async fn get_aggregation_jobs_for_task(ephemeral_datastore: EphemeralDatastore) 
             // is not returned.
             let unrelated_task = TaskBuilder::new(
                 task::BatchMode::LeaderSelected {
-                    max_batch_size: None,
                     batch_time_window_size: None,
                 },
                 VdafInstance::Fake { rounds: 1 },
@@ -3661,7 +3656,6 @@ async fn leader_selected_collection_job_acquire_release_happy_path(
         CollectionJobAcquireTestCase {
             task_ids: Vec::from([task_id]),
             batch_mode: task::BatchMode::LeaderSelected {
-                max_batch_size: Some(10),
                 batch_time_window_size: None,
             },
             reports,
@@ -4504,7 +4498,6 @@ async fn roundtrip_batch_aggregation_leader_selected(ephemeral_datastore: Epheme
 
     let task = TaskBuilder::new(
         task::BatchMode::LeaderSelected {
-            max_batch_size: Some(10),
             batch_time_window_size: None,
         },
         VdafInstance::Fake { rounds: 1 },
@@ -4522,7 +4515,6 @@ async fn roundtrip_batch_aggregation_leader_selected(ephemeral_datastore: Epheme
             Box::pin(async move {
                 let other_task = TaskBuilder::new(
                     task::BatchMode::LeaderSelected {
-                        max_batch_size: Some(10),
                         batch_time_window_size: None,
                     },
                     VdafInstance::Fake { rounds: 1 },
@@ -4888,7 +4880,6 @@ async fn roundtrip_aggregate_share_job_leader_selected(ephemeral_datastore: Ephe
             Box::pin(async move {
                 let task = TaskBuilder::new(
                     task::BatchMode::LeaderSelected {
-                        max_batch_size: None,
                         batch_time_window_size: None,
                     },
                     VdafInstance::Fake { rounds: 1 },
@@ -5044,7 +5035,6 @@ async fn roundtrip_outstanding_batch(ephemeral_datastore: EphemeralDatastore) {
             Box::pin(async move {
                 let task_1 = TaskBuilder::new(
                     task::BatchMode::LeaderSelected {
-                        max_batch_size: Some(10),
                         batch_time_window_size: None,
                     },
                     VdafInstance::Fake { rounds: 1 },
@@ -5098,7 +5088,6 @@ async fn roundtrip_outstanding_batch(ephemeral_datastore: EphemeralDatastore) {
 
                 let task_2 = TaskBuilder::new(
                     task::BatchMode::LeaderSelected {
-                        max_batch_size: Some(10),
                         batch_time_window_size: Some(batch_time_window_size),
                     },
                     VdafInstance::Fake { rounds: 1 },
@@ -5676,7 +5665,6 @@ async fn delete_expired_aggregation_artifacts(ephemeral_datastore: EphemeralData
                 .unwrap();
                 let leader_leader_selected_task = TaskBuilder::new(
                     task::BatchMode::LeaderSelected {
-                        max_batch_size: Some(10),
                         batch_time_window_size: None,
                     },
                     VdafInstance::Fake { rounds: 1 },
@@ -5687,7 +5675,6 @@ async fn delete_expired_aggregation_artifacts(ephemeral_datastore: EphemeralData
                 .unwrap();
                 let helper_leader_selected_task = TaskBuilder::new(
                     task::BatchMode::LeaderSelected {
-                        max_batch_size: Some(10),
                         batch_time_window_size: None,
                     },
                     VdafInstance::Fake { rounds: 1 },
@@ -6217,7 +6204,6 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                 .unwrap();
                 let leader_leader_selected_task = TaskBuilder::new(
                     task::BatchMode::LeaderSelected {
-                        max_batch_size: Some(10),
                         batch_time_window_size: None,
                     },
                     VdafInstance::Fake { rounds: 1 },
@@ -6228,7 +6214,6 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                 .unwrap();
                 let helper_leader_selected_task = TaskBuilder::new(
                     task::BatchMode::LeaderSelected {
-                        max_batch_size: Some(10),
                         batch_time_window_size: None,
                     },
                     VdafInstance::Fake { rounds: 1 },
@@ -6239,7 +6224,6 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                 .unwrap();
                 let leader_leader_selected_time_bucketed_task = TaskBuilder::new(
                     task::BatchMode::LeaderSelected {
-                        max_batch_size: Some(10),
                         batch_time_window_size: Some(Duration::from_hours(24).unwrap()),
                     },
                     VdafInstance::Fake { rounds: 1 },
@@ -7554,7 +7538,6 @@ async fn roundtrip_task_aggregation_counter(ephemeral_datastore: EphemeralDatast
                 // Put a task for us to increment counters for.
                 let task = TaskBuilder::new(
                     task::BatchMode::LeaderSelected {
-                        max_batch_size: None,
                         batch_time_window_size: None,
                     },
                     VdafInstance::Fake { rounds: 1 },

--- a/docs/samples/tasks.yaml
+++ b/docs/samples/tasks.yaml
@@ -94,10 +94,7 @@
 
 - task_id: "D-hCKPuqL2oTf7ZVRVyMP5VGt43EAEA8q34mDf6p1JE"
   peer_aggregator_endpoint: "https://example.org/"
-  # For tasks using the leader-selected batch mode, an additional `max_batch_size`
-  # parameter must be provided.
   batch_mode: !LeaderSelected
-    max_batch_size: 100
     batch_time_window_size: null
   vdaf: Prio3Count
   role: Helper

--- a/integration_tests/tests/integration/in_cluster.rs
+++ b/integration_tests/tests/integration/in_cluster.rs
@@ -446,10 +446,8 @@ impl InClusterJanusPair {
                 other => panic!("unsupported vdaf {other:?}"),
             },
             min_batch_size: task.min_batch_size(),
-            max_batch_size: match task.batch_mode() {
-                BatchMode::TimeInterval => None,
-                BatchMode::LeaderSelected { max_batch_size, .. } => *max_batch_size,
-            },
+            // TODO(#3436): once divviup-api is updated for DAP-13, drop max_batch_size entirely.
+            max_batch_size: None,
             batch_time_window_size_seconds: match task.batch_mode() {
                 BatchMode::TimeInterval => None,
                 BatchMode::LeaderSelected {
@@ -614,7 +612,6 @@ async fn in_cluster_leader_selected() {
     let janus_pair = InClusterJanusPair::new(
         VdafInstance::Prio3Count,
         BatchMode::LeaderSelected {
-            max_batch_size: Some(110),
             batch_time_window_size: None,
         },
     )
@@ -639,7 +636,6 @@ async fn in_cluster_time_bucketed_leader_selected() {
     let janus_pair = InClusterJanusPair::new(
         VdafInstance::Prio3Count,
         BatchMode::LeaderSelected {
-            max_batch_size: Some(110),
             batch_time_window_size: Some(JanusDuration::from_hours(8).unwrap()),
         },
     )
@@ -939,7 +935,6 @@ async fn in_cluster_histogram_dp_noise() {
             ),
         },
         BatchMode::LeaderSelected {
-            max_batch_size: Some(110),
             batch_time_window_size: Some(JanusDuration::from_hours(8).unwrap()),
         },
     )
@@ -1006,7 +1001,6 @@ async fn in_cluster_sumvec_dp_noise() {
             ),
         },
         BatchMode::LeaderSelected {
-            max_batch_size: Some(110),
             batch_time_window_size: Some(JanusDuration::from_hours(8).unwrap()),
         },
     )

--- a/integration_tests/tests/integration/janus.rs
+++ b/integration_tests/tests/integration/janus.rs
@@ -270,7 +270,6 @@ async fn janus_janus_leader_selected() {
         TEST_NAME,
         VdafInstance::Prio3Count,
         BatchMode::LeaderSelected {
-            max_batch_size: Some(50),
             batch_time_window_size: None,
         },
     )
@@ -295,7 +294,6 @@ async fn janus_in_process_leader_selected() {
     // Start servers.
     let janus_pair = JanusInProcessPair::new(TaskBuilder::new(
         BatchMode::LeaderSelected {
-            max_batch_size: Some(50),
             batch_time_window_size: None,
         },
         VdafInstance::Prio3Count,

--- a/integration_tests/tests/integration/simulation/arbitrary.rs
+++ b/integration_tests/tests/integration/simulation/arbitrary.rs
@@ -18,9 +18,6 @@ use crate::simulation::{
 
 impl Arbitrary for Config {
     fn arbitrary(g: &mut Gen) -> Self {
-        let mut batch_size_limits = [max(u8::arbitrary(g), 1), max(u8::arbitrary(g), 1)];
-        batch_size_limits.sort();
-
         let mut aggregation_job_size_limits = [max(u8::arbitrary(g), 1), max(u8::arbitrary(g), 1)];
         aggregation_job_size_limits.sort();
 
@@ -28,8 +25,7 @@ impl Arbitrary for Config {
 
         Self {
             time_precision,
-            min_batch_size: batch_size_limits[0].into(),
-            max_batch_size: bool::arbitrary(g).then_some(batch_size_limits[1].into()),
+            min_batch_size: max(u8::arbitrary(g), 1).into(),
             batch_time_window_size: bool::arbitrary(g).then_some(Duration::from_seconds(
                 u64::from(max(u8::arbitrary(g), 1)) * time_precision.as_seconds(),
             )),
@@ -42,12 +38,6 @@ impl Arbitrary for Config {
 
     fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
         let mut choices = Vec::with_capacity(3);
-        if self.max_batch_size.is_some() {
-            choices.push(Self {
-                max_batch_size: None,
-                ..self.clone()
-            });
-        }
         if self.batch_time_window_size.is_some() {
             choices.push(Self {
                 batch_time_window_size: None,

--- a/integration_tests/tests/integration/simulation/model.rs
+++ b/integration_tests/tests/integration/simulation/model.rs
@@ -20,10 +20,6 @@ pub(super) struct Config {
     /// DAP task parameter: minimum batch size.
     pub(super) min_batch_size: u64,
 
-    /// DAP task parameter: maximum batch size. This is only used with leader-selected tasks, and
-    /// ignored otherwise.
-    pub(super) max_batch_size: Option<u64>,
-
     /// Janus-specific task parameter: batch time window size (for the time-bucketed leader-selected
     /// feature). This is only used with leader-selected tasks, and ignored otherwise.
     pub(super) batch_time_window_size: Option<Duration>,

--- a/integration_tests/tests/integration/simulation/reproduction.rs
+++ b/integration_tests/tests/integration/simulation/reproduction.rs
@@ -18,7 +18,6 @@ fn successful_collection_time_interval() {
         config: Config {
             time_precision: Duration::from_seconds(3600),
             min_batch_size: 4,
-            max_batch_size: None,
             batch_time_window_size: None,
             report_expiry_age: Some(Duration::from_seconds(7200)),
             min_aggregation_job_size: 1,
@@ -91,7 +90,6 @@ fn successful_collection_leader_selected() {
         config: Config {
             time_precision: Duration::from_seconds(3600),
             min_batch_size: 4,
-            max_batch_size: Some(6),
             batch_time_window_size: None,
             report_expiry_age: Some(Duration::from_seconds(7200)),
             min_aggregation_job_size: 1,
@@ -127,71 +125,6 @@ fn successful_collection_leader_selected() {
             Op::CollectorPoll { collection_job_id },
             Op::Upload {
                 report_time: START_TIME,
-                count: 4,
-            },
-            Op::AggregationJobCreator,
-            Op::AggregationJobDriver,
-            Op::CollectorStart {
-                collection_job_id,
-                query: Query::LeaderSelected,
-            },
-            Op::CollectionJobDriver,
-            Op::CollectorPoll { collection_job_id },
-        ]),
-    };
-    assert!(!Simulation::run(input).is_failure());
-}
-
-#[test]
-/// Reproduction of https://github.com/divviup/janus/issues/3323.
-fn repro_slow_uploads_with_max_batch_size() {
-    install_test_trace_subscriber();
-
-    let collection_job_id = random();
-    let input = Input {
-        is_leader_selected: true,
-        config: Config {
-            time_precision: Duration::from_seconds(3600),
-            min_batch_size: 4,
-            max_batch_size: Some(6),
-            batch_time_window_size: None,
-            report_expiry_age: Some(Duration::from_seconds(7200)),
-            min_aggregation_job_size: 1,
-            max_aggregation_job_size: 10,
-        },
-        ops: Vec::from([
-            Op::Upload {
-                report_time: START_TIME,
-                count: 1,
-            },
-            Op::AggregationJobCreator,
-            Op::AggregationJobDriver,
-            Op::AdvanceTime {
-                amount: Duration::from_seconds(3600),
-            },
-            Op::LeaderGarbageCollector,
-            Op::Upload {
-                report_time: Time::from_seconds_since_epoch(1_700_003_600),
-                count: 1,
-            },
-            Op::AggregationJobCreator,
-            Op::AggregationJobDriver,
-            Op::AdvanceTime {
-                amount: Duration::from_seconds(3600),
-            },
-            Op::LeaderGarbageCollector,
-            Op::Upload {
-                report_time: Time::from_seconds_since_epoch(1_700_007_200),
-                count: 1,
-            },
-            Op::AggregationJobCreator,
-            Op::AggregationJobDriver,
-            Op::AdvanceTime {
-                amount: Duration::from_seconds(3600),
-            },
-            Op::LeaderGarbageCollector,
-            Op::Upload {
-                report_time: Time::from_seconds_since_epoch(1_700_010_800),
                 count: 4,
             },
             Op::AggregationJobCreator,
@@ -217,7 +150,6 @@ fn repro_gc_changes_aggregation_job_retry_time_interval() {
         config: Config {
             time_precision: Duration::from_seconds(3600),
             min_batch_size: 1,
-            max_batch_size: None,
             batch_time_window_size: None,
             report_expiry_age: Some(Duration::from_seconds(7200)),
             min_aggregation_job_size: 2,
@@ -257,7 +189,6 @@ fn repro_gc_changes_aggregation_job_retry_leader_selected() {
         config: Config {
             time_precision: Duration::from_seconds(3600),
             min_batch_size: 1,
-            max_batch_size: None,
             batch_time_window_size: None,
             report_expiry_age: Some(Duration::from_seconds(7200)),
             min_aggregation_job_size: 2,
@@ -297,7 +228,6 @@ fn repro_recreate_gcd_batch_job_count_underflow() {
         config: Config {
             time_precision: Duration::from_seconds(1000),
             min_batch_size: 100,
-            max_batch_size: None,
             batch_time_window_size: None,
             report_expiry_age: Some(Duration::from_seconds(4000)),
             min_aggregation_job_size: 2,
@@ -336,7 +266,6 @@ fn repro_abandoned_aggregation_job_batch_mismatch() {
         config: Config {
             time_precision: Duration::from_seconds(1000),
             min_batch_size: 1,
-            max_batch_size: None,
             batch_time_window_size: None,
             report_expiry_age: None,
             min_aggregation_job_size: 1,
@@ -385,7 +314,6 @@ fn repro_helper_accumulate_on_retried_request() {
         config: Config {
             time_precision: Duration::from_seconds(1000),
             min_batch_size: 1,
-            max_batch_size: None,
             batch_time_window_size: None,
             report_expiry_age: None,
             min_aggregation_job_size: 1,

--- a/integration_tests/tests/integration/simulation/setup.rs
+++ b/integration_tests/tests/integration/simulation/setup.rs
@@ -170,7 +170,6 @@ impl Components {
 
         let batch_mode = if input.is_leader_selected {
             BatchMode::LeaderSelected {
-                max_batch_size: input.config.max_batch_size,
                 batch_time_window_size: input.config.batch_time_window_size,
             }
         } else {

--- a/interop_binaries/src/commands/janus_interop_aggregator.rs
+++ b/interop_binaries/src/commands/janus_interop_aggregator.rs
@@ -90,7 +90,6 @@ async fn handle_add_task(
     let batch_mode = match request.batch_mode {
         1 => task::BatchMode::TimeInterval,
         2 => task::BatchMode::LeaderSelected {
-            max_batch_size: request.max_batch_size,
             batch_time_window_size: None,
         },
         _ => {

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -297,7 +297,6 @@ pub struct AggregatorAddTaskRequest {
     pub vdaf_verify_key: String, // in unpadded base64url
     pub batch_mode: u8,
     pub min_batch_size: u64,
-    pub max_batch_size: Option<u64>,
     pub time_precision: u64,           // in seconds
     pub collector_hpke_config: String, // in unpadded base64url
     pub task_expiration: Option<u64>,  // in seconds since the epoch
@@ -305,11 +304,9 @@ pub struct AggregatorAddTaskRequest {
 
 impl AggregatorAddTaskRequest {
     pub fn from_task(task: Task, role: Role) -> Self {
-        let (batch_mode, max_batch_size) = match task.batch_mode() {
-            BatchMode::TimeInterval => (TimeInterval::CODE as u8, None),
-            BatchMode::LeaderSelected { max_batch_size, .. } => {
-                (LeaderSelected::CODE as u8, *max_batch_size)
-            }
+        let batch_mode = match task.batch_mode() {
+            BatchMode::TimeInterval => TimeInterval::CODE as u8,
+            BatchMode::LeaderSelected { .. } => LeaderSelected::CODE as u8,
         };
         Self {
             task_id: *task.id(),
@@ -329,7 +326,6 @@ impl AggregatorAddTaskRequest {
             vdaf_verify_key: URL_SAFE_NO_PAD.encode(task.opaque_vdaf_verify_key().as_ref()),
             batch_mode,
             min_batch_size: task.min_batch_size(),
-            max_batch_size,
             time_precision: task.time_precision().as_seconds(),
             collector_hpke_config: URL_SAFE_NO_PAD.encode(
                 task.collector_hpke_keypair()

--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -47,14 +47,12 @@ async fn run(
 ) -> serde_json::Value {
     install_test_trace_subscriber();
 
-    let (batch_mode_json, max_batch_size) = match query_kind {
+    let batch_mode_json = match query_kind {
         QueryKind::TimeInterval => {
-            let batch_mode = json!(TimeInterval::CODE as u8);
-            (batch_mode, None)
+            json!(TimeInterval::CODE as u8)
         }
         QueryKind::LeaderSelected => {
-            let batch_mode = json!(LeaderSelected::CODE as u8);
-            (batch_mode, Some(json!(measurements.len())))
+            json!(LeaderSelected::CODE as u8)
         }
     };
 
@@ -282,7 +280,7 @@ async fn run(
         .expect("\"collector_hpke_config\" value is not a string");
 
     // Send a /internal/test/add_task request to the leader.
-    let mut leader_add_task_request_body = json!({
+    let leader_add_task_request_body = json!({
         "task_id": task_id_encoded,
         "leader": internal_leader_endpoint,
         "helper": internal_helper_endpoint,
@@ -296,12 +294,6 @@ async fn run(
         "time_precision": TIME_PRECISION,
         "collector_hpke_config": collector_hpke_config_encoded,
     });
-    if let Some(max_batch_size) = &max_batch_size {
-        leader_add_task_request_body
-            .as_object_mut()
-            .unwrap()
-            .insert("max_batch_size".to_string(), max_batch_size.clone());
-    }
     let leader_add_task_response = http_client
         .post(
             local_leader_endpoint
@@ -334,7 +326,7 @@ async fn run(
     );
 
     // Send a /internal/test/add_task request to the helper.
-    let mut helper_add_task_request_body = json!({
+    let helper_add_task_request_body = json!({
         "task_id": task_id_encoded,
         "leader": internal_leader_endpoint,
         "helper": internal_helper_endpoint,
@@ -347,12 +339,6 @@ async fn run(
         "time_precision": TIME_PRECISION,
         "collector_hpke_config": collector_hpke_config_encoded,
     });
-    if let Some(max_batch_size) = &max_batch_size {
-        helper_add_task_request_body
-            .as_object_mut()
-            .unwrap()
-            .insert("max_batch_size".to_string(), max_batch_size.clone());
-    }
     let helper_add_task_response = http_client
         .post(
             local_helper_endpoint


### PR DESCRIPTION
This parameter was removed in DAP-12, and we do not have any reason to keep it as functionality over-and-above what is specified in DAP, so we remove this parameter from Janus. The aggregation job creator will now always create batches which are exactly min_batch_size, matching previous functionality if max_batch_size was unspecified.