### PR TITLE
Upgrade testcontainers, use aws-lc-rs in more places

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1548,6 +1548,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c7b13d0780cb82722fd59f6f57f925e143427e4a75313a6c77243bf5326ae6"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5445,7 +5456,7 @@ dependencies = [
  "byteorder",
  "crc",
  "dotenvy",
- "etcetera",
+ "etcetera 0.8.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -5649,9 +5660,9 @@ dependencies = [
 
 [[package]]
 name = "testcontainers"
-version = "0.23.3"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a4f01f39bb10fc2a5ab23eb0d888b1e2bb168c157f61a1b98e6c501c639c74"
+checksum = "23bb7577dca13ad86a78e8271ef5d322f37229ec83b8d98da6d996c588a1ddb1"
 dependencies = [
  "async-trait",
  "bollard",
@@ -5659,7 +5670,7 @@ dependencies = [
  "bytes",
  "docker_credential",
  "either",
- "etcetera",
+ "etcetera 0.10.0",
  "futures",
  "log",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,7 +637,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "shlex",
  "syn 2.0.87",
  "which",
@@ -4334,53 +4334,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
-dependencies = [
- "bytes",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash 1.1.0",
- "rustls",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
-dependencies = [
- "bytes",
- "rand 0.8.5",
- "ring",
- "rustc-hash 2.0.0",
- "rustls",
- "slab",
- "thiserror 1.0.69",
- "tinyvec",
- "tracing",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
-dependencies = [
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4567,7 +4520,6 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
@@ -4706,12 +4658,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc-hash"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4755,7 +4701,6 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.0",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ signal-hook-tokio = "0.3.1"
 sqlx = { version = "0.8.5", default-features = false }
 stopper = "0.2.8"
 tempfile = "3.19.1"
-testcontainers = "0.23.3"
+testcontainers = { version = "0.24.0", default-features = false, features = ["aws-lc-rs"] }
 thiserror = "2.0"
 tracing = "0.1.41"
 tracing-chrome = "0.7.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ quickcheck = { version = "1.0.3", default-features = false }
 quickcheck_macros = "1.0.0"
 rand = "0.8"
 rayon = "1.10.0"
-reqwest = { version = "0.12.15", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.12.15", default-features = false, features = ["rustls-tls-webpki-roots-no-provider"] }
 regex = "1.11.1"
 retry-after = "0.4.0"
 rstest = "0.22.0"

--- a/aggregator/src/aggregator/aggregation_job_driver/tests.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver/tests.rs
@@ -31,6 +31,7 @@ use janus_aggregator_core::{
 };
 use janus_core::{
     hpke::HpkeKeypair,
+    initialize_rustls,
     report_id::ReportIdChecksumExt,
     retries::test_util::LimitedRetryer,
     test_util::{install_test_trace_subscriber, run_vdaf, runtime::TestRuntimeManager},
@@ -72,6 +73,7 @@ async fn aggregation_job_driver() {
 
     // Setup.
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
     let clock = MockClock::default();
     let mut runtime_manager = TestRuntimeManager::new();
@@ -364,6 +366,7 @@ async fn aggregation_job_driver() {
 async fn leader_sync_time_interval_aggregation_job_init_single_step() {
     // Setup: insert a client report and add it to a new aggregation job.
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
     let clock = MockClock::default();
     let ephemeral_datastore = ephemeral_datastore().await;
@@ -809,6 +812,7 @@ async fn leader_sync_time_interval_aggregation_job_init_single_step() {
 async fn leader_sync_time_interval_aggregation_job_init_two_steps() {
     // Setup: insert a client report and add it to a new aggregation job.
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
     let clock = MockClock::default();
     let ephemeral_datastore = ephemeral_datastore().await;
@@ -1081,6 +1085,7 @@ async fn leader_sync_time_interval_aggregation_job_init_partially_garbage_collec
 
     // Setup: insert an "old" and "new" client report, and add them to a new aggregation job.
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
     let clock = MockClock::new(OLDEST_ALLOWED_REPORT_TIMESTAMP);
     let ephemeral_datastore = ephemeral_datastore().await;
@@ -1463,6 +1468,7 @@ async fn leader_sync_time_interval_aggregation_job_init_partially_garbage_collec
 async fn leader_sync_leader_selected_aggregation_job_init_single_step() {
     // Setup: insert a client report and add it to a new aggregation job.
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
     let clock = MockClock::default();
     let ephemeral_datastore = ephemeral_datastore().await;
@@ -1774,6 +1780,7 @@ async fn leader_sync_leader_selected_aggregation_job_init_single_step() {
 async fn leader_sync_leader_selected_aggregation_job_init_two_steps() {
     // Setup: insert a client report and add it to a new aggregation job.
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
     let clock = MockClock::default();
     let ephemeral_datastore = ephemeral_datastore().await;
@@ -2046,6 +2053,7 @@ async fn leader_sync_time_interval_aggregation_job_continue() {
     // Setup: insert a client report and add it to an aggregation job whose state has already
     // been stepped once.
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
     let clock = MockClock::default();
     let ephemeral_datastore = ephemeral_datastore().await;
@@ -2391,6 +2399,7 @@ async fn leader_sync_leader_selected_aggregation_job_continue() {
     // Setup: insert a client report and add it to an aggregation job whose state has already
     // been stepped once.
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
     let clock = MockClock::default();
     let ephemeral_datastore = ephemeral_datastore().await;
@@ -2690,6 +2699,7 @@ async fn leader_sync_leader_selected_aggregation_job_continue() {
 async fn leader_async_aggregation_job_init_to_pending() {
     // Setup: insert a client report and add it to a new aggregation job.
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
     let clock = MockClock::default();
     let ephemeral_datastore = ephemeral_datastore().await;
@@ -2949,6 +2959,7 @@ async fn leader_async_aggregation_job_init_to_pending() {
 async fn leader_async_aggregation_job_init_to_pending_two_step() {
     // Setup: insert a client report and add it to a new aggregation job.
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
     let clock = MockClock::default();
     let ephemeral_datastore = ephemeral_datastore().await;
@@ -3208,6 +3219,7 @@ async fn leader_async_aggregation_job_init_to_pending_two_step() {
 async fn leader_async_aggregation_job_continue_to_pending() {
     // Setup: insert a client report and add it to a new aggregation job.
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
     let clock = MockClock::default();
     let ephemeral_datastore = ephemeral_datastore().await;
@@ -3469,6 +3481,7 @@ async fn leader_async_aggregation_job_continue_to_pending() {
 async fn leader_async_aggregation_job_init_poll_to_pending() {
     // Setup: insert a client report and add it to a new aggregation job.
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
     let clock = MockClock::default();
     let ephemeral_datastore = ephemeral_datastore().await;
@@ -3720,6 +3733,7 @@ async fn leader_async_aggregation_job_init_poll_to_pending() {
 async fn leader_async_aggregation_job_init_poll_to_pending_two_step() {
     // Setup: insert a client report and add it to a new aggregation job.
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
     let clock = MockClock::default();
     let ephemeral_datastore = ephemeral_datastore().await;
@@ -3971,6 +3985,7 @@ async fn leader_async_aggregation_job_init_poll_to_pending_two_step() {
 async fn leader_async_aggregation_job_init_poll_to_finished() {
     // Setup: insert a client report and add it to a new aggregation job.
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
     let clock = MockClock::default();
     let ephemeral_datastore = ephemeral_datastore().await;
@@ -4227,6 +4242,7 @@ async fn leader_async_aggregation_job_init_poll_to_finished() {
 async fn leader_async_aggregation_job_init_poll_to_continue() {
     // Setup: insert a client report and add it to a new aggregation job.
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
     let clock = MockClock::default();
     let ephemeral_datastore = ephemeral_datastore().await;
@@ -4489,6 +4505,7 @@ async fn leader_async_aggregation_job_continue_poll_to_pending() {
     // Setup: insert a client report and add it to an aggregation job whose state has already
     // been stepped once.
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
     let clock = MockClock::default();
     let ephemeral_datastore = ephemeral_datastore().await;
@@ -4742,6 +4759,7 @@ async fn leader_async_aggregation_job_continue_poll_to_finished() {
     // Setup: insert a client report and add it to an aggregation job whose state has already
     // been stepped once.
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
     let clock = MockClock::default();
     let ephemeral_datastore = ephemeral_datastore().await;
@@ -4997,6 +5015,7 @@ async fn leader_async_aggregation_job_continue_poll_to_finished() {
 async fn helper_async_init_processing_to_finished() {
     // Setup: insert an aggregation job with a report aggregation in state HelperInitProcessing.
     install_test_trace_subscriber();
+    initialize_rustls();
     let clock = MockClock::default();
     let ephemeral_datastore = ephemeral_datastore().await;
     let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
@@ -5231,6 +5250,7 @@ async fn helper_async_init_processing_to_finished() {
 async fn helper_async_init_processing_to_continue() {
     // Setup: insert an aggregation job with a report aggregation in state HelperInitProcessing.
     install_test_trace_subscriber();
+    initialize_rustls();
     let clock = MockClock::default();
     let ephemeral_datastore = ephemeral_datastore().await;
     let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
@@ -5467,6 +5487,7 @@ async fn helper_async_init_processing_to_continue() {
 async fn helper_async_continue_processing_to_finished() {
     // Setup: insert an aggregation job with a report aggregation in state HelperContinueProcessing.
     install_test_trace_subscriber();
+    initialize_rustls();
     let clock = MockClock::default();
     let ephemeral_datastore = ephemeral_datastore().await;
     let ds = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
@@ -5711,6 +5732,7 @@ struct CancelAggregationJobTestCase {
 async fn setup_cancel_aggregation_job_test() -> CancelAggregationJobTestCase {
     // Setup: insert a client report and add it to a new aggregation job.
     install_test_trace_subscriber();
+    initialize_rustls();
     let clock = MockClock::default();
     let ephemeral_datastore = ephemeral_datastore().await;
     let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);
@@ -5984,6 +6006,7 @@ async fn cancel_aggregation_job_helper_aggregation_job_deletion_fails() {
 #[tokio::test]
 async fn abandon_failing_aggregation_job_with_retryable_error() {
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
     let clock = MockClock::default();
     let mut runtime_manager = TestRuntimeManager::new();
@@ -6236,6 +6259,7 @@ async fn abandon_failing_aggregation_job_with_retryable_error() {
 #[tokio::test]
 async fn abandon_failing_aggregation_job_with_fatal_error() {
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
     let clock = MockClock::default();
     let mut runtime_manager = TestRuntimeManager::new();

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -810,6 +810,7 @@ mod tests {
         test_util::noop_meter,
     };
     use janus_core::{
+        initialize_rustls,
         retries::test_util::LimitedRetryer,
         test_util::{install_test_trace_subscriber, runtime::TestRuntimeManager},
         time::{Clock, IntervalExt, MockClock, TimeExt},
@@ -978,6 +979,7 @@ mod tests {
     #[tokio::test]
     async fn drive_collection_job() {
         install_test_trace_subscriber();
+        initialize_rustls();
         let mut server = mockito::Server::new_async().await;
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
@@ -1457,6 +1459,7 @@ mod tests {
     async fn abandon_collection_job() {
         // Setup: insert a collection job into the datastore.
         install_test_trace_subscriber();
+        initialize_rustls();
         let mut server = mockito::Server::new_async().await;
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;
@@ -1515,6 +1518,7 @@ mod tests {
     #[tokio::test]
     async fn abandon_failing_collection_job_with_fatal_error() {
         install_test_trace_subscriber();
+        initialize_rustls();
         let mut server = mockito::Server::new_async().await;
         let clock = MockClock::default();
         let mut runtime_manager = TestRuntimeManager::new();
@@ -1611,6 +1615,7 @@ mod tests {
     #[tokio::test]
     async fn abandon_failing_collection_job_with_retryable_error() {
         install_test_trace_subscriber();
+        initialize_rustls();
         let mut server = mockito::Server::new_async().await;
         let clock = MockClock::default();
         let mut runtime_manager = TestRuntimeManager::new();
@@ -1714,6 +1719,7 @@ mod tests {
     async fn delete_collection_job() {
         // Setup: insert a collection job into the datastore.
         install_test_trace_subscriber();
+        initialize_rustls();
         let mut server = mockito::Server::new_async().await;
         let clock = MockClock::default();
         let ephemeral_datastore = ephemeral_datastore().await;

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -904,6 +904,7 @@ pub mod test_util {
     };
     use janus_core::{
         hpke::HpkeKeypair,
+        initialize_rustls,
         test_util::{install_test_trace_subscriber, runtime::TestRuntime},
         time::MockClock,
     };
@@ -947,6 +948,7 @@ pub mod test_util {
     impl HttpHandlerTest {
         pub async fn new() -> Self {
             install_test_trace_subscriber();
+            initialize_rustls();
             let clock = MockClock::default();
             let ephemeral_datastore = ephemeral_datastore().await;
             let datastore = Arc::new(ephemeral_datastore.datastore(clock.clone()).await);

--- a/aggregator/src/aggregator/http_handlers/tests/report.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/report.rs
@@ -16,6 +16,7 @@ use janus_aggregator_core::{
 };
 use janus_core::{
     hpke::{self, HpkeApplicationInfo, HpkeKeypair, Label},
+    initialize_rustls,
     test_util::{install_test_trace_subscriber, runtime::TestRuntime},
     time::{Clock, MockClock, TimeExt},
     vdaf::VdafInstance,
@@ -447,6 +448,7 @@ async fn upload_handler_helper() {
 #[tokio::test(flavor = "multi_thread")]
 async fn upload_handler_error_fanout() {
     install_test_trace_subscriber();
+    initialize_rustls();
     let clock = MockClock::default();
     let ephemeral_datastore = EphemeralDatastoreBuilder::new()
         .with_database_pool_wait_timeout(Some(StdDuration::from_millis(100)))

--- a/aggregator/src/aggregator/problem_details.rs
+++ b/aggregator/src/aggregator/problem_details.rs
@@ -116,7 +116,9 @@ mod tests {
     use http::Method;
     use janus_aggregator_core::{test_util::noop_meter, TIME_HISTOGRAM_BOUNDARIES};
     use janus_core::{
+        initialize_rustls,
         retries::test_util::LimitedRetryer,
+        test_util::install_test_trace_subscriber,
         time::{Clock, RealClock},
     };
     use janus_messages::{
@@ -150,6 +152,8 @@ mod tests {
 
     #[tokio::test]
     async fn problem_details_round_trip() {
+        install_test_trace_subscriber();
+        initialize_rustls();
         let request_histogram = noop_meter()
             .f64_histogram("janus_http_request_duration")
             .with_unit("s")

--- a/aggregator/src/aggregator/upload_tests.rs
+++ b/aggregator/src/aggregator/upload_tests.rs
@@ -19,6 +19,7 @@ use janus_aggregator_core::{
 };
 use janus_core::{
     hpke::{self, HpkeApplicationInfo, HpkeKeypair, Label},
+    initialize_rustls,
     test_util::{
         install_test_trace_subscriber,
         runtime::{TestRuntime, TestRuntimeManager},
@@ -55,6 +56,7 @@ impl UploadTest {
         R: Runtime + Send + Sync + 'static,
     {
         install_test_trace_subscriber();
+        initialize_rustls();
 
         let clock = MockClock::default();
         let vdaf = Prio3Count::new_count(2).unwrap();

--- a/aggregator/src/binaries/janus_cli.rs
+++ b/aggregator/src/binaries/janus_cli.rs
@@ -1,5 +1,5 @@
 use crate::{
-    binary_utils::{database_pool, datastore, initialize_rustls, read_config, CommonBinaryOptions},
+    binary_utils::{database_pool, datastore, read_config, CommonBinaryOptions},
     config::{BinaryConfig, CommonConfig},
     metrics::{install_metrics_exporter, MetricsExporterHandle},
     trace::{install_trace_subscriber, TraceGuards},
@@ -18,6 +18,7 @@ use janus_core::{
     auth_tokens::AuthenticationToken,
     cli::{AeadAlgorithm, KdfAlgorithm, KemAlgorithm},
     hpke::HpkeKeypair,
+    initialize_rustls,
     time::{Clock, RealClock},
 };
 use janus_messages::{
@@ -751,7 +752,7 @@ mod tests {
             fetch_datastore_keys, CommandLineOptions, ConfigFile, KubernetesSecretOptions,
             LazyKubeClient,
         },
-        binary_utils::{initialize_rustls, CommonBinaryOptions},
+        binary_utils::CommonBinaryOptions,
         config::{
             default_max_transaction_retries,
             test_util::{generate_db_config, generate_metrics_config, generate_trace_config},
@@ -769,6 +770,7 @@ mod tests {
     use janus_core::{
         auth_tokens::AuthenticationToken,
         hpke::HpkeKeypair,
+        initialize_rustls,
         test_util::{kubernetes, roundtrip_encoding},
         time::RealClock,
         vdaf::{vdaf_dp_strategies, VdafInstance},

--- a/aggregator/src/binary_utils.rs
+++ b/aggregator/src/binary_utils.rs
@@ -17,7 +17,7 @@ use deadpool_postgres::{Manager, Pool, PoolError, Runtime, Timeouts};
 use futures::StreamExt;
 use janus_aggregator_api::git_revision;
 use janus_aggregator_core::datastore::{Crypter, Datastore};
-use janus_core::time::Clock;
+use janus_core::{initialize_rustls, time::Clock};
 use opentelemetry::metrics::Meter;
 use opentelemetry_sdk::metrics::MetricError;
 use rayon::{ThreadPoolBuildError, ThreadPoolBuilder};
@@ -532,13 +532,6 @@ fn initialize_rayon(stack_size: Option<usize>) -> Result<(), ThreadPoolBuildErro
         builder = builder.stack_size(stack_size);
     }
     builder.build_global()
-}
-
-pub(crate) fn initialize_rustls() {
-    // Choose aws-lc-rs as the default rustls crypto provider. This is what's currently enabled by
-    // the default Cargo feature. Specifying a default provider here prevents runtime errors if
-    // another dependency also enables the ring feature.
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 }
 
 #[cfg(test)]

--- a/aggregator/tests/integration/graceful_shutdown.rs
+++ b/aggregator/tests/integration/graceful_shutdown.rs
@@ -27,8 +27,8 @@ use janus_aggregator_core::{
     task::{test_util::TaskBuilder, AggregationMode, BatchMode},
 };
 use janus_core::{
-    hpke::HpkeCiphersuite, test_util::install_test_trace_subscriber, time::RealClock,
-    vdaf::VdafInstance,
+    hpke::HpkeCiphersuite, initialize_rustls, test_util::install_test_trace_subscriber,
+    time::RealClock, vdaf::VdafInstance,
 };
 use janus_messages::{Duration, HpkeAeadId, HpkeKdfId, HpkeKemId};
 use reqwest::Url;
@@ -126,6 +126,7 @@ fn forward_stdout_stderr(
 
 async fn graceful_shutdown<C: BinaryConfig + Serialize>(binary_name: &str, mut config: C) {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     // This datastore will be used indirectly by the child process, which
     // will connect to its backing database separately.

--- a/client/src/tests/mod.rs
+++ b/client/src/tests/mod.rs
@@ -3,7 +3,8 @@ use assert_matches::assert_matches;
 use hex_literal::hex;
 use http::{header::CONTENT_TYPE, StatusCode};
 use janus_core::{
-    hpke::HpkeKeypair, retries::test_util::test_http_request_exponential_backoff,
+    hpke::HpkeKeypair, initialize_rustls,
+    retries::test_util::test_http_request_exponential_backoff,
     test_util::install_test_trace_subscriber,
 };
 use janus_messages::{Duration, HpkeConfigList, Report, Role, Time};
@@ -56,6 +57,7 @@ fn aggregator_endpoints_end_in_slash() {
 #[tokio::test]
 async fn upload_prio3_count() {
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
     let client = setup_client(&server, Prio3::new_count(2).unwrap()).await;
 
@@ -78,6 +80,7 @@ async fn upload_prio3_count() {
 #[tokio::test]
 async fn upload_prio3_invalid_measurement() {
     install_test_trace_subscriber();
+    initialize_rustls();
     let server = mockito::Server::new_async().await;
     let vdaf = Prio3::new_sum(2, 16).unwrap();
     let client = setup_client(&server, vdaf).await;
@@ -91,6 +94,7 @@ async fn upload_prio3_invalid_measurement() {
 #[tokio::test]
 async fn upload_prio3_http_status_code() {
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
     let client = setup_client(&server, Prio3::new_count(2).unwrap()).await;
 
@@ -118,6 +122,7 @@ async fn upload_prio3_http_status_code() {
 #[tokio::test]
 async fn upload_problem_details() {
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
     let client = setup_client(&server, Prio3::new_count(2).unwrap()).await;
 
@@ -159,6 +164,7 @@ async fn upload_problem_details() {
 #[tokio::test]
 async fn upload_bad_time_precision() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     let client = Client::builder(
         random(),
@@ -179,6 +185,7 @@ async fn upload_bad_time_precision() {
 #[tokio::test]
 async fn report_timestamp() {
     install_test_trace_subscriber();
+    initialize_rustls();
     let server = mockito::Server::new_async().await;
     let vdaf = Prio3::new_count(2).unwrap();
     let mut client = setup_client(&server, vdaf).await;
@@ -215,6 +222,7 @@ async fn report_timestamp() {
 #[tokio::test]
 async fn aggregator_hpke() {
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
     let server_url = Url::parse(&server.url()).unwrap();
     let http_client = &default_http_client().unwrap();
@@ -260,6 +268,7 @@ async fn aggregator_hpke() {
 #[tokio::test]
 async fn unsupported_hpke_algorithms() {
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
     let server_url = Url::parse(&server.url()).unwrap();
     let http_client = &default_http_client().unwrap();

--- a/client/src/tests/ohttp.rs
+++ b/client/src/tests/ohttp.rs
@@ -8,7 +8,7 @@ use assert_matches::assert_matches;
 use bhttp::{Message, Mode, StatusCode};
 use http::header::{ACCEPT, CONTENT_TYPE};
 use janus_core::{
-    hpke::HpkeKeypair, http::HttpErrorResponse,
+    hpke::HpkeKeypair, http::HttpErrorResponse, initialize_rustls,
     retries::test_util::test_http_request_exponential_backoff,
     test_util::install_test_trace_subscriber,
 };
@@ -73,6 +73,7 @@ async fn mocked_ohttp_keys(server: &mut mockito::ServerGuard) -> (mockito::Mock,
 #[tokio::test]
 async fn successful_upload() {
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
 
     let (mocked_ohttp_keys, ohttp_server) = mocked_ohttp_keys(&mut server).await;
@@ -150,6 +151,7 @@ async fn successful_upload() {
 #[tokio::test]
 async fn ohttp_keyconfigs_http_error() {
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
 
     let mocked_ohttp_keys = server
@@ -170,6 +172,7 @@ async fn ohttp_keyconfigs_http_error() {
 #[tokio::test]
 async fn ohttp_keyconfigs_malformed_response_body() {
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
 
     let mocked_ohttp_keys = server
@@ -193,6 +196,7 @@ async fn ohttp_keyconfigs_malformed_response_body() {
 #[tokio::test]
 async fn ohttp_keyconfigs_wrong_content_type() {
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
 
     let key_config = KeyConfig::new(
@@ -223,6 +227,7 @@ async fn ohttp_keyconfigs_wrong_content_type() {
 #[tokio::test]
 async fn http_client_error_from_relay() {
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
 
     let (mocked_ohttp_keys, _) = mocked_ohttp_keys(&mut server).await;
@@ -250,6 +255,7 @@ async fn http_client_error_from_relay() {
 #[tokio::test]
 async fn http_client_error_from_target() {
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
 
     let (mocked_ohttp_keys, ohttp_server) = mocked_ohttp_keys(&mut server).await;
@@ -289,6 +295,7 @@ async fn http_client_error_from_target() {
 #[tokio::test]
 async fn encapsulated_server_message_is_http_request() {
     install_test_trace_subscriber();
+    initialize_rustls();
     let mut server = mockito::Server::new_async().await;
 
     let (mocked_ohttp_keys, ohttp_server) = mocked_ohttp_keys(&mut server).await;

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -798,6 +798,7 @@ mod tests {
     use janus_core::{
         auth_tokens::AuthenticationToken,
         hpke::{self, HpkeApplicationInfo, HpkeKeypair, Label},
+        initialize_rustls,
         retries::test_util::test_http_request_exponential_backoff,
         test_util::{install_test_trace_subscriber, run_vdaf, VdafTranscript},
     };
@@ -918,6 +919,8 @@ mod tests {
 
     #[test]
     fn leader_endpoint_end_in_slash() {
+        install_test_trace_subscriber();
+        initialize_rustls();
         let hpke_keypair = HpkeKeypair::test();
         let collector = Collector::new(
             random(),
@@ -948,6 +951,7 @@ mod tests {
     #[tokio::test]
     async fn successful_collect_prio3_count() {
         install_test_trace_subscriber();
+        initialize_rustls();
         let mut server = mockito::Server::new_async().await;
         let vdaf = Prio3::new_count(2).unwrap();
         let transcript = run_vdaf(&vdaf, &random(), &random(), &(), &random(), &true);
@@ -1055,6 +1059,7 @@ mod tests {
     #[tokio::test]
     async fn successful_collect_prio3_sum() {
         install_test_trace_subscriber();
+        initialize_rustls();
         let mut server = mockito::Server::new_async().await;
         let vdaf = Prio3::new_sum(2, 255).unwrap();
         let transcript = run_vdaf(&vdaf, &random(), &random(), &(), &random(), &144);
@@ -1123,6 +1128,7 @@ mod tests {
     #[tokio::test]
     async fn successful_collect_prio3_histogram() {
         install_test_trace_subscriber();
+        initialize_rustls();
         let mut server = mockito::Server::new_async().await;
         let vdaf = Prio3::new_histogram(2, 4, 2).unwrap();
         let transcript = run_vdaf(&vdaf, &random(), &random(), &(), &random(), &3);
@@ -1192,6 +1198,7 @@ mod tests {
     #[tokio::test]
     async fn successful_collect_prio3_fixedpoint_boundedl2_vec_sum() {
         install_test_trace_subscriber();
+        initialize_rustls();
         let mut server = mockito::Server::new_async().await;
         let vdaf = Prio3::new_fixedpoint_boundedl2_vec_sum(2, 3).unwrap();
         const FP32_4_INV: I1F31 = I1F31::lit("0.25");
@@ -1271,6 +1278,7 @@ mod tests {
     #[tokio::test]
     async fn successful_collect_leader_selected() {
         install_test_trace_subscriber();
+        initialize_rustls();
         let mut server = mockito::Server::new_async().await;
         let vdaf = Prio3::new_count(2).unwrap();
         let transcript = run_vdaf(&vdaf, &random(), &random(), &(), &random(), &true);
@@ -1334,6 +1342,7 @@ mod tests {
     #[tokio::test]
     async fn successful_collect_authentication_bearer() {
         install_test_trace_subscriber();
+        initialize_rustls();
         let mut server = mockito::Server::new_async().await;
         let vdaf = Prio3::new_count(2).unwrap();
         let transcript = run_vdaf(&vdaf, &random(), &random(), &(), &random(), &true);
@@ -1417,6 +1426,7 @@ mod tests {
     #[tokio::test]
     async fn failed_collect_start() {
         install_test_trace_subscriber();
+        initialize_rustls();
         let mut server = mockito::Server::new_async().await;
         let vdaf = Prio3::new_count(2).unwrap();
         let collector = setup_collector(&mut server, vdaf);
@@ -1508,6 +1518,7 @@ mod tests {
     #[tokio::test]
     async fn failed_collect_poll() {
         install_test_trace_subscriber();
+        initialize_rustls();
         let mut server = mockito::Server::new_async().await;
         let vdaf = Prio3::new_count(2).unwrap();
         let collector = setup_collector(&mut server, vdaf);
@@ -1748,6 +1759,7 @@ mod tests {
     #[tokio::test]
     async fn collect_poll_retry_after() {
         install_test_trace_subscriber();
+        initialize_rustls();
         let mut server = mockito::Server::new_async().await;
         let vdaf = Prio3::new_count(2).unwrap();
         let collector = setup_collector(&mut server, vdaf);
@@ -1841,6 +1853,7 @@ mod tests {
         // the amount of time that poll_until_complete() sleeps. `tokio::time::pause()` cannot be
         // used for this because hyper uses `tokio::time::Interval` internally, see issue #234.
         install_test_trace_subscriber();
+        initialize_rustls();
         let mut server = mockito::Server::new_async().await;
         let vdaf = Prio3::new_count(2).unwrap();
         let mut collector = setup_collector(&mut server, vdaf);
@@ -1982,6 +1995,7 @@ mod tests {
     #[tokio::test]
     async fn successful_delete() {
         install_test_trace_subscriber();
+        initialize_rustls();
         let mut server = mockito::Server::new_async().await;
         let vdaf = dummy::Vdaf::new(1);
         let collector = setup_collector(&mut server, vdaf);
@@ -2019,6 +2033,7 @@ mod tests {
     #[tokio::test]
     async fn failed_delete() {
         install_test_trace_subscriber();
+        initialize_rustls();
         let mut server = mockito::Server::new_async().await;
         let vdaf = dummy::Vdaf::new(1);
         let collector = setup_collector(&mut server, vdaf);
@@ -2052,6 +2067,7 @@ mod tests {
     #[tokio::test]
     async fn poll_content_length_header() {
         install_test_trace_subscriber();
+        initialize_rustls();
         let mut server = mockito::Server::new_async().await;
         let vdaf = Prio3::new_count(2).unwrap();
         let transcript = run_vdaf(&vdaf, &random(), &random(), &(), &random(), &true);

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -59,6 +59,7 @@ quickcheck = { workspace = true, optional = true }
 rand.workspace = true
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
+rustls.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, optional = true }
 serde_yaml.workspace = true

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -59,3 +59,10 @@ pub fn url_ensure_trailing_slash(mut url: Url) -> Url {
     }
     url
 }
+
+/// Choose aws-lc-rs as the default rustls crypto provider. This is what's currently enabled by the
+/// default Cargo feature. Specifying a default provider here prevents runtime errors if another
+/// dependency also enables the ring feature.
+pub fn initialize_rustls() {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+}

--- a/core/src/retries.rs
+++ b/core/src/retries.rs
@@ -345,6 +345,7 @@ pub mod test_util {
 #[cfg(test)]
 mod tests {
     use crate::{
+        initialize_rustls,
         retries::{
             retry_http_request, retry_http_request_notify, test_util::LimitedRetryer,
             ExponentialWithTotalDelayBuilder,
@@ -361,6 +362,7 @@ mod tests {
     #[tokio::test]
     async fn http_retry_client_error() {
         install_test_trace_subscriber();
+        initialize_rustls();
         let mut server = mockito::Server::new_async().await;
 
         let mock_404 = server
@@ -396,6 +398,7 @@ mod tests {
     #[tokio::test]
     async fn http_retry_server_error() {
         install_test_trace_subscriber();
+        initialize_rustls();
         let mut server = mockito::Server::new_async().await;
 
         let mock_500 = server
@@ -434,6 +437,7 @@ mod tests {
     #[tokio::test]
     async fn http_retry_server_error_unimplemented() {
         install_test_trace_subscriber();
+        initialize_rustls();
         let mut server = mockito::Server::new_async().await;
 
         let mock_501 = server
@@ -465,6 +469,7 @@ mod tests {
     #[tokio::test]
     async fn http_retry_server_error_eventually_succeeds() {
         install_test_trace_subscriber();
+        initialize_rustls();
         let mut server = mockito::Server::new_async().await;
 
         let mock_500 = server
@@ -501,6 +506,7 @@ mod tests {
     #[tokio::test]
     async fn http_retry_timeout() {
         install_test_trace_subscriber();
+        initialize_rustls();
 
         let tcp_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let bound_port = tcp_listener.local_addr().unwrap().port();
@@ -536,6 +542,7 @@ mod tests {
     #[tokio::test]
     async fn http_retry_connection_reset() {
         install_test_trace_subscriber();
+        initialize_rustls();
 
         let tcp_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let bound_port = tcp_listener.local_addr().unwrap().port();
@@ -580,6 +587,7 @@ mod tests {
     #[tokio::test]
     async fn http_retry_server_json_problem() {
         install_test_trace_subscriber();
+        initialize_rustls();
         let mut server = mockito::Server::new_async().await;
 
         let mock_problem = server
@@ -611,6 +619,7 @@ mod tests {
     #[tokio::test]
     async fn http_retry_server_json_problem_versioned_doc() {
         install_test_trace_subscriber();
+        initialize_rustls();
         let mut server = mockito::Server::new_async().await;
 
         // Ensure that even with a complex media type, we parse a problem

--- a/integration_tests/tests/integration/simulation/bad_client.rs
+++ b/integration_tests/tests/integration/simulation/bad_client.rs
@@ -13,6 +13,7 @@ use janus_aggregator_core::{
 use janus_core::{
     hpke::{self, HpkeApplicationInfo, HpkeKeypair, Label},
     http::HttpErrorResponse,
+    initialize_rustls,
     retries::retry_http_request,
     test_util::{install_test_trace_subscriber, runtime::TestRuntime},
     time::{Clock, RealClock, TimeExt},
@@ -375,6 +376,7 @@ async fn aggregator_hpke_config(
 #[tokio::test(flavor = "multi_thread")]
 async fn bad_client_report_validity() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     let clock = RealClock::default();
     let ephemeral_datastore = ephemeral_datastore().await;

--- a/integration_tests/tests/integration/simulation/quicktest.rs
+++ b/integration_tests/tests/integration/simulation/quicktest.rs
@@ -1,7 +1,7 @@
 use std::{env, sync::Arc};
 
 use janus_aggregator_core::datastore::test_util::EphemeralDatabase;
-use janus_core::test_util::install_test_trace_subscriber;
+use janus_core::{initialize_rustls, test_util::install_test_trace_subscriber};
 use quickcheck::{Gen, QuickCheck, TestResult};
 use tokio::runtime::Runtime;
 
@@ -17,6 +17,7 @@ use crate::simulation::{
 #[ignore = "slow quickcheck test"]
 fn simulation_test_time_interval_no_fault_injection() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     let _ephemeral_database = DatabaseHandle::new();
 
@@ -29,6 +30,7 @@ fn simulation_test_time_interval_no_fault_injection() {
 #[ignore = "slow quickcheck test"]
 fn simulation_test_leader_selected_no_fault_injection() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     let _ephemeral_database = DatabaseHandle::new();
 
@@ -42,6 +44,7 @@ fn simulation_test_leader_selected_no_fault_injection() {
 #[ignore = "slow quickcheck test"]
 fn simulation_test_time_interval_with_fault_injection() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     let _ephemeral_database = DatabaseHandle::new();
 
@@ -55,6 +58,7 @@ fn simulation_test_time_interval_with_fault_injection() {
 #[ignore = "slow quickcheck test"]
 fn simulation_test_leader_selected_with_fault_injection() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     let _ephemeral_database = DatabaseHandle::new();
 
@@ -68,6 +72,7 @@ fn simulation_test_leader_selected_with_fault_injection() {
 #[ignore = "slow quickcheck test"]
 fn simulation_test_key_rotator() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     let _ephemeral_database = DatabaseHandle::new();
 

--- a/integration_tests/tests/integration/simulation/reproduction.rs
+++ b/integration_tests/tests/integration/simulation/reproduction.rs
@@ -1,5 +1,5 @@
 use janus_aggregator_core::task::AggregationMode;
-use janus_core::{test_util::install_test_trace_subscriber, time::TimeExt};
+use janus_core::{initialize_rustls, test_util::install_test_trace_subscriber, time::TimeExt};
 use janus_messages::{Duration, Interval, Time};
 use rand::random;
 
@@ -12,6 +12,7 @@ use crate::simulation::{
 #[test]
 fn successful_collection_time_interval() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     let collection_job_id = random();
     let input = Input {
@@ -85,6 +86,7 @@ fn successful_collection_time_interval() {
 #[test]
 fn successful_collection_leader_selected() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     let collection_job_id = random();
     let input = Input {
@@ -146,6 +148,7 @@ fn successful_collection_leader_selected() {
 #[test]
 fn successful_collection_asynchronous() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     let collection_job_id = random();
     let input = Input {
@@ -240,6 +243,7 @@ fn successful_collection_asynchronous() {
 /// Regression test for https://github.com/divviup/janus/issues/2442.
 fn repro_gc_changes_aggregation_job_retry_time_interval() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     let input = Input {
         is_leader_selected: false,
@@ -280,6 +284,7 @@ fn repro_gc_changes_aggregation_job_retry_time_interval() {
 /// Regression test for https://github.com/divviup/janus/issues/2442.
 fn repro_gc_changes_aggregation_job_retry_leader_selected() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     let input = Input {
         is_leader_selected: true,
@@ -320,6 +325,7 @@ fn repro_gc_changes_aggregation_job_retry_leader_selected() {
 /// Regression test for https://github.com/divviup/janus/issues/2464.
 fn repro_recreate_gcd_batch_job_count_underflow() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     let input = Input {
         is_leader_selected: false,
@@ -358,6 +364,7 @@ fn repro_recreate_gcd_batch_job_count_underflow() {
 #[ignore = "failing test"]
 fn repro_abandoned_aggregation_job_batch_mismatch() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     let collection_job_id = random();
     let input = Input {
@@ -408,6 +415,7 @@ fn repro_abandoned_aggregation_job_batch_mismatch() {
 /// Reproduction of the issue fixed by https://github.com/divviup/janus/pull/2355.
 fn repro_helper_accumulate_on_retried_request() {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     let input = Input {
         is_leader_selected: false,

--- a/interop_binaries/src/bin/janus_interop.rs
+++ b/interop_binaries/src/bin/janus_interop.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand};
+use janus_core::initialize_rustls;
 use janus_interop_binaries::commands::{
     janus_interop_aggregator, janus_interop_client, janus_interop_collector,
 };
@@ -31,6 +32,7 @@ enum Nested {
 }
 
 fn main() -> Result<(), anyhow::Error> {
+    initialize_rustls();
     match Options::parse() {
         Options::Client(options) | Options::Default(Nested::Client(options)) => options.run(),
         Options::Aggregator(options) | Options::Default(Nested::Aggregator(options)) => {

--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -5,6 +5,7 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use fixed::types::{I1F15, I1F31};
 use futures::future::join_all;
 use janus_core::{
+    initialize_rustls,
     test_util::install_test_trace_subscriber,
     time::{Clock, RealClock, TimeExt},
     vdaf::VERIFY_KEY_LENGTH_PRIO3,
@@ -46,6 +47,7 @@ async fn run(
     aggregation_parameter: &[u8],
 ) -> serde_json::Value {
     install_test_trace_subscriber();
+    initialize_rustls();
 
     let batch_mode_json = match query_kind {
         QueryKind::TimeInterval => {

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -718,6 +718,8 @@ mod tests {
     use janus_core::{
         auth_tokens::{BearerToken, DapAuthToken},
         hpke::HpkeKeypair,
+        initialize_rustls,
+        test_util::install_test_trace_subscriber,
     };
     use janus_messages::TaskId;
     use prio::codec::Encode;
@@ -744,6 +746,9 @@ mod tests {
 
     #[tokio::test]
     async fn argument_handling() {
+        install_test_trace_subscriber();
+        initialize_rustls();
+
         let hpke_keypair = HpkeKeypair::test();
         let encoded_hpke_config =
             URL_SAFE_NO_PAD.encode(hpke_keypair.config().get_encoded().unwrap());


### PR DESCRIPTION
This upgrades the testcontainers dependency, and changes feature flags on it and reqwest to use aws-lc-rs more. We now only depend on ring for tokio-postgres-rustls and rustls-platform-verifier. I had to explicitly initialize the rustls crypto provider in more tests, because reqwest only has special handling for there being no installed default crypto provider when its ring feature is enabled.