### PR TITLE
`janus_cli`: get aggregation and collection jobs

### DIFF
--- a/aggregator/src/binaries/janus_cli.rs
+++ b/aggregator/src/binaries/janus_cli.rs
@@ -197,7 +197,7 @@ enum Command {
         task: TaskId,
 
         /// List only this collection job
-        #[clap(long, required_unless_present = "task", value_name = "BASE64URL")]
+        #[clap(long, value_name = "BASE64URL")]
         job: Option<CollectionJobId>,
     },
 

--- a/aggregator/src/binaries/janus_cli.rs
+++ b/aggregator/src/binaries/janus_cli.rs
@@ -8,10 +8,11 @@ use anyhow::{anyhow, Context, Result};
 use aws_lc_rs::aead::AES_128_GCM;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use clap::Parser;
+use itertools::Itertools;
 use janus_aggregator_api::git_revision;
 use janus_aggregator_core::{
-    datastore::{self, models::HpkeKeyState, Datastore},
-    task::{AggregatorTask, SerializedAggregatorTask},
+    datastore::{self, models::HpkeKeyState, Datastore, Transaction},
+    task::{AggregatorTask, QueryType, SerializedAggregatorTask},
     taskprov::{PeerAggregator, VerifyKeyInit},
 };
 use janus_core::{
@@ -19,18 +20,23 @@ use janus_core::{
     cli::{AeadAlgorithm, KdfAlgorithm, KemAlgorithm},
     hpke::HpkeKeypair,
     time::{Clock, RealClock},
+    vdaf_dispatch,
 };
 use janus_messages::{
-    codec::Encode as _, Duration, HpkeAeadId, HpkeConfig, HpkeConfigId, HpkeKdfId, HpkeKemId, Role,
+    codec::Encode as _,
+    query_type::{FixedSize, TimeInterval},
+    AggregationJobId, CollectionJobId, Duration, HpkeAeadId, HpkeConfig, HpkeConfigId, HpkeKdfId,
+    HpkeKemId, Role, TaskId,
 };
 use k8s_openapi::api::core::v1::Secret;
 use kube::api::{ObjectMeta, PostParams};
 use opentelemetry::global::meter;
-use prio::codec::Decode as _;
+use prio::{codec::Decode as _, vdaf::Aggregator};
 use rand::{distributions::Standard, thread_rng, Rng};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeMap,
+    fmt::Debug,
     path::{Path, PathBuf},
     sync::{Arc, OnceLock},
 };
@@ -180,6 +186,34 @@ enum Command {
         #[clap(flatten)]
         kubernetes_secret_options: KubernetesSecretOptions,
     },
+
+    /// List collection jobs in the datastore
+    ListCollectionJobs {
+        #[clap(flatten)]
+        kubernetes_secret_options: KubernetesSecretOptions,
+
+        /// List collection jobs for this task
+        #[clap(long, value_name = "BASE64URL")]
+        task: TaskId,
+
+        /// List only this collection job
+        #[clap(long, required_unless_present = "task", value_name = "BASE64URL")]
+        job: Option<CollectionJobId>,
+    },
+
+    /// List aggregation jobs in the datastore
+    ListAggregationJobs {
+        #[clap(flatten)]
+        kubernetes_secret_options: KubernetesSecretOptions,
+
+        /// List aggregation jobs for this task
+        #[clap(long, value_name = "BASE64URL")]
+        task: TaskId,
+
+        /// List only this aggregation job
+        #[clap(long, value_name = "BASE64URL")]
+        job: Option<AggregationJobId>,
+    },
 }
 
 impl Command {
@@ -328,8 +362,239 @@ impl Command {
                 )
                 .await
             }
