### PR TITLE
Stream `BatchAggregation` rows to DB in groups

### DIFF
--- a/aggregator/src/binaries/aggregator.rs
+++ b/aggregator/src/binaries/aggregator.rs
@@ -370,6 +370,11 @@ pub struct Config {
     /// the cost of collection.
     pub batch_aggregation_shard_count: u64,
 
+    /// The maximum number of futures to await concurrenctly while servicing jobs. Higher values
+    /// will cause higher peak memory usage.
+    #[serde(default = "default_max_future_concurrency")]
+    pub max_future_concurrency: usize,
+
     /// Defines the number of shards to break report & aggregation metric counters into. Increasing
     /// this value will reduce the amount of database contention during report uploads &
     /// aggregations, while increasing the cost of getting task metrics.
@@ -414,6 +419,10 @@ fn default_task_counter_shard_count() -> u64 {
     32
 }
 
+fn default_max_future_concurrency() -> usize {
+    10000
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct GarbageCollectorConfig {
@@ -454,6 +463,7 @@ impl Config {
                 self.max_upload_batch_write_delay_ms,
             ),
             batch_aggregation_shard_count: self.batch_aggregation_shard_count,
+            max_future_concurrency: self.max_future_concurrency,
             task_counter_shard_count: self.task_counter_shard_count,
             taskprov_config: self.taskprov_config,
             hpke_configs_refresh_interval: match self.hpke_configs_refresh_interval {
@@ -598,6 +608,7 @@ mod tests {
             max_upload_batch_size: 100,
             max_upload_batch_write_delay_ms: 250,
             batch_aggregation_shard_count: 32,
+            max_future_concurrency: 10000,
             task_counter_shard_count: 64,
             taskprov_config: TaskprovConfig::default(),
             hpke_configs_refresh_interval: Some(42),

--- a/aggregator/tests/integration/graceful_shutdown.rs
+++ b/aggregator/tests/integration/graceful_shutdown.rs
@@ -316,6 +316,7 @@ async fn aggregator_shutdown() {
         max_upload_batch_size: 100,
         max_upload_batch_write_delay_ms: 250,
         batch_aggregation_shard_count: 32,
+        max_future_concurrency: 10000,
         task_counter_shard_count: 64,
         hpke_configs_refresh_interval: None,
         task_cache_ttl_s: None,
@@ -462,6 +463,7 @@ async fn collection_job_driver_shutdown() {
         min_collection_job_retry_delay_s: 1,
         max_collection_job_retry_delay_s: 1,
         collection_job_retry_delay_exponential_factor: 1.0,
+        max_future_concurrency: 10000,
     };
 
     graceful_shutdown("collection_job_driver", config).await;

--- a/docs/samples/advanced_config/aggregator.yaml
+++ b/docs/samples/advanced_config/aggregator.yaml
@@ -112,6 +112,10 @@ max_upload_batch_write_delay_ms: 250
 # than the equivalent setting in the collection job driver. (required)
 batch_aggregation_shard_count: 32
 
+# The maximum number of futures to await concurrenctly while servicing jobs.
+# Higher values will cause higher peak memory usage. (optional, default: 10000)
+max_future_concurrency: 10000
+
 # Defines the number of shards to break report & aggregation metric counters
 # into. Increasing this value will reduce the amount of database contention
 # during report uploads & aggregations, while increasing the cost of getting

--- a/docs/samples/advanced_config/collection_job_driver.yaml
+++ b/docs/samples/advanced_config/collection_job_driver.yaml
@@ -85,6 +85,10 @@ job_discovery_interval_s: 10
 # Maximum number of collection jobs to step concurrently. (required)
 max_concurrent_job_workers: 10
 
+# Maximum number of futures to await concurrently while servicing individual jobs. (optional;
+# defaults to 10000)
+max_future_concurrency: 10000
+
 # Duration of leases of collection jobs being processed. (required)
 worker_lease_duration_s: 600
 

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -170,6 +170,7 @@ impl JanusInProcess {
             max_upload_batch_size: 100,
             max_upload_batch_write_delay_ms: 100,
             batch_aggregation_shard_count: 32,
+            max_future_concurrency: 1000,
             task_counter_shard_count: 64,
             hpke_configs_refresh_interval: None,
             task_cache_ttl_s: None,
@@ -234,6 +235,7 @@ impl JanusInProcess {
             min_collection_job_retry_delay_s: 1,
             max_collection_job_retry_delay_s: 1,
             collection_job_retry_delay_exponential_factor: 1.0,
+            max_future_concurrency: 1000,
         };
         let key_rotator_config = KeyRotatorConfig {
             common_config,

--- a/integration_tests/tests/integration/simulation/setup.rs
+++ b/integration_tests/tests/integration/simulation/setup.rs
@@ -87,6 +87,7 @@ impl SimulationAggregator {
                 max_upload_batch_write_delay: StdDuration::from_secs(0),
                 batch_aggregation_shard_count: BATCH_AGGREGATION_SHARD_COUNT.try_into().unwrap(),
                 task_counter_shard_count: TASK_COUNTER_SHARD_COUNT,
+                max_future_concurrency: 10000,
                 hpke_configs_refresh_interval: HpkeKeypairCache::DEFAULT_REFRESH_INTERVAL,
                 hpke_config_signing_key: None,
                 // We only support Taskprov on the helper side, so leave it disabled.
@@ -306,6 +307,7 @@ impl Components {
             &state.meter,
             BATCH_AGGREGATION_SHARD_COUNT.try_into().unwrap(),
             RetryStrategy::new(StdDuration::ZERO, StdDuration::ZERO, 1.0).unwrap(),
+            10000,
         ));
         let collection_job_driver_acquirer_cb =
             Box::new(collection_job_driver.make_incomplete_job_acquirer_callback(


### PR DESCRIPTION
If time precision is small, or the task's time interval is large, then a large number of `BatchAggregation`s may be needed to satisfy a collection job, whether that's existing ones that contain some prepared report shares or empty ones that we write to force serialization conflicts with other database transactions. Doing `try_join_all` on hundreds of thousands of futures all at once causes a huge number of allocations, which can cause significant memory pressure due to (1) allocating all the objects that the futures need and (2) the fact that many of these futures will race to populate the prepare SQL statement cache, allocating rather large strings along the way.

A first step toward alleviating that is to use
`TryStreamExt::try_for_each_concurrent` so that we only handle a limited number of futures at once. We do this in both of the transactions in `step_collection_job_generic` which put or update `BatchAggregation`s, and the equivalent code path on the helper side.

The number of futures we'll run at once is configurable. The default is set to 10,000, which is not particularly scientific. I'm not seeing a very clear correlation between performance and that figure. But my thinking is that if ~300,000 futures at once was too much, and if peak memory usage is linear in the number of futures we run concurrently, then 10,000 should cut peak memory usage by an order of magnitude, and then some. That seems like an OK default, and we can tune this more in deployments.

Part of #3857