### PR TITLE
Move remainder of project to `AsyncAggregator`

### DIFF
--- a/aggregator/src/aggregator/aggregate_share.rs
+++ b/aggregator/src/aggregator/aggregate_share.rs
@@ -7,10 +7,11 @@ use janus_aggregator_core::{
         models::{BatchAggregation, BatchAggregationState},
     },
     task::AggregatorTask,
+    AsyncAggregator,
 };
 use janus_core::{report_id::ReportIdChecksumExt, time::IntervalExt as _};
 use janus_messages::{batch_mode::BatchMode, Interval, ReportIdChecksum};
-use prio::vdaf::{self, Aggregatable};
+use prio::vdaf::Aggregatable;
 
 /// Computes the aggregate share over the provided batch aggregations.
 ///
@@ -21,7 +22,7 @@ use prio::vdaf::{self, Aggregatable};
 pub(crate) async fn compute_aggregate_share<
     const SEED_SIZE: usize,
     B: BatchMode,
-    A: vdaf::Aggregator<SEED_SIZE, 16>,
+    A: AsyncAggregator<SEED_SIZE>,
 >(
     task: &AggregatorTask,
     batch_aggregations: &[BatchAggregation<SEED_SIZE, B, A>],

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -53,7 +53,6 @@ use opentelemetry::{
 use prio::{
     codec::{Decode, Encode},
     topology::ping_pong::{PingPongContinuedValue, PingPongState, PingPongTopology},
-    vdaf,
 };
 use rayon::iter::{IndexedParallelIterator as _, IntoParallelIterator as _, ParallelIterator as _};
 use reqwest::Method;
@@ -1811,7 +1810,7 @@ where
 
 /// SteppedAggregation represents a report aggregation along with the associated preparation-state
 /// transition representing the next step for the leader.
-struct SteppedAggregation<const SEED_SIZE: usize, A: vdaf::Aggregator<SEED_SIZE, 16>> {
+struct SteppedAggregation<const SEED_SIZE: usize, A: AsyncAggregator<SEED_SIZE>> {
     report_aggregation: ReportAggregation<SEED_SIZE, A>,
     leader_state: PingPongState<SEED_SIZE, 16, A>,
 }

--- a/aggregator/src/aggregator/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/aggregation_job_init.rs
@@ -404,7 +404,10 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
 pub mod test_util {
     use crate::aggregator::test_util::generate_helper_report_share;
-    use janus_aggregator_core::task::{test_util::Task, AggregatorTask};
+    use janus_aggregator_core::{
+        task::{test_util::Task, AggregatorTask},
+        AsyncAggregator,
+    };
     use janus_core::{
         test_util::{run_vdaf, VdafTranscript},
         time::{Clock, MockClock, TimeExt as _},
@@ -437,7 +440,7 @@ pub mod test_util {
 
     impl<const VERIFY_KEY_SIZE: usize, V> PrepareInitGenerator<VERIFY_KEY_SIZE, V>
     where
-        V: vdaf::Vdaf + vdaf::Aggregator<VERIFY_KEY_SIZE, 16> + vdaf::Client<16>,
+        V: AsyncAggregator<VERIFY_KEY_SIZE> + vdaf::Client<16>,
     {
         pub fn new(
             clock: MockClock,
@@ -602,7 +605,7 @@ mod tests {
 
     pub(super) struct AggregationJobInitTestCase<
         const VERIFY_KEY_SIZE: usize,
-        V: vdaf::Aggregator<VERIFY_KEY_SIZE, 16>,
+        V: AsyncAggregator<VERIFY_KEY_SIZE>,
     > {
         pub(super) clock: MockClock,
         pub(super) task: Task,
@@ -637,7 +640,7 @@ mod tests {
 
     async fn setup_aggregate_init_test_for_vdaf<
         const VERIFY_KEY_SIZE: usize,
-        V: vdaf::Aggregator<VERIFY_KEY_SIZE, 16> + vdaf::Client<16>,
+        V: AsyncAggregator<VERIFY_KEY_SIZE> + vdaf::Client<16>,
     >(
         vdaf: V,
         vdaf_instance: VdafInstance,
@@ -682,7 +685,7 @@ mod tests {
 
     async fn setup_aggregate_init_test_without_sending_request<
         const VERIFY_KEY_SIZE: usize,
-        V: vdaf::Aggregator<VERIFY_KEY_SIZE, 16> + vdaf::Client<16>,
+        V: AsyncAggregator<VERIFY_KEY_SIZE> + vdaf::Client<16>,
     >(
         vdaf: V,
         vdaf_instance: VdafInstance,

--- a/aggregator/src/aggregator/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/aggregation_job_init.rs
@@ -581,6 +581,7 @@ mod tests {
             AggregationMode, BatchMode,
         },
         test_util::noop_meter,
+        AsyncAggregator,
     };
     use janus_core::{
         auth_tokens::{AuthenticationToken, DAP_AUTH_HEADER},

--- a/aggregator/src/aggregator/aggregation_job_writer.rs
+++ b/aggregator/src/aggregator/aggregation_job_writer.rs
@@ -904,15 +904,12 @@ where
 }
 
 #[derive(Clone)]
-pub struct WritableReportAggregation<const SEED_SIZE: usize, A>
-where
-    A: vdaf::Aggregator<SEED_SIZE, 16>,
-{
+pub struct WritableReportAggregation<const SEED_SIZE: usize, A: AsyncAggregator<SEED_SIZE>> {
     report_aggregation: ReportAggregation<SEED_SIZE, A>,
     output_share: Option<A::OutputShare>,
 }
 
-impl<const SEED_SIZE: usize, A: vdaf::Aggregator<SEED_SIZE, 16>>
+impl<const SEED_SIZE: usize, A: AsyncAggregator<SEED_SIZE>>
     WritableReportAggregation<SEED_SIZE, A>
 {
     /// Creates a new WritableReportAggregation.
@@ -945,7 +942,7 @@ impl<const SEED_SIZE: usize, A: vdaf::Aggregator<SEED_SIZE, 16>>
 ///
 /// See [`ReportAggregation`] and [`ReportAggregationMetadata`].
 #[async_trait]
-pub trait ReportAggregationUpdate<const SEED_SIZE: usize, A: vdaf::Aggregator<SEED_SIZE, 16>>:
+pub trait ReportAggregationUpdate<const SEED_SIZE: usize, A: AsyncAggregator<SEED_SIZE>>:
     Clone + Send + Sync
 {
     type Borrowed: ReportAggregationUpdate<SEED_SIZE, A>;

--- a/aggregator/src/aggregator/aggregation_job_writer.rs
+++ b/aggregator/src/aggregator/aggregation_job_writer.rs
@@ -28,7 +28,6 @@ use opentelemetry::{
     metrics::{Counter, Histogram},
     KeyValue,
 };
-use prio::vdaf;
 use rand::{thread_rng, Rng as _};
 use std::{borrow::Cow, collections::HashMap, marker::PhantomData, sync::Arc};
 use tokio::try_join;

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -23,6 +23,7 @@ use janus_aggregator_core::{
     },
     taskprov::{taskprov_task_id, test_util::PeerAggregatorBuilder, PeerAggregator},
     test_util::noop_meter,
+    AsyncAggregator,
 };
 use janus_core::{
     hpke::{self, HpkeApplicationInfo, HpkeKeypair, Label},
@@ -44,7 +45,7 @@ use janus_messages::{
 };
 use prio::{
     flp::gadgets::ParallelSumMultithreaded,
-    vdaf::{dummy, Aggregator, Client, Vdaf},
+    vdaf::{dummy, Client, Vdaf},
 };
 use rand::random;
 use serde_json::json;
@@ -86,7 +87,7 @@ impl TaskprovTestCase<0, dummy::Vdaf> {
 
 impl<const VERIFY_KEY_SIZE: usize, V> TaskprovTestCase<VERIFY_KEY_SIZE, V>
 where
-    V: Vdaf + Client<16> + Aggregator<VERIFY_KEY_SIZE, 16> + Clone,
+    V: Vdaf + Client<16> + AsyncAggregator<VERIFY_KEY_SIZE>,
 {
     async fn with_vdaf(
         vdaf_config: VdafConfig,


### PR DESCRIPTION
Adopt the supertrait in the remaining parts of the crate where it's appropriate. This one is rather noisier than previous PRs because the most egregious `where` blocks have been expunged already.

We still have some "bare" `prio::vdaf::Aggregator` in the client libraries, but I don't think it'd be appropriate to use `AsyncAggregator` there.