### PR TITLE
Fix supervisord key rotator program

### DIFF
--- a/Dockerfile.interop_aggregator
+++ b/Dockerfile.interop_aggregator
@@ -79,6 +79,7 @@ COPY interop_binaries/config/supervisord.conf \
     interop_binaries/config/aggregation_job_creator.yaml \
     interop_binaries/config/aggregation_job_driver.yaml \
     interop_binaries/config/collection_job_driver.yaml \
+    interop_binaries/config/key_rotator.yaml \
     /etc/janus/
 ARG PROFILE
 COPY --from=builder-interop /src/target/$PROFILE/janus_interop /usr/local/bin/janus_interop_aggregator

--- a/interop_binaries/config/aggregator.yaml
+++ b/interop_binaries/config/aggregator.yaml
@@ -10,3 +10,4 @@ listen_address: 0.0.0.0:8081
 max_upload_batch_size: 100
 max_upload_batch_write_delay_ms: 100
 batch_aggregation_shard_count: 32
+key_rotator: null

--- a/interop_binaries/config/supervisord.conf
+++ b/interop_binaries/config/supervisord.conf
@@ -49,6 +49,8 @@ stderr_logfile=/logs/collection_job_driver_stderr.log
 [program:key_rotator]
 command=/usr/local/bin/janus_aggregator key_rotator --config-file /etc/janus/key_rotator.yaml
 autostart=false
+expected=0
+startsecs=0
 environment=DATASTORE_KEYS=OSjfC8QVPATwO3uVJcAnTA
 stdout_logfile=/logs/key_rotator_stdout.log
 stderr_logfile=/logs/key_rotator_stderr.log


### PR DESCRIPTION
While looking closely at the aggregator interop test container, I noticed that the key rotator program was failing and restarting repeatedly, because its configuration file was missing. This PR fixes that, reconfigures supervisord to expect the program to successfully exit soon after startup, and disables the key rotator component inside the aggregator program.