### PR TITLE
Bump MSRV to 1.80.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2021"
 homepage = "https://divviup.org"
 license = "MPL-2.0"
 repository = "https://github.com/divviup/janus"
-rust-version = "1.77.0"
+rust-version = "1.80.0"
 version = "0.8.0-prerelease-1"
 
 [workspace.dependencies]

--- a/aggregator/src/binaries/janus_cli.rs
+++ b/aggregator/src/binaries/janus_cli.rs
@@ -736,7 +736,6 @@ impl From<kube::Client> for LazyKubeClient {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use crate::{

--- a/aggregator_api/src/routes.rs
+++ b/aggregator_api/src/routes.rs
@@ -26,7 +26,7 @@ use rand::random;
 use ring::digest::{digest, SHA256};
 use std::{
     str::FromStr,
-    sync::{Arc, OnceLock},
+    sync::{Arc, LazyLock},
     unreachable,
 };
 use trillium::{Conn, Status};
@@ -36,9 +36,8 @@ pub(super) async fn get_config(
     _: &mut Conn,
     State(config): State<Arc<Config>>,
 ) -> Json<AggregatorApiConfig> {
-    static VERSION: OnceLock<String> = OnceLock::new();
-    let software_version =
-        VERSION.get_or_init(|| format!("{}-{}", env!("CARGO_PKG_VERSION"), git_revision()));
+    static VERSION: LazyLock<String> =
+        LazyLock::new(|| format!("{}-{}", env!("CARGO_PKG_VERSION"), git_revision()));
 
     Json(AggregatorApiConfig {
         protocol: "DAP-09",
@@ -61,7 +60,7 @@ pub(super) async fn get_config(
             "PureDpDiscreteLaplace",
         ],
         software_name: "Janus",
-        software_version,
+        software_version: &VERSION,
     })
 }
 

--- a/aggregator_core/src/taskprov.rs
+++ b/aggregator_core/src/taskprov.rs
@@ -9,7 +9,7 @@ use serde::{
     de::{self, Visitor},
     Deserialize, Serialize, Serializer,
 };
-use std::{fmt, str::FromStr, sync::OnceLock};
+use std::{fmt, str::FromStr, sync::LazyLock};
 use url::Url;
 
 #[derive(Educe, Clone, Copy, PartialEq, Eq)]
@@ -131,8 +131,7 @@ pub struct PeerAggregator {
 ///
 /// [1]: https://www.ietf.org/archive/id/draft-wang-ppm-dap-taskprov-04.html#name-deriving-the-vdaf-verificat
 fn taskprov_salt() -> &'static Salt {
-    static SALT: OnceLock<Salt> = OnceLock::new();
-    SALT.get_or_init(|| {
+    static SALT: LazyLock<Salt> = LazyLock::new(|| {
         Salt::new(
             HKDF_SHA256,
             &[
@@ -141,7 +140,8 @@ fn taskprov_salt() -> &'static Salt {
                 0x72, 0x3a, 0xf, 0xfe,
             ],
         )
-    })
+    });
+    &SALT
 }
 
 impl PeerAggregator {

--- a/core/src/auth_tokens.rs
+++ b/core/src/auth_tokens.rs
@@ -11,7 +11,7 @@ use ring::{
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 use std::{
     str::{self, FromStr},
-    sync::OnceLock,
+    sync::LazyLock,
 };
 
 /// HTTP header where auth tokens are provided in messages between participants.
@@ -242,11 +242,9 @@ impl BearerToken {
     ///
     /// [1]: https://datatracker.ietf.org/doc/html/rfc6750#section-2.1
     fn validate(value: &str) -> Result<(), anyhow::Error> {
-        static REGEX: OnceLock<Regex> = OnceLock::new();
-
-        let regex = REGEX.get_or_init(|| Regex::new("^[-A-Za-z0-9._~+/]+=*$").unwrap());
-
-        if regex.is_match(value) {
+        static REGEX: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new("^[-A-Za-z0-9._~+/]+=*$").unwrap());
+        if REGEX.is_match(value) {
             Ok(())
         } else {
             Err(anyhow::anyhow!("bearer token has invalid format"))

--- a/integration_tests/tests/integration/in_cluster.rs
+++ b/integration_tests/tests/integration/in_cluster.rs
@@ -666,7 +666,7 @@ mod rate_limits {
     use std::{
         env,
         fs::File,
-        sync::{Arc, OnceLock},
+        sync::{Arc, LazyLock},
         time::Duration,
     };
     use tokio::sync::Semaphore;
@@ -687,14 +687,13 @@ mod rate_limits {
 
     impl TestConfig {
         fn load() -> &'static Self {
-            static CONFIG: OnceLock<TestConfig> = OnceLock::new();
-
-            CONFIG.get_or_init(|| {
+            static CONFIG: LazyLock<TestConfig> = LazyLock::new(|| {
                 serde_json::from_reader(
                     File::open(env::var("JANUS_E2E_RATE_LIMIT_TEST_CONFIG").unwrap()).unwrap(),
                 )
                 .unwrap()
-            })
+            });
+            &CONFIG
         }
     }
 


### PR DESCRIPTION
This is, at time of writing, the "stable minus two releases" that Janus supports. Also, clean up a few uses of OnceLock -- mostly to replace with the simpler LazyLock stabilized in 1.80, in one place replacing it with an async mutex as neither OnceLock nor LazyLock were appropriate as the initializing function would be async.