### PR TITLE
`janus_messages`: introduce `MediaType` trait

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/aggregation_job_continue.rs
@@ -201,7 +201,9 @@ pub mod test_util {
     use crate::aggregator::http_handlers::test_util::{decode_response_body, take_problem_details};
     use assert_matches::assert_matches;
     use janus_aggregator_core::task::test_util::Task;
-    use janus_messages::{AggregationJobContinueReq, AggregationJobId, AggregationJobResp};
+    use janus_messages::{
+        AggregationJobContinueReq, AggregationJobId, AggregationJobResp, MediaType,
+    };
     use prio::codec::Encode;
     use serde_json::json;
     use trillium::{Handler, KnownHeaderName, Status};

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -42,7 +42,7 @@ use janus_core::{
     vdaf_dispatch,
 };
 use janus_messages::{
-    AggregationJobContinueReq, AggregationJobInitializeReq, AggregationJobResp,
+    AggregationJobContinueReq, AggregationJobInitializeReq, AggregationJobResp, MediaType,
     PartialBatchSelector, PrepareContinue, PrepareInit, PrepareResp, PrepareStepResult,
     ReportError, ReportMetadata, ReportShare, Role,
     batch_mode::{LeaderSelected, TimeInterval},

--- a/aggregator/src/aggregator/aggregation_job_driver/tests.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver/tests.rs
@@ -41,7 +41,7 @@ use janus_core::{
 };
 use janus_messages::{
     AggregationJobContinueReq, AggregationJobInitializeReq, AggregationJobResp, AggregationJobStep,
-    Duration, Extension, ExtensionType, Interval, PartialBatchSelector, PrepareContinue,
+    Duration, Extension, ExtensionType, Interval, MediaType, PartialBatchSelector, PrepareContinue,
     PrepareInit, PrepareResp, PrepareStepResult, ReportError, ReportIdChecksum, ReportMetadata,
     ReportShare, Role, Time,
     batch_mode::{LeaderSelected, TimeInterval},

--- a/aggregator/src/aggregator/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/aggregation_job_init.rs
@@ -456,8 +456,8 @@ pub mod test_util {
         time::{Clock, MockClock, TimeExt as _},
     };
     use janus_messages::{
-        AggregationJobId, AggregationJobInitializeReq, Extension, HpkeConfig, PrepareInit,
-        ReportMetadata, ReportShare,
+        AggregationJobId, AggregationJobInitializeReq, Extension, HpkeConfig, MediaType,
+        PrepareInit, ReportMetadata, ReportShare,
         batch_mode::{self},
     };
     use prio::{
@@ -637,8 +637,8 @@ mod tests {
     };
     use janus_messages::{
         AggregationJobId, AggregationJobInitializeReq, AggregationJobResp, Duration, Extension,
-        ExtensionType, PartialBatchSelector, PrepareResp, PrepareStepResult, ReportError,
-        ReportMetadata, batch_mode::TimeInterval,
+        ExtensionType, MediaType, PartialBatchSelector, PrepareResp, PrepareStepResult,
+        ReportError, ReportMetadata, batch_mode::TimeInterval,
     };
     use prio::{
         codec::Encode,

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -24,7 +24,7 @@ use janus_core::{
     vdaf_dispatch,
 };
 use janus_messages::{
-    AggregateShare, AggregateShareReq, BatchSelector,
+    AggregateShare, AggregateShareReq, BatchSelector, MediaType,
     batch_mode::{BatchMode, LeaderSelected, TimeInterval},
 };
 use opentelemetry::{
@@ -846,8 +846,8 @@ mod tests {
     };
     use janus_messages::{
         AggregateShare, AggregateShareReq, AggregationJobStep, BatchSelector, Duration,
-        HpkeCiphertext, HpkeConfigId, Interval, Query, ReportIdChecksum, batch_mode::TimeInterval,
-        problem_type::DapProblemType,
+        HpkeCiphertext, HpkeConfigId, Interval, MediaType, Query, ReportIdChecksum,
+        batch_mode::TimeInterval, problem_type::DapProblemType,
     };
     use prio::{
         codec::{Decode, Encode},

--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -29,7 +29,7 @@ use janus_core::{
 };
 use janus_messages::{
     AggregateShareAad, AggregationJobStep, BatchId, BatchSelector, CollectionJobId,
-    CollectionJobReq, CollectionJobResp, Interval, Query, Role, Time,
+    CollectionJobReq, CollectionJobResp, Interval, MediaType, Query, Role, Time,
     batch_mode::{BatchMode as BatchModeTrait, LeaderSelected, TimeInterval},
 };
 use prio::{

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -22,8 +22,8 @@ use janus_core::{
 use janus_messages::{
     AggregateShare, AggregateShareReq, AggregationJobContinueReq, AggregationJobId,
     AggregationJobInitializeReq, AggregationJobResp, AggregationJobStep, CollectionJobId,
-    CollectionJobReq, CollectionJobResp, HpkeConfigList, Report, TaskId, batch_mode::TimeInterval,
-    codec::Decode, problem_type::DapProblemType, taskprov::TaskConfig,
+    CollectionJobReq, CollectionJobResp, HpkeConfigList, MediaType, Report, TaskId,
+    batch_mode::TimeInterval, codec::Decode, problem_type::DapProblemType, taskprov::TaskConfig,
 };
 use mime::Mime;
 use opentelemetry::{

--- a/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
@@ -20,7 +20,7 @@ use janus_core::{
 };
 use janus_messages::{
     AggregateShare as AggregateShareMessage, AggregateShareAad, AggregateShareReq, BatchSelector,
-    Duration, Interval, ReportIdChecksum, Role, Time,
+    Duration, Interval, MediaType, ReportIdChecksum, Role, Time,
     batch_mode::{self, TimeInterval},
 };
 use prio::{

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_get.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_get.rs
@@ -17,8 +17,8 @@ use janus_core::{
     vdaf::VdafInstance,
 };
 use janus_messages::{
-    AggregationJobId, AggregationJobResp, AggregationJobStep, Interval, PrepareInit, PrepareResp,
-    PrepareStepResult, ReportMetadata, batch_mode::TimeInterval,
+    AggregationJobId, AggregationJobResp, AggregationJobStep, Interval, MediaType, PrepareInit,
+    PrepareResp, PrepareStepResult, ReportMetadata, batch_mode::TimeInterval,
 };
 use prio::vdaf::dummy;
 use rand::random;

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
@@ -28,8 +28,9 @@ use janus_core::{
 };
 use janus_messages::{
     AggregationJobId, AggregationJobInitializeReq, AggregationJobResp, Extension, ExtensionType,
-    HpkeCiphertext, HpkeConfigId, InputShareAad, Interval, PartialBatchSelector, PrepareInit,
-    PrepareStepResult, ReportError, ReportIdChecksum, ReportMetadata, ReportShare, Role, Time,
+    HpkeCiphertext, HpkeConfigId, InputShareAad, Interval, MediaType, PartialBatchSelector,
+    PrepareInit, PrepareStepResult, ReportError, ReportIdChecksum, ReportMetadata, ReportShare,
+    Role, Time,
     batch_mode::{LeaderSelected, TimeInterval},
 };
 use prio::{codec::Encode, vdaf::dummy};

--- a/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
@@ -14,7 +14,7 @@ use janus_core::{
 };
 use janus_messages::{
     AggregateShareAad, BatchSelector, CollectionJobId, CollectionJobReq, CollectionJobResp,
-    Duration, Interval, Query, Role, Time, batch_mode::TimeInterval,
+    Duration, Interval, MediaType, Query, Role, Time, batch_mode::TimeInterval,
 };
 use prio::{
     codec::{Decode, Encode},

--- a/aggregator/src/aggregator/http_handlers/tests/hpke_config.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/hpke_config.rs
@@ -20,7 +20,7 @@ use janus_core::{
     test_util::runtime::TestRuntime,
     vdaf::VdafInstance,
 };
-use janus_messages::{HpkeConfigId, HpkeConfigList, Role};
+use janus_messages::{HpkeConfigId, HpkeConfigList, MediaType, Role};
 use prio::codec::Decode as _;
 use std::{collections::HashMap, sync::Arc};
 use trillium::{KnownHeaderName, Status};

--- a/aggregator/src/aggregator/http_handlers/tests/report.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/report.rs
@@ -22,7 +22,7 @@ use janus_core::{
     vdaf::VdafInstance,
 };
 use janus_messages::{
-    Duration, HpkeCiphertext, HpkeConfigId, InputShareAad, PlaintextInputShare, Report,
+    Duration, HpkeCiphertext, HpkeConfigId, InputShareAad, MediaType, PlaintextInputShare, Report,
     ReportMetadata, Role, TaskId,
 };
 use opentelemetry::Key;

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -36,7 +36,7 @@ use janus_core::{
 use janus_messages::{
     AggregateShare as AggregateShareMessage, AggregateShareAad, AggregateShareReq,
     AggregationJobContinueReq, AggregationJobId, AggregationJobInitializeReq, AggregationJobResp,
-    AggregationJobStep, BatchSelector, Duration, Extension, ExtensionType, Interval,
+    AggregationJobStep, BatchSelector, Duration, Extension, ExtensionType, Interval, MediaType,
     PartialBatchSelector, PrepareContinue, PrepareInit, PrepareResp, PrepareStepResult,
     ReportError, ReportIdChecksum, ReportShare, Role, TaskId, Time,
     batch_mode::{self, LeaderSelected},

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -58,8 +58,8 @@ use janus_core::{
     vdaf::vdaf_application_context,
 };
 use janus_messages::{
-    Duration, HpkeConfig, HpkeConfigList, InputShareAad, PlaintextInputShare, Report, ReportId,
-    ReportMetadata, Role, TaskId, Time,
+    Duration, HpkeConfig, HpkeConfigList, InputShareAad, MediaType, PlaintextInputShare, Report,
+    ReportId, ReportMetadata, Role, TaskId, Time,
 };
 #[cfg(feature = "ohttp")]
 use ohttp::{ClientRequest, KeyConfig};

--- a/client/src/tests/mod.rs
+++ b/client/src/tests/mod.rs
@@ -7,7 +7,7 @@ use janus_core::{
     retries::test_util::test_http_request_exponential_backoff,
     test_util::install_test_trace_subscriber,
 };
-use janus_messages::{Duration, HpkeConfigList, Report, Role, Time};
+use janus_messages::{Duration, HpkeConfigList, MediaType, Report, Role, Time};
 use prio::{
     codec::Encode,
     vdaf::{self, prio3::Prio3},

--- a/client/src/tests/ohttp.rs
+++ b/client/src/tests/ohttp.rs
@@ -1,5 +1,3 @@
-use std::io::Cursor;
-
 use crate::{
     Client, Error, OHTTP_KEYS_MEDIA_TYPE, OHTTP_REQUEST_MEDIA_TYPE, OHTTP_RESPONSE_MEDIA_TYPE,
     OhttpConfig,
@@ -12,7 +10,7 @@ use janus_core::{
     retries::test_util::test_http_request_exponential_backoff,
     test_util::install_test_trace_subscriber,
 };
-use janus_messages::{Duration, Report};
+use janus_messages::{Duration, MediaType, Report};
 use ohttp::{
     KeyConfig, SymmetricSuite,
     hpke::{Aead, Kdf},
@@ -22,6 +20,7 @@ use prio::{
     vdaf::prio3::{Prio3, Prio3Count},
 };
 use rand::random;
+use std::io::Cursor;
 use url::Url;
 
 async fn build_client(server: &mockito::ServerGuard) -> Result<Client<Prio3Count>, Error> {

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -80,7 +80,7 @@ use janus_core::{
 };
 use janus_messages::{
     AggregateShareAad, BatchSelector, CollectionJobId, CollectionJobReq, CollectionJobResp,
-    PartialBatchSelector, Query, Role, TaskId,
+    MediaType, PartialBatchSelector, Query, Role, TaskId,
     batch_mode::{BatchMode, TimeInterval},
 };
 use mime::Mime;
@@ -784,8 +784,8 @@ mod tests {
     };
     use janus_messages::{
         AggregateShareAad, BatchId, BatchSelector, CollectionJobId, CollectionJobReq,
-        CollectionJobResp, Duration, HpkeCiphertext, Interval, PartialBatchSelector, Query, Role,
-        TaskId, Time,
+        CollectionJobResp, Duration, HpkeCiphertext, Interval, MediaType, PartialBatchSelector,
+        Query, Role, TaskId, Time,
         batch_mode::{LeaderSelected, TimeInterval},
         problem_type::DapProblemType,
     };

--- a/integration_tests/tests/integration/simulation/bad_client.rs
+++ b/integration_tests/tests/integration/simulation/bad_client.rs
@@ -20,7 +20,7 @@ use janus_core::{
     vdaf::{VERIFY_KEY_LENGTH_PRIO3, VdafInstance, vdaf_application_context, vdaf_dp_strategies},
 };
 use janus_messages::{
-    HpkeConfig, HpkeConfigList, InputShareAad, PlaintextInputShare, Report, ReportId,
+    HpkeConfig, HpkeConfigList, InputShareAad, MediaType, PlaintextInputShare, Report, ReportId,
     ReportMetadata, Role, TaskId, Time,
 };
 use prio::{

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -38,6 +38,12 @@ pub mod taskprov;
 #[cfg(test)]
 mod tests;
 
+/// Messages which have an HTTP media type associated with them.
+pub trait MediaType: Encode {
+    /// The HTTP media type used with the encoded representation of this object.
+    const MEDIA_TYPE: &'static str;
+}
+
 /// Errors returned by functions and methods in this module
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -1220,9 +1226,6 @@ impl Decode for HpkeConfig {
 pub struct HpkeConfigList(Vec<HpkeConfig>);
 
 impl HpkeConfigList {
-    /// The media type associated with this protocol message.
-    pub const MEDIA_TYPE: &'static str = "application/dap-hpke-config-list";
-
     /// Construct an HPKE configuration list.
     pub fn new(hpke_configs: Vec<HpkeConfig>) -> Self {
         Self(hpke_configs)
@@ -1231,6 +1234,10 @@ impl HpkeConfigList {
     pub fn hpke_configs(&self) -> &[HpkeConfig] {
         &self.0
     }
+}
+
+impl MediaType for HpkeConfigList {
+    const MEDIA_TYPE: &'static str = "application/dap-hpke-config-list";
 }
 
 impl Encode for HpkeConfigList {
@@ -1383,9 +1390,6 @@ pub struct Report {
 }
 
 impl Report {
-    /// The media type associated with this protocol message.
-    pub const MEDIA_TYPE: &'static str = "application/dap-report";
-
     /// Construct a report from its components.
     pub fn new(
         metadata: ReportMetadata,
@@ -1420,6 +1424,10 @@ impl Report {
     pub fn helper_encrypted_input_share(&self) -> &HpkeCiphertext {
         &self.helper_encrypted_input_share
     }
+}
+
+impl MediaType for Report {
+    const MEDIA_TYPE: &'static str = "application/dap-report";
 }
 
 impl Encode for Report {
@@ -1534,9 +1542,6 @@ pub struct CollectionJobReq<B: BatchMode> {
 }
 
 impl<B: BatchMode> CollectionJobReq<B> {
-    /// The media type associated with this protocol message.
-    pub const MEDIA_TYPE: &'static str = "application/dap-collection-job-req";
-
     /// Constructs a new collect request from its components.
     pub fn new(query: Query<B>, aggregation_parameter: Vec<u8>) -> Self {
         Self {
@@ -1554,6 +1559,10 @@ impl<B: BatchMode> CollectionJobReq<B> {
     pub fn aggregation_parameter(&self) -> &[u8] {
         &self.aggregation_parameter
     }
+}
+
+impl<B: BatchMode> MediaType for CollectionJobReq<B> {
+    const MEDIA_TYPE: &'static str = "application/dap-collection-job-req";
 }
 
 impl<B: BatchMode> Encode for CollectionJobReq<B> {
@@ -1715,9 +1724,8 @@ pub enum CollectionJobResp<B: BatchMode> {
     },
 }
 
-impl<B: BatchMode> CollectionJobResp<B> {
-    /// The media type associated with this protocol message.
-    pub const MEDIA_TYPE: &'static str = "application/dap-collection-job-resp";
+impl<B: BatchMode> MediaType for CollectionJobResp<B> {
+    const MEDIA_TYPE: &'static str = "application/dap-collection-job-resp";
 }
 
 impl<B: BatchMode> Encode for CollectionJobResp<B> {
@@ -2302,9 +2310,6 @@ pub struct AggregationJobInitializeReq<B: BatchMode> {
 }
 
 impl<B: BatchMode> AggregationJobInitializeReq<B> {
-    /// The media type associated with this protocol message.
-    pub const MEDIA_TYPE: &'static str = "application/dap-aggregation-job-init-req";
-
     /// Constructs an aggregate initialization request from its components.
     pub fn new(
         aggregation_parameter: Vec<u8>,
@@ -2333,6 +2338,10 @@ impl<B: BatchMode> AggregationJobInitializeReq<B> {
     pub fn prepare_inits(&self) -> &[PrepareInit] {
         &self.prepare_inits
     }
+}
+
+impl<B: BatchMode> MediaType for AggregationJobInitializeReq<B> {
+    const MEDIA_TYPE: &'static str = "application/dap-aggregation-job-init-req";
 }
 
 impl<B: BatchMode> Encode for AggregationJobInitializeReq<B> {
@@ -2432,9 +2441,6 @@ pub struct AggregationJobContinueReq {
 }
 
 impl AggregationJobContinueReq {
-    /// The media type associated with this protocol message.
-    pub const MEDIA_TYPE: &'static str = "application/dap-aggregation-job-continue-req";
-
     /// Constructs a new aggregate continuation response from its components.
     pub fn new(step: AggregationJobStep, prepare_continues: Vec<PrepareContinue>) -> Self {
         Self {
@@ -2453,6 +2459,10 @@ impl AggregationJobContinueReq {
     pub fn prepare_continues(&self) -> &[PrepareContinue] {
         &self.prepare_continues
     }
+}
+
+impl MediaType for AggregationJobContinueReq {
+    const MEDIA_TYPE: &'static str = "application/dap-aggregation-job-continue-req";
 }
 
 impl Encode for AggregationJobContinueReq {
@@ -2487,9 +2497,9 @@ pub enum AggregationJobResp {
     Finished { prepare_resps: Vec<PrepareResp> },
 }
 
-impl AggregationJobResp {
+impl MediaType for AggregationJobResp {
     /// The media type associated with this protocol message.
-    pub const MEDIA_TYPE: &'static str = "application/dap-aggregation-job-resp";
+    const MEDIA_TYPE: &'static str = "application/dap-aggregation-job-resp";
 }
 
 impl Encode for AggregationJobResp {
@@ -2618,9 +2628,6 @@ pub struct AggregateShareReq<B: BatchMode> {
 }
 
 impl<B: BatchMode> AggregateShareReq<B> {
-    /// The media type associated with this protocol message.
-    pub const MEDIA_TYPE: &'static str = "application/dap-aggregate-share-req";
-
     /// Constructs a new aggregate share request from its components.
     pub fn new(
         batch_selector: BatchSelector<B>,
@@ -2655,6 +2662,10 @@ impl<B: BatchMode> AggregateShareReq<B> {
     pub fn checksum(&self) -> &ReportIdChecksum {
         &self.checksum
     }
+}
+
+impl<B: BatchMode> MediaType for AggregateShareReq<B> {
+    const MEDIA_TYPE: &'static str = "application/dap-aggregate-share-req";
 }
 
 impl<B: BatchMode> Encode for AggregateShareReq<B> {
@@ -2700,9 +2711,6 @@ pub struct AggregateShare {
 }
 
 impl AggregateShare {
-    /// The media type associated with this protocol message.
-    pub const MEDIA_TYPE: &'static str = "application/dap-aggregate-share";
-
     /// Constructs a new aggregate share response from its components.
     pub fn new(encrypted_aggregate_share: HpkeCiphertext) -> Self {
         Self {
@@ -2714,6 +2722,10 @@ impl AggregateShare {
     pub fn encrypted_aggregate_share(&self) -> &HpkeCiphertext {
         &self.encrypted_aggregate_share
     }
+}
+
+impl MediaType for AggregateShare {
+    const MEDIA_TYPE: &'static str = "application/dap-aggregate-share";
 }
 
 impl Encode for AggregateShare {


### PR DESCRIPTION
The `MediaType` trait identifies messages that have an HTTP media type associated with them, intended for use in `content-type` HTTP headers. Various types defined in `janus_messages` already had an associated `MEDIA_TYPE` constant, which is now part of the trait. This means that elsewhere, we can use a trait bound like `prio::codec::Decode + MediaType` to generically check that an incoming message has the desired content-type and then decode it into the desired structure.