### PR TITLE
Allow making smaller aggregation jobs after delay

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -54,7 +54,7 @@ use prio::{
 };
 use rand::{random, thread_rng, Rng};
 use std::{
-    cmp::min,
+    cmp::{max, min},
     collections::{HashMap, HashSet},
     sync::Arc,
     time::Duration,
@@ -88,6 +88,10 @@ pub struct AggregationJobCreator<C: Clock> {
     max_aggregation_job_size: usize,
     /// Maximum number of reports to load at a time when creating aggregation jobs.
     aggregation_job_creation_report_window: usize,
+    /// Maximum expected time difference between a report's timestamp and when it is uploaded. For
+    /// time interval tasks, this is used to decide when to create an aggregation job with fewer
+    /// than `min_aggregation_job_size` reports.
+    late_report_grace_period: janus_messages::Duration,
 }
 
 impl<C: Clock + 'static> AggregationJobCreator<C> {
@@ -100,6 +104,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
         min_aggregation_job_size: usize,
         max_aggregation_job_size: usize,
         aggregation_job_creation_report_window: usize,
+        late_report_grace_period: janus_messages::Duration,
     ) -> AggregationJobCreator<C> {
         assert!(
             min_aggregation_job_size > 0,
@@ -118,6 +123,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
             min_aggregation_job_size,
             max_aggregation_job_size,
             aggregation_job_creation_report_window,
+            late_report_grace_period,
         }
     }
 
@@ -295,7 +301,9 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
         }
     }
 
-    // Returns true if at least one aggregation job was created.
+    /// This returns `true` if at least one aggregation job at or above the
+    /// minimum size was created. This is used as a hint to schedule the next
+    /// run of the aggregation job creator.
     #[tracing::instrument(
         name = "AggregationJobCreator::create_aggregation_jobs_for_task",
         skip(self, task),
@@ -548,6 +556,13 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
         }
     }
 
+    /// Create aggregation jobs.
+    ///
+    /// This method is specialized for time interval tasks, using a VDAF with a trivial aggregation
+    /// parameter (and thus eager aggregation).
+    ///
+    /// This returns `true` if at least one aggregation job at or above the minimum size was
+    /// created. This is used as a hint to schedule the next run of the aggregation job creator.
     async fn create_aggregation_jobs_for_time_interval_task_no_param<const SEED_SIZE: usize, A>(
         self: Arc<Self>,
         task: Arc<AggregatorTask>,
@@ -583,10 +598,11 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                         .await?;
                     reports.sort_by_key(|report_metadata| *report_metadata.time());
 
-                    // Generate aggregation jobs & report aggregations based on the reports we read.
-                    // We attempt to generate reports from touching a minimal number of batches by
-                    // generating as many aggregation jobs in the allowed size range for each batch
-                    // before considering using reports from the next batch.
+                    // Generate aggregation jobs and report aggregations based on the reports we
+                    // read. We attempt to generate aggregation jobs such that their reports touch a
+                    // minimal number of batches by generating as many aggregation jobs in the
+                    // allowed size range as possible for each batch before considering using
+                    // reports from the next batch.
                     let mut aggregation_job_writer =
                         AggregationJobWriter::<SEED_SIZE, _, _, InitialWrite, _>::new(
                             Arc::clone(&task),
@@ -595,6 +611,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                         );
                     let mut report_ids_to_scrub = HashSet::new();
                     let mut outstanding_reports = Vec::new();
+                    let mut any_normal_size_agg_job = false;
                     {
                         // We have to place `reports_by_batch` in this block, as some of its
                         // internal types are not Send/Sync & thus cannot be held across an await
@@ -617,17 +634,43 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                             // Fill `outstanding_reports` from `reports_by_batch` until we have at
                             // least the minimum aggregation job size available. If we run out of
                             // reports from `reports_by_batch` without meeting the minimum
-                            // aggregation job size, we are done generating aggregation jobs.
-                            if outstanding_reports.len() < this.min_aggregation_job_size {
-                                if let Some((_, new_reports)) = reports_by_batch.next() {
-                                    outstanding_reports.extend(new_reports);
-                                    continue;
-                                } else {
-                                    // If we get here, we have consumed all of `reports_by_batch`
-                                    // and we still don't have enough outstanding reports for an
-                                    // aggregation job -- we are done.
+                            // aggregation job size, we may create one aggregation job smaller than
+                            // the minimum size.
+                            if outstanding_reports.len() >= this.min_aggregation_job_size {
+                                any_normal_size_agg_job = true;
+                            } else if let Some((_, new_reports)) = reports_by_batch.next() {
+                                outstanding_reports.extend(new_reports);
+                                continue;
+                            } else {
+                                // If we get here, we have consumed all of `reports_by_batch`
+                                // and we still don't have enough outstanding reports for an
+                                // aggregation job. If we have yet to create any aggregation
+                                // job, and the reports are sufficiently old, we will fall
+                                // through and create a smaller aggregation job anyway.
+                                // Otherwise, we are done.
+                                if any_normal_size_agg_job {
+                                    // We have made progress this run, so it's fine to stop now.
                                     break;
                                 }
+                                let Some(oldest_report) = outstanding_reports.first() else {
+                                    // No reports. The remainder of this loop requires
+                                    // `outstanding_reports` to be non-empty.
+                                    break;
+                                };
+                                // Calculate the time when this report will be old enough that
+                                // the late report grace period has passed. Round the grace
+                                // period up to the time precision in case it is larger.
+                                let Ok(aggressive_aggregation_time) = oldest_report.time().add(
+                                    &max(this.late_report_grace_period, *task.time_precision()),
+                                ) else {
+                                    break;
+                                };
+                                if tx.clock().now() < aggressive_aggregation_time {
+                                    // Report is not old enough to merit a below-minimum size aggregation job.
+                                    break;
+                                }
+                                // Fall through and create an aggregation job smaller than
+                                // `min_aggregation_job_size`.
                             }
 
                             // For the rest of the iteration of this loop, we'll generate a single
@@ -712,7 +755,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                         })),
                     )?;
 
