### PR TITLE
cargo-deny: ignore instant and derivative unmaintained warnings

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,15 @@ all-features = true
 
 [advisories]
 version = 2
+ignore = [
+    # `instant` is unmaintained, but it is feature-complete and small, so it is unlikely to have
+    # bugs or security vulnerabilities.
+    "RUSTSEC-2024-0384",
+
+    # Use of `derivative` has been removed from production code. It still exists as transitive
+    # dependency on integration_tests.
+    "RUSTSEC-2024-0388"
+]
 
 [bans]
 multiple-versions = "allow"


### PR DESCRIPTION
`derivative` will naturally be fully phased out once we update divviup-client.

`instant` we will leave for the foreseeable future. If SHTF and this dependency is broken, we can use https://github.com/divviup/janus/commit/c4692719923009b0e7e1596b1850a98d02ce7a5d as a workaround.