### PR TITLE
Use reference to parent span where appropriate

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/aggregation_job_continue.rs
@@ -80,7 +80,7 @@ where
         let aggregation_job = Arc::clone(&aggregation_job);
 
         move || {
-            let span = info_span!(parent: parent_span, "step_aggregation_job threadpool task");
+            let span = info_span!(parent: &parent_span, "step_aggregation_job threadpool task");
             let ctx = vdaf_application_context(task.id());
 
             report_aggregations

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -437,7 +437,7 @@ where
 
             move || {
                 let span = info_span!(
-                    parent: parent_span,
+                    parent: &parent_span,
                     "step_aggregation_job_aggregate_init threadpool task"
                 );
                 let ctx = vdaf_application_context(&task_id);
@@ -716,7 +716,7 @@ where
 
             move || {
                 let span = info_span!(
-                    parent: parent_span,
+                    parent: &parent_span,
                     "step_aggregation_job_aggregate_continue threadpool task"
                 );
                 let ctx = vdaf_application_context(&task_id);
@@ -1105,7 +1105,7 @@ where
 
             move || {
                 let span = info_span!(
-                    parent: parent_span,
+                    parent: &parent_span,
                     "process_response_from_helper threadpool task"
                 );
                 let ctx = vdaf_application_context(&task_id);

--- a/aggregator/src/aggregator/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/aggregation_job_init.rs
@@ -116,7 +116,7 @@ where
 
         move || {
             let span =
-                info_span!(parent: parent_span, "compute_helper_aggregate_init threadpool task");
+                info_span!(parent: &parent_span, "compute_helper_aggregate_init threadpool task");
             let ctx = vdaf_application_context(task.id());
 
             report_aggregations


### PR DESCRIPTION
While investigating another issue, I noticed the following panic in the output of `janus_aggregator`:

```
thread 'tokio-runtime-worker' panicked at <snip>
tried to clone Id(274877906948), but no span exists with that ID
This may be caused by consuming a parent span (`parent: span`) rather
than borrowing it (`parent: &span`).
```

The backtrace pointed me to our usage of the `tracing::info_span` macro. The error message and documentation ([1]) make it clear enough you're meant to use a reference to the parent span and not the value. I audited our usage of `info_span!` and related macros and fixed them all.

[1]: https://docs.rs/tracing/0.1.41/tracing/index.html#using-the-macros