### PR TITLE
Add btree index over aggregation_jobs to help GC, 0.7 backport

### DIFF
--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -103,7 +103,7 @@ macro_rules! supported_schema_versions {
 // version is seen, [`Datastore::new`] fails.
 //
 // Note that the latest supported version must be first in the list.
-supported_schema_versions!(7);
+supported_schema_versions!(8, 7);
 
 /// Datastore represents a datastore for Janus, with support for transactional reads and writes.
 /// In practice, Datastore instances are currently backed by a PostgreSQL database.

--- a/db/00000000000008_aggregation_jobs_expresssion_index.down.sql
+++ b/db/00000000000008_aggregation_jobs_expresssion_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX aggregation_jobs_task_and_upper_client_timestamp_interval;

--- a/db/00000000000008_aggregation_jobs_expresssion_index.up.sql
+++ b/db/00000000000008_aggregation_jobs_expresssion_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX aggregation_jobs_task_and_upper_client_timestamp_interval ON aggregation_jobs (task_id, UPPER(client_timestamp_interval));


### PR DESCRIPTION
This is a backport of #3864.