+
+            Command::ListCollectionJobs {
+                task,
+                job,
+                kubernetes_secret_options,
+            } => {
+                let datastore = datastore_from_opts(
+                    kubernetes_secret_options,
+                    command_line_options,
+                    config_file,
+                    &kube_client,
+                )
+                .await?;
+
+                datastore
+                    .run_tx("janus-cli-list-collection-jobs", |tx| {
+                        let task_id = *task;
+                        let job_id = *job;
+                        Box::pin(async move {
+                            dispatch_list_collection_jobs(tx, &task_id, job_id)
+                                .await
+                                .map_err(|e| {
+                                    janus_aggregator_core::datastore::Error::User(e.into())
+                                })
+                        })
+                    })
+                    .await
+                    .context("couldn't list collection jobs")
+            }
+
+            Command::ListAggregationJobs {
+                task,
+                job,
+                kubernetes_secret_options,
+            } => {
+                let datastore = datastore_from_opts(
+                    kubernetes_secret_options,
+                    command_line_options,
+                    config_file,
+                    &kube_client,
+                )
+                .await?;
+
+                datastore
+                    .run_tx("janus-cli-list-aggregation-jobs", |tx| {
+                        let task_id = *task;
+                        let job_id = *job;
+                        Box::pin(async move {
+                            dispatch_list_aggregation_jobs(tx, &task_id, job_id)
+                                .await
+                                .map_err(|e| {
+                                    janus_aggregator_core::datastore::Error::User(e.into())
+                                })
+                        })
+                    })
+                    .await
+                    .context("couldn't list aggregation jobs")
+            }
         }
     }
+}
+
+fn pretty_print_jobs_and_leases<
+    Job: Debug,
+    Lease: Debug,
+    JobIter: Iterator<Item = Job>,
+    LeaseIter: Iterator<Item = Lease>,
+>(
+    jobs: JobIter,
+    leases: LeaseIter,
+) {
+    // There should always be the same number of items in both iterators, because they were
+    // constructed from the same database rows.
+    for (job, lease) in jobs.zip(leases) {
+        println!("{job:#?}\n{lease:#?}\n");
+    }
+}
+
+async fn dispatch_list_collection_jobs(
+    tx: &Transaction<'_, RealClock>,
+    task_id: &TaskId,
+    collection_job_id: Option<CollectionJobId>,
+) -> Result<(), crate::aggregator::Error> {
+    // vdaf_dispatch! expands into (among other things) a method call that returns
+    // `prio::vdaf::VdafError` and has ? applied to it. This function's own logic deals with methods
+    // that return `janus_aggregator_core::datastore::Error`. Because this function is declared to
+    // return `janus_aggregator::aggregator::Error`, ? can resolve both those errors into a single
+    // type, and then we can wrap that into `datastore::Error::User` in the calling context.
+    let task = tx
+        .get_aggregator_task(task_id)
+        .await?
+        .ok_or_else(|| anyhow!("found no task with provided ID"))
+        .unwrap();
+    vdaf_dispatch!(task.vdaf(), (vdaf, VdafType, VERIFY_KEY_LENGTH) => {
+        match task.query_type() {
+            QueryType::TimeInterval => {
+                list_collection_jobs_generic::<
+                    VERIFY_KEY_LENGTH,
+                    TimeInterval,
+                    VdafType,
+                >(tx, &vdaf, task.id(), collection_job_id).await?;
+            }
+            QueryType::FixedSize { .. } => {
+                list_collection_jobs_generic::<
+                    VERIFY_KEY_LENGTH,
+                    FixedSize,
+                    VdafType,
+                >(tx, &vdaf, task.id(), collection_job_id).await?;
+            }
+        };
+    });
+
+    Ok(())
+}
+
+async fn list_collection_jobs_generic<
+    const SEED_SIZE: usize,
+    Q: janus_messages::query_type::QueryType,
+    A: Aggregator<SEED_SIZE, 16>,
+>(
+    tx: &Transaction<'_, RealClock>,
+    vdaf: &A,
+    task_id: &TaskId,
+    collection_job_id: Option<CollectionJobId>,
+) -> Result<(), crate::aggregator::Error> {
+    let (jobs, leases) = if let Some(job_id) = collection_job_id {
+        let job = tx
+            .get_collection_job::<SEED_SIZE, Q, A>(vdaf, task_id, &job_id)
+            .await?;
+
+        let lease = tx
+            .get_collection_job_lease::<SEED_SIZE, Q, A>(task_id, &job_id)
+            .await?;
+
+        (Vec::from(job.as_slice()), Vec::from(lease.as_slice()))
+    } else {
+        let jobs = tx
+            .get_collection_jobs_for_task::<SEED_SIZE, Q, A>(vdaf, task_id)
+            .await?;
+
+        let leases = tx
+            .get_collection_job_leases_by_task::<SEED_SIZE, Q, A>(task_id)
+            .await?;
+
+        (jobs, leases)
+    };
+
+    pretty_print_jobs_and_leases(
+        jobs.into_iter().sorted_by_key(|job| *job.id()),
+        leases
+            .into_iter()
+            .sorted_by_key(|lease| *lease.leased().collection_job_id()),
+    );
+
+    Ok(())
+}
+
+async fn dispatch_list_aggregation_jobs(
+    tx: &Transaction<'_, RealClock>,
+    task_id: &TaskId,
+    aggregation_job_id: Option<AggregationJobId>,
+) -> Result<(), crate::aggregator::Error> {
+    // We need this function so that its return type can provide error type hints to ?. See comment
+    // in dispatch_list_collection_jobs for details.
+    let task = tx
+        .get_aggregator_task(task_id)
+        .await?
+        .ok_or_else(|| anyhow!("found no task with provided ID"))
+        .unwrap();
+    vdaf_dispatch!(task.vdaf(), (vdaf, VdafType, VERIFY_KEY_LENGTH) => {
+        // We don't need the vdaf value here, but need to provide this type hint to the compiler
+        // so it can figure out what `prio::vdaf::Vdaf` to instantiate inside of `vdaf_dispatch!`.
+        let _vdaf: VdafType = vdaf;
+        match task.query_type() {
+            QueryType::TimeInterval => {
+                list_aggregation_jobs_generic::<
+                    VERIFY_KEY_LENGTH,
+                    TimeInterval,
+                    VdafType,
+                >(tx,task.id(), aggregation_job_id).await?;
+            }
+            QueryType::FixedSize { .. } => {
+                list_aggregation_jobs_generic::<
+                    VERIFY_KEY_LENGTH,
+                    FixedSize,
+                    VdafType,
+                >(tx, task.id(), aggregation_job_id).await?;
+            }
+        };
+    });
+
+    Ok(())
+}
+
+async fn list_aggregation_jobs_generic<
+    const SEED_SIZE: usize,
+    Q: janus_messages::query_type::QueryType,
+    A: Aggregator<SEED_SIZE, 16>,
+>(
+    tx: &Transaction<'_, RealClock>,
+    task_id: &TaskId,
+    aggregation_job_id: Option<AggregationJobId>,
+) -> Result<(), crate::aggregator::Error> {
+    let (jobs, leases) = if let Some(job_id) = aggregation_job_id {
+        let job = tx
+            .get_aggregation_job::<SEED_SIZE, Q, A>(task_id, &job_id)
+            .await?;
+
+        let lease = tx
+            .get_aggregation_job_lease::<SEED_SIZE, Q, A>(task_id, &job_id)
+            .await?;
+
+        (Vec::from(job.as_slice()), Vec::from(lease.as_slice()))
+    } else {
+        let jobs = tx
+            .get_aggregation_jobs_for_task::<SEED_SIZE, Q, A>(task_id)
+            .await?;
+
+        let leases = tx
+            .get_aggregation_job_leases_by_task::<SEED_SIZE, Q, A>(task_id)
+            .await?;
+
+        (jobs, leases)
+    };
+
+    pretty_print_jobs_and_leases(
+        jobs.into_iter().sorted_by_key(|job| *job.id()),
+        leases
+            .into_iter()
+            .sorted_by_key(|lease| *lease.leased().aggregation_job_id()),
+    );
+
+    Ok(())
 }
 
 async fn install_tracing_and_metrics_handlers(

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -1884,7 +1884,6 @@ WHERE aggregation_jobs.task_id = $1
     }
 
     /// get_aggregation_jobs_for_task returns all aggregation jobs for a given task ID.