-                    Ok(!aggregation_job_writer.is_empty())
+                    Ok(any_normal_size_agg_job)
                 })
             })
             .await?)
@@ -1046,6 +1089,7 @@ mod tests {
             1,
             100,
             5000,
+            janus_messages::Duration::from_seconds(3600),
         ));
         let stopper = Stopper::new();
         let task_handle = task::spawn(Arc::clone(&job_creator).run(stopper.clone()));
@@ -1227,6 +1271,7 @@ mod tests {
             MIN_AGGREGATION_JOB_SIZE,
             MAX_AGGREGATION_JOB_SIZE,
             5000,
+            janus_messages::Duration::from_seconds(3600),
         ));
         Arc::clone(&job_creator)
             .create_aggregation_jobs_for_task(Arc::clone(&task))
@@ -1412,6 +1457,7 @@ mod tests {
             2,
             100,
             5000,
+            janus_messages::Duration::from_seconds(3600),
         ));
         Arc::clone(&job_creator)
             .create_aggregation_jobs_for_task(Arc::clone(&task))
@@ -1638,6 +1684,7 @@ mod tests {
             MIN_AGGREGATION_JOB_SIZE,
             MAX_AGGREGATION_JOB_SIZE,
             5000,
+            janus_messages::Duration::from_seconds(3600),
         ));
         Arc::clone(&job_creator)
             .create_aggregation_jobs_for_task(Arc::clone(&task))
@@ -1805,6 +1852,7 @@ mod tests {
             MIN_AGGREGATION_JOB_SIZE,
             MAX_AGGREGATION_JOB_SIZE,
             5000,
+            janus_messages::Duration::from_seconds(3600),
         ));
         Arc::clone(&job_creator)
             .create_aggregation_jobs_for_task(Arc::clone(&task))
@@ -2022,6 +2070,7 @@ mod tests {
             MIN_AGGREGATION_JOB_SIZE,
             MAX_AGGREGATION_JOB_SIZE,
             5000,
+            janus_messages::Duration::from_seconds(3600),
         ));
         Arc::clone(&job_creator)
             .create_aggregation_jobs_for_task(Arc::clone(&task))
