### PR TITLE
Wait more for database in interop containers

### DIFF
--- a/interop_binaries/setup.sh
+++ b/interop_binaries/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-timeout 5m bash -c 'until pg_isready -U postgres; do sleep 1; done'
+timeout 5m bash -c 'until pg_isready -U postgres && psql -U postgres -c "SELECT 1;"; do sleep 1; done'
 sqlx migrate run --source /etc/janus/migrations --database-url postgres://postgres@127.0.0.1:5432/postgres
 /usr/bin/supervisorctl -c /etc/janus/supervisord.conf start janus_interop_aggregator
 /usr/bin/supervisorctl -c /etc/janus/supervisord.conf start aggregator


### PR DESCRIPTION
This tweaks the setup script in the interop containers to wait until the database is ready to handle queries. `pg_isready` on its own only tries to set up a connection, but it seems this isn't sufficient, as @jcjones ran into an error of `the database system is starting up` on the following line.