### PR TITLE
Fix Clippy lints

### DIFF
--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -302,7 +302,7 @@ async fn taskprov_aggregate_init() {
         .await
         .status()
         .unwrap();
-        assert_eq!(status, Status::Forbidden, "{}", name);
+        assert_eq!(status, Status::Forbidden, "{name}");
 
         let mut test_conn = put(test
             .task
@@ -333,7 +333,7 @@ async fn taskprov_aggregate_init() {
             AggregationJobResp::Finished { prepare_resps } => prepare_resps
         );
 
-        assert_eq!(prepare_resps.len(), 1, "{}", name);
+        assert_eq!(prepare_resps.len(), 1, "{name}");
         let prepare_step = prepare_resps.first().unwrap();
         assert_eq!(
             prepare_step.report_id(),
@@ -762,7 +762,7 @@ async fn taskprov_opt_out_peer_aggregator_wrong_role() {
             "status": Status::BadRequest as u16,
             "type": "urn:ietf:params:ppm:dap:error:invalidTask",
             "title": "Aggregator has opted out of the indicated task.",
-            "taskid": format!("{}", another_task_id),
+            "taskid": format!("{another_task_id}"),
         })
     );
 }
@@ -831,7 +831,7 @@ async fn taskprov_opt_out_peer_aggregator_does_not_exist() {
             "status": Status::BadRequest as u16,
             "type": "urn:ietf:params:ppm:dap:error:invalidTask",
             "title": "Aggregator has opted out of the indicated task.",
-            "taskid": format!("{}", another_task_id),
+            "taskid": format!("{another_task_id}"),
         })
     );
 }

