### PR TITLE
Optimize `get_unfilled_outstanding_batches()` query

### DIFF
--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -4663,19 +4663,14 @@ ON CONFLICT(task_id, batch_id) DO UPDATE
             let stmt = self
                 .prepare_cached(
                     "-- get_unfilled_outstanding_batches()
-WITH non_gc_batches AS (
-    SELECT batch_identifier
-    FROM batch_aggregations
-    WHERE task_id = $1
-    GROUP BY batch_identifier
-    HAVING MAX(UPPER(client_timestamp_interval)) >= $3
-)
 SELECT batch_id FROM outstanding_batches
 WHERE task_id = $1
   AND time_bucket_start = $2
   AND state = 'FILLING'
-  AND EXISTS(SELECT 1 FROM non_gc_batches
-             WHERE batch_identifier = outstanding_batches.batch_id)",
+  AND (SELECT MAX(UPPER(client_timestamp_interval)) FROM batch_aggregations
+          WHERE batch_identifier = outstanding_batches.batch_id
+            AND task_id = $1
+  ) >= $3",
                 )
                 .await?;
             self.query(
@@ -4695,19 +4690,14 @@ WHERE task_id = $1
             let stmt = self
                 .prepare_cached(
                     "-- get_unfilled_outstanding_batches()
-WITH non_gc_batches AS (
-    SELECT batch_identifier
-    FROM batch_aggregations
-    WHERE task_id = $1
-    GROUP BY batch_identifier
-    HAVING MAX(UPPER(client_timestamp_interval)) >= $2
-)
 SELECT batch_id FROM outstanding_batches
 WHERE task_id = $1
   AND time_bucket_start IS NULL
   AND state = 'FILLING'
-  AND EXISTS(SELECT 1 FROM non_gc_batches
-             WHERE batch_identifier = outstanding_batches.batch_id)",
+  AND (SELECT MAX(UPPER(client_timestamp_interval)) FROM batch_aggregations
+          WHERE batch_identifier = outstanding_batches.batch_id
+            AND task_id = $1
+  ) >= $2",
                 )
                 .await?;
             self.query(


### PR DESCRIPTION
This optimizes a query that recently got very slow in staging. I replaced the subquery over a CTE with a subquery over `batch_aggregations` directly. I think the query is functionally equivalent. Instead of finding all batch identifiers that are not GC-eligible, we check whether a particular batch is GC-eligible. Since we are only interested in `FILLING` outstanding batches in the first place, and only a small number of batches for some task should be outstanding at the same time, let alone `FILLING`, eliminating this CTE gets rid of a lot of wasted work. Here are query plan results from staging:

```sql
-- Before
WITH non_gc_batches AS (
    SELECT batch_identifier
    FROM batch_aggregations
    WHERE task_id = 304
    GROUP BY batch_identifier
    HAVING MAX(UPPER(client_timestamp_interval)) >= '2025-05-19 18:02:52.365495+00'::timestamp
)
SELECT batch_id FROM outstanding_batches
WHERE task_id = 304
  AND time_bucket_start IS NULL
  AND state = 'FILLING'
  AND EXISTS(SELECT 1 FROM non_gc_batches
             WHERE batch_identifier = outstanding_batches.batch_id);
```

```
 Hash Join  (cost=42657.58..43114.79 rows=6 width=33) (actual time=7165.018..7170.008 rows=1 loops=1)
   Hash Cond: (batch_aggregations.batch_identifier = outstanding_batches.batch_id)
   ->  HashAggregate  (cost=42655.07..42997.07 rows=9120 width=29) (actual time=7164.922..7169.542 rows=2105 loops=1)
         Group Key: batch_aggregations.batch_identifier
         Filter: (max(upper(batch_aggregations.client_timestamp_interval)) >= '2025-05-19 18:02:52.365495'::timestamp without time zone)
         Batches: 1  Memory Usage: 1041kB
         ->  Bitmap Heap Scan on batch_aggregations  (cost=703.83..42138.30 rows=68903 width=47) (actual time=763.853..4615.486 rows=67348 loops=1)
               Recheck Cond: (task_id = 304)
               Heap Blocks: exact=33398
               ->  Bitmap Index Scan on batch_aggregations_gc_time  (cost=0.00..686.60 rows=68903 width=0) (actual time=695.868..695.869 rows=73779 loops=1)
                     Index Cond: (task_id = 304)
   ->  Hash  (cost=2.50..2.50 rows=1 width=33) (actual time=0.039..0.040 rows=1 loops=1)
         Buckets: 1024  Batches: 1  Memory Usage: 9kB
         ->  Index Scan using outstanding_batches_unique_task_id_batch_id on outstanding_batches  (cost=0.28..2.50 rows=1 width=33) (actual time=0.035..0.036 rows=1 loops=1)
               Index Cond: (task_id = 304)
               Filter: ((time_bucket_start IS NULL) AND (state = 'FILLING'::outstanding_batch_state))
 Planning Time: 12.908 ms
 Execution Time: 7173.440 ms
```

```sql
-- After
SELECT batch_id FROM outstanding_batches
WHERE task_id = 304
  AND time_bucket_start IS NULL
  AND state = 'FILLING'
  AND (SELECT MAX(UPPER(client_timestamp_interval)) FROM batch_aggregations
          WHERE batch_identifier = outstanding_batches.batch_id
            AND task_id = 304
  ) >= '2025-05-19 18:02:52.365495+00'::timestamp;
```

```
 Index Scan using outstanding_batches_task_id_and_time_bucket_start on outstanding_batches  (cost=0.28..6.41 rows=1 width=33) (actual time=0.238..0.240 rows=1 loops=1)
   Index Cond: ((task_id = 304) AND (time_bucket_start IS NULL))
   Filter: ((SubPlan 1) >= '2025-05-19 18:02:52.365495'::timestamp without time zone)
   SubPlan 1
     ->  Aggregate  (cost=3.90..3.91 rows=1 width=8) (actual time=0.201..0.202 rows=1 loops=1)
           ->  Index Scan using batch_aggregations_unique_task_id_batch_id_aggregation_param on batch_aggregations  (cost=0.55..3.89 rows=2 width=18) (actual time=0.045..0.180 rows=22 loops=1)
                 Index Cond: ((task_id = 304) AND (batch_identifier = outstanding_batches.batch_id))
 Planning Time: 0.455 ms
 Execution Time: 0.319 ms
```

Note that we are now using a partial index to discharge the `state = 'FILLING'` predicate. Aside from that, we discharge four other predicates with index conditions. Only the predicate on the MAX aggregate needs to be run as a filter.