### PR TITLE
Upgrade Kind

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -47,7 +47,7 @@ jobs:
       # We should always make sure that the `kind` CLI we install is from the
       # same release as the node image version used by
       # `janus_core::test_util::kubernetes::EphemeralCluster`
-      run: go install sigs.k8s.io/kind@v0.27.0
+      run: go install sigs.k8s.io/kind@v0.29.0
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@master
       with:

--- a/README.md
+++ b/README.md
@@ -126,15 +126,15 @@ preceding minor versions.
 Tests require that [`docker`](https://www.docker.com) and
 [`kind`](https://kind.sigs.k8s.io) be installed on the machine running the tests
 and in the `PATH` of the test-runner's environment. The `docker` daemon must be
-running. CI tests currently use [`kind` 0.27.0][kind-release] and the
-corresponding Kubernetes 1.32 node image
-(kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f).
+running. CI tests currently use [`kind` 0.29.0][kind-release] and the
+corresponding Kubernetes 1.33 node image
+(kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f).
 Using the same versions for local development is recommended.
 
 To run Janus tests, execute `cargo test`. To run tests on Docker images, execute
 `cargo xtask test-docker`.
 
-[kind-release]: https://github.com/kubernetes-sigs/kind/releases/tag/v0.27.0
+[kind-release]: https://github.com/kubernetes-sigs/kind/releases/tag/v0.29.0
 
 Note that `podman` is not an acceptable substitute for `docker`. There are
 subtle incompatibilities between the two that will cause tests to fail.

--- a/core/src/test_util/kubernetes.rs
+++ b/core/src/test_util/kubernetes.rs
@@ -179,10 +179,10 @@ impl EphemeralCluster {
 
         let backoff = ConstantBuilder::new().build();
 
-        // Use kind to start the cluster, with the node image from kind v0.27.0 for Kubernetes 1.32,
+        // Use kind to start the cluster, with the node image from kind v0.29.0 for Kubernetes 1.33,
         // matching current regular GKE release channel. This image version should be bumped in
         // lockstep with the version of kind installed by the ci-build workflow.
-        // https://github.com/kubernetes-sigs/kind/releases/tag/v0.27.0
+        // https://github.com/kubernetes-sigs/kind/releases/tag/v0.29.0
         // https://cloud.google.com/kubernetes-engine/docs/release-notes#regular-channel
         let output = (|| {
             Command::new("kind")
@@ -194,8 +194,8 @@ impl EphemeralCluster {
                     "--name",
                     &kind_cluster_name,
                     "--image",
-                    "kindest/node:v1.32.2@sha256:\
-                                 f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f",
+                    "kindest/node:v1.33.1@sha256:\
+                     050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f",
                 ])
                 .stdin(Stdio::null())
                 .stdout(Stdio::piped())


### PR DESCRIPTION
This upgrades Kind to 0.29 and Kubernetes to 1.33 in tests.