### PR TITLE
Harmonize errors with draft-ietf-ppm-dap-15

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_driver/tests.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver/tests.rs
@@ -1610,7 +1610,7 @@ async fn leader_sync_leader_selected_aggregation_job_init_single_step() {
                 .unwrap()
                 .path(),
         )
-        .with_status(500)
+        .with_status(400)
         .with_header("Content-Type", "application/problem+json")
         .with_body("{\"type\": \"urn:ietf:params:ppm:dap:error:invalidMessage\"}")
         .create_async()
@@ -1660,7 +1660,7 @@ async fn leader_sync_leader_selected_aggregation_job_init_single_step() {
     assert_matches!(
         error,
         Error::Http(error_response) => {
-            assert_eq!(error_response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+            assert_eq!(error_response.status(), StatusCode::BAD_REQUEST);
             assert_eq!(*error_response.dap_problem_type().unwrap(), DapProblemType::InvalidMessage);
         }
     );

--- a/aggregator/src/aggregator/aggregation_job_driver/tests.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver/tests.rs
@@ -1612,7 +1612,7 @@ async fn leader_sync_leader_selected_aggregation_job_init_single_step() {
         )
         .with_status(500)
         .with_header("Content-Type", "application/problem+json")
-        .with_body("{\"type\": \"urn:ietf:params:ppm:dap:error:unauthorizedRequest\"}")
+        .with_body("{\"type\": \"urn:ietf:params:ppm:dap:error:invalidMessage\"}")
         .create_async()
         .await;
     let (header, value) = agg_auth_token.request_authentication();
@@ -1661,7 +1661,7 @@ async fn leader_sync_leader_selected_aggregation_job_init_single_step() {
         error,
         Error::Http(error_response) => {
             assert_eq!(error_response.status(), StatusCode::INTERNAL_SERVER_ERROR);
-            assert_eq!(*error_response.dap_problem_type().unwrap(), DapProblemType::UnauthorizedRequest);
+            assert_eq!(*error_response.dap_problem_type().unwrap(), DapProblemType::InvalidMessage);
         }
     );
     aggregation_job_driver

--- a/aggregator/src/aggregator/batch_mode.rs
+++ b/aggregator/src/aggregator/batch_mode.rs
@@ -175,7 +175,11 @@ impl CollectableBatchMode for TimeInterval {
             .any(|agg_param| agg_param != aggregation_param)
         {
             return Err(datastore::Error::User(
-                Error::BatchQueriedMultipleTimes(*task.id()).into(),
+                Error::InvalidMessage(
+                    Some(*task.id()),
+                    "batch has already been collected with another aggregation parameter",
+                )
+                .into(),
             ));
         }
         Ok(())
@@ -223,7 +227,11 @@ impl CollectableBatchMode for LeaderSelected {
             .any(|agg_param| agg_param != aggregation_param)
         {
             return Err(datastore::Error::User(
-                Error::BatchQueriedMultipleTimes(*task.id()).into(),
+                Error::InvalidMessage(
+                    Some(*task.id()),
+                    "batch has already been collected with another aggregation parameter",
+                )
+                .into(),
             ));
         }
         Ok(())

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -1253,7 +1253,7 @@ mod tests {
                 AggregateShareReq::<TimeInterval>::MEDIA_TYPE,
             )
             .match_body(leader_request.get_encoded().unwrap())
-            .with_status(500)
+            .with_status(400)
             .with_header("Content-Type", "application/problem+json")
             .with_body("{\"type\": \"urn:ietf:params:ppm:dap:error:invalidMessage\"}")
             .create_async()
@@ -1267,7 +1267,7 @@ mod tests {
             error,
             Error::Http(error_response) => {
                 assert_matches!(error_response.dap_problem_type(), Some(DapProblemType::InvalidMessage));
-                assert_eq!(error_response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+                assert_eq!(error_response.status(), StatusCode::BAD_REQUEST);
             }
         );
 

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -1255,7 +1255,7 @@ mod tests {
             .match_body(leader_request.get_encoded().unwrap())
             .with_status(500)
             .with_header("Content-Type", "application/problem+json")
-            .with_body("{\"type\": \"urn:ietf:params:ppm:dap:error:batchQueriedMultipleTimes\"}")
+            .with_body("{\"type\": \"urn:ietf:params:ppm:dap:error:invalidMessage\"}")
             .create_async()
             .await;
 
@@ -1266,7 +1266,7 @@ mod tests {
         assert_matches!(
             error,
             Error::Http(error_response) => {
-                assert_matches!(error_response.dap_problem_type(), Some(DapProblemType::BatchQueriedMultipleTimes));
+                assert_matches!(error_response.dap_problem_type(), Some(DapProblemType::InvalidMessage));
                 assert_eq!(error_response.status(), StatusCode::INTERNAL_SERVER_ERROR);
             }
         );

--- a/aggregator/src/aggregator/error.rs
+++ b/aggregator/src/aggregator/error.rs
@@ -54,9 +54,6 @@ pub enum Error {
     /// Corresponds to `unrecognizedTask` in DAP.
     #[error("task {0}: unrecognized task")]
     UnrecognizedTask(TaskId),
-    /// Corresponds to `missingTaskID` in DAP.
-    #[error("no task ID in request")]
-    MissingTaskId,
     /// An attempt was made to act on an unknown aggregation job.
     #[error("task {0}: unrecognized aggregation job: {1}")]
     UnrecognizedAggregationJob(TaskId, AggregationJobId),
@@ -99,10 +96,6 @@ pub enum Error {
     /// sets of reports were aggregated.
     #[error("{0}")]
     BatchMismatch(Box<BatchMismatch>),
-    /// Corresponds to `batchQueriedMultipleTimes` in DAP. A collect or aggregate share request was
-    /// rejected because there was already a distinct query against the relevant batch.
-    #[error("task {0}: batch queried multiple times")]
-    BatchQueriedMultipleTimes(TaskId),
     /// A collect or aggregate share request was rejected because the batch overlaps with a
     /// previously collected one.
     #[error("task {0}: queried batch {1} overlaps with previously collected batch(es)")]
@@ -140,7 +133,7 @@ pub enum Error {
     BadRequest(String),
     /// Corresponds to taskprov `invalidTask`. See the [Taskprov specification][1] for details.
     ///
-    /// [1]: https://www.ietf.org/archive/id/draft-wang-ppm-dap-taskprov-04.html#name-conventions-and-definitions
+    /// [1]: https://datatracker.ietf.org/doc/html/draft-ietf-ppm-dap-taskprov-01#table-1
     #[error("aggregator has opted out of the indicated task: {1}")]
     InvalidTask(TaskId, OptOutReason),
     /// An error occurred when trying to ensure differential privacy.
@@ -292,7 +285,6 @@ impl Error {
             Error::InvalidMessage(_, _) => "unrecognized_message",
             Error::StepMismatch { .. } => "step_mismatch",
             Error::UnrecognizedTask(_) => "unrecognized_task",
-            Error::MissingTaskId => "missing_task_id",
             Error::UnrecognizedAggregationJob(_, _) => "unrecognized_aggregation_job",
             Error::AbandonedAggregationJob(_, _) => "abandoned_aggregation_job",
             Error::DeletedAggregationJob(_, _) => "deleted_aggregation_job",
@@ -306,7 +298,6 @@ impl Error {
             Error::InvalidBatchSize(_, _) => "invalid_batch_size",
             Error::Url(_) => "url",
             Error::BatchMismatch { .. } => "batch_mismatch",
-            Error::BatchQueriedMultipleTimes(_) => "batch_queried_multiple_times",
             Error::BatchOverlap(_, _) => "batch_overlap",
             Error::Hpke(_) => "hpke",
             Error::TaskParameters(_) => "task_parameters",

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -71,10 +71,13 @@ async fn run_error_handler(error: &Error, mut conn: Conn) -> Conn {
                     .with_detail(rejection.reason().detail()),
             ),
         },
-        Error::InvalidMessage(task_id, _) => {
+        Error::InvalidMessage(task_id, detail) => {
             let mut doc = ProblemDocument::new_dap(DapProblemType::InvalidMessage);
             if let Some(task_id) = task_id {
                 doc = doc.with_task_id(task_id);
+            }
+            if !detail.is_empty() {
+                doc = doc.with_detail(detail);
             }
             conn.with_problem_document(&doc)
         }
@@ -123,15 +126,7 @@ async fn run_error_handler(error: &Error, mut conn: Conn) -> Conn {
             .with_collection_job_id(collection_job_id),
         ),
         Error::UnrecognizedCollectionJob(_, _) => conn.with_status(Status::NotFound),
-
-        Error::UnauthorizedRequest(task_id) => conn.with_problem_document(
-            &ProblemDocument::new(
-                "https://docs.divviup.org/references/janus-errors#unauthorized-request",
-                "The request's authorization is not valid.",
-                Status::Forbidden,
-            )
-            .with_task_id(task_id),
-        ),
+        Error::UnauthorizedRequest(..) => conn.with_status(Status::Forbidden),
         Error::InvalidBatchSize(task_id, _) => conn.with_problem_document(
             &ProblemDocument::new_dap(DapProblemType::InvalidBatchSize).with_task_id(task_id),
         ),

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -84,9 +84,6 @@ async fn run_error_handler(error: &Error, mut conn: Conn) -> Conn {
         Error::UnrecognizedTask(task_id) => conn.with_problem_document(
             &ProblemDocument::new_dap(DapProblemType::UnrecognizedTask).with_task_id(task_id),
         ),
-        Error::MissingTaskId => {
-            conn.with_problem_document(&ProblemDocument::new_dap(DapProblemType::MissingTaskId))
-        }
         Error::UnrecognizedAggregationJob(task_id, _aggregation_job_id) => conn
             .with_problem_document(
                 &ProblemDocument::new_dap(DapProblemType::UnrecognizedAggregationJob)
@@ -128,7 +125,12 @@ async fn run_error_handler(error: &Error, mut conn: Conn) -> Conn {
         Error::UnrecognizedCollectionJob(_, _) => conn.with_status(Status::NotFound),
 
         Error::UnauthorizedRequest(task_id) => conn.with_problem_document(
-            &ProblemDocument::new_dap(DapProblemType::UnauthorizedRequest).with_task_id(task_id),
+            &ProblemDocument::new(
+                "https://docs.divviup.org/references/janus-errors#unauthorized-request",
+                "The request's authorization is not valid.",
+                Status::Forbidden,
+            )
+            .with_task_id(task_id),
         ),
         Error::InvalidBatchSize(task_id, _) => conn.with_problem_document(
             &ProblemDocument::new_dap(DapProblemType::InvalidBatchSize).with_task_id(task_id),
@@ -143,10 +145,6 @@ async fn run_error_handler(error: &Error, mut conn: Conn) -> Conn {
             &ProblemDocument::new_dap(DapProblemType::BatchMismatch)
                 .with_task_id(&inner.task_id)
                 .with_detail(&inner.to_string()),
-        ),
-        Error::BatchQueriedMultipleTimes(task_id) => conn.with_problem_document(
-            &ProblemDocument::new_dap(DapProblemType::BatchQueriedMultipleTimes)
-                .with_task_id(task_id),
         ),
         Error::Hpke(_)
         | Error::Datastore(_)

--- a/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
@@ -595,8 +595,8 @@ async fn aggregate_share_request() {
             take_problem_details(&mut test_conn).await,
             json!({
                 "status": Status::BadRequest as u16,
-                "type": "urn:ietf:params:ppm:dap:error:batchQueriedMultipleTimes",
-                "title": "The batch described by the query has been queried already.",
+                "type": "urn:ietf:params:ppm:dap:error:invalidMessage",
+                "title": "The message type for a response was incorrect or the payload was malformed.",
                 "taskid": format!("{}", task.id()),
             })
         );

--- a/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
@@ -597,6 +597,7 @@ async fn aggregate_share_request() {
                 "status": Status::BadRequest as u16,
                 "type": "urn:ietf:params:ppm:dap:error:invalidMessage",
                 "title": "The message type for a response was incorrect or the payload was malformed.",
+                "detail": "batch has already been collected with another aggregation parameter",
                 "taskid": format!("{}", task.id()),
             })
         );

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_continue.rs
@@ -1714,6 +1714,7 @@ async fn aggregate_continue_unexpected_transition() {
         Status::BadRequest,
         "urn:ietf:params:ppm:dap:error:invalidMessage",
         "The message type for a response was incorrect or the payload was malformed.",
+        Some("leader sent unexpected, duplicate, or out-of-order prepare steps"),
         None,
     )
     .await;
@@ -1873,6 +1874,7 @@ async fn aggregate_continue_out_of_order_transition() {
         Status::BadRequest,
         "urn:ietf:params:ppm:dap:error:invalidMessage",
         "The message type for a response was incorrect or the payload was malformed.",
+        Some("leader sent unexpected, duplicate, or out-of-order prepare steps"),
         None,
     )
     .await;
@@ -1972,6 +1974,7 @@ async fn aggregate_continue_for_non_waiting_aggregation() {
         Status::BadRequest,
         "urn:ietf:params:ppm:dap:error:invalidMessage",
         "The message type for a response was incorrect or the payload was malformed.",
+        Some("leader sent prepare step for non-CONTINUE report aggregation"),
         None,
     )
     .await;

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
@@ -171,19 +171,8 @@ async fn aggregate_wrong_agg_auth_token() {
             test_conn = test_conn.with_request_header(auth_header, auth_value);
         }
 
-        let mut test_conn = test_conn.run_async(&handler).await;
-
-        let want_status = u16::from(Status::Forbidden);
-        assert_eq!(
-            take_problem_details(&mut test_conn).await,
-            json!({
-                "status": want_status,
-                "type": "https://docs.divviup.org/references/janus-errors#unauthorized-request",
-                "title": "The request's authorization is not valid.",
-                "taskid": format!("{}", task.id()),
-            })
-        );
-        assert_eq!(want_status, test_conn.status().unwrap() as u16);
+        let status = test_conn.run_async(&handler).await.status().unwrap();
+        assert_eq!(status, Status::Forbidden);
     }
 }
 
@@ -1148,6 +1137,7 @@ async fn aggregate_init_duplicated_report_id() {
             "status": want_status,
             "type": "urn:ietf:params:ppm:dap:error:invalidMessage",
             "title": "The message type for a response was incorrect or the payload was malformed.",
+            "detail": "aggregate request contains duplicate report IDs",
             "taskid": format!("{}", task.id()),
         })
     );

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
@@ -178,7 +178,7 @@ async fn aggregate_wrong_agg_auth_token() {
             take_problem_details(&mut test_conn).await,
             json!({
                 "status": want_status,
-                "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
+                "type": "https://docs.divviup.org/references/janus-errors#unauthorized-request",
                 "title": "The request's authorization is not valid.",
                 "taskid": format!("{}", task.id()),
             })

--- a/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
@@ -220,7 +220,7 @@ async fn collection_job_put_request_unauthenticated() {
         take_problem_details(&mut test_conn).await,
         json!({
             "status": want_status,
-            "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
+            "type": "https://docs.divviup.org/references/janus-errors#unauthorized-request",
             "title": "The request's authorization is not valid.",
             "taskid": format!("{}", test_case.task.id()),
         })
@@ -241,7 +241,7 @@ async fn collection_job_put_request_unauthenticated() {
         take_problem_details(&mut test_conn).await,
         json!({
             "status": want_status,
-            "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
+            "type": "https://docs.divviup.org/references/janus-errors#unauthorized-request",
             "title": "The request's authorization is not valid.",
             "taskid": format!("{}", test_case.task.id()),
         })
@@ -258,7 +258,7 @@ async fn collection_job_put_request_unauthenticated() {
         take_problem_details(&mut test_conn).await,
         json!({
             "status": want_status,
-            "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
+            "type": "https://docs.divviup.org/references/janus-errors#unauthorized-request",
             "title": "The request's authorization is not valid.",
             "taskid": format!("{}", test_case.task.id()),
         })
@@ -301,7 +301,7 @@ async fn collection_job_get_request_unauthenticated_collection_jobs() {
         take_problem_details(&mut test_conn).await,
         json!({
             "status": want_status,
-            "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
+            "type": "https://docs.divviup.org/references/janus-errors#unauthorized-request",
             "title": "The request's authorization is not valid.",
             "taskid": format!("{}", test_case.task.id()),
         })
@@ -321,7 +321,7 @@ async fn collection_job_get_request_unauthenticated_collection_jobs() {
         take_problem_details(&mut test_conn).await,
         json!({
             "status": want_status,
-            "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
+            "type": "https://docs.divviup.org/references/janus-errors#unauthorized-request",
             "title": "The request's authorization is not valid.",
             "taskid": format!("{}", test_case.task.id()),
         })
@@ -338,7 +338,7 @@ async fn collection_job_get_request_unauthenticated_collection_jobs() {
         take_problem_details(&mut test_conn).await,
         json!({
             "status": want_status,
-            "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
+            "type": "https://docs.divviup.org/references/janus-errors#unauthorized-request",
             "title": "The request's authorization is not valid.",
             "taskid": format!("{}", test_case.task.id()),
         })
@@ -587,8 +587,8 @@ async fn collection_job_put_request_batch_queried_multiple_times() {
         take_problem_details(&mut test_conn).await,
         json!({
             "status": Status::BadRequest as u16,
-            "type": "urn:ietf:params:ppm:dap:error:batchQueriedMultipleTimes",
-            "title": "The batch described by the query has been queried already.",
+            "type": "urn:ietf:params:ppm:dap:error:invalidMessage",
+            "title": "The message type for a response was incorrect or the payload was malformed.",
             "taskid": format!("{}", test_case.task.id()),
         })
     );

--- a/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
@@ -211,59 +211,32 @@ async fn collection_job_put_request_unauthenticated() {
     );
 
     // Incorrect authentication token.
-    let mut test_conn = test_case
+    let status = test_case
         .put_collection_job_with_auth_token(&collection_job_id, &req, Some(&random()))
-        .await;
-
-    let want_status = u16::from(Status::Forbidden);
-    assert_eq!(
-        take_problem_details(&mut test_conn).await,
-        json!({
-            "status": want_status,
-            "type": "https://docs.divviup.org/references/janus-errors#unauthorized-request",
-            "title": "The request's authorization is not valid.",
-            "taskid": format!("{}", test_case.task.id()),
-        })
-    );
-    assert_eq!(want_status, test_conn.status().unwrap());
+        .await
+        .status()
+        .unwrap();
+    assert_eq!(status, Status::Forbidden);
 
     // Aggregator authentication token.
-    let mut test_conn = test_case
+    let status = test_case
         .put_collection_job_with_auth_token(
             &collection_job_id,
             &req,
             Some(test_case.task.aggregator_auth_token()),
         )
-        .await;
-
-    let want_status = u16::from(Status::Forbidden);
-    assert_eq!(
-        take_problem_details(&mut test_conn).await,
-        json!({
-            "status": want_status,
-            "type": "https://docs.divviup.org/references/janus-errors#unauthorized-request",
-            "title": "The request's authorization is not valid.",
-            "taskid": format!("{}", test_case.task.id()),
-        })
-    );
-    assert_eq!(want_status, test_conn.status().unwrap());
+        .await
+        .status()
+        .unwrap();
+    assert_eq!(status, Status::Forbidden);
 
     // Missing authentication token.
-    let mut test_conn = test_case
+    let status = test_case
         .put_collection_job_with_auth_token(&collection_job_id, &req, None)
-        .await;
-
-    let want_status = u16::from(Status::Forbidden);
-    assert_eq!(
-        take_problem_details(&mut test_conn).await,
-        json!({
-            "status": want_status,
-            "type": "https://docs.divviup.org/references/janus-errors#unauthorized-request",
-            "title": "The request's authorization is not valid.",
-            "taskid": format!("{}", test_case.task.id()),
-        })
-    );
-    assert_eq!(want_status, test_conn.status().unwrap());
+        .await
+        .status()
+        .unwrap();
+    assert_eq!(status, Status::Forbidden);
 }
 
 #[tokio::test]
@@ -292,58 +265,31 @@ async fn collection_job_get_request_unauthenticated_collection_jobs() {
     assert_eq!(test_conn.status().unwrap(), Status::Created);
 
     // Incorrect authentication token.
-    let mut test_conn = test_case
+    let status = test_case
         .get_collection_job_with_auth_token(&collection_job_id, Some(&random()))
-        .await;
-
-    let want_status = u16::from(Status::Forbidden);
-    assert_eq!(
-        take_problem_details(&mut test_conn).await,
-        json!({
-            "status": want_status,
-            "type": "https://docs.divviup.org/references/janus-errors#unauthorized-request",
-            "title": "The request's authorization is not valid.",
-            "taskid": format!("{}", test_case.task.id()),
-        })
-    );
-    assert_eq!(want_status, test_conn.status().unwrap());
+        .await
+        .status()
+        .unwrap();
+    assert_eq!(status, Status::Forbidden);
 
     // Aggregator authentication token.
-    let mut test_conn = test_case
+    let status = test_case
         .get_collection_job_with_auth_token(
             &collection_job_id,
             Some(test_case.task.aggregator_auth_token()),
         )
-        .await;
-
-    let want_status = u16::from(Status::Forbidden);
-    assert_eq!(
-        take_problem_details(&mut test_conn).await,
-        json!({
-            "status": want_status,
-            "type": "https://docs.divviup.org/references/janus-errors#unauthorized-request",
-            "title": "The request's authorization is not valid.",
-            "taskid": format!("{}", test_case.task.id()),
-        })
-    );
-    assert_eq!(want_status, test_conn.status().unwrap());
+        .await
+        .status()
+        .unwrap();
+    assert_eq!(status, Status::Forbidden);
 
     // Missing authentication token.
-    let mut test_conn = test_case
+    let status = test_case
         .get_collection_job_with_auth_token(&collection_job_id, None)
-        .await;
-
-    let want_status = u16::from(Status::Forbidden);
-    assert_eq!(
-        take_problem_details(&mut test_conn).await,
-        json!({
-            "status": want_status,
-            "type": "https://docs.divviup.org/references/janus-errors#unauthorized-request",
-            "title": "The request's authorization is not valid.",
-            "taskid": format!("{}", test_case.task.id()),
-        })
-    );
-    assert_eq!(want_status, test_conn.status().unwrap());
+        .await
+        .status()
+        .unwrap();
+    assert_eq!(status, Status::Forbidden);
 }
 
 #[tokio::test]
@@ -589,6 +535,7 @@ async fn collection_job_put_request_batch_queried_multiple_times() {
             "status": Status::BadRequest as u16,
             "type": "urn:ietf:params:ppm:dap:error:invalidMessage",
             "title": "The message type for a response was incorrect or the payload was malformed.",
+            "detail": "batch has already been collected with another aggregation parameter",
             "taskid": format!("{}", test_case.task.id()),
         })
     );

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -298,7 +298,7 @@ async fn taskprov_aggregate_init() {
             take_problem_details(&mut test_conn).await,
             json!({
                 "status": u16::from(Status::Forbidden),
-                "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
+                "type": "https://docs.divviup.org/references/janus-errors#unauthorized-request",
                 "title": "The request's authorization is not valid.",
                 "taskid": format!("{}", test.task_id),
             }),
@@ -922,7 +922,7 @@ async fn taskprov_aggregate_continue() {
         take_problem_details(&mut test_conn).await,
         json!({
             "status": u16::from(Status::Forbidden),
-            "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
+            "type": "https://docs.divviup.org/references/janus-errors#unauthorized-request",
             "title": "The request's authorization is not valid.",
             "taskid": format!("{}", test.task_id),
         })
@@ -1035,7 +1035,7 @@ async fn taskprov_aggregate_share() {
         take_problem_details(&mut test_conn).await,
         json!({
             "status": u16::from(Status::Forbidden),
-            "type": "urn:ietf:params:ppm:dap:error:unauthorizedRequest",
+            "type": "https://docs.divviup.org/references/janus-errors#unauthorized-request",
             "title": "The request's authorization is not valid.",
             "taskid": format!("{}", test.task_id),
         })

--- a/messages/src/problem_type.rs
+++ b/messages/src/problem_type.rs
@@ -2,23 +2,26 @@ use std::str::FromStr;
 
 /// Representation of the different problem types defined in [DAP][1].
 ///
-/// [1]: https://www.ietf.org/archive/id/draft-ietf-ppm-dap-07.html#table-1
+/// [1]: https://www.ietf.org/archive/id/draft-ietf-ppm-dap-15.html#table-1
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DapProblemType {
     InvalidMessage,
     UnrecognizedTask,
-    StepMismatch,
-    MissingTaskId,
     UnrecognizedAggregationJob,
     OutdatedConfig,
     ReportRejected,
     ReportTooEarly,
     BatchInvalid,
     InvalidBatchSize,
-    BatchQueriedMultipleTimes,
+    InvalidAggregationParameter,
     BatchMismatch,
-    UnauthorizedRequest,
+    StepMismatch,
     BatchOverlap,
+    UnsupportedExtension,
+    /// A task defined via Taskprov was rejected by the aggregator. Error defined by
+    /// draft-ietf-ppm-dap-taskprov ([1]).
+    ///
+    /// [1]: https://datatracker.ietf.org/doc/html/draft-ietf-ppm-dap-taskprov-01#table-1
     InvalidTask,
 }
 
@@ -28,8 +31,6 @@ impl DapProblemType {
         match self {
             DapProblemType::InvalidMessage => "urn:ietf:params:ppm:dap:error:invalidMessage",
             DapProblemType::UnrecognizedTask => "urn:ietf:params:ppm:dap:error:unrecognizedTask",
-            DapProblemType::StepMismatch => "urn:ietf:params:ppm:dap:error:stepMismatch",
-            DapProblemType::MissingTaskId => "urn:ietf:params:ppm:dap:error:missingTaskID",
             DapProblemType::UnrecognizedAggregationJob => {
                 "urn:ietf:params:ppm:dap:error:unrecognizedAggregationJob"
             }
@@ -38,14 +39,15 @@ impl DapProblemType {
             DapProblemType::ReportTooEarly => "urn:ietf:params:ppm:dap:error:reportTooEarly",
             DapProblemType::BatchInvalid => "urn:ietf:params:ppm:dap:error:batchInvalid",
             DapProblemType::InvalidBatchSize => "urn:ietf:params:ppm:dap:error:invalidBatchSize",
-            DapProblemType::BatchQueriedMultipleTimes => {
-                "urn:ietf:params:ppm:dap:error:batchQueriedMultipleTimes"
+            DapProblemType::InvalidAggregationParameter => {
+                "urn:ietf:params:ppm:dap:error:invalidAggregationParameter"
             }
             DapProblemType::BatchMismatch => "urn:ietf:params:ppm:dap:error:batchMismatch",
-            DapProblemType::UnauthorizedRequest => {
-                "urn:ietf:params:ppm:dap:error:unauthorizedRequest"
-            }
+            DapProblemType::StepMismatch => "urn:ietf:params:ppm:dap:error:stepMismatch",
             DapProblemType::BatchOverlap => "urn:ietf:params:ppm:dap:error:batchOverlap",
+            DapProblemType::UnsupportedExtension => {
+                "urn:ietf:params:ppm:dap:error:unsupportedExtension"
+            }
             DapProblemType::InvalidTask => "urn:ietf:params:ppm:dap:error:invalidTask",
         }
     }
@@ -58,12 +60,6 @@ impl DapProblemType {
             }
             DapProblemType::UnrecognizedTask => {
                 "An endpoint received a message with an unknown task ID."
-            }
-            DapProblemType::StepMismatch => {
-                "The leader and helper are not on the same step of VDAF preparation."
-            }
-            DapProblemType::MissingTaskId => {
-                "HPKE configuration was requested without specifying a task ID."
             }
             DapProblemType::UnrecognizedAggregationJob => {
                 "An endpoint received a message with an unknown aggregation job ID."
@@ -79,16 +75,17 @@ impl DapProblemType {
             DapProblemType::InvalidBatchSize => {
                 "The number of reports included in the batch is invalid."
             }
-            DapProblemType::BatchQueriedMultipleTimes => {
-                "The batch described by the query has been queried already."
-            }
+            DapProblemType::InvalidAggregationParameter => "The aggregation parameter is invalid.",
             DapProblemType::BatchMismatch => {
                 "Leader and helper disagree on reports aggregated in a batch."
             }
-            DapProblemType::UnauthorizedRequest => "The request's authorization is not valid.",
+            DapProblemType::StepMismatch => {
+                "The leader and helper are not on the same step of VDAF preparation."
+            }
             DapProblemType::BatchOverlap => {
                 "The queried batch overlaps with a previously queried batch."
             }
+            DapProblemType::UnsupportedExtension => "The report includes an unsupported extension.",
             DapProblemType::InvalidTask => "Aggregator has opted out of the indicated task.",
         }
     }
@@ -107,8 +104,6 @@ impl FromStr for DapProblemType {
             "urn:ietf:params:ppm:dap:error:unrecognizedTask" => {
                 Ok(DapProblemType::UnrecognizedTask)
             }
-            "urn:ietf:params:ppm:dap:error:stepMismatch" => Ok(DapProblemType::StepMismatch),
-            "urn:ietf:params:ppm:dap:error:missingTaskID" => Ok(DapProblemType::MissingTaskId),
             "urn:ietf:params:ppm:dap:error:unrecognizedAggregationJob" => {
                 Ok(DapProblemType::UnrecognizedAggregationJob)
             }
@@ -119,14 +114,12 @@ impl FromStr for DapProblemType {
             "urn:ietf:params:ppm:dap:error:invalidBatchSize" => {
                 Ok(DapProblemType::InvalidBatchSize)
             }
-            "urn:ietf:params:ppm:dap:error:batchQueriedMultipleTimes" => {
-                Ok(DapProblemType::BatchQueriedMultipleTimes)
-            }
             "urn:ietf:params:ppm:dap:error:batchMismatch" => Ok(DapProblemType::BatchMismatch),
-            "urn:ietf:params:ppm:dap:error:unauthorizedRequest" => {
-                Ok(DapProblemType::UnauthorizedRequest)
-            }
+            "urn:ietf:params:ppm:dap:error:stepMismatch" => Ok(DapProblemType::StepMismatch),
             "urn:ietf:params:ppm:dap:error:batchOverlap" => Ok(DapProblemType::BatchOverlap),
+            "urn:ietf:params:ppm:dap:error:unsupportedExtension" => {
+                Ok(DapProblemType::UnsupportedExtension)
+            }
             "urn:ietf:params:ppm:dap:error:invalidTask" => Ok(DapProblemType::InvalidTask),
             _ => Err(DapProblemTypeParseError),
         }


### PR DESCRIPTION
draft-ietf-ppm-dap-15 (forthcoming) will make some changes to the fart problem types defined by DAP.

- `unauthorizedRequest` is gone. We still have `aggregator::Error::UnauthorizedRequest`, but now we construct a problem document with a URN pointing to Divvi Up docs (which will be updated in [133][1].
- `batchQueriedMultipleTimes` is gone, and now instead we are instructed to provide `invalidMessage` if someone tries to change a collection or aggregate share's aggregation parameter. Accordingly we remove `aggregator::Error::BatchQueriedMultipleTimes`.
- `aggregator::Error::MissingTaskId` was not used anywhere except tests.
- We no loner need `DapProblemTypeExt` because all DAP problem types can now be represented as HTTP 400 Bad Request, per DAP's guidance to use the most general possible status.
- We add a problem type `unsupportedExtension`. However we don't use it, since it's only prescribed when the Leader rejects a report, and our Leader doesn't currently handle any extensions (we just opaquely write them to the datastore).
- I re-ordered the `DapProblemType` enum to match the table in draft-ietf-ppm-dap-15.

[1]: https://github.com/divviup/public-docs/issues/133