### PR TITLE
Fix lints from nightly Clippy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
  "futures-lite 2.3.0",
  "parking",
  "polling",
- "rustix 0.38.40",
+ "rustix 0.38.44",
  "slab",
  "tracing",
  "windows-sys 0.52.0",
@@ -347,7 +347,7 @@ dependencies = [
  "cfg-if",
  "event-listener 5.3.1",
  "futures-lite 2.3.0",
- "rustix 0.38.40",
+ "rustix 0.38.44",
  "tracing",
 ]
 
@@ -363,7 +363,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.40",
+ "rustix 0.38.44",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.48.0",
@@ -3298,7 +3298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4031,7 +4031,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 0.38.40",
+ "rustix 0.38.44",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -4684,15 +4684,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.40"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.14",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6731,7 +6731,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.40",
+ "rustix 0.38.44",
 ]
 
 [[package]]

--- a/aggregator/src/aggregator/batch_creator.rs
+++ b/aggregator/src/aggregator/batch_creator.rs
@@ -519,7 +519,7 @@ impl Eq for UpdatedOutstandingBatch {}
 
 impl PartialOrd for UpdatedOutstandingBatch {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.new_max_size.cmp(&other.new_max_size))
+        Some(self.cmp(other))
     }
 }
 

--- a/aggregator/src/aggregator/error.rs
+++ b/aggregator/src/aggregator/error.rs
@@ -249,7 +249,7 @@ impl ReportRejectionReason {
 
 impl Display for ReportRejectionReason {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/aggregator/src/aggregator/queue.rs
+++ b/aggregator/src/aggregator/queue.rs
@@ -304,10 +304,9 @@ impl Metrics {
         let outstanding_requests = Arc::new(AtomicU64::new(0));
         let _outstanding_requests_gauge = meter
             .u64_observable_gauge(Self::get_outstanding_requests_name(prefix))
-            .with_description(concat!(
-                "The approximate number of requests currently being serviced by the ",
-                "aggregator."
-            ))
+            .with_description(
+                "The approximate number of requests currently being serviced by the aggregator.",
+            )
             .with_unit("{request}")
             .with_callback({
                 let outstanding_requests = Arc::clone(&outstanding_requests);
@@ -320,9 +319,9 @@ impl Metrics {
                     .into_iter()
                     .join("_"),
             )
-            .with_description(concat!(
-                "The maximum number of requests that the aggregator can service at a time."
-            ))
+            .with_description(
+                "The maximum number of requests that the aggregator can service at a time.",
+            )
             .with_unit("{request}")
             .with_callback(move |observer| observer.observe(max_outstanding_requests, &[]))
             .build();

--- a/aggregator_core/src/datastore/test_util.rs
+++ b/aggregator_core/src/datastore/test_util.rs
@@ -188,7 +188,7 @@ impl EphemeralDatabase {
 async fn buffer_printer(buffer: std::pin::Pin<Box<dyn AsyncBufRead + Send>>) {
     let mut lines = buffer.lines();
     while let Ok(Some(line)) = lines.next_line().await {
-        println!("{}", line);
+        println!("{line}");
     }
 }
 
@@ -283,8 +283,7 @@ impl EphemeralDatastore {
             .version;
         if target >= current_version {
             panic!(
-                "target version ({}) must be less than the current database version ({})",
-                target, current_version,
+                "target version ({target}) must be less than the current database version ({current_version})",
             );
         }
 
@@ -294,7 +293,7 @@ impl EphemeralDatastore {
             self.migrator
                 .undo(&mut connection, v)
                 .await
-                .unwrap_or_else(|e| panic!("failed to downgrade to version {}: {}", v, e));
+                .unwrap_or_else(|e| panic!("failed to downgrade to version {v}: {e}"));
         }
     }
 }

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -1062,7 +1062,7 @@ impl Decode for HpkePublicKey {
 
 impl Debug for HpkePublicKey {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "HpkePublicKey({})", self)
+        write!(f, "HpkePublicKey({self})")
     }
 }
 

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -611,7 +611,7 @@ where
         PollResult::NotReady(retry_after) => {
             println!("State: Not ready");
             match retry_after {
-                Some(retry_after) => println!("Retry after: {:?}", retry_after),
+                Some(retry_after) => println!("Retry after: {retry_after:?}"),
                 None => println!("Retry after: Not provided"),
             }
             Err(Error::PollNotReady)
@@ -655,7 +655,7 @@ fn print_collection<V: vdaf::Collector, B: BatchModeExt>(
     let (start, duration) = collection.interval();
 
     println!("Number of reports: {}", collection.report_count());
-    println!("Interval start: {}", start);
+    println!("Interval start: {start}");
     println!("Interval end: {}", *start + *duration);
     println!(
         "Interval length: {:?}",


### PR DESCRIPTION
This fixes some lints reported by Clippy with the most recent nightly toolchain. I also updated `rustix` to fix a compilation issue.