### PR TITLE
Use reference to parent span where appropriate

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -2133,7 +2133,7 @@ impl VdafOps {
             let agg_param = Arc::clone(&agg_param);
 
             move || {
-                let span = info_span!(parent: parent_span, "handle_aggregate_init_generic threadpool task");
+                let span = info_span!(parent: &parent_span, "handle_aggregate_init_generic threadpool task");
 
                 req
                     .prepare_inits()

--- a/aggregator/src/aggregator/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/aggregation_job_continue.rs
@@ -158,7 +158,7 @@ impl VdafOps {
             let aggregation_job = Arc::clone(&aggregation_job);
 
             move || {
-                let span = info_span!(parent: parent_span, "step_aggregation_job threadpool task");
+                let span = info_span!(parent: &parent_span, "step_aggregation_job threadpool task");
 
                 prep_steps_and_ras.into_par_iter().try_for_each_with(
                     (sender, span),

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -339,7 +339,7 @@ where
 
             move || {
                 let span = info_span!(
-                    parent: parent_span,
+                    parent: &parent_span,
                     "step_aggregation_job_aggregate_init threadpool task"
                 );
 
@@ -603,7 +603,7 @@ where
 
             move || {
                 let span = info_span!(
-                    parent: parent_span,
+                    parent: &parent_span,
                     "step_aggregation_job_aggregate_continue threadpool task"
                 );
 
@@ -795,7 +795,7 @@ where
 
             move || {
                 let span = info_span!(
-                    parent: parent_span,
+                    parent: &parent_span,
                     "process_Response_from_helper threadpool task"
                 );
 


### PR DESCRIPTION
While investigating another issue, I noticed the following panic in the output of `janus_aggregator`:

```
thread 'tokio-runtime-worker' panicked at <snip>
tried to clone Id(274877906948), but no span exists with that ID
This may be caused by consuming a parent span (`parent: span`) rather
than borrowing it (`parent: &span`).
```

The backtrace pointed me to our usage of the `tracing::info_span` macro. The error message and documentation ([1]) make it clear enough you're meant to use a reference to the parent span and not the value. I audited our usage of `info_span!` and related macros and fixed them all.

[1]: https://docs.rs/tracing/0.1.41/tracing/index.html#using-the-macros