### PR TITLE
Ignore unmaintained advisory for backoff

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,10 @@ ignore = [
     # bugs or security vulnerabilities.
     "RUSTSEC-2024-0384",
 
+    # `backoff` is unmaintained, but it is a simple dependency, and we don't
+    # plan to backport our migration to `backon` to this release branch.
+    "RUSTSEC-2025-0012",
+
     # Janus never uses the protobuf format for exposing metrics, and in any case we would not be
     # handling untrusted input.
     "RUSTSEC-2024-0437",


### PR DESCRIPTION
This ignores the advisory regarding `backoff` being unmaintained on the release/0.7 branch. I don't think we need to backport our migration to `backon` to this branch. This will clean up check statuses.