-    #[cfg(feature = "test-util")]
     #[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
     #[tracing::instrument(skip(self), err(level = Level::DEBUG))]
     pub async fn get_aggregation_jobs_for_task<const SEED_SIZE: usize, Q, A>(
@@ -3111,7 +3110,7 @@ WHERE task_id = $1
         .collect()
     }
 
-    #[cfg(feature = "test-util")]
+    /// Retrieve all collection jobs for the specified task.
     pub async fn get_collection_jobs_for_task<
         const SEED_SIZE: usize,
         Q: QueryType,

--- a/aggregator_core/src/datastore/leases.rs
+++ b/aggregator_core/src/datastore/leases.rs
@@ -1,0 +1,313 @@
+use crate::datastore::{
+    models::{AcquiredAggregationJob, AcquiredCollectionJob, LeaseToken},
+    task, Error, RowExt, Transaction,
+};
+use chrono::NaiveDateTime;
+use janus_core::{
+    time::{Clock, TimeExt},
+    vdaf::VdafInstance,
+};
+use janus_messages::{query_type::QueryType, AggregationJobId, CollectionJobId, Duration, TaskId};
+use postgres_types::{Json, Timestamp};
+use prio::{codec::Decode, vdaf};
+use std::fmt::Debug;
+use tokio_postgres::Row;
+
+impl<C: Clock> Transaction<'_, C> {
+    /// Return the lease on a collection job for the provided ID, or `None` if no such collection
+    /// job exists.
+    ///
+    /// # Discussion
+    ///
+    /// Unlike `acquire_incomplete_collection_jobs`, this method does not acquire a lease, but
+    /// merely constructs a representation of the lease. Holding the returned value will not prevent
+    /// another caller from acquiring the lease and stepping the job.
+    pub async fn get_collection_job_lease<
+        const SEED_SIZE: usize,
+        Q: QueryType,
+        A: vdaf::Aggregator<SEED_SIZE, 16>,
+    >(
+        &self,
+        task_id: &TaskId,
+        collection_job_id: &CollectionJobId,
+    ) -> Result<Option<MaybeLease<AcquiredCollectionJob>>, Error> {
+        let task_info = match self.task_info_for(task_id).await? {
+            Some(task_info) => task_info,
+            None => return Ok(None),
+        };
+        let now = self.clock.now().as_naive_date_time()?;
+
+        let stmt = self
+            .prepare_cached(
+                r#"-- get_collection_job_lease
+SELECT
+    collection_jobs.id, collection_jobs.collection_job_id, collection_jobs.batch_identifier,
+    collection_jobs.aggregation_param, collection_jobs.lease_expiry, collection_jobs.lease_token,
+    collection_jobs.lease_attempts, collection_jobs.step_attempts, tasks.task_id, tasks.query_type,
+    tasks.vdaf, tasks.time_precision
+FROM collection_jobs JOIN tasks ON tasks.id = collection_jobs.task_id
+WHERE collection_jobs.task_id = $1
+    AND collection_jobs.collection_job_id = $2
+    AND COALESCE(
+        LOWER(batch_interval),
+        (SELECT MAX(UPPER(ba.client_timestamp_interval))
+            FROM batch_aggregations ba
+            WHERE ba.task_id = collection_jobs.task_id
+                AND ba.batch_identifier = collection_jobs.batch_identifier
+                AND ba.aggregation_param = collection_jobs.aggregation_param),
+        '-infinity'::TIMESTAMP)
+        >= COALESCE(
+            $3::TIMESTAMP - tasks.report_expiry_age * '1 second'::INTERVAL,
+            '-infinity'::TIMESTAMP
+        )"#,
+            )
+            .await?;
+
+        self.query_opt(
+            &stmt,
+            &[
+                /* task ID */ &task_info.pkey,
+                /* collection_job_id*/ &collection_job_id.as_ref(),
+                /* now */ &now,
+            ],
+        )
+        .await?
+        .map(|row| maybe_leased_collection_job_from_row(&row))
+        .transpose()
+    }
+
+    /// Return the leases on collection jobs for the provided task ID.
+    ///
+    /// # Discussion
+    ///
+    /// Unlike `acquire_incomplete_collection_jobs`, this method does not acquire leases, but
+    /// merely constructs representations of leases. Holding the returned value will not prevent
+    /// another caller from acquiring the leases and stepping the jobs.
+    pub async fn get_collection_job_leases_by_task<
+        const SEED_SIZE: usize,
+        Q: QueryType,
+        A: vdaf::Aggregator<SEED_SIZE, 16>,
+    >(
+        &self,
+        task_id: &TaskId,
+    ) -> Result<Vec<MaybeLease<AcquiredCollectionJob>>, Error> {
+        let task_info = match self.task_info_for(task_id).await? {
+            Some(task_info) => task_info,
+            None => return Ok(Vec::new()),
+        };
+        let now = self.clock.now().as_naive_date_time()?;
+
+        let stmt = self
+            .prepare_cached(
+                r#"-- get_collection_job_leases_by_task
+SELECT
+    collection_jobs.id, collection_jobs.collection_job_id, collection_jobs.batch_identifier,
+    collection_jobs.aggregation_param, collection_jobs.lease_expiry, collection_jobs.lease_token,
+    collection_jobs.lease_attempts, collection_jobs.step_attempts, tasks.task_id, tasks.query_type,
+    tasks.vdaf, tasks.time_precision
+FROM collection_jobs JOIN tasks ON tasks.id = collection_jobs.task_id
+WHERE collection_jobs.task_id = $1
+    AND COALESCE(
+        LOWER(batch_interval),
+        (SELECT MAX(UPPER(ba.client_timestamp_interval))
+            FROM batch_aggregations ba
+            WHERE ba.task_id = collection_jobs.task_id
+                AND ba.batch_identifier = collection_jobs.batch_identifier
+                AND ba.aggregation_param = collection_jobs.aggregation_param),
+        '-infinity'::TIMESTAMP)
+        >= COALESCE(
+            $2::TIMESTAMP - tasks.report_expiry_age * '1 second'::INTERVAL,
+            '-infinity'::TIMESTAMP
+        )"#,
+            )
+            .await?;
+
+        self.query(&stmt, &[/* task ID */ &task_info.pkey, /* now */ &now])
+            .await?
+            .iter()
+            .map(maybe_leased_collection_job_from_row)
+            .collect()
+    }
+
+    /// Return the lease on an aggregation job for the provided ID, or `None` if no such aggregation
+    /// job exists.
+    ///
+    /// # Discussion
+    ///
+    /// Unlike `acquire_incomplete_aggregation_jobs`, this method does not acquire a lease, but
+    /// merely constructs a representation of the lease. Holding the returned value will not prevent
+    /// another caller from acquiring the lease and stepping the job.
+    pub async fn get_aggregation_job_lease<
+        const SEED_SIZE: usize,
+        Q: QueryType,
+        A: vdaf::Aggregator<SEED_SIZE, 16>,
+    >(
+        &self,
+        task_id: &TaskId,
+        aggregation_job_id: &AggregationJobId,
+    ) -> Result<Option<MaybeLease<AcquiredAggregationJob>>, Error> {
+        let task_info = match self.task_info_for(task_id).await? {
+            Some(task_info) => task_info,
+            None => return Ok(None),
+        };
+
+        let stmt = self
+            .prepare_cached(
+                r#"-- get_aggregation_job_lease
+SELECT
+    aggregation_jobs.id, aggregation_jobs.aggregation_job_id, aggregation_jobs.lease_expiry, aggregation_jobs.lease_token,
+    aggregation_jobs.lease_attempts,  tasks.query_type,
+    tasks.vdaf, tasks.task_id
+FROM aggregation_jobs JOIN tasks ON tasks.id = aggregation_jobs.task_id
+WHERE aggregation_jobs.task_id = $1
+    AND aggregation_jobs.aggregation_job_id = $2
+    AND UPPER(aggregation_jobs.client_timestamp_interval) >= $3"#,
+            )
+            .await?;
+
+        self.query_opt(
+            &stmt,
+            &[
+                /* task ID */ &task_info.pkey,
+                /* aggregation_job_id*/ &aggregation_job_id.as_ref(),
+                /* threshold */
+                &task_info.report_expiry_threshold(&self.clock.now().as_naive_date_time()?)?,
+            ],
+        )
+        .await?
+        .map(|row| maybe_leased_aggregation_job_from_row(&row))
+        .transpose()
+    }
+
+    /// Return the leases on aggregation jobs for the provided task ID.
+    ///
+    /// # Discussion
+    ///
+    /// Unlike `acquire_incomplete_aggregation_jobs`, this method does not acquire leases, but
+    /// merely constructs representations of leases. Holding the returned value will not prevent
+    /// another caller from acquiring the leases and stepping the jobs.
+    pub async fn get_aggregation_job_leases_by_task<
+        const SEED_SIZE: usize,
+        Q: QueryType,
+        A: vdaf::Aggregator<SEED_SIZE, 16>,
+    >(
+        &self,
+        task_id: &TaskId,
+    ) -> Result<Vec<MaybeLease<AcquiredAggregationJob>>, Error> {
+        let task_info = match self.task_info_for(task_id).await? {
+            Some(task_info) => task_info,
+            None => return Ok(Vec::new()),
+        };
+
+        let stmt = self
+            .prepare_cached(
+                r#"-- get_aggregation_job_lease
+SELECT
+    aggregation_jobs.id, aggregation_jobs.aggregation_job_id, aggregation_jobs.lease_expiry, aggregation_jobs.lease_token,
+    aggregation_jobs.lease_attempts,  tasks.query_type,
+    tasks.vdaf, tasks.task_id
+FROM aggregation_jobs JOIN tasks ON tasks.id = aggregation_jobs.task_id
+WHERE aggregation_jobs.task_id = $1
+    AND UPPER(aggregation_jobs.client_timestamp_interval) >= $2"#,
+            )
+            .await?;
+
+        self.query(
+            &stmt,
+            &[
+                /* task ID */ &task_info.pkey,
+                /* threshold */
+                &task_info.report_expiry_threshold(&self.clock.now().as_naive_date_time()?)?,
+            ],
+        )
+        .await?
+        .iter()
+        .map(maybe_leased_aggregation_job_from_row)
+        .collect()
+    }
+}
+
+/// A representation of a lease on a job. Unlike a
+/// `janus_aggregator::core::datastore::models::Lease`, this does not constitute a held lease on a
+/// job. In fact, the job might not be leased at all, in which case the `lease_token` and
+/// `lease_expiry_time` fields are `None`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MaybeLease<T> {
+    leased: T,
+    lease_expiry_time: Timestamp<NaiveDateTime>,
+    lease_token: Option<LeaseToken>,
+    lease_attempts: usize,
+}
+
+impl<T> MaybeLease<T> {
+    pub fn leased(&self) -> &T {
+        &self.leased
+    }
+}
+
+fn maybe_leased_collection_job_from_row(
+    row: &Row,
+) -> Result<MaybeLease<AcquiredCollectionJob>, Error> {
+    let lease_expiry_time = row.try_get("lease_expiry")?;
+    let lease_token = row.get_nullable_bytea_and_convert::<LeaseToken>("lease_token")?;
+    let lease_attempts = row.get_bigint_and_convert("lease_attempts")?;
+
+    Ok(MaybeLease {
+        leased: acquired_collection_job_from_row(row)?,
+        lease_expiry_time,
+        lease_token,
+        lease_attempts,
+    })
+}
+
+pub(crate) fn acquired_collection_job_from_row(row: &Row) -> Result<AcquiredCollectionJob, Error> {
+    let task_id = TaskId::get_decoded(row.get("task_id"))?;
+    let collection_job_id = row.get_bytea_and_convert::<CollectionJobId>("collection_job_id")?;
+    let query_type = row.try_get::<_, Json<task::QueryType>>("query_type")?.0;
+    let vdaf = row.try_get::<_, Json<VdafInstance>>("vdaf")?.0;
+    let time_precision = Duration::from_seconds(row.get_bigint_and_convert("time_precision")?);
+    let encoded_batch_identifier = row.get("batch_identifier");
+    let encoded_aggregation_param = row.get("aggregation_param");
+    let step_attempts = row.get_bigint_and_convert("step_attempts")?;
+
+    Ok(AcquiredCollectionJob::new(
+        task_id,
+        collection_job_id,
+        query_type,
+        vdaf,
+        time_precision,
+        encoded_batch_identifier,
+        encoded_aggregation_param,
+        step_attempts,
+    ))
+}
+
+fn maybe_leased_aggregation_job_from_row(
+    row: &Row,
+) -> Result<MaybeLease<AcquiredAggregationJob>, Error> {
+    let lease_expiry_time = row.try_get("lease_expiry")?;
+    let lease_token = row.get_nullable_bytea_and_convert::<LeaseToken>("lease_token")?;
+    let lease_attempts = row.get_bigint_and_convert("lease_attempts")?;
+
+    Ok(MaybeLease {
+        leased: acquired_aggregation_job_from_row(row)?,
+        lease_expiry_time,
+        lease_token,
+        lease_attempts,
+    })
+}
+
+pub(crate) fn acquired_aggregation_job_from_row(
+    row: &Row,
+) -> Result<AcquiredAggregationJob, Error> {
+    let task_id = TaskId::get_decoded(row.get("task_id"))?;
+    let aggregation_job_id = row.get_bytea_and_convert::<AggregationJobId>("aggregation_job_id")?;
+    let query_type = row.try_get::<_, Json<task::QueryType>>("query_type")?.0;
+    let vdaf = row.try_get::<_, Json<VdafInstance>>("vdaf")?.0;
+    Ok(AcquiredAggregationJob::new(
+        task_id,
+        aggregation_job_id,
+        query_type,
+        vdaf,
+    ))
+}

--- a/aggregator_core/src/datastore/leases.rs
+++ b/aggregator_core/src/datastore/leases.rs
@@ -1,3 +1,5 @@
+//! Database accessors for leased jobs.
+
 use crate::datastore::{
     models::{AcquiredAggregationJob, AcquiredCollectionJob, LeaseToken},
     task, Error, RowExt, Transaction,


### PR DESCRIPTION
Adds new subcommands to `janus_cli` to enable easily getting information about aggregation and collection jobs and any leases on them.