### PR TITLE
Upgrade to opentelemetry-rust 0.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,31 +286,11 @@ checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
 dependencies = [
  "async-channel 2.2.0",
  "async-executor",
- "async-io 2.3.2",
+ "async-io",
  "async-lock 3.3.0",
  "blocking",
  "futures-lite 2.3.0",
  "once_cell",
-]
-
-[[package]]
-name = "async-io"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
-dependencies = [
- "async-lock 2.8.0",
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-lite 1.13.0",
- "log",
- "parking",
- "polling 2.8.0",
- "rustix 0.37.27",
- "slab",
- "socket2 0.4.10",
- "waker-fn",
 ]
 
 [[package]]
@@ -325,8 +305,8 @@ dependencies = [
  "futures-io",
  "futures-lite 2.3.0",
  "parking",
- "polling 3.6.0",
- "rustix 0.38.40",
+ "polling",
+ "rustix",
  "slab",
  "tracing",
  "windows-sys 0.52.0",
@@ -354,19 +334,21 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "1.8.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88"
+checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
 dependencies = [
- "async-io 1.13.0",
- "async-lock 2.8.0",
+ "async-channel 2.2.0",
+ "async-io",
+ "async-lock 3.3.0",
  "async-signal",
+ "async-task",
  "blocking",
  "cfg-if",
- "event-listener 3.1.0",
- "futures-lite 1.13.0",
- "rustix 0.38.40",
- "windows-sys 0.48.0",
+ "event-listener 5.3.1",
+ "futures-lite 2.3.0",
+ "rustix",
+ "tracing",
 ]
 
 [[package]]
@@ -375,13 +357,13 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5"
 dependencies = [
- "async-io 2.3.2",
+ "async-io",
  "async-lock 2.8.0",
  "atomic-waker",
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.40",
+ "rustix",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.48.0",
@@ -389,20 +371,20 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
+checksum = "c634475f29802fde2b8f0b505b1bd00dfe4df7d4a000f0b36f7671197d5c3615"
 dependencies = [
  "async-channel 1.9.0",
  "async-global-executor",
- "async-io 1.13.0",
- "async-lock 2.8.0",
+ "async-io",
+ "async-lock 3.3.0",
  "async-process",
  "crossbeam-utils",
  "futures-channel",
  "futures-core",
  "futures-io",
- "futures-lite 1.13.0",
+ "futures-lite 2.3.0",
  "gloo-timers",
  "kv-log-macro",
  "log",
@@ -1610,17 +1592,6 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
@@ -2029,9 +2000,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2461,7 +2432,7 @@ dependencies = [
  "http-body",
  "hyper",
  "pin-project-lite",
- "socket2 0.5.6",
+ "socket2",
  "tokio",
  "tower",
  "tower-service",
@@ -2689,17 +2660,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3374,12 +3334,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
@@ -3718,23 +3672,23 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "opentelemetry"
-version = "0.24.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c365a63eec4f55b7efeceb724f1336f26a9cf3427b70e59e2cd2a5b947fba96"
+checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
- "once_cell",
  "pin-project-lite",
  "thiserror 1.0.69",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.17.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b925a602ffb916fb7421276b86756027b37ee708f9dce2dbdcc51739f07e727"
+checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
 dependencies = [
  "async-trait",
  "futures-core",
@@ -3750,22 +3704,23 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-prometheus"
-version = "0.17.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4191ce34aa274621861a7a9d68dbcf618d5b6c66b10081631b61fd81fbc015"
+checksum = "1b834e966ea5e2d03dfe5f2253f03d22cce21403ee940265070eeee96cee0bcc"
 dependencies = [
  "once_cell",
  "opentelemetry",
  "opentelemetry_sdk",
  "prometheus",
  "protobuf",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.7.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ee9f20bff9c984511a02f082dc8ede839e4a9bf15cc2487c8d6fea5ad850d9"
+checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -3775,15 +3730,15 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.16.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cefe0543875379e47eb5f1e68ff83f45cc41366a92dfd0d073d513bf68e9a05"
+checksum = "bc1b6902ff63b32ef6c489e8048c5e253e2e4a803ea3ea7e783914536eb15c52"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.24.1"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692eac490ec80f24a17828d49b40b60f5aeaccdfe6a503f939713afd22bc28df"
+checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3791,7 +3746,6 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "glob",
- "once_cell",
  "opentelemetry",
  "percent-encoding",
  "rand",
@@ -4089,22 +4043,6 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "polling"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
-dependencies = [
- "autocfg",
- "bitflags 1.3.2",
- "cfg-if",
- "concurrent-queue",
- "libc",
- "log",
- "pin-project-lite",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "polling"
 version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c976a60b2d7e99d6f229e414670a9b85d13ac305cc6d1e9c134de58c5aaaf6"
@@ -4113,7 +4051,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 0.38.40",
+ "rustix",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -4465,7 +4403,7 @@ checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
 dependencies = [
  "libc",
  "once_cell",
- "socket2 0.5.6",
+ "socket2",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -4783,20 +4721,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.3.8",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "rustix"
 version = "0.38.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
@@ -4804,7 +4728,7 @@ dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.14",
+ "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
 
@@ -5336,16 +5260,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
@@ -5720,7 +5634,7 @@ dependencies = [
  "fastrand 2.1.1",
  "getrandom",
  "once_cell",
- "rustix 0.38.40",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -5871,7 +5785,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.6",
+ "socket2",
  "tokio-macros",
  "tracing",
  "windows-sys 0.52.0",
@@ -5908,7 +5822,7 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "rand",
- "socket2 0.5.6",
+ "socket2",
  "tokio",
  "tokio-util",
  "whoami",
@@ -6039,7 +5953,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "socket2 0.5.6",
+ "socket2",
  "tokio",
  "tokio-stream",
  "tower",
@@ -6156,9 +6070,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.25.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9784ed4da7d921bc8df6963f8c80a0e4ce34ba6ba76668acadd3edbd985ff3b"
+checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
 dependencies = [
  "js-sys",
  "once_cell",
@@ -6344,9 +6258,9 @@ dependencies = [
 
 [[package]]
 name = "trillium-opentelemetry"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "369989011133b91f356bc790cfda4eae9243ffd33929dfb067fb135a728f88af"
+checksum = "3b5e36d8e79ad6b8858715b9342b4d761d936dcd884f5680ecfb15c0076fa46a"
 dependencies = [
  "opentelemetry",
  "opentelemetry-semantic-conventions",
@@ -6802,7 +6716,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.40",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,10 +65,10 @@ kube = { version = "0.94.2", default-features = false, features = ["client", "ru
 mockito = "1.6.1"
 num_enum = "0.7.3"
 ohttp = { version = "0.5.1", default-features = false }
-opentelemetry = { version = "0.24", default-features = false, features = ["trace", "metrics"] }
-opentelemetry-otlp = { version = "0.17", default-features = false, features = ["trace", "metrics", "grpc-tonic"] }
-opentelemetry-prometheus = "0.17"
-opentelemetry_sdk = { version = "0.24", default-features = false, features = ["trace", "metrics"] }
+opentelemetry = { version = "0.27", default-features = false, features = ["trace", "metrics"] }
+opentelemetry-otlp = { version = "0.27", default-features = false, features = ["trace", "metrics", "grpc-tonic"] }
+opentelemetry-prometheus = "0.27"
+opentelemetry_sdk = { version = "0.27", default-features = false, features = ["trace", "metrics"] }
 pem = "3"
 postgres-protocol = "0.6.7"
 postgres-types = "0.2.8"
@@ -108,7 +108,7 @@ thiserror = "2.0"
 tracing = "0.1.41"
 tracing-chrome = "0.7.2"
 tracing-log = "0.2.0"
-tracing-opentelemetry = "0.25"
+tracing-opentelemetry = "0.28"
 tracing-stackdriver = "0.10.0"
 tracing-subscriber = "0.3"
 tokio = { version = "1.43", features = ["full", "tracing"] }
@@ -120,7 +120,7 @@ trillium-api = { version = "0.2.0-rc.12", default-features = false }
 trillium-caching-headers = "0.2.3"
 trillium-head = "0.2.3"
 trillium-macros = "0.0.6"
-trillium-opentelemetry = "0.9.0"
+trillium-opentelemetry = "0.10.0"
 trillium-prometheus = "0.2.0"
 trillium-proxy = { version = "0.5.5", default-features = false }
 trillium-router = "0.4.1"

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -18,12 +18,10 @@ fpvec_bounded_l2 = ["dep:fixed", "janus_core/fpvec_bounded_l2"]
 tokio-console = ["dep:console-subscriber"]
 otlp = [
     "dep:opentelemetry-otlp",
-    "dep:opentelemetry_sdk",
     "dep:tracing-opentelemetry",
 ]
 prometheus = [
     "dep:opentelemetry-prometheus",
-    "dep:opentelemetry_sdk",
     "dep:prometheus",
     "dep:trillium-prometheus",
 ]
@@ -66,7 +64,7 @@ moka = { version = "0.12.10", features = ["future"] }
 opentelemetry.workspace = true
 opentelemetry-otlp = { workspace = true, features = ["metrics"], optional = true }
 opentelemetry-prometheus = { workspace = true, optional = true }
-opentelemetry_sdk = { workspace = true, features = ["rt-tokio"], optional = true }
+opentelemetry_sdk = { workspace = true, features = ["rt-tokio"] }
 pem.workspace = true
 postgres-protocol = { workspace = true }
 postgres-types = { workspace = true, features = ["derive", "array-impls"] }

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -293,7 +293,7 @@ impl<C: Clock> Aggregator<C> {
                 "Number of decryption failures in the tasks/{task-id}/reports endpoint.",
             )
             .with_unit("{error}")
-            .init();
+            .build();
         upload_decrypt_failure_counter.add(0, &[]);
 
         let upload_decode_failure_counter = meter
@@ -302,7 +302,7 @@ impl<C: Clock> Aggregator<C> {
                 "Number of message decode failures in the tasks/{task-id}/reports endpoint.",
             )
             .with_unit("{error}")
-            .init();
+            .build();
         upload_decode_failure_counter.add(0, &[]);
 
         let report_aggregation_success_counter = report_aggregation_success_counter(meter);

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -21,6 +21,7 @@ use janus_aggregator_core::{
         Datastore,
     },
     task::{self, AggregatorTask},
+    TIME_HISTOGRAM_BOUNDARIES,
 };
 #[cfg(feature = "fpvec_bounded_l2")]
 use janus_core::vdaf::Prio3FixedPointBoundedL2VecSumBitSize;
@@ -128,13 +129,15 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
             .f64_histogram("janus_task_update_time")
             .with_description("Time spent updating tasks.")
             .with_unit("s")
-            .init();
+            .with_boundaries(TIME_HISTOGRAM_BOUNDARIES.to_vec())
+            .build();
         let job_creation_time_histogram = self
             .meter
             .f64_histogram("janus_job_creation_time")
             .with_description("Time spent creating aggregation jobs.")
             .with_unit("s")
-            .init();
+            .with_boundaries(TIME_HISTOGRAM_BOUNDARIES.to_vec())
+            .build();
 
         // Set up an interval to occasionally update our view of tasks in the DB.
         // (This will fire immediately, so we'll immediately load tasks from the DB when we enter

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -29,6 +29,7 @@ use janus_aggregator_core::{
         Datastore,
     },
     task::{self, AggregatorTask, VerifyKey},
+    TIME_HISTOGRAM_BOUNDARIES,
 };
 use janus_core::{
     retries::{is_retryable_http_client_error, is_retryable_http_status},
@@ -111,14 +112,14 @@ where
             .u64_counter("janus_job_cancellations")
             .with_description("Count of cancelled jobs.")
             .with_unit("{job}")
-            .init();
+            .build();
         job_cancel_counter.add(0, &[]);
 
         let job_retry_counter = meter
             .u64_counter("janus_job_retries")
             .with_description("Count of retried job steps.")
             .with_unit("{step}")
-            .init();
+            .build();
         job_retry_counter.add(0, &[]);
 
         let http_request_duration_histogram = meter
@@ -127,7 +128,8 @@ where
                 "The amount of time elapsed while making an HTTP request to a helper.",
             )
             .with_unit("s")
-            .init();
+            .with_boundaries(TIME_HISTOGRAM_BOUNDARIES.to_vec())
+            .build();
 
         Self {
             batch_aggregation_shard_count,

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -16,7 +16,7 @@ use janus_aggregator_core::{
         models::{AcquiredCollectionJob, BatchAggregation, CollectionJobState, Lease},
         Datastore,
     },
-    task,
+    task, TIME_HISTOGRAM_BOUNDARIES,
 };
 use janus_core::{
     retries::{is_retryable_http_client_error, is_retryable_http_status},
@@ -666,7 +666,7 @@ impl CollectionJobDriverMetrics {
             .u64_counter("janus_collection_jobs_finished")
             .with_description("Count of finished collection jobs.")
             .with_unit("{job}")
-            .init();
+            .build();
         jobs_finished_counter.add(0, &[]);
 
         let http_request_duration_histogram = meter
@@ -675,13 +675,14 @@ impl CollectionJobDriverMetrics {
                 "The amount of time elapsed while making an HTTP request to a helper.",
             )
             .with_unit("s")
-            .init();
+            .with_boundaries(TIME_HISTOGRAM_BOUNDARIES.to_vec())
+            .build();
 
         let jobs_abandoned_counter = meter
             .u64_counter("janus_collection_jobs_abandoned")
             .with_description("Count of abandoned collection jobs.")
             .with_unit("{job}")
-            .init();
+            .build();
         jobs_abandoned_counter.add(0, &[]);
 
         let deleted_jobs_encountered_counter = meter
@@ -691,7 +692,7 @@ impl CollectionJobDriverMetrics {
                  deleted.",
             )
             .with_unit("{job}")
-            .init();
+            .build();
         deleted_jobs_encountered_counter.add(0, &[]);
 
         let unexpected_job_state_counter = meter
@@ -701,14 +702,14 @@ impl CollectionJobDriverMetrics {
                  state.",
             )
             .with_unit("{job}")
-            .init();
+            .build();
         unexpected_job_state_counter.add(0, &[]);
 
         let job_steps_retried_counter = meter
             .u64_counter("janus_job_retries")
             .with_description("Count of retried job steps.")
             .with_unit("{step}")
-            .init();
+            .build();
         job_steps_retried_counter.add(0, &[]);
 
         Self {

--- a/aggregator/src/aggregator/garbage_collector.rs
+++ b/aggregator/src/aggregator/garbage_collector.rs
@@ -42,17 +42,17 @@ impl<C: Clock> GarbageCollector<C> {
             .u64_counter("janus_gc_deleted_reports")
             .with_description("Count of client reports deleted by the garbage collector.")
             .with_unit("{report}")
-            .init();
+            .build();
         let deleted_aggregation_job_counter = meter
             .u64_counter("janus_gc_deleted_aggregation_jobs")
             .with_description("Count of aggregation jobs deleted by the garbage collector.")
             .with_unit("{job}")
-            .init();
+            .build();
         let deleted_batch_counter = meter
             .u64_counter("janus_gc_deleted_batches")
             .with_description("Count of batches deleted by the garbage collector.")
             .with_unit("{batch}")
-            .init();
+            .build();
 
         deleted_report_counter.add(0, &[]);
         deleted_aggregation_job_counter.add(0, &[]);

--- a/aggregator/src/aggregator/http_handlers/tests/report.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/report.rs
@@ -7,7 +7,7 @@ use crate::{
         },
         test_util::{create_report, create_report_custom, default_aggregator_config},
     },
-    metrics::test_util::InMemoryMetricsInfrastructure,
+    metrics::test_util::InMemoryMetricInfrastructure,
 };
 use janus_aggregator_core::{
     datastore::test_util::{ephemeral_datastore, EphemeralDatastoreBuilder},
@@ -527,7 +527,7 @@ async fn upload_handler_error_fanout() {
 async fn upload_client_early_disconnect() {
     install_test_trace_subscriber();
 
-    let in_memory_metrics = InMemoryMetricsInfrastructure::new();
+    let in_memory_metrics = InMemoryMetricInfrastructure::new();
     let clock = MockClock::default();
     let ephemeral_datastore = ephemeral_datastore().await;
     let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);

--- a/aggregator/src/aggregator/problem_details.rs
+++ b/aggregator/src/aggregator/problem_details.rs
@@ -137,7 +137,7 @@ mod tests {
     use bytes::Bytes;
     use futures::future::join_all;
     use http::Method;
-    use janus_aggregator_core::test_util::noop_meter;
+    use janus_aggregator_core::{test_util::noop_meter, TIME_HISTOGRAM_BOUNDARIES};
     use janus_core::{
         retries::test_util::LimitedRetryer,
         time::{Clock, RealClock},
@@ -179,7 +179,8 @@ mod tests {
         let request_histogram = noop_meter()
             .f64_histogram("janus_http_request_duration")
             .with_unit("s")
-            .init();
+            .with_boundaries(TIME_HISTOGRAM_BOUNDARIES.to_vec())
+            .build();
 
         struct TestCase {
             error_factory: Box<dyn Fn() -> Error + Send + Sync>,

--- a/aggregator/src/binary_utils/job_driver.rs
+++ b/aggregator/src/binary_utils/job_driver.rs
@@ -2,7 +2,10 @@
 
 use anyhow::Context as _;
 use chrono::NaiveDateTime;
-use janus_aggregator_core::datastore::{self, models::Lease};
+use janus_aggregator_core::{
+    datastore::{self, models::Lease},
+    TIME_HISTOGRAM_BOUNDARIES,
+};
 use janus_core::{time::Clock, Runtime};
 use opentelemetry::{metrics::Meter, KeyValue};
 use rand::{thread_rng, Rng};
@@ -101,13 +104,15 @@ where
             .f64_histogram("janus_job_acquire_time")
             .with_description("Time spent acquiring jobs.")
             .with_unit("s")
-            .init();
+            .with_boundaries(TIME_HISTOGRAM_BOUNDARIES.to_vec())
+            .build();
         let job_step_time_histogram = self
             .meter
             .f64_histogram("janus_job_step_time")
             .with_description("Time spent stepping jobs.")
             .with_unit("s")
-            .init();
+            .with_boundaries(TIME_HISTOGRAM_BOUNDARIES.to_vec())
+            .build();
 
         // Set up state for the job driver run.
         let sem = Arc::new(Semaphore::new(self.max_concurrent_job_workers));

--- a/aggregator/src/config.rs
+++ b/aggregator/src/config.rs
@@ -323,7 +323,7 @@ mod tests {
             test_util::{generate_db_config, generate_metrics_config, generate_trace_config},
             CommonConfig, DbConfig, JobDriverConfig,
         },
-        metrics::{MetricsExporterConfiguration, PollTimeHistogramConfiguration},
+        metrics::MetricsExporterConfiguration,
         trace::OpenTelemetryTraceConfiguration,
     };
     use assert_matches::assert_matches;
@@ -427,23 +427,9 @@ metrics_config:
       port: 9464
   tokio:
     enabled: true
-    enable_poll_time_histogram: true
-    poll_time_histogram: !log
-      min_value_us: 100
-      max_value_us: 3000000
-      max_relative_error: 0.25
 ";
         let config: CommonConfig = serde_yaml::from_str(input).unwrap();
         let tokio_config = config.metrics_config.tokio.unwrap();
         assert!(tokio_config.enabled);
-        assert!(tokio_config.enable_poll_time_histogram);
-        assert_eq!(
-            tokio_config.poll_time_histogram,
-            PollTimeHistogramConfiguration::Log {
-                min_value_us: Some(100),
-                max_value_us: Some(3_000_000),
-                max_relative_error: Some(0.25),
-            }
-        );
     }
 }

--- a/aggregator/src/metrics/test_util.rs
+++ b/aggregator/src/metrics/test_util.rs
@@ -4,29 +4,29 @@ use opentelemetry::metrics::{Meter, MeterProvider};
 use opentelemetry_sdk::{
     metrics::{data::Metric, PeriodicReader, SdkMeterProvider},
     runtime,
-    testing::metrics::InMemoryMetricsExporter,
+    testing::metrics::InMemoryMetricExporter,
 };
 use tokio::task::spawn_blocking;
 
 #[derive(Clone)]
-pub(crate) struct InMemoryMetricsInfrastructure {
-    /// The in-memory metrics exporter
-    pub exporter: InMemoryMetricsExporter,
+pub(crate) struct InMemoryMetricInfrastructure {
+    /// The in-memory metric exporter
+    pub exporter: InMemoryMetricExporter,
     /// The meter provider.
     pub meter_provider: SdkMeterProvider,
     /// A meter, with the name "test".
     pub meter: Meter,
 }
 
-impl InMemoryMetricsInfrastructure {
-    /// Create an [`InMemoryMetricsExporter`], then use it to create an [`SdkMeterProvider`] and
+impl InMemoryMetricInfrastructure {
+    /// Create an [`InMemoryMetricExporter`], then use it to create an [`SdkMeterProvider`] and
     /// [`Meter`].
-    pub(crate) fn new() -> InMemoryMetricsInfrastructure {
-        let exporter = InMemoryMetricsExporter::default();
+    pub(crate) fn new() -> InMemoryMetricInfrastructure {
+        let exporter = InMemoryMetricExporter::default();
         let reader = PeriodicReader::builder(exporter.clone(), runtime::Tokio).build();
         let meter_provider = SdkMeterProvider::builder().with_reader(reader).build();
         let meter = meter_provider.meter("test");
-        InMemoryMetricsInfrastructure {
+        InMemoryMetricInfrastructure {
             exporter,
             meter_provider,
             meter,

--- a/aggregator/src/metrics/tokio_runtime.rs
+++ b/aggregator/src/metrics/tokio_runtime.rs
@@ -1,619 +1,305 @@
 #[cfg(tokio_unstable)]
 use std::time::Duration;
-use std::time::SystemTime;
-
-use educe::Educe;
-use opentelemetry::{metrics::MetricsError, InstrumentationLibrary, KeyValue};
-#[cfg(tokio_unstable)]
-use opentelemetry_sdk::metrics::data::{Histogram, HistogramDataPoint, Sum, Temporality};
-use opentelemetry_sdk::metrics::{
-    data::{DataPoint, Gauge, Metric, ScopeMetrics},
-    reader::MetricProducer,
-};
-use tokio::runtime::{self, RuntimeMetrics};
-#[cfg(tokio_unstable)]
-use tokio::runtime::{HistogramConfiguration, LogHistogram};
 
 #[cfg(tokio_unstable)]
-use crate::metrics::PollTimeHistogramConfiguration;
-use crate::metrics::TokioMetricsConfiguration;
+use opentelemetry::metrics::Meter;
+use opentelemetry::{metrics::MeterProvider, KeyValue};
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+use tokio::runtime::RuntimeMetrics;
 
-pub(crate) fn configure_runtime(
-    _runtime_builder: &mut runtime::Builder,
-    _config: &TokioMetricsConfiguration,
-) {
-    #[cfg(tokio_unstable)]
-    if _config.enable_poll_time_histogram {
-        _runtime_builder.enable_metrics_poll_time_histogram();
-        match _config.poll_time_histogram {
-            PollTimeHistogramConfiguration::Linear {
-                resolution_us,
-                num_buckets,
-            } => {
-                _runtime_builder.metrics_poll_time_histogram_configuration(
-                    HistogramConfiguration::linear(
-                        Duration::from_micros(resolution_us),
-                        num_buckets,
-                    ),
-                );
-            }
-            PollTimeHistogramConfiguration::Log {
-                min_value_us,
-                max_value_us,
-                max_relative_error,
-            } => {
-                let mut histogram_builder = LogHistogram::builder();
-                if let Some(min_value_us) = min_value_us {
-                    let min_value = Duration::from_micros(min_value_us);
-                    histogram_builder = histogram_builder.min_value(min_value);
-                }
-                if let Some(max_value_us) = max_value_us {
-                    let max_value = Duration::from_micros(max_value_us);
-                    histogram_builder = histogram_builder.max_value(max_value);
-                }
-                if let Some(max_relative_error) = max_relative_error {
-                    histogram_builder = histogram_builder.max_error(max_relative_error);
-                }
-                _runtime_builder.metrics_poll_time_histogram_configuration(
-                    HistogramConfiguration::log(histogram_builder.build()),
-                );
-            }
-        }
-    }
-}
+pub(super) fn initialize(runtime_metrics: RuntimeMetrics, meter_provider: &SdkMeterProvider) {
+    let meter = meter_provider.meter("tokio-runtime-metrics");
 
-#[derive(Educe)]
-#[educe(Debug)]
-pub(super) struct TokioRuntimeMetrics {
-    runtime_metrics: RuntimeMetrics,
+    let num_workers = runtime_metrics.num_workers();
 
-    #[educe(Debug(ignore))]
-    scope: InstrumentationLibrary,
-
-    #[educe(Debug(ignore))]
-    start_time: SystemTime,
-
-    num_workers: usize,
-
-    #[educe(Debug(ignore))]
-    attributes_global_queue: Vec<KeyValue>,
-
-    #[cfg(tokio_unstable)]
-    unstable: UnstableTokioRuntimeMetrics,
-}
-
-#[cfg(tokio_unstable)]
-#[derive(Educe)]
-#[educe(Debug)]
-struct UnstableTokioRuntimeMetrics {
-    poll_time_histogram_num_buckets: usize,
-
-    poll_time_histogram_bucket_bounds: Vec<f64>,
-
-    #[educe(Debug(ignore))]
-    attributes_local: Vec<KeyValue>,
-
-    #[educe(Debug(ignore))]
-    attributes_local_overflow: Vec<KeyValue>,
-
-    #[educe(Debug(ignore))]
-    attributes_remote: Vec<KeyValue>,
-
-    #[educe(Debug(ignore))]
-    attributes_local_queue_worker: Vec<Vec<KeyValue>>,
-
-    #[educe(Debug(ignore))]
-    attributes_blocking_queue: Vec<KeyValue>,
-}
-
-impl TokioRuntimeMetrics {
-    pub(super) fn new(runtime_metrics: RuntimeMetrics) -> Self {
-        let scope = InstrumentationLibrary::builder("tokio-runtime-metrics").build();
-
-        let start_time = SystemTime::now();
-
-        let num_workers = runtime_metrics.num_workers();
-        let attributes_global_queue = Vec::from([KeyValue::new("queue", "global")].as_slice());
-
-        #[cfg(tokio_unstable)]
-        let unstable = {
-            let poll_time_histogram_enabled = runtime_metrics.poll_time_histogram_enabled();
-            let poll_time_histogram_num_buckets = runtime_metrics.poll_time_histogram_num_buckets();
-            let all_but_last_bucket = if poll_time_histogram_enabled {
-                0..poll_time_histogram_num_buckets - 1
-            } else {
-                0..0
-            };
-            let poll_time_histogram_bucket_bounds = all_but_last_bucket
-                .map(|bucket| {
-                    runtime_metrics
-                        .poll_time_histogram_bucket_range(bucket)
-                        .end
-                        .as_secs_f64()
-                })
-                .collect();
-
-            let attributes_local = Vec::from([KeyValue::new("queue", "local")].as_slice());
-            let attributes_local_overflow =
-                Vec::from([KeyValue::new("queue", "local_overflow")].as_slice());
-            let attributes_remote = Vec::from([KeyValue::new("queue", "remote")].as_slice());
-            let attributes_local_queue_worker = (0..num_workers)
-                .map(|i| {
-                    Vec::from(
-                        [
-                            KeyValue::new("queue", "local"),
-                            KeyValue::new("worker", i64::try_from(i).unwrap()),
-                        ]
-                        .as_slice(),
-                    )
-                })
-                .collect();
-            let attributes_blocking_queue =
-                Vec::from([KeyValue::new("queue", "blocking")].as_slice());
-
-            UnstableTokioRuntimeMetrics {
-                poll_time_histogram_num_buckets,
-                poll_time_histogram_bucket_bounds,
-                attributes_local,
-                attributes_local_overflow,
-                attributes_remote,
-                attributes_local_queue_worker,
-                attributes_blocking_queue,
-            }
-        };
-
-        Self {
-            runtime_metrics,
-            scope,
-            start_time,
-            num_workers,
-            attributes_global_queue,
-            #[cfg(tokio_unstable)]
-            unstable,
-        }
-    }
-}
-
-impl MetricProducer for TokioRuntimeMetrics {
-    fn produce(&self) -> Result<ScopeMetrics, MetricsError> {
-        let now = SystemTime::now();
-
-        let mut metrics = Vec::with_capacity(19);
-        metrics.push(Metric {
-            name: "tokio.thread.worker.count".into(),
-            description: "Number of runtime worker threads".into(),
-            unit: "{thread}".into(),
-            data: Box::new(Gauge::<u64> {
-                data_points: Vec::from([DataPoint {
-                    attributes: Vec::default(),
-                    start_time: Some(self.start_time),
-                    time: Some(now),
-                    value: u64::try_from(self.num_workers).unwrap_or(u64::MAX),
-                    exemplars: Vec::new(),
-                }]),
-            }),
-        });
-
-        #[cfg(not(tokio_unstable))]
-        {
-            let global_queue_depth = self.runtime_metrics.global_queue_depth();
-            metrics.push(Metric {
-                name: "tokio.queue.depth".into(),
-                description: "Number of tasks currently in the runtime's global queue".into(),
-                unit: "{task}".into(),
-                data: Box::new(Gauge::<u64> {
-                    data_points: {
-                        let mut data_points = Vec::with_capacity(self.num_workers + 2);
-                        data_points.push(DataPoint {
-                            attributes: self.attributes_global_queue.clone(),
-                            start_time: Some(self.start_time),
-                            time: Some(now),
-                            value: u64::try_from(global_queue_depth).unwrap_or(u64::MAX),
-                            exemplars: Vec::new(),
-                        });
-                        data_points
-                    },
-                }),
-            });
-        }
-
-        #[cfg(tokio_unstable)]
-        self.produce_unstable_metrics(&mut metrics, now);
-
-        Ok(ScopeMetrics {
-            scope: self.scope.clone(),
-            metrics,
+    meter
+        .u64_observable_gauge("tokio.thread.worker.count")
+        .with_description("Number of runtime worker threads")
+        .with_unit("{thread}")
+        .with_callback({
+            let num_workers_u64 = u64::try_from(num_workers).unwrap_or(u64::MAX);
+            move |observer| observer.observe(num_workers_u64, &[])
         })
-    }
+        .build();
+
+    #[cfg(not(tokio_unstable))]
+    meter
+        .u64_observable_gauge("tokio.queue.depth")
+        .with_description("Number of tasks currently in the runtime's global queue")
+        .with_unit("{task}")
+        .with_callback({
+            let runtime_metrics = runtime_metrics.clone();
+            move |observer| {
+                observer.observe(
+                    u64::try_from(runtime_metrics.global_queue_depth()).unwrap_or(u64::MAX),
+                    &[KeyValue::new("queue", "global")],
+                )
+            }
+        })
+        .build();
+
+    #[cfg(tokio_unstable)]
+    initialize_unstable_metrics(runtime_metrics, meter);
 }
 
 #[cfg(tokio_unstable)]
-impl TokioRuntimeMetrics {
-    fn produce_unstable_metrics(&self, metrics: &mut Vec<Metric>, now: SystemTime) {
-        let num_blocking_threads = self.runtime_metrics.num_blocking_threads();
-        let num_alive_tasks = self.runtime_metrics.num_alive_tasks();
-        let num_idle_blocking_threads = self.runtime_metrics.num_idle_blocking_threads();
-        let spawned_task_count = self.runtime_metrics.spawned_tasks_count();
-        let remote_schedule_count = self.runtime_metrics.remote_schedule_count();
-        let budget_forced_yield_count = self.runtime_metrics.budget_forced_yield_count();
-        let global_queue_depth = self.runtime_metrics.global_queue_depth();
-        let blocking_queue_depth = self.runtime_metrics.blocking_queue_depth();
-        let io_driver_fd_registered_count = self.runtime_metrics.io_driver_fd_registered_count();
-        let io_driver_fd_deregistered_count =
-            self.runtime_metrics.io_driver_fd_deregistered_count();
-        let io_driver_ready_count = self.runtime_metrics.io_driver_ready_count();
+fn initialize_unstable_metrics(runtime_metrics: RuntimeMetrics, meter: Meter) {
+    let num_workers = runtime_metrics.num_workers();
 
-        let mut park_count = 0;
-        let mut noop_count = 0;
-        let mut steal_count = 0;
-        let mut steal_operations = 0;
-        let mut poll_count = 0;
-        let mut total_busy_duration = Duration::from_secs(0);
-        let mut local_schedule_count = 0;
-        let mut overflow_count = 0;
-        let mut local_queue_depth = vec![0; self.num_workers];
-        let mut poll_time_histogram_bucket_count =
-            vec![0; self.unstable.poll_time_histogram_num_buckets];
-        let mut worker_mean_poll_time_sum = Duration::from_secs(0);
-        for (worker, worker_local_queue_depth) in local_queue_depth.iter_mut().enumerate() {
-            park_count += self.runtime_metrics.worker_park_count(worker);
-            noop_count += self.runtime_metrics.worker_noop_count(worker);
-            steal_count += self.runtime_metrics.worker_steal_count(worker);
-            steal_operations += self.runtime_metrics.worker_steal_operations(worker);
-            poll_count += self.runtime_metrics.worker_poll_count(worker);
-            total_busy_duration += self.runtime_metrics.worker_total_busy_duration(worker);
-            local_schedule_count += self.runtime_metrics.worker_local_schedule_count(worker);
-            overflow_count += self.runtime_metrics.worker_overflow_count(worker);
-
-            *worker_local_queue_depth = self.runtime_metrics.worker_local_queue_depth(worker);
-
-            for (bucket, out) in poll_time_histogram_bucket_count.iter_mut().enumerate() {
-                *out += self
-                    .runtime_metrics
-                    .poll_time_histogram_bucket_count(worker, bucket);
+    meter
+        .u64_observable_gauge("tokio.thread.blocking.count")
+        .with_description(
+            "Number of additional threads spawned by the runtime for blocking operations",
+        )
+        .with_unit("{thread}")
+        .with_callback({
+            let runtime_metrics = runtime_metrics.clone();
+            move |observer| {
+                observer.observe(
+                    u64::try_from(runtime_metrics.num_blocking_threads()).unwrap_or(u64::MAX),
+                    &[],
+                )
             }
+        })
+        .build();
 
-            worker_mean_poll_time_sum += self.runtime_metrics.worker_mean_poll_time(worker);
-        }
-        let mean_poll_time = worker_mean_poll_time_sum / u32::try_from(self.num_workers).unwrap();
+    meter
+        .u64_observable_gauge("tokio.task.alive.count")
+        .with_description("Number of alive tasks in the runtime")
+        .with_unit("{task}")
+        .with_callback({
+            let runtime_metrics = runtime_metrics.clone();
+            move |observer| {
+                observer.observe(
+                    u64::try_from(runtime_metrics.num_alive_tasks()).unwrap_or(u64::MAX),
+                    &[],
+                )
+            }
+        })
+        .build();
 
-        metrics.extend([
-            Metric {
-                name: "tokio.thread.blocking.count".into(),
-                description: "Number of additional threads spawned by the runtime for blocking \
-                              operations"
-                    .into(),
-                unit: "{thread}".into(),
-                data: Box::new(Gauge::<u64> {
-                    data_points: Vec::from([DataPoint {
-                        attributes: Vec::new(),
-                        start_time: Some(self.start_time),
-                        time: Some(now),
-                        value: u64::try_from(num_blocking_threads).unwrap_or(u64::MAX),
-                        exemplars: Vec::new(),
-                    }]),
-                }),
-            },
-            Metric {
-                name: "tokio.task.alive.count".into(),
-                description: "Number of alive tasks in the runtime".into(),
-                unit: "{task}".into(),
-                data: Box::new(Gauge::<u64> {
-                    data_points: Vec::from([DataPoint {
-                        attributes: Vec::new(),
-                        start_time: Some(self.start_time),
-                        time: Some(now),
-                        value: u64::try_from(num_alive_tasks).unwrap_or(u64::MAX),
-                        exemplars: Vec::new(),
-                    }]),
-                }),
-            },
-            Metric {
-                name: "tokio.thread.blocking.idle.count".into(),
-                description: "Number of additional threads for blocking operations which are idle"
-                    .into(),
-                unit: "{thread}".into(),
-                data: Box::new(Gauge::<u64> {
-                    data_points: Vec::from([DataPoint {
-                        attributes: Vec::new(),
-                        start_time: Some(self.start_time),
-                        time: Some(now),
-                        value: u64::try_from(num_idle_blocking_threads).unwrap_or(u64::MAX),
-                        exemplars: Vec::new(),
-                    }]),
-                }),
-            },
-            Metric {
-                name: "tokio.task.spawned".into(),
-                description: "Total number of tasks spawned in the runtime".into(),
-                unit: "{task}".into(),
-                data: Box::new(Sum::<u64> {
-                    data_points: Vec::from([DataPoint {
-                        attributes: Vec::new(),
-                        start_time: Some(self.start_time),
-                        time: Some(now),
-                        value: spawned_task_count,
-                        exemplars: Vec::new(),
-                    }]),
-                    temporality: Temporality::Cumulative,
-                    is_monotonic: true,
-                }),
-            },
-            Metric {
-                name: "tokio.task.scheduled".into(),
-                description: "Number of tasks scheduled, either to the thread's own local queue, \
-                              from a worker thread to the global queue due to overflow, or \
-                              from a remote thread to the global queue"
-                    .into(),
-                unit: "{task}".into(),
-                data: Box::new(Sum::<u64> {
-                    data_points: Vec::from([
-                        DataPoint {
-                            attributes: self.unstable.attributes_local.clone(),
-                            start_time: Some(self.start_time),
-                            time: Some(now),
-                            value: local_schedule_count,
-                            exemplars: Vec::new(),
-                        },
-                        DataPoint {
-                            attributes: self.unstable.attributes_local_overflow.clone(),
-                            start_time: Some(self.start_time),
-                            time: Some(now),
-                            value: overflow_count,
-                            exemplars: Vec::new(),
-                        },
-                        DataPoint {
-                            attributes: self.unstable.attributes_remote.clone(),
-                            start_time: Some(self.start_time),
-                            time: Some(now),
-                            value: remote_schedule_count,
-                            exemplars: Vec::new(),
-                        },
-                    ]),
-                    temporality: Temporality::Cumulative,
-                    is_monotonic: true,
-                }),
-            },
-            Metric {
-                name: "tokio.task.budget_forced_yield".into(),
-                description: "Number of times tasks have been forced to yield because their task \
-                              budget was exhausted"
-                    .into(),
-                unit: "".into(),
-                data: Box::new(Sum::<u64> {
-                    data_points: Vec::from([DataPoint {
-                        attributes: Vec::new(),
-                        start_time: Some(self.start_time),
-                        time: Some(now),
-                        value: budget_forced_yield_count,
-                        exemplars: Vec::new(),
-                    }]),
-                    temporality: Temporality::Cumulative,
-                    is_monotonic: true,
-                }),
-            },
-            Metric {
-                name: "tokio.park".into(),
-                description: "Total number of times worker threads have parked".into(),
-                unit: "".into(),
-                data: Box::new(Sum::<u64> {
-                    data_points: Vec::from([DataPoint {
-                        attributes: Vec::new(),
-                        start_time: Some(self.start_time),
-                        time: Some(now),
-                        value: park_count,
-                        exemplars: Vec::new(),
-                    }]),
-                    temporality: Temporality::Cumulative,
-                    is_monotonic: true,
-                }),
-            },
-            Metric {
-                name: "tokio.noop".into(),
-                description: "Total number of times worker threads unparked and parked again \
-                              without doing any work"
-                    .into(),
-                unit: "".into(),
-                data: Box::new(Sum::<u64> {
-                    data_points: Vec::from([DataPoint {
-                        attributes: Vec::new(),
-                        start_time: Some(self.start_time),
-                        time: Some(now),
-                        value: noop_count,
-                        exemplars: Vec::new(),
-                    }]),
-                    temporality: Temporality::Cumulative,
-                    is_monotonic: true,
-                }),
-            },
-            Metric {
-                name: "tokio.task.stolen".into(),
-                description: "Total number of tasks stolen between worker threads".into(),
-                unit: "{task}".into(),
-                data: Box::new(Sum::<u64> {
-                    data_points: Vec::from([DataPoint {
-                        attributes: Vec::new(),
-                        start_time: Some(self.start_time),
-                        time: Some(now),
-                        value: steal_count,
-                        exemplars: Vec::new(),
-                    }]),
-                    temporality: Temporality::Cumulative,
-                    is_monotonic: true,
-                }),
-            },
-            Metric {
-                name: "tokio.steals".into(),
-                description: "Number of times worker threads successfully stole one or more tasks"
-                    .into(),
-                unit: "{operation}".into(),
-                data: Box::new(Sum::<u64> {
-                    data_points: Vec::from([DataPoint {
-                        attributes: Vec::new(),
-                        start_time: Some(self.start_time),
-                        time: Some(now),
-                        value: steal_operations,
-                        exemplars: Vec::new(),
-                    }]),
-                    temporality: Temporality::Cumulative,
-                    is_monotonic: true,
-                }),
-            },
-            Metric {
-                name: "tokio.thread.worker.busy.time".into(),
-                description: "Total amount of time that all worker threads have been busy".into(),
-                unit: "s".into(),
-                data: Box::new(Sum::<f64> {
-                    data_points: Vec::from([DataPoint {
-                        attributes: Vec::new(),
-                        start_time: Some(self.start_time),
-                        time: Some(now),
-                        value: total_busy_duration.as_secs_f64(),
-                        exemplars: Vec::new(),
-                    }]),
-                    temporality: Temporality::Cumulative,
-                    is_monotonic: true,
-                }),
-            },
-            Metric {
-                name: "tokio.queue.depth".into(),
-                description: "Number of tasks currently in the runtime's global queue, \
-                              blocking thread pool queue, or a worker's local queue"
-                    .into(),
-                unit: "{task}".into(),
-                data: Box::new(Gauge::<u64> {
-                    data_points: {
-                        let mut data_points = Vec::with_capacity(self.num_workers + 2);
-                        data_points.extend(
-                            local_queue_depth
-                                .into_iter()
-                                .zip(self.unstable.attributes_local_queue_worker.iter())
-                                .map(|(worker_local_queue_depth, attributes)| DataPoint {
-                                    attributes: attributes.clone(),
-                                    start_time: Some(self.start_time),
-                                    time: Some(now),
-                                    value: u64::try_from(worker_local_queue_depth)
-                                        .unwrap_or(u64::MAX),
-                                    exemplars: Vec::new(),
-                                }),
-                        );
-                        data_points.push(DataPoint {
-                            attributes: self.attributes_global_queue.clone(),
-                            start_time: Some(self.start_time),
-                            time: Some(now),
-                            value: u64::try_from(global_queue_depth).unwrap_or(u64::MAX),
-                            exemplars: Vec::new(),
-                        });
-                        data_points.push(DataPoint {
-                            attributes: self.unstable.attributes_blocking_queue.clone(),
-                            start_time: Some(self.start_time),
-                            time: Some(now),
-                            value: u64::try_from(blocking_queue_depth).unwrap_or(u64::MAX),
-                            exemplars: Vec::new(),
-                        });
-                        data_points
-                    },
-                }),
-            },
-            Metric {
-                name: "tokio.task.poll.time".into(),
-                description: "Histogram of task poll times".into(),
-                unit: "s".into(),
-                data: Box::new(Histogram::<f64> {
-                    data_points: Vec::from([HistogramDataPoint {
-                        attributes: Vec::new(),
-                        start_time: self.start_time,
-                        time: now,
-                        count: poll_count,
-                        bounds: self.unstable.poll_time_histogram_bucket_bounds.clone(),
-                        bucket_counts: poll_time_histogram_bucket_count,
-                        min: Some(f64::NAN),
-                        max: Some(f64::NAN),
-                        sum: f64::NAN,
-                        exemplars: Vec::new(),
-                    }]),
-                    temporality: Temporality::Cumulative,
-                }),
-            },
-            Metric {
-                name: "tokio.task.poll.time.average".into(),
-                description: "Exponentially weighted moving average of task poll times".into(),
-                unit: "s".into(),
-                data: Box::new(Gauge::<f64> {
-                    data_points: Vec::from([DataPoint {
-                        attributes: Vec::new(),
-                        start_time: Some(self.start_time),
-                        time: Some(now),
-                        value: mean_poll_time.as_secs_f64(),
-                        exemplars: Vec::new(),
-                    }]),
-                }),
-            },
-            Metric {
-                name: "tokio.io.fd.count".into(),
-                description: "Number of file descriptors currently registered with the I/O driver"
-                    .into(),
-                unit: "{fd}".into(),
-                data: Box::new(Gauge::<u64> {
-                    data_points: Vec::from([DataPoint {
-                        attributes: Vec::new(),
-                        start_time: Some(self.start_time),
-                        time: Some(now),
-                        value: io_driver_fd_registered_count
-                            .saturating_sub(io_driver_fd_deregistered_count),
-                        exemplars: Vec::new(),
-                    }]),
-                }),
-            },
-            Metric {
-                name: "tokio.io.fd.registered".into(),
-                description: "Total number of file descriptors registered by the I/O driver".into(),
-                unit: "{fd}".into(),
-                data: Box::new(Sum::<u64> {
-                    data_points: Vec::from([DataPoint {
-                        attributes: Vec::new(),
-                        start_time: Some(self.start_time),
-                        time: Some(now),
-                        value: io_driver_fd_registered_count,
-                        exemplars: Vec::new(),
-                    }]),
-                    temporality: Temporality::Cumulative,
-                    is_monotonic: true,
-                }),
-            },
-            Metric {
-                name: "tokio.io.fd.deregistered".into(),
-                description: "Total number of file descriptors deregistered by the I/O driver"
-                    .into(),
-                unit: "{fd}".into(),
-                data: Box::new(Sum::<u64> {
-                    data_points: Vec::from([DataPoint {
-                        attributes: Vec::new(),
-                        start_time: Some(self.start_time),
-                        time: Some(now),
-                        value: io_driver_fd_deregistered_count,
-                        exemplars: Vec::new(),
-                    }]),
-                    temporality: Temporality::Cumulative,
-                    is_monotonic: true,
-                }),
-            },
-            Metric {
-                name: "tokio.io.ready_events".into(),
-                description: "Number of ready events processed by the I/O driver".into(),
-                unit: "{event}".into(),
-                data: Box::new(Sum::<u64> {
-                    data_points: Vec::from([DataPoint {
-                        attributes: Vec::new(),
-                        start_time: Some(self.start_time),
-                        time: Some(now),
-                        value: io_driver_ready_count,
-                        exemplars: Vec::new(),
-                    }]),
-                    temporality: Temporality::Cumulative,
-                    is_monotonic: true,
-                }),
-            },
-        ]);
-    }
+    meter
+        .u64_observable_gauge("tokio.thread.blocking.idle.count")
+        .with_description("Number of additional threads for blocking operations which are idle")
+        .with_unit("{thread}")
+        .with_callback({
+            let runtime_metrics = runtime_metrics.clone();
+            move |observer| {
+                observer.observe(
+                    u64::try_from(runtime_metrics.num_idle_blocking_threads()).unwrap_or(u64::MAX),
+                    &[],
+                )
+            }
+        })
+        .build();
+
+    meter
+        .u64_observable_counter("tokio.task.spawned")
+        .with_description("Total number of tasks spawned in the runtime")
+        .with_unit("{task}")
+        .with_callback({
+            let runtime_metrics = runtime_metrics.clone();
+            move |observer| observer.observe(runtime_metrics.spawned_tasks_count(), &[])
+        })
+        .build();
+
+    meter
+        .u64_observable_counter("tokio.task.scheduled")
+        .with_description(
+            "Number of tasks scheduled, either ot the thread's own local queue, \
+            from a worker thread to the global queue due to overflow, or \
+            from a remote thread to the global queue",
+        )
+        .with_unit("{task}")
+        .with_callback({
+            let runtime_metrics = runtime_metrics.clone();
+            move |observer| {
+                let remote_schedule_count = runtime_metrics.remote_schedule_count();
+
+                let mut local_schedule_count = 0;
+                let mut overflow_count = 0;
+                for worker in 0..num_workers {
+                    local_schedule_count += runtime_metrics.worker_local_schedule_count(worker);
+                    overflow_count += runtime_metrics.worker_overflow_count(worker);
+                }
+
+                observer.observe(local_schedule_count, &[KeyValue::new("queue", "local")]);
+                observer.observe(overflow_count, &[KeyValue::new("queue", "local_overflow")]);
+                observer.observe(remote_schedule_count, &[KeyValue::new("queue", "remote")]);
+            }
+        })
+        .build();
+
+    meter
+        .u64_observable_counter("tokio.task.budget_forced_yield")
+        .with_description(
+            "Number of times tasks have been forced to yield because their task budget was \
+            exhausted",
+        )
+        .with_callback({
+            let runtime_metrics = runtime_metrics.clone();
+            move |observer| {
+                observer.observe(runtime_metrics.budget_forced_yield_count(), &[]);
+            }
+        })
+        .build();
+
+    meter
+        .u64_observable_counter("tokio.park")
+        .with_description("Total number of times worker threads have parked")
+        .with_callback({
+            let runtime_metrics = runtime_metrics.clone();
+            move |observer| {
+                let mut park_count = 0;
+                for worker in 0..num_workers {
+                    park_count += runtime_metrics.worker_park_count(worker);
+                }
+                observer.observe(park_count, &[]);
+            }
+        })
+        .build();
+
+    meter
+        .u64_observable_counter("tokio.noop")
+        .with_description(
+            "Total number of times worker threads unparked and parked again without doing any work",
+        )
+        .with_callback({
+            let runtime_metrics = runtime_metrics.clone();
+            move |observer| {
+                let mut noop_count = 0;
+                for worker in 0..num_workers {
+                    noop_count += runtime_metrics.worker_noop_count(worker);
+                }
+                observer.observe(noop_count, &[]);
+            }
+        })
+        .build();
+
+    meter
+        .u64_observable_counter("tokio.task.stolen")
+        .with_description("Total number of tasks stolen between worker threads")
+        .with_unit("{task}")
+        .with_callback({
+            let runtime_metrics = runtime_metrics.clone();
+            move |observer| {
+                let mut steal_count = 0;
+                for worker in 0..num_workers {
+                    steal_count += runtime_metrics.worker_steal_count(worker);
+                }
+                observer.observe(steal_count, &[]);
+            }
+        })
+        .build();
+
+    meter
+        .u64_observable_counter("tokio.steals")
+        .with_description("Nuber of times worker threads successfully stole one or more tasks")
+        .with_unit("{operation}")
+        .with_callback({
+            let runtime_metrics = runtime_metrics.clone();
+            move |observer| {
+                let mut steal_operations = 0;
+                for worker in 0..num_workers {
+                    steal_operations += runtime_metrics.worker_steal_operations(worker);
+                }
+                observer.observe(steal_operations, &[]);
+            }
+        })
+        .build();
+
+    meter
+        .f64_observable_counter("tokio.thread.worker.busy.time")
+        .with_description("Total amount of time that all worker threads have been busy")
+        .with_unit("s")
+        .with_callback({
+            let runtime_metrics = runtime_metrics.clone();
+            move |observer| {
+                let mut total_busy_duration = Duration::from_secs(0);
+                for worker in 0..num_workers {
+                    total_busy_duration += runtime_metrics.worker_total_busy_duration(worker);
+                }
+                observer.observe(total_busy_duration.as_secs_f64(), &[]);
+            }
+        })
+        .build();
+
+    meter
+        .u64_observable_gauge("tokio.queue.depth")
+        .with_description(
+            "Number of tasks currently in the runtime's global queue, blocking thread pool queue, \
+            or a worker's local queue",
+        )
+        .with_unit("{task}")
+        .with_callback({
+            let runtime_metrics = runtime_metrics.clone();
+            move |observer| {
+                for worker in 0..num_workers {
+                    observer.observe(
+                        u64::try_from(runtime_metrics.worker_local_queue_depth(worker))
+                            .unwrap_or(u64::MAX),
+                        &[
+                            KeyValue::new("queue", "local"),
+                            KeyValue::new("worker", i64::try_from(worker).unwrap()),
+                        ],
+                    );
+                }
+                observer.observe(
+                    u64::try_from(runtime_metrics.global_queue_depth()).unwrap_or(u64::MAX),
+                    &[KeyValue::new("queue", "global")],
+                );
+                observer.observe(
+                    u64::try_from(runtime_metrics.blocking_queue_depth()).unwrap_or(u64::MAX),
+                    &[KeyValue::new("queue", "blocking")],
+                );
+            }
+        })
+        .build();
+
+    meter
+        .u64_observable_gauge("tokio.io.fd.count")
+        .with_description("Number of file descriptors currently registered with the I/O driver")
+        .with_unit("{fd}")
+        .with_callback({
+            let runtime_metrics = runtime_metrics.clone();
+            move |observer| {
+                observer.observe(
+                    runtime_metrics
+                        .io_driver_fd_registered_count()
+                        .saturating_sub(runtime_metrics.io_driver_fd_deregistered_count()),
+                    &[],
+                )
+            }
+        })
+        .build();
+
+    meter
+        .u64_observable_counter("tokio.io.fd.registered")
+        .with_description("Total number of file descriptors registered by the I/O driver")
+        .with_unit("{fd}")
+        .with_callback({
+            let runtime_metrics = runtime_metrics.clone();
+            move |observer| observer.observe(runtime_metrics.io_driver_fd_registered_count(), &[])
+        })
+        .build();
+
+    meter
+        .u64_observable_counter("tokio.io.fd.deregistered")
+        .with_description("Total number of file descriptors deregistered by the I/O driver")
+        .with_unit("{fd}")
+        .with_callback({
+            let runtime_metrics = runtime_metrics.clone();
+            move |observer| observer.observe(runtime_metrics.io_driver_fd_deregistered_count(), &[])
+        })
+        .build();
+
+    meter
+        .u64_observable_counter("tokio.io.ready_events")
+        .with_description("Number of ready events processed by the I/O driver")
+        .with_unit("{event}")
+        .with_callback({
+            let runtime_metrics = runtime_metrics.clone();
+            move |observer| observer.observe(runtime_metrics.io_driver_ready_count(), &[])
+        })
+        .build();
 }

--- a/docs/samples/advanced_config/aggregation_job_creator.yaml
+++ b/docs/samples/advanced_config/aggregation_job_creator.yaml
@@ -76,17 +76,6 @@ metrics_config:
     # binary must have been compiled with the flag `--cfg tokio_unstable`.
     # (optional)
     enabled: false
-    # Enable a histogram of task poll times. This introduces some additional
-    # overhead. (optional)
-    enable_poll_time_histogram: false
-    # Configure the scale and parameters of the poll time histogram. Defaults
-    # to a linear scale. (optional)
-    poll_time_histogram:
-      linear:
-        # Sets the poll time histogram's resolution. (optional)
-        resolution_us: 100
-        # Sets the number of buckets in the poll time histogram. (optional)
-        num_buckets: 10
 
 # Aggregation job creator-specific parameters:
 

--- a/docs/samples/advanced_config/aggregation_job_driver.yaml
+++ b/docs/samples/advanced_config/aggregation_job_driver.yaml
@@ -76,17 +76,6 @@ metrics_config:
     # binary must have been compiled with the flag `--cfg tokio_unstable`.
     # (optional)
     enabled: false
-    # Enable a histogram of task poll times. This introduces some additional
-    # overhead. (optional)
-    enable_poll_time_histogram: false
-    # Configure the scale and parameters of the poll time histogram. Defaults
-    # to a linear scale. (optional)
-    poll_time_histogram:
-      linear:
-        # Sets the poll time histogram's resolution. (optional)
-        resolution_us: 100
-        # Sets the number of buckets in the poll time histogram. (optional)
-        num_buckets: 10
 
 # Stack size, in bytes, for threads used for VDAF preparation. (optional)
 thread_pool_stack_size: 2097152

--- a/docs/samples/advanced_config/aggregator.yaml
+++ b/docs/samples/advanced_config/aggregator.yaml
@@ -78,17 +78,6 @@ metrics_config:
     # binary must have been compiled with the flag `--cfg tokio_unstable`.
     # (optional)
     enabled: false
-    # Enable a histogram of task poll times. This introduces some additional
-    # overhead. (optional)
-    enable_poll_time_histogram: false
-    # Configure the scale and parameters of the poll time histogram. Defaults to
-    # a linear scale. (optional)
-    poll_time_histogram:
-      linear:
-        # Sets the poll time histogram's resolution. (optional)
-        resolution_us: 100
-        # Sets the number of buckets in the poll time histogram. (optional)
-        num_buckets: 10
 
 # Stack size, in bytes, for threads used for VDAF preparation. (optional)
 thread_pool_stack_size: 2097152

--- a/docs/samples/advanced_config/collection_job_driver.yaml
+++ b/docs/samples/advanced_config/collection_job_driver.yaml
@@ -76,17 +76,6 @@ metrics_config:
     # binary must have been compiled with the flag `--cfg tokio_unstable`.
     # (optional)
     enabled: false
-    # Enable a histogram of task poll times. This introduces some additional
-    # overhead. (optional)
-    enable_poll_time_histogram: false
-    # Configure the scale and parameters of the poll time histogram. Defaults
-    # to a linear scale. (optional)
-    poll_time_histogram:
-      linear:
-        # Sets the poll time histogram's resolution. (optional)
-        resolution_us: 100
-        # Sets the number of buckets in the poll time histogram. (optional)
-        num_buckets: 10
 
 # Collection job driver-related parameters:
 

--- a/docs/samples/advanced_config/garbage_collector.yaml
+++ b/docs/samples/advanced_config/garbage_collector.yaml
@@ -76,17 +76,6 @@ metrics_config:
     # binary must have been compiled with the flag `--cfg tokio_unstable`.
     # (optional)
     enabled: false
-    # Enable a histogram of task poll times. This introduces some additional
-    # overhead. (optional)
-    enable_poll_time_histogram: false
-    # Configure the scale and parameters of the poll time histogram. Defaults
-    # to a linear scale. (optional)
-    poll_time_histogram:
-      linear:
-        # Sets the poll time histogram's resolution. (optional)
-        resolution_us: 100
-        # Sets the number of buckets in the poll time histogram. (optional)
-        num_buckets: 10
 
 # Garbage collector-specific parameters:
 garbage_collection:

--- a/docs/samples/advanced_config/janus_cli.yaml
+++ b/docs/samples/advanced_config/janus_cli.yaml
@@ -76,14 +76,3 @@ metrics_config:
     # binary must have been compiled with the flag `--cfg tokio_unstable`.
     # (optional)
     enabled: false
-    # Enable a histogram of task poll times. This introduces some additional
-    # overhead. (optional)
-    enable_poll_time_histogram: false
-    # Configure the scale and parameters of the poll time histogram. Defaults
-    # to a linear scale. (optional)
-    poll_time_histogram:
-      linear:
-        # Sets the poll time histogram's resolution. (optional)
-        resolution_us: 100
-        # Sets the number of buckets in the poll time histogram. (optional)
-        num_buckets: 10


### PR DESCRIPTION
This upgrades to the 0.27 release of opentelemetry-rust. This includes the following changes:

- Various OTel APIs were renamed.
- The `Meter` no longer allows supplying a multi-callback for several instruments. Instead, separate callbacks are registered on each instrument. Additionally, `observe()` can no longer be called on observable gauges, etc.; this method has moved to the argument provided to the instrument's callback.
- Support for the `MetricProducer` trait has been removed. As a result, the (unstable) Tokio poll time histogram has been removed, and the remaining Tokio runtime metrics have been reimplemented with SDK instruments.
- Histogram boundaries can now be set directly on instrument builders. Thus, I have done so and removed our custom `View`.
- `NoopMeterProvider` was removed in this release, so I vendored it for use in tests.