### PR TITLE
Bump MSRV to 1.81

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2021"
 homepage = "https://divviup.org"
 license = "MPL-2.0"
 repository = "https://github.com/divviup/janus"
-rust-version = "1.80.0"
+rust-version = "1.81.0"
 version = "0.8.0-prerelease-1"
 
 [workspace.dependencies]


### PR DESCRIPTION
See https://github.com/divviup/janus/pull/3519#issuecomment-2512804503, for the time being, we can only build on 1.81 or later.