### PR TITLE
Update wire version and readme to DAP-15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2777,7 +2777,7 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "janus_aggregator"
-version = "0.8.0-prerelease-1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2802,7 +2802,7 @@ dependencies = [
  "janus_aggregator_api",
  "janus_aggregator_core",
  "janus_core",
- "janus_messages 0.8.0-prerelease-1",
+ "janus_messages 0.8.0",
  "k8s-openapi",
  "kube",
  "mime",
@@ -2866,7 +2866,7 @@ dependencies = [
 
 [[package]]
 name = "janus_aggregator_api"
-version = "0.8.0-prerelease-1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2878,7 +2878,7 @@ dependencies = [
  "git-version",
  "janus_aggregator_core",
  "janus_core",
- "janus_messages 0.8.0-prerelease-1",
+ "janus_messages 0.8.0",
  "opentelemetry",
  "querystring",
  "rand 0.9.2",
@@ -2899,7 +2899,7 @@ dependencies = [
 
 [[package]]
 name = "janus_aggregator_core"
-version = "0.8.0-prerelease-1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2920,7 +2920,7 @@ dependencies = [
  "itertools 0.13.0",
  "janus_aggregator_core",
  "janus_core",
- "janus_messages 0.8.0-prerelease-1",
+ "janus_messages 0.8.0",
  "k8s-openapi",
  "kube",
  "opentelemetry",
@@ -2953,7 +2953,7 @@ dependencies = [
 
 [[package]]
 name = "janus_client"
-version = "0.8.0-prerelease-1"
+version = "0.8.0"
 dependencies = [
  "assert_matches",
  "backon",
@@ -2963,7 +2963,7 @@ dependencies = [
  "http",
  "itertools 0.13.0",
  "janus_core",
- "janus_messages 0.8.0-prerelease-1",
+ "janus_messages 0.8.0",
  "mockito",
  "ohttp",
  "prio 0.18.1-alpha.0",
@@ -2979,7 +2979,7 @@ dependencies = [
 
 [[package]]
 name = "janus_collector"
-version = "0.8.0-prerelease-1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2991,7 +2991,7 @@ dependencies = [
  "hpke-dispatch",
  "janus_collector",
  "janus_core",
- "janus_messages 0.8.0-prerelease-1",
+ "janus_messages 0.8.0",
  "mime",
  "mockito",
  "prio 0.18.1-alpha.0",
@@ -3008,7 +3008,7 @@ dependencies = [
 
 [[package]]
 name = "janus_core"
-version = "0.8.0-prerelease-1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3027,7 +3027,7 @@ dependencies = [
  "http",
  "http-api-problem",
  "janus_core",
- "janus_messages 0.8.0-prerelease-1",
+ "janus_messages 0.8.0",
  "k8s-openapi",
  "kube",
  "mime",
@@ -3060,7 +3060,7 @@ dependencies = [
 
 [[package]]
 name = "janus_integration_tests"
-version = "0.8.0-prerelease-1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3080,7 +3080,7 @@ dependencies = [
  "janus_collector",
  "janus_core",
  "janus_interop_binaries",
- "janus_messages 0.8.0-prerelease-1",
+ "janus_messages 0.8.0",
  "k8s-openapi",
  "kube",
  "opentelemetry",
@@ -3107,7 +3107,7 @@ dependencies = [
 
 [[package]]
 name = "janus_interop_binaries"
-version = "0.8.0-prerelease-1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "backon",
@@ -3123,7 +3123,7 @@ dependencies = [
  "janus_collector",
  "janus_core",
  "janus_interop_binaries",
- "janus_messages 0.8.0-prerelease-1",
+ "janus_messages 0.8.0",
  "prio 0.18.1-alpha.0",
  "rand 0.9.2",
  "regex",
@@ -3163,14 +3163,14 @@ dependencies = [
 
 [[package]]
 name = "janus_messages"
-version = "0.8.0-prerelease-1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_matches",
  "base64 0.22.1",
  "educe",
  "hex",
- "janus_messages 0.8.0-prerelease-1",
+ "janus_messages 0.8.0",
  "num_enum",
  "pretty_assertions",
  "prio 0.18.1-alpha.0",
@@ -3183,7 +3183,7 @@ dependencies = [
 
 [[package]]
 name = "janus_tools"
-version = "0.8.0-prerelease-1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3193,7 +3193,7 @@ dependencies = [
  "fixed",
  "janus_collector",
  "janus_core",
- "janus_messages 0.8.0-prerelease-1",
+ "janus_messages 0.8.0",
  "prio 0.18.1-alpha.0",
  "rand 0.9.2",
  "reqwest",
@@ -7402,7 +7402,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.8.0-prerelease-1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,14 +52,14 @@ hpke-dispatch = "0.8.0"
 http = "1.3"
 http-api-problem = "0.58.0"
 itertools = "0.13"
-janus_aggregator = { version = "0.8.0-prerelease-1", path = "aggregator" }
-janus_aggregator_api = { version = "0.8.0-prerelease-1", path = "aggregator_api" }
-janus_aggregator_core = { version = "0.8.0-prerelease-1", path = "aggregator_core" }
-janus_client = { version = "0.8.0-prerelease-1", path = "client" }
-janus_collector = { version = "0.8.0-prerelease-1", path = "collector" }
-janus_core = { version = "0.8.0-prerelease-1", path = "core" }
-janus_interop_binaries = { version = "0.8.0-prerelease-1", path = "interop_binaries" }
-janus_messages = { version = "0.8.0-prerelease-1", path = "messages" }
+janus_aggregator = { version = "0.8.0", path = "aggregator" }
+janus_aggregator_api = { version = "0.8.0", path = "aggregator_api" }
+janus_aggregator_core = { version = "0.8.0", path = "aggregator_core" }
+janus_client = { version = "0.8.0", path = "client" }
+janus_collector = { version = "0.8.0", path = "collector" }
+janus_core = { version = "0.8.0", path = "core" }
+janus_interop_binaries = { version = "0.8.0", path = "interop_binaries" }
+janus_messages = { version = "0.8.0", path = "messages" }
 k8s-openapi = { version = "0.24.0", features = ["v1_32"] }  # keep this version in sync with what is referenced by the indirect dependency via `kube`
 kube = { version = "0.99.0", default-features = false, features = ["client", "rustls-tls", "aws-lc-rs"] }
 mime = "0.3.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://divviup.org"
 license = "MPL-2.0"
 repository = "https://github.com/divviup/janus"
 rust-version = "1.85.0"
-version = "0.8.0-prerelease-1"
+version = "0.8.0"
 
 [workspace.dependencies]
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ branch.
 | `release/0.5` | [`draft-ietf-ppm-dap-04`][dap-04] | Yes | Unmaintained as of June 24, 2024 |
 | `release/0.6` | [`draft-ietf-ppm-dap-07`][dap-07] | Yes, [with errata](#draft-ietf-ppm-dap-07-errata) | Unmaintained as of June 24, 2024 |
 | `release/0.7` | [`draft-ietf-ppm-dap-09`][dap-09] | Yes, [with errata](#draft-ietf-ppm-dap-09-errata) | Supported |
-| `main` | [`draft-ietf-ppm-dap-14`][dap-14] | Yes | Supported |
+| `main` | [`draft-ietf-ppm-dap-15`][dap-15] | Yes | Supported |
 
 Note that not every DAP draft has been implemented.
 
@@ -54,7 +54,7 @@ Note that not every DAP draft has been implemented.
 [dap-04]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/04/
 [dap-07]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/07/
 [dap-09]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/09/
-[dap-14]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/14/
+[dap-15]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/15/
 [dap-gh]: https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap
 
 ### `draft-ietf-ppm-dap-07` errata

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -46,7 +46,7 @@ pub mod taskprov {
 
 /// This value is used in a few places throughout the protocol to identify the draft of DAP being
 /// implemented.
-const DAP_VERSION_IDENTIFIER: &str = "dap-14";
+const DAP_VERSION_IDENTIFIER: &str = "dap-15";
 
 /// Returns the given [`Url`], possibly modified to end with a slash.
 ///


### PR DESCRIPTION
From the [DAP-15 changelog](https://datatracker.ietf.org/doc/html/draft-ietf-ppm-dap-15#name-change-log):

 ## With code changes

- Specify body of responses to aggregation job GET requests. (https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/651)
  -  PR #3630
- Align with RFC 9205 recommendations. (*) (https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/673, https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/683) 
  - The most significant changes are to HTTP status codes, which now should be treated as their most general class, and we shouldn't rely on specific codes. As part of #3878, an audit of `send_request_to_helper` shows that the Leader no longer relies on the returned status from the Helper.
- Define consistent semantics for long-running interactions: aggregation jobs, collection jobs and aggregate shares. (*) (https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/674, https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/675, https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/677)
  -  PRs #3919 and #3927 both handled parts of these changes, as part of #3879.
  - PRs https://github.com/divviup/janus/pull/3947, https://github.com/divviup/janus/pull/3968, and https://github.com/divviup/janus/pull/3974 handled the changes for Aggregate Shares. 

 ## Without code changes
- Add diagram illustrating object lifecycles and relationships. (https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/655) Does not produce code changes.
- Use aasvg for prettier diagrams. (https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/657) Does not produce code changes.
- Add more precise description of time and intervals. (https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/658) Does not produce code changes.
- Reorganize text for clarity and flow. (https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/659, https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/660, https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/661, https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/663, https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/665, https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/666, https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/668, https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/672, https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/678, https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/680, https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/684, https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/653, https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/654) Does not produce code changes.
- Add security consideration for predictable task IDs. (https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/679) Does not produce codec changes.

This PR fixes #3877