### PR TITLE
Use `Box<dyn Error>` as catch-all in error enums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2890,6 +2890,7 @@ dependencies = [
 name = "janus_collector"
 version = "0.8.0-prerelease-1"
 dependencies = [
+ "anyhow",
  "assert_matches",
  "backon",
  "base64 0.22.1",

--- a/aggregator/src/cache.rs
+++ b/aggregator/src/cache.rs
@@ -113,7 +113,7 @@ impl HpkeKeypairCache {
             sleep(Self::WAIT_RETRY_INTERVAL).await;
         }
         Err(Error::Internal(
-            "no active HPKE keys present in database".to_string(),
+            "no active HPKE keys present in database".into(),
         ))
     }
 

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -18,6 +18,7 @@ fpvec_bounded_l2 = ["dep:fixed", "janus_core/fpvec_bounded_l2", "prio/experiment
 test-util = []
 
 [dependencies]
+anyhow.workspace = true
 backon = { workspace = true }
 chrono.workspace = true
 educe.workspace = true


### PR DESCRIPTION
Recent changes to guarantee aligned times, intervals and durations have prompted us to look closely at some nuanced error handling in Janus. Our error enums generally provide structured variants to represent specific failure modes, but inevitably, we end up with "catch-all" variants like `janus_aggregator::aggregator::Error`'s `Internal` or `BadRequest` which wrap a `String`, an opaque description of whatever went wrong.

Sometimes, that string is a flattened error of some type that occurs so infrequently that we don't think it's worth adding a variant to the error enum. But it's still unfortunate to lose the structure of the error chain. A compromise here is to replace variants like `Internal(String)` with `Internal(Box<dyn std::error::Error>)`. The standard `Error` trait is implemented for `String` and `&str`, so we can still instantiate these variants with simple descriptions of what went wrong, but if there _is_ some underlying error, we can box it and stick it in the enum, so that at least we'll get a little more information if we ever print out the error, even if matching on its structure in code would require downcasting gymnastics.

There were several cases where we'd construct a string that incorporated the underlying error's description. We now instead use an `anyhow::Error` created via `anyhow::Context` to add a context string to the underlying error while preserving its value and structure.

The downside here is that there are probably cases where we're unnecessarily doing double indirection: I think a `Box<String>` is a heap allocation pointing to another heap allocation. We're also inserting a whole extra `anyhow::Error` into some error chains. However I would expect this to only happen on error paths, which shouldn't be performance critical anyway. Additionally, I would bet that the struct representation of many of these errors is often _smaller_ than the description string, which could include several dozen characters of prose as well as whatever actual error code or path the error contains.