### PR TITLE
Enforce interval validation for BatchAggregation jobs

### DIFF
--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -4127,11 +4127,8 @@ WHERE task_id = $1
             B::to_batch_interval(batch_aggregation.batch_identifier()).map(SqlInterval::from);
         let encoded_state_values = batch_aggregation.state().encoded_values_from_state()?;
 
-        // This validates _only_ the start time of the interval, not the duration, as these
-        // client_timestamp_intervals' durations must exclude the next batch interval.
         batch_aggregation
             .client_timestamp_interval()
-            .start()
             .validate_precision(&task_info.time_precision)
             .map_err(|e| {
                 Self::unaligned_time_error(

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -3859,7 +3859,7 @@ async fn time_interval_collection_job_acquire_release_happy_path(
     )]);
     let batch_interval = Interval::new(
         Time::from_seconds_since_epoch(0),
-        Duration::from_seconds(100),
+        Duration::from_hours(8).unwrap(),
     )
     .unwrap();
     let aggregation_job_id = random();
@@ -4286,7 +4286,7 @@ async fn collection_job_acquire_job_max(ephemeral_datastore: EphemeralDatastore)
     let aggregation_job_ids: [_; 2] = random();
     let batch_interval = Interval::new(
         Time::from_seconds_since_epoch(0),
-        Duration::from_seconds(100),
+        Duration::from_hours(8).unwrap(),
     )
     .unwrap();
     let aggregation_jobs = Vec::from([
@@ -6551,7 +6551,9 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
             .iter()
             .fold(Interval::EMPTY, |left, right| {
                 left.merged_with(right).unwrap()
-            });
+            })
+            .align_to_time_precision(task.time_precision())
+            .unwrap();
 
         let batch_aggregation = BatchAggregation::<0, B, dummy::Vdaf>::new(
             *task.id(),
@@ -7161,6 +7163,7 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
 
     // Advance the clock to "enable" report expiry.
     clock.advance(&REPORT_EXPIRY_AGE);
+    clock.advance(&TIME_PRECISION);
 
     // Run.
     let deleted_batch_counts = ds


### PR DESCRIPTION
The last `Interval`-dependent object that isn't doing full Interval time precision validation was `BatchAggregation`, as there were a lot of pieces that needed to be resolved first in https://github.com/divviup/janus/pull/3820 and https://github.com/divviup/janus/pull/3796.

One remaining thing I see to do -- which I could do in this PR -- is to change the `setup_collection_job_acquire_test_case` method in the datastore tests to use a global const `TIME_PRECISION` of 100s like roughly half the tests in this file do, instead of using the default of 8h. But that's another host of little test changes. Comments welcome.