### PR TITLE
Adopt Rust 2024 edition and MSRV 1.85

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ members = [
 resolver = "2"
 
 [workspace.package]
-edition = "2021"
+edition = "2024"
 homepage = "https://divviup.org"
 license = "MPL-2.0"
 repository = "https://github.com/divviup/janus"
-rust-version = "1.81.0"
+rust-version = "1.85.0"
 version = "0.8.0-prerelease-1"
 
 [workspace.dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM rust:1.88.0-alpine AS chef
 ENV CARGO_INCREMENTAL=0
 RUN apk add --no-cache libc-dev cmake make
-RUN cargo install cargo-chef --version 0.1.60 && \
+RUN cargo install cargo-chef --version 0.1.71 && \
     rm -r $CARGO_HOME/registry
 WORKDIR /src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.87.0-alpine AS chef
+FROM rust:1.88.0-alpine AS chef
 ENV CARGO_INCREMENTAL=0
 RUN apk add --no-cache libc-dev cmake make
 RUN cargo install cargo-chef --version 0.1.60 && \

--- a/Dockerfile.interop
+++ b/Dockerfile.interop
@@ -1,7 +1,7 @@
 ARG BINARY
 ARG PROFILE=release
 
-FROM rust:1.87.0-alpine AS chef
+FROM rust:1.88.0-alpine AS chef
 ENV CARGO_INCREMENTAL=0
 RUN apk add --no-cache libc-dev cmake make
 RUN cargo install cargo-chef --version 0.1.60 && \

--- a/Dockerfile.interop
+++ b/Dockerfile.interop
@@ -4,7 +4,7 @@ ARG PROFILE=release
 FROM rust:1.88.0-alpine AS chef
 ENV CARGO_INCREMENTAL=0
 RUN apk add --no-cache libc-dev cmake make
-RUN cargo install cargo-chef --version 0.1.60 && \
+RUN cargo install cargo-chef --version 0.1.71 && \
     rm -r $CARGO_HOME/registry
 WORKDIR /src
 

--- a/Dockerfile.interop_aggregator
+++ b/Dockerfile.interop_aggregator
@@ -3,7 +3,7 @@ ARG PROFILE=release
 FROM rust:1.88.0-alpine AS chef
 ENV CARGO_INCREMENTAL=0
 RUN apk add --no-cache libc-dev cmake make
-RUN cargo install cargo-chef --version 0.1.60 && \
+RUN cargo install cargo-chef --version 0.1.71 && \
     rm -r $CARGO_HOME/registry
 WORKDIR /src
 

--- a/Dockerfile.interop_aggregator
+++ b/Dockerfile.interop_aggregator
@@ -1,6 +1,6 @@
 ARG PROFILE=release
 
-FROM rust:1.87.0-alpine AS chef
+FROM rust:1.88.0-alpine AS chef
 ENV CARGO_INCREMENTAL=0
 RUN apk add --no-cache libc-dev cmake make
 RUN cargo install cargo-chef --version 0.1.60 && \
@@ -60,7 +60,7 @@ COPY tools /src/tools
 COPY xtask /src/xtask
 RUN cargo build --features fpvec_bounded_l2 --profile $PROFILE -p janus_interop_binaries
 
-FROM rust:1.87.0-alpine AS sqlx
+FROM rust:1.88.0-alpine AS sqlx
 ENV CARGO_INCREMENTAL=0
 ARG SQLX_VERSION=0.7.2
 RUN apk add --no-cache libc-dev

--- a/Dockerfile.sqlx
+++ b/Dockerfile.sqlx
@@ -1,4 +1,4 @@
-FROM rust:1.87.0-alpine AS builder
+FROM rust:1.88.0-alpine AS builder
 ENV CARGO_INCREMENTAL=0
 ARG SQLX_VERSION
 RUN apk add libc-dev

--- a/aggregator/src/aggregator/aggregate_share.rs
+++ b/aggregator/src/aggregator/aggregate_share.rs
@@ -3,16 +3,16 @@
 use super::Error;
 use itertools::iproduct;
 use janus_aggregator_core::{
+    AsyncAggregator,
     batch_mode::CollectableBatchMode,
     datastore::{
         self,
         models::{BatchAggregation, BatchAggregationState},
     },
     task::AggregatorTask,
-    AsyncAggregator,
 };
 use janus_core::{report_id::ReportIdChecksumExt, time::IntervalExt as _};
-use janus_messages::{batch_mode::BatchMode, Interval, ReportIdChecksum, TaskId};
+use janus_messages::{Interval, ReportIdChecksum, TaskId, batch_mode::BatchMode};
 use prio::vdaf::Aggregatable;
 use std::{borrow::Cow, collections::HashMap};
 
@@ -114,7 +114,7 @@ where
                 ..
             } => (aggregate_share, report_count, checksum),
             BatchAggregationState::Scrubbed => {
-                return Err(Error::Datastore(datastore::Error::Scrubbed))
+                return Err(Error::Datastore(datastore::Error::Scrubbed));
             }
         };
 

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -1768,8 +1768,11 @@ where
         &self,
         datastore: Arc<Datastore<C>>,
         lease_duration: Duration,
-    ) -> impl Fn(usize) -> BoxFuture<'static, Result<Vec<Lease<AcquiredAggregationJob>>, datastore::Error>>
-    {
+    ) -> impl Fn(
+        usize,
+    )
+        -> BoxFuture<'static, Result<Vec<Lease<AcquiredAggregationJob>>, datastore::Error>>
+           + use<C, R> {
         move |max_acquire_count: usize| {
             let datastore = Arc::clone(&datastore);
 

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -1,8 +1,8 @@
 use crate::{
     aggregator::{
-        aggregate_step_failure_counter,
-        aggregation_job_continue::{compute_helper_aggregate_continue, AggregateContinueMetrics},
-        aggregation_job_init::{compute_helper_aggregate_init, AggregateInitMetrics},
+        Error, RequestBody, aggregate_step_failure_counter,
+        aggregation_job_continue::{AggregateContinueMetrics, compute_helper_aggregate_continue},
+        aggregation_job_init::{AggregateInitMetrics, compute_helper_aggregate_init},
         aggregation_job_writer::{
             AggregationJobWriter, AggregationJobWriterMetrics, UpdateWrite,
             WritableReportAggregation,
@@ -11,7 +11,6 @@ use crate::{
         error::handle_ping_pong_error,
         http_handlers::AGGREGATION_JOB_ROUTE,
         report_aggregation_success_counter, send_request_to_helper, write_task_aggregation_counter,
-        Error, RequestBody,
     },
     cache::HpkeKeypairCache,
     metrics::{
@@ -19,23 +18,22 @@ use crate::{
         past_report_clock_skew_histogram,
     },
 };
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use backon::BackoffBuilder;
 use bytes::Bytes;
 use educe::Educe;
 use futures::future::BoxFuture;
-use http::{header::RETRY_AFTER, HeaderValue};
+use http::{HeaderValue, header::RETRY_AFTER};
 use janus_aggregator_core::{
+    AsyncAggregator, TIME_HISTOGRAM_BOUNDARIES,
     datastore::{
-        self,
+        self, Datastore,
         models::{
             AcquiredAggregationJob, AggregationJob, AggregationJobState, Lease, ReportAggregation,
             ReportAggregationState,
         },
-        Datastore,
     },
     task::{self, AggregatorTask},
-    AsyncAggregator, TIME_HISTOGRAM_BOUNDARIES,
 };
 use janus_core::{
     retries::{is_retryable_http_client_error, is_retryable_http_status},
@@ -44,14 +42,14 @@ use janus_core::{
     vdaf_dispatch,
 };
 use janus_messages::{
-    batch_mode::{LeaderSelected, TimeInterval},
     AggregationJobContinueReq, AggregationJobInitializeReq, AggregationJobResp,
     PartialBatchSelector, PrepareContinue, PrepareInit, PrepareResp, PrepareStepResult,
     ReportError, ReportMetadata, ReportShare, Role,
+    batch_mode::{LeaderSelected, TimeInterval},
 };
 use opentelemetry::{
-    metrics::{Counter, Histogram, Meter},
     KeyValue,
+    metrics::{Counter, Histogram, Meter},
 };
 use prio::{
     codec::{Decode, Encode},
@@ -69,10 +67,10 @@ use std::{
 };
 use tokio::{
     join,
-    sync::{mpsc, Mutex},
+    sync::{Mutex, mpsc},
     try_join,
 };
-use tracing::{debug, error, info, info_span, trace_span, warn, Span};
+use tracing::{Span, debug, error, info, info_span, trace_span, warn};
 
 #[cfg(test)]
 mod tests;
@@ -1393,7 +1391,7 @@ where
                             report_aggregation.state().state_name()
                         )
                         .into(),
-                    ))
+                    ));
                 }
             }
         }
@@ -1772,7 +1770,7 @@ where
         usize,
     )
         -> BoxFuture<'static, Result<Vec<Lease<AcquiredAggregationJob>>, datastore::Error>>
