### PR TITLE
Upgrade libprio to alpha prerelease

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4298,7 +4298,8 @@ dependencies = [
 [[package]]
 name = "prio"
 version = "0.17.0-alpha.0"
-source = "git+https://github.com/divviup/libprio-rs?rev=3c1aeb30c661d373566749a81589fc0a4045f89a#3c1aeb30c661d373566749a81589fc0a4045f89a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b19b2345e231fb86cd581c8a19708390922b4a40f76153ee63f7e6c3c0581e"
 dependencies = [
  "aes 0.8.4",
  "bitvec",
@@ -4306,7 +4307,6 @@ dependencies = [
  "ctr 0.9.2",
  "fiat-crypto",
  "fixed",
- "getrandom",
  "hex",
  "hmac 0.12.1",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,9 +75,7 @@ postgres-types = "0.2.8"
 pretty_assertions = "1.4.1"
 # Disable default features so that individual workspace crates can choose to
 # re-enable them
-# TODO(#3436): switch to a released version of libprio, once there is a released version implementing VDAF-13
-# prio = { version = "0.16.7", default-features = false, features = ["experimental"] }
-prio = { git = "https://github.com/divviup/libprio-rs", rev = "3c1aeb30c661d373566749a81589fc0a4045f89a", default-features = false, features = ["experimental"] }
+prio = { version = "0.17.0-alpha.0", default-features = false, features = ["experimental"] }
 prometheus = "0.13.4"
 querystring = "1.1.0"
 quickcheck = { version = "1.0.3", default-features = false }

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -829,7 +829,7 @@ impl<C: Clock> TaskAggregator<C> {
             }
 
             VdafInstance::Prio3Sum { max_measurement } => {
-                let vdaf = Prio3::new_sum(2, u128::from(*max_measurement))?;
+                let vdaf = Prio3::new_sum(2, *max_measurement)?;
                 let verify_key = task.vdaf_verify_key()?;
                 VdafOps::Prio3Sum(Arc::new(vdaf), verify_key)
             }

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -312,7 +312,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
             }
 
             (task::BatchMode::TimeInterval, VdafInstance::Prio3Sum { max_measurement }) => {
-                let vdaf = Arc::new(Prio3::new_sum(2, u128::from(*max_measurement))?);
+                let vdaf = Arc::new(Prio3::new_sum(2, *max_measurement)?);
                 self.create_aggregation_jobs_for_time_interval_task_no_param::<VERIFY_KEY_LENGTH, Prio3Sum>(task, vdaf)
                     .await
             }
@@ -402,7 +402,11 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                 VdafInstance::Prio3Count,
             ) => {
                 let vdaf: Arc<
-                    Prio3<prio::flp::types::Count<Field64>, vdaf::xof::XofTurboShake128, 16>,
+                    Prio3<
+                        prio::flp::types::Count<Field64>,
+                        vdaf::xof::XofTurboShake128,
+                        VERIFY_KEY_LENGTH,
+                    >,
                 > = Arc::new(Prio3::new_count(2)?);
                 let batch_time_window_size = *batch_time_window_size;
                 self.create_aggregation_jobs_for_leader_selected_task_no_param::<
@@ -417,7 +421,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                 },
                 VdafInstance::Prio3Sum { max_measurement },
             ) => {
-                let vdaf = Arc::new(Prio3::new_sum(2, u128::from(*max_measurement))?);
+                let vdaf = Arc::new(Prio3::new_sum(2, *max_measurement)?);
                 let batch_time_window_size = *batch_time_window_size;
                 self.create_aggregation_jobs_for_leader_selected_task_no_param::<
                     VERIFY_KEY_LENGTH,

--- a/aggregator_api/src/tests.rs
+++ b/aggregator_api/src/tests.rs
@@ -26,7 +26,7 @@ use janus_core::{
     hpke::HpkeKeypair,
     test_util::install_test_trace_subscriber,
     time::MockClock,
-    vdaf::{vdaf_dp_strategies, VdafInstance},
+    vdaf::{vdaf_dp_strategies, VdafInstance, VERIFY_KEY_LENGTH},
 };
 use janus_messages::{
     Duration, HpkeAeadId, HpkeConfig, HpkeConfigId, HpkeKdfId, HpkeKemId, HpkePublicKey, Role,
@@ -183,7 +183,12 @@ async fn post_task_bad_role() {
     // Setup: create a datastore & handler.
     let (handler, _ephemeral_datastore, _) = setup_api_test().await;
 
-    let vdaf_verify_key = SecretBytes::new(thread_rng().sample_iter(Standard).take(16).collect());
+    let vdaf_verify_key = SecretBytes::new(
+        thread_rng()
+            .sample_iter(Standard)
+            .take(VERIFY_KEY_LENGTH)
+            .collect(),
+    );
     let aggregator_auth_token = AuthenticationToken::DapAuth(random());
 
     let req = PostTaskReq {
@@ -217,7 +222,12 @@ async fn post_task_unauthorized() {
     // Setup: create a datastore & handler.
     let (handler, _ephemeral_datastore, _) = setup_api_test().await;
 
-    let vdaf_verify_key = SecretBytes::new(thread_rng().sample_iter(Standard).take(16).collect());
+    let vdaf_verify_key = SecretBytes::new(
+        thread_rng()
+            .sample_iter(Standard)
+            .take(VERIFY_KEY_LENGTH)
+            .collect(),
+    );
     let aggregator_auth_token = AuthenticationToken::DapAuth(random());
 
     let req = PostTaskReq {
@@ -252,7 +262,12 @@ async fn post_task_helper_no_optional_fields() {
     // Setup: create a datastore & handler.
     let (handler, _ephemeral_datastore, ds) = setup_api_test().await;
 
-    let vdaf_verify_key = SecretBytes::new(thread_rng().sample_iter(Standard).take(16).collect());
+    let vdaf_verify_key = SecretBytes::new(
+        thread_rng()
+            .sample_iter(Standard)
+            .take(VERIFY_KEY_LENGTH)
+            .collect(),
+    );
 
     // Verify: posting a task creates a new task which matches the request.
     let req = PostTaskReq {
@@ -332,7 +347,12 @@ async fn post_task_helper_with_aggregator_auth_token() {
     // Setup: create a datastore & handler.
     let (handler, _ephemeral_datastore, _) = setup_api_test().await;
 
-    let vdaf_verify_key = SecretBytes::new(thread_rng().sample_iter(Standard).take(16).collect());
+    let vdaf_verify_key = SecretBytes::new(
+        thread_rng()
+            .sample_iter(Standard)
+            .take(VERIFY_KEY_LENGTH)
+            .collect(),
+    );
     let aggregator_auth_token = AuthenticationToken::DapAuth(random());
 
     // Verify: posting a task with role = helper and an aggregator auth token fails
@@ -368,7 +388,12 @@ async fn post_task_idempotence() {
     let (handler, ephemeral_datastore, _) = setup_api_test().await;
     let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
-    let vdaf_verify_key = SecretBytes::new(thread_rng().sample_iter(Standard).take(16).collect());
+    let vdaf_verify_key = SecretBytes::new(
+        thread_rng()
+            .sample_iter(Standard)
+            .take(VERIFY_KEY_LENGTH)
+            .collect(),
+    );
     let aggregator_auth_token = AuthenticationToken::DapAuth(random());
 
     // Verify: posting a task creates a new task which matches the request.
@@ -442,7 +467,12 @@ async fn post_task_leader_all_optional_fields() {
     // Setup: create a datastore & handler.
     let (handler, _ephemeral_datastore, ds) = setup_api_test().await;
 
-    let vdaf_verify_key = SecretBytes::new(thread_rng().sample_iter(Standard).take(16).collect());
+    let vdaf_verify_key = SecretBytes::new(
+        thread_rng()
+            .sample_iter(Standard)
+            .take(VERIFY_KEY_LENGTH)
+            .collect(),
+    );
     let aggregator_auth_token = AuthenticationToken::DapAuth(random());
     let collector_auth_token_hash = AuthenticationTokenHash::from(&random());
     // Verify: posting a task creates a new task which matches the request.
@@ -522,7 +552,12 @@ async fn post_task_leader_no_aggregator_auth_token() {
     // Setup: create a datastore & handler.
     let (handler, _ephemeral_datastore, _) = setup_api_test().await;
 
-    let vdaf_verify_key = SecretBytes::new(thread_rng().sample_iter(Standard).take(16).collect());
+    let vdaf_verify_key = SecretBytes::new(
+        thread_rng()
+            .sample_iter(Standard)
+            .take(VERIFY_KEY_LENGTH)
+            .collect(),
+    );
 
     // Verify: posting a task with role = Leader and no aggregator auth token fails
     let req = PostTaskReq {

--- a/core/src/dp.rs
+++ b/core/src/dp.rs
@@ -61,7 +61,7 @@ impl AggregatorWithNoise<0, 16, NoDifferentialPrivacy> for dummy::Vdaf {
 }
 
 // identity strategy implementations for vdafs from libprio
-impl TypeWithNoise<NoDifferentialPrivacy> for prio::flp::types::Sum<Field128> {
+impl TypeWithNoise<NoDifferentialPrivacy> for prio::flp::types::Sum<Field64> {
     fn add_noise_to_result(
         &self,
         _dp_strategy: &NoDifferentialPrivacy,

--- a/core/src/vdaf.rs
+++ b/core/src/vdaf.rs
@@ -13,7 +13,7 @@ use std::str;
 
 /// The length of the verify key parameter for Prio3 VDAF instantiations using
 /// [`XofTurboShake128`][prio::vdaf::xof::XofTurboShake128].
-pub const VERIFY_KEY_LENGTH: usize = 16;
+pub const VERIFY_KEY_LENGTH: usize = 32;
 
 /// Private use algorithm ID for a customized version of Prio3SumVec. This value was chosen for
 /// interoperability with Daphne.
@@ -265,7 +265,7 @@ macro_rules! vdaf_dispatch_impl_base {
             }
 
             ::janus_core::vdaf::VdafInstance::Prio3Sum { max_measurement } => {
-                let $vdaf = ::prio::vdaf::prio3::Prio3::new_sum(2, *max_measurement as u128)?;
+                let $vdaf = ::prio::vdaf::prio3::Prio3::new_sum(2, *max_measurement)?;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Sum;
                 const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH;
                 type $DpStrategy = janus_core::dp::NoDifferentialPrivacy;

--- a/integration_tests/tests/integration/common.rs
+++ b/integration_tests/tests/integration/common.rs
@@ -396,7 +396,7 @@ pub async fn submit_measurements_and_verify_aggregate(
             .await;
         }
         VdafInstance::Prio3Sum { max_measurement } => {
-            let max_measurement = u128::from(*max_measurement);
+            let max_measurement = *max_measurement;
             let vdaf = Prio3::new_sum(2, max_measurement).unwrap();
 
             let measurements: Vec<_> =

--- a/interop_binaries/src/commands/janus_interop_client.rs
+++ b/interop_binaries/src/commands/janus_interop_client.rs
@@ -124,9 +124,9 @@ async fn handle_upload(
         }
 
         VdafInstance::Prio3Sum { max_measurement } => {
-            let measurement = parse_primitive_measurement::<u128>(request.measurement.clone())?;
-            let vdaf = Prio3::new_sum(2, u128::from(max_measurement))
-                .context("failed to construct Prio3Sum VDAF")?;
+            let measurement = parse_primitive_measurement::<u64>(request.measurement.clone())?;
+            let vdaf =
+                Prio3::new_sum(2, max_measurement).context("failed to construct Prio3Sum VDAF")?;
             handle_upload_generic(http_client, vdaf, request, measurement).await?;
         }
 

--- a/interop_binaries/src/commands/janus_interop_collector.rs
+++ b/interop_binaries/src/commands/janus_interop_collector.rs
@@ -305,8 +305,8 @@ async fn handle_collection_start(
         }
 
         (ParsedQuery::TimeInterval(batch_interval), VdafInstance::Prio3Sum { max_measurement }) => {
-            let vdaf = Prio3::new_sum(2, u128::from(max_measurement))
-                .context("failed to construct Prio3Sum VDAF")?;
+            let vdaf =
+                Prio3::new_sum(2, max_measurement).context("failed to construct Prio3Sum VDAF")?;
             handle_collect_generic(
                 http_client,
                 task_state,
@@ -314,7 +314,7 @@ async fn handle_collection_start(
                 vdaf,
                 &agg_param,
                 |_| None,
-                |result| AggregationResult::Number(NumberAsString(*result)),
+                |result| AggregationResult::Number(NumberAsString(u128::from(*result))),
             )
             .await?
         }
@@ -516,8 +516,8 @@ async fn handle_collection_start(
         },
 
         (ParsedQuery::LeaderSelected, VdafInstance::Prio3Sum { max_measurement }) => {
-            let vdaf = Prio3::new_sum(2, u128::from(max_measurement))
-                .context("failed to construct Prio3Sum VDAF")?;
+            let vdaf =
+                Prio3::new_sum(2, max_measurement).context("failed to construct Prio3Sum VDAF")?;
             handle_collect_generic(
                 http_client,
                 task_state,
@@ -525,7 +525,7 @@ async fn handle_collection_start(
                 vdaf,
                 &agg_param,
                 |selector| Some(*selector.batch_id()),
-                |result| AggregationResult::Number(NumberAsString(*result)),
+                |result| AggregationResult::Number(NumberAsString(u128::from(*result))),
             )
             .await?
         }

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -465,7 +465,7 @@ macro_rules! options_vdaf_dispatch {
                 body
             }
             (VdafType::Sum, None, None, Some(max_measurement)) => {
-                let $vdaf = Prio3::new_sum(2, u128::from(max_measurement))
+                let $vdaf = Prio3::new_sum(2, u64::from(max_measurement))
                     .map_err(|err| Error::Anyhow(err.into()))?;
                 let body = $body;
                 body


### PR DESCRIPTION
This upgrades libprio, so we are now VDAF-interoperable. This includes a change to the field used by Prio3Sum and a change to the XofTurboShake128 seed size.