@@ -2191,6 +2240,7 @@ mod tests {
             MIN_AGGREGATION_JOB_SIZE,
             MAX_AGGREGATION_JOB_SIZE,
             5000,
+            janus_messages::Duration::from_seconds(3600),
         ));
         Arc::clone(&job_creator)
             .create_aggregation_jobs_for_task(Arc::clone(&task))
@@ -2455,6 +2505,7 @@ mod tests {
             MIN_AGGREGATION_JOB_SIZE,
             MAX_AGGREGATION_JOB_SIZE,
             5000,
+            janus_messages::Duration::from_seconds(3600),
         ));
         Arc::clone(&job_creator)
             .create_aggregation_jobs_for_task(Arc::clone(&task))
@@ -2750,6 +2801,7 @@ mod tests {
             MIN_AGGREGATION_JOB_SIZE,
             MAX_AGGREGATION_JOB_SIZE,
             5000,
+            janus_messages::Duration::from_seconds(3600),
         ));
         Arc::clone(&job_creator)
             .create_aggregation_jobs_for_task(Arc::clone(&task))
@@ -3042,6 +3094,7 @@ mod tests {
             MIN_AGGREGATION_JOB_SIZE,
             MAX_AGGREGATION_JOB_SIZE,
             5000,
+            janus_messages::Duration::from_seconds(3600),
         ));
         Arc::clone(&job_creator)
             .create_aggregation_jobs_for_task(Arc::clone(&task))
