### PR TITLE
Add missing fields to manual PartialEq implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ constcat = "0.5"
 deadpool = "0.12.2"
 deadpool-postgres = "0.14.1"
 divviup-client = "0.4"
-educe = { version = "0.6.0", default-features = false, features = ["Debug"] }
+educe = { version = "0.6.0", default-features = false, features = ["Debug", "PartialEq", "Eq"] }
 fixed = "1.29"
 futures = "0.3.31"
 git-version = "0.3.9"

--- a/aggregator/src/aggregator/aggregation_job_driver/tests.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver/tests.rs
@@ -302,7 +302,7 @@ async fn aggregation_job_driver() {
             batch_identifier,
             aggregation_param,
             0,
-            Interval::from_time(&time).unwrap(),
+            Interval::new(time, *task.time_precision()).unwrap(),
             BatchAggregationState::Aggregating {
                 aggregate_share: Some(transcript.leader_aggregate_share),
                 report_count: 1,
@@ -684,7 +684,7 @@ async fn leader_sync_time_interval_aggregation_job_init_single_step() {
         batch_identifier,
         (),
         0,
-        Interval::from_time(&time).unwrap(),
+        Interval::new(time, *task.time_precision()).unwrap(),
         BatchAggregationState::Aggregating {
             aggregate_share: Some(transcript.leader_output_share.clone().into()),
             report_count: 1,
@@ -1015,7 +1015,7 @@ async fn leader_sync_time_interval_aggregation_job_init_two_steps() {
             batch_identifier,
             aggregation_param,
             0,
-            Interval::from_time(&time).unwrap(),
+            Interval::new(time, *task.time_precision()).unwrap(),
             BatchAggregationState::Aggregating {
                 aggregate_share: None,
                 report_count: 0,
@@ -1417,7 +1417,7 @@ async fn leader_sync_time_interval_aggregation_job_init_partially_garbage_collec
         gc_ineligible_batch_identifier,
         (),
         0,
-        Interval::from_time(&gc_ineligible_time).unwrap(),
+        Interval::new(gc_ineligible_time, *task.time_precision()).unwrap(),
         BatchAggregationState::Aggregating {
             aggregate_share: Some(gc_ineligible_transcript.leader_output_share.clone().into()),
             report_count: 1,
@@ -2897,7 +2897,7 @@ async fn leader_async_aggregation_job_init_to_pending() {
             batch_identifier,
             aggregation_param,
             0,
-            Interval::from_time(&time).unwrap(),
+            Interval::new(time, *task.time_precision()).unwrap(),
             BatchAggregationState::Aggregating {
                 aggregate_share: None,
                 report_count: 0,
@@ -3156,7 +3156,7 @@ async fn leader_async_aggregation_job_init_to_pending_two_step() {
             batch_identifier,
             aggregation_param,
             0,
-            Interval::from_time(&time).unwrap(),
+            Interval::new(time, *task.time_precision()).unwrap(),
             BatchAggregationState::Aggregating {
                 aggregate_share: None,
                 report_count: 0,
@@ -3669,7 +3669,7 @@ async fn leader_async_aggregation_job_init_poll_to_pending() {
             batch_identifier,
             aggregation_param,
             0,
-            Interval::from_time(&time).unwrap(),
+            Interval::new(time, *task.time_precision()).unwrap(),
             BatchAggregationState::Aggregating {
                 aggregate_share: None,
                 report_count: 0,
@@ -3920,7 +3920,7 @@ async fn leader_async_aggregation_job_init_poll_to_pending_two_step() {
             batch_identifier,
             aggregation_param,
             0,
-            Interval::from_time(&time).unwrap(),
+            Interval::new(time, *task.time_precision()).unwrap(),
             BatchAggregationState::Aggregating {
                 aggregate_share: None,
                 report_count: 0,
@@ -4176,7 +4176,7 @@ async fn leader_async_aggregation_job_init_poll_to_finished() {
             batch_identifier,
             aggregation_param,
             0,
-            Interval::from_time(&time).unwrap(),
+            Interval::new(time, *task.time_precision()).unwrap(),
             BatchAggregationState::Aggregating {
                 aggregate_share: Some(transcript.leader_output_share.into()),
                 report_count: 1,
@@ -4437,7 +4437,7 @@ async fn leader_async_aggregation_job_init_poll_to_continue() {
             batch_identifier,
             aggregation_param,
             0,
-            Interval::from_time(&time).unwrap(),
+            Interval::new(time, *task.time_precision()).unwrap(),
             BatchAggregationState::Aggregating {
                 aggregate_share: None,
                 report_count: 0,
@@ -6244,7 +6244,7 @@ async fn abandon_failing_aggregation_job_with_retryable_error() {
             batch_identifier,
             (),
             0,
-            Interval::from_time(&time).unwrap(),
+            Interval::new(time, time_precision).unwrap(),
             BatchAggregationState::Aggregating {
                 aggregate_share: None,
                 report_count: 0,
@@ -6490,7 +6490,7 @@ async fn abandon_failing_aggregation_job_with_fatal_error() {
             batch_identifier,
             (),
             0,
-            Interval::from_time(&time).unwrap(),
+            Interval::new(time, time_precision).unwrap(),
             BatchAggregationState::Aggregating {
                 aggregate_share: None,
                 report_count: 0,

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -1619,6 +1619,7 @@ where
             && self.batch_identifier == other.batch_identifier
             && self.aggregation_parameter == other.aggregation_parameter
             && self.ord == other.ord
+            && self.client_timestamp_interval == other.client_timestamp_interval
             && self.state == other.state
     }
 }

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -98,7 +98,7 @@ impl From<&AuthenticationTokenHash> for AuthenticationTokenType {
 /// Represents a report as it is stored in the Leader's database, corresponding to an unscrubbed row
 /// in `client_reports`.
 #[derive(Clone, Educe)]
-#[educe(Debug)]
+#[educe(Debug, PartialEq, Eq)]
 pub struct LeaderStoredReport<const SEED_SIZE: usize, A>
 where
     A: vdaf::Aggregator<SEED_SIZE, 16>,
@@ -283,30 +283,6 @@ where
     }
 }
 
-impl<const SEED_SIZE: usize, A> PartialEq for LeaderStoredReport<SEED_SIZE, A>
-where
-    A: vdaf::Aggregator<SEED_SIZE, 16>,
-    A::InputShare: PartialEq,
-    A::PublicShare: PartialEq,
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.task_id == other.task_id
-            && self.metadata == other.metadata
-            && self.public_share == other.public_share
-            && self.leader_private_extensions == other.leader_private_extensions
-            && self.leader_input_share == other.leader_input_share
-            && self.helper_encrypted_input_share == other.helper_encrypted_input_share
-    }
-}
-
-impl<const SEED_SIZE: usize, A> Eq for LeaderStoredReport<SEED_SIZE, A>
-where
-    A: vdaf::Aggregator<SEED_SIZE, 16>,
-    A::InputShare: Eq,
-    A::PublicShare: PartialEq,
-{
-}
-
 #[cfg(feature = "test-util")]
 impl LeaderStoredReport<0, prio::vdaf::dummy::Vdaf> {
     pub fn new_dummy(task_id: TaskId, when: Time) -> Self {
@@ -388,7 +364,7 @@ impl AggregatorRole {
 
 /// AggregationJob represents an aggregation job from the DAP specification.
 #[derive(Clone, Educe)]
-#[educe(Debug)]
+#[educe(Debug, PartialEq, Eq)]
 pub struct AggregationJob<const SEED_SIZE: usize, B: BatchMode, A: vdaf::Aggregator<SEED_SIZE, 16>>
 {
     /// The ID of the task this aggregation job belongs to.
@@ -522,30 +498,6 @@ impl<const SEED_SIZE: usize, A: vdaf::Aggregator<SEED_SIZE, 16>>
     pub fn batch_id(&self) -> &BatchId {
         self.partial_batch_identifier()
     }
-}
-
-impl<const SEED_SIZE: usize, B: BatchMode, A: vdaf::Aggregator<SEED_SIZE, 16>> PartialEq
-    for AggregationJob<SEED_SIZE, B, A>
-where
-    A::AggregationParam: PartialEq,
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.task_id == other.task_id
-            && self.aggregation_job_id == other.aggregation_job_id
-            && self.aggregation_parameter == other.aggregation_parameter
-            && self.batch_id == other.batch_id
-            && self.client_timestamp_interval == other.client_timestamp_interval
-            && self.state == other.state
-            && self.step == other.step
-            && self.last_request_hash == other.last_request_hash
-    }
-}
-
-impl<const SEED_SIZE: usize, B: BatchMode, A: vdaf::Aggregator<SEED_SIZE, 16>> Eq
-    for AggregationJob<SEED_SIZE, B, A>
-where
-    A::AggregationParam: Eq,
-{
 }
 
 /// AggregationJobState represents the state of an aggregation job. It corresponds to the
@@ -811,6 +763,11 @@ impl AcquiredCollectionJob {
 
 /// ReportAggregation represents a the state of a single client report's ongoing aggregation.
 #[derive(Clone, Debug)]
+// PartialEq and Eq are gated on the `test-util` feature  as we do not wish to compare preparation
+// states in non-test code, since doing so would require a constant-time comparison to avoid risking
+// leaking information about the preparation state.
+#[cfg_attr(feature = "test-util", derive(Educe))]
+#[cfg_attr(feature = "test-util", educe(PartialEq, Eq))]
 pub struct ReportAggregation<const SEED_SIZE: usize, A: vdaf::Aggregator<SEED_SIZE, 16>> {
     task_id: TaskId,
     aggregation_job_id: AggregationJobId,
@@ -898,45 +855,6 @@ impl<const SEED_SIZE: usize, A: vdaf::Aggregator<SEED_SIZE, 16>> ReportAggregati
     pub fn with_state(self, state: ReportAggregationState<SEED_SIZE, A>) -> Self {
         Self { state, ..self }
     }
-}
-
-// This trait implementation is gated on the `test-util` feature as we do not wish to compare
-// preparation states in non-test code, since doing so would require a constant-time comparison to
-// avoid risking leaking information about the preparation state.
-#[cfg(feature = "test-util")]
-impl<const SEED_SIZE: usize, A: vdaf::Aggregator<SEED_SIZE, 16>> PartialEq
-    for ReportAggregation<SEED_SIZE, A>
-where
-    A::InputShare: PartialEq,
-    A::PrepareShare: PartialEq,
-    A::PrepareState: PartialEq,
-    A::PublicShare: PartialEq,
-    A::OutputShare: PartialEq,
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.task_id == other.task_id
-            && self.aggregation_job_id == other.aggregation_job_id
-            && self.report_id == other.report_id
-            && self.time == other.time
-            && self.ord == other.ord
-            && self.last_prep_resp == other.last_prep_resp
-            && self.state == other.state
-    }
-}
-
-// This trait implementation is gated on the `test-util` feature as we do not wish to compare
-// preparation states in non-test code, since doing so would require a constant-time comparison to
-// avoid risking leaking information about the preparation state.
-#[cfg(feature = "test-util")]
-impl<const SEED_SIZE: usize, A: vdaf::Aggregator<SEED_SIZE, 16>> Eq
-    for ReportAggregation<SEED_SIZE, A>
-where
-    A::InputShare: Eq,
-    A::PrepareShare: Eq,
-    A::PrepareState: Eq,
-    A::PublicShare: Eq,
-    A::OutputShare: Eq,
-{
 }
 
 /// ReportAggregationState represents the state of a single report aggregation. It corresponds
@@ -1409,6 +1327,7 @@ impl ReportAggregationMetadata {
 /// consists of one or more `BatchAggregation`s merged together.
 #[derive(Clone, Educe)]
 #[educe(Debug)]
+#[cfg_attr(feature = "test-util", educe(PartialEq, Eq))]
 pub struct BatchAggregation<
     const SEED_SIZE: usize,
     B: BatchMode,
@@ -1605,32 +1524,6 @@ impl<const SEED_SIZE: usize, A: vdaf::Aggregator<SEED_SIZE, 16>>
     pub fn batch_id(&self) -> &BatchId {
         self.batch_identifier()
     }
-}
-
-#[cfg(feature = "test-util")]
-impl<const SEED_SIZE: usize, B: BatchMode, A: vdaf::Aggregator<SEED_SIZE, 16>> PartialEq
-    for BatchAggregation<SEED_SIZE, B, A>
-where
-    A::AggregationParam: PartialEq,
-    A::AggregateShare: PartialEq,
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.task_id == other.task_id
-            && self.batch_identifier == other.batch_identifier
-            && self.aggregation_parameter == other.aggregation_parameter
-            && self.ord == other.ord
-            && self.client_timestamp_interval == other.client_timestamp_interval
-            && self.state == other.state
-    }
-}
-
-#[cfg(feature = "test-util")]
-impl<const SEED_SIZE: usize, B: BatchMode, A: vdaf::Aggregator<SEED_SIZE, 16>> Eq
-    for BatchAggregation<SEED_SIZE, B, A>
-where
-    A::AggregationParam: Eq,
-    A::AggregateShare: Eq,
-{
 }
 
 /// Represents the state of a batch aggregation.
@@ -1869,7 +1762,7 @@ where
 /// CollectionJob represents a row in the `collection_jobs` table, used by leaders to represent
 /// running collection jobs and store the results of completed ones.
 #[derive(Clone, Educe)]
-#[educe(Debug)]
+#[educe(Debug, PartialEq, Eq)]
 pub struct CollectionJob<const SEED_SIZE: usize, B: BatchMode, A: vdaf::Aggregator<SEED_SIZE, 16>> {
     /// The task ID for this collection job.
     task_id: TaskId,
@@ -1970,29 +1863,6 @@ impl<const SEED_SIZE: usize, A: vdaf::Aggregator<SEED_SIZE, 16>>
     pub fn batch_id(&self) -> &BatchId {
         self.batch_identifier()
     }
-}
-
-impl<const SEED_SIZE: usize, B: BatchMode, A: vdaf::Aggregator<SEED_SIZE, 16>> PartialEq
-    for CollectionJob<SEED_SIZE, B, A>
-where
-    A::AggregationParam: PartialEq,
-    CollectionJobState<SEED_SIZE, A>: PartialEq,
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.task_id == other.task_id
-            && self.collection_job_id == other.collection_job_id
-            && self.batch_identifier == other.batch_identifier
-            && self.aggregation_parameter == other.aggregation_parameter
-            && self.state == other.state
-    }
-}
-
-impl<const SEED_SIZE: usize, B: BatchMode, A: vdaf::Aggregator<SEED_SIZE, 16>> Eq
-    for CollectionJob<SEED_SIZE, B, A>
-where
-    A::AggregationParam: Eq,
-    CollectionJobState<SEED_SIZE, A>: Eq,
-{
 }
 
 #[derive(Clone, Educe)]
@@ -2101,7 +1971,7 @@ pub enum CollectionJobStateCode {
 /// AggregateShareJob represents a row in the `aggregate_share_jobs` table, used by helpers to
 /// store the results of handling an AggregateShareReq from the leader.
 #[derive(Clone, Educe)]
-#[educe(Debug)]
+#[educe(Debug, PartialEq, Eq)]
 pub struct AggregateShareJob<
     const SEED_SIZE: usize,
     B: BatchMode,
@@ -2198,30 +2068,6 @@ impl<const SEED_SIZE: usize, A: vdaf::Aggregator<SEED_SIZE, 16>>
     pub fn batch_id(&self) -> &BatchId {
         self.batch_identifier()
     }
-}
-
-impl<const SEED_SIZE: usize, B: BatchMode, A: vdaf::Aggregator<SEED_SIZE, 16>> PartialEq
-    for AggregateShareJob<SEED_SIZE, B, A>
-where
-    A::AggregationParam: PartialEq,
-    A::AggregateShare: PartialEq,
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.task_id == other.task_id
-            && self.batch_identifier == other.batch_identifier
-            && self.aggregation_parameter == other.aggregation_parameter
-            && self.helper_aggregate_share == other.helper_aggregate_share
-            && self.report_count == other.report_count
-            && self.checksum == other.checksum
-    }
-}
-
-impl<const SEED_SIZE: usize, B: BatchMode, A: vdaf::Aggregator<SEED_SIZE, 16>> Eq
-    for AggregateShareJob<SEED_SIZE, B, A>
-where
-    A::AggregationParam: Eq,
-    A::AggregateShare: Eq,
-{
 }
 
 /// An outstanding batch, which is a batch which has not yet started collection. Such a batch may

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -225,7 +225,7 @@ where
 }
 
 /// The result of a collection operation.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Collection<T, B>
 where
     B: BatchMode,
@@ -281,26 +281,6 @@ where
             aggregate_result,
         }
     }
-}
-
-impl<T, B> PartialEq for Collection<T, B>
-where
-    T: PartialEq,
-    B: BatchMode,
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.partial_batch_selector == other.partial_batch_selector
-            && self.report_count == other.report_count
-            && self.interval == other.interval
-            && self.aggregate_result == other.aggregate_result
-    }
-}
-
-impl<T, B> Eq for Collection<T, B>
-where
-    T: Eq,
-    B: BatchMode,
-{
 }
 
 /// Builder for configuring a [`Collector`].


### PR DESCRIPTION
This fixes #3834, and fixes test breakages by moving off of `Interval::from_time()` (see #3827). It also changes various manual implementations so that they start by destructuring their arguments. This uncovered one more missing field in the collector crate.