### PR TITLE
Ignore rand upgrades on 0.7 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -90,6 +90,9 @@ updates:
       - dependency-name: prio
         update-types:
           - version-update:semver-minor
+      - dependency-name: rand
+        update-types:
+          - version-update:semver-minor
       # opentelemetry-rust has removed support for pull exporters, including
       # opentelemetry-prometheus, and will add it back after the 1.0 release.
       - dependency-name: opentelemetry


### PR DESCRIPTION
This tells Dependabot to ignore rand 0.9 on the release/0.7 branch. This should clean up an error message in previous Dependabot logs. Dependabot can't handle the `min_const_gen` Cargo feature going away with the upgrade. We don't want to take this upgrade anyway, since it is not compatible with the libprio-rs version we're using.