### PR TITLE
Add verification of aggregation mode in PeerAggregator

### DIFF
--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -106,7 +106,8 @@ where
             .with_endpoint(url::Url::parse("https://leader.example.com/").unwrap())
             .with_peer_role(Role::Leader)
             .with_collector_hpke_config(collector_hpke_keypair.config().clone())
-            .build();
+            .build()
+            .unwrap();
 
         datastore
             .run_unnamed_tx(|tx| {

--- a/aggregator/src/binaries/janus_cli.rs
+++ b/aggregator/src/binaries/janus_cli.rs
@@ -429,7 +429,7 @@ async fn add_taskprov_peer_aggregator<C: Clock>(
         tolerable_clock_skew,
         Vec::from([aggregator_auth_token.clone()]),
         collector_auth_tokens,
-    ));
+    )?);
 
     if !dry_run {
         datastore
@@ -1129,7 +1129,8 @@ mod tests {
             tolerable_clock_skew,
             Vec::from([aggregator_auth_token]),
             Vec::from([collector_auth_token]),
-        );
+        )
+        .unwrap();
 
         let got_peer_aggregator = ds
             .run_unnamed_tx(|tx| {

--- a/aggregator_api/src/routes.rs
+++ b/aggregator_api/src/routes.rs
@@ -456,7 +456,8 @@ pub(super) async fn post_taskprov_peer_aggregator<C: Clock>(
         req.tolerable_clock_skew,
         req.aggregator_auth_tokens,
         req.collector_auth_tokens,
-    );
+    )
+    .map_err(|e| Error::BadRequest(format!("Invalid request: {e}")))?;
 
     let inserted = ds
         .run_tx("post_taskprov_peer_aggregator", |tx| {

--- a/aggregator_api/src/tests.rs
+++ b/aggregator_api/src/tests.rs
@@ -1455,11 +1455,13 @@ async fn get_taskprov_peer_aggregator() {
     let leader = PeerAggregatorBuilder::new()
         .with_endpoint(Url::parse("https://leader.example.com/").unwrap())
         .with_peer_role(Role::Leader)
-        .build();
+        .build()
+        .unwrap();
     let helper = PeerAggregatorBuilder::new()
         .with_endpoint(Url::parse("https://helper.example.com/").unwrap())
         .with_peer_role(Role::Helper)
-        .build();
+        .build()
+        .unwrap();
 
     ds.run_unnamed_tx(|tx| {
         let leader = leader.clone();
@@ -1531,7 +1533,8 @@ async fn post_taskprov_peer_aggregator() {
     let leader = PeerAggregatorBuilder::new()
         .with_endpoint(endpoint.clone())
         .with_peer_role(Role::Leader)
-        .build();
+        .build()
+        .unwrap();
 
     let req = PostTaskprovPeerAggregatorReq {
         endpoint,
@@ -1607,7 +1610,8 @@ async fn delete_taskprov_peer_aggregator() {
     let leader = PeerAggregatorBuilder::new()
         .with_endpoint(endpoint.clone())
         .with_peer_role(Role::Leader)
-        .build();
+        .build()
+        .unwrap();
 
     ds.run_unnamed_tx(|tx| {
         let leader = leader.clone();

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -5310,7 +5310,7 @@ SELECT ord, type, token FROM taskprov_collector_auth_tokens
         let collector_auth_tokens =
             decrypt_tokens(collector_auth_token_rows, "taskprov_collector_auth_tokens")?;
 
-        Ok(PeerAggregator::new(
+        PeerAggregator::new(
             endpoint,
             peer_role.as_role(),
             aggregation_mode,
@@ -5320,7 +5320,8 @@ SELECT ord, type, token FROM taskprov_collector_auth_tokens
             tolerable_clock_skew,
             aggregator_auth_tokens,
             collector_auth_tokens,
-        ))
+        )
+        .map_err(|e| Error::User(e.into()))
     }
 
     #[tracing::instrument(skip(self), err(level = Level::DEBUG))]

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -7505,17 +7505,20 @@ async fn roundtrip_taskprov_peer_aggregator(ephemeral_datastore: EphemeralDatast
     // Basic aggregator.
     let example_leader_peer_aggregator = PeerAggregatorBuilder::new()
         .with_peer_role(Role::Leader)
-        .build();
+        .build()
+        .unwrap();
     let example_helper_peer_aggregator = PeerAggregatorBuilder::new()
         .with_peer_role(Role::Helper)
         .with_aggregator_auth_tokens(Vec::from([random(), random()]))
         .with_collector_auth_tokens(Vec::new())
-        .build();
+        .build()
+        .unwrap();
     let another_example_leader_peer_aggregator = PeerAggregatorBuilder::new()
         .with_endpoint(Url::parse("https://another.example.com/").unwrap())
         .with_aggregator_auth_tokens(Vec::new())
         .with_collector_auth_tokens(Vec::from([random(), random()]))
-        .build();
+        .build()
+        .unwrap();
 
     datastore
         .run_tx("test-put-peer-aggregator", |tx| {
@@ -7544,7 +7547,7 @@ async fn roundtrip_taskprov_peer_aggregator(ephemeral_datastore: EphemeralDatast
         datastore
             .run_unnamed_tx(|tx| {
                 Box::pin(async move {
-                    let colliding_peer_aggregator = PeerAggregatorBuilder::new().build();
+                    let colliding_peer_aggregator = PeerAggregatorBuilder::new().build().unwrap();
                     tx.put_taskprov_peer_aggregator(&colliding_peer_aggregator)
                         .await
                 })


### PR DESCRIPTION
Closes #3666. This makes `PeerAggregator::new()` and `PeerAggregatorBuilder::build()` fallible, and adds a couple validation checks.