-           + use<C, R> {
+    + use<C, R> {
         move |max_acquire_count: usize| {
             let datastore = Arc::clone(&datastore);
 

--- a/aggregator/src/aggregator/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/aggregation_job_init.rs
@@ -2,17 +2,17 @@
 
 use crate::{
     aggregator::{
-        aggregation_job_writer::WritableReportAggregation, error::handle_ping_pong_error,
-        AggregatorMetrics, Error,
+        AggregatorMetrics, Error, aggregation_job_writer::WritableReportAggregation,
+        error::handle_ping_pong_error,
     },
     cache::HpkeKeypairCache,
 };
 use assert_matches::assert_matches;
 use janus_aggregator_core::{
+    AsyncAggregator,
     batch_mode::AccumulableBatchMode,
     datastore::models::{AggregationJob, ReportAggregation, ReportAggregationState},
     task::AggregatorTask,
-    AsyncAggregator,
 };
 use janus_core::{
     hpke::{self, HpkeApplicationInfo, Label},
@@ -24,8 +24,8 @@ use janus_messages::{
     Role,
 };
 use opentelemetry::{
-    metrics::{Counter, Histogram},
     KeyValue,
+    metrics::{Counter, Histogram},
 };
 use prio::{
     codec::{Decode as _, Encode, ParameterizedDecode},
@@ -34,7 +34,7 @@ use prio::{
 use rayon::iter::{IntoParallelIterator as _, ParallelIterator as _};
 use std::{collections::HashMap, panic, sync::Arc};
 use tokio::sync::mpsc;
-use tracing::{debug, info_span, trace_span, Span};
+use tracing::{Span, debug, info_span, trace_span};
 
 #[derive(Clone)]
 pub struct AggregateInitMetrics {
@@ -448,17 +448,17 @@ where
 pub mod test_util {
     use crate::aggregator::test_util::generate_helper_report_share;
     use janus_aggregator_core::{
-        task::{test_util::Task, AggregatorTask},
         AsyncAggregator,
+        task::{AggregatorTask, test_util::Task},
     };
     use janus_core::{
-        test_util::{run_vdaf, VdafTranscript},
+        test_util::{VdafTranscript, run_vdaf},
         time::{Clock, MockClock, TimeExt as _},
     };
     use janus_messages::{
-        batch_mode::{self},
         AggregationJobId, AggregationJobInitializeReq, Extension, HpkeConfig, PrepareInit,
         ReportMetadata, ReportShare,
+        batch_mode::{self},
     };
     use prio::{
         codec::Encode,
@@ -466,7 +466,7 @@ pub mod test_util {
     };
     use rand::random;
     use trillium::{Handler, KnownHeaderName};
-    use trillium_testing::{prelude::put, TestConn};
+    use trillium_testing::{TestConn, prelude::put};
 
     #[derive(Clone)]
     pub struct PrepareInitGenerator<const VERIFY_KEY_SIZE: usize, V>
@@ -611,23 +611,23 @@ pub mod test_util {
 #[cfg(test)]
 mod tests {
     use crate::aggregator::{
-        aggregation_job_init::test_util::{put_aggregation_job, PrepareInitGenerator},
-        http_handlers::{
-            test_util::{decode_response_body, take_problem_details},
-            AggregatorHandlerBuilder,
-        },
         Config,
+        aggregation_job_init::test_util::{PrepareInitGenerator, put_aggregation_job},
+        http_handlers::{
+            AggregatorHandlerBuilder,
+            test_util::{decode_response_body, take_problem_details},
+        },
     };
     use assert_matches::assert_matches;
     use http::StatusCode;
     use janus_aggregator_core::{
-        datastore::test_util::{ephemeral_datastore, EphemeralDatastore},
+        AsyncAggregator,
+        datastore::test_util::{EphemeralDatastore, ephemeral_datastore},
         task::{
-            test_util::{Task, TaskBuilder},
             AggregationMode, BatchMode,
+            test_util::{Task, TaskBuilder},
         },
         test_util::noop_meter,
-        AsyncAggregator,
     };
     use janus_core::{
         auth_tokens::{AuthenticationToken, DAP_AUTH_HEADER},
@@ -636,9 +636,9 @@ mod tests {
         vdaf::VdafInstance,
     };
     use janus_messages::{
-        batch_mode::TimeInterval, AggregationJobId, AggregationJobInitializeReq,
-        AggregationJobResp, Duration, Extension, ExtensionType, PartialBatchSelector, PrepareResp,
-        PrepareStepResult, ReportError, ReportMetadata,
+        AggregationJobId, AggregationJobInitializeReq, AggregationJobResp, Duration, Extension,
+        ExtensionType, PartialBatchSelector, PrepareResp, PrepareStepResult, ReportError,
+        ReportMetadata, batch_mode::TimeInterval,
     };
     use prio::{
         codec::Encode,

--- a/aggregator/src/aggregator/aggregation_job_writer.rs
+++ b/aggregator/src/aggregator/aggregation_job_writer.rs
@@ -5,17 +5,17 @@ use crate::Operation;
 use async_trait::async_trait;
 use futures::future::try_join_all;
 use janus_aggregator_core::{
+    AsyncAggregator,
     batch_mode::AccumulableBatchMode,
     datastore::{
+        Error, Transaction,
         models::{
             AggregationJob, AggregationJobState, BatchAggregation, BatchAggregationState,
             ReportAggregation, ReportAggregationMetadata, ReportAggregationMetadataState,
             ReportAggregationState, TaskAggregationCounter,
         },
-        Error, Transaction,
     },
     task::AggregatorTask,
-    AsyncAggregator,
 };
 #[cfg(feature = "fpvec_bounded_l2")]
 use janus_core::vdaf::Prio3FixedPointBoundedL2VecSumBitSize;
@@ -25,13 +25,13 @@ use janus_messages::{
     ReportIdChecksum, Time,
 };
 use opentelemetry::{
-    metrics::{Counter, Histogram},
     KeyValue,
+    metrics::{Counter, Histogram},
 };
-use rand::{rng, Rng as _};
+use rand::{Rng as _, rng};
 use std::{borrow::Cow, collections::HashMap, marker::PhantomData, sync::Arc};
 use tokio::try_join;
-use tracing::{warn, Level};
+use tracing::{Level, warn};
 
 /// Buffers pending writes to aggregation jobs and their report aggregations.
 pub struct AggregationJobWriter<const SEED_SIZE: usize, B, A, WT, RA>

--- a/aggregator/src/aggregator/batch_creator.rs
+++ b/aggregator/src/aggregator/batch_creator.rs
@@ -3,26 +3,26 @@
 use crate::aggregator::aggregation_job_writer::{AggregationJobWriter, InitialWrite};
 use futures::future::try_join_all;
 use janus_aggregator_core::{
+    AsyncAggregator,
     datastore::{
+        Error, Transaction,
         models::{
             AggregationJob, AggregationJobState, OutstandingBatch, ReportAggregationMetadata,
             ReportAggregationMetadataState, UnaggregatedReport,
         },
-        Error, Transaction,
     },
-    AsyncAggregator,
 };
 use janus_core::time::{Clock, DurationExt, TimeExt};
 use janus_messages::{
-    batch_mode::LeaderSelected, AggregationJobStep, BatchId, Duration, Interval, ReportId, TaskId,
-    Time,
+    AggregationJobStep, BatchId, Duration, Interval, ReportId, TaskId, Time,
+    batch_mode::LeaderSelected,
 };
 use opentelemetry::metrics::Histogram;
 use prio::codec::Encode;
 use rand::random;
 use std::{
-    cmp::{max, min, Ordering},
-    collections::{binary_heap::PeekMut, hash_map, BinaryHeap, HashMap, HashSet, VecDeque},
+    cmp::{Ordering, max, min},
+    collections::{BinaryHeap, HashMap, HashSet, VecDeque, binary_heap::PeekMut, hash_map},
     ops::RangeInclusive,
     sync::Arc,
 };

--- a/aggregator/src/aggregator/batch_mode.rs
+++ b/aggregator/src/aggregator/batch_mode.rs
@@ -1,18 +1,18 @@
 use super::{
-    error::{ReportRejection, ReportRejectionReason},
     Error,
+    error::{ReportRejection, ReportRejectionReason},
 };
 use async_trait::async_trait;
 use janus_aggregator_core::{
-    batch_mode::{AccumulableBatchMode, CollectableBatchMode as CoreCollectableBatchMode},
-    datastore::{self, models::LeaderStoredReport, Transaction},
-    task::AggregatorTask,
     AsyncAggregator,
+    batch_mode::{AccumulableBatchMode, CollectableBatchMode as CoreCollectableBatchMode},
+    datastore::{self, Transaction, models::LeaderStoredReport},
+    task::AggregatorTask,
 };
 use janus_core::time::Clock;
 use janus_messages::{
-    batch_mode::{BatchMode, LeaderSelected, TimeInterval},
     Role,
+    batch_mode::{BatchMode, LeaderSelected, TimeInterval},
 };
 
 #[async_trait]

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -1,9 +1,9 @@
 //! Implements portions of collect sub-protocol for DAP leader and helper.
 
 use crate::aggregator::{
-    aggregate_share::AggregateShareComputer, batch_mode::CollectableBatchMode,
-    http_handlers::AGGREGATE_SHARES_ROUTE, send_request_to_helper, BatchAggregationsIterator,
-    Error, RequestBody,
+    BatchAggregationsIterator, Error, RequestBody, aggregate_share::AggregateShareComputer,
+    batch_mode::CollectableBatchMode, http_handlers::AGGREGATE_SHARES_ROUTE,
+    send_request_to_helper,
 };
 use anyhow::bail;
 use backon::BackoffBuilder;
@@ -11,12 +11,12 @@ use bytes::Bytes;
 use educe::Educe;
 use futures::{future::BoxFuture, stream::TryStreamExt};
 use janus_aggregator_core::{
+    AsyncAggregator, AsyncAggregatorWithNoise, TIME_HISTOGRAM_BOUNDARIES,
     datastore::{
-        self,
+        self, Datastore,
         models::{AcquiredCollectionJob, BatchAggregation, CollectionJobState, Lease},
-        Datastore,
     },
-    task, AsyncAggregator, AsyncAggregatorWithNoise, TIME_HISTOGRAM_BOUNDARIES,
+    task,
 };
 use janus_core::{
     retries::{is_retryable_http_client_error, is_retryable_http_status},
@@ -24,12 +24,12 @@ use janus_core::{
     vdaf_dispatch,
 };
 use janus_messages::{
-    batch_mode::{BatchMode, LeaderSelected, TimeInterval},
     AggregateShare, AggregateShareReq, BatchSelector,
+    batch_mode::{BatchMode, LeaderSelected, TimeInterval},
 };
 use opentelemetry::{
-    metrics::{Counter, Histogram, Meter},
     KeyValue, Value,
+    metrics::{Counter, Histogram, Meter},
 };
 use prio::{
     codec::{Decode, Encode},
@@ -571,7 +571,7 @@ where
         usize,
     )
         -> BoxFuture<'static, Result<Vec<Lease<AcquiredCollectionJob>>, datastore::Error>>
-           + use<C, R> {
+    + use<C, R> {
         move |maximum_acquire_count| {
             let datastore = Arc::clone(&datastore);
             Box::pin(async move {
@@ -813,42 +813,41 @@ impl RetryStrategy {
 mod tests {
     use crate::{
         aggregator::{
+            Error,
             collection_job_driver::{CollectionJobDriver, RetryStrategy},
             test_util::BATCH_AGGREGATION_SHARD_COUNT,
-            Error,
         },
         binary_utils::job_driver::JobDriver,
     };
     use assert_matches::assert_matches;
-    use http::{header::CONTENT_TYPE, StatusCode};
+    use http::{StatusCode, header::CONTENT_TYPE};
     use janus_aggregator_core::{
         datastore::{
+            Datastore,
             models::{
                 AcquiredCollectionJob, AggregationJob, AggregationJobState, BatchAggregation,
                 BatchAggregationState, CollectionJob, CollectionJobState, LeaderStoredReport,
                 Lease, ReportAggregation, ReportAggregationState,
             },
             test_util::ephemeral_datastore,
-            Datastore,
         },
         task::{
-            test_util::{Task, TaskBuilder},
             AggregationMode, BatchMode,
+            test_util::{Task, TaskBuilder},
         },
         test_util::noop_meter,
     };
     use janus_core::{
-        initialize_rustls,
+        Runtime, initialize_rustls,
         retries::test_util::LimitedRetryer,
         test_util::{install_test_trace_subscriber, runtime::TestRuntimeManager},
         time::{Clock, MockClock, TimeExt},
         vdaf::VdafInstance,
-        Runtime,
     };
     use janus_messages::{
-        batch_mode::TimeInterval, problem_type::DapProblemType, AggregateShare, AggregateShareReq,
-        AggregationJobStep, BatchSelector, Duration, HpkeCiphertext, HpkeConfigId, Interval, Query,
-        ReportIdChecksum,
+        AggregateShare, AggregateShareReq, AggregationJobStep, BatchSelector, Duration,
+        HpkeCiphertext, HpkeConfigId, Interval, Query, ReportIdChecksum, batch_mode::TimeInterval,
+        problem_type::DapProblemType,
     };
     use prio::{
         codec::{Decode, Encode},
@@ -1858,8 +1857,7 @@ mod tests {
             .as_secs();
 
             assert_eq!(
-                want_delay_s,
-                got_delay_s,
+                want_delay_s, got_delay_s,
                 "RetryDelay({min_delay_s}, {max_delay_s}, {exponential_factor}).compute_retry_delay({step_attempts})"
             );
         }

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -567,8 +567,11 @@ where
         &self,
         datastore: Arc<Datastore<C>>,
         lease_duration: Duration,
-    ) -> impl Fn(usize) -> BoxFuture<'static, Result<Vec<Lease<AcquiredCollectionJob>>, datastore::Error>>
-    {
+    ) -> impl Fn(
+        usize,
+    )
+        -> BoxFuture<'static, Result<Vec<Lease<AcquiredCollectionJob>>, datastore::Error>>
+           + use<C, R> {
         move |maximum_acquire_count| {
             let datastore = Arc::clone(&datastore);
             Box::pin(async move {

--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -1,22 +1,22 @@
 use crate::aggregator::{
+    Config,
     http_handlers::test_util::{decode_response_body, take_problem_details},
     test_util::BATCH_AGGREGATION_SHARD_COUNT,
-    Config,
 };
 use assert_matches::assert_matches;
 use http::StatusCode;
 use janus_aggregator_core::{
     datastore::{
+        Datastore,
         models::{
             AggregationJob, AggregationJobState, BatchAggregation, BatchAggregationState,
             CollectionJobState, LeaderStoredReport, ReportAggregation, ReportAggregationState,
         },
-        test_util::{ephemeral_datastore, EphemeralDatastore},
-        Datastore,
+        test_util::{EphemeralDatastore, ephemeral_datastore},
     },
     task::{
-        test_util::{Task, TaskBuilder},
         AggregationMode, BatchMode,
+        test_util::{Task, TaskBuilder},
     },
     test_util::noop_meter,
 };
@@ -28,9 +28,9 @@ use janus_core::{
     vdaf::VdafInstance,
 };
 use janus_messages::{
-    batch_mode::{BatchMode as BatchModeTrait, LeaderSelected, TimeInterval},
     AggregateShareAad, AggregationJobStep, BatchId, BatchSelector, CollectionJobId,
     CollectionJobReq, CollectionJobResp, Interval, Query, Role, Time,
+    batch_mode::{BatchMode as BatchModeTrait, LeaderSelected, TimeInterval},
 };
 use prio::{
     codec::{Decode, Encode},
@@ -41,9 +41,8 @@ use serde_json::json;
 use std::{collections::HashSet, sync::Arc};
 use trillium::{Handler, KnownHeaderName, Status};
 use trillium_testing::{
-    assert_headers,
+    TestConn, assert_headers,
     prelude::{get, put},
-    TestConn,
 };
 
 use super::http_handlers::AggregatorHandlerBuilder;
@@ -298,8 +297,8 @@ pub(crate) async fn setup_collection_job_test_case(
     }
 }
 
-async fn setup_leader_selected_current_batch_collection_job_test_case(
-) -> (CollectionJobTestCase, BatchId, BatchId, Interval) {
+async fn setup_leader_selected_current_batch_collection_job_test_case()
+-> (CollectionJobTestCase, BatchId, BatchId, Interval) {
     let test_case = setup_collection_job_test_case(
         Role::Leader,
         BatchMode::LeaderSelected {

--- a/aggregator/src/aggregator/error.rs
+++ b/aggregator/src/aggregator/error.rs
@@ -4,7 +4,7 @@ use janus_messages::{
     AggregationJobId, AggregationJobStep, CollectionJobId, HpkeConfigId, Interval, ReportError,
     ReportId, ReportIdChecksum, Role, TaskId, Time,
 };
-use opentelemetry::{metrics::Counter, KeyValue};
+use opentelemetry::{KeyValue, metrics::Counter};
 use prio::{topology::ping_pong::PingPongError, vdaf::VdafError};
 use std::{
     fmt::{self, Display, Formatter},

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -1,34 +1,34 @@
 use super::{
-    error::{ArcError, ReportRejectionReason},
-    queue::{queued_lifo, LIFORequestQueue},
     Aggregator, Config, Error,
+    error::{ArcError, ReportRejectionReason},
+    queue::{LIFORequestQueue, queued_lifo},
 };
 use crate::aggregator::problem_details::{ProblemDetailsConnExt, ProblemDocument};
 use anyhow::Context;
 use async_trait::async_trait;
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use janus_aggregator_api::BYTES_HISTOGRAM_BOUNDARIES;
 use janus_aggregator_core::{
-    datastore::Datastore, datastore::Error as datastoreError, instrumented,
-    taskprov::taskprov_task_id, TIME_HISTOGRAM_BOUNDARIES,
+    TIME_HISTOGRAM_BOUNDARIES, datastore::Datastore, datastore::Error as datastoreError,
+    instrumented, taskprov::taskprov_task_id,
 };
 use janus_core::{
+    Runtime,
     auth_tokens::{AuthenticationToken, DAP_AUTH_HEADER},
     http::extract_bearer_token,
     taskprov::TASKPROV_HEADER,
     time::Clock,
-    Runtime,
 };
 use janus_messages::{
-    batch_mode::TimeInterval, codec::Decode, problem_type::DapProblemType, taskprov::TaskConfig,
     AggregateShare, AggregateShareReq, AggregationJobContinueReq, AggregationJobId,
     AggregationJobInitializeReq, AggregationJobResp, AggregationJobStep, CollectionJobId,
-    CollectionJobReq, CollectionJobResp, HpkeConfigList, Report, TaskId,
+    CollectionJobReq, CollectionJobResp, HpkeConfigList, Report, TaskId, batch_mode::TimeInterval,
+    codec::Decode, problem_type::DapProblemType, taskprov::TaskConfig,
 };
 use mime::Mime;
 use opentelemetry::{
-    metrics::{Counter, Meter},
     KeyValue,
+    metrics::{Counter, Meter},
 };
 use prio::codec::Encode;
 use querystring::querify;
@@ -37,7 +37,7 @@ use std::sync::Arc;
 use std::{borrow::Cow, time::Duration as StdDuration};
 use tracing::warn;
 use trillium::{Conn, Handler, KnownHeaderName, Status};
-use trillium_api::{api, State, TryFromConn};
+use trillium_api::{State, TryFromConn, api};
 use trillium_caching_headers::{CacheControlDirective, CachingHeadersExt as _};
 use trillium_opentelemetry::Metrics;
 use trillium_router::{Router, RouterConnExt};
@@ -911,8 +911,8 @@ pub mod test_util {
     use crate::aggregator::test_util::default_aggregator_config;
     use janus_aggregator_core::{
         datastore::{
-            test_util::{ephemeral_datastore, EphemeralDatastore},
             Datastore,
+            test_util::{EphemeralDatastore, ephemeral_datastore},
         },
         test_util::noop_meter,
     };
@@ -925,7 +925,7 @@ pub mod test_util {
     use janus_messages::codec::Decode;
     use std::sync::Arc;
     use trillium::Handler;
-    use trillium_testing::{assert_headers, TestConn};
+    use trillium_testing::{TestConn, assert_headers};
 
     use super::AggregatorHandlerBuilder;
 

--- a/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
@@ -1,6 +1,6 @@
 use crate::aggregator::{
     error::BatchMismatch,
-    http_handlers::test_util::{decode_response_body, take_problem_details, HttpHandlerTest},
+    http_handlers::test_util::{HttpHandlerTest, decode_response_body, take_problem_details},
 };
 use assert_matches::assert_matches;
 use futures::future::try_join_all;
@@ -8,8 +8,8 @@ use janus_aggregator_core::{
     batch_mode::CollectableBatchMode,
     datastore::models::{BatchAggregation, BatchAggregationState},
     task::{
-        test_util::{Task, TaskBuilder},
         AggregationMode, BatchMode,
+        test_util::{Task, TaskBuilder},
     },
 };
 use janus_core::{
@@ -19,9 +19,9 @@ use janus_core::{
     vdaf::VdafInstance,
 };
 use janus_messages::{
-    batch_mode::{self, TimeInterval},
     AggregateShare as AggregateShareMessage, AggregateShareAad, AggregateShareReq, BatchSelector,
     Duration, Interval, ReportIdChecksum, Role, Time,
+    batch_mode::{self, TimeInterval},
 };
 use prio::{
     codec::{Decode, Encode},
@@ -29,7 +29,7 @@ use prio::{
 };
 use serde_json::json;
 use trillium::{Handler, KnownHeaderName, Status};
-use trillium_testing::{assert_headers, prelude::post, TestConn};
+use trillium_testing::{TestConn, assert_headers, prelude::post};
 
 pub(crate) async fn post_aggregate_share_request<B: batch_mode::BatchMode>(
     task: &Task,

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_continue.rs
@@ -1,23 +1,24 @@
 use crate::aggregator::{
+    BatchAggregationsIterator,
     aggregation_job_continue::test_util::{
         post_aggregation_job_and_decode, post_aggregation_job_expecting_error,
     },
     http_handlers::test_util::HttpHandlerTest,
     test_util::{
-        assert_task_aggregation_counter, generate_helper_report_share,
-        BATCH_AGGREGATION_SHARD_COUNT,
+        BATCH_AGGREGATION_SHARD_COUNT, assert_task_aggregation_counter,
+        generate_helper_report_share,
     },
-    BatchAggregationsIterator,
 };
 use assert_matches::assert_matches;
 use futures::future::try_join_all;
 use janus_aggregator_core::{
     batch_mode::CollectableBatchMode,
     datastore::models::{
-        merge_batch_aggregations_by_batch, AggregationJob, AggregationJobState, BatchAggregation,
-        BatchAggregationState, ReportAggregation, ReportAggregationState, TaskAggregationCounter,
+        AggregationJob, AggregationJobState, BatchAggregation, BatchAggregationState,
+        ReportAggregation, ReportAggregationState, TaskAggregationCounter,
+        merge_batch_aggregations_by_batch,
     },
-    task::{test_util::TaskBuilder, AggregationMode, BatchMode, VerifyKey},
+    task::{AggregationMode, BatchMode, VerifyKey, test_util::TaskBuilder},
 };
 use janus_core::{
     report_id::ReportIdChecksumExt,
@@ -26,13 +27,13 @@ use janus_core::{
     vdaf::VdafInstance,
 };
 use janus_messages::{
-    batch_mode::TimeInterval, AggregationJobContinueReq, AggregationJobResp, AggregationJobStep,
-    Duration, Interval, PrepareContinue, PrepareResp, PrepareStepResult, ReportError, ReportId,
-    ReportIdChecksum, ReportMetadata, Role, Time,
+    AggregationJobContinueReq, AggregationJobResp, AggregationJobStep, Duration, Interval,
+    PrepareContinue, PrepareResp, PrepareStepResult, ReportError, ReportId, ReportIdChecksum,
+    ReportMetadata, Role, Time, batch_mode::TimeInterval,
 };
 use prio::{
     topology::ping_pong::PingPongMessage,
-    vdaf::{dummy, Aggregator},
+    vdaf::{Aggregator, dummy},
 };
 use rand::random;
 use std::sync::Arc;

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_get.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_get.rs
@@ -1,5 +1,5 @@
 use crate::aggregator::{
-    http_handlers::test_util::{decode_response_body, HttpHandlerTest},
+    http_handlers::test_util::{HttpHandlerTest, decode_response_body},
     test_util::generate_helper_report_share,
 };
 use janus_aggregator_core::{
@@ -7,8 +7,8 @@ use janus_aggregator_core::{
         AggregationJob, AggregationJobState, ReportAggregation, ReportAggregationState,
     },
     task::{
-        test_util::{Task, TaskBuilder},
         AggregationMode, BatchMode, VerifyKey,
+        test_util::{Task, TaskBuilder},
     },
 };
 use janus_core::{
@@ -17,14 +17,14 @@ use janus_core::{
     vdaf::VdafInstance,
 };
 use janus_messages::{
-    batch_mode::TimeInterval, AggregationJobId, AggregationJobResp, AggregationJobStep, Interval,
-    PrepareInit, PrepareResp, PrepareStepResult, ReportMetadata,
+    AggregationJobId, AggregationJobResp, AggregationJobStep, Interval, PrepareInit, PrepareResp,
+    PrepareStepResult, ReportMetadata, batch_mode::TimeInterval,
 };
 use prio::vdaf::dummy;
 use rand::random;
 use std::sync::Arc;
 use trillium::{Handler, Status};
-use trillium_testing::{assert_headers, prelude::get, TestConn};
+use trillium_testing::{TestConn, assert_headers, prelude::get};
 
 #[tokio::test]
 async fn aggregation_job_get_ready() {

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
@@ -1,13 +1,13 @@
 #![allow(clippy::unit_arg)] // allow reference to dummy::Vdaf's public share, which has the unit type
 
 use crate::aggregator::{
-    aggregation_job_init::test_util::{put_aggregation_job, PrepareInitGenerator},
-    http_handlers::test_util::{decode_response_body, take_problem_details, HttpHandlerTest},
-    test_util::{
-        assert_task_aggregation_counter, generate_helper_report_share,
-        generate_helper_report_share_for_plaintext, BATCH_AGGREGATION_SHARD_COUNT,
-    },
     BatchAggregationsIterator,
+    aggregation_job_init::test_util::{PrepareInitGenerator, put_aggregation_job},
+    http_handlers::test_util::{HttpHandlerTest, decode_response_body, take_problem_details},
+    test_util::{
+        BATCH_AGGREGATION_SHARD_COUNT, assert_task_aggregation_counter,
+        generate_helper_report_share, generate_helper_report_share_for_plaintext,
+    },
 };
 use assert_matches::assert_matches;
 use futures::future::try_join_all;
@@ -16,7 +16,7 @@ use janus_aggregator_core::{
         AggregationJobState, BatchAggregation, BatchAggregationState, ReportAggregationState,
         TaskAggregationCounter,
     },
-    task::{test_util::TaskBuilder, AggregationMode, BatchMode, VerifyKey},
+    task::{AggregationMode, BatchMode, VerifyKey, test_util::TaskBuilder},
 };
 use janus_core::{
     auth_tokens::AuthenticationToken,
@@ -27,16 +27,16 @@ use janus_core::{
     vdaf::VdafInstance,
 };
 use janus_messages::{
-    batch_mode::{LeaderSelected, TimeInterval},
     AggregationJobId, AggregationJobInitializeReq, AggregationJobResp, Extension, ExtensionType,
     HpkeCiphertext, HpkeConfigId, InputShareAad, Interval, PartialBatchSelector, PrepareInit,
     PrepareStepResult, ReportError, ReportIdChecksum, ReportMetadata, ReportShare, Role, Time,
+    batch_mode::{LeaderSelected, TimeInterval},
 };
 use prio::{codec::Encode, vdaf::dummy};
 use rand::random;
 use serde_json::json;
 use trillium::{KnownHeaderName, Status};
-use trillium_testing::{assert_headers, prelude::put, TestConn};
+use trillium_testing::{TestConn, assert_headers, prelude::put};
 
 #[tokio::test]
 async fn aggregate_leader() {

--- a/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
@@ -1,20 +1,20 @@
 use crate::aggregator::{
     collection_job_tests::setup_collection_job_test_case,
-    http_handlers::test_util::{decode_response_body, take_problem_details, HttpHandlerTest},
+    http_handlers::test_util::{HttpHandlerTest, decode_response_body, take_problem_details},
 };
 use assert_matches::assert_matches;
 use janus_aggregator_core::{
     batch_mode::AccumulableBatchMode,
     datastore::models::{CollectionJob, CollectionJobState},
-    task::{test_util::TaskBuilder, AggregationMode, BatchMode},
+    task::{AggregationMode, BatchMode, test_util::TaskBuilder},
 };
 use janus_core::{
     hpke::{self, HpkeApplicationInfo, Label},
     vdaf::VdafInstance,
 };
 use janus_messages::{
-    batch_mode::TimeInterval, AggregateShareAad, BatchSelector, CollectionJobId, CollectionJobReq,
-    CollectionJobResp, Duration, Interval, Query, Role, Time,
+    AggregateShareAad, BatchSelector, CollectionJobId, CollectionJobReq, CollectionJobResp,
+    Duration, Interval, Query, Role, Time, batch_mode::TimeInterval,
 };
 use prio::{
     codec::{Decode, Encode},

--- a/aggregator/src/aggregator/http_handlers/tests/helper_e2e.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/helper_e2e.rs
@@ -1,9 +1,10 @@
 use assert_matches::assert_matches;
-use janus_aggregator_core::task::{test_util::TaskBuilder, AggregationMode, BatchMode};
+use janus_aggregator_core::task::{AggregationMode, BatchMode, test_util::TaskBuilder};
 use janus_core::{report_id::ReportIdChecksumExt, vdaf::VdafInstance};
 use janus_messages::{
-    batch_mode::LeaderSelected, AggregateShareReq, AggregationJobInitializeReq, AggregationJobResp,
-    BatchSelector, PartialBatchSelector, PrepareStepResult, ReportError, ReportIdChecksum,
+    AggregateShareReq, AggregationJobInitializeReq, AggregationJobResp, BatchSelector,
+    PartialBatchSelector, PrepareStepResult, ReportError, ReportIdChecksum,
+    batch_mode::LeaderSelected,
 };
 use prio::{
     codec::{Decode, Encode},
@@ -14,9 +15,9 @@ use trillium::Status;
 use trillium_testing::assert_status;
 
 use crate::aggregator::{
-    aggregation_job_init::test_util::{put_aggregation_job, PrepareInitGenerator},
+    aggregation_job_init::test_util::{PrepareInitGenerator, put_aggregation_job},
     http_handlers::{
-        test_util::{take_response_body, HttpHandlerTest},
+        test_util::{HttpHandlerTest, take_response_body},
         tests::aggregate_share::post_aggregate_share_request,
     },
 };

--- a/aggregator/src/aggregator/http_handlers/tests/hpke_config.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/hpke_config.rs
@@ -1,18 +1,18 @@
 use crate::{
     aggregator::{
+        Config,
         http_handlers::{
-            test_util::{take_response_body, HttpHandlerTest},
             AggregatorHandlerBuilder, HPKE_CONFIG_SIGNATURE_HEADER,
+            test_util::{HttpHandlerTest, take_response_body},
         },
         test_util::{hpke_config_signing_key, hpke_config_verification_key},
-        Config,
     },
     config::TaskprovConfig,
 };
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use janus_aggregator_core::{
     datastore::models::HpkeKeyState,
-    task::{test_util::TaskBuilder, AggregationMode, BatchMode},
+    task::{AggregationMode, BatchMode, test_util::TaskBuilder},
     test_util::noop_meter,
 };
 use janus_core::{
@@ -24,7 +24,7 @@ use janus_messages::{HpkeConfigId, HpkeConfigList, Role};
 use prio::codec::Decode as _;
 use std::{collections::HashMap, sync::Arc};
 use trillium::{KnownHeaderName, Status};
-use trillium_testing::{assert_headers, prelude::get, TestConn};
+use trillium_testing::{TestConn, assert_headers, prelude::get};
 
 #[tokio::test]
 async fn hpke_config() {

--- a/aggregator/src/aggregator/http_handlers/tests/report.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/report.rs
@@ -2,16 +2,16 @@ use crate::{
     aggregator::{
         error::ReportRejectionReason,
         http_handlers::{
-            test_util::{take_problem_details, HttpHandlerTest},
             AggregatorHandlerBuilder,
+            test_util::{HttpHandlerTest, take_problem_details},
         },
         test_util::{create_report, create_report_custom, default_aggregator_config},
     },
     metrics::test_util::InMemoryMetricInfrastructure,
 };
 use janus_aggregator_core::{
-    datastore::test_util::{ephemeral_datastore, EphemeralDatastoreBuilder},
-    task::{test_util::TaskBuilder, AggregationMode, BatchMode},
+    datastore::test_util::{EphemeralDatastoreBuilder, ephemeral_datastore},
+    task::{AggregationMode, BatchMode, test_util::TaskBuilder},
     test_util::noop_meter,
 };
 use janus_core::{
@@ -37,7 +37,7 @@ use tokio::{
     time::{sleep, timeout},
 };
 use trillium::{KnownHeaderName, Status};
-use trillium_testing::{assert_headers, prelude::post, TestConn};
+use trillium_testing::{TestConn, assert_headers, prelude::post};
 use trillium_tokio::Stopper;
 
 #[tokio::test]
@@ -795,10 +795,12 @@ async fn upload_client_early_disconnect() {
         .downcast_ref::<Sum<u64>>()
         .unwrap();
     assert_eq!(counter_data.data_points.len(), 2);
-    assert!(counter_data
-        .data_points
-        .iter()
-        .all(|data_point| data_point.value == 2));
+    assert!(
+        counter_data
+            .data_points
+            .iter()
+            .all(|data_point| data_point.value == 2)
+    );
     assert_eq!(
         counter_data
             .data_points
@@ -822,10 +824,12 @@ async fn upload_client_early_disconnect() {
         .downcast_ref::<Histogram<f64>>()
         .unwrap();
     assert_eq!(histogram_data.data_points.len(), 2);
-    assert!(histogram_data
-        .data_points
-        .iter()
-        .all(|data_point| data_point.count == 2));
+    assert!(
+        histogram_data
+            .data_points
+            .iter()
+            .all(|data_point| data_point.count == 2)
+    );
     assert_eq!(
         histogram_data
             .data_points

--- a/aggregator/src/aggregator/key_rotator.rs
+++ b/aggregator/src/aggregator/key_rotator.rs
@@ -178,7 +178,7 @@ impl<'a, C: Clock> HpkeKeyRotator<'a, C> {
         // config error, rather than attempting to decrypt them with the wrong key.
         let newest_id = keypairs
             .iter()
-            .max_by_key(|(&id, _)| id)
+            .max_by_key(|&(id, _)| id)
             .map(|(&id, _)| id.into())
             .unwrap_or(0);
         let available_ids = Box::new((newest_id..=u8::MAX).chain(0..newest_id).filter_map(

--- a/aggregator/src/aggregator/key_rotator.rs
+++ b/aggregator/src/aggregator/key_rotator.rs
@@ -1,12 +1,12 @@
 #[allow(unused_imports)]
 use crate::aggregator::Config as AggregatorConfig; // used in doccomment.
 use crate::cache::HpkeKeypairCache;
-use anyhow::{anyhow, Error};
+use anyhow::{Error, anyhow};
 use educe::Educe;
-use futures::{future::try_join_all, FutureExt};
+use futures::{FutureExt, future::try_join_all};
 use janus_aggregator_core::datastore::{
-    models::{HpkeKeyState, HpkeKeypair},
     Datastore, Error as DatastoreError, Transaction,
+    models::{HpkeKeyState, HpkeKeypair},
 };
 use janus_core::{
     hpke::{self, HpkeCiphersuite},
@@ -15,7 +15,7 @@ use janus_core::{
 use janus_messages::{Duration, HpkeAeadId, HpkeConfigId, HpkeKdfId, HpkeKemId, Time};
 #[cfg(test)]
 use quickcheck::{Arbitrary, Gen};
-use serde::{de, Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de};
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     sync::Arc,
@@ -506,9 +506,9 @@ mod tests {
 
     use itertools::Itertools;
     use janus_aggregator_core::datastore::{
+        Datastore,
         models::{HpkeKeyState, HpkeKeypair},
         test_util::ephemeral_datastore,
-        Datastore,
     };
     use janus_core::{
         hpke::{self, HpkeCiphersuite},
@@ -519,7 +519,7 @@ mod tests {
     use quickcheck::{Arbitrary, Gen, TestResult};
     use quickcheck_macros::quickcheck;
 
-    use crate::aggregator::key_rotator::{duration_since, HpkeKeyRotatorConfig, KeyRotator};
+    use crate::aggregator::key_rotator::{HpkeKeyRotatorConfig, KeyRotator, duration_since};
 
     use super::HpkeKeyRotator;
 

--- a/aggregator/src/aggregator/problem_details.rs
+++ b/aggregator/src/aggregator/problem_details.rs
@@ -1,4 +1,4 @@
-use janus_messages::{problem_type::DapProblemType, AggregationJobId, CollectionJobId, TaskId};
+use janus_messages::{AggregationJobId, CollectionJobId, TaskId, problem_type::DapProblemType};
 use serde::Serialize;
 use trillium::{Conn, KnownHeaderName, Status};
 use trillium_api::ApiConnExt;
@@ -107,14 +107,15 @@ impl ProblemDetailsConnExt for Conn {
 #[cfg(test)]
 mod tests {
     use crate::aggregator::{
+        Error, RequestBody,
         error::{BatchMismatch, ReportRejection, ReportRejectionReason},
-        send_request_to_helper, Error, RequestBody,
+        send_request_to_helper,
     };
     use assert_matches::assert_matches;
     use bytes::Bytes;
     use futures::future::join_all;
     use http::Method;
-    use janus_aggregator_core::{test_util::noop_meter, TIME_HISTOGRAM_BOUNDARIES};
+    use janus_aggregator_core::{TIME_HISTOGRAM_BOUNDARIES, test_util::noop_meter};
     use janus_core::{
         initialize_rustls,
         retries::test_util::LimitedRetryer,
@@ -122,8 +123,8 @@ mod tests {
         time::{Clock, RealClock},
     };
     use janus_messages::{
-        problem_type::{DapProblemType, DapProblemTypeParseError},
         Duration, Interval, ReportIdChecksum,
+        problem_type::{DapProblemType, DapProblemTypeParseError},
     };
     use rand::random;
     use reqwest::Client;

--- a/aggregator/src/aggregator/queue.rs
+++ b/aggregator/src/aggregator/queue.rs
@@ -4,16 +4,15 @@ use opentelemetry_sdk::metrics::MetricError;
 use std::{
     collections::BTreeMap,
     sync::{
-        atomic::{AtomicU64, Ordering},
         Arc,
+        atomic::{AtomicU64, Ordering},
     },
 };
 use tokio::{
     select,
     sync::{
-        mpsc,
+        OwnedSemaphorePermit, Semaphore, mpsc,
         oneshot::{self},
-        OwnedSemaphorePermit, Semaphore,
     },
     task::JoinHandle,
 };
@@ -342,23 +341,23 @@ impl Metrics {
 mod tests {
     use std::{
         sync::{
-            atomic::{AtomicU32, Ordering},
             Arc,
+            atomic::{AtomicU32, Ordering},
         },
         time::Duration,
     };
 
     use async_trait::async_trait;
     use backon::{BackoffBuilder, ExponentialBuilder, Retryable};
-    use futures::{future::join_all, Future};
+    use futures::{Future, future::join_all};
     use janus_aggregator_core::test_util::noop_meter;
     use janus_core::test_util::install_test_trace_subscriber;
     use opentelemetry_sdk::metrics::data::Gauge;
-    use quickcheck::{quickcheck, Arbitrary, TestResult};
+    use quickcheck::{Arbitrary, TestResult, quickcheck};
     use tokio::{
         runtime::Builder as RuntimeBuilder,
         sync::Notify,
-        task::{yield_now, JoinHandle},
+        task::{JoinHandle, yield_now},
         time::{sleep, timeout},
     };
     use tracing::debug;
@@ -368,7 +367,7 @@ mod tests {
     use super::Error;
 
     use crate::{
-        aggregator::queue::{queued_lifo, LIFORequestQueue, Metrics},
+        aggregator::queue::{LIFORequestQueue, Metrics, queued_lifo},
         metrics::test_util::InMemoryMetricInfrastructure,
     };
 

--- a/aggregator/src/aggregator/report_writer.rs
+++ b/aggregator/src/aggregator/report_writer.rs
@@ -1,21 +1,20 @@
 use crate::aggregator::{
+    Error,
     batch_mode::UploadableBatchMode,
     error::{ReportRejection, ReportRejectionReason},
-    Error,
 };
 use async_trait::async_trait;
 use futures::future::{join_all, try_join_all};
 use janus_aggregator_core::{
-    datastore::{
-        self,
-        models::{LeaderStoredReport, TaskUploadCounter},
-        Datastore, Transaction,
-    },
     AsyncAggregator,
+    datastore::{
+        self, Datastore, Transaction,
+        models::{LeaderStoredReport, TaskUploadCounter},
+    },
 };
-use janus_core::{time::Clock, Runtime};
+use janus_core::{Runtime, time::Clock};
 use janus_messages::TaskId;
-use rand::{rng, Rng};
+use rand::{Rng, rng};
 use std::{
     collections::BTreeMap,
     fmt::Debug,
@@ -27,7 +26,7 @@ use std::{
 use tokio::{
     select,
     sync::{mpsc, oneshot},
-    time::{sleep_until, Instant},
+    time::{Instant, sleep_until},
 };
 use tracing::{debug, error};
 

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -1,51 +1,51 @@
 use crate::{
     aggregator::{
+        Config,
         aggregation_job_init::test_util::PrepareInitGenerator,
         http_handlers::test_util::{decode_response_body, take_problem_details},
-        Config,
     },
     config::TaskprovConfig,
 };
 use assert_matches::assert_matches;
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use janus_aggregator_core::{
+    AsyncAggregator,
     datastore::{
+        Datastore,
         models::{
             AggregateShareJob, AggregationJob, AggregationJobState, BatchAggregation,
             BatchAggregationState, HpkeKeyState, ReportAggregation, ReportAggregationState,
         },
-        test_util::{ephemeral_datastore, EphemeralDatastore},
-        Datastore,
+        test_util::{EphemeralDatastore, ephemeral_datastore},
     },
     task::{
-        test_util::{Task, TaskBuilder},
         AggregationMode, BatchMode,
+        test_util::{Task, TaskBuilder},
     },
-    taskprov::{taskprov_task_id, test_util::PeerAggregatorBuilder, PeerAggregator},
+    taskprov::{PeerAggregator, taskprov_task_id, test_util::PeerAggregatorBuilder},
     test_util::noop_meter,
-    AsyncAggregator,
 };
 use janus_core::{
     hpke::{self, HpkeApplicationInfo, HpkeKeypair, Label},
     report_id::ReportIdChecksumExt,
     taskprov::TASKPROV_HEADER,
-    test_util::{install_test_trace_subscriber, runtime::TestRuntime, VdafTranscript},
+    test_util::{VdafTranscript, install_test_trace_subscriber, runtime::TestRuntime},
     time::{Clock, DurationExt, MockClock, TimeExt},
     vdaf::new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128,
 };
 use janus_messages::{
-    batch_mode::{self, LeaderSelected},
-    codec::{Decode, Encode},
-    taskprov::{TaskConfig, VdafConfig},
     AggregateShare as AggregateShareMessage, AggregateShareAad, AggregateShareReq,
     AggregationJobContinueReq, AggregationJobId, AggregationJobInitializeReq, AggregationJobResp,
     AggregationJobStep, BatchSelector, Duration, Extension, ExtensionType, Interval,
     PartialBatchSelector, PrepareContinue, PrepareInit, PrepareResp, PrepareStepResult,
     ReportError, ReportIdChecksum, ReportShare, Role, TaskId, Time,
+    batch_mode::{self, LeaderSelected},
+    codec::{Decode, Encode},
+    taskprov::{TaskConfig, VdafConfig},
 };
 use prio::{
     flp::gadgets::ParallelSumMultithreaded,
-    vdaf::{dummy, Client, Vdaf},
+    vdaf::{Client, Vdaf, dummy},
 };
 use rand::random;
 use serde_json::json;

--- a/aggregator/src/aggregator/test_util.rs
+++ b/aggregator/src/aggregator/test_util.rs
@@ -1,13 +1,13 @@
 use crate::{aggregator::Config, binaries::aggregator::parse_pem_ec_private_key};
 use aws_lc_rs::signature::EcdsaKeyPair;
 use janus_aggregator_core::{
-    datastore::{models::TaskAggregationCounter, Datastore},
+    datastore::{Datastore, models::TaskAggregationCounter},
     task::AggregatorTask,
 };
 use janus_core::{
     hpke::{self, HpkeApplicationInfo, HpkeKeypair, Label},
     time::MockClock,
-    vdaf::{vdaf_application_context, VdafInstance},
+    vdaf::{VdafInstance, vdaf_application_context},
 };
 use janus_messages::{
     Extension, HpkeConfig, InputShareAad, PlaintextInputShare, Report, ReportId, ReportMetadata,
@@ -15,11 +15,11 @@ use janus_messages::{
 };
 use prio::{
     codec::Encode,
-    vdaf::{self, prio3::Prio3Count, Client},
+    vdaf::{self, Client, prio3::Prio3Count},
 };
 use rand::random;
 use std::time::Duration;
-use tokio::time::{sleep, Instant};
+use tokio::time::{Instant, sleep};
 
 pub(crate) const BATCH_AGGREGATION_SHARD_COUNT: u64 = 32;
 
@@ -44,7 +44,7 @@ pub(crate) fn hpke_config_signing_key() -> EcdsaKeyPair {
 }
 
 pub fn hpke_config_verification_key() -> aws_lc_rs::signature::UnparsedPublicKey<Vec<u8>> {
-    use aws_lc_rs::signature::{KeyPair, UnparsedPublicKey, ECDSA_P256_SHA256_ASN1};
+    use aws_lc_rs::signature::{ECDSA_P256_SHA256_ASN1, KeyPair, UnparsedPublicKey};
     UnparsedPublicKey::new(
         &ECDSA_P256_SHA256_ASN1,
         hpke_config_signing_key().public_key().as_ref().to_vec(),

--- a/aggregator/src/aggregator/upload_tests.rs
+++ b/aggregator/src/aggregator/upload_tests.rs
@@ -1,23 +1,24 @@
 use crate::aggregator::{
+    Aggregator, Config, Error,
     error::ReportRejectionReason,
     test_util::{create_report, create_report_custom, default_aggregator_config},
-    Aggregator, Config, Error,
 };
 use assert_matches::assert_matches;
 use futures::future::try_join_all;
 use janus_aggregator_core::{
     datastore::{
-        models::{CollectionJob, CollectionJobState, TaskUploadCounter},
-        test_util::{ephemeral_datastore, EphemeralDatastore},
         Datastore,
+        models::{CollectionJob, CollectionJobState, TaskUploadCounter},
+        test_util::{EphemeralDatastore, ephemeral_datastore},
     },
     task::{
-        test_util::{Task, TaskBuilder},
         AggregationMode, BatchMode,
+        test_util::{Task, TaskBuilder},
     },
     test_util::noop_meter,
 };
 use janus_core::{
+    Runtime,
     hpke::{self, HpkeApplicationInfo, HpkeKeypair, Label},
     initialize_rustls,
     test_util::{
@@ -25,12 +26,11 @@ use janus_core::{
         runtime::{TestRuntime, TestRuntimeManager},
     },
     time::{Clock, MockClock, TimeExt},
-    vdaf::{VdafInstance, VERIFY_KEY_LENGTH_PRIO3},
-    Runtime,
+    vdaf::{VERIFY_KEY_LENGTH_PRIO3, VdafInstance},
 };
 use janus_messages::{
-    batch_mode::TimeInterval, Duration, HpkeCiphertext, HpkeConfigId, InputShareAad, Interval,
-    PlaintextInputShare, Query, Report, Role,
+    Duration, HpkeCiphertext, HpkeConfigId, InputShareAad, Interval, PlaintextInputShare, Query,
+    Report, Role, batch_mode::TimeInterval,
 };
 use prio::{codec::Encode, vdaf::prio3::Prio3Count};
 use rand::random;

--- a/aggregator/src/binaries/aggregation_job_creator.rs
+++ b/aggregator/src/binaries/aggregation_job_creator.rs
@@ -124,9 +124,8 @@ impl BinaryConfig for Config {
 mod tests {
     use super::{Config, Options};
     use crate::config::{
-        default_max_transaction_retries,
+        CommonConfig, default_max_transaction_retries,
         test_util::{generate_db_config, generate_metrics_config, generate_trace_config},
-        CommonConfig,
     };
     use clap::CommandFactory;
     use janus_core::test_util::roundtrip_encoding;

--- a/aggregator/src/binaries/aggregation_job_driver.rs
+++ b/aggregator/src/binaries/aggregation_job_driver.rs
@@ -1,12 +1,12 @@
 use crate::{
     aggregator::aggregation_job_driver::AggregationJobDriver,
-    binary_utils::{job_driver::JobDriver, BinaryContext, BinaryOptions, CommonBinaryOptions},
+    binary_utils::{BinaryContext, BinaryOptions, CommonBinaryOptions, job_driver::JobDriver},
     cache::HpkeKeypairCache,
     config::{BinaryConfig, CommonConfig, JobDriverConfig, TaskprovConfig},
 };
 use anyhow::{Context, Result};
 use clap::Parser;
-use janus_core::{time::RealClock, TokioRuntime};
+use janus_core::{TokioRuntime, time::RealClock};
 use serde::{Deserialize, Serialize};
 use std::{fmt::Debug, sync::Arc, time::Duration};
 use tracing::info;
@@ -177,9 +177,8 @@ fn default_default_async_poll_interval() -> u64 {
 mod tests {
     use super::{Config, Options};
     use crate::config::{
-        default_max_transaction_retries,
+        CommonConfig, JobDriverConfig, TaskprovConfig, default_max_transaction_retries,
         test_util::{generate_db_config, generate_metrics_config, generate_trace_config},
-        CommonConfig, JobDriverConfig, TaskprovConfig,
     };
     use clap::CommandFactory;
     use janus_core::test_util::roundtrip_encoding;

--- a/aggregator/src/binaries/aggregator.rs
+++ b/aggregator/src/binaries/aggregator.rs
@@ -2,27 +2,27 @@ use crate::{
     aggregator::{
         self,
         http_handlers::{AggregatorHandlerBuilder, HelperAggregationRequestQueue},
-        key_rotator::{deserialize_hpke_key_rotator_config, HpkeKeyRotatorConfig, KeyRotator},
+        key_rotator::{HpkeKeyRotatorConfig, KeyRotator, deserialize_hpke_key_rotator_config},
     },
     binaries::garbage_collector::run_garbage_collector,
-    binary_utils::{setup_server, BinaryContext, BinaryOptions, CommonBinaryOptions},
+    binary_utils::{BinaryContext, BinaryOptions, CommonBinaryOptions, setup_server},
     cache::{
         HpkeKeypairCache, TASK_AGGREGATOR_CACHE_DEFAULT_CAPACITY, TASK_AGGREGATOR_CACHE_DEFAULT_TTL,
     },
     config::{BinaryConfig, CommonConfig, TaskprovConfig},
 };
-use anyhow::{anyhow, Context, Result};
-use aws_lc_rs::signature::{EcdsaKeyPair, ECDSA_P256_SHA256_ASN1_SIGNING};
+use anyhow::{Context, Result, anyhow};
+use aws_lc_rs::signature::{ECDSA_P256_SHA256_ASN1_SIGNING, EcdsaKeyPair};
 use clap::Parser;
 use educe::Educe;
 use janus_aggregator_api::{self, aggregator_api_handler};
 use janus_aggregator_core::datastore::Datastore;
-use janus_core::{auth_tokens::AuthenticationToken, time::RealClock, TokioRuntime};
+use janus_core::{TokioRuntime, auth_tokens::AuthenticationToken, time::RealClock};
 use opentelemetry::metrics::Meter;
 use sec1::EcPrivateKey;
-use serde::{de, Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de};
 use std::{
-    future::{ready, Future},
+    future::{Future, ready},
     path::PathBuf,
 };
 use std::{iter::Iterator, net::SocketAddr, sync::Arc, time::Duration};
@@ -266,12 +266,12 @@ where
             (None, None) => {
                 return Err(de::Error::custom(
                     "one of listen_address or path_prefix must be provided",
-                ))
+                ));
             }
             (Some(_), Some(_)) => {
                 return Err(de::Error::custom(
                     "only one of listen_address and path_prefix must be specified",
-                ))
+                ));
             }
             _ => {}
         }
@@ -520,12 +520,11 @@ mod tests {
         aggregator::{
             self,
             key_rotator::HpkeKeyRotatorConfig,
-            test_util::{hpke_config_signing_key, HPKE_CONFIG_SIGNING_KEY_PEM},
+            test_util::{HPKE_CONFIG_SIGNING_KEY_PEM, hpke_config_signing_key},
         },
         config::{
-            default_max_transaction_retries,
+            BinaryConfig, CommonConfig, TaskprovConfig, default_max_transaction_retries,
             test_util::{generate_db_config, generate_metrics_config, generate_trace_config},
-            BinaryConfig, CommonConfig, TaskprovConfig,
         },
         metrics::{MetricsExporterConfiguration, OtlpExporterConfiguration},
         trace::{
@@ -535,7 +534,7 @@ mod tests {
     use assert_matches::assert_matches;
     use aws_lc_rs::{
         rand::SystemRandom,
-        signature::{KeyPair, UnparsedPublicKey, ECDSA_P256_SHA256_ASN1},
+        signature::{ECDSA_P256_SHA256_ASN1, KeyPair, UnparsedPublicKey},
     };
     use clap::CommandFactory;
     use janus_core::{hpke::HpkeCiphersuite, test_util::roundtrip_encoding};

--- a/aggregator/src/binaries/collection_job_driver.rs
+++ b/aggregator/src/binaries/collection_job_driver.rs
@@ -1,11 +1,11 @@
 use crate::{
     aggregator::collection_job_driver::{CollectionJobDriver, RetryStrategy},
-    binary_utils::{job_driver::JobDriver, BinaryContext, BinaryOptions, CommonBinaryOptions},
+    binary_utils::{BinaryContext, BinaryOptions, CommonBinaryOptions, job_driver::JobDriver},
     config::{BinaryConfig, CommonConfig, JobDriverConfig},
 };
 use anyhow::{Context, Result};
 use clap::Parser;
-use janus_core::{time::RealClock, TokioRuntime};
+use janus_core::{TokioRuntime, time::RealClock};
 use serde::{Deserialize, Serialize};
 use std::{fmt::Debug, sync::Arc, time::Duration};
 use tracing::info;
@@ -193,9 +193,8 @@ impl BinaryConfig for Config {
 mod tests {
     use super::{Config, Options};
     use crate::config::{
-        default_max_transaction_retries,
+        CommonConfig, JobDriverConfig, default_max_transaction_retries,
         test_util::{generate_db_config, generate_metrics_config, generate_trace_config},
-        CommonConfig, JobDriverConfig,
     };
     use clap::CommandFactory;
     use janus_core::test_util::roundtrip_encoding;

--- a/aggregator/src/binaries/garbage_collector.rs
+++ b/aggregator/src/binaries/garbage_collector.rs
@@ -126,9 +126,8 @@ mod tests {
     use crate::{
         binaries::aggregator::GarbageCollectorConfig,
         config::{
-            default_max_transaction_retries,
+            CommonConfig, default_max_transaction_retries,
             test_util::{generate_db_config, generate_metrics_config, generate_trace_config},
-            CommonConfig,
         },
     };
 

--- a/aggregator/src/binaries/janus_cli.rs
+++ b/aggregator/src/binaries/janus_cli.rs
@@ -662,7 +662,7 @@ impl KubernetesSecretOptions {
         options: &CommonBinaryOptions,
         kube_client: &LazyKubeClient,
     ) -> Result<Vec<String>> {
-        if let Some(ref secrets_namespace) = &self.secrets_k8s_namespace {
+        if let Some(secrets_namespace) = &self.secrets_k8s_namespace {
             fetch_datastore_keys(
                 kube_client,
                 secrets_namespace,

--- a/aggregator/src/binaries/janus_cli.rs
+++ b/aggregator/src/binaries/janus_cli.rs
@@ -1,16 +1,16 @@
 use crate::{
-    binary_utils::{database_pool, datastore, read_config, CommonBinaryOptions},
+    binary_utils::{CommonBinaryOptions, database_pool, datastore, read_config},
     config::{BinaryConfig, CommonConfig},
-    metrics::{install_metrics_exporter, MetricsExporterHandle},
-    trace::{install_trace_subscriber, TraceGuards},
+    metrics::{MetricsExporterHandle, install_metrics_exporter},
+    trace::{TraceGuards, install_trace_subscriber},
 };
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use aws_lc_rs::aead::AES_128_GCM;
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use clap::Parser;
 use janus_aggregator_api::git_revision;
 use janus_aggregator_core::{
-    datastore::{self, models::HpkeKeyState, Datastore},
+    datastore::{self, Datastore, models::HpkeKeyState},
     task::{AggregationMode, AggregatorTask, SerializedAggregatorTask},
     taskprov::{PeerAggregator, VerifyKeyInit},
 };
@@ -22,13 +22,13 @@ use janus_core::{
     time::{Clock, RealClock},
 };
 use janus_messages::{
-    codec::Encode as _, Duration, HpkeAeadId, HpkeConfig, HpkeConfigId, HpkeKdfId, HpkeKemId, Role,
+    Duration, HpkeAeadId, HpkeConfig, HpkeConfigId, HpkeKdfId, HpkeKemId, Role, codec::Encode as _,
 };
 use k8s_openapi::api::core::v1::Secret;
 use kube::api::{ObjectMeta, PostParams};
 use opentelemetry::global::meter;
 use prio::codec::Decode as _;
-use rand::{distr::StandardUniform, rng, Rng};
+use rand::{Rng, distr::StandardUniform, rng};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeMap,
@@ -740,22 +740,21 @@ impl From<kube::Client> for LazyKubeClient {
 mod tests {
     use crate::{
         binaries::janus_cli::{
-            fetch_datastore_keys, CommandLineOptions, ConfigFile, KubernetesSecretOptions,
-            LazyKubeClient,
+            CommandLineOptions, ConfigFile, KubernetesSecretOptions, LazyKubeClient,
+            fetch_datastore_keys,
         },
         binary_utils::CommonBinaryOptions,
         config::{
-            default_max_transaction_retries,
+            CommonConfig, default_max_transaction_retries,
             test_util::{generate_db_config, generate_metrics_config, generate_trace_config},
-            CommonConfig,
         },
     };
-    use aws_lc_rs::aead::{UnboundKey, AES_128_GCM};
-    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+    use aws_lc_rs::aead::{AES_128_GCM, UnboundKey};
+    use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
     use clap::CommandFactory;
     use janus_aggregator_core::{
-        datastore::{models::HpkeKeyState, test_util::ephemeral_datastore, Datastore},
-        task::{test_util::TaskBuilder, AggregationMode, AggregatorTask, BatchMode},
+        datastore::{Datastore, models::HpkeKeyState, test_util::ephemeral_datastore},
+        task::{AggregationMode, AggregatorTask, BatchMode, test_util::TaskBuilder},
         taskprov::{PeerAggregator, VerifyKeyInit},
     };
     use janus_core::{
@@ -764,11 +763,11 @@ mod tests {
         initialize_rustls,
         test_util::{kubernetes, roundtrip_encoding},
         time::RealClock,
-        vdaf::{vdaf_dp_strategies, VdafInstance},
+        vdaf::{VdafInstance, vdaf_dp_strategies},
     };
     use janus_messages::{
-        codec::Encode, Duration, HpkeAeadId, HpkeConfig, HpkeConfigId, HpkeKdfId, HpkeKemId, Role,
-        TaskId,
+        Duration, HpkeAeadId, HpkeConfig, HpkeConfigId, HpkeKdfId, HpkeKemId, Role, TaskId,
+        codec::Encode,
     };
     use prio::codec::Decode;
     use rand::random;
@@ -777,7 +776,7 @@ mod tests {
         io::Write,
         net::{Ipv4Addr, SocketAddr},
     };
-    use tempfile::{tempdir, NamedTempFile};
+    use tempfile::{NamedTempFile, tempdir};
     use tokio::fs;
     use url::Url;
 

--- a/aggregator/src/binaries/key_rotator.rs
+++ b/aggregator/src/binaries/key_rotator.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     aggregator::key_rotator::{
-        deserialize_hpke_key_rotator_config, HpkeKeyRotatorConfig, KeyRotator,
+        HpkeKeyRotatorConfig, KeyRotator, deserialize_hpke_key_rotator_config,
     },
     binary_utils::{BinaryContext, BinaryOptions, CommonBinaryOptions},
     config::{BinaryConfig, CommonConfig},
@@ -98,13 +98,12 @@ mod tests {
 
     use crate::{
         aggregator::key_rotator::{
-            default_active_duration, default_expired_duration, default_hpke_ciphersuites,
-            default_pending_duration, HpkeKeyRotatorConfig,
+            HpkeKeyRotatorConfig, default_active_duration, default_expired_duration,
+            default_hpke_ciphersuites, default_pending_duration,
         },
         config::{
-            default_max_transaction_retries,
+            CommonConfig, default_max_transaction_retries,
             test_util::{generate_db_config, generate_metrics_config, generate_trace_config},
-            CommonConfig,
         },
     };
 

--- a/aggregator/src/binary_utils.rs
+++ b/aggregator/src/binary_utils.rs
@@ -5,12 +5,12 @@ pub mod job_driver;
 use crate::{
     config::{BinaryConfig, DbConfig},
     metrics::install_metrics_exporter,
-    trace::{install_trace_subscriber, TraceReloadHandle},
+    trace::{TraceReloadHandle, install_trace_subscriber},
 };
-use anyhow::{anyhow, Context as _, Result};
-use aws_lc_rs::aead::{LessSafeKey, UnboundKey, AES_128_GCM};
+use anyhow::{Context as _, Result, anyhow};
+use aws_lc_rs::aead::{AES_128_GCM, LessSafeKey, UnboundKey};
 use backon::{BackoffBuilder, ExponentialBuilder, Retryable};
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use clap::Parser;
 use deadpool::managed::TimeoutType;
 use deadpool_postgres::{Manager, Pool, PoolError, Runtime, Timeouts};
@@ -40,7 +40,7 @@ use tokio_postgres_rustls::MakeRustlsConnect;
 use tracing::{debug, info};
 use tracing_subscriber::EnvFilter;
 use trillium::{Handler, Info, Init, Status};
-use trillium_api::{api, State};
+use trillium_api::{State, api};
 use trillium_head::Head;
 use trillium_router::Router;
 use trillium_tokio::Stopper;
@@ -539,8 +539,8 @@ mod tests {
     use crate::{
         aggregator::http_handlers::test_util::take_response_body,
         binary_utils::{
-            database_pool, initialize_rustls, register_database_pool_status_metrics,
-            zpages_handler, CommonBinaryOptions,
+            CommonBinaryOptions, database_pool, initialize_rustls,
+            register_database_pool_status_metrics, zpages_handler,
         },
         config::DbConfig,
         metrics::test_util::InMemoryMetricInfrastructure,
@@ -553,8 +553,8 @@ mod tests {
     };
     use opentelemetry_sdk::metrics::data::Gauge;
     use std::fs;
-    use testcontainers::{core::Mount, runners::AsyncRunner, ContainerRequest, ImageExt};
-    use tracing_subscriber::{reload, EnvFilter};
+    use testcontainers::{ContainerRequest, ImageExt, core::Mount, runners::AsyncRunner};
+    use tracing_subscriber::{EnvFilter, reload};
     use trillium::Status;
     use trillium_testing::prelude::*;
 

--- a/aggregator/src/binary_utils/job_driver.rs
+++ b/aggregator/src/binary_utils/job_driver.rs
@@ -3,12 +3,12 @@
 use anyhow::Context as _;
 use chrono::NaiveDateTime;
 use janus_aggregator_core::{
-    datastore::{self, models::Lease},
     TIME_HISTOGRAM_BOUNDARIES,
+    datastore::{self, models::Lease},
 };
-use janus_core::{time::Clock, Runtime};
-use opentelemetry::{metrics::Meter, KeyValue};
-use rand::{rng, Rng};
+use janus_core::{Runtime, time::Clock};
+use opentelemetry::{KeyValue, metrics::Meter};
+use rand::{Rng, rng};
 use std::{
     fmt::{Debug, Display},
     future::Future,
@@ -19,7 +19,7 @@ use tokio::{
     sync::{Semaphore, SemaphorePermit},
     time::{self, Instant},
 };
-use tracing::{debug, error, info_span, Instrument};
+use tracing::{Instrument, debug, error, info_span};
 use trillium_tokio::Stopper;
 
 /// Periodically seeks incomplete jobs in the datastore and drives them concurrently.
@@ -50,15 +50,15 @@ pub struct JobDriver<C: Clock, R, JobAcquirer, JobStepper> {
 }
 
 impl<
-        C,
-        R,
-        JobStepperError,
-        JobAcquirer,
-        JobAcquirerFuture,
-        JobStepper,
-        JobStepperFuture,
-        AcquiredJob,
-    > JobDriver<C, R, JobAcquirer, JobStepper>
+    C,
+    R,
+    JobStepperError,
+    JobAcquirer,
+    JobAcquirerFuture,
+    JobStepper,
+    JobStepperFuture,
+    AcquiredJob,
+> JobDriver<C, R, JobAcquirer, JobStepper>
 where
     C: Clock,
     R: Runtime + Send + Sync + 'static,
@@ -276,10 +276,10 @@ mod tests {
         test_util::noop_meter,
     };
     use janus_core::{
+        Runtime,
         test_util::{install_test_trace_subscriber, runtime::TestRuntimeManager},
         time::MockClock,
         vdaf::VdafInstance,
-        Runtime,
     };
     use janus_messages::{AggregationJobId, TaskId};
     use rand::random;

--- a/aggregator/src/cache.rs
+++ b/aggregator/src/cache.rs
@@ -1,19 +1,19 @@
 //! Various in-memory caches that can be used by an aggregator.
 
-use crate::aggregator::{report_writer::ReportWriteBatcher, Error, TaskAggregator};
+use crate::aggregator::{Error, TaskAggregator, report_writer::ReportWriteBatcher};
 use janus_aggregator_core::{
     datastore::{
-        models::{HpkeKeyState, HpkeKeypair},
         Datastore,
+        models::{HpkeKeyState, HpkeKeypair},
     },
     taskprov::PeerAggregator,
 };
 use janus_core::{hpke, time::Clock};
 use janus_messages::{HpkeConfig, HpkeConfigId, Role, TaskId};
 use moka::{
+    Entry,
     future::{Cache, CacheBuilder},
     ops::compute::Op,
-    Entry,
 };
 use std::{
     collections::HashMap,
@@ -276,7 +276,7 @@ mod tests {
 
     use janus_aggregator_core::{
         datastore::{models::HpkeKeyState, test_util::ephemeral_datastore},
-        task::{test_util::TaskBuilder, AggregationMode, BatchMode},
+        task::{AggregationMode, BatchMode, test_util::TaskBuilder},
     };
     use janus_core::{
         hpke::HpkeKeypair,

--- a/aggregator/src/config.rs
+++ b/aggregator/src/config.rs
@@ -3,7 +3,7 @@
 use crate::{metrics::MetricsConfiguration, trace::TraceConfiguration};
 use educe::Educe;
 use janus_core::retries::ExponentialWithTotalDelayBuilder;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use std::{
     fmt::Debug,
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -319,9 +319,8 @@ pub mod test_util {
 mod tests {
     use crate::{
         config::{
-            default_max_transaction_retries,
+            CommonConfig, DbConfig, JobDriverConfig, default_max_transaction_retries,
             test_util::{generate_db_config, generate_metrics_config, generate_trace_config},
-            CommonConfig, DbConfig, JobDriverConfig,
         },
         metrics::MetricsExporterConfiguration,
         trace::OpenTelemetryTraceConfiguration,

--- a/aggregator/src/metrics.rs
+++ b/aggregator/src/metrics.rs
@@ -2,8 +2,8 @@
 
 use anyhow::anyhow;
 use opentelemetry::{
-    metrics::{Counter, Histogram, Meter},
     KeyValue,
+    metrics::{Counter, Histogram, Meter},
 };
 use serde::{Deserialize, Serialize};
 use std::net::AddrParseError;
@@ -32,8 +32,8 @@ use {
     janus_aggregator_api::git_revision,
     opentelemetry::global::set_meter_provider,
     opentelemetry_sdk::{
-        metrics::{MetricError, SdkMeterProvider},
         Resource,
+        metrics::{MetricError, SdkMeterProvider},
     },
 };
 

--- a/aggregator/src/metrics/test_util.rs
+++ b/aggregator/src/metrics/test_util.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use opentelemetry::metrics::{Meter, MeterProvider};
 use opentelemetry_sdk::{
-    metrics::{data::Metric, PeriodicReader, SdkMeterProvider},
+    metrics::{PeriodicReader, SdkMeterProvider, data::Metric},
     runtime,
     testing::metrics::InMemoryMetricExporter,
 };

--- a/aggregator/src/metrics/tests/prometheus.rs
+++ b/aggregator/src/metrics/tests/prometheus.rs
@@ -12,8 +12,8 @@ use janus_core::{
 };
 use opentelemetry::metrics::MeterProvider as _;
 use prometheus::{
-    proto::{Metric, MetricType},
     Registry,
+    proto::{Metric, MetricType},
 };
 use std::{collections::HashMap, net::Ipv4Addr, sync::Arc};
 use trillium::Handler;

--- a/aggregator/src/metrics/tokio_runtime.rs
+++ b/aggregator/src/metrics/tokio_runtime.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 #[cfg(tokio_unstable)]
 use opentelemetry::metrics::Meter;
-use opentelemetry::{metrics::MeterProvider, KeyValue};
+use opentelemetry::{KeyValue, metrics::MeterProvider};
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use tokio::runtime::RuntimeMetrics;
 

--- a/aggregator/src/trace.rs
+++ b/aggregator/src/trace.rs
@@ -2,14 +2,14 @@
 
 use serde::{Deserialize, Serialize};
 use std::{
-    io::{stdout, IsTerminal},
+    io::{IsTerminal, stdout},
     net::SocketAddr,
 };
 use tracing::Level;
 use tracing_chrome::{ChromeLayerBuilder, TraceStyle};
 use tracing_log::LogTracer;
 use tracing_subscriber::{
-    filter::FromEnvError, layer::SubscriberExt, reload, EnvFilter, Layer, Registry,
+    EnvFilter, Layer, Registry, filter::FromEnvError, layer::SubscriberExt, reload,
 };
 
 #[cfg(feature = "otlp")]

--- a/aggregator/tests/integration/graceful_shutdown.rs
+++ b/aggregator/tests/integration/graceful_shutdown.rs
@@ -3,7 +3,7 @@
 //! process. The process should promptly shut down, and this test will fail if
 //! it times out waiting for the process to do so.
 
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use janus_aggregator::{
     aggregator::key_rotator::HpkeKeyRotatorConfig,
     binaries::{
@@ -16,15 +16,15 @@ use janus_aggregator::{
         garbage_collector::Config as GarbageCollectorBinaryConfig,
     },
     config::{
-        default_max_transaction_retries, BinaryConfig, CommonConfig, DbConfig, JobDriverConfig,
-        TaskprovConfig,
+        BinaryConfig, CommonConfig, DbConfig, JobDriverConfig, TaskprovConfig,
+        default_max_transaction_retries,
     },
     metrics::MetricsConfiguration,
     trace::TraceConfiguration,
 };
 use janus_aggregator_core::{
     datastore::test_util::ephemeral_datastore,
-    task::{test_util::TaskBuilder, AggregationMode, BatchMode},
+    task::{AggregationMode, BatchMode, test_util::TaskBuilder},
 };
 use janus_core::{
     hpke::HpkeCiphersuite, initialize_rustls, test_util::install_test_trace_subscriber,

--- a/aggregator_api/src/lib.rs
+++ b/aggregator_api/src/lib.rs
@@ -79,7 +79,7 @@ pub fn aggregator_api_handler<C: Clock>(
     ds: Arc<Datastore<C>>,
     cfg: Config,
     meter: &Meter,
-) -> impl Handler {
+) -> impl Handler + use<C> {
     (
         // State used by endpoint handlers.
         State(ds),
@@ -142,7 +142,7 @@ pub fn aggregator_api_handler<C: Clock>(
     )
 }
 
-async fn auth_check(conn: &mut Conn, (): ()) -> impl Handler {
+async fn auth_check(conn: &mut Conn, (): ()) -> Option<(Status, Halt)> {
     let (Some(cfg), Ok(Some(bearer_token))) =
         (conn.state::<Arc<Config>>(), extract_bearer_token(conn))
     else {

--- a/aggregator_api/src/lib.rs
+++ b/aggregator_api/src/lib.rs
@@ -7,8 +7,9 @@ mod tests;
 use async_trait::async_trait;
 use git_version::git_version;
 use janus_aggregator_core::{
+    TIME_HISTOGRAM_BOUNDARIES,
     datastore::{self, Datastore},
-    instrumented, TIME_HISTOGRAM_BOUNDARIES,
+    instrumented,
 };
 use janus_core::{auth_tokens::AuthenticationToken, hpke, http::extract_bearer_token, time::Clock};
 use janus_messages::{HpkeConfigId, RoleParseError, TaskId};
@@ -22,7 +23,7 @@ use trillium::{
     Status,
     Status::{NotAcceptable, UnsupportedMediaType},
 };
-use trillium_api::{api, Halt, State};
+use trillium_api::{Halt, State, api};
 use trillium_opentelemetry::Metrics;
 use trillium_router::{Router, RouterConnExt};
 use url::Url;

--- a/aggregator_api/src/models.rs
+++ b/aggregator_api/src/models.rs
@@ -1,4 +1,4 @@
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use educe::Educe;
 use janus_aggregator_core::{
     datastore::models::{HpkeKeyState, HpkeKeypair, TaskAggregationCounter, TaskUploadCounter},
@@ -10,8 +10,8 @@ use janus_core::{
     vdaf::VdafInstance,
 };
 use janus_messages::{
-    batch_mode::Code as SupportedBatchMode, Duration, HpkeAeadId, HpkeConfig, HpkeKdfId, HpkeKemId,
-    Role, TaskId, Time,
+    Duration, HpkeAeadId, HpkeConfig, HpkeKdfId, HpkeKemId, Role, TaskId, Time,
+    batch_mode::Code as SupportedBatchMode,
 };
 use serde::{Deserialize, Deserializer, Serialize};
 use url::Url;

--- a/aggregator_api/src/routes.rs
+++ b/aggregator_api/src/routes.rs
@@ -1,27 +1,26 @@
 use crate::{
-    git_revision,
+    Config, ConnExt, Error, git_revision,
     models::{
         AggregatorApiConfig, AggregatorRole, DeleteTaskprovPeerAggregatorReq,
         GetTaskAggregationMetricsResp, GetTaskIdsResp, GetTaskUploadMetricsResp, HpkeConfigResp,
         PatchHpkeConfigReq, PatchTaskReq, PostTaskReq, PostTaskprovPeerAggregatorReq,
         PutHpkeConfigReq, SupportedVdaf, TaskResp, TaskprovPeerAggregatorResp,
     },
-    Config, ConnExt, Error,
 };
 use anyhow::Context;
-use aws_lc_rs::digest::{digest, SHA256};
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use aws_lc_rs::digest::{SHA256, digest};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use janus_aggregator_core::{
+    SecretBytes,
     datastore::{self, Datastore},
     task::{AggregatorTask, AggregatorTaskParameters},
     taskprov::PeerAggregator,
-    SecretBytes,
 };
 use janus_core::{auth_tokens::AuthenticationTokenHash, hpke::HpkeKeypair, time::Clock};
 use janus_messages::HpkeConfigId;
 use janus_messages::{
-    batch_mode::Code as SupportedBatchMode, Duration, HpkeAeadId, HpkeKdfId, HpkeKemId, Role,
-    TaskId,
+    Duration, HpkeAeadId, HpkeKdfId, HpkeKemId, Role, TaskId,
+    batch_mode::Code as SupportedBatchMode,
 };
 use querystring::querify;
 use rand::random;

--- a/aggregator_api/src/tests.rs
+++ b/aggregator_api/src/tests.rs
@@ -1,48 +1,46 @@
 use crate::{
-    aggregator_api_handler,
+    CONTENT_TYPE, Config, aggregator_api_handler,
     models::{
         DeleteTaskprovPeerAggregatorReq, GetTaskAggregationMetricsResp, GetTaskIdsResp,
         GetTaskUploadMetricsResp, HpkeConfigResp, PatchHpkeConfigReq, PostTaskReq,
         PostTaskprovPeerAggregatorReq, PutHpkeConfigReq, TaskResp, TaskprovPeerAggregatorResp,
     },
-    Config, CONTENT_TYPE,
 };
 use assert_matches::assert_matches;
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use futures::future::try_join_all;
 use janus_aggregator_core::{
+    SecretBytes,
     datastore::{
-        models::{HpkeKeyState, TaskAggregationCounter, TaskUploadCounter},
-        test_util::{ephemeral_datastore, EphemeralDatastore},
         Datastore,
+        models::{HpkeKeyState, TaskAggregationCounter, TaskUploadCounter},
+        test_util::{EphemeralDatastore, ephemeral_datastore},
     },
     task::{
-        test_util::TaskBuilder, AggregationMode, AggregatorTask, AggregatorTaskParameters,
-        BatchMode,
+        AggregationMode, AggregatorTask, AggregatorTaskParameters, BatchMode,
+        test_util::TaskBuilder,
     },
     taskprov::test_util::PeerAggregatorBuilder,
     test_util::noop_meter,
-    SecretBytes,
 };
 use janus_core::{
     auth_tokens::{AuthenticationToken, AuthenticationTokenHash},
     hpke::HpkeKeypair,
     test_util::install_test_trace_subscriber,
     time::MockClock,
-    vdaf::{vdaf_dp_strategies, VdafInstance, VERIFY_KEY_LENGTH_PRIO3},
+    vdaf::{VERIFY_KEY_LENGTH_PRIO3, VdafInstance, vdaf_dp_strategies},
 };
 use janus_messages::{
     Duration, HpkeAeadId, HpkeConfig, HpkeConfigId, HpkeKdfId, HpkeKemId, HpkePublicKey, Role,
     TaskId, Time,
 };
-use rand::{distr::StandardUniform, random, rng, Rng};
-use serde_test::{assert_ser_tokens, assert_tokens, Token};
+use rand::{Rng, distr::StandardUniform, random, rng};
+use serde_test::{Token, assert_ser_tokens, assert_tokens};
 use std::{iter, sync::Arc};
 use trillium::{Handler, Status};
 use trillium_testing::{
-    assert_body_contains, assert_response, assert_status,
+    Url, assert_body_contains, assert_response, assert_status,
     prelude::{delete, get, patch, post, put},
-    Url,
 };
 
 const AUTH_TOKEN: &str = "Y29sbGVjdG9yLWFiY2RlZjAw";

--- a/aggregator_core/src/batch_mode.rs
+++ b/aggregator_core/src/batch_mode.rs
@@ -1,18 +1,17 @@
 use crate::{
+    AsyncAggregator,
     datastore::{
-        self,
+        self, Transaction,
         models::{BatchAggregation, CollectionJob},
-        Transaction,
     },
     task::AggregatorTask,
-    AsyncAggregator,
 };
 use async_trait::async_trait;
 use futures::future::try_join_all;
 use janus_core::time::{Clock, IntervalExt as _, TimeExt as _};
 use janus_messages::{
-    batch_mode::{BatchMode, LeaderSelected, TimeInterval},
     Duration, Interval, Query, TaskId, Time,
+    batch_mode::{BatchMode, LeaderSelected, TimeInterval},
 };
 use std::iter;
 
@@ -421,10 +420,10 @@ impl CollectableBatchMode for LeaderSelected {
 mod tests {
     use crate::{
         batch_mode::CollectableBatchMode,
-        task::{test_util::TaskBuilder, AggregationMode, BatchMode},
+        task::{AggregationMode, BatchMode, test_util::TaskBuilder},
     };
     use janus_core::vdaf::VdafInstance;
-    use janus_messages::{batch_mode::TimeInterval, Duration, Interval, Time};
+    use janus_messages::{Duration, Interval, Time, batch_mode::TimeInterval};
 
     #[test]
     fn validate_collect_identifier() {

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -12,12 +12,12 @@ use self::models::{
 #[cfg(feature = "test-util")]
 use crate::VdafHasAggregationParameter;
 use crate::{
+    AsyncAggregator, SecretBytes, TIME_HISTOGRAM_BOUNDARIES,
     batch_mode::{AccumulableBatchMode, CollectableBatchMode},
     task::{self, AggregationMode, AggregatorTask, AggregatorTaskParameters},
     taskprov::PeerAggregator,
-    AsyncAggregator, SecretBytes, TIME_HISTOGRAM_BOUNDARIES,
 };
-use aws_lc_rs::aead::{self, LessSafeKey, AES_128_GCM};
+use aws_lc_rs::aead::{self, AES_128_GCM, LessSafeKey};
 use chrono::NaiveDateTime;
 use futures::future::try_join_all;
 use janus_core::{
@@ -27,19 +27,19 @@ use janus_core::{
     vdaf::VdafInstance,
 };
 use janus_messages::{
-    batch_mode::{BatchMode, LeaderSelected, TimeInterval},
     AggregationJobId, BatchId, CollectionJobId, Duration, Extension, HpkeCiphertext, HpkeConfig,
     HpkeConfigId, Interval, PrepareContinue, PrepareInit, PrepareResp, Query, ReportId,
     ReportIdChecksum, ReportMetadata, Role, TaskId, Time,
+    batch_mode::{BatchMode, LeaderSelected, TimeInterval},
 };
 use models::UnaggregatedReport;
 use opentelemetry::{
-    metrics::{Counter, Histogram, Meter},
     KeyValue,
+    metrics::{Counter, Histogram, Meter},
 };
 use postgres_types::{FromSql, Json, Timestamp, ToSql};
 use prio::{
-    codec::{decode_u16_items, encode_u16_items, CodecError, Decode, Encode, ParameterizedDecode},
+    codec::{CodecError, Decode, Encode, ParameterizedDecode, decode_u16_items, encode_u16_items},
     topology::ping_pong::PingPongContinuation,
 };
 use rand::random;
@@ -51,16 +51,16 @@ use std::{
     io::Cursor,
     mem::size_of,
     ops::RangeInclusive,
-    pin::{pin, Pin},
+    pin::{Pin, pin},
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
     },
     time::{Duration as StdDuration, Instant},
 };
 use tokio::{sync::Barrier, try_join};
-use tokio_postgres::{error::SqlState, row::RowIndex, IsolationLevel, Row, Statement, ToStatement};
-use tracing::{error, Level};
+use tokio_postgres::{IsolationLevel, Row, Statement, ToStatement, error::SqlState, row::RowIndex};
+use tracing::{Level, error};
 use url::Url;
 
 pub mod models;

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -1,6 +1,6 @@
 //! This module contains models used by the datastore that are not DAP messages.
 
-use crate::{datastore::Error, task, AsyncAggregator};
+use crate::{AsyncAggregator, datastore::Error, task};
 use base64::{display::Base64Display, engine::general_purpose::URL_SAFE_NO_PAD};
 use chrono::NaiveDateTime;
 use clap::ValueEnum;
@@ -13,17 +13,17 @@ use janus_core::{
     vdaf::VdafInstance,
 };
 use janus_messages::{
-    batch_mode::{BatchMode, LeaderSelected, TimeInterval},
     AggregationJobId, AggregationJobStep, BatchId, CollectionJobId, Duration, Extension,
     HpkeCiphertext, HpkeConfigId, Interval, PrepareContinue, PrepareInit, PrepareResp, Query,
     ReportError, ReportId, ReportIdChecksum, ReportMetadata, Role, TaskId, Time,
+    batch_mode::{BatchMode, LeaderSelected, TimeInterval},
 };
 use postgres_protocol::types::{
-    range_from_sql, range_to_sql, timestamp_from_sql, timestamp_to_sql, Range, RangeBound,
+    Range, RangeBound, range_from_sql, range_to_sql, timestamp_from_sql, timestamp_to_sql,
 };
-use postgres_types::{accepts, to_sql_checked, FromSql, ToSql};
+use postgres_types::{FromSql, ToSql, accepts, to_sql_checked};
 use prio::{
-    codec::{encode_u16_items, Encode},
+    codec::{Encode, encode_u16_items},
     topology::ping_pong::PingPongContinuation,
     vdaf::Aggregatable,
 };
@@ -535,9 +535,9 @@ impl TryFrom<&[u8]> for LeaseToken {
     type Error = &'static str;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self(value.try_into().map_err(|_| {
-            "byte slice has incorrect length for LeaseToken"
-        })?))
+        Ok(Self(value.try_into().map_err(
+            |_| "byte slice has incorrect length for LeaseToken",
+        )?))
     }
 }
 

--- a/aggregator_core/src/datastore/test_util.rs
+++ b/aggregator_core/src/datastore/test_util.rs
@@ -2,7 +2,7 @@ use crate::{
     datastore::{Crypter, Datastore, Transaction},
     test_util::noop_meter,
 };
-use aws_lc_rs::aead::{LessSafeKey, UnboundKey, AES_128_GCM};
+use aws_lc_rs::aead::{AES_128_GCM, LessSafeKey, UnboundKey};
 use backon::{BackoffBuilder, ConstantBuilder, Retryable};
 use chrono::NaiveDateTime;
 use deadpool_postgres::{Manager, Pool, Timeouts};
@@ -11,10 +11,10 @@ use janus_core::{
     time::{Clock, MockClock, TimeExt},
 };
 use janus_messages::Time;
-use rand::{distr::StandardUniform, random, rng, Rng};
+use rand::{Rng, distr::StandardUniform, random, rng};
 use sqlx::{
-    migrate::{Migrate, Migrator},
     Connection, PgConnection,
+    migrate::{Migrate, Migrator},
 };
 use std::{
     env,
@@ -25,16 +25,16 @@ use std::{
     thread::JoinHandle,
     time::Duration,
 };
-use testcontainers::{core::Mount, runners::AsyncRunner, ContainerRequest, ImageExt};
+use testcontainers::{ContainerRequest, ImageExt, core::Mount, runners::AsyncRunner};
 use tokio::{
     io::{AsyncBufRead, AsyncBufReadExt},
     join,
     sync::{
-        oneshot::{self, Sender},
         Mutex,
+        oneshot::{self, Sender},
     },
 };
-use tokio_postgres::{connect, Config, NoTls};
+use tokio_postgres::{Config, NoTls, connect};
 use tracing::trace;
 
 use super::SUPPORTED_SCHEMA_VERSIONS;

--- a/aggregator_core/src/lib.rs
+++ b/aggregator_core/src/lib.rs
@@ -12,7 +12,7 @@ use prio::{
     vdaf::{Aggregator, AggregatorWithNoise},
 };
 use std::hash::Hash;
-use tracing::{debug, info_span, Instrument, Span};
+use tracing::{Instrument, Span, debug, info_span};
 use trillium::{Conn, Handler, Status};
 use trillium_macros::Handler;
 use trillium_router::RouterConnExt;
@@ -67,27 +67,27 @@ pub trait AsyncAggregator<const VERIFY_KEY_SIZE: usize>:
 
 /// Blanket implementation for conforming VDAFs.
 impl<
-        const VERIFY_KEY_SIZE: usize,
-        A: Aggregator<
-                VERIFY_KEY_SIZE,
-                16,
-                AggregationParam: Send + Sync + PartialEq + Eq + Hash + Ord,
-                AggregateShare: Send + Sync + PartialEq,
-                InputShare: Send + Sync + PartialEq,
-                PrepareMessage: Send + Sync + PartialEq,
-                PrepareShare: Send + Sync + PartialEq,
-                PublicShare: Send + Sync + PartialEq,
-                OutputShare: Send + Sync + PartialEq + Eq,
-                PrepareState: Send
-                                  + Sync
-                                  + Encode
-                                  + PartialEq
-                                  + for<'a> ParameterizedDecode<(&'a Self, usize)>,
-            >
-            + 'static
-            + Send
-            + Sync,
-    > AsyncAggregator<VERIFY_KEY_SIZE> for A
+    const VERIFY_KEY_SIZE: usize,
+    A: Aggregator<
+            VERIFY_KEY_SIZE,
+            16,
+            AggregationParam: Send + Sync + PartialEq + Eq + Hash + Ord,
+            AggregateShare: Send + Sync + PartialEq,
+            InputShare: Send + Sync + PartialEq,
+            PrepareMessage: Send + Sync + PartialEq,
+            PrepareShare: Send + Sync + PartialEq,
+            PublicShare: Send + Sync + PartialEq,
+            OutputShare: Send + Sync + PartialEq + Eq,
+            PrepareState: Send
+                              + Sync
+                              + Encode
+                              + PartialEq
+                              + for<'a> ParameterizedDecode<(&'a Self, usize)>,
+        >
+        + 'static
+        + Send
+        + Sync,
+> AsyncAggregator<VERIFY_KEY_SIZE> for A
 {
 }
 
@@ -97,10 +97,10 @@ pub trait AsyncAggregatorWithNoise<const VERIFY_KEY_SIZE: usize, S: Differential
 }
 
 impl<
-        const VERIFY_KEY_SIZE: usize,
-        S: DifferentialPrivacyStrategy,
-        A: AsyncAggregator<VERIFY_KEY_SIZE> + AggregatorWithNoise<VERIFY_KEY_SIZE, 16, S>,
-    > AsyncAggregatorWithNoise<VERIFY_KEY_SIZE, S> for A
+    const VERIFY_KEY_SIZE: usize,
+    S: DifferentialPrivacyStrategy,
+    A: AsyncAggregator<VERIFY_KEY_SIZE> + AggregatorWithNoise<VERIFY_KEY_SIZE, 16, S>,
+> AsyncAggregatorWithNoise<VERIFY_KEY_SIZE, S> for A
 {
 }
 
@@ -156,8 +156,8 @@ pub mod test_util {
     use std::sync::Arc;
 
     use opentelemetry::{
-        metrics::{InstrumentProvider, Meter, MeterProvider},
         InstrumentationScope,
+        metrics::{InstrumentProvider, Meter, MeterProvider},
     };
 
     pub fn noop_meter() -> Meter {

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -2,7 +2,7 @@
 
 use crate::SecretBytes;
 use anyhow::anyhow;
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use educe::Educe;
 use janus_core::{
     auth_tokens::{AuthenticationToken, AuthenticationTokenHash},
@@ -10,11 +10,11 @@ use janus_core::{
     vdaf::VdafInstance,
 };
 use janus_messages::{
-    batch_mode, AggregationJobId, AggregationJobStep, Duration, HpkeConfig, Role, TaskId, Time,
+    AggregationJobId, AggregationJobStep, Duration, HpkeConfig, Role, TaskId, Time, batch_mode,
 };
 use postgres_types::{FromSql, ToSql};
-use rand::{distr::StandardUniform, random, rng, Rng};
-use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
+use rand::{Rng, distr::StandardUniform, random, rng};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as _};
 use std::{array::TryFromSliceError, str::FromStr};
 use url::Url;
 
@@ -778,11 +778,11 @@ impl<'de> Deserialize<'de> for AggregatorTask {
 #[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
 pub mod test_util {
     use crate::{
+        SecretBytes,
         task::{
             AggregationMode, AggregatorTask, AggregatorTaskParameters, BatchMode,
             CommonTaskParameters, Error, VerifyKey,
         },
-        SecretBytes,
     };
     use educe::Educe;
     use janus_core::{
@@ -796,7 +796,7 @@ pub mod test_util {
         AggregationJobId, AggregationJobStep, CollectionJobId, Duration, HpkeConfigId, Role,
         TaskId, Time,
     };
-    use rand::{distr::StandardUniform, random, rng, Rng};
+    use rand::{Rng, distr::StandardUniform, random, rng};
     use std::collections::HashMap;
     use url::Url;
 
@@ -1360,11 +1360,11 @@ pub mod test_util {
 #[cfg(test)]
 mod tests {
     use crate::{
-        task::{
-            test_util::TaskBuilder, AggregationMode, AggregatorTask, AggregatorTaskParameters,
-            BatchMode, VdafInstance,
-        },
         SecretBytes,
+        task::{
+            AggregationMode, AggregatorTask, AggregatorTaskParameters, BatchMode, VdafInstance,
+            test_util::TaskBuilder,
+        },
     };
     use assert_matches::assert_matches;
     use janus_core::{
@@ -1379,7 +1379,7 @@ mod tests {
     };
     use rand::random;
     use serde_json::json;
-    use serde_test::{assert_de_tokens, assert_tokens, Token};
+    use serde_test::{Token, assert_de_tokens, assert_tokens};
 
     #[test]
     fn leader_task_serialization() {

--- a/aggregator_core/src/taskprov.rs
+++ b/aggregator_core/src/taskprov.rs
@@ -1,20 +1,20 @@
 use crate::{
-    task::{AggregationMode, Error},
     SecretBytes,
+    task::{AggregationMode, Error},
 };
 use anyhow::anyhow;
 use aws_lc_rs::{
-    digest::{self, digest, Digest, SHA256},
-    hkdf::{KeyType, Salt, HKDF_SHA256},
+    digest::{self, Digest, SHA256, digest},
+    hkdf::{HKDF_SHA256, KeyType, Salt},
 };
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use educe::Educe;
 use janus_core::{auth_tokens::AuthenticationToken, vdaf::VdafInstance};
 use janus_messages::{Duration, HpkeConfig, Role, TaskId};
 use rand::{distr::StandardUniform, prelude::Distribution};
 use serde::{
-    de::{self, Visitor},
     Deserialize, Serialize, Serializer,
+    de::{self, Visitor},
 };
 use std::{fmt, str::FromStr, sync::LazyLock};
 use url::Url;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -44,14 +44,14 @@ use backon::BackoffBuilder;
 use bhttp::{ControlData, Message, Mode};
 use educe::Educe;
 #[cfg(feature = "ohttp")]
-use http::{header::ACCEPT, HeaderValue};
-use http::{header::CONTENT_TYPE, StatusCode};
+use http::{HeaderValue, header::ACCEPT};
+use http::{StatusCode, header::CONTENT_TYPE};
 use itertools::Itertools;
 use janus_core::{
-    hpke::{self, is_hpke_config_supported, HpkeApplicationInfo, Label},
+    hpke::{self, HpkeApplicationInfo, Label, is_hpke_config_supported},
     http::HttpErrorResponse,
     retries::{
-        http_request_exponential_backoff, retry_http_request, ExponentialWithTotalDelayBuilder,
+        ExponentialWithTotalDelayBuilder, http_request_exponential_backoff, retry_http_request,
     },
     time::{Clock, RealClock, TimeExt},
     url_ensure_trailing_slash,

--- a/client/src/tests/mod.rs
+++ b/client/src/tests/mod.rs
@@ -1,7 +1,7 @@
-use crate::{aggregator_hpke_config, default_http_client, Client, ClientParameters, Error};
+use crate::{Client, ClientParameters, Error, aggregator_hpke_config, default_http_client};
 use assert_matches::assert_matches;
 use hex_literal::hex;
-use http::{header::CONTENT_TYPE, StatusCode};
+use http::{StatusCode, header::CONTENT_TYPE};
 use janus_core::{
     hpke::HpkeKeypair, initialize_rustls,
     retries::test_util::test_http_request_exponential_backoff,

--- a/client/src/tests/ohttp.rs
+++ b/client/src/tests/ohttp.rs
@@ -1,8 +1,8 @@
 use std::io::Cursor;
 
 use crate::{
-    Client, Error, OhttpConfig, OHTTP_KEYS_MEDIA_TYPE, OHTTP_REQUEST_MEDIA_TYPE,
-    OHTTP_RESPONSE_MEDIA_TYPE,
+    Client, Error, OHTTP_KEYS_MEDIA_TYPE, OHTTP_REQUEST_MEDIA_TYPE, OHTTP_RESPONSE_MEDIA_TYPE,
+    OhttpConfig,
 };
 use assert_matches::assert_matches;
 use bhttp::{Message, Mode, StatusCode};
@@ -14,8 +14,8 @@ use janus_core::{
 };
 use janus_messages::{Duration, Report};
 use ohttp::{
-    hpke::{Aead, Kdf},
     KeyConfig, SymmetricSuite,
+    hpke::{Aead, Kdf},
 };
 use prio::{
     codec::Decode,

--- a/collector/src/credential.rs
+++ b/collector/src/credential.rs
@@ -46,7 +46,7 @@ impl PrivateCollectorCredential {
 #[cfg(test)]
 mod tests {
     use crate::credential::PrivateCollectorCredential;
-    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+    use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
     use janus_core::{
         auth_tokens::AuthenticationToken,
         hpke::{HpkeKeypair, HpkePrivateKey},

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -73,15 +73,15 @@ use janus_core::{
     hpke::{self, HpkeApplicationInfo, HpkeKeypair},
     http::HttpErrorResponse,
     retries::{
-        http_request_exponential_backoff, retry_http_request, ExponentialWithTotalDelayBuilder,
+        ExponentialWithTotalDelayBuilder, http_request_exponential_backoff, retry_http_request,
     },
     time::{DurationExt, TimeExt},
     url_ensure_trailing_slash,
 };
 use janus_messages::{
-    batch_mode::{BatchMode, TimeInterval},
     AggregateShareAad, BatchSelector, CollectionJobId, CollectionJobReq, CollectionJobResp,
     PartialBatchSelector, Query, Role, TaskId,
+    batch_mode::{BatchMode, TimeInterval},
 };
 use mime::Mime;
 use prio::{
@@ -90,8 +90,8 @@ use prio::{
 };
 use rand::random;
 use reqwest::{
-    header::{HeaderValue, ToStrError, CONTENT_LENGTH, CONTENT_TYPE, RETRY_AFTER},
     StatusCode,
+    header::{CONTENT_LENGTH, CONTENT_TYPE, HeaderValue, RETRY_AFTER, ToStrError},
 };
 pub use retry_after;
 use retry_after::{FromHeaderValueError, RetryAfter};
@@ -99,7 +99,7 @@ use std::{
     convert::TryFrom,
     time::{Duration as StdDuration, SystemTime},
 };
-use tokio::time::{sleep, Instant};
+use tokio::time::{Instant, sleep};
 use tracing::debug;
 use url::Url;
 
@@ -702,7 +702,7 @@ impl<V: vdaf::Collector> Collector<V> {
                 if let Some(deadline) = deadline {
                     let recommendation_is_past_deadline = Instant::now()
                         .checked_add(retry_after_duration)
-                        .map_or(true, |recommendation| recommendation > deadline);
+                        .is_none_or(|recommendation| recommendation > deadline);
 
                     if recommendation_is_past_deadline {
                         debug!(
@@ -780,25 +780,25 @@ mod tests {
         hpke::{self, HpkeApplicationInfo, HpkeKeypair, Label},
         initialize_rustls,
         retries::test_util::test_http_request_exponential_backoff,
-        test_util::{install_test_trace_subscriber, run_vdaf, VdafTranscript},
+        test_util::{VdafTranscript, install_test_trace_subscriber, run_vdaf},
     };
     use janus_messages::{
-        batch_mode::{LeaderSelected, TimeInterval},
-        problem_type::DapProblemType,
         AggregateShareAad, BatchId, BatchSelector, CollectionJobId, CollectionJobReq,
         CollectionJobResp, Duration, HpkeCiphertext, Interval, PartialBatchSelector, Query, Role,
         TaskId, Time,
+        batch_mode::{LeaderSelected, TimeInterval},
+        problem_type::DapProblemType,
     };
     use mockito::Matcher;
     use prio::{
         codec::Encode,
         field::Field64,
-        vdaf::{self, dummy, prio3::Prio3, AggregateShare, OutputShare},
+        vdaf::{self, AggregateShare, OutputShare, dummy, prio3::Prio3},
     };
     use rand::random;
     use reqwest::{
-        header::{AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE},
         StatusCode, Url,
+        header::{AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE},
     };
     use retry_after::RetryAfter;
 

--- a/core/src/auth_tokens.rs
+++ b/core/src/auth_tokens.rs
@@ -1,14 +1,14 @@
 use anyhow::anyhow;
 use aws_lc_rs::{
     constant_time,
-    digest::{digest, SHA256, SHA256_OUTPUT_LEN},
+    digest::{SHA256, SHA256_OUTPUT_LEN, digest},
 };
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use educe::Educe;
-use http::{header::AUTHORIZATION, HeaderValue};
+use http::{HeaderValue, header::AUTHORIZATION};
 use rand::{distr::StandardUniform, prelude::Distribution};
 use regex::Regex;
-use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error};
 use std::{
     str::{self, FromStr},
     sync::LazyLock,

--- a/core/src/dp.rs
+++ b/core/src/dp.rs
@@ -3,19 +3,19 @@ use fixed::traits::Fixed;
 #[cfg(feature = "fpvec_bounded_l2")]
 use prio::flp::{
     gadgets::PolyEval,
-    types::fixedpoint_l2::{compatible_float::CompatibleFloat, FixedPointBoundedL2VecSum},
+    types::fixedpoint_l2::{FixedPointBoundedL2VecSum, compatible_float::CompatibleFloat},
 };
 #[cfg(feature = "test-util")]
-use prio::vdaf::{dummy, AggregatorWithNoise};
+use prio::vdaf::{AggregatorWithNoise, dummy};
 use prio::{
     dp::{
         DifferentialPrivacyBudget, DifferentialPrivacyDistribution, DifferentialPrivacyStrategy,
         DpError,
     },
-    field::{Field128, Field64},
+    field::{Field64, Field128},
     flp::{
-        gadgets::{Mul, ParallelSumGadget},
         TypeWithNoise,
+        gadgets::{Mul, ParallelSumGadget},
     },
 };
 use serde::{Deserialize, Serialize};

--- a/core/src/hpke.rs
+++ b/core/src/hpke.rs
@@ -1,6 +1,6 @@
 //! Encryption and decryption of messages using HPKE (RFC 9180).
 use crate::DAP_VERSION_IDENTIFIER;
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use constcat::concat;
 use educe::Educe;
 use hpke_dispatch::{HpkeError, Kem, Keypair};
@@ -8,8 +8,8 @@ use janus_messages::{
     HpkeAeadId, HpkeCiphertext, HpkeConfig, HpkeConfigId, HpkeKdfId, HpkeKemId, HpkePublicKey, Role,
 };
 use serde::{
-    de::{self, Visitor},
     Deserialize, Serialize, Serializer,
+    de::{self, Visitor},
 };
 use std::{
     fmt::{self, Debug},
@@ -360,7 +360,7 @@ impl HpkeKeypair {
 mod tests {
     use super::{HpkeApplicationInfo, Label};
     #[allow(deprecated)]
-    use crate::hpke::{open, seal, HpkeKeypair, HpkePrivateKey};
+    use crate::hpke::{HpkeKeypair, HpkePrivateKey, open, seal};
     use hpke_dispatch::{Kem, Keypair};
     use janus_messages::{
         HpkeAeadId, HpkeCiphertext, HpkeConfig, HpkeConfigId, HpkeKdfId, HpkeKemId, HpkePublicKey,

--- a/core/src/http.rs
+++ b/core/src/http.rs
@@ -4,7 +4,7 @@ use http::StatusCode;
 use http_api_problem::{HttpApiProblem, PROBLEM_JSON_MEDIA_TYPE};
 use janus_messages::problem_type::DapProblemType;
 use mime;
-use reqwest::{header::CONTENT_TYPE, Response};
+use reqwest::{Response, header::CONTENT_TYPE};
 use std::fmt::{self, Display, Formatter};
 use tracing::warn;
 use trillium::{Conn, HeaderValue};

--- a/core/src/report_id.rs
+++ b/core/src/report_id.rs
@@ -1,6 +1,6 @@
 //! Extensions on report ID representations from `janus_messages`.
 
-use aws_lc_rs::digest::{digest, SHA256, SHA256_OUTPUT_LEN};
+use aws_lc_rs::digest::{SHA256, SHA256_OUTPUT_LEN, digest};
 use janus_messages::{ReportId, ReportIdChecksum};
 
 /// Additional methods for working with a [`ReportIdChecksum`].

--- a/core/src/retries.rs
+++ b/core/src/retries.rs
@@ -347,8 +347,8 @@ mod tests {
     use crate::{
         initialize_rustls,
         retries::{
-            retry_http_request, retry_http_request_notify, test_util::LimitedRetryer,
-            ExponentialWithTotalDelayBuilder,
+            ExponentialWithTotalDelayBuilder, retry_http_request, retry_http_request_notify,
+            test_util::LimitedRetryer,
         },
         test_util::install_test_trace_subscriber,
     };

--- a/core/src/test_util/kubernetes.rs
+++ b/core/src/test_util/kubernetes.rs
@@ -5,9 +5,9 @@ use backon::{BackoffBuilder, BlockingRetryable, ConstantBuilder};
 use futures::TryStreamExt;
 use k8s_openapi::api::core::v1::{Pod, Service};
 use kube::{
+    Api, ResourceExt,
     api::ListParams,
     config::{KubeConfigOptions, Kubeconfig},
-    Api, ResourceExt,
 };
 use rand::random;
 use std::{
@@ -289,7 +289,7 @@ mod tests {
     use super::EphemeralCluster;
     use crate::test_util::install_test_trace_subscriber;
     use k8s_openapi::api::core::v1::Node;
-    use kube::{api::ListParams, Api};
+    use kube::{Api, api::ListParams};
 
     #[tokio::test]
     async fn create_clusters() {

--- a/core/src/test_util/mod.rs
+++ b/core/src/test_util/mod.rs
@@ -7,10 +7,10 @@ use prio::{
     },
     vdaf,
 };
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 use std::{fmt::Debug, sync::Once};
 use tracing_log::LogTracer;
-use tracing_subscriber::{prelude::*, EnvFilter, Registry};
+use tracing_subscriber::{EnvFilter, Registry, prelude::*};
 
 pub mod kubernetes;
 pub mod runtime;

--- a/core/src/test_util/runtime.rs
+++ b/core/src/test_util/runtime.rs
@@ -4,10 +4,10 @@ use std::{
     collections::HashMap,
     future::Future,
     hash::Hash,
-    panic::{resume_unwind, AssertUnwindSafe},
+    panic::{AssertUnwindSafe, resume_unwind},
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     },
 };
 use tokio::{

--- a/core/src/test_util/testcontainers.rs
+++ b/core/src/test_util/testcontainers.rs
@@ -1,7 +1,7 @@
 //! Testing functionality that interacts with the testcontainers library.
 
 use std::{borrow::Cow, process::Command};
-use testcontainers::{core::WaitFor, Image};
+use testcontainers::{Image, core::WaitFor};
 
 /// A [`testcontainers::Image`] that provides a Postgres server.
 #[derive(Debug, Default)]

--- a/core/src/vdaf.rs
+++ b/core/src/vdaf.rs
@@ -1,12 +1,12 @@
 use crate::DAP_VERSION_IDENTIFIER;
-use janus_messages::{taskprov, TaskId};
+use janus_messages::{TaskId, taskprov};
 use prio::{
     field::Field64,
     flp::{
         gadgets::{Mul, ParallelSumGadget},
         types::SumVec,
     },
-    vdaf::{prio3::Prio3, xof::XofHmacSha256Aes128, VdafError},
+    vdaf::{VdafError, prio3::Prio3, xof::XofHmacSha256Aes128},
 };
 use serde::{Deserialize, Serialize};
 use std::str;
@@ -614,15 +614,15 @@ macro_rules! vdaf_dispatch {
 mod tests {
     #[cfg(feature = "fpvec_bounded_l2")]
     use crate::vdaf::Prio3FixedPointBoundedL2VecSumBitSize;
-    use crate::vdaf::{vdaf_dp_strategies, VdafInstance};
+    use crate::vdaf::{VdafInstance, vdaf_dp_strategies};
     use assert_matches::assert_matches;
-    #[cfg(feature = "fpvec_bounded_l2")]
-    use prio::dp::{distributions::ZCdpDiscreteGaussian, ZCdpBudget};
     use prio::dp::{
-        distributions::{DiscreteLaplaceDpStrategy, PureDpDiscreteLaplace},
         DifferentialPrivacyStrategy, PureDpBudget, Rational,
+        distributions::{DiscreteLaplaceDpStrategy, PureDpDiscreteLaplace},
     };
-    use serde_test::{assert_tokens, Token};
+    #[cfg(feature = "fpvec_bounded_l2")]
+    use prio::dp::{ZCdpBudget, distributions::ZCdpDiscreteGaussian};
+    use serde_test::{Token, assert_tokens};
 
     #[test]
     fn vdaf_serialization() {

--- a/integration_tests/src/client.rs
+++ b/integration_tests/src/client.rs
@@ -1,9 +1,9 @@
 use crate::TaskParameters;
 use anyhow::anyhow;
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use janus_client::Client;
 use janus_core::vdaf::{Prio3SumVecField64MultiproofHmacSha256Aes128, VdafInstance};
-use janus_interop_binaries::{get_rust_log_level, ContainerLogsDropGuard};
+use janus_interop_binaries::{ContainerLogsDropGuard, get_rust_log_level};
 use janus_messages::{Duration, TaskId, Time};
 use prio::{
     codec::Encode,
@@ -15,12 +15,12 @@ use prio::{
     },
 };
 use rand::random;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::env;
 use testcontainers::{
-    core::{wait::HealthWaitStrategy, WaitFor},
-    runners::AsyncRunner,
     ContainerRequest, Image, ImageExt,
+    core::{WaitFor, wait::HealthWaitStrategy},
+    runners::AsyncRunner,
 };
 use url::Url;
 

--- a/integration_tests/src/daphne.rs
+++ b/integration_tests/src/daphne.rs
@@ -3,11 +3,11 @@
 use crate::interop_api;
 use janus_aggregator_core::task::test_util::{Task, TaskBuilder};
 use janus_interop_binaries::{
-    get_rust_log_level, test_util::await_ready_ok, ContainerLogsDropGuard, ContainerLogsSource,
+    ContainerLogsDropGuard, ContainerLogsSource, get_rust_log_level, test_util::await_ready_ok,
 };
 use janus_messages::{Role, Time};
 use serde_json::json;
-use testcontainers::{runners::AsyncRunner, ContainerRequest, GenericImage, ImageExt};
+use testcontainers::{ContainerRequest, GenericImage, ImageExt, runners::AsyncRunner};
 use url::Url;
 
 const DAPHNE_HELPER_IMAGE_NAME_AND_TAG: &str = "cloudflare/daphne-worker-helper:sha-f6b3ef1";

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -2,7 +2,7 @@
 
 #[cfg(feature = "testcontainer")]
 use crate::interop_api;
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use janus_aggregator::{
     binaries::{
         aggregation_job_creator::{
@@ -19,26 +19,26 @@ use janus_aggregator::{
     },
     binary_utils::{BinaryContext, CommonBinaryOptions},
     config::{
-        default_max_transaction_retries, CommonConfig, DbConfig, JobDriverConfig, TaskprovConfig,
+        CommonConfig, DbConfig, JobDriverConfig, TaskprovConfig, default_max_transaction_retries,
     },
     metrics::MetricsConfiguration,
     trace::{TokioConsoleConfiguration, TraceConfiguration},
 };
 use janus_aggregator_core::{
-    datastore::test_util::{ephemeral_datastore, EphemeralDatastore},
+    datastore::test_util::{EphemeralDatastore, ephemeral_datastore},
     task::test_util::Task,
     test_util::noop_meter,
 };
 use janus_core::time::RealClock;
 #[cfg(feature = "testcontainer")]
 use janus_interop_binaries::{
-    get_rust_log_level, test_util::await_http_server, testcontainer::Aggregator,
-    ContainerLogsDropGuard,
+    ContainerLogsDropGuard, get_rust_log_level, test_util::await_http_server,
+    testcontainer::Aggregator,
 };
 use janus_messages::Role;
 use std::net::{Ipv4Addr, SocketAddr};
 #[cfg(feature = "testcontainer")]
-use testcontainers::{runners::AsyncRunner, ContainerRequest, ImageExt};
+use testcontainers::{ContainerRequest, ImageExt, runners::AsyncRunner};
 use trillium_tokio::Stopper;
 
 /// Represents a running Janus test instance in a container.

--- a/integration_tests/tests/integration/common.rs
+++ b/integration_tests/tests/integration/common.rs
@@ -1,26 +1,26 @@
 use backon::{BackoffBuilder, ConstantBuilder, Retryable};
 use itertools::Itertools;
-use janus_aggregator_core::task::{test_util::TaskBuilder, BatchMode};
+use janus_aggregator_core::task::{BatchMode, test_util::TaskBuilder};
 use janus_collector::{Collection, Collector};
 use janus_core::{
-    retries::{test_util::test_http_request_exponential_backoff, ExponentialWithTotalDelayBuilder},
+    retries::{ExponentialWithTotalDelayBuilder, test_util::test_http_request_exponential_backoff},
     time::{Clock, RealClock, TimeExt},
-    vdaf::{new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128, VdafInstance},
+    vdaf::{VdafInstance, new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128},
 };
 use janus_integration_tests::{
-    client::{ClientBackend, ClientImplementation, InteropClientEncoding},
     AggregatorEndpointFragments, EndpointFragments, TaskParameters,
+    client::{ClientBackend, ClientImplementation, InteropClientEncoding},
 };
 use janus_messages::{
+    Duration, Interval, Query, Time,
     batch_mode::{self, LeaderSelected},
     problem_type::DapProblemType,
-    Duration, Interval, Query, Time,
 };
 use prio::{
     flp::gadgets::ParallelSumMultithreaded,
     vdaf::{self, prio3::Prio3},
 };
-use rand::{random, rng, seq::IteratorRandom as _, Rng};
+use rand::{Rng, random, rng, seq::IteratorRandom as _};
 use std::{iter, time::Duration as StdDuration};
 use tokio::time::{self, sleep};
 use url::Url;
@@ -363,9 +363,8 @@ pub async fn submit_measurements_and_verify_aggregate(
             let num_true_measurements = total_measurements / 2;
             let num_false_measurements = total_measurements - num_true_measurements;
             assert!(num_true_measurements > 0 && num_false_measurements > 0);
-            let measurements = iter::repeat(true)
-                .take(num_true_measurements)
-                .interleave(iter::repeat(false).take(num_false_measurements))
+            let measurements = iter::repeat_n(true, num_true_measurements)
+                .interleave(iter::repeat_n(false, num_false_measurements))
                 .collect::<Vec<_>>();
             let test_case = AggregationTestCase {
                 measurements,

--- a/integration_tests/tests/integration/daphne.rs
+++ b/integration_tests/tests/integration/daphne.rs
@@ -1,13 +1,13 @@
 use crate::{
-    common::{build_test_task, submit_measurements_and_verify_aggregate, TestContext},
+    common::{TestContext, build_test_task, submit_measurements_and_verify_aggregate},
     initialize_rustls,
 };
-use janus_aggregator_core::task::{test_util::TaskBuilder, AggregationMode, BatchMode};
+use janus_aggregator_core::task::{AggregationMode, BatchMode, test_util::TaskBuilder};
 use janus_core::{test_util::install_test_trace_subscriber, vdaf::VdafInstance};
 #[cfg(feature = "testcontainer")]
 use janus_integration_tests::janus::JanusContainer;
 use janus_integration_tests::{
-    client::ClientBackend, daphne::Daphne, janus::JanusInProcess, AggregatorEndpointFragments,
+    AggregatorEndpointFragments, client::ClientBackend, daphne::Daphne, janus::JanusInProcess,
 };
 use janus_interop_binaries::test_util::generate_network_name;
 use janus_messages::Role;

--- a/integration_tests/tests/integration/divviup_ts.rs
+++ b/integration_tests/tests/integration/divviup_ts.rs
@@ -2,13 +2,13 @@
 //! These tests check interoperation between the divviup-ts client and Janus aggregators.
 
 use crate::{
-    common::{build_test_task, submit_measurements_and_verify_aggregate, TestContext},
+    common::{TestContext, build_test_task, submit_measurements_and_verify_aggregate},
     initialize_rustls,
 };
-use janus_aggregator_core::task::{test_util::TaskBuilder, AggregationMode, BatchMode};
+use janus_aggregator_core::task::{AggregationMode, BatchMode, test_util::TaskBuilder};
 use janus_core::{
     test_util::install_test_trace_subscriber,
-    vdaf::{vdaf_dp_strategies, VdafInstance},
+    vdaf::{VdafInstance, vdaf_dp_strategies},
 };
 use janus_integration_tests::{
     client::{ClientBackend, InteropClient},

--- a/integration_tests/tests/integration/in_cluster.rs
+++ b/integration_tests/tests/integration/in_cluster.rs
@@ -2,8 +2,8 @@
 
 use crate::{
     common::{
-        build_test_task, collect_aggregate_result_generic,
-        submit_measurements_and_verify_aggregate, submit_measurements_generic, TestContext,
+        TestContext, build_test_task, collect_aggregate_result_generic,
+        submit_measurements_and_verify_aggregate, submit_measurements_generic,
     },
     initialize_rustls,
 };
@@ -13,7 +13,7 @@ use divviup_client::{
     Client, DivviupClient, Histogram, HpkeConfig, NewAggregator, NewSharedAggregator, NewTask,
     SumVec, Vdaf,
 };
-use janus_aggregator_core::task::{test_util::TaskBuilder, AggregationMode, BatchMode};
+use janus_aggregator_core::task::{AggregationMode, BatchMode, test_util::TaskBuilder};
 #[cfg(feature = "ohttp")]
 use janus_client::OhttpConfig;
 use janus_collector::PrivateCollectorCredential;
@@ -25,13 +25,13 @@ use janus_core::{
         kubernetes::{Cluster, PortForward},
     },
     time::DurationExt,
-    vdaf::{vdaf_dp_strategies, VdafInstance},
+    vdaf::{VdafInstance, vdaf_dp_strategies},
 };
-use janus_integration_tests::{client::ClientBackend, TaskParameters};
+use janus_integration_tests::{TaskParameters, client::ClientBackend};
 use janus_messages::{Duration as JanusDuration, TaskId};
 use prio::{
     dp::{
-        distributions::PureDpDiscreteLaplace, DifferentialPrivacyStrategy, PureDpBudget, Rational,
+        DifferentialPrivacyStrategy, PureDpBudget, Rational, distributions::PureDpDiscreteLaplace,
     },
     field::{Field128, FieldElementWithInteger},
     vdaf::prio3::Prio3,
@@ -988,9 +988,11 @@ async fn in_cluster_histogram_dp_noise() {
     // noise values will be zero simultaneously.
     assert_ne!(aggregate_result, un_noised_result);
 
-    assert!(aggregate_result
-        .iter()
-        .all(|x| *x < Field128::modulus() / 4 || *x > Field128::modulus() / 4 * 3));
+    assert!(
+        aggregate_result
+            .iter()
+            .all(|x| *x < Field128::modulus() / 4 || *x > Field128::modulus() / 4 * 3)
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1060,7 +1062,9 @@ async fn in_cluster_sumvec_dp_noise() {
     // noise values will be zero simultaneously.
     assert_ne!(aggregate_result, un_noised_result);
 
-    assert!(aggregate_result
-        .iter()
-        .all(|x| *x < Field128::modulus() / 4 || *x > Field128::modulus() / 4 * 3));
+    assert!(
+        aggregate_result
+            .iter()
+            .all(|x| *x < Field128::modulus() / 4 || *x > Field128::modulus() / 4 * 3)
+    );
 }

--- a/integration_tests/tests/integration/in_cluster.rs
+++ b/integration_tests/tests/integration/in_cluster.rs
@@ -955,7 +955,7 @@ async fn in_cluster_histogram_dp_noise() {
         .min_batch_size
         .try_into()
         .unwrap();
-    let measurements = iter::repeat(0).take(total_measurements).collect::<Vec<_>>();
+    let measurements = iter::repeat_n(0, total_measurements).collect::<Vec<_>>();
     let client_implementation = ClientBackend::InProcess
         .build(
             TEST_NAME,
@@ -1028,9 +1028,8 @@ async fn in_cluster_sumvec_dp_noise() {
         .min_batch_size
         .try_into()
         .unwrap();
-    let measurements = iter::repeat(vec![0; VECTOR_LENGTH])
-        .take(total_measurements)
-        .collect::<Vec<_>>();
+    let measurements =
+        iter::repeat_n(vec![0; VECTOR_LENGTH], total_measurements).collect::<Vec<_>>();
     let client_implementation = ClientBackend::InProcess
         .build(
             TEST_NAME,

--- a/integration_tests/tests/integration/janus.rs
+++ b/integration_tests/tests/integration/janus.rs
@@ -1,24 +1,24 @@
 use crate::{
     common::{
-        build_test_task, collect_aggregate_result_generic,
-        submit_measurements_and_verify_aggregate, submit_measurements_generic, TestContext,
+        TestContext, build_test_task, collect_aggregate_result_generic,
+        submit_measurements_and_verify_aggregate, submit_measurements_generic,
     },
     initialize_rustls,
 };
-use janus_aggregator_core::task::{test_util::TaskBuilder, AggregationMode, BatchMode};
+use janus_aggregator_core::task::{AggregationMode, BatchMode, test_util::TaskBuilder};
 use janus_core::{
     test_util::install_test_trace_subscriber,
-    vdaf::{vdaf_dp_strategies, VdafInstance},
+    vdaf::{VdafInstance, vdaf_dp_strategies},
 };
 #[cfg(feature = "testcontainer")]
 use janus_integration_tests::janus::JanusContainer;
-use janus_integration_tests::{client::ClientBackend, janus::JanusInProcess, TaskParameters};
+use janus_integration_tests::{TaskParameters, client::ClientBackend, janus::JanusInProcess};
 #[cfg(feature = "testcontainer")]
 use janus_interop_binaries::test_util::generate_network_name;
 use janus_messages::Role;
 use prio::{
     dp::{
-        distributions::PureDpDiscreteLaplace, DifferentialPrivacyStrategy, PureDpBudget, Rational,
+        DifferentialPrivacyStrategy, PureDpBudget, Rational, distributions::PureDpDiscreteLaplace,
     },
     field::{Field128, FieldElementWithInteger},
     vdaf::prio3::Prio3,
@@ -534,7 +534,7 @@ async fn janus_in_process_histogram_dp_noise() {
         .min_batch_size
         .try_into()
         .unwrap();
-    let measurements = iter::repeat(0).take(total_measurements).collect::<Vec<_>>();
+    let measurements = iter::repeat_n(0, total_measurements).collect::<Vec<_>>();
     let client_implementation = ClientBackend::InProcess
         .build(
             TEST_NAME,
@@ -567,9 +567,11 @@ async fn janus_in_process_histogram_dp_noise() {
     // noise values will be zero simultaneously.
     assert_ne!(aggregate_result, un_noised_result);
 
-    assert!(aggregate_result
-        .iter()
-        .all(|x| *x < Field128::modulus() / 4 || *x > Field128::modulus() / 4 * 3));
+    assert!(
+        aggregate_result
+            .iter()
+            .all(|x| *x < Field128::modulus() / 4 || *x > Field128::modulus() / 4 * 3)
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -603,9 +605,8 @@ async fn janus_in_process_sumvec_dp_noise() {
         .min_batch_size
         .try_into()
         .unwrap();
-    let measurements = iter::repeat(vec![0; VECTOR_LENGTH])
-        .take(total_measurements)
-        .collect::<Vec<_>>();
+    let measurements =
+        iter::repeat_n(vec![0; VECTOR_LENGTH], total_measurements).collect::<Vec<_>>();
     let client_implementation = ClientBackend::InProcess
         .build(
             TEST_NAME,
@@ -637,7 +638,9 @@ async fn janus_in_process_sumvec_dp_noise() {
     // noise values will be zero simultaneously.
     assert_ne!(aggregate_result, un_noised_result);
 
-    assert!(aggregate_result
-        .iter()
-        .all(|x| *x < Field128::modulus() / 4 || *x > Field128::modulus() / 4 * 3));
+    assert!(
+        aggregate_result
+            .iter()
+            .all(|x| *x < Field128::modulus() / 4 || *x > Field128::modulus() / 4 * 3)
+    );
 }

--- a/integration_tests/tests/integration/simulation/arbitrary.rs
+++ b/integration_tests/tests/integration/simulation/arbitrary.rs
@@ -9,12 +9,12 @@ use std::cmp::max;
 use janus_aggregator_core::task::AggregationMode;
 use janus_core::time::{DurationExt, TimeExt};
 use janus_messages::{CollectionJobId, Duration, Interval, Time};
-use quickcheck::{empty_shrinker, Arbitrary, Gen};
+use quickcheck::{Arbitrary, Gen, empty_shrinker};
 use rand::random;
 
 use crate::simulation::{
-    model::{Config, Input, Op},
     START_TIME,
+    model::{Config, Input, Op},
 };
 
 impl Arbitrary for Config {

--- a/integration_tests/tests/integration/simulation/bad_client.rs
+++ b/integration_tests/tests/integration/simulation/bad_client.rs
@@ -5,8 +5,8 @@ use janus_aggregator::aggregator::http_handlers::AggregatorHandlerBuilder;
 use janus_aggregator_core::{
     datastore::{models::HpkeKeyState, test_util::ephemeral_datastore},
     task::{
-        test_util::{Task, TaskBuilder},
         AggregationMode,
+        test_util::{Task, TaskBuilder},
     },
     test_util::noop_meter,
 };
@@ -17,7 +17,7 @@ use janus_core::{
     retries::retry_http_request,
     test_util::{install_test_trace_subscriber, runtime::TestRuntime},
     time::{Clock, RealClock, TimeExt},
-    vdaf::{vdaf_application_context, vdaf_dp_strategies, VdafInstance, VERIFY_KEY_LENGTH_PRIO3},
+    vdaf::{VERIFY_KEY_LENGTH_PRIO3, VdafInstance, vdaf_application_context, vdaf_dp_strategies},
 };
 use janus_messages::{
     HpkeConfig, HpkeConfigList, InputShareAad, PlaintextInputShare, Report, ReportId,
@@ -26,14 +26,14 @@ use janus_messages::{
 use prio::{
     codec::{Decode, Encode, ParameterizedDecode},
     field::{Field128, FieldElement},
-    flp::{gadgets::ParallelSum, types::Histogram, Flp},
+    flp::{Flp, gadgets::ParallelSum, types::Histogram},
     vdaf::{
-        prio3::{optimal_chunk_length, Prio3, Prio3Histogram, Prio3InputShare, Prio3PublicShare},
-        xof::{Seed, Xof, XofTurboShake128},
         AggregateShare, Aggregator, Client as _, Collector, PrepareTransition, Vdaf,
+        prio3::{Prio3, Prio3Histogram, Prio3InputShare, Prio3PublicShare, optimal_chunk_length},
+        xof::{Seed, Xof, XofTurboShake128},
     },
 };
-use rand::{distr::StandardUniform, random, rng, Rng};
+use rand::{Rng, distr::StandardUniform, random, rng};
 use std::{net::Ipv4Addr, sync::Arc};
 use tokio::net::TcpListener;
 use trillium_tokio::Stopper;

--- a/integration_tests/tests/integration/simulation/quicktest.rs
+++ b/integration_tests/tests/integration/simulation/quicktest.rs
@@ -122,5 +122,5 @@ fn new_quick_check() -> QuickCheck {
         .ok()
         .and_then(|arg| arg.parse().ok())
         .unwrap_or(400);
-    quick_check.gen(Gen::new(gen_size))
+    quick_check.r#gen(Gen::new(gen_size))
 }

--- a/integration_tests/tests/integration/simulation/reproduction.rs
+++ b/integration_tests/tests/integration/simulation/reproduction.rs
@@ -4,9 +4,9 @@ use janus_messages::{Duration, Interval, Time};
 use rand::random;
 
 use crate::simulation::{
+    START_TIME,
     model::{Config, Input, Op, Query},
     run::Simulation,
-    START_TIME,
 };
 
 #[test]

--- a/integration_tests/tests/integration/simulation/run.rs
+++ b/integration_tests/tests/integration/simulation/run.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     ops::ControlFlow,
-    panic::{catch_unwind, AssertUnwindSafe},
+    panic::{AssertUnwindSafe, catch_unwind},
     sync::Arc,
     time::{Duration as StdDuration, Instant},
 };
@@ -11,33 +11,33 @@ use futures::future::join_all;
 use janus_aggregator::aggregator;
 use janus_aggregator_core::{
     datastore::models::AggregatorRole,
-    task::{test_util::Task, AggregatorTask},
+    task::{AggregatorTask, test_util::Task},
     test_util::noop_meter,
 };
 use janus_collector::{Collection, CollectionJob, PollResult};
 use janus_core::{
     test_util::runtime::TestRuntimeManager,
     time::{Clock, MockClock},
-    vdaf::{vdaf_dp_strategies, VdafInstance},
+    vdaf::{VdafInstance, vdaf_dp_strategies},
 };
 use janus_messages::{
-    batch_mode::{LeaderSelected, TimeInterval},
     CollectionJobId, Duration, Time,
+    batch_mode::{LeaderSelected, TimeInterval},
 };
 use opentelemetry::metrics::Meter;
-use prio::vdaf::prio3::{optimal_chunk_length, Prio3, Prio3Histogram};
+use prio::vdaf::prio3::{Prio3, Prio3Histogram, optimal_chunk_length};
 use quickcheck::TestResult;
 use tokio::time::timeout;
-use tracing::{debug, error, info, info_span, warn, Instrument};
+use tracing::{Instrument, debug, error, info, info_span, warn};
 use trillium_tokio::Stopper;
 
 use crate::simulation::{
+    START_TIME,
     bad_client::{
         upload_replay_report, upload_report_invalid_measurement, upload_report_not_rounded,
     },
     model::{Input, Op, Query},
     setup::Components,
-    START_TIME,
 };
 
 pub(super) const MAX_REPORTS: usize = 400;

--- a/integration_tests/tests/integration/simulation/setup.rs
+++ b/integration_tests/tests/integration/simulation/setup.rs
@@ -7,14 +7,13 @@ use crate::simulation::{
 use futures::future::BoxFuture;
 use janus_aggregator::{
     aggregator::{
-        self,
+        self, Config as AggregatorConfig,
         aggregation_job_creator::AggregationJobCreator,
         aggregation_job_driver::AggregationJobDriver,
         collection_job_driver::{CollectionJobDriver, RetryStrategy},
         garbage_collector::GarbageCollector,
         http_handlers::AggregatorHandlerBuilder,
         key_rotator::KeyRotator,
-        Config as AggregatorConfig,
     },
     cache::{
         HpkeKeypairCache, TASK_AGGREGATOR_CACHE_DEFAULT_CAPACITY, TASK_AGGREGATOR_CACHE_DEFAULT_TTL,
@@ -22,21 +21,20 @@ use janus_aggregator::{
 };
 use janus_aggregator_core::{
     datastore::{
-        self,
+        self, Datastore,
         models::{AcquiredAggregationJob, AcquiredCollectionJob, Lease},
-        test_util::{ephemeral_datastore, EphemeralDatastore},
-        Datastore,
+        test_util::{EphemeralDatastore, ephemeral_datastore},
     },
     task::{
-        test_util::{Task, TaskBuilder},
         BatchMode,
+        test_util::{Task, TaskBuilder},
     },
 };
-use janus_client::{default_http_client, Client};
+use janus_client::{Client, default_http_client};
 use janus_collector::Collector;
 use janus_core::{
-    retries::ExponentialWithTotalDelayBuilder, test_util::runtime::TestRuntime, time::MockClock,
-    Runtime,
+    Runtime, retries::ExponentialWithTotalDelayBuilder, test_util::runtime::TestRuntime,
+    time::MockClock,
 };
 use prio::vdaf::prio3::Prio3Histogram;
 use std::{

--- a/interop_binaries/src/commands/janus_interop_aggregator.rs
+++ b/interop_binaries/src/commands/janus_interop_aggregator.rs
@@ -1,19 +1,19 @@
 use crate::{
-    status::{ERROR, SUCCESS},
     AddTaskResponse, AggregatorAddTaskRequest, AggregatorRole,
+    status::{ERROR, SUCCESS},
 };
 use anyhow::Context;
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use clap::Parser;
 use futures::future::try_join_all;
 use janus_aggregator::{
-    binary_utils::{janus_main, BinaryOptions, CommonBinaryOptions},
+    binary_utils::{BinaryOptions, CommonBinaryOptions, janus_main},
     config::{BinaryConfig, CommonConfig},
 };
 use janus_aggregator_core::{
+    SecretBytes,
     datastore::Datastore,
     task::{self, AggregationMode, AggregatorTask, AggregatorTaskParameters},
-    SecretBytes,
 };
 use janus_core::{
     auth_tokens::{AuthenticationToken, AuthenticationTokenHash},
@@ -25,8 +25,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{net::SocketAddr, sync::Arc};
 use trillium::{Conn, Handler, Status};
-use trillium_api::{api, ApiConnExt, Json};
-use trillium_proxy::{upstream::IntoUpstreamSelector, Client, Proxy};
+use trillium_api::{ApiConnExt, Json, api};
+use trillium_proxy::{Client, Proxy, upstream::IntoUpstreamSelector};
 use trillium_router::Router;
 use trillium_tokio::ClientConfig;
 use url::Url;
@@ -63,7 +63,7 @@ async fn handle_add_task(
 
     let aggregator_parameters = match (request.role, request.collector_authentication_token) {
         (AggregatorRole::Leader, None) => {
-            return Err(anyhow::anyhow!("collector authentication token is missing"))
+            return Err(anyhow::anyhow!("collector authentication token is missing"));
         }
         (AggregatorRole::Leader, Some(collector_authentication_token)) => {
             AggregatorTaskParameters::Leader {
@@ -94,7 +94,7 @@ async fn handle_add_task(
             return Err(anyhow::anyhow!(
                 "invalid batch mode: {}",
                 request.batch_mode
-            ))
+            ));
         }
     };
 
@@ -202,9 +202,7 @@ pub struct Options {
 
 impl BinaryOptions for Options {
     fn common_options(&self) -> &CommonBinaryOptions {
-        {
-            &self.common
-        }
+        &self.common
     }
 }
 

--- a/interop_binaries/src/commands/janus_interop_client.rs
+++ b/interop_binaries/src/commands/janus_interop_client.rs
@@ -1,20 +1,19 @@
 use crate::{
-    install_tracing_subscriber,
+    ErrorHandler, NumberAsString, VdafObject, install_tracing_subscriber,
     status::{ERROR, SUCCESS},
-    ErrorHandler, NumberAsString, VdafObject,
 };
 use anyhow::Context;
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use clap::Parser;
 use educe::Educe;
 #[cfg(feature = "fpvec_bounded_l2")]
 use fixed::{
-    types::extra::{U15, U31},
     FixedI16, FixedI32,
+    types::extra::{U15, U31},
 };
 #[cfg(feature = "fpvec_bounded_l2")]
 use janus_core::vdaf::Prio3FixedPointBoundedL2VecSumBitSize;
-use janus_core::vdaf::{new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128, VdafInstance};
+use janus_core::vdaf::{VdafInstance, new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128};
 use janus_messages::{Duration, TaskId, Time};
 #[cfg(feature = "fpvec_bounded_l2")]
 use prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSumMultithreaded;
@@ -27,7 +26,7 @@ use prio::{
 use serde::{Deserialize, Serialize};
 use std::{fmt::Display, net::Ipv4Addr, str::FromStr};
 use trillium::{Conn, Handler};
-use trillium_api::{api, Json, State};
+use trillium_api::{Json, State, api};
 use trillium_router::Router;
 use url::Url;
 

--- a/interop_binaries/src/commands/janus_interop_collector.rs
+++ b/interop_binaries/src/commands/janus_interop_collector.rs
@@ -1,10 +1,10 @@
 use crate::{
+    ErrorHandler, HpkeConfigRegistry, Keyring, NumberAsString, VdafObject,
     install_tracing_subscriber,
     status::{COMPLETE, ERROR, IN_PROGRESS, SUCCESS},
-    ErrorHandler, HpkeConfigRegistry, Keyring, NumberAsString, VdafObject,
 };
 use anyhow::Context;
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use clap::Parser;
 use educe::Educe;
 #[cfg(feature = "fpvec_bounded_l2")]
@@ -20,8 +20,8 @@ use janus_core::{
     vdaf::new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128,
 };
 use janus_messages::{
-    batch_mode::BatchMode, BatchId, Duration, HpkeConfig, Interval, PartialBatchSelector, Query,
-    TaskId, Time,
+    BatchId, Duration, HpkeConfig, Interval, PartialBatchSelector, Query, TaskId, Time,
+    batch_mode::BatchMode,
 };
 #[cfg(feature = "fpvec_bounded_l2")]
 use prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSum;
@@ -34,14 +34,14 @@ use rand::{distr::StandardUniform, prelude::Distribution, random};
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{hash_map::Entry, HashMap},
+    collections::{HashMap, hash_map::Entry},
     net::Ipv4Addr,
     sync::Arc,
     time::Duration as StdDuration,
 };
 use tokio::{sync::Mutex, task::JoinHandle};
 use trillium::{Conn, Handler};
-use trillium_api::{api, Json, State};
+use trillium_api::{Json, State, api};
 use trillium_router::Router;
 
 #[derive(Educe, Deserialize)]
@@ -286,7 +286,7 @@ async fn handle_collection_start(
             return Err(anyhow::anyhow!(
                 "unsupported batch mode: {}",
                 request.query.batch_mode
-            ))
+            ));
         }
     };
 

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -1,25 +1,25 @@
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use educe::Educe;
-use janus_aggregator_core::task::{test_util::Task, BatchMode};
+use janus_aggregator_core::task::{BatchMode, test_util::Task};
 #[cfg(feature = "fpvec_bounded_l2")]
 use janus_core::vdaf::Prio3FixedPointBoundedL2VecSumBitSize;
 use janus_core::{
     hpke::HpkeKeypair,
-    vdaf::{vdaf_dp_strategies, VdafInstance},
+    vdaf::{VdafInstance, vdaf_dp_strategies},
 };
 use janus_messages::{
-    batch_mode::{BatchMode as _, LeaderSelected, TimeInterval},
     HpkeAeadId, HpkeConfigId, HpkeKdfId, HpkeKemId, Role, TaskId, Time,
+    batch_mode::{BatchMode as _, LeaderSelected, TimeInterval},
 };
 use prio::codec::Encode;
 use rand::random;
-use serde::{de::Visitor, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Visitor};
 use std::{
     collections::HashMap,
     env::{self, VarError},
     fmt::Display,
-    fs::{create_dir_all, File},
-    io::{stderr, Write},
+    fs::{File, create_dir_all},
+    io::{Write, stderr},
     marker::PhantomData,
     ops::Deref,
     path::PathBuf,
@@ -30,8 +30,8 @@ use std::{
 use testcontainers::{ContainerAsync, Image};
 use tokio::sync::Mutex;
 use tracing_log::LogTracer;
-use tracing_subscriber::{prelude::*, EnvFilter, Registry};
-use trillium::{async_trait, Conn, Handler, Status};
+use tracing_subscriber::{EnvFilter, Registry, prelude::*};
+use trillium::{Conn, Handler, Status, async_trait};
 use trillium_api::ApiConnExt;
 use url::Url;
 

--- a/interop_binaries/src/testcontainer.rs
+++ b/interop_binaries/src/testcontainer.rs
@@ -4,7 +4,7 @@
 //! and provide them.
 
 use std::env;
-use testcontainers::{core::WaitFor, Image};
+use testcontainers::{Image, core::WaitFor};
 
 // Note that testcontainers always assembles image names in the format "$NAME:$TAG". Images will
 // typically be provided as digests, of the form "sha256:$HASH". We will parse these into a 'name'

--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "testcontainer")]
 
 use backon::{BackoffBuilder, ExponentialBuilder};
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use fixed::types::{I1F15, I1F31};
 use futures::future::join_all;
 use janus_core::{
@@ -11,21 +11,20 @@ use janus_core::{
     vdaf::VERIFY_KEY_LENGTH_PRIO3,
 };
 use janus_interop_binaries::{
-    get_rust_log_level,
+    ContainerLogsDropGuard, get_rust_log_level,
     test_util::{await_ready_ok, generate_network_name, generate_unique_name},
     testcontainer::{Aggregator, Client, Collector},
-    ContainerLogsDropGuard,
 };
 use janus_messages::{
-    batch_mode::{BatchMode, LeaderSelected, TimeInterval},
     Duration, TaskId,
+    batch_mode::{BatchMode, LeaderSelected, TimeInterval},
 };
 use prio::codec::Encode;
 use rand::random;
-use reqwest::{header::CONTENT_TYPE, StatusCode, Url};
-use serde_json::{json, Value};
+use reqwest::{StatusCode, Url, header::CONTENT_TYPE};
+use serde_json::{Value, json};
 use std::time::Duration as StdDuration;
-use testcontainers::{runners::AsyncRunner, ContainerRequest, ImageExt};
+use testcontainers::{ContainerRequest, ImageExt, runners::AsyncRunner};
 use tokio::time::sleep;
 
 const JSON_MEDIA_TYPE: &str = "application/json";

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -5,21 +5,21 @@
 
 use self::batch_mode::{BatchMode, LeaderSelected, TimeInterval};
 use anyhow::anyhow;
-use base64::{display::Base64Display, engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, display::Base64Display, engine::general_purpose::URL_SAFE_NO_PAD};
 use core::slice;
 use educe::Educe;
 use num_enum::{FromPrimitive, IntoPrimitive, TryFromPrimitive};
 use prio::{
     codec::{
-        decode_u16_items, decode_u32_items, encode_u16_items, encode_u32_items, CodecError, Decode,
-        Encode,
+        CodecError, Decode, Encode, decode_u16_items, decode_u32_items, encode_u16_items,
+        encode_u32_items,
     },
     topology::ping_pong::PingPongMessage,
 };
-use rand::{distr::StandardUniform, prelude::Distribution, Rng};
+use rand::{Rng, distr::StandardUniform, prelude::Distribution};
 use serde::{
-    de::{self, Visitor},
     Deserialize, Serialize, Serializer,
+    de::{self, Visitor},
 };
 use std::{
     fmt::{self, Debug, Display, Formatter},

--- a/messages/src/taskprov.rs
+++ b/messages/src/taskprov.rs
@@ -2,12 +2,12 @@
 //!
 //! [1]: https://datatracker.ietf.org/doc/draft-wang-ppm-dap-taskprov/
 
-use crate::{batch_mode, Duration, Error, Time, Url};
+use crate::{Duration, Error, Time, Url, batch_mode};
 use anyhow::anyhow;
 use num_enum::TryFromPrimitive;
 use prio::codec::{
-    decode_u16_items, decode_u8_items, encode_u16_items, encode_u8_items, CodecError, Decode,
-    Encode,
+    CodecError, Decode, Encode, decode_u8_items, decode_u16_items, encode_u8_items,
+    encode_u16_items,
 };
 use std::{fmt::Debug, io::Cursor};
 
@@ -402,7 +402,7 @@ impl Decode for VdafConfig {
             val => {
                 return Err(CodecError::Other(
                     anyhow!("unexpected VDAF type code value {}", val).into(),
-                ))
+                ));
             }
         };
 
@@ -502,9 +502,8 @@ impl Decode for TaskbindExtensionType {
 #[cfg(test)]
 mod tests {
     use crate::{
-        batch_mode, roundtrip_encoding,
+        Duration, Time, Url, batch_mode, roundtrip_encoding,
         taskprov::{TaskConfig, TaskbindExtension, TaskbindExtensionType, VdafConfig},
-        Duration, Time, Url,
     };
     use assert_matches::assert_matches;
     use prio::codec::{CodecError, Decode as _};

--- a/messages/src/tests/aggregation.rs
+++ b/messages/src/tests/aggregation.rs
@@ -1,8 +1,8 @@
 use crate::{
-    roundtrip_encoding, AggregationJobContinueReq, AggregationJobInitializeReq, AggregationJobResp,
-    AggregationJobStep, BatchId, Extension, ExtensionType, HpkeCiphertext, HpkeConfigId,
-    LeaderSelected, PartialBatchSelector, PrepareContinue, PrepareInit, PrepareResp,
-    PrepareStepResult, ReportError, ReportId, ReportMetadata, ReportShare, Time,
+    AggregationJobContinueReq, AggregationJobInitializeReq, AggregationJobResp, AggregationJobStep,
+    BatchId, Extension, ExtensionType, HpkeCiphertext, HpkeConfigId, LeaderSelected,
+    PartialBatchSelector, PrepareContinue, PrepareInit, PrepareResp, PrepareStepResult,
+    ReportError, ReportId, ReportMetadata, ReportShare, Time, roundtrip_encoding,
 };
 use prio::topology::ping_pong::PingPongMessage;
 

--- a/messages/src/tests/collection.rs
+++ b/messages/src/tests/collection.rs
@@ -1,8 +1,7 @@
 use crate::{
-    roundtrip_encoding, AggregateShare, AggregateShareAad, AggregateShareReq, BatchId,
-    BatchSelector, CollectionJobReq, CollectionJobResp, Duration, HpkeCiphertext, HpkeConfigId,
-    Interval, LeaderSelected, PartialBatchSelector, Query, ReportIdChecksum, TaskId, Time,
-    TimeInterval,
+    AggregateShare, AggregateShareAad, AggregateShareReq, BatchId, BatchSelector, CollectionJobReq,
+    CollectionJobResp, Duration, HpkeCiphertext, HpkeConfigId, Interval, LeaderSelected,
+    PartialBatchSelector, Query, ReportIdChecksum, TaskId, Time, TimeInterval, roundtrip_encoding,
 };
 use prio::codec::Decode;
 

--- a/messages/src/tests/common.rs
+++ b/messages/src/tests/common.rs
@@ -1,7 +1,7 @@
-use crate::{roundtrip_encoding, Duration, Interval, Role, TaskId, Time, Url};
+use crate::{Duration, Interval, Role, TaskId, Time, Url, roundtrip_encoding};
 use assert_matches::assert_matches;
 use prio::codec::{CodecError, Decode, Encode};
-use serde_test::{assert_de_tokens_error, assert_tokens, Token};
+use serde_test::{Token, assert_de_tokens_error, assert_tokens};
 
 #[test]
 fn roundtrip_url() {

--- a/messages/src/tests/hpke.rs
+++ b/messages/src/tests/hpke.rs
@@ -1,8 +1,8 @@
 use crate::{
-    roundtrip_encoding, HpkeAeadId, HpkeCiphertext, HpkeConfig, HpkeConfigId, HpkeConfigList,
-    HpkeKdfId, HpkeKemId, HpkePublicKey,
+    HpkeAeadId, HpkeCiphertext, HpkeConfig, HpkeConfigId, HpkeConfigList, HpkeKdfId, HpkeKemId,
+    HpkePublicKey, roundtrip_encoding,
 };
-use serde_test::{assert_de_tokens_error, assert_tokens, Token};
+use serde_test::{Token, assert_de_tokens_error, assert_tokens};
 
 #[test]
 fn roundtrip_hpke_config_id() {

--- a/messages/src/tests/query.rs
+++ b/messages/src/tests/query.rs
@@ -1,6 +1,6 @@
 use crate::{
-    batch_mode, roundtrip_encoding, BatchId, Duration, Interval, LeaderSelected, Query, TaskId,
-    Time, TimeInterval,
+    BatchId, Duration, Interval, LeaderSelected, Query, TaskId, Time, TimeInterval, batch_mode,
+    roundtrip_encoding,
 };
 
 #[test]

--- a/messages/src/tests/upload.rs
+++ b/messages/src/tests/upload.rs
@@ -1,6 +1,6 @@
 use crate::{
-    roundtrip_encoding, Extension, ExtensionType, HpkeCiphertext, HpkeConfigId, InputShareAad,
-    PlaintextInputShare, Report, ReportId, ReportMetadata, TaskId, Time,
+    Extension, ExtensionType, HpkeCiphertext, HpkeConfigId, InputShareAad, PlaintextInputShare,
+    Report, ReportId, ReportMetadata, TaskId, Time, roundtrip_encoding,
 };
 
 #[test]

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -1,36 +1,36 @@
 use anyhow::Context;
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use clap::{
+    Args, CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum,
     builder::{NonEmptyStringValueParser, StringValueParser, TypedValueParser},
     error::ErrorKind,
-    Args, CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum,
 };
 #[cfg(feature = "fpvec_bounded_l2")]
 use fixed::types::extra::{U15, U31};
 #[cfg(feature = "fpvec_bounded_l2")]
 use fixed::{FixedI16, FixedI32};
 use janus_collector::{
-    default_http_client, AuthenticationToken, Collection, CollectionJob, Collector, PollResult,
-    PrivateCollectorCredential,
+    AuthenticationToken, Collection, CollectionJob, Collector, PollResult,
+    PrivateCollectorCredential, default_http_client,
 };
 use janus_core::{
     hpke::{HpkeKeypair, HpkePrivateKey},
     retries::ExponentialWithTotalDelayBuilder,
 };
 use janus_messages::{
-    batch_mode::{BatchMode, LeaderSelected, TimeInterval},
     CollectionJobId, Duration, HpkeConfig, Interval, PartialBatchSelector, Query, TaskId, Time,
+    batch_mode::{BatchMode, LeaderSelected, TimeInterval},
 };
 #[cfg(feature = "fpvec_bounded_l2")]
 use prio::vdaf::prio3::Prio3FixedPointBoundedL2VecSum;
 use prio::{
     codec::Decode,
-    vdaf::{self, prio3::Prio3, Vdaf},
+    vdaf::{self, Vdaf, prio3::Prio3},
 };
 use rand::random;
 use std::{fmt::Debug, fs::File, path::PathBuf, process::exit, time::Duration as StdDuration};
 use tracing_log::LogTracer;
-use tracing_subscriber::{prelude::*, EnvFilter, Registry};
+use tracing_subscriber::{EnvFilter, Registry, prelude::*};
 use url::Url;
 
 /// Enum to propagate errors through this program. Clap errors are handled separately from all
@@ -684,7 +684,7 @@ trait BatchModeExt: BatchMode {
     const IS_PARTIAL_BATCH_SELECTOR_TRIVIAL: bool;
 
     fn format_partial_batch_selector(partial_batch_selector: &PartialBatchSelector<Self>)
-        -> String;
+    -> String;
 }
 
 impl BatchModeExt for TimeInterval {
@@ -708,12 +708,12 @@ impl BatchModeExt for LeaderSelected {
 #[cfg(test)]
 mod tests {
     use crate::{
-        run, AuthenticationOptions, AuthenticationToken, Error, HpkeConfigOptions, Options,
-        QueryOptions, Subcommands, VdafType,
+        AuthenticationOptions, AuthenticationToken, Error, HpkeConfigOptions, Options,
+        QueryOptions, Subcommands, VdafType, run,
     };
     use assert_matches::assert_matches;
-    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-    use clap::{error::ErrorKind, CommandFactory, Parser};
+    use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+    use clap::{CommandFactory, Parser, error::ErrorKind};
     use janus_collector::PrivateCollectorCredential;
     use janus_core::{
         auth_tokens::{BearerToken, DapAuthToken},

--- a/tools/src/bin/dap_decode.rs
+++ b/tools/src/bin/dap_decode.rs
@@ -1,15 +1,15 @@
 use anyhow::Result;
 use clap::{Parser, ValueEnum};
 use janus_messages::{
-    batch_mode::{LeaderSelected, TimeInterval},
     AggregateShare, AggregateShareReq, AggregationJobContinueReq, AggregationJobInitializeReq,
     AggregationJobResp, CollectionJobReq, CollectionJobResp, HpkeConfig, HpkeConfigList, Report,
+    batch_mode::{LeaderSelected, TimeInterval},
 };
 use prio::codec::Decode;
 use std::{
     fmt::Debug,
     fs::File,
-    io::{stdin, Read},
+    io::{Read, stdin},
 };
 
 fn main() -> Result<()> {

--- a/tools/src/bin/hpke_keygen.rs
+++ b/tools/src/bin/hpke_keygen.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use clap::Parser;
 use janus_core::{
     cli::{AeadAlgorithm, KdfAlgorithm, KemAlgorithm},
@@ -8,7 +8,7 @@ use janus_core::{
 use janus_messages::HpkeConfigId;
 use prio::codec::Encode;
 use serde_yaml::to_writer;
-use std::io::{stdout, Write};
+use std::io::{Write, stdout};
 
 fn main() -> Result<()> {
     let options = Options::parse();

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use clap::{Args, Parser};
 use serde::Deserialize;
 use std::{


### PR DESCRIPTION
This PR is rather noisy because `cargo fmt`'s opinions about how to order `use` statements and some other syntax points have changed: whether to use semicolons in some places and I think formatting inside macros? I don't love how much history is tainted by this change, but we'll have to go to the 2024 edition someday, so we may as well bite the bullet. To highlight some non-perfunctory changes:

- clippy: replace a few cases of `Iterator.repeat().take()` with `Iterator.repeat_n`
- Dockerfiles: move to Rust 1.88 and update `cargo-chef` to 1.71. We were on 1.60, which for one reason or another doesn't recognize the 2024 edition.
- I had to use the new `use<..>` syntax in a couple places where the compiler directed me to ([RPIT lifetime capture rules](https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html))
- aggregator_api: changed the function signature of `auth_check` to return `Option<..>` instead of `impl Handler` due to changes to [RPIT lifetime capture rules](https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html)
- `gen` keyword is now reserved, so we have to escape a call to a method of that name as `r#gen`