### PR TITLE
Switch to VDAF-13.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,6 +1065,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "constcat"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4938185353434999ef52c81753c8cca8955ed38042fc29913db3751916f3b7ab"
+
+[[package]]
 name = "content_inspector"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1437,7 +1443,7 @@ dependencies = [
  "num-bigint",
  "num-rational",
  "pad-adapter",
- "prio",
+ "prio 0.16.7",
  "serde",
  "serde_json",
  "thiserror 2.0.3",
@@ -2569,7 +2575,7 @@ dependencies = [
  "pem",
  "postgres-protocol",
  "postgres-types",
- "prio",
+ "prio 0.17.0-alpha.0",
  "prometheus",
  "quickcheck",
  "quickcheck_macros",
@@ -2678,7 +2684,7 @@ dependencies = [
  "opentelemetry",
  "postgres-protocol",
  "postgres-types",
- "prio",
+ "prio 0.17.0-alpha.0",
  "rand",
  "regex",
  "reqwest",
@@ -2719,7 +2725,7 @@ dependencies = [
  "janus_messages 0.8.0-prerelease-1",
  "mockito",
  "ohttp",
- "prio",
+ "prio 0.17.0-alpha.0",
  "rand",
  "reqwest",
  "thiserror 1.0.69",
@@ -2745,7 +2751,7 @@ dependencies = [
  "janus_core",
  "janus_messages 0.8.0-prerelease-1",
  "mockito",
- "prio",
+ "prio 0.17.0-alpha.0",
  "rand",
  "reqwest",
  "retry-after",
@@ -2768,6 +2774,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "constcat",
  "derivative",
  "fixed",
  "futures",
@@ -2780,7 +2787,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "mockito",
- "prio",
+ "prio 0.17.0-alpha.0",
  "quickcheck",
  "rand",
  "regex",
@@ -2832,7 +2839,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "opentelemetry",
- "prio",
+ "prio 0.17.0-alpha.0",
  "quickcheck",
  "rand",
  "regex",
@@ -2871,7 +2878,7 @@ dependencies = [
  "janus_core",
  "janus_interop_binaries",
  "janus_messages 0.8.0-prerelease-1",
- "prio",
+ "prio 0.17.0-alpha.0",
  "rand",
  "regex",
  "reqwest",
@@ -2902,7 +2909,7 @@ dependencies = [
  "derivative",
  "hex",
  "num_enum",
- "prio",
+ "prio 0.16.7",
  "rand",
  "serde",
  "thiserror 1.0.69",
@@ -2920,7 +2927,7 @@ dependencies = [
  "hex",
  "num_enum",
  "pretty_assertions",
- "prio",
+ "prio 0.17.0-alpha.0",
  "rand",
  "serde",
  "serde_test",
@@ -2942,7 +2949,7 @@ dependencies = [
  "janus_collector",
  "janus_core",
  "janus_messages 0.8.0-prerelease-1",
- "prio",
+ "prio 0.17.0-alpha.0",
  "rand",
  "reqwest",
  "serde_json",
@@ -4056,6 +4063,33 @@ dependencies = [
  "fiat-crypto",
  "fixed",
  "getrandom",
+ "hmac 0.12.1",
+ "num-bigint",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+ "rand",
+ "rand_core",
+ "serde",
+ "sha2 0.10.8",
+ "sha3",
+ "subtle",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "prio"
+version = "0.17.0-alpha.0"
+source = "git+https://github.com/divviup/libprio-rs?rev=c85e537682a7932edc0c44c80049df0429d6fa4c#c85e537682a7932edc0c44c80049df0429d6fa4c"
+dependencies = [
+ "aes 0.8.4",
+ "bitvec",
+ "byteorder",
+ "ctr 0.9.2",
+ "fiat-crypto",
+ "fixed",
+ "getrandom",
  "hex",
  "hmac 0.12.1",
  "num-bigint",
@@ -4071,7 +4105,7 @@ dependencies = [
  "sha2 0.10.8",
  "sha3",
  "subtle",
- "thiserror 1.0.69",
+ "thiserror 2.0.3",
  "zipf",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ cfg-if = "1.0.0"
 chrono = { version = "0.4.38", default-features = false }
 clap = { version = "4.5.21", features = ["cargo", "derive", "env"] }
 console-subscriber = "0.4.1"
+constcat = "0.5"
 deadpool = "0.12.1"
 deadpool-postgres = "0.14.0"
 derivative = "2.2.0"
@@ -73,7 +74,9 @@ postgres-types = "0.2.8"
 pretty_assertions = "1.4.1"
 # Disable default features so that individual workspace crates can choose to
 # re-enable them
-prio = { version = "0.16.7", default-features = false, features = ["experimental"] }
+# TODO(#3436): switch to a released version of libprio, once there is a released version implementing VDAF-13
+# prio = { version = "0.16.7", default-features = false, features = ["experimental"] }
+prio = { git = "https://github.com/divviup/libprio-rs", rev = "c85e537682a7932edc0c44c80049df0429d6fa4c", default-features = false, features = ["experimental"] }
 prometheus = "0.13.4"
 querystring = "1.1.0"
 quickcheck = { version = "1.0.3", default-features = false }

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -58,7 +58,7 @@ use janus_core::{
     retries::retry_http_request_notify,
     time::{Clock, DurationExt, IntervalExt, TimeExt},
     vdaf::{
-        new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128,
+        new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128, vdaf_application_context,
         Prio3SumVecField64MultiproofHmacSha256Aes128, VdafInstance, VERIFY_KEY_LENGTH,
     },
     Runtime,
@@ -1978,12 +1978,13 @@ impl VdafOps {
 
             move || {
                 let span = info_span!(parent: parent_span, "handle_aggregate_init_generic threadpool task");
+                let ctx = vdaf_application_context(task.id());
 
                 req
                     .prepare_inits()
                     .par_iter()
                     .enumerate()
-                    .try_for_each_with((sender, span), |(sender, span), (ord, prepare_init)| {
+                    .try_for_each(|(ord, prepare_init)| {
                         let _entered = span.enter();
 
                         // If decryption fails, then the aggregator MUST fail with error `hpke-decrypt-error`. (§4.4.2.2)
@@ -2182,6 +2183,7 @@ impl VdafOps {
                             trace_span!("VDAF preparation (helper initialization)").in_scope(|| {
                                 vdaf.helper_initialized(
                                     verify_key.as_bytes(),
+                                    &ctx,
                                     &agg_param,
                                     /* report ID is used as VDAF nonce */
                                     prepare_init.report_share().metadata().id().as_ref(),
@@ -2189,7 +2191,7 @@ impl VdafOps {
                                     &input_share,
                                     prepare_init.message(),
                                 )
-                                .and_then(|transition| transition.evaluate(&vdaf))
+                                .and_then(|transition| transition.evaluate(&ctx, &vdaf))
                                 .map_err(|error| {
                                     handle_ping_pong_error(
                                         task.id(),

--- a/aggregator/src/aggregator/aggregate_init_tests.rs
+++ b/aggregator/src/aggregator/aggregate_init_tests.rs
@@ -132,6 +132,7 @@ where
     ) -> (ReportShare, VdafTranscript<VERIFY_KEY_SIZE, V>) {
         let transcript = run_vdaf(
             &self.vdaf,
+            self.task.id(),
             self.task.vdaf_verify_key().unwrap().as_bytes(),
             &self.aggregation_param,
             report_metadata.id(),

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -976,6 +976,7 @@ mod tests {
         let leader_report_metadata = ReportMetadata::new(random(), report_time);
         let leader_transcript = run_vdaf(
             vdaf.as_ref(),
+            leader_task.id(),
             leader_task.vdaf_verify_key().unwrap().as_bytes(),
             &(),
             leader_report_metadata.id(),
@@ -1166,6 +1167,7 @@ mod tests {
                     let report_metadata = ReportMetadata::new(random(), report_time);
                     let transcript = run_vdaf(
                         vdaf.as_ref(),
+                        task.id(),
                         task.vdaf_verify_key().unwrap().as_bytes(),
                         &(),
                         report_metadata.id(),
@@ -1344,6 +1346,7 @@ mod tests {
         let first_report_metadata = ReportMetadata::new(random(), report_time);
         let first_transcript = run_vdaf(
             vdaf.as_ref(),
+            task.id(),
             task.vdaf_verify_key().unwrap().as_bytes(),
             &(),
             first_report_metadata.id(),
@@ -1360,6 +1363,7 @@ mod tests {
         let second_report_metadata = ReportMetadata::new(random(), report_time);
         let second_transcript = run_vdaf(
             vdaf.as_ref(),
+            task.id(),
             task.vdaf_verify_key().unwrap().as_bytes(),
             &(),
             second_report_metadata.id(),
@@ -1556,6 +1560,7 @@ mod tests {
                 let report_metadata = ReportMetadata::new(random(), report_time);
                 let transcript = run_vdaf(
                     vdaf.as_ref(),
+                    task.id(),
                     task.vdaf_verify_key().unwrap().as_bytes(),
                     &(),
                     report_metadata.id(),
@@ -1740,6 +1745,7 @@ mod tests {
                 let report_metadata = ReportMetadata::new(random(), report_time);
                 let transcript = run_vdaf(
                     vdaf.as_ref(),
+                    task.id(),
                     task.vdaf_verify_key().unwrap().as_bytes(),
                     &(),
                     report_metadata.id(),
@@ -1937,6 +1943,7 @@ mod tests {
                 let report_metadata = ReportMetadata::new(random(), report_time);
                 let transcript = run_vdaf(
                     vdaf.as_ref(),
+                    task.id(),
                     task.vdaf_verify_key().unwrap().as_bytes(),
                     &(),
                     report_metadata.id(),
@@ -2098,6 +2105,7 @@ mod tests {
                 let report_metadata = ReportMetadata::new(random(), report_time);
                 let transcript = run_vdaf(
                     vdaf.as_ref(),
+                    task.id(),
                     task.vdaf_verify_key().unwrap().as_bytes(),
                     &(),
                     report_metadata.id(),
@@ -2211,6 +2219,7 @@ mod tests {
         let last_report_metadata = ReportMetadata::new(random(), report_time);
         let last_transcript = run_vdaf(
             vdaf.as_ref(),
+            task.id(),
             task.vdaf_verify_key().unwrap().as_bytes(),
             &(),
             last_report_metadata.id(),
@@ -2358,6 +2367,7 @@ mod tests {
                 let report_metadata = ReportMetadata::new(random(), report_time);
                 let transcript = run_vdaf(
                     vdaf.as_ref(),
+                    task.id(),
                     task.vdaf_verify_key().unwrap().as_bytes(),
                     &(),
                     report_metadata.id(),
@@ -2474,6 +2484,7 @@ mod tests {
                 let report_metadata = ReportMetadata::new(random(), report_time);
                 let transcript = run_vdaf(
                     vdaf.as_ref(),
+                    task.id(),
                     task.vdaf_verify_key().unwrap().as_bytes(),
                     &(),
                     report_metadata.id(),
@@ -2629,6 +2640,7 @@ mod tests {
                 let report_metadata = ReportMetadata::new(random(), report_time_1);
                 let transcript = run_vdaf(
                     vdaf.as_ref(),
+                    task.id(),
                     task.vdaf_verify_key().unwrap().as_bytes(),
                     &(),
                     report_metadata.id(),
@@ -2649,6 +2661,7 @@ mod tests {
                 let report_metadata = ReportMetadata::new(random(), report_time_2);
                 let transcript = run_vdaf(
                     vdaf.as_ref(),
+                    task.id(),
                     task.vdaf_verify_key().unwrap().as_bytes(),
                     &(),
                     report_metadata.id(),

--- a/aggregator/src/aggregator/aggregation_job_driver/tests.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver/tests.rs
@@ -89,6 +89,7 @@ async fn aggregation_job_driver() {
 
     let transcript = run_vdaf(
         vdaf.as_ref(),
+        task.id(),
         verify_key.as_bytes(),
         &aggregation_param,
         report_metadata.id(),
@@ -366,6 +367,7 @@ async fn step_time_interval_aggregation_job_init_single_step() {
 
     let transcript = run_vdaf(
         vdaf.as_ref(),
+        task.id(),
         verify_key.as_bytes(),
         &(),
         report_metadata.id(),
@@ -697,6 +699,7 @@ async fn step_time_interval_aggregation_job_init_two_steps() {
 
     let transcript = run_vdaf(
         vdaf.as_ref(),
+        task.id(),
         verify_key.as_bytes(),
         &aggregation_param,
         report_metadata.id(),
@@ -962,6 +965,7 @@ async fn step_time_interval_aggregation_job_init_partially_garbage_collected() {
 
     let gc_eligible_transcript = run_vdaf(
         vdaf.as_ref(),
+        task.id(),
         verify_key.as_bytes(),
         &(),
         gc_eligible_report_metadata.id(),
@@ -969,6 +973,7 @@ async fn step_time_interval_aggregation_job_init_partially_garbage_collected() {
     );
     let gc_ineligible_transcript = run_vdaf(
         vdaf.as_ref(),
+        task.id(),
         verify_key.as_bytes(),
         &(),
         gc_ineligible_report_metadata.id(),
@@ -1314,6 +1319,7 @@ async fn step_leader_selected_aggregation_job_init_single_step() {
 
     let transcript = run_vdaf(
         vdaf.as_ref(),
+        task.id(),
         verify_key.as_bytes(),
         &(),
         report_metadata.id(),
@@ -1601,6 +1607,7 @@ async fn step_leader_selected_aggregation_job_init_two_steps() {
 
     let transcript = run_vdaf(
         vdaf.as_ref(),
+        task.id(),
         verify_key.as_bytes(),
         &aggregation_param,
         report_metadata.id(),
@@ -1856,6 +1863,7 @@ async fn step_time_interval_aggregation_job_continue() {
     let aggregation_param = dummy::AggregationParam(7);
     let transcript = run_vdaf(
         vdaf.as_ref(),
+        task.id(),
         verify_key.as_bytes(),
         &aggregation_param,
         report_metadata.id(),
@@ -2172,6 +2180,7 @@ async fn step_leader_selected_aggregation_job_continue() {
     let aggregation_param = dummy::AggregationParam(7);
     let transcript = run_vdaf(
         vdaf.as_ref(),
+        task.id(),
         verify_key.as_bytes(),
         &aggregation_param,
         report_metadata.id(),
@@ -2458,6 +2467,7 @@ async fn setup_cancel_aggregation_job_test() -> CancelAggregationJobTestCase {
 
     let transcript = run_vdaf(
         vdaf.as_ref(),
+        task.id(),
         verify_key.as_bytes(),
         &(),
         report_metadata.id(),
@@ -2726,6 +2736,7 @@ async fn abandon_failing_aggregation_job_with_retryable_error() {
     let report_metadata = ReportMetadata::new(random(), time);
     let transcript = run_vdaf(
         &vdaf,
+        task.id(),
         verify_key.as_bytes(),
         &(),
         report_metadata.id(),
@@ -2968,6 +2979,7 @@ async fn abandon_failing_aggregation_job_with_fatal_error() {
     let report_metadata = ReportMetadata::new(random(), time);
     let transcript = run_vdaf(
         &vdaf,
+        task.id(),
         verify_key.as_bytes(),
         &(),
         report_metadata.id(),

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_continue.rs
@@ -68,6 +68,7 @@ async fn aggregate_continue() {
     );
     let transcript_0 = run_vdaf(
         vdaf.as_ref(),
+        task.id(),
         verify_key.as_bytes(),
         &aggregation_param,
         report_metadata_0.id(),
@@ -94,6 +95,7 @@ async fn aggregate_continue() {
     );
     let transcript_1 = run_vdaf(
         vdaf.as_ref(),
+        task.id(),
         verify_key.as_bytes(),
         &aggregation_param,
         report_metadata_1.id(),
@@ -123,6 +125,7 @@ async fn aggregate_continue() {
     );
     let transcript_2 = run_vdaf(
         vdaf.as_ref(),
+        task.id(),
         verify_key.as_bytes(),
         &aggregation_param,
         report_metadata_2.id(),
@@ -398,6 +401,7 @@ async fn aggregate_continue_accumulate_batch_aggregation() {
     let report_metadata_0 = ReportMetadata::new(random(), report_time_0);
     let transcript_0 = run_vdaf(
         &vdaf,
+        task.id(),
         verify_key.as_bytes(),
         &aggregation_param,
         report_metadata_0.id(),
@@ -423,6 +427,7 @@ async fn aggregate_continue_accumulate_batch_aggregation() {
     let report_metadata_1 = ReportMetadata::new(random(), report_time_1);
     let transcript_1 = run_vdaf(
         &vdaf,
+        task.id(),
         verify_key.as_bytes(),
         &aggregation_param,
         report_metadata_1.id(),
@@ -450,6 +455,7 @@ async fn aggregate_continue_accumulate_batch_aggregation() {
     );
     let transcript_2 = run_vdaf(
         &vdaf,
+        task.id(),
         verify_key.as_bytes(),
         &aggregation_param,
         report_metadata_2.id(),
@@ -745,6 +751,7 @@ async fn aggregate_continue_accumulate_batch_aggregation() {
     let report_metadata_3 = ReportMetadata::new(random(), report_time_3);
     let transcript_3 = run_vdaf(
         &vdaf,
+        task.id(),
         verify_key.as_bytes(),
         &aggregation_param,
         report_metadata_3.id(),
@@ -772,6 +779,7 @@ async fn aggregate_continue_accumulate_batch_aggregation() {
     );
     let transcript_4 = run_vdaf(
         &vdaf,
+        task.id(),
         verify_key.as_bytes(),
         &aggregation_param,
         report_metadata_4.id(),
@@ -799,6 +807,7 @@ async fn aggregate_continue_accumulate_batch_aggregation() {
     );
     let transcript_5 = run_vdaf(
         &vdaf,
+        task.id(),
         verify_key.as_bytes(),
         &aggregation_param,
         report_metadata_5.id(),
@@ -1036,6 +1045,7 @@ async fn aggregate_continue_leader_sends_non_continue_or_finish_transition() {
     let aggregation_param = dummy::AggregationParam(7);
     let transcript = run_vdaf(
         &dummy::Vdaf::new(2),
+        task.id(),
         task.vdaf_verify_key().unwrap().as_bytes(),
         &aggregation_param,
         &report_id,
@@ -1151,6 +1161,7 @@ async fn aggregate_continue_prep_step_fails() {
     let aggregation_param = dummy::AggregationParam(7);
     let transcript = run_vdaf(
         &vdaf,
+        task.id(),
         task.vdaf_verify_key().unwrap().as_bytes(),
         &aggregation_param,
         &report_id,
@@ -1320,6 +1331,7 @@ async fn aggregate_continue_unexpected_transition() {
     let aggregation_param = dummy::AggregationParam(7);
     let transcript = run_vdaf(
         &dummy::Vdaf::new(2),
+        task.id(),
         task.vdaf_verify_key().unwrap().as_bytes(),
         &aggregation_param,
         &report_id,
@@ -1433,6 +1445,7 @@ async fn aggregate_continue_out_of_order_transition() {
     let aggregation_param = dummy::AggregationParam(7);
     let transcript_0 = run_vdaf(
         &dummy::Vdaf::new(2),
+        task.id(),
         task.vdaf_verify_key().unwrap().as_bytes(),
         &aggregation_param,
         &report_id_0,
@@ -1442,6 +1455,7 @@ async fn aggregate_continue_out_of_order_transition() {
     let report_id_1 = random();
     let transcript_1 = run_vdaf(
         &dummy::Vdaf::new(2),
+        task.id(),
         task.vdaf_verify_key().unwrap().as_bytes(),
         &aggregation_param,
         &report_id_1,

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
@@ -287,6 +287,7 @@ async fn aggregate_init() {
     );
     let transcript_5 = run_vdaf(
         &vdaf,
+        task.id(),
         verify_key.as_bytes(),
         &dummy::AggregationParam(0),
         report_metadata_5.id(),
@@ -317,6 +318,7 @@ async fn aggregate_init() {
     );
     let transcript_6 = run_vdaf(
         &vdaf,
+        task.id(),
         verify_key.as_bytes(),
         &dummy::AggregationParam(0),
         report_metadata_6.id(),
@@ -347,6 +349,7 @@ async fn aggregate_init() {
     );
     let transcript_7 = run_vdaf(
         &vdaf,
+        task.id(),
         verify_key.as_bytes(),
         &dummy::AggregationParam(0),
         report_metadata_7.id(),

--- a/aggregator/src/aggregator/test_util.rs
+++ b/aggregator/src/aggregator/test_util.rs
@@ -6,7 +6,7 @@ use janus_aggregator_core::{
 use janus_core::{
     hpke::{self, HpkeApplicationInfo, HpkeKeypair, Label},
     time::MockClock,
-    vdaf::VdafInstance,
+    vdaf::{vdaf_application_context, VdafInstance},
 };
 use janus_messages::{
     Extension, HpkeConfig, InputShareAad, PlaintextInputShare, Report, ReportId, ReportMetadata,
@@ -74,7 +74,9 @@ pub fn create_report_custom(
     let vdaf = Prio3Count::new_count(2).unwrap();
     let report_metadata = ReportMetadata::new(id, report_timestamp);
 
-    let (public_share, measurements) = vdaf.shard(&true, id.as_ref()).unwrap();
+    let (public_share, measurements) = vdaf
+        .shard(&vdaf_application_context(task.id()), &true, id.as_ref())
+        .unwrap();
 
     let associated_data = InputShareAad::new(
         *task.id(),

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -2251,10 +2251,18 @@ async fn get_aggregation_jobs_for_task(ephemeral_datastore: EphemeralDatastore) 
 async fn roundtrip_report_aggregation(ephemeral_datastore: EphemeralDatastore) {
     install_test_trace_subscriber();
 
+    let task_id = random();
     let report_id = random();
     let vdaf = Arc::new(dummy::Vdaf::new(2));
     let aggregation_param = dummy::AggregationParam(5);
-    let vdaf_transcript = run_vdaf(vdaf.as_ref(), &[], &aggregation_param, &report_id, &13);
+    let vdaf_transcript = run_vdaf(
+        vdaf.as_ref(),
+        &task_id,
+        &[],
+        &aggregation_param,
+        &report_id,
+        &13,
+    );
 
     for (ord, (role, state)) in [
         (
@@ -2567,11 +2575,19 @@ async fn get_report_aggregations_for_aggregation_job(ephemeral_datastore: Epheme
     let clock = MockClock::new(OLDEST_ALLOWED_REPORT_TIMESTAMP);
     let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
+    let task_id = random();
     let report_id = random();
     let vdaf = Arc::new(dummy::Vdaf::new(2));
     let aggregation_param = dummy::AggregationParam(7);
 
-    let vdaf_transcript = run_vdaf(vdaf.as_ref(), &[], &aggregation_param, &report_id, &13);
+    let vdaf_transcript = run_vdaf(
+        vdaf.as_ref(),
+        &task_id,
+        &[],
+        &aggregation_param,
+        &report_id,
+        &13,
+    );
 
     let task = TaskBuilder::new(
         task::BatchMode::TimeInterval,
@@ -2714,11 +2730,19 @@ async fn create_report_aggregation_from_client_reports_table(
     let clock = MockClock::new(OLDEST_ALLOWED_REPORT_TIMESTAMP);
     let ds = ephemeral_datastore.datastore(clock.clone()).await;
 
+    let task_id = random();
     let report_id = random();
     let vdaf = Arc::new(dummy::Vdaf::new(2));
     let aggregation_param = dummy::AggregationParam(7);
 
-    let vdaf_transcript = run_vdaf(vdaf.as_ref(), &[], &aggregation_param, &report_id, &13);
+    let vdaf_transcript = run_vdaf(
+        vdaf.as_ref(),
+        &task_id,
+        &[],
+        &aggregation_param,
+        &report_id,
+        &13,
+    );
 
     let task = TaskBuilder::new(
         task::BatchMode::TimeInterval,
@@ -5141,6 +5165,7 @@ async fn roundtrip_outstanding_batch(ephemeral_datastore: EphemeralDatastore) {
                 let report_id_0_1 = random();
                 let transcript = run_vdaf(
                     &dummy::Vdaf::default(),
+                    task_1.id(),
                     task_1.vdaf_verify_key().unwrap().as_bytes(),
                     &dummy::AggregationParam(0),
                     &report_id_0_1,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -53,6 +53,7 @@ use janus_core::{
     retries::{http_request_exponential_backoff, retry_http_request},
     time::{Clock, RealClock, TimeExt},
     url_ensure_trailing_slash,
+    vdaf::vdaf_application_context,
 };
 use janus_messages::{
     Duration, HpkeConfig, HpkeConfigList, InputShareAad, PlaintextInputShare, Report, ReportId,
@@ -576,7 +577,11 @@ impl<V: vdaf::Client<16>> Client<V> {
     /// uploaded.
     fn prepare_report(&self, measurement: &V::Measurement, time: &Time) -> Result<Report, Error> {
         let report_id: ReportId = random();
-        let (public_share, input_shares) = self.vdaf.shard(measurement, report_id.as_ref())?;
+        let (public_share, input_shares) = self.vdaf.shard(
+            &vdaf_application_context(&self.parameters.task_id),
+            measurement,
+            report_id.as_ref(),
+        )?;
         assert_eq!(input_shares.len(), 2); // DAP only supports VDAFs using two aggregators.
 
         let time = time

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -915,7 +915,7 @@ mod tests {
         install_test_trace_subscriber();
         let mut server = mockito::Server::new_async().await;
         let vdaf = Prio3::new_count(2).unwrap();
-        let transcript = run_vdaf(&vdaf, &random(), &(), &random(), &true);
+        let transcript = run_vdaf(&vdaf, &random(), &random(), &(), &random(), &true);
         let collector = setup_collector(&mut server, vdaf);
         let (auth_header, auth_value) = collector.authentication.request_authentication();
 
@@ -1016,7 +1016,7 @@ mod tests {
         install_test_trace_subscriber();
         let mut server = mockito::Server::new_async().await;
         let vdaf = Prio3::new_sum(2, 8).unwrap();
-        let transcript = run_vdaf(&vdaf, &random(), &(), &random(), &144);
+        let transcript = run_vdaf(&vdaf, &random(), &random(), &(), &random(), &144);
         let collector = setup_collector(&mut server, vdaf);
 
         let batch_interval = Interval::new(
@@ -1084,7 +1084,7 @@ mod tests {
         install_test_trace_subscriber();
         let mut server = mockito::Server::new_async().await;
         let vdaf = Prio3::new_histogram(2, 4, 2).unwrap();
-        let transcript = run_vdaf(&vdaf, &random(), &(), &random(), &3);
+        let transcript = run_vdaf(&vdaf, &random(), &random(), &(), &random(), &3);
         let collector = setup_collector(&mut server, vdaf);
 
         let batch_interval = Interval::new(
@@ -1159,6 +1159,7 @@ mod tests {
         let transcript = run_vdaf(
             &vdaf,
             &random(),
+            &random(),
             &(),
             &random(),
             &vec![FP32_16_INV, FP32_8_INV, FP32_4_INV],
@@ -1231,7 +1232,7 @@ mod tests {
         install_test_trace_subscriber();
         let mut server = mockito::Server::new_async().await;
         let vdaf = Prio3::new_count(2).unwrap();
-        let transcript = run_vdaf(&vdaf, &random(), &(), &random(), &true);
+        let transcript = run_vdaf(&vdaf, &random(), &random(), &(), &random(), &true);
         let collector = setup_collector(&mut server, vdaf);
 
         let batch_id = random();
@@ -1294,7 +1295,7 @@ mod tests {
         install_test_trace_subscriber();
         let mut server = mockito::Server::new_async().await;
         let vdaf = Prio3::new_count(2).unwrap();
-        let transcript = run_vdaf(&vdaf, &random(), &(), &random(), &true);
+        let transcript = run_vdaf(&vdaf, &random(), &random(), &(), &random(), &true);
         let server_url = Url::parse(&server.url()).unwrap();
         let hpke_keypair = HpkeKeypair::test();
         let collector = Collector::builder(
@@ -1955,7 +1956,7 @@ mod tests {
         install_test_trace_subscriber();
         let mut server = mockito::Server::new_async().await;
         let vdaf = Prio3::new_count(2).unwrap();
-        let transcript = run_vdaf(&vdaf, &random(), &(), &random(), &true);
+        let transcript = run_vdaf(&vdaf, &random(), &random(), &(), &random(), &true);
         let collector = setup_collector(&mut server, vdaf);
         let (auth_header, auth_value) = collector.authentication.request_authentication();
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -41,6 +41,7 @@ base64.workspace = true
 bytes.workspace = true
 chrono = { workspace = true, features = ["clock"] }
 clap.workspace = true
+constcat.workspace = true
 derivative.workspace = true
 fixed = { workspace = true, optional = true }
 futures = { workspace = true }

--- a/core/src/hpke.rs
+++ b/core/src/hpke.rs
@@ -1,5 +1,7 @@
 //! Encryption and decryption of messages using HPKE (RFC 9180).
+use crate::DAP_VERSION_IDENTIFIER;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use constcat::concat;
 use derivative::Derivative;
 use hpke_dispatch::{HpkeError, Kem, Keypair};
 use janus_messages::{
@@ -63,8 +65,8 @@ impl Label {
     /// Get the message-specific portion of the application info string for this label.
     pub fn as_bytes(&self) -> &'static [u8] {
         match self {
-            Self::InputShare => b"dap-09 input share",
-            Self::AggregateShare => b"dap-09 aggregate share",
+            Self::InputShare => concat!(DAP_VERSION_IDENTIFIER, " input share").as_bytes(),
+            Self::AggregateShare => concat!(DAP_VERSION_IDENTIFIER, " aggregate share").as_bytes(),
         }
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -44,6 +44,10 @@ pub mod taskprov {
     pub const TASKPROV_HEADER: &str = "dap-taskprov";
 }
 
+/// This value is used in a few places throughout the protocol to identify the draft of DAP being
+/// implemented.
+const DAP_VERSION_IDENTIFIER: &str = "dap-13";
+
 /// Returns the given [`Url`], possibly modified to end with a slash.
 ///
 /// Aggregator endpoint URLs should end with a slash if they will be used with [`Url::join`],

--- a/core/src/vdaf.rs
+++ b/core/src/vdaf.rs
@@ -1,5 +1,6 @@
+use crate::DAP_VERSION_IDENTIFIER;
 use derivative::Derivative;
-use janus_messages::taskprov;
+use janus_messages::{taskprov, TaskId};
 use prio::{
     field::Field64,
     flp::{
@@ -22,6 +23,18 @@ const ALGORITHM_ID_PRIO3_SUM_VEC_FIELD64_MULTIPROOF_HMACSHA256_AES128: u32 = 0xF
 /// The length of the verify key parameter when using [`XofHmacSha256Aes128`]. This XOF is not part
 /// of the VDAF specification.
 pub const VERIFY_KEY_LENGTH_HMACSHA256_AES128: usize = 32;
+
+/// Computes the VDAF "application context", which is an opaque byte string used by many VDAF
+/// operations for domain-separation purposes. In DAP, this is the DAP draft number concatenated
+/// with the task ID.
+pub fn vdaf_application_context(
+    task_id: &TaskId,
+) -> [u8; DAP_VERSION_IDENTIFIER.len() + TaskId::LEN] {
+    let mut ctx = [0u8; DAP_VERSION_IDENTIFIER.len() + TaskId::LEN];
+    ctx[..DAP_VERSION_IDENTIFIER.len()].copy_from_slice(DAP_VERSION_IDENTIFIER.as_bytes());
+    ctx[DAP_VERSION_IDENTIFIER.len()..].copy_from_slice(task_id.as_ref());
+    ctx
+}
 
 /// Bitsize parameter for the `Prio3FixedPointBoundedL2VecSum` VDAF.
 #[cfg(feature = "fpvec_bounded_l2")]


### PR DESCRIPTION
I currently pin to a specific commit in libprio-rs tracking the VDAF-13 implementation, as the implementation is currently ongoing. I am fairly confident that the only breaking interface changes have already been implemented: there is a new "application context string", which is computed as the concatenation of hte current DAP draft in use & the task ID.

Also, bump the version tag while I'm at it, since I touched it anyway.