### PR TITLE
`janus_client`: cache HPKE configurations

### DIFF
--- a/client/src/tests/mod.rs
+++ b/client/src/tests/mod.rs
@@ -1,4 +1,4 @@
-use crate::{aggregator_hpke_config, default_http_client, Client, ClientParameters, Error};
+use crate::{default_http_client, Client, ClientParameters, Error, HpkeConfiguration};
 use assert_matches::assert_matches;
 use hex_literal::hex;
 use http::{header::CONTENT_TYPE, StatusCode};
@@ -186,7 +186,12 @@ async fn report_timestamp() {
     client.parameters.time_precision = Duration::from_seconds(100);
     assert_eq!(
         client
-            .prepare_report(&true, &Time::from_seconds_since_epoch(101))
+            .prepare_report(
+                &true,
+                &Time::from_seconds_since_epoch(101),
+                client.leader_hpke_config.lock().await.get().await.unwrap(),
+                client.helper_hpke_config.lock().await.get().await.unwrap(),
+            )
             .unwrap()
             .metadata()
             .time(),
@@ -195,7 +200,12 @@ async fn report_timestamp() {
 
     assert_eq!(
         client
-            .prepare_report(&true, &Time::from_seconds_since_epoch(5200))
+            .prepare_report(
+                &true,
+                &Time::from_seconds_since_epoch(5200),
+                client.leader_hpke_config.lock().await.get().await.unwrap(),
+                client.helper_hpke_config.lock().await.get().await.unwrap(),
+            )
             .unwrap()
             .metadata()
             .time(),
@@ -204,7 +214,12 @@ async fn report_timestamp() {
 
     assert_eq!(
         client
-            .prepare_report(&true, &Time::from_seconds_since_epoch(9814))
+            .prepare_report(
+                &true,
+                &Time::from_seconds_since_epoch(9814),
+                client.leader_hpke_config.lock().await.get().await.unwrap(),
+                client.helper_hpke_config.lock().await.get().await.unwrap(),
+            )
             .unwrap()
             .metadata()
             .time(),
@@ -213,56 +228,9 @@ async fn report_timestamp() {
 }
 
 #[tokio::test]
-async fn aggregator_hpke() {
-    install_test_trace_subscriber();
-    let mut server = mockito::Server::new_async().await;
-    let server_url = Url::parse(&server.url()).unwrap();
-    let http_client = &default_http_client().unwrap();
-    let mut client_parameters = ClientParameters::new(
-        random(),
-        server_url.clone(),
-        server_url,
-        Duration::from_seconds(1),
-    );
-    client_parameters.http_request_retry_parameters = test_http_request_exponential_backoff();
-
-    let keypair = HpkeKeypair::test();
-    let hpke_config_list = HpkeConfigList::new(Vec::from([keypair.config().clone()]));
-    let mock = server
-        .mock(
-            "GET",
-            format!("/hpke_config?task_id={}", &client_parameters.task_id).as_str(),
-        )
-        .with_status(200)
-        .with_header(CONTENT_TYPE.as_str(), HpkeConfigList::MEDIA_TYPE)
-        .with_body(hpke_config_list.get_encoded().unwrap())
-        .expect(1)
-        .create_async()
-        .await;
-
-    let got_hpke_config =
-        aggregator_hpke_config(None, &client_parameters, &Role::Leader, http_client)
-            .await
-            .unwrap();
-    assert_eq!(&got_hpke_config, keypair.config());
-
-    // Fetching HPKE config again should not hit the mock server
-    let got_hpke_config = aggregator_hpke_config(
-        Some(got_hpke_config),
-        &client_parameters,
-        &Role::Leader,
-        http_client,
-    )
-    .await
-    .unwrap();
-    assert_eq!(&got_hpke_config, keypair.config());
-
-    mock.assert_async().await;
-}
-
-#[tokio::test]
 async fn unsupported_hpke_algorithms() {
     install_test_trace_subscriber();
+
     let mut server = mockito::Server::new_async().await;
     let server_url = Url::parse(&server.url()).unwrap();
     let http_client = &default_http_client().unwrap();
@@ -308,11 +276,10 @@ async fn unsupported_hpke_algorithms() {
         .create_async()
         .await;
 
-    let got_hpke_config =
-        aggregator_hpke_config(None, &client_parameters, &Role::Leader, http_client)
-            .await
-            .unwrap();
-    assert_eq!(got_hpke_config, good_hpke_config);
+    let mut hpke_config = HpkeConfiguration::new(&client_parameters, &Role::Leader, http_client)
+        .await
+        .unwrap();
+    assert_eq!(hpke_config.get().await.unwrap(), &good_hpke_config);
 
     mock.assert_async().await;
 }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -30,6 +30,7 @@ test-util = [
     "prio/test-util",
     "tokio/macros",
     "tokio/sync",
+    "tokio/test-util",
 ]
 
 [dependencies]

--- a/core/src/http.rs
+++ b/core/src/http.rs
@@ -8,6 +8,10 @@ use std::fmt::{self, Display, Formatter};
 use tracing::warn;
 use trillium::{Conn, HeaderValue};
 
+pub mod cached_resource;
+#[cfg(test)]
+mod cached_resource_tests;
+
 /// This captures an HTTP status code and parsed problem details document from an HTTP response.
 #[derive(Debug)]
 pub struct HttpErrorResponse {

--- a/core/src/http/cached_resource.rs
+++ b/core/src/http/cached_resource.rs
@@ -1,0 +1,190 @@
+//! Fetch HTTP resources, honoring the `Cache-Control` header ([1]) provided by the server.
+//!
+//! [1]: https://datatracker.ietf.org/doc/html/rfc9111#section-5.2
+
+use crate::{http::HttpErrorResponse, retries::retry_http_request};
+use backoff::{exponential::ExponentialBackoff, SystemClock};
+use http::{
+    header::{CACHE_CONTROL, CONTENT_TYPE},
+    HeaderValue,
+};
+use prio::codec::Decode;
+use std::time::Duration;
+use tokio::time::Instant;
+use url::Url;
+
+/// Errors that may arise while managing cached HTTP resources.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("HTTP client error: {0}")]
+    HttpClient(#[from] reqwest::Error),
+    #[error("codec error: {0}")]
+    Codec(#[from] prio::codec::CodecError),
+    #[error("HTTP response status {0}")]
+    Http(Box<HttpErrorResponse>),
+    #[error("URL parse: {0}")]
+    Url(#[from] url::ParseError),
+    #[error("unexpected server response {0}")]
+    UnexpectedServerResponse(&'static str),
+}
+
+impl From<Result<HttpErrorResponse, reqwest::Error>> for Error {
+    fn from(result: Result<HttpErrorResponse, reqwest::Error>) -> Self {
+        match result {
+            Ok(http_error_response) => Error::Http(Box::new(http_error_response)),
+            Err(error) => error.into(),
+        }
+    }
+}
+
+/// A cached HTTP resource.
+#[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
+pub enum CachedResource<Resource> {
+    Static(Resource),
+    Refreshable(Refresher<Resource>),
+}
+
+impl<Resource: Decode> CachedResource<Resource> {
+    /// Fetch and cache the resource at the provided URL.
+    pub async fn new(
+        resource_url: Url,
+        expected_content_type: &'static str,
+        http_client: &reqwest::Client,
+        http_request_retry_parameters: ExponentialBackoff<SystemClock>,
+    ) -> Result<Self, Error> {
+        let (resource, expires_at) = Refresher::refresh(
+            http_client,
+            &http_request_retry_parameters,
+            &resource_url,
+            expected_content_type,
+        )
+        .await?;
+
+        Ok(Self::Refreshable(Refresher {
+            resource,
+            expires_at,
+            http_client: http_client.clone(),
+            http_request_retry_parameters: http_request_retry_parameters.clone(),
+            resource_url,
+            expected_content_type,
+        }))
+    }
+
+    /// Returns the cached resource. Refetches if it has expired.
+    pub async fn resource(&mut self) -> Result<&Resource, Error> {
+        match self {
+            Self::Refreshable(refresher) => refresher.resource().await,
+            Self::Static(ref resource) => Ok(resource),
+        }
+    }
+}
+
+/// Caches an HTTP resource based on the cache-control header provided by the server.
+#[derive(Debug, Clone)]
+pub struct Refresher<Resource> {
+    resource: Resource,
+    expires_at: Option<Instant>,
+    http_client: reqwest::Client,
+    resource_url: Url,
+    expected_content_type: &'static str,
+    http_request_retry_parameters: ExponentialBackoff<SystemClock>,
+}
+
+impl<Resource: Decode> Refresher<Resource> {
+    async fn resource(&mut self) -> Result<&Resource, Error> {
+        // Refresh if we are past expiration.
+        if self
+            .expires_at
+            .map(|expires_at| Instant::now() > expires_at)
+            // If no expiration is provided, use cached resource forever.
+            .unwrap_or(false)
+        {
+            (self.resource, self.expires_at) = Self::refresh(
+                &self.http_client,
+                &self.http_request_retry_parameters,
+                &self.resource_url,
+                self.expected_content_type,
+            )
+            .await?;
+        }
+
+        Ok(&self.resource)
+    }
+
+    async fn refresh(
+        http_client: &reqwest::Client,
+        http_request_retry_parameters: &ExponentialBackoff<SystemClock>,
+        resource_url: &Url,
+        expected_content_type: &'static str,
+    ) -> Result<(Resource, Option<Instant>), Error> {
+        let response = retry_http_request(http_request_retry_parameters.clone(), || async {
+            http_client.get(resource_url.clone()).send().await
+        })
+        .await?;
+        let status = response.status();
+        if !status.is_success() {
+            return Err(Error::Http(Box::new(HttpErrorResponse::from(status))));
+        }
+
+        let content_type =
+            response
+                .headers()
+                .get(CONTENT_TYPE)
+                .ok_or(Error::UnexpectedServerResponse(
+                    "no content type in server response",
+                ))?;
+        if content_type != expected_content_type {
+            return Err(Error::UnexpectedServerResponse(
+                "unexpected content type in server response",
+            ));
+        }
+
+        let expires_at = expires_at(response.headers().get_all(CACHE_CONTROL));
+
+        Ok((Resource::get_decoded(response.body())?, expires_at))
+    }
+}
+
+/// Parse the provided cache-control header values ([1]) and determine when the resource they were
+/// attached to expires, or None if the resource cannot be cached. This function only handles the
+/// "max-age" and "no-cache" response directives ([2]). If any unrecognized or malformed response
+/// directive is encountered, then the resource will not be cached.
+///
+/// [1]: https://datatracker.ietf.org/doc/html/rfc9111#section-5.2
+/// [2]: https://datatracker.ietf.org/doc/html/rfc9111#section-5.2.2
+pub(crate) fn expires_at<'a, I: IntoIterator<Item = &'a HeaderValue>>(
+    cache_control_directives: I,
+) -> Option<Instant> {
+    let mut expires_at = None;
+
+    for directive in cache_control_directives {
+        let directive = match directive.to_str() {
+            Ok(directive) => directive,
+            Err(_) => return None,
+        }
+        .to_lowercase();
+
+        // If we encounter no-cache, then regardless of other directives, never cache the resource.
+        if directive == "no-cache" {
+            return None;
+        }
+
+        if let Some(max_age) = directive.strip_prefix("max-age=") {
+            let parsed = match max_age.parse() {
+                Ok(parsed) => parsed,
+                Err(_) => return None,
+            };
+
+            if expires_at.is_some() {
+                return None;
+            }
+
+            expires_at = Instant::now().checked_add(Duration::from_secs(parsed));
+        } else {
+            return None;
+        }
+    }
+
+    expires_at
+}

--- a/core/src/http/cached_resource_tests.rs
+++ b/core/src/http/cached_resource_tests.rs
@@ -1,0 +1,195 @@
+use crate::{
+    http::cached_resource::{expires_at, CachedResource},
+    retries::test_util::test_http_request_exponential_backoff,
+    test_util::install_test_trace_subscriber,
+};
+use http::{
+    header::{CACHE_CONTROL, CONTENT_TYPE},
+    HeaderValue,
+};
+use janus_messages::Time;
+use prio::codec::Encode;
+use std::time::Duration;
+use tokio::time::Instant;
+use url::Url;
+
+#[tokio::test]
+async fn no_cache_control() {
+    install_test_trace_subscriber();
+    tokio::time::pause();
+
+    let mut server = mockito::Server::new_async().await;
+    let server_url = Url::parse(&server.url()).unwrap();
+    let http_client = reqwest::Client::builder().build().unwrap();
+
+    let time = Time::from_seconds_since_epoch(0);
+    let mock = server
+        .mock("GET", "/resource")
+        .with_status(200)
+        .with_body(time.get_encoded().unwrap())
+        .with_header(CONTENT_TYPE.as_str(), "time")
+        .expect(1)
+        .create_async()
+        .await;
+
+    // new() will fetch the resource from server. Because no cache-control is provided, resource()
+    // should not refetch.
+    let mut resource = CachedResource::<Time>::new(
+        server_url.join("resource").unwrap(),
+        "time",
+        &http_client,
+        test_http_request_exponential_backoff(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(resource.resource().await.unwrap(), &time);
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn with_cache_control() {
+    install_test_trace_subscriber();
+    tokio::time::pause();
+
+    let mut server = mockito::Server::new_async().await;
+    let server_url = Url::parse(&server.url()).unwrap();
+    let http_client = reqwest::Client::builder().build().unwrap();
+    let time = Time::from_seconds_since_epoch(0);
+    let mock = server
+        .mock("GET", "/resource")
+        .with_status(200)
+        .with_header(CACHE_CONTROL.as_str(), "max-age=86400")
+        .with_header(CONTENT_TYPE.as_str(), "time")
+        .with_body(time.get_encoded().unwrap())
+        .expect(2)
+        .create_async()
+        .await;
+
+    // new() will fetch the resource from the server. Because the cache is not expired, resource()
+    // should not refetch.
+    let mut resource = CachedResource::<Time>::new(
+        server_url.join("resource").unwrap(),
+        "time",
+        &http_client,
+        test_http_request_exponential_backoff(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(resource.resource().await.unwrap(), &time);
+
+    // Should not have two matches yet
+    assert!(!mock.matched());
+
+    // Advance time far enough to invalidate cache. resource() should refetch.
+    tokio::time::advance(Duration::from_secs(86401)).await;
+
+    assert_eq!(resource.resource().await.unwrap(), &time);
+
+    // Now we should have matched twice
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn malformed_cache_control() {
+    install_test_trace_subscriber();
+    tokio::time::pause();
+
+    let mut server = mockito::Server::new_async().await;
+    let server_url = Url::parse(&server.url()).unwrap();
+    let http_client = reqwest::Client::builder().build().unwrap();
+    let time = Time::from_seconds_since_epoch(0);
+    let mock = server
+        .mock("GET", "/resource")
+        .with_status(200)
+        .with_header(CACHE_CONTROL.as_str(), "malformed")
+        .with_header(CONTENT_TYPE.as_str(), "time")
+        .with_body(time.get_encoded().unwrap())
+        .expect(1)
+        .create_async()
+        .await;
+
+    // The cache control header should be ignored because it's malformed, meaning the resource will
+    // be fetched only once.
+    let mut resource = CachedResource::<Time>::new(
+        server_url.join("resource").unwrap(),
+        "time",
+        &http_client,
+        test_http_request_exponential_backoff(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(resource.resource().await.unwrap(), &time);
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn wrong_content_type() {
+    install_test_trace_subscriber();
+    tokio::time::pause();
+
+    let mut server = mockito::Server::new_async().await;
+    let server_url = Url::parse(&server.url()).unwrap();
+    let http_client = reqwest::Client::builder().build().unwrap();
+    let time = Time::from_seconds_since_epoch(0);
+    let mock = server
+        .mock("GET", "/resource")
+        .with_status(200)
+        .with_header(CACHE_CONTROL.as_str(), "malformed")
+        .with_header(CONTENT_TYPE.as_str(), "time")
+        .with_body(time.get_encoded().unwrap())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let _resource = CachedResource::<Time>::new(
+        server_url.join("resource").unwrap(),
+        "nottime",
+        &http_client,
+        test_http_request_exponential_backoff(),
+    )
+    .await
+    .unwrap_err();
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn static_resource() {
+    install_test_trace_subscriber();
+    tokio::time::pause();
+
+    // When a static resource is provided, the refresher shouldn't make any network requests
+    let time = Time::from_seconds_since_epoch(0);
+
+    let mut resource = CachedResource::<Time>::Static(time);
+    assert_eq!(resource.resource().await.unwrap(), &time);
+}
+
+#[rstest::rstest]
+#[case::no_cache(&["no-cache"], None)]
+#[case::max_age(&["max-age=1000"], Some(1000))]
+#[case::max_age_and_no_cache(&["max-age=1000", "no-cache"], None)]
+#[case::no_directive(&[], None)]
+#[case::unknown_directive(&["unknown"], None)]
+#[case::malformed_max_age(&["max-age=notanumber"], None)]
+#[case::multiple_max_age(&["max-age=1000", "max-age=999"], None)]
+// max_age = u64::MAX - 1000 + 1. Should overflow when added to the mock clock.
+#[case::max_age_overflow(&["max-age=18446744073709550616"], None)]
+#[tokio::test]
+async fn cache_control_expiry(#[case] headers: &[&str], #[case] output: Option<u64>) {
+    tokio::time::pause();
+
+    let now = Instant::now();
+
+    let header_values: Vec<_> = headers
+        .iter()
+        .map(|h| HeaderValue::from_str(h).unwrap())
+        .collect();
+
+    assert_eq!(
+        expires_at(&header_values),
+        output.map(|increment| now.checked_add(Duration::from_secs(increment)).unwrap())
+    );
+}


### PR DESCRIPTION
Adds a `janus_core::http::cached_resource` module which GETs an HTTP resource and then caches it, honoring the `no-cache` and `max-age` `cache-control` directives. We then use this in `janus_client` to cache HPKE configurations.

Part of #3159