--- a/aggregator/src/metrics/tests/prometheus.rs
+++ b/aggregator/src/metrics/tests/prometheus.rs
@@ -48,8 +48,7 @@ async fn prometheus_metrics_pull() {
     let text = String::from_utf8(response.body().to_vec()).unwrap();
     assert!(
         text.contains("HELP") && text.contains("TYPE"),
-        "Exported metrics: {:?}",
-        text
+        "Exported metrics: {text:?}"
     );
 
     join_handle.abort();

--- a/aggregator_api/src/tests.rs
+++ b/aggregator_api/src/tests.rs
@@ -69,7 +69,7 @@ async fn setup_api_test() -> (impl Handler, EphemeralDatastore, Arc<Datastore<Mo
 async fn get_config() {
     let (handler, ..) = setup_api_test().await;
     let mut conn = get("/")
-        .with_request_header("Authorization", format!("Bearer {}", AUTH_TOKEN))
+        .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
         .with_request_header("Accept", CONTENT_TYPE)
         .run_async(&handler)
         .await;
@@ -790,7 +790,7 @@ async fn patch_task(#[case] role: Role) {
     );
 
     // Verify: patching the task with a null task end time returns the expected result.
-    let mut conn = patch(format!("/tasks/{}", task_id))
+    let mut conn = patch(format!("/tasks/{task_id}"))
         .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
         .with_request_header("Accept", CONTENT_TYPE)
         .with_request_body(r#"{"task_end": null}"#)
@@ -816,7 +816,7 @@ async fn patch_task(#[case] role: Role) {
     // Verify: patching the task with a task end time that isn't a multiple of the time precision
     // returns BadRequest.
     assert_response!(
-        patch(format!("/tasks/{}", task_id))
+        patch(format!("/tasks/{task_id}"))
             .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
             .with_request_header("Accept", CONTENT_TYPE)
             .with_request_body(r#"{"task_end": 1337}"#)
@@ -828,7 +828,7 @@ async fn patch_task(#[case] role: Role) {
 
     // Verify: patching the task with a task end time returns the expected result.
     let expected_time = Some(Time::from_seconds_since_epoch(2000));
-    let mut conn = patch(format!("/tasks/{}", task_id))
+    let mut conn = patch(format!("/tasks/{task_id}"))
         .with_request_header("Authorization", format!("Bearer {AUTH_TOKEN}"))
         .with_request_header("Accept", CONTENT_TYPE)
         .with_request_body(r#"{"task_end": 2000}"#)
@@ -865,7 +865,7 @@ async fn patch_task(#[case] role: Role) {
 
     // Verify: unauthorized requests are denied appropriately.
     assert_response!(
-        patch(format!("/tasks/{}", task_id))
+        patch(format!("/tasks/{task_id}"))
             .with_request_header("Accept", CONTENT_TYPE)
             .with_request_body("{}")
             .run_async(&handler)

--- a/messages/src/tests/aggregation.rs
+++ b/messages/src/tests/aggregation.rs
@@ -696,9 +696,7 @@ fn roundtrip_aggregation_job_resp() {
     roundtrip_encoding(&[
         (
             AggregationJobResp::Processing,
-            concat!(
-                "00", // status
-            ),
+            "00", // status
         ),
         (
             AggregationJobResp::Finished {

--- a/messages/src/tests/collection.rs
+++ b/messages/src/tests/collection.rs
@@ -155,9 +155,7 @@ fn roundtrip_collection_job_resp() {
     roundtrip_encoding(&[
         (
             CollectionJobResp::<TimeInterval>::Processing,
-            concat!(
-                "00", // status
-            ),
+            "00", // status
         ),
         (
             CollectionJobResp::Finished {
@@ -285,9 +283,7 @@ fn roundtrip_collection_job_resp() {
     roundtrip_encoding(&[
         (
             CollectionJobResp::<LeaderSelected>::Processing,
-            concat!(
-                "00", // status
-            ),
+            "00", // status
         ),
         (
             CollectionJobResp::Finished {

--- a/messages/src/tests/common.rs
+++ b/messages/src/tests/common.rs
@@ -23,13 +23,13 @@ fn roundtrip_url() {
 
     // Zero length string
     assert_matches!(
-        Url::get_decoded(&hex::decode(concat!("0000")).unwrap()),
+        Url::get_decoded(&hex::decode("0000").unwrap()),
         Err(CodecError::Other(_))
     );
 
     // Non-ascii string
     assert_matches!(
-        Url::get_decoded(&hex::decode(concat!("0001FF")).unwrap()),
+        Url::get_decoded(&hex::decode("0001FF").unwrap()),
         Err(CodecError::Other(_))
     );
 }

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -799,7 +799,7 @@ mod tests {
         ];
         match Options::try_parse_from(correct_arguments) {
             Ok(got) => assert_eq!(got, expected),
-            Err(e) => panic!("{}\narguments were {:?}", e, correct_arguments),
+            Err(e) => panic!("{e}\narguments were {correct_arguments:?}"),
         }
 
         assert_eq!(
@@ -1028,7 +1028,7 @@ mod tests {
         ];
         match Options::try_parse_from(correct_arguments) {
             Ok(got) => assert_eq!(got, expected),
-            Err(e) => panic!("{}\narguments were {:?}", e, correct_arguments),
+            Err(e) => panic!("{e}\narguments were {correct_arguments:?}"),
         }
 
         // Check that clap enforces all the constraints we need on combinations of query arguments.
@@ -1239,7 +1239,7 @@ mod tests {
             "1000".to_string(),
             "--vdaf=count".to_string(),
             format!("--authorization-bearer-token={}", bearer_token.as_str()),
-            format!("--collector-credential={}", SAMPLE_COLLECTOR_CREDENTIAL),
+            format!("--collector-credential={SAMPLE_COLLECTOR_CREDENTIAL}"),
         ]);
 
         assert_eq!(
@@ -1300,8 +1300,7 @@ mod tests {
 
         let mut collector_credential_mutually_exclusive = correct_arguments.clone();
         collector_credential_mutually_exclusive.push(format!(
-            "--collector-credential={}",
-            SAMPLE_COLLECTOR_CREDENTIAL
+            "--collector-credential={SAMPLE_COLLECTOR_CREDENTIAL}",
         ));
         assert_eq!(
             Options::try_parse_from(collector_credential_mutually_exclusive)
@@ -1376,7 +1375,7 @@ mod tests {
         ];
         match Options::try_parse_from(correct_arguments) {
             Ok(got) => assert_eq!(got, expected),
-            Err(e) => panic!("{}\narguments were {:?}", e, correct_arguments),
+            Err(e) => panic!("{e}\narguments were {correct_arguments:?}"),
         }
 
         let collection_job_id = random();
@@ -1403,7 +1402,7 @@ mod tests {
         ];
         match Options::try_parse_from(correct_arguments) {
             Ok(got) => assert_eq!(got, expected),
-            Err(e) => panic!("{}\narguments were {:?}", e, correct_arguments),
+            Err(e) => panic!("{e}\narguments were {correct_arguments:?}"),
         }
     }
 
@@ -1462,7 +1461,7 @@ mod tests {
         ];
         match Options::try_parse_from(correct_arguments) {
             Ok(got) => assert_eq!(got, expected),
-            Err(e) => panic!("{}\narguments were {:?}", e, correct_arguments),
+            Err(e) => panic!("{e}\narguments were {correct_arguments:?}"),
         }
 
         let mut bad_arguments = correct_arguments;


### PR DESCRIPTION
This fixes some Clippy lints that newly appear with the 1.88 toolchain.