### PR TITLE
Add safeguard to bump-version job

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -67,6 +67,15 @@ jobs:
           ref: '${{ matrix.target_branch }}'
           token: '${{ secrets.DIVVIUP_GITHUB_AUTOMATION_RELEASE_PAT }}'
 
+      - name: Check current version
+        # Check that the current version is not a pre-release version. Those
+        # must be bumped by hand, since the pre-release component of a version
+        # number is unstructured.
+        run: |
+          cargo metadata --no-deps --format-version 1 | \
+          jq -r '.packages | .[] | select(.name == "janus_aggregator") | .version' | \
+          grep '^[0-9.]\+$'
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:


### PR DESCRIPTION
This adds a check to the `make-version` workflow to avoid running it when the current version is a pre-release version. See divviup/libprio-rs#1282.