@@ -3247,6 +3300,7 @@ mod tests {
             1,
             MAX_AGGREGATION_JOB_SIZE,
             5000,
+            janus_messages::Duration::from_seconds(3600),
         ));
         Arc::clone(&job_creator)
             .create_aggregation_jobs_for_time_interval_task_with_param::<0, dummy::Vdaf>(

--- a/aggregator/tests/integration/graceful_shutdown.rs
+++ b/aggregator/tests/integration/graceful_shutdown.rs
@@ -378,6 +378,7 @@ async fn aggregation_job_creator_shutdown() {
         min_aggregation_job_size: 100,
         max_aggregation_job_size: 100,
         aggregation_job_creation_report_window: 5000,
+        late_report_grace_period_s: 3600,
     };
 
     graceful_shutdown("aggregation_job_creator", config).await;

--- a/docs/samples/advanced_config/aggregation_job_creator.yaml
+++ b/docs/samples/advanced_config/aggregation_job_creator.yaml
@@ -109,3 +109,9 @@ max_aggregation_job_size: 100
 # Maximum number of reports to load at a time when creating aggregation jobs.
 # (optional, defaults to 5000)
 aggregation_job_creation_report_window: 5000
+
+# Maximum expected time difference between a report's timestamp and when it is
+# uploaded. For time interval tasks, this is used to decide when to create an
+# aggregation job with fewer than `min_aggregation_job_size` reports. (optional,
+# defaults to 3600)
+late_report_grace_period_s: 3600

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -189,6 +189,7 @@ impl JanusInProcess {
             min_aggregation_job_size: 1,
             max_aggregation_job_size: 100,
             aggregation_job_creation_report_window: 5000,
+            late_report_grace_period_s: 3600,
         };
         let aggregation_job_driver_options = AggregationJobDriverOptions {
             common: common_binary_options.clone(),

--- a/integration_tests/tests/integration/simulation/arbitrary.rs
+++ b/integration_tests/tests/integration/simulation/arbitrary.rs
@@ -25,6 +25,7 @@ impl Arbitrary for Config {
         aggregation_job_size_limits.sort();
 
         let time_precision = Duration::from_seconds(3600);
+        let late_report_grace_period = Duration::from_seconds(3600);
 
         Self {
             time_precision,
@@ -37,6 +38,7 @@ impl Arbitrary for Config {
                 .then_some(Duration::from_seconds(u16::arbitrary(g).into())),
             min_aggregation_job_size: aggregation_job_size_limits[0].into(),
             max_aggregation_job_size: aggregation_job_size_limits[1].into(),
+            late_report_grace_period,
         }
     }
 

--- a/integration_tests/tests/integration/simulation/model.rs
+++ b/integration_tests/tests/integration/simulation/model.rs
@@ -36,6 +36,9 @@ pub(super) struct Config {
 
     /// Aggregation job creator configuration: maximum aggregation job size.
     pub(super) max_aggregation_job_size: usize,
+
+    /// Aggregation job creator configuration: late report grace period.
+    pub(super) late_report_grace_period: Duration,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/integration_tests/tests/integration/simulation/reproduction.rs
+++ b/integration_tests/tests/integration/simulation/reproduction.rs
@@ -23,6 +23,7 @@ fn successful_collection_time_interval() {
             report_expiry_age: Some(Duration::from_seconds(7200)),
             min_aggregation_job_size: 1,
             max_aggregation_job_size: 10,
+            late_report_grace_period: Duration::from_seconds(3600),
         },
         ops: Vec::from([
             Op::Upload {
@@ -96,6 +97,7 @@ fn successful_collection_fixed_size() {
             report_expiry_age: Some(Duration::from_seconds(7200)),
             min_aggregation_job_size: 1,
             max_aggregation_job_size: 10,
+            late_report_grace_period: Duration::from_seconds(3600),
         },
         ops: Vec::from([
             Op::Upload {
@@ -158,6 +160,7 @@ fn repro_slow_uploads_with_max_batch_size() {
             report_expiry_age: Some(Duration::from_seconds(7200)),
             min_aggregation_job_size: 1,
             max_aggregation_job_size: 10,
+            late_report_grace_period: Duration::from_seconds(3600),
         },
         ops: Vec::from([
             Op::Upload {
@@ -222,6 +225,7 @@ fn repro_gc_changes_aggregation_job_retry_time_interval() {
             report_expiry_age: Some(Duration::from_seconds(7200)),
             min_aggregation_job_size: 2,
             max_aggregation_job_size: 2,
+            late_report_grace_period: Duration::from_seconds(3600),
         },
         ops: Vec::from([
             Op::Upload {
@@ -262,6 +266,7 @@ fn repro_gc_changes_aggregation_job_retry_fixed_size() {
             report_expiry_age: Some(Duration::from_seconds(7200)),
             min_aggregation_job_size: 2,
             max_aggregation_job_size: 2,
+            late_report_grace_period: Duration::from_seconds(3600),
         },
         ops: Vec::from([
             Op::Upload {
@@ -302,6 +307,7 @@ fn repro_recreate_gcd_batch_job_count_underflow() {
             report_expiry_age: Some(Duration::from_seconds(4000)),
             min_aggregation_job_size: 2,
             max_aggregation_job_size: 2,
+            late_report_grace_period: Duration::from_seconds(3600),
         },
         ops: Vec::from([
             Op::Upload {
@@ -341,6 +347,7 @@ fn repro_abandoned_aggregation_job_batch_mismatch() {
             report_expiry_age: None,
             min_aggregation_job_size: 1,
             max_aggregation_job_size: 1,
+            late_report_grace_period: Duration::from_seconds(3600),
         },
         ops: Vec::from([
             Op::Upload {
@@ -390,6 +397,7 @@ fn repro_helper_accumulate_on_retried_request() {
             report_expiry_age: None,
             min_aggregation_job_size: 1,
             max_aggregation_job_size: 1,
+            late_report_grace_period: Duration::from_seconds(3600),
         },
         ops: Vec::from([
             Op::Upload {

--- a/integration_tests/tests/integration/simulation/setup.rs
+++ b/integration_tests/tests/integration/simulation/setup.rs
@@ -250,6 +250,7 @@ impl Components {
             input.config.min_aggregation_job_size,
             input.config.max_aggregation_job_size,
             5000,
+            input.config.late_report_grace_period,
         ));
 
         let aggregation_job_driver = Arc::new(AggregationJobDriver::new(


### PR DESCRIPTION
This implements a fix for #3427 on the 0.7 release branch, following the approach outlined there. I added a `std::cmp::max()` call to use `time_precision` in lieu of the new grace period in case it is larger.

I'm opening this as a draft for now while I work on testing.