### PR TITLE
fix `cache-control: no-cache` handling

### DIFF
--- a/core/src/http/cached_resource.rs
+++ b/core/src/http/cached_resource.rs
@@ -165,9 +165,10 @@ pub(crate) fn expires_at<'a, I: IntoIterator<Item = &'a HeaderValue>>(
         }
         .to_lowercase();
 
-        // If we encounter no-cache, then regardless of other directives, never cache the resource.
+        // If we encounter no-cache, then regardless of other directives, never cache the resource
+        // by indicating it expires now.
         if directive == "no-cache" {
-            return None;
+            return Some(Instant::now());
         }
 
         if let Some(max_age) = directive.strip_prefix("max-age=") {

--- a/core/src/http/cached_resource_tests.rs
+++ b/core/src/http/cached_resource_tests.rs
@@ -48,6 +48,49 @@ async fn no_cache_control() {
 }
 
 #[tokio::test]
+async fn with_no_cache_directive() {
+    install_test_trace_subscriber();
+
+    tokio::time::pause();
+
+    let mut server = mockito::Server::new_async().await;
+    let server_url = Url::parse(&server.url()).unwrap();
+    let http_client = reqwest::Client::builder().build().unwrap();
+
+    let time = Time::from_seconds_since_epoch(0);
+    let mock = server
+        .mock("GET", "/resource")
+        .with_status(200)
+        .with_header(CACHE_CONTROL.as_str(), "no-cache")
+        .with_header(CONTENT_TYPE.as_str(), "time")
+        .with_body(time.get_encoded().unwrap())
+        .expect(2)
+        .create_async()
+        .await;
+
+    // new() will fetch the resource from the server. Because there is a no-cache directive,
+    // resource() should refetch, but only after time advances at all.
+    let mut resource = CachedResource::<Time>::new(
+        server_url.join("resource").unwrap(),
+        "time",
+        &http_client,
+        test_http_request_exponential_backoff(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(resource.resource().await.unwrap(), &time);
+
+    // Should not have two matches yet.
+    assert!(!mock.matched());
+
+    // Advance time by the smallest increment to invalidate cached resource.
+    tokio::time::advance(Duration::from_nanos(1)).await;
+    assert_eq!(resource.resource().await.unwrap(), &time);
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
 async fn with_cache_control() {
     install_test_trace_subscriber();
     tokio::time::pause();
@@ -168,9 +211,9 @@ async fn static_resource() {
 }
 
 #[rstest::rstest]
-#[case::no_cache(&["no-cache"], None)]
+#[case::no_cache(&["no-cache"], Some(0))]
 #[case::max_age(&["max-age=1000"], Some(1000))]
-#[case::max_age_and_no_cache(&["max-age=1000", "no-cache"], None)]
+#[case::max_age_and_no_cache(&["max-age=1000", "no-cache"], Some(0))]
 #[case::no_directive(&[], None)]
 #[case::unknown_directive(&["unknown"], None)]
 #[case::malformed_max_age(&["max-age=notanumber"], None)]


### PR DESCRIPTION
We had inadequate test coverage for resource served with the `no-cache` directive, so we incorrectly would retain such resources indefinitely. Now we mark them as expiring the instant they are fetched.

Part of #3159