### PR TITLE
Fix aggregation job driver test

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_driver/tests.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver/tests.rs
@@ -4000,7 +4000,7 @@ async fn async_aggregation_job_init_poll_to_finished() {
     assert_eq!(want_report_aggregation, got_report_aggregation);
     assert_eq!(want_batch_aggregations, got_batch_aggregations);
 
-    assert_task_aggregation_counter(&ds, *task.id(), TaskAggregationCounter::new_with_values(0))
+    assert_task_aggregation_counter(&ds, *task.id(), TaskAggregationCounter::new_with_values(1))
         .await;
 }
 

--- a/aggregator/src/aggregator/test_util.rs
+++ b/aggregator/src/aggregator/test_util.rs
@@ -171,6 +171,8 @@ pub async fn assert_task_aggregation_counter(
 ) {
     // We can't coordinate with the counter-update tasks, so we loop on polling them.
 
+    sleep(Duration::from_millis(100)).await;
+
     let end_instant = Instant::now() + Duration::from_secs(10);
     loop {
         let now = Instant::now();


### PR DESCRIPTION
Fixes #3617. The `async_aggregation_job_init_poll_to_finished` test had an incorrect expected value for the task aggregation counter, expecting 0 instead of 1, and most of the time, the test's polling loop happened to run before a background async task incremented the counter. Only under higher CPU load would the counter be incremented first, and then the polling loop would never succeed. This PR fixes the expected counter value (since this unit test expects the aggregation job to be finished during this request) and adds an initial wait of 0.1s before polling the database. The additional wait should make it significantly more likely that counter increments happen before the first poll. I also ran the test suite with a longer initial wait to confirm there weren't any other similar bugs.

We could remove the need for polling by using our `Runtime` trait to spawn these background tasks, and then using `TestRuntime` to wait until the expected number of counter increment tasks finish. I went with this change for now to address the flakiness with a simpler change.