### PR TITLE
Use backoff/retry on Kubernetes test `kind cluster delete` operations

### DIFF
--- a/core/src/test_util/kubernetes.rs
+++ b/core/src/test_util/kubernetes.rs
@@ -220,7 +220,7 @@ impl EphemeralCluster {
 impl Drop for EphemeralCluster {
     fn drop(&mut self) {
         // Delete the cluster that was created when we created the EphemeralCluster.
-        assert!(Command::new("kind")
+        let output = Command::new("kind")
             .args([
                 "delete",
                 "cluster",
@@ -230,11 +230,17 @@ impl Drop for EphemeralCluster {
                 &self.kind_cluster_name,
             ])
             .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .unwrap()
-            .success())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "`kind delete cluster` failed\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
     }
 }
 


### PR DESCRIPTION
In my setup I get a lot of timing errors during runs of `cargo test --profile ci --locked --all-targets --features=prometheus`, and they are all around the automatic teardown of the `kind` cluster:

```
ERROR: failed to delete cluster "janus-ephemeral-bfc0838a": failed to delete nodes: command "docker rm -f -v janus-ephemeral-bfc0838a-control-plane" failed with error: exit status 1

Command Output: Error response from daemon: cannot remove container "/janus-ephemeral-bfc0838a-control-plane": could not kill: tried to kill container, but did not receive an exit event
```

This PR uses `backon` to retry that cluster delete, using the [default 3 tries, 1s between each](https://docs.rs/backon/latest/backon/struct.ConstantBuilder.html) Constant Backoff. 

Note this is our first use of the blocking backoff implementation, as this is not an `async` function.