### PR TITLE
remove unneeded `Arc` in collection job tests

### DIFF
--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -781,10 +781,10 @@ async fn collection_job_put_idempotence_leader_selected_no_extra_reports() {
 
     let collection_job_id_1 = random();
     let collection_job_id_2 = random();
-    let request: Arc<CollectionJobReq<LeaderSelected>> = Arc::new(CollectionJobReq::new(
+    let request = CollectionJobReq::new(
         Query::new_leader_selected(),
         dummy::AggregationParam(0).get_encoded().unwrap(),
-    ));
+    );
 
     // Create the first collection job.
     let response = test_case
@@ -827,10 +827,10 @@ async fn collection_job_batch_mode_misaligned() {
 
     // LeaderSelected != TimeInterval
     let collection_job_id = random();
-    let request: Arc<CollectionJobReq<LeaderSelected>> = Arc::new(CollectionJobReq::new(
+    let request = CollectionJobReq::new(
         Query::new_leader_selected(),
         dummy::AggregationParam(0).get_encoded().unwrap(),
-    ));
+    );
 
     let mut response = test_case
         .put_collection_job(&collection_job_id, &request)


### PR DESCRIPTION
While looking over #3928, I was wondering why the `CollectionJobReq` in the test needs to be in an `Arc` and why the type annotation is needed. Sure enough, we can elide those in the new test as well as in an existing one and the compiler doesn't gripe. Probably left over from a refactor of a more complex test that previously used a database transaction to double check something.