### PR TITLE
Fix collector poll_timing test

### DIFF
--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -1951,10 +1951,16 @@ mod tests {
             .await;
 
         // Manipulate backoff settings so that we make one or two requests and time out.
+        collector.http_request_retry_parameters = collector
+            .http_request_retry_parameters
+            .with_total_delay(Some(std::time::Duration::from_millis(3)))
+            .with_min_delay(std::time::Duration::from_millis(2))
+            .with_max_delay(std::time::Duration::from_millis(2));
         collector.collect_poll_wait_parameters = collector
             .collect_poll_wait_parameters
             .with_total_delay(Some(std::time::Duration::from_millis(15)))
-            .with_min_delay(std::time::Duration::from_millis(10));
+            .with_min_delay(std::time::Duration::from_millis(10))
+            .with_max_delay(std::time::Duration::from_millis(10));
         let mock_collect_poll_no_retry_after = server
             .mock("GET", collection_job_path.as_str())
             .with_status(200)


### PR DESCRIPTION
This test was taking too long to run for me when I ran it locally. It looks like it's taking around five minutes in CI. I noticed that `max_delay` was still very low, and thus determining `backoff_duration`. Since `backon` accounts for time spent sleeping instead of wall clock time, this increases the number of iterations, and thus the overhead and total time elapsed. I increased `max_delay` to match `min_delay`, and then similarly modified the HTTP request parameters as well.