### PR TITLE
cargo-deny: ignore instant and derivative unmaintained warnings - 0.7 backport

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,15 @@ all-features = true
 
 [advisories]
 version = 2
+ignore = [
+    # `instant` is unmaintained, but it is feature-complete and small, so it is unlikely to have
+    # bugs or security vulnerabilities.
+    "RUSTSEC-2024-0384",
+
+    # Use of `derivative` has been removed from production code. It still exists as transitive
+    # dependency on integration_tests.
+    "RUSTSEC-2024-0388"
+]
 
 [bans]
 multiple-versions = "allow"


### PR DESCRIPTION
This is a backport of #3508 to the release/0.7 branch.