### PR TITLE
Lazily instantiate empty batch aggregations

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -3304,8 +3304,7 @@ impl VdafOps {
                         batch_aggregations,
                     );
 
-                    let aggregate_share =
-                        Arc::new(Mutex::new(AggregateShareComputer::new(&task)));
+                    let aggregate_share = Arc::new(Mutex::new(AggregateShareComputer::new(&task)));
 
                     // Rather than awaiting all the futures at once, which can cause heap growth
                     // proportional to the number of batch aggregations to write, put them into an

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -3314,7 +3314,7 @@ impl VdafOps {
                         batch_aggregation_shard_count,
                         aggregate_share_req.batch_selector().batch_identifier(),
                         &aggregation_param,
-                        batch_aggregations,
+                        batch_aggregations.into_iter().map(Cow::Owned),
                     );
 
                     // Rather than awaiting all the futures at once, which can cause heap growth
@@ -3322,7 +3322,7 @@ impl VdafOps {
                     // buffered stream so that they get run in groups of bounded size. #3857
                     futures::stream::iter(batch_aggregations_iter.map(Result::Ok))
                         .try_for_each_concurrent(max_future_concurrency, async |(ba, is_update)| {
-                            let ba = ba.scrubbed();
+                            let ba = ba.into_owned().scrubbed();
                             if is_update {
                                 tx.update_batch_aggregation(&ba).await
                             } else {

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -3320,7 +3320,7 @@ impl VdafOps {
                     // Rather than awaiting all the futures at once, which can cause heap growth
                     // proportional to the number of batch aggregations to write, put them into an
                     // buffered stream so that they get run in groups of bounded size. #3857
-                    futures::stream::iter(batch_aggregations_iter.map(Result::Ok))
+                    futures::stream::iter(batch_aggregations_iter.map(Ok))
                         .try_for_each_concurrent(max_future_concurrency, async |(ba, is_update)| {
                             let ba = ba.into_owned().scrubbed();
                             if is_update {

--- a/aggregator/src/aggregator/aggregate_share.rs
+++ b/aggregator/src/aggregator/aggregate_share.rs
@@ -257,16 +257,16 @@ where
                 ord,
             })?;
 
-        // If we have a real BA for that key, yield it, removing it from the HashMap. This lets us
-        // return a value without cloning, and since this iterator gets consumed, the value can't be
-        // yielded again anyway.
+        // If we have a real BA for that key, yield it, removing it from the HashMap. If the value
+        // is Cow::Owned, this saves us a Clone, and as this iterator gets consumed, the value
+        // can't be yielded again anyway.
         self.real_batch_aggregations
             .remove(&key)
             .map(|real_ba| (real_ba, true))
             .or_else(|| {
-                // If there was no real BA, synthesize an empty one. This is why we have to yield an
-                // owned value in the other case: we can't instantiate a BA here and return a
-                // reference.
+                // If there was no real BA, synthesize an empty one. This is why we have to yield a
+                // Cow in the other case: we can't instantiate a struct BatchAggregation here and
+                // return `&BatchAggregation`.
                 Some((
                     Cow::Owned(BatchAggregation::<SEED_SIZE, B, A>::new(
                         self.task_id,

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -315,7 +315,7 @@ where
                     // Rather than awaiting all the futures at once, which can cause heap growth
                     // proportional to the number of batch aggregations to write, put them into an
                     // buffered stream so that they get run in groups of bounded size. #3857
-                    futures::stream::iter(batch_aggregations_iter.clone().map(Result::Ok))
+                    futures::stream::iter(batch_aggregations_iter.clone().map(Ok))
                         .try_for_each_concurrent(max_future_concurrency, async |(ba, is_update)| {
                             if is_update {
                                 tx.update_batch_aggregation(&ba).await
@@ -448,13 +448,13 @@ where
                             // Put all the futures into a buffered stream so that we don't incur the
                             // combined memory footprint of all the futures at once. #3857
                             futures::stream::iter(batch_aggregations_iter.map(|(v, _)| {
-                                Result::Ok(BatchAggregation::scrubbed(v.into_owned()))
+                                Ok(BatchAggregation::scrubbed(v.into_owned()))
                             })).try_for_each_concurrent(max_future_concurrency, async |ba| {
                                 tx.update_batch_aggregation(&ba).await
                             }).await?;
 
                             tx.release_collection_job(&lease, None).await?;
-                            metrics.jobs_finished_counter.add( 1, &[]);
+                            metrics.jobs_finished_counter.add(1, &[]);
                         }
 
                         CollectionJobState::Deleted => {

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -1,9 +1,9 @@
 //! Implements portions of collect sub-protocol for DAP leader and helper.
 
 use crate::aggregator::{
-    aggregate_share::compute_aggregate_share, batch_mode::CollectableBatchMode,
-    empty_batch_aggregations, http_handlers::AGGREGATE_SHARES_ROUTE, send_request_to_helper, Error,
-    RequestBody,
+    aggregate_share::AggregateShareComputer, batch_mode::CollectableBatchMode,
+    http_handlers::AGGREGATE_SHARES_ROUTE, send_request_to_helper, BatchAggregationsIterator,
+    Error, RequestBody,
 };
 use anyhow::bail;
 use backon::BackoffBuilder;
@@ -36,8 +36,8 @@ use prio::{
     dp::DifferentialPrivacyStrategy,
 };
 use reqwest::Method;
-use std::{iter::repeat, sync::Arc, time::Duration};
-use tokio::try_join;
+use std::{iter::repeat_with, sync::Arc, time::Duration};
+use tokio::{sync::Mutex, try_join};
 use tracing::{error, info, warn};
 
 /// Drives a collection job.
@@ -145,17 +145,16 @@ where
             B::BatchIdentifier::get_decoded(lease.leased().encoded_batch_identifier())
                 .map_err(Error::MessageDecode)?,
         );
-        let aggregation_param = Arc::new(
+        let aggregation_param =
             A::AggregationParam::get_decoded(lease.leased().encoded_aggregation_param())
-                .map_err(Error::MessageDecode)?,
-        );
+                .map_err(Error::MessageDecode)?;
 
         let rslt = datastore
             .run_tx("step_collection_job_1", |tx| {
                 let vdaf = Arc::clone(&vdaf);
                 let lease = Arc::clone(&lease);
                 let collection_identifier = Arc::clone(&collection_identifier);
-                let aggregation_param = Arc::clone(&aggregation_param);
+                let aggregation_param = aggregation_param.clone();
                 let batch_aggregation_shard_count = self.batch_aggregation_shard_count;
                 let collection_retry_strategy = self.collection_retry_strategy.clone();
                 let metrics = self.metrics.clone();
@@ -268,17 +267,16 @@ where
                     // There is no pre-existing finished collection job, but the collection job is
                     // ready to be completed. Read batch aggregations so that we can compute the
                     // final aggregate value.
-                    let mut batch_aggregations =
-                        B::get_batch_aggregations_for_collection_identifier(
-                            tx,
-                            lease.leased().task_id(),
-                            lease.leased().time_precision(),
-                            vdaf.as_ref(),
-                            &collection_identifier,
-                            &aggregation_param,
-                        )
-                        .await?;
-
+                    let batch_aggregations = B::get_batch_aggregations_for_collection_identifier(
+                        tx,
+                        lease.leased().task_id(),
+                        lease.leased().time_precision(),
+                        vdaf.as_ref(),
+                        &collection_identifier,
+                        &aggregation_param,
+                    )
+                    .await?
+                    .into_iter()
                     // Mark batch aggregations as collected to avoid further aggregation. (We don't
                     // need to do this if there is a FINISHED collection job since that job will
                     // have marked the batch aggregations.)
@@ -288,68 +286,76 @@ where
                     // for any that have not already been written to storage. We do this
                     // transactionally to avoid the possibility of overwriting other transactions'
                     // updates to batch aggregations.
-                    batch_aggregations = batch_aggregations
-                        .into_iter()
-                        .map(|ba| ba.collected())
-                        .collect::<Result<Vec<_>, _>>()?;
+                    .map(|ba| ba.collected())
+                    .collect::<Result<Vec<_>, _>>()?
+                    .into_iter();
 
-                    let empty_batch_aggregations = empty_batch_aggregations(
+                    let batch_aggregations_iter = BatchAggregationsIterator::new(
                         &task,
                         batch_aggregation_shard_count,
                         collection_job.batch_identifier(),
-                        collection_job.aggregation_parameter(),
-                        &batch_aggregations,
+                        &aggregation_param,
+                        batch_aggregations,
                     );
+
+                    let aggregate_share = Arc::new(Mutex::new(AggregateShareComputer::new(&task)));
 
                     // Rather than awaiting all the futures at once, which can cause heap growth
                     // proportional to the number of batch aggregations to write, put them into an
                     // buffered stream so that they get run in groups of bounded size. #3857
                     futures::stream::iter(
-                        batch_aggregations
-                            .iter()
-                            // existing batch aggregatons must be updated so zip with true
-                            .zip(repeat(true))
-                            // empty batch aggregations are new so zip with false
-                            .chain(empty_batch_aggregations.iter().zip(repeat(false)))
+                        batch_aggregations_iter
+                            .clone()
+                            .zip(repeat_with(|| Arc::clone(&aggregate_share)))
                             .map(Result::Ok),
                     )
-                    .try_for_each_concurrent(max_future_concurrency, async |(ba, is_update)| {
-                        if is_update {
-                            tx.update_batch_aggregation(ba).await
-                        } else {
-                            tx.put_batch_aggregation(ba).await
-                        }
-                    })
+                    .try_for_each_concurrent(
+                        max_future_concurrency,
+                        async |((ba, is_update), aggregate_share)| {
+                            // Empty batch aggregations cannot contribute to the aggregate share so
+                            // don't bother including them
+                            if is_update {
+                                aggregate_share
+                                    .lock()
+                                    .await
+                                    .update(&ba)
+                                    .map_err(|e| datastore::Error::User(e.into()))?;
+                                tx.update_batch_aggregation(&ba).await
+                            } else {
+                                tx.put_batch_aggregation(&ba).await
+                            }
+                        },
+                    )
                     .await?;
 
-                    batch_aggregations = batch_aggregations
-                        .into_iter()
-                        .chain(empty_batch_aggregations.into_iter())
-                        .collect();
+                    let leader_aggregate_share = aggregate_share
+                        .lock()
+                        .await
+                        .finalize()
+                        .map_err(|e| datastore::Error::User(e.into()))?;
 
-                    Ok(Some((task, collection_job, batch_aggregations)))
+                    Ok(Some((
+                        task,
+                        collection_job,
+                        batch_aggregations_iter,
+                        leader_aggregate_share,
+                    )))
                 })
             })
             .await?;
 
-        let (task, collection_job, batch_aggregations) = match rslt {
-            Some((task, collection_job, batch_aggregations)) => {
-                (task, collection_job, batch_aggregations)
+        let (task, collection_job, all_bas_iter, mut leader_aggregate_share) = match rslt {
+            Some((task, collection_job, all_bas_iter, leader_aggregate_share)) => {
+                (task, collection_job, all_bas_iter, leader_aggregate_share)
             }
             None => return Ok(()),
         };
 
-        // Compute our aggregate share and ask the Helper to do the same.
-        let (mut leader_aggregate_share, report_count, client_timestamp_interval, checksum) =
-            compute_aggregate_share::<SEED_SIZE, B, A>(&task, &batch_aggregations)
-                .await
-                .map_err(|e| datastore::Error::User(e.into()))?;
-
         vdaf.add_noise_to_agg_share(
             &dp_strategy,
             collection_job.aggregation_parameter(),
-            &mut leader_aggregate_share,
-            report_count.try_into()?,
+            &mut leader_aggregate_share.aggregate_share,
+            leader_aggregate_share.report_count.try_into()?,
         )
         .map_err(Error::DifferentialPrivacy)?;
 
@@ -371,8 +377,8 @@ where
                             .aggregation_parameter()
                             .get_encoded()
                             .map_err(Error::MessageEncode)?,
-                        report_count,
-                        checksum,
+                        leader_aggregate_share.report_count,
+                        leader_aggregate_share.checksum,
                     )
                     .get_encoded()
                     .map_err(Error::MessageEncode)?,
@@ -390,20 +396,14 @@ where
         // job URI can serve it up. Scrub the batch aggregations, as we are now done with them, too.
         let collection_job = Arc::new(
             collection_job.with_state(CollectionJobState::Finished {
-                report_count,
-                client_timestamp_interval,
+                report_count: leader_aggregate_share.report_count,
+                client_timestamp_interval: leader_aggregate_share.client_timestamp_interval,
                 encrypted_helper_aggregate_share: AggregateShare::get_decoded(http_response.body())
                     .map_err(Error::MessageDecode)?
                     .encrypted_aggregate_share()
                     .clone(),
-                leader_aggregate_share,
+                leader_aggregate_share: leader_aggregate_share.aggregate_share,
             }),
-        );
-        let batch_aggregations = Arc::new(
-            batch_aggregations
-                .into_iter()
-                .map(BatchAggregation::scrubbed)
-                .collect::<Vec<_>>(),
         );
 
         datastore
@@ -411,7 +411,7 @@ where
                 let vdaf = Arc::clone(&vdaf);
                 let lease = Arc::clone(&lease);
                 let collection_job = Arc::clone(&collection_job);
-                let batch_aggregations = Arc::clone(&batch_aggregations);
+                let batch_aggregations = all_bas_iter.clone();
                 let metrics = self.metrics.clone();
                 let max_future_concurrency = self.max_future_concurrency;
 
@@ -436,13 +436,14 @@ where
                         CollectionJobState::Start => {
                             tx.update_collection_job::<SEED_SIZE, B, A>(&collection_job).await?;
 
+                            // Scrub all the batch aggregations, including the empty ones.
                             // Put all the futures into a buffered stream so that we don't incur the
                             // combined memory footprint of all the futures at once. #3857
-                            futures::stream::iter(batch_aggregations.iter().map(Result::Ok))
-                                .try_for_each_concurrent(max_future_concurrency, |ba| {
-                                    tx.update_batch_aggregation(ba)
-                                })
-                                .await?;
+                            futures::stream::iter(
+                                batch_aggregations.map(|(v, _)| Result::Ok(BatchAggregation::scrubbed(v)))
+                            ).try_for_each_concurrent(max_future_concurrency, async |ba| {
+                                tx.update_batch_aggregation(&ba).await
+                            }).await?;
 
                             tx.release_collection_job(&lease, None).await?;
                             metrics.jobs_finished_counter.add( 1, &[]);

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_continue.rs
@@ -2,12 +2,12 @@ use crate::aggregator::{
     aggregation_job_continue::test_util::{
         post_aggregation_job_and_decode, post_aggregation_job_expecting_error,
     },
-    empty_batch_aggregations,
     http_handlers::test_util::HttpHandlerTest,
     test_util::{
         assert_task_aggregation_counter, generate_helper_report_share,
         BATCH_AGGREGATION_SHARD_COUNT,
     },
+    BatchAggregationsIterator,
 };
 use assert_matches::assert_matches;
 use futures::future::try_join_all;
@@ -245,7 +245,7 @@ async fn aggregate_continue_sync() {
                 // Write collected batch aggregations for the interval that report_share_2 falls
                 // into, which will cause it to fail to prepare.
                 try_join_all(
-                    empty_batch_aggregations::<0, TimeInterval, dummy::Vdaf>(
+                    BatchAggregationsIterator::<0, TimeInterval, dummy::Vdaf>::new(
                         &helper_task,
                         BATCH_AGGREGATION_SHARD_COUNT,
                         &Interval::new(
@@ -254,10 +254,11 @@ async fn aggregate_continue_sync() {
                         )
                         .unwrap(),
                         &aggregation_param,
-                        &[],
+                        [],
                     )
+                    .collect::<Vec<_>>()
                     .iter()
-                    .map(|ba| tx.put_batch_aggregation(ba)),
+                    .map(|(ba, _)| tx.put_batch_aggregation(ba)),
                 )
                 .await
                 .unwrap();
@@ -776,16 +777,17 @@ async fn aggregate_continue_accumulate_batch_aggregation() {
     )
     .unwrap();
 
+    // Write collected batch aggregations for the interval that report_share_2 falls
+    // into, which will cause it to fail to prepare.
     let second_batch_want_batch_aggregations: Vec<_> =
-        empty_batch_aggregations::<0, TimeInterval, dummy::Vdaf>(
+        BatchAggregationsIterator::<0, TimeInterval, dummy::Vdaf>::new(
             &helper_task,
             BATCH_AGGREGATION_SHARD_COUNT,
             &second_batch_identifier,
             &aggregation_param,
-            &[],
+            [],
         )
-        .into_iter()
-        .map(|ba| {
+        .map(|(ba, _)| {
             BatchAggregation::new(
                 *ba.task_id(),
                 *ba.batch_identifier(),

--- a/aggregator_core/src/batch_mode.rs
+++ b/aggregator_core/src/batch_mode.rs
@@ -176,7 +176,7 @@ impl AccumulableBatchMode for LeaderSelected {
 /// [`AccumulableBatchMode`] with additional functionality required for collection.
 #[async_trait]
 pub trait CollectableBatchMode: AccumulableBatchMode {
-    type Iter: Iterator<Item = Self::BatchIdentifier> + Send + Sync;
+    type Iter: Iterator<Item = Self::BatchIdentifier> + Send + Sync + Clone;
 
     /// Retrieves the batch identifier for a given query.
     async fn collection_identifier_for_query<C: Clock>(
@@ -332,9 +332,9 @@ impl CollectableBatchMode for TimeInterval {
 // This type only exists because the CollectableBatchMode trait requires specifying the type of the
 // iterator explicitly (i.e. it cannot be inferred or replaced with an `impl Trait` expression), and
 // the type of the iterator created via method chaining does not have a type which is expressible.
+#[derive(Clone)]
 pub struct TimeIntervalBatchIdentifierIter {
     step: u64,
-
     total_step_count: u64,
     start: Time,
     time_precision: Duration,


### PR DESCRIPTION
When handing a collection job or aggregate share, we want to write lots of batch aggregations rows. Often, the vast majority of these will be empty batch aggregations that exist only to force conflicts with other SQL transactions. Rather than allocating all these empty BAs at once, we now create a `BatchAggregationsIterator` which lazily constructs them. In order to decide whether an empty BA is needed for a given `(batch_identifier, ord)` tuple, the `BatchAggregationsIterator` needs to know what real batch aggregations exist, so it takes ownership of the `Vec<BatchAggregation<_>>` returned by
`CollectableBatchMode::get_batch_aggregations_for_collection_identifier` and yields a unified stream of both real and empty/synthetic BAs.

In order to avoid traversing this iterator multiple times (which would require cloning the potentially large vector of real BAs), this also introduces `AggregateShareComputer`, which expands the previous `compute_aggregate_share` oneshot function into a structure implementing the initialize/update/finalize pattern familiar from hashers. Now, we can incrementally compute aggregate shares while consuming the BA iterator.

Part of #3857