### PR TITLE
Update janus_messages, remove ignore in deny.toml, 0.7 backport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1363,17 +1363,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1440,7 +1429,7 @@ checksum = "29ff1e7ce34595633b7da26cd617c0f48c48bb7b0f000d05a0cc73b4788c1016"
 dependencies = [
  "base64 0.22.1",
  "email_address",
- "janus_messages 0.7.43",
+ "janus_messages 0.7.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "num-bigint",
  "num-rational",
@@ -3103,24 +3092,6 @@ dependencies = [
 
 [[package]]
 name = "janus_messages"
-version = "0.7.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "849928487588a01e92a7b59099ff60d4eb9ec1627c6878667a86bbf033cf3efa"
-dependencies = [
- "anyhow",
- "base64 0.22.1",
- "derivative",
- "hex",
- "num_enum",
- "prio",
- "rand 0.8.5",
- "serde",
- "thiserror 1.0.69",
- "url",
-]
-
-[[package]]
-name = "janus_messages"
 version = "0.7.55"
 dependencies = [
  "anyhow",
@@ -3134,6 +3105,24 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_test",
+ "thiserror 2.0.12",
+ "url",
+]
+
+[[package]]
+name = "janus_messages"
+version = "0.7.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ea151826d3dfa95391502d64e847b747a66500dd9d669a823bd0c55e91f331"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "educe",
+ "hex",
+ "num_enum",
+ "prio",
+ "rand 0.8.5",
+ "serde",
  "thiserror 2.0.12",
  "url",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -11,10 +11,6 @@ ignore = [
     # `instant` is unmaintained, but it is feature-complete and small, so it is unlikely to have
     # bugs or security vulnerabilities.
     "RUSTSEC-2024-0384",
-
-    # Use of `derivative` has been removed from production code. It still exists as transitive
-    # dependency on integration_tests.
-    "RUSTSEC-2024-0388"
 ]
 
 [bans]


### PR DESCRIPTION
This is a backport of #3742.