### PR TITLE
`janus_client`: cache HPKE and OHTTP keys

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -49,7 +49,7 @@ use http::{StatusCode, header::CONTENT_TYPE};
 use itertools::Itertools;
 use janus_core::{
     hpke::{self, HpkeApplicationInfo, Label, is_hpke_config_supported},
-    http::HttpErrorResponse,
+    http::{HttpErrorResponse, cached_resource::CachedResource},
     retries::{
         ExponentialWithTotalDelayBuilder, http_request_exponential_backoff, retry_http_request,
     },
@@ -63,14 +63,14 @@ use janus_messages::{
 };
 #[cfg(feature = "ohttp")]
 use ohttp::{ClientRequest, KeyConfig};
-use prio::{
-    codec::{Decode, Encode},
-    vdaf,
-};
+#[cfg(feature = "ohttp")]
+use ohttp_keys::OhttpKeys;
+use prio::{codec::Encode, vdaf};
 use rand::random;
 #[cfg(feature = "ohttp")]
 use std::io::Cursor;
-use std::{convert::Infallible, fmt::Debug, time::SystemTimeError};
+use std::{convert::Infallible, fmt::Debug, sync::Arc, time::SystemTimeError};
+use tokio::sync::Mutex;
 use url::Url;
 
 #[cfg(test)]
@@ -92,6 +92,8 @@ pub enum Error {
     Vdaf(#[from] prio::vdaf::VdafError),
     #[error("HPKE error: {0}")]
     Hpke(#[from] janus_core::hpke::Error),
+    #[error("Cached resource error: {0}")]
+    CachedResource(#[from] janus_core::http::cached_resource::Error),
     #[error("unexpected server response {0}")]
     UnexpectedServerResponse(&'static str),
     #[error("time conversion error: {0}")]
@@ -199,93 +201,6 @@ impl ClientParameters {
     }
 }
 
-/// Fetches HPKE configuration from the specified aggregator using the aggregator endpoints in the
-/// provided [`ClientParameters`].
-#[tracing::instrument(err)]
-async fn aggregator_hpke_config(
-    hpke_config: Option<HpkeConfig>,
-    client_parameters: &ClientParameters,
-    aggregator_role: &Role,
-    http_client: &reqwest::Client,
-) -> Result<HpkeConfig, Error> {
-    if let Some(hpke_config) = hpke_config {
-        return Ok(hpke_config);
-    }
-
-    let request_url = client_parameters.hpke_config_endpoint(aggregator_role)?;
-    let hpke_config_response = retry_http_request(
-        client_parameters.http_request_retry_parameters.build(),
-        || async { http_client.get(request_url.clone()).send().await },
-    )
-    .await?;
-    let status = hpke_config_response.status();
-    if !status.is_success() {
-        return Err(Error::Http(Box::new(HttpErrorResponse::from(status))));
-    }
-
-    let hpke_configs = HpkeConfigList::get_decoded(hpke_config_response.body())?;
-
-    if hpke_configs.hpke_configs().is_empty() {
-        return Err(Error::UnexpectedServerResponse(
-            "aggregator provided empty HpkeConfigList",
-        ));
-    }
-
-    // Take the first supported HpkeConfig from the list. Return the first error otherwise.
-    let mut first_error = None;
-    for config in hpke_configs.hpke_configs() {
-        match is_hpke_config_supported(config) {
-            Ok(()) => return Ok(config.clone()),
-            Err(e) => {
-                if first_error.is_none() {
-                    first_error = Some(e);
-                }
-            }
-        }
-    }
-    // Unwrap safety: we checked that the list is nonempty, and if we fell through to here, we must
-    // have seen at least one error.
-    Err(first_error.unwrap().into())
-}
-
-/// Fetches OHTTP HPKE key configurations for the provided OHTTP config.
-#[tracing::instrument(err)]
-#[cfg(feature = "ohttp")]
-async fn ohttp_key_configs(
-    http_request_retry_parameters: ExponentialWithTotalDelayBuilder,
-    ohttp_config: &OhttpConfig,
-    http_client: &reqwest::Client,
-) -> Result<Vec<KeyConfig>, Error> {
-    // TODO(#3159): store/fetch OHTTP key configs in a cache-control aware persistent cache.
-    let keys_response = retry_http_request(http_request_retry_parameters.build(), || async {
-        http_client
-            .get(ohttp_config.key_configs.clone())
-            .header(ACCEPT, OHTTP_KEYS_MEDIA_TYPE)
-            .send()
-            .await
-    })
-    .await?;
-
-    if !keys_response.status().is_success() {
-        return Err(Error::Http(Box::new(HttpErrorResponse::from(
-            keys_response.status(),
-        ))));
-    }
-
-    if keys_response
-        .headers()
-        .get(CONTENT_TYPE)
-        .map(HeaderValue::as_bytes)
-        != Some(OHTTP_KEYS_MEDIA_TYPE.as_bytes())
-    {
-        return Err(Error::UnexpectedServerResponse(
-            "content type wrong for OHTTP keys",
-        ));
-    }
-
-    Ok(KeyConfig::decode_list(keys_response.body().as_ref())?)
-}
-
 /// Construct a [`reqwest::Client`] suitable for use in a DAP [`Client`].
 pub fn default_http_client() -> Result<reqwest::Client, Error> {
     Ok(reqwest::Client::builder()
@@ -356,31 +271,21 @@ impl<V: vdaf::Client<16>> ClientBuilder<V> {
         } else {
             default_http_client()?
         };
-        // TODO(#3159): store/fetch HPKE configurations in a cache-control aware persistent cache
+
+        let fetch_hpke_config = async |hpke_config, role| match hpke_config {
+            Some(hpke_config) => Ok(HpkeConfiguration::new_static(hpke_config)),
+            None => HpkeConfiguration::new(&self.parameters, role, &http_client).await,
+        };
+
         let (leader_hpke_config, helper_hpke_config) = tokio::try_join!(
-            aggregator_hpke_config(
-                self.leader_hpke_config,
-                &self.parameters,
-                &Role::Leader,
-                &http_client
-            ),
-            aggregator_hpke_config(
-                self.helper_hpke_config,
-                &self.parameters,
-                &Role::Helper,
-                &http_client
-            ),
+            fetch_hpke_config(self.leader_hpke_config, &Role::Leader),
+            fetch_hpke_config(self.helper_hpke_config, &Role::Helper),
         )?;
 
         #[cfg(feature = "ohttp")]
         let ohttp_config = if let Some(ohttp_config) = self.ohttp_config {
-            let key_configs = ohttp_key_configs(
-                self.parameters.http_request_retry_parameters,
-                &ohttp_config,
-                &http_client,
-            )
-            .await?;
-            Some((ohttp_config, key_configs))
+            let key_configs = OhttpKeys::new(ohttp_config, &self.parameters, &http_client).await?;
+            Some(Arc::new(Mutex::new(key_configs)))
         } else {
             None
         };
@@ -391,8 +296,8 @@ impl<V: vdaf::Client<16>> ClientBuilder<V> {
             parameters: self.parameters,
             vdaf: self.vdaf,
             http_client,
-            leader_hpke_config,
-            helper_hpke_config,
+            leader_hpke_config: Arc::new(Mutex::new(leader_hpke_config)),
+            helper_hpke_config: Arc::new(Mutex::new(helper_hpke_config)),
         })
     }
 
@@ -422,8 +327,12 @@ impl<V: vdaf::Client<16>> ClientBuilder<V> {
             #[cfg(feature = "ohttp")]
             ohttp_config: None,
             http_client,
-            leader_hpke_config,
-            helper_hpke_config,
+            leader_hpke_config: Arc::new(Mutex::new(HpkeConfiguration::new_static(
+                leader_hpke_config,
+            ))),
+            helper_hpke_config: Arc::new(Mutex::new(HpkeConfiguration::new_static(
+                helper_hpke_config,
+            ))),
         })
     }
 
@@ -504,10 +413,10 @@ pub struct Client<V: vdaf::Client<16>> {
     parameters: ClientParameters,
     vdaf: V,
     #[cfg(feature = "ohttp")]
-    ohttp_config: Option<(OhttpConfig, Vec<KeyConfig>)>,
+    ohttp_config: Option<Arc<Mutex<OhttpKeys>>>,
     http_client: reqwest::Client,
-    leader_hpke_config: HpkeConfig,
-    helper_hpke_config: HpkeConfig,
+    leader_hpke_config: Arc<Mutex<HpkeConfiguration>>,
+    helper_hpke_config: Arc<Mutex<HpkeConfiguration>>,
 }
 
 impl<V: vdaf::Client<16>> Client<V> {
@@ -580,7 +489,13 @@ impl<V: vdaf::Client<16>> Client<V> {
 
     /// Shard a measurement, encrypt its shares, and construct a [`janus_messages::Report`] to be
     /// uploaded.
-    fn prepare_report(&self, measurement: &V::Measurement, time: &Time) -> Result<Report, Error> {
+    fn prepare_report(
+        &self,
+        measurement: &V::Measurement,
+        time: &Time,
+        leader_hpke_config: &HpkeConfig,
+        helper_hpke_config: &HpkeConfig,
+    ) -> Result<Report, Error> {
         let report_id: ReportId = random();
         let (public_share, input_shares) = self.vdaf.shard(
             &vdaf_application_context(&self.parameters.task_id),
@@ -600,8 +515,8 @@ impl<V: vdaf::Client<16>> Client<V> {
         let encoded_public_share = public_share.get_encoded()?;
 
         let (leader_encrypted_input_share, helper_encrypted_input_share) = [
-            (&self.leader_hpke_config, &Role::Leader),
-            (&self.helper_hpke_config, &Role::Helper),
+            (leader_hpke_config, &Role::Leader),
+            (helper_hpke_config, &Role::Helper),
         ]
         .into_iter()
         .zip(input_shares)
@@ -683,7 +598,20 @@ impl<V: vdaf::Client<16>> Client<V> {
         Error: From<<T as TryInto<Time>>::Error>,
     {
         let report = self
-            .prepare_report(measurement, &time.try_into()?)?
+            .prepare_report(
+                measurement,
+                &time.try_into()?,
+                self.leader_hpke_config
+                    .lock()
+                    .await
+                    .get(&self.http_client)
+                    .await?,
+                self.helper_hpke_config
+                    .lock()
+                    .await
+                    .get(&self.http_client)
+                    .await?,
+            )?
             .get_encoded()?;
         let upload_endpoint = self
             .parameters
@@ -732,12 +660,16 @@ impl<V: vdaf::Client<16>> Client<V> {
         upload_endpoint: &Url,
         request_body: &[u8],
     ) -> Result<StatusCode, Error> {
-        let (ohttp_config, key_configs) =
-            if let Some((ohttp_config, key_configs)) = &self.ohttp_config {
-                (ohttp_config, key_configs)
-            } else {
-                return self.put_report(upload_endpoint, request_body).await;
-            };
+        let ohttp_config = if let Some(ohttp_config) = &self.ohttp_config {
+            ohttp_config
+        } else {
+            return self.put_report(upload_endpoint, request_body).await;
+        };
+
+        let mut ohttp_config = ohttp_config.lock().await;
+        let key_configs = ohttp_config
+            .get(&self.http_client, &self.parameters)
+            .await?;
 
         // Construct a Message representing the upload request...
         let mut message = Message::request(
@@ -810,5 +742,126 @@ impl<V: vdaf::Client<16>> Client<V> {
         };
 
         Ok(status)
+    }
+}
+
+/// An HPKE configuration advertised by an aggregator.
+#[derive(Debug, Clone)]
+pub(crate) struct HpkeConfiguration {
+    hpke_config_list: CachedResource<HpkeConfigList>,
+}
+
+impl HpkeConfiguration {
+    pub(crate) async fn new(
+        client_parameters: &ClientParameters,
+        aggregator_role: &Role,
+        http_client: &reqwest::Client,
+    ) -> Result<Self, Error> {
+        let hpke_config_url = client_parameters.hpke_config_endpoint(aggregator_role)?;
+
+        Ok(Self {
+            hpke_config_list: CachedResource::new(
+                hpke_config_url,
+                http_client,
+                client_parameters.http_request_retry_parameters,
+            )
+            .await?,
+        })
+    }
+
+    pub(crate) fn new_static(hpke_configuration: HpkeConfig) -> Self {
+        Self {
+            hpke_config_list: CachedResource::Static(HpkeConfigList::new(vec![hpke_configuration])),
+        }
+    }
+
+    pub(crate) async fn get(
+        &mut self,
+        http_client: &reqwest::Client,
+    ) -> Result<&HpkeConfig, Error> {
+        let hpke_config_list = self.hpke_config_list.resource(http_client).await?;
+
+        if hpke_config_list.hpke_configs().is_empty() {
+            return Err(Error::UnexpectedServerResponse(
+                "aggregator provided empty HpkeConfigList",
+            ));
+        }
+
+        // Take the first supported HpkeConfig from the list. Return the first error otherwise.
+        let mut first_error = None;
+        for config in hpke_config_list.hpke_configs() {
+            match is_hpke_config_supported(config) {
+                Ok(()) => return Ok(config),
+                Err(e) => {
+                    if first_error.is_none() {
+                        first_error = Some(e);
+                    }
+                }
+            }
+        }
+        // Unwrap safety: we checked that the list is nonempty, and if we fell through to here, we must
+        // have seen at least one error.
+        Err(first_error.unwrap().into())
+    }
+}
+
+#[cfg(feature = "ohttp")]
+pub mod ohttp_keys {
+    use crate::{ClientParameters, Error, OHTTP_KEYS_MEDIA_TYPE, OhttpConfig};
+    use janus_core::http::cached_resource::{CachedResource, FromBytes};
+    use janus_messages::MediaType;
+    use ohttp::KeyConfig;
+    use url::Url;
+
+    /// Shim around a vector of OHTTP key configs so that we can implement traits on it locally.
+    #[derive(Debug, Clone)]
+    pub(crate) struct OhttpKeyConfigs(pub Vec<KeyConfig>);
+
+    impl FromBytes for OhttpKeyConfigs {
+        fn from_bytes(
+            bytes: &[u8],
+        ) -> Result<Self, Box<dyn std::error::Error + 'static + Send + Sync>> {
+            Ok(Self(KeyConfig::decode_list(bytes).map_err(|e| {
+                janus_core::http::cached_resource::Error::Decode(Box::new(e))
+            })?))
+        }
+    }
+
+    impl MediaType for OhttpKeyConfigs {
+        const MEDIA_TYPE: &'static str = OHTTP_KEYS_MEDIA_TYPE;
+    }
+
+    /// Key configurations advertised by an OHTTP relay.
+    #[derive(Debug, Clone)]
+    pub(crate) struct OhttpKeys {
+        pub relay: Url,
+        key_configs: CachedResource<OhttpKeyConfigs>,
+    }
+
+    impl OhttpKeys {
+        pub(crate) async fn new(
+            ohttp_config: OhttpConfig,
+            client_parameters: &ClientParameters,
+            http_client: &reqwest::Client,
+        ) -> Result<Self, Error> {
+            Ok(Self {
+                relay: ohttp_config.relay,
+                key_configs: CachedResource::new(
+                    ohttp_config.key_configs,
+                    http_client,
+                    client_parameters.http_request_retry_parameters,
+                )
+                .await?,
+            })
+        }
+
+        #[tracing::instrument(err)]
+        pub(crate) async fn get(
+            &mut self,
+            http_client: &reqwest::Client,
+            client_parameters: &ClientParameters,
+        ) -> Result<&[KeyConfig], Error> {
+            Ok(&self.key_configs.resource(http_client).await?.0)
+        }
     }
 }

--- a/client/src/tests/mod.rs
+++ b/client/src/tests/mod.rs
@@ -196,20 +196,8 @@ async fn report_timestamp() {
             .prepare_report(
                 &true,
                 &Time::from_seconds_since_epoch(101),
-                client
-                    .leader_hpke_config
-                    .lock()
-                    .await
-                    .get(&client.http_client)
-                    .await
-                    .unwrap(),
-                client
-                    .helper_hpke_config
-                    .lock()
-                    .await
-                    .get(&client.http_client)
-                    .await
-                    .unwrap(),
+                client.leader_hpke_config.lock().await.get().await.unwrap(),
+                client.helper_hpke_config.lock().await.get().await.unwrap(),
             )
             .unwrap()
             .metadata()
@@ -222,20 +210,8 @@ async fn report_timestamp() {
             .prepare_report(
                 &true,
                 &Time::from_seconds_since_epoch(5200),
-                client
-                    .leader_hpke_config
-                    .lock()
-                    .await
-                    .get(&client.http_client)
-                    .await
-                    .unwrap(),
-                client
-                    .helper_hpke_config
-                    .lock()
-                    .await
-                    .get(&client.http_client)
-                    .await
-                    .unwrap(),
+                client.leader_hpke_config.lock().await.get().await.unwrap(),
+                client.helper_hpke_config.lock().await.get().await.unwrap(),
             )
             .unwrap()
             .metadata()
@@ -248,20 +224,8 @@ async fn report_timestamp() {
             .prepare_report(
                 &true,
                 &Time::from_seconds_since_epoch(9814),
-                client
-                    .leader_hpke_config
-                    .lock()
-                    .await
-                    .get(&client.http_client)
-                    .await
-                    .unwrap(),
-                client
-                    .helper_hpke_config
-                    .lock()
-                    .await
-                    .get(&client.http_client)
-                    .await
-                    .unwrap(),
+                client.leader_hpke_config.lock().await.get().await.unwrap(),
+                client.helper_hpke_config.lock().await.get().await.unwrap(),
             )
             .unwrap()
             .metadata()
@@ -277,7 +241,7 @@ async fn unsupported_hpke_algorithms() {
 
     let mut server = mockito::Server::new_async().await;
     let server_url = Url::parse(&server.url()).unwrap();
-    let http_client = &default_http_client().unwrap();
+    let http_client = default_http_client().unwrap();
     let mut client_parameters = ClientParameters::new(
         random(),
         server_url.clone(),
@@ -320,10 +284,7 @@ async fn unsupported_hpke_algorithms() {
     let mut hpke_config = HpkeConfiguration::new(&client_parameters, &Role::Leader, http_client)
         .await
         .unwrap();
-    assert_eq!(
-        hpke_config.get(http_client).await.unwrap(),
-        &good_hpke_config
-    );
+    assert_eq!(hpke_config.get().await.unwrap(), &good_hpke_config);
 
     mock.assert_async().await;
 }

--- a/client/src/tests/ohttp.rs
+++ b/client/src/tests/ohttp.rs
@@ -6,7 +6,9 @@ use assert_matches::assert_matches;
 use bhttp::{Message, Mode, StatusCode};
 use http::header::{ACCEPT, CONTENT_TYPE};
 use janus_core::{
-    hpke::HpkeKeypair, http::HttpErrorResponse, initialize_rustls,
+    hpke::HpkeKeypair,
+    http::{HttpErrorResponse, cached_resource},
+    initialize_rustls,
     retries::test_util::test_http_request_exponential_backoff,
     test_util::install_test_trace_subscriber,
 };
@@ -163,7 +165,10 @@ async fn ohttp_keyconfigs_http_error() {
         .await;
 
     let error = build_client(&server).await.unwrap_err();
-    assert_matches!(error, Error::Http(_));
+    assert_matches!(
+        error,
+        Error::CachedResource(cached_resource::Error::Http(_))
+    );
 
     mocked_ohttp_keys.assert_async().await;
 }
@@ -187,7 +192,10 @@ async fn ohttp_keyconfigs_malformed_response_body() {
 
     let error = build_client(&server).await.unwrap_err();
 
-    assert_matches!(error, Error::Ohttp(_));
+    assert_matches!(
+        error,
+        Error::CachedResource(cached_resource::Error::Decode(_))
+    );
 
     mocked_ohttp_keys.assert_async().await;
 }
@@ -218,7 +226,10 @@ async fn ohttp_keyconfigs_wrong_content_type() {
 
     let error = build_client(&server).await.unwrap_err();
 
-    assert_matches!(error, Error::UnexpectedServerResponse(_));
+    assert_matches!(
+        error,
+        Error::CachedResource(cached_resource::Error::UnexpectedServerResponse(_))
+    );
 
     mocked_ohttp_keys.assert_async().await;
 }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -31,6 +31,7 @@ test-util = [
     "prio/test-util",
     "tokio/macros",
     "tokio/sync",
+    "tokio/test-util",
 ]
 
 [dependencies]

--- a/core/src/http.rs
+++ b/core/src/http.rs
@@ -9,6 +9,10 @@ use std::fmt::{self, Display, Formatter};
 use tracing::warn;
 use trillium::{Conn, HeaderValue};
 
+pub mod cached_resource;
+#[cfg(test)]
+mod cached_resource_tests;
+
 /// This captures an HTTP status code and parsed problem details document from an HTTP response.
 #[derive(Debug)]
 pub struct HttpErrorResponse {

--- a/core/src/http/cached_resource.rs
+++ b/core/src/http/cached_resource.rs
@@ -1,0 +1,204 @@
+//! Fetch HTTP resources, honoring the `Cache-Control` header ([1]) provided by the server.
+//!
+//! [1]: https://datatracker.ietf.org/doc/html/rfc9111#section-5.2
+
+use crate::{
+    http::HttpErrorResponse,
+    retries::{ExponentialWithTotalDelayBuilder, retry_http_request},
+};
+use backon::BackoffBuilder;
+use http::{
+    HeaderValue,
+    header::{ACCEPT, CACHE_CONTROL, CONTENT_TYPE},
+};
+use janus_messages::MediaType;
+use prio::codec::Decode;
+use std::time::Duration;
+use tokio::time::Instant;
+use url::Url;
+
+/// Errors that may arise while managing cached HTTP resources.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum Error {
+    #[error("HTTP client error: {0}")]
+    HttpClient(#[from] reqwest::Error),
+    #[error("decode error: {0}")]
+    Decode(Box<dyn std::error::Error + 'static + Send + Sync>),
+    #[error("HTTP response status {0}")]
+    Http(Box<HttpErrorResponse>),
+    #[error("URL parse: {0}")]
+    Url(#[from] url::ParseError),
+    #[error("unexpected server response {0}")]
+    UnexpectedServerResponse(&'static str),
+}
+
+impl From<Result<HttpErrorResponse, reqwest::Error>> for Error {
+    fn from(result: Result<HttpErrorResponse, reqwest::Error>) -> Self {
+        match result {
+            Ok(http_error_response) => Error::Http(Box::new(http_error_response)),
+            Err(error) => error.into(),
+        }
+    }
+}
+
+pub trait FromBytes: Sized {
+    fn from_bytes(bytes: &[u8])
+    -> Result<Self, Box<dyn std::error::Error + 'static + Send + Sync>>;
+}
+
+impl<D: Decode> FromBytes for D {
+    fn from_bytes(
+        bytes: &[u8],
+    ) -> Result<Self, Box<dyn std::error::Error + 'static + Send + Sync>> {
+        D::get_decoded(bytes).map_err(Into::into)
+    }
+}
+
+/// A cached HTTP resource.
+// TODO(#3159): persist the cache to storage.
+#[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
+pub enum CachedResource<Resource> {
+    Static(Resource),
+    Refreshable(Refresher<Resource>),
+}
+
+impl<Resource: FromBytes + MediaType> CachedResource<Resource> {
+    /// Fetch and cache the resource at the provided URL.
+    pub async fn new(
+        resource_url: Url,
+        http_client: &reqwest::Client,
+        http_request_retry_parameters: ExponentialWithTotalDelayBuilder,
+    ) -> Result<Self, Error> {
+        let (resource, expires_at) =
+            Refresher::refresh(http_client, http_request_retry_parameters, &resource_url).await?;
+
+        Ok(Self::Refreshable(Refresher {
+            resource,
+            expires_at,
+            resource_url,
+            http_request_retry_parameters,
+        }))
+    }
+
+    /// Returns the cached resource. Refetches if it has expired.
+    pub async fn resource(&mut self, http_client: &reqwest::Client) -> Result<&Resource, Error> {
+        match self {
+            Self::Refreshable(refresher) => refresher.resource(http_client).await,
+            Self::Static(resource) => Ok(resource),
+        }
+    }
+}
+
+/// Caches an HTTP resource based on the cache-control header provided by the server.
+#[derive(Debug, Clone)]
+pub struct Refresher<Resource> {
+    resource: Resource,
+    expires_at: Option<Instant>,
+    resource_url: Url,
+    http_request_retry_parameters: ExponentialWithTotalDelayBuilder,
+}
+
+impl<Resource: FromBytes + MediaType> Refresher<Resource> {
+    async fn resource(&mut self, http_client: &reqwest::Client) -> Result<&Resource, Error> {
+        // Refresh if we are past expiration.
+        if self
+            .expires_at
+            .map(|expires_at| Instant::now() > expires_at)
+            // If no expiration is provided, use cached resource forever.
+            .unwrap_or(false)
+        {
+            (self.resource, self.expires_at) = Self::refresh(
+                http_client,
+                self.http_request_retry_parameters,
+                &self.resource_url,
+            )
+            .await?;
+        }
+        Ok(&self.resource)
+    }
+
+    async fn refresh(
+        http_client: &reqwest::Client,
+        http_request_retry_parameters: ExponentialWithTotalDelayBuilder,
+        resource_url: &Url,
+    ) -> Result<(Resource, Option<Instant>), Error> {
+        let response = retry_http_request(http_request_retry_parameters.build(), || async {
+            http_client
+                .get(resource_url.clone())
+                .header(ACCEPT, Resource::MEDIA_TYPE)
+                .send()
+                .await
+        })
+        .await?;
+        let status = response.status();
+        if !status.is_success() {
+            return Err(Error::Http(Box::new(HttpErrorResponse::from(status))));
+        }
+
+        let content_type =
+            response
+                .headers()
+                .get(CONTENT_TYPE)
+                .ok_or(Error::UnexpectedServerResponse(
+                    "no content type in server response",
+                ))?;
+        if content_type != Resource::MEDIA_TYPE {
+            return Err(Error::UnexpectedServerResponse(
+                "unexpected content type in server response",
+            ));
+        }
+
+        let expires_at = expires_at(response.headers().get_all(CACHE_CONTROL));
+
+        Ok((
+            Resource::from_bytes(response.body()).map_err(Error::Decode)?,
+            expires_at,
+        ))
+    }
+}
+
+/// Parse the provided cache-control header values ([1]) and determine when the resource they were
+/// attached to expires, or None if the resource cannot be cached. This function only handles the
+/// "max-age" and "no-cache" response directives ([2]). If any unrecognized or malformed response
+/// directive is encountered, then the resource will not be cached.
+///
+/// [1]: https://datatracker.ietf.org/doc/html/rfc9111#section-5.2
+/// [2]: https://datatracker.ietf.org/doc/html/rfc9111#section-5.2.2
+pub(crate) fn expires_at<'a, I: IntoIterator<Item = &'a HeaderValue>>(
+    cache_control_directives: I,
+) -> Option<Instant> {
+    let mut expires_at = None;
+
+    for directive in cache_control_directives {
+        let directive = match directive.to_str() {
+            Ok(directive) => directive,
+            Err(_) => return None,
+        }
+        .to_lowercase();
+
+        // If we encounter no-cache, then regardless of other directives, never cache the resource
+        // by indicating it expires now.
+        if directive == "no-cache" {
+            return Some(Instant::now());
+        }
+
+        if let Some(max_age) = directive.strip_prefix("max-age=") {
+            let parsed = match max_age.parse() {
+                Ok(parsed) => parsed,
+                Err(_) => return None,
+            };
+
+            if expires_at.is_some() {
+                return None;
+            }
+
+            expires_at = Instant::now().checked_add(Duration::from_secs(parsed));
+        } else {
+            return None;
+        }
+    }
+
+    expires_at
+}

--- a/core/src/http/cached_resource_tests.rs
+++ b/core/src/http/cached_resource_tests.rs
@@ -1,0 +1,292 @@
+use crate::{
+    http::cached_resource::{CachedResource, expires_at},
+    initialize_rustls,
+    retries::test_util::test_http_request_exponential_backoff,
+    test_util::install_test_trace_subscriber,
+};
+use http::{
+    HeaderValue,
+    header::{CACHE_CONTROL, CONTENT_TYPE},
+};
+use janus_messages::MediaType;
+use prio::codec::{Decode, Encode};
+use std::time::Duration;
+use tokio::time::Instant;
+use url::Url;
+
+#[derive(Debug, Eq)]
+struct TestResource {}
+
+impl Encode for TestResource {
+    fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), prio::codec::CodecError> {
+        ().encode(bytes)
+    }
+
+    fn encoded_len(&self) -> Option<usize> {
+        ().encoded_len()
+    }
+}
+
+impl Decode for TestResource {
+    fn decode(_: &mut std::io::Cursor<&[u8]>) -> Result<Self, prio::codec::CodecError> {
+        Ok(TestResource {})
+    }
+}
+
+impl PartialEq for TestResource {
+    fn eq(&self, _: &Self) -> bool {
+        true
+    }
+}
+
+impl MediaType for TestResource {
+    const MEDIA_TYPE: &'static str = "application/test-resource";
+}
+
+#[tokio::test]
+async fn no_cache_control() {
+    install_test_trace_subscriber();
+    initialize_rustls();
+
+    tokio::time::pause();
+
+    let mut server = mockito::Server::new_async().await;
+    let server_url = Url::parse(&server.url()).unwrap();
+    let http_client = reqwest::Client::builder().build().unwrap();
+
+    let mock = server
+        .mock("GET", "/resource")
+        .with_status(200)
+        .with_body(TestResource {}.get_encoded().unwrap())
+        .with_header(CONTENT_TYPE.as_str(), TestResource::MEDIA_TYPE)
+        .expect(1)
+        .create_async()
+        .await;
+
+    // new() will fetch the resource from server. Because no cache-control is provided, resource()
+    // should refetch.
+    let mut resource = CachedResource::<TestResource>::new(
+        server_url.join("resource").unwrap(),
+        &http_client,
+        test_http_request_exponential_backoff(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        resource.resource(&http_client).await.unwrap(),
+        &TestResource {}
+    );
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn with_no_cache_directive() {
+    install_test_trace_subscriber();
+    initialize_rustls();
+
+    tokio::time::pause();
+
+    let mut server = mockito::Server::new_async().await;
+    let server_url = Url::parse(&server.url()).unwrap();
+    let http_client = reqwest::Client::builder().build().unwrap();
+
+    let mock = server
+        .mock("GET", "/resource")
+        .with_status(200)
+        .with_header(CACHE_CONTROL.as_str(), "no-cache")
+        .with_header(CONTENT_TYPE.as_str(), TestResource::MEDIA_TYPE)
+        .with_body(TestResource {}.get_encoded().unwrap())
+        .expect(2)
+        .create_async()
+        .await;
+
+    // new() will fetch the resource from the server. Because there is a no-cache directive,
+    // resource() should refetch, but only after time advances at all.
+    let mut resource = CachedResource::<TestResource>::new(
+        server_url.join("resource").unwrap(),
+        &http_client,
+        test_http_request_exponential_backoff(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        resource.resource(&http_client).await.unwrap(),
+        &TestResource {}
+    );
+
+    // Should not have two matches yet.
+    assert!(!mock.matched());
+
+    // Advance time by the smallest increment to invalidate cached resource.
+    tokio::time::advance(Duration::from_nanos(1)).await;
+    assert_eq!(
+        resource.resource(&http_client).await.unwrap(),
+        &TestResource {}
+    );
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn with_max_age_directive() {
+    install_test_trace_subscriber();
+    initialize_rustls();
+
+    tokio::time::pause();
+
+    let mut server = mockito::Server::new_async().await;
+    let server_url = Url::parse(&server.url()).unwrap();
+    let http_client = reqwest::Client::builder().build().unwrap();
+
+    let mock = server
+        .mock("GET", "/resource")
+        .with_status(200)
+        .with_header(CACHE_CONTROL.as_str(), "max-age=86400")
+        .with_header(CONTENT_TYPE.as_str(), TestResource::MEDIA_TYPE)
+        .with_body(TestResource {}.get_encoded().unwrap())
+        .expect(2)
+        .create_async()
+        .await;
+
+    // new() will fetch the resource from the server. Because the cache is not expired, resource()
+    // should not refetch.
+    let mut resource = CachedResource::<TestResource>::new(
+        server_url.join("resource").unwrap(),
+        &http_client,
+        test_http_request_exponential_backoff(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        resource.resource(&http_client).await.unwrap(),
+        &TestResource {}
+    );
+
+    // Should not have two matches yet
+    assert!(!mock.matched());
+
+    // Advance time far enough to invalidate cache. resource() should refetch.
+    tokio::time::advance(Duration::from_secs(86401)).await;
+
+    assert_eq!(
+        resource.resource(&http_client).await.unwrap(),
+        &TestResource {}
+    );
+
+    // Now we should have matched twice
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn malformed_cache_control() {
+    install_test_trace_subscriber();
+    initialize_rustls();
+
+    tokio::time::pause();
+
+    let mut server = mockito::Server::new_async().await;
+    let server_url = Url::parse(&server.url()).unwrap();
+    let http_client = reqwest::Client::builder().build().unwrap();
+
+    let mock = server
+        .mock("GET", "/resource")
+        .with_status(200)
+        .with_header(CACHE_CONTROL.as_str(), "malformed")
+        .with_header(CONTENT_TYPE.as_str(), TestResource::MEDIA_TYPE)
+        .with_body(TestResource {}.get_encoded().unwrap())
+        .expect(1)
+        .create_async()
+        .await;
+
+    // The cache control header should be ignored because it's malformed, meaning the resource will
+    // be fetched only once.
+    let mut resource = CachedResource::<TestResource>::new(
+        server_url.join("resource").unwrap(),
+        &http_client,
+        test_http_request_exponential_backoff(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        resource.resource(&http_client).await.unwrap(),
+        &TestResource {}
+    );
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn wrong_content_type() {
+    install_test_trace_subscriber();
+    initialize_rustls();
+
+    tokio::time::pause();
+
+    let mut server = mockito::Server::new_async().await;
+    let server_url = Url::parse(&server.url()).unwrap();
+    let http_client = reqwest::Client::builder().build().unwrap();
+
+    let mock = server
+        .mock("GET", "/resource")
+        .with_status(200)
+        .with_header(CACHE_CONTROL.as_str(), "malformed")
+        .with_header(CONTENT_TYPE.as_str(), "wrong-media-type")
+        .with_body(TestResource {}.get_encoded().unwrap())
+        .expect(1)
+        .create_async()
+        .await;
+
+    CachedResource::<TestResource>::new(
+        server_url.join("resource").unwrap(),
+        &http_client,
+        test_http_request_exponential_backoff(),
+    )
+    .await
+    .unwrap_err();
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn static_resource() {
+    install_test_trace_subscriber();
+    tokio::time::pause();
+
+    // When a static resource is provided, the refresher shouldn't make any network requests
+    let mut resource = CachedResource::Static(TestResource {});
+    assert_eq!(
+        resource
+            .resource(&reqwest::Client::builder().build().unwrap())
+            .await
+            .unwrap(),
+        &TestResource {}
+    );
+}
+
+#[rstest::rstest]
+#[case::no_cache(&["no-cache"], Some(0))]
+#[case::max_age(&["max-age=1000"], Some(1000))]
+#[case::max_age_and_no_cache(&["max-age=1000", "no-cache"], Some(0))]
+#[case::no_directive(&[], None)]
+#[case::unknown_directive(&["unknown"], None)]
+#[case::malformed_max_age(&["max-age=notanumber"], None)]
+#[case::multiple_max_age(&["max-age=1000", "max-age=999"], None)]
+// max_age = u64::MAX - 1000 + 1. Should overflow when added to the mock clock.
+#[case::max_age_overflow(&["max-age=18446744073709550616"], None)]
+#[tokio::test]
+async fn cache_control_expiry(#[case] headers: &[&str], #[case] output: Option<u64>) {
+    tokio::time::pause();
+
+    let now = Instant::now();
+
+    let header_values: Vec<_> = headers
+        .iter()
+        .map(|h| HeaderValue::from_str(h).unwrap())
+        .collect();
+
+    assert_eq!(
+        expires_at(&header_values),
+        output.map(|increment| now.checked_add(Duration::from_secs(increment)).unwrap())
+    );
+}

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -39,7 +39,7 @@ pub mod taskprov;
 mod tests;
 
 /// Messages which have an HTTP media type associated with them.
-pub trait MediaType: Encode {
+pub trait MediaType {
     /// The HTTP media type used with the encoded representation of this object.
     const MEDIA_TYPE: &'static str;
 }


### PR DESCRIPTION
Adds a `janus_core::http::cached_resource` module which GETs an HTTP resource and then caches it, honoring the `no-cache` and `max-age` `cache-control` directives. We then use this in `janus_client` to cache HPKE configurations and OHTTP keys.

This is a forward-port of #3903, which went into `release/0.7`. The major differences:

- use the `janus_messages::MediaType` trait to figure out the desired media type instead of passing it around as an argument
- cache OHTTP keys as well as HPKE keys
- introduce a `FromBytes` trait and use that in `CachedResource` instead of `prio::codec::Decode` to gracefully handle `Vec<ohttp::KeyConfig`>
- avoid cloning values where possible

Part of #3159
