### PR TITLE
`janus_cli`: get aggregation and collection jobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6127,7 +6127,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "socket2",
+ "socket2 0.5.9",
  "tokio",
  "tokio-stream",
  "tower 0.5.2",

--- a/aggregator/src/binaries/janus_cli.rs
+++ b/aggregator/src/binaries/janus_cli.rs
@@ -8,10 +8,12 @@ use anyhow::{Context, Result, anyhow};
 use aws_lc_rs::aead::AES_128_GCM;
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use clap::Parser;
+use itertools::Itertools;
 use janus_aggregator_api::git_revision;
 use janus_aggregator_core::{
-    datastore::{self, Datastore, models::HpkeKeyState},
-    task::{AggregationMode, AggregatorTask, SerializedAggregatorTask},
+    AsyncAggregator,
+    datastore::{self, Datastore, Transaction, models::HpkeKeyState},
+    task::{AggregationMode, AggregatorTask, BatchMode, SerializedAggregatorTask},
     taskprov::{PeerAggregator, VerifyKeyInit},
 };
 use janus_core::{
@@ -20,9 +22,13 @@ use janus_core::{
     hpke::HpkeKeypair,
     initialize_rustls,
     time::{Clock, RealClock},
+    vdaf_dispatch,
 };
 use janus_messages::{
-    Duration, HpkeAeadId, HpkeConfig, HpkeConfigId, HpkeKdfId, HpkeKemId, Role, codec::Encode as _,
+    AggregationJobId, CollectionJobId, Duration, HpkeAeadId, HpkeConfig, HpkeConfigId, HpkeKdfId,
+    HpkeKemId, Role, TaskId,
+    batch_mode::{LeaderSelected, TimeInterval},
+    codec::Encode as _,
 };
 use k8s_openapi::api::core::v1::Secret;
 use kube::api::{ObjectMeta, PostParams};
@@ -32,6 +38,7 @@ use rand::{Rng, distr::StandardUniform, rng};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeMap,
+    fmt::Debug,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -182,6 +189,34 @@ enum Command {
         #[clap(flatten)]
         kubernetes_secret_options: KubernetesSecretOptions,
     },
+
+    /// List collection jobs in the datastore
+    ListCollectionJobs {
+        #[clap(flatten)]
+        kubernetes_secret_options: KubernetesSecretOptions,
+
+        /// List collection jobs for this task
+        #[clap(long, value_name = "BASE64URL")]
+        task: TaskId,
+
+        /// List only this collection job
+        #[clap(long, value_name = "BASE64URL")]
+        job: Option<CollectionJobId>,
+    },
+
+    /// List aggregation jobs in the datastore
+    ListAggregationJobs {
+        #[clap(flatten)]
+        kubernetes_secret_options: KubernetesSecretOptions,
+
+        /// List aggregation jobs for this task
+        #[clap(long, value_name = "BASE64URL")]
+        task: TaskId,
+
+        /// List only this aggregation job
+        #[clap(long, value_name = "BASE64URL")]
+        job: Option<AggregationJobId>,
+    },
 }
 
 impl Command {
@@ -329,8 +364,239 @@ impl Command {
                 )
                 .await
             }
+
+            Command::ListCollectionJobs {
+                task,
+                job,
+                kubernetes_secret_options,
+            } => {
+                let datastore = datastore_from_opts(
+                    kubernetes_secret_options,
+                    command_line_options,
+                    config_file,
+                    &kube_client,
+                )
+                .await?;
+
+                datastore
+                    .run_tx("janus-cli-list-collection-jobs", |tx| {
+                        let task_id = *task;
+                        let job_id = *job;
+                        Box::pin(async move {
+                            dispatch_list_collection_jobs(tx, &task_id, job_id)
+                                .await
+                                .map_err(|e| {
+                                    janus_aggregator_core::datastore::Error::User(e.into())
+                                })
+                        })
+                    })
+                    .await
+                    .context("couldn't list collection jobs")
+            }
+
+            Command::ListAggregationJobs {
+                task,
+                job,
+                kubernetes_secret_options,
+            } => {
+                let datastore = datastore_from_opts(
+                    kubernetes_secret_options,
+                    command_line_options,
+                    config_file,
+                    &kube_client,
+                )
+                .await?;
+
+                datastore
+                    .run_tx("janus-cli-list-aggregation-jobs", |tx| {
+                        let task_id = *task;
+                        let job_id = *job;
+                        Box::pin(async move {
+                            dispatch_list_aggregation_jobs(tx, &task_id, job_id)
+                                .await
+                                .map_err(|e| {
+                                    janus_aggregator_core::datastore::Error::User(e.into())
+                                })
+                        })
+                    })
+                    .await
+                    .context("couldn't list aggregation jobs")
+            }
         }
     }
+}
+
+fn pretty_print_jobs_and_leases<
+    Job: Debug,
+    Lease: Debug,
+    JobIter: Iterator<Item = Job>,
+    LeaseIter: Iterator<Item = Lease>,
+>(
+    jobs: JobIter,
+    leases: LeaseIter,
+) {
+    // There should always be the same number of items in both iterators, because they were
+    // constructed from the same database rows.
+    for (job, lease) in jobs.zip(leases) {
+        println!("{job:#?}\n{lease:#?}\n");
+    }
+}
+
+async fn dispatch_list_collection_jobs(
+    tx: &Transaction<'_, RealClock>,
+    task_id: &TaskId,
+    collection_job_id: Option<CollectionJobId>,
+) -> Result<(), crate::aggregator::Error> {
+    // vdaf_dispatch! expands into (among other things) a method call that returns
+    // `prio::vdaf::VdafError` and has ? applied to it. This function's own logic deals with methods
+    // that return `janus_aggregator_core::datastore::Error`. Because this function is declared to
+    // return `janus_aggregator::aggregator::Error`, ? can resolve both those errors into a single
+    // type, and then we can wrap that into `datastore::Error::User` in the calling context.
+    let task = tx
+        .get_aggregator_task(task_id)
+        .await?
+        .ok_or_else(|| anyhow!("found no task with provided ID"))
+        .unwrap();
+    vdaf_dispatch!(task.vdaf(), (vdaf, VdafType, VERIFY_KEY_LENGTH) => {
+        match task.batch_mode() {
+            BatchMode::TimeInterval => {
+                list_collection_jobs_generic::<
+                    VERIFY_KEY_LENGTH,
+                    TimeInterval,
+                    VdafType,
+                >(tx, &vdaf, task.id(), collection_job_id).await?;
+            }
+            BatchMode::LeaderSelected { .. } => {
+                list_collection_jobs_generic::<
+                    VERIFY_KEY_LENGTH,
+                    LeaderSelected,
+                    VdafType,
+                >(tx, &vdaf, task.id(), collection_job_id).await?;
+            }
+        };
+    });
+
+    Ok(())
+}
+
+async fn list_collection_jobs_generic<
+    const SEED_SIZE: usize,
+    B: janus_messages::batch_mode::BatchMode,
+    A: AsyncAggregator<SEED_SIZE>,
+>(
+    tx: &Transaction<'_, RealClock>,
+    vdaf: &A,
+    task_id: &TaskId,
+    collection_job_id: Option<CollectionJobId>,
+) -> Result<(), crate::aggregator::Error> {
+    let (jobs, leases) = if let Some(job_id) = collection_job_id {
+        let job = tx
+            .get_collection_job::<SEED_SIZE, B, A>(vdaf, task_id, &job_id)
+            .await?;
+
+        let lease = tx
+            .get_collection_job_lease::<SEED_SIZE, B, A>(task_id, &job_id)
+            .await?;
+
+        (Vec::from(job.as_slice()), Vec::from(lease.as_slice()))
+    } else {
+        let jobs = tx
+            .get_collection_jobs_for_task::<SEED_SIZE, B, A>(vdaf, task_id)
+            .await?;
+
+        let leases = tx
+            .get_collection_job_leases_by_task::<SEED_SIZE, B, A>(task_id)
+            .await?;
+
+        (jobs, leases)
+    };
+
+    pretty_print_jobs_and_leases(
+        jobs.into_iter().sorted_by_key(|job| *job.id()),
+        leases
+            .into_iter()
+            .sorted_by_key(|lease| *lease.leased().collection_job_id()),
+    );
+
+    Ok(())
+}
+
+async fn dispatch_list_aggregation_jobs(
+    tx: &Transaction<'_, RealClock>,
+    task_id: &TaskId,
+    aggregation_job_id: Option<AggregationJobId>,
+) -> Result<(), crate::aggregator::Error> {
+    // We need this function so that its return type can provide error type hints to ?. See comment
+    // in dispatch_list_collection_jobs for details.
+    let task = tx
+        .get_aggregator_task(task_id)
+        .await?
+        .ok_or_else(|| anyhow!("found no task with provided ID"))
+        .unwrap();
+    vdaf_dispatch!(task.vdaf(), (vdaf, VdafType, VERIFY_KEY_LENGTH) => {
+        // We don't need the vdaf value here, but need to provide this type hint to the compiler
+        // so it can figure out what `prio::vdaf::Vdaf` to instantiate inside of `vdaf_dispatch!`.
+        let _vdaf: VdafType = vdaf;
+        match task.batch_mode() {
+            BatchMode::TimeInterval => {
+                list_aggregation_jobs_generic::<
+                    VERIFY_KEY_LENGTH,
+                    TimeInterval,
+                    VdafType,
+                >(tx,task.id(), aggregation_job_id).await?;
+            }
+            BatchMode::LeaderSelected { .. } => {
+                list_aggregation_jobs_generic::<
+                    VERIFY_KEY_LENGTH,
+                    LeaderSelected,
+                    VdafType,
+                >(tx, task.id(), aggregation_job_id).await?;
+            }
+        };
+    });
+
+    Ok(())
+}
+
+async fn list_aggregation_jobs_generic<
+    const SEED_SIZE: usize,
+    B: janus_messages::batch_mode::BatchMode,
+    A: AsyncAggregator<SEED_SIZE>,
+>(
+    tx: &Transaction<'_, RealClock>,
+    task_id: &TaskId,
+    aggregation_job_id: Option<AggregationJobId>,
+) -> Result<(), crate::aggregator::Error> {
+    let (jobs, leases) = if let Some(job_id) = aggregation_job_id {
+        let job = tx
+            .get_aggregation_job::<SEED_SIZE, B, A>(task_id, &job_id)
+            .await?;
+
+        let lease = tx
+            .get_aggregation_job_lease::<SEED_SIZE, B, A>(task_id, &job_id)
+            .await?;
+
+        (Vec::from(job.as_slice()), Vec::from(lease.as_slice()))
+    } else {
+        let jobs = tx
+            .get_aggregation_jobs_for_task::<SEED_SIZE, B, A>(task_id)
+            .await?;
+
+        let leases = tx
+            .get_aggregation_job_leases_by_task::<SEED_SIZE, B, A>(task_id)
+            .await?;
+
+        (jobs, leases)
+    };
+
+    pretty_print_jobs_and_leases(
+        jobs.into_iter().sorted_by_key(|job| *job.id()),
+        leases
+            .into_iter()
+            .sorted_by_key(|lease| *lease.leased().aggregation_job_id()),
+    );
+
+    Ok(())
 }
 
 async fn install_tracing_and_metrics_handlers(

--- a/aggregator_core/src/datastore/leases.rs
+++ b/aggregator_core/src/datastore/leases.rs
@@ -1,0 +1,316 @@
+//! Database accessors for leased jobs.
+
+use crate::datastore::{
+    AsyncAggregator, Error, RowExt, Transaction,
+    models::{AcquiredAggregationJob, AcquiredCollectionJob, LeaseToken},
+    task,
+};
+use chrono::NaiveDateTime;
+use janus_core::{
+    time::{Clock, TimeExt},
+    vdaf::VdafInstance,
+};
+use janus_messages::{AggregationJobId, CollectionJobId, Duration, TaskId, batch_mode::BatchMode};
+use postgres_types::{Json, Timestamp};
+use prio::codec::Decode;
+use std::fmt::Debug;
+use tokio_postgres::Row;
+
+impl<C: Clock> Transaction<'_, C> {
+    /// Return the lease on a collection job for the provided ID, or `None` if no such collection
+    /// job exists.
+    ///
+    /// # Discussion
+    ///
+    /// Unlike `acquire_incomplete_collection_jobs`, this method does not acquire a lease, but
+    /// merely constructs a representation of the lease. Holding the returned value will not prevent
+    /// another caller from acquiring the lease and stepping the job.
+    pub async fn get_collection_job_lease<
+        const SEED_SIZE: usize,
+        B: BatchMode,
+        A: AsyncAggregator<SEED_SIZE>,
+    >(
+        &self,
+        task_id: &TaskId,
+        collection_job_id: &CollectionJobId,
+    ) -> Result<Option<MaybeLease<AcquiredCollectionJob>>, Error> {
+        let task_info = match self.task_info_for(task_id).await? {
+            Some(task_info) => task_info,
+            None => return Ok(None),
+        };
+        let now = self.clock.now().as_naive_date_time()?;
+
+        let stmt = self
+            .prepare_cached(
+                r#"-- get_collection_job_lease
+SELECT
+    collection_jobs.id, collection_jobs.collection_job_id, collection_jobs.batch_identifier,
+    collection_jobs.aggregation_param, collection_jobs.lease_expiry, collection_jobs.lease_token,
+    collection_jobs.lease_attempts, collection_jobs.step_attempts, tasks.task_id, tasks.batch_mode,
+    tasks.vdaf, tasks.time_precision
+FROM collection_jobs JOIN tasks ON tasks.id = collection_jobs.task_id
+WHERE collection_jobs.task_id = $1
+    AND collection_jobs.collection_job_id = $2
+    AND COALESCE(
+        LOWER(batch_interval),
+        (SELECT MAX(UPPER(ba.client_timestamp_interval))
+            FROM batch_aggregations ba
+            WHERE ba.task_id = collection_jobs.task_id
+                AND ba.batch_identifier = collection_jobs.batch_identifier
+                AND ba.aggregation_param = collection_jobs.aggregation_param),
+        '-infinity'::TIMESTAMP)
+        >= COALESCE(
+            $3::TIMESTAMP - tasks.report_expiry_age * '1 second'::INTERVAL,
+            '-infinity'::TIMESTAMP
+        )"#,
+            )
+            .await?;
+
+        self.query_opt(
+            &stmt,
+            &[
+                /* task ID */ &task_info.pkey,
+                /* collection_job_id*/ &collection_job_id.as_ref(),
+                /* now */ &now,
+            ],
+        )
+        .await?
+        .map(|row| maybe_leased_collection_job_from_row(&row))
+        .transpose()
+    }
+
+    /// Return the leases on collection jobs for the provided task ID.
+    ///
+    /// # Discussion
+    ///
+    /// Unlike `acquire_incomplete_collection_jobs`, this method does not acquire leases, but
+    /// merely constructs representations of leases. Holding the returned value will not prevent
+    /// another caller from acquiring the leases and stepping the jobs.
+    pub async fn get_collection_job_leases_by_task<
+        const SEED_SIZE: usize,
+        B: BatchMode,
+        A: AsyncAggregator<SEED_SIZE>,
+    >(
+        &self,
+        task_id: &TaskId,
+    ) -> Result<Vec<MaybeLease<AcquiredCollectionJob>>, Error> {
+        let task_info = match self.task_info_for(task_id).await? {
+            Some(task_info) => task_info,
+            None => return Ok(Vec::new()),
+        };
+        let now = self.clock.now().as_naive_date_time()?;
+
+        let stmt = self
+            .prepare_cached(
+                r#"-- get_collection_job_leases_by_task
+SELECT
+    collection_jobs.id, collection_jobs.collection_job_id, collection_jobs.batch_identifier,
+    collection_jobs.aggregation_param, collection_jobs.lease_expiry, collection_jobs.lease_token,
+    collection_jobs.lease_attempts, collection_jobs.step_attempts, tasks.task_id, tasks.batch_mode,
+    tasks.vdaf, tasks.time_precision
+FROM collection_jobs JOIN tasks ON tasks.id = collection_jobs.task_id
+WHERE collection_jobs.task_id = $1
+    AND COALESCE(
+        LOWER(batch_interval),
+        (SELECT MAX(UPPER(ba.client_timestamp_interval))
+            FROM batch_aggregations ba
+            WHERE ba.task_id = collection_jobs.task_id
+                AND ba.batch_identifier = collection_jobs.batch_identifier
+                AND ba.aggregation_param = collection_jobs.aggregation_param),
+        '-infinity'::TIMESTAMP)
+        >= COALESCE(
+            $2::TIMESTAMP - tasks.report_expiry_age * '1 second'::INTERVAL,
+            '-infinity'::TIMESTAMP
+        )"#,
+            )
+            .await?;
+
+        self.query(&stmt, &[/* task ID */ &task_info.pkey, /* now */ &now])
+            .await?
+            .iter()
+            .map(maybe_leased_collection_job_from_row)
+            .collect()
+    }
+
+    /// Return the lease on an aggregation job for the provided ID, or `None` if no such aggregation
+    /// job exists.
+    ///
+    /// # Discussion
+    ///
+    /// Unlike `acquire_incomplete_aggregation_jobs`, this method does not acquire a lease, but
+    /// merely constructs a representation of the lease. Holding the returned value will not prevent
+    /// another caller from acquiring the lease and stepping the job.
+    pub async fn get_aggregation_job_lease<
+        const SEED_SIZE: usize,
+        B: BatchMode,
+        A: AsyncAggregator<SEED_SIZE>,
+    >(
+        &self,
+        task_id: &TaskId,
+        aggregation_job_id: &AggregationJobId,
+    ) -> Result<Option<MaybeLease<AcquiredAggregationJob>>, Error> {
+        let task_info = match self.task_info_for(task_id).await? {
+            Some(task_info) => task_info,
+            None => return Ok(None),
+        };
+
+        let stmt = self
+            .prepare_cached(
+                r#"-- get_aggregation_job_lease
+SELECT
+    aggregation_jobs.id, aggregation_jobs.aggregation_job_id, aggregation_jobs.lease_expiry,
+    aggregation_jobs.lease_token, aggregation_jobs.lease_attempts,  tasks.batch_mode, tasks.vdaf,
+    tasks.task_id
+FROM aggregation_jobs JOIN tasks ON tasks.id = aggregation_jobs.task_id
+WHERE aggregation_jobs.task_id = $1
+    AND aggregation_jobs.aggregation_job_id = $2
+    AND UPPER(aggregation_jobs.client_timestamp_interval) >= $3"#,
+            )
+            .await?;
+
+        self.query_opt(
+            &stmt,
+            &[
+                /* task ID */ &task_info.pkey,
+                /* aggregation_job_id*/ &aggregation_job_id.as_ref(),
+                /* threshold */
+                &task_info.report_expiry_threshold(&self.clock.now().as_naive_date_time()?)?,
+            ],
+        )
+        .await?
+        .map(|row| maybe_leased_aggregation_job_from_row(&row))
+        .transpose()
+    }
+
+    /// Return the leases on aggregation jobs for the provided task ID.
+    ///
+    /// # Discussion
+    ///
+    /// Unlike `acquire_incomplete_aggregation_jobs`, this method does not acquire leases, but
+    /// merely constructs representations of leases. Holding the returned value will not prevent
+    /// another caller from acquiring the leases and stepping the jobs.
+    pub async fn get_aggregation_job_leases_by_task<
+        const SEED_SIZE: usize,
+        B: BatchMode,
+        A: AsyncAggregator<SEED_SIZE>,
+    >(
+        &self,
+        task_id: &TaskId,
+    ) -> Result<Vec<MaybeLease<AcquiredAggregationJob>>, Error> {
+        let task_info = match self.task_info_for(task_id).await? {
+            Some(task_info) => task_info,
+            None => return Ok(Vec::new()),
+        };
+
+        let stmt = self
+            .prepare_cached(
+                r#"-- get_aggregation_job_lease
+SELECT
+    aggregation_jobs.id, aggregation_jobs.aggregation_job_id, aggregation_jobs.lease_expiry,
+    aggregation_jobs.lease_token, aggregation_jobs.lease_attempts,  tasks.batch_mode, tasks.vdaf,
+    tasks.task_id
+FROM aggregation_jobs JOIN tasks ON tasks.id = aggregation_jobs.task_id
+WHERE aggregation_jobs.task_id = $1
+    AND UPPER(aggregation_jobs.client_timestamp_interval) >= $2"#,
+            )
+            .await?;
+
+        self.query(
+            &stmt,
+            &[
+                /* task ID */ &task_info.pkey,
+                /* threshold */
+                &task_info.report_expiry_threshold(&self.clock.now().as_naive_date_time()?)?,
+            ],
+        )
+        .await?
+        .iter()
+        .map(maybe_leased_aggregation_job_from_row)
+        .collect()
+    }
+}
+
+/// A representation of a lease on a job. Unlike a
+/// `janus_aggregator::core::datastore::models::Lease`, this does not constitute a held lease on a
+/// job. In fact, the job might not be leased at all, in which case the `lease_token` and
+/// `lease_expiry_time` fields are `None`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MaybeLease<T> {
+    leased: T,
+    pub(crate) lease_expiry_time: Timestamp<NaiveDateTime>,
+    pub(crate) lease_token: Option<LeaseToken>,
+    pub(crate) lease_attempts: usize,
+}
+
+impl<T> MaybeLease<T> {
+    pub fn leased(&self) -> &T {
+        &self.leased
+    }
+}
+
+fn maybe_leased_collection_job_from_row(
+    row: &Row,
+) -> Result<MaybeLease<AcquiredCollectionJob>, Error> {
+    let lease_expiry_time = row.try_get("lease_expiry")?;
+    let lease_token = row.get_nullable_bytea_and_convert::<LeaseToken>("lease_token")?;
+    let lease_attempts = row.get_bigint_and_convert("lease_attempts")?;
+
+    Ok(MaybeLease {
+        leased: acquired_collection_job_from_row(row)?,
+        lease_expiry_time,
+        lease_token,
+        lease_attempts,
+    })
+}
+
+pub(crate) fn acquired_collection_job_from_row(row: &Row) -> Result<AcquiredCollectionJob, Error> {
+    let task_id = TaskId::get_decoded(row.get("task_id"))?;
+    let collection_job_id = row.get_bytea_and_convert::<CollectionJobId>("collection_job_id")?;
+    let query_type = row.try_get::<_, Json<task::BatchMode>>("batch_mode")?.0;
+    let vdaf = row.try_get::<_, Json<VdafInstance>>("vdaf")?.0;
+    let time_precision = Duration::from_seconds(row.get_bigint_and_convert("time_precision")?);
+    let encoded_batch_identifier = row.get("batch_identifier");
+    let encoded_aggregation_param = row.get("aggregation_param");
+    let step_attempts = row.get_bigint_and_convert("step_attempts")?;
+
+    Ok(AcquiredCollectionJob::new(
+        task_id,
+        collection_job_id,
+        query_type,
+        vdaf,
+        time_precision,
+        encoded_batch_identifier,
+        encoded_aggregation_param,
+        step_attempts,
+    ))
+}
+
+fn maybe_leased_aggregation_job_from_row(
+    row: &Row,
+) -> Result<MaybeLease<AcquiredAggregationJob>, Error> {
+    let lease_expiry_time = row.try_get("lease_expiry")?;
+    let lease_token = row.get_nullable_bytea_and_convert::<LeaseToken>("lease_token")?;
+    let lease_attempts = row.get_bigint_and_convert("lease_attempts")?;
+
+    Ok(MaybeLease {
+        leased: acquired_aggregation_job_from_row(row)?,
+        lease_expiry_time,
+        lease_token,
+        lease_attempts,
+    })
+}
+
+pub(crate) fn acquired_aggregation_job_from_row(
+    row: &Row,
+) -> Result<AcquiredAggregationJob, Error> {
+    let task_id = TaskId::get_decoded(row.get("task_id"))?;
+    let aggregation_job_id = row.get_bytea_and_convert::<AggregationJobId>("aggregation_job_id")?;
+    let query_type = row.try_get::<_, Json<task::BatchMode>>("batch_mode")?.0;
+    let vdaf = row.try_get::<_, Json<VdafInstance>>("vdaf")?.0;
+    Ok(AcquiredAggregationJob::new(
+        task_id,
+        aggregation_job_id,
+        query_type,
+        vdaf,
+    ))
+}

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -39,6 +39,7 @@ use janus_messages::{
     ReportIdChecksum, ReportMetadata, ReportShare, Role, TaskId, Time,
     batch_mode::{BatchMode, LeaderSelected, TimeInterval},
 };
+use postgres_types::Timestamp;
 use prio::{
     codec::{Decode, Encode},
     dp::{
@@ -1966,104 +1967,190 @@ async fn aggregation_job_acquire_release(ephemeral_datastore: EphemeralDatastore
         .take(AGGREGATION_JOB_COUNT)
         .collect();
     task_and_aggregation_job_ids.sort();
+    let leader_aggregation_job_ids: Vec<_> = task_and_aggregation_job_ids
+        .iter()
+        .filter(|(t, _)| t == leader_task.id())
+        .map(|(_, j)| *j)
+        .collect();
 
+    let (finished_aggregation_job_id, expired_aggregation_job_id) = ds
+        .run_unnamed_tx(|tx| {
+            let leader_task = leader_task.clone();
+            let helper_task = helper_task.clone();
+            let task_and_aggregation_job_ids = task_and_aggregation_job_ids.clone();
+
+            Box::pin(async move {
+                // Write a few aggregation jobs we expect to be able to retrieve with
+                // acquire_incomplete_aggregation_jobs().
+                tx.put_aggregator_task(&leader_task).await.unwrap();
+                tx.put_aggregator_task(&helper_task).await.unwrap();
+
+                try_join_all(task_and_aggregation_job_ids.into_iter().map(
+                    |(task_id, aggregation_job_id)| async move {
+                        tx.put_aggregation_job(&AggregationJob::<
+                            VERIFY_KEY_LENGTH_PRIO3,
+                            TimeInterval,
+                            Prio3Count,
+                        >::new(
+                            task_id,
+                            aggregation_job_id,
+                            (),
+                            (),
+                            Interval::new(
+                                OLDEST_ALLOWED_REPORT_TIMESTAMP
+                                    .add(&Duration::from_seconds(LEASE_DURATION.as_secs()))
+                                    .unwrap()
+                                    .add(&Duration::from_seconds(LEASE_DURATION.as_secs()))
+                                    .unwrap()
+                                    .to_batch_interval_start(&TIME_PRECISION)
+                                    .unwrap(),
+                                TIME_PRECISION,
+                            )
+                            .unwrap(),
+                            AggregationJobState::Active,
+                            AggregationJobStep::from(0),
+                        ))
+                        .await
+                    },
+                ))
+                .await
+                .unwrap();
+
+                // Write an aggregation job that is finished. We don't want to retrieve this one.
+                let finished_aggregation_job_id = random();
+                tx.put_aggregation_job(&AggregationJob::<
+                    VERIFY_KEY_LENGTH_PRIO3,
+                    TimeInterval,
+                    Prio3Count,
+                >::new(
+                    *leader_task.id(),
+                    finished_aggregation_job_id,
+                    (),
+                    (),
+                    Interval::new(OLDEST_ALLOWED_REPORT_TIMESTAMP, TIME_PRECISION).unwrap(),
+                    AggregationJobState::Finished,
+                    AggregationJobStep::from(1),
+                ))
+                .await
+                .unwrap();
+
+                // Write an expired aggregation job. We don't want to retrieve this one, either.
+                let expired_aggregation_job_id = random();
+                tx.put_aggregation_job(&AggregationJob::<
+                    VERIFY_KEY_LENGTH_PRIO3,
+                    TimeInterval,
+                    Prio3Count,
+                >::new(
+                    *leader_task.id(),
+                    expired_aggregation_job_id,
+                    (),
+                    (),
+                    Interval::new(
+                        Time::from_seconds_since_epoch(0),
+                        *leader_task.time_precision(),
+                    )
+                    .unwrap(),
+                    AggregationJobState::Active,
+                    AggregationJobStep::from(0),
+                ))
+                .await
+                .unwrap();
+
+                // Write an aggregation job that is awaiting a request from the Leader. We don't want to
+                // retrieve this one, either.
+                tx.put_aggregation_job(&AggregationJob::<
+                    VERIFY_KEY_LENGTH_PRIO3,
+                    TimeInterval,
+                    Prio3Count,
+                >::new(
+                    *helper_task.id(),
+                    random(),
+                    (),
+                    (),
+                    Interval::new(Time::from_seconds_since_epoch(0), TIME_PRECISION).unwrap(),
+                    AggregationJobState::AwaitingRequest,
+                    AggregationJobStep::from(0),
+                ))
+                .await
+                .unwrap();
+
+                Ok((finished_aggregation_job_id, expired_aggregation_job_id))
+            })
+        })
+        .await
+        .unwrap();
+
+    // Getting aggregation job leases should not not acquire leases and should not affect acquiring
+    // them later.
     ds.run_unnamed_tx(|tx| {
-        let leader_task = leader_task.clone();
-        let helper_task = helper_task.clone();
-        let task_and_aggregation_job_ids = task_and_aggregation_job_ids.clone();
+        let (task, mut maybe_leased_aggregation_job_ids) = (
+            leader_task.clone(),
+            leader_aggregation_job_ids.clone().into_iter().chain(
+                // When we get leases, we expect to see the finished and expired jobs (because we
+                // haven't advanced time yet), but not the helper job (because we query on the
+                // leader task).
+                Vec::from([finished_aggregation_job_id, expired_aggregation_job_id])).collect::<Vec<_>>(),
 
+        );
         Box::pin(async move {
-            // Write a few aggregation jobs we expect to be able to retrieve with
-            // acquire_incomplete_aggregation_jobs().
-            tx.put_aggregator_task(&leader_task).await.unwrap();
-            tx.put_aggregator_task(&helper_task).await.unwrap();
-
-            try_join_all(task_and_aggregation_job_ids.into_iter().map(
-                |(task_id, aggregation_job_id)| async move {
-                    tx.put_aggregation_job(&AggregationJob::<
-                        VERIFY_KEY_LENGTH_PRIO3,
-                        TimeInterval,
-                        Prio3Count,
-                    >::new(
-                        task_id,
-                        aggregation_job_id,
-                        (),
-                        (),
-                        Interval::new(
-                            OLDEST_ALLOWED_REPORT_TIMESTAMP
-                                .add(&Duration::from_seconds(LEASE_DURATION.as_secs()))
-                                .unwrap()
-                                .add(&Duration::from_seconds(LEASE_DURATION.as_secs()))
-                                .unwrap()
-                                .to_batch_interval_start(&TIME_PRECISION)
-                                .unwrap(),
-                            TIME_PRECISION,
-                        )
-                        .unwrap(),
-                        AggregationJobState::Active,
-                        AggregationJobStep::from(0),
-                    ))
-                    .await
-                },
-            ))
-            .await
-            .unwrap();
-
-            // Write an aggregation job that is finished. We don't want to retrieve this one.
-            tx.put_aggregation_job(&AggregationJob::<
-                VERIFY_KEY_LENGTH_PRIO3,
-                TimeInterval,
-                Prio3Count,
-            >::new(
-                *leader_task.id(),
-                random(),
-                (),
-                (),
-                Interval::new(OLDEST_ALLOWED_REPORT_TIMESTAMP, TIME_PRECISION).unwrap(),
-                AggregationJobState::Finished,
-                AggregationJobStep::from(1),
-            ))
-            .await
-            .unwrap();
-
-            // Write an expired aggregation job. We don't want to retrieve this one, either.
-            tx.put_aggregation_job(&AggregationJob::<
-                VERIFY_KEY_LENGTH_PRIO3,
-                TimeInterval,
-                Prio3Count,
-            >::new(
-                *leader_task.id(),
-                random(),
-                (),
-                (),
-                Interval::new(
-                    Time::from_seconds_since_epoch(0),
-                    *leader_task.time_precision(),
+            let maybe_leases = tx
+                .get_aggregation_job_leases_by_task::<VERIFY_KEY_LENGTH_PRIO3, TimeInterval, Prio3Count>(
+                    task.id(),
                 )
-                .unwrap(),
-                AggregationJobState::Active,
-                AggregationJobStep::from(0),
-            ))
-            .await
-            .unwrap();
+                .await
+                .unwrap();
 
-            // Write an aggregation job that is awaiting a request from the Leader. We don't want to
-            // retrieve this one, either.
-            tx.put_aggregation_job(&AggregationJob::<
-                VERIFY_KEY_LENGTH_PRIO3,
-                TimeInterval,
-                Prio3Count,
-            >::new(
-                *helper_task.id(),
-                random(),
-                (),
-                (),
-                Interval::new(Time::from_seconds_since_epoch(0), TIME_PRECISION).unwrap(),
-                AggregationJobState::AwaitingRequest,
-                AggregationJobStep::from(0),
-            ))
-            .await
-            .unwrap();
+            let mut seen_aggregation_job_ids = Vec::new();
+            for maybe_lease in maybe_leases {
+                assert_eq!(maybe_lease.lease_expiry_time, Timestamp::NegInfinity);
+                assert_eq!(maybe_lease.lease_token, None);
+                assert_eq!(maybe_lease.lease_attempts, 0);
+
+                seen_aggregation_job_ids.push(*maybe_lease.leased().aggregation_job_id());
+            }
+
+            maybe_leased_aggregation_job_ids.sort();
+            seen_aggregation_job_ids.sort();
+            assert_eq!(maybe_leased_aggregation_job_ids, seen_aggregation_job_ids);
+
+            let no_such_task = tx
+                .get_aggregation_job_leases_by_task::<VERIFY_KEY_LENGTH_PRIO3, TimeInterval, Prio3Count>(
+                    &random(),
+                )
+                .await
+                .unwrap();
+            assert!(no_such_task.is_empty());
+
+            let maybe_lease = tx
+                .get_aggregation_job_lease::<VERIFY_KEY_LENGTH_PRIO3, TimeInterval, Prio3Count>(
+                    task.id(),
+                    &maybe_leased_aggregation_job_ids[0],
+                )
+                .await
+                .unwrap()
+                .unwrap();
+
+            assert_eq!(maybe_lease.lease_expiry_time, Timestamp::NegInfinity);
+            assert_eq!(maybe_lease.lease_token, None);
+            assert_eq!(maybe_lease.lease_attempts, 0);
+
+            let no_such_aggregation_job = tx
+                .get_aggregation_job_lease::<VERIFY_KEY_LENGTH_PRIO3, TimeInterval, Prio3Count>(
+                    task.id(),
+                    &random(),
+                )
+                .await
+                .unwrap();
+            assert!(no_such_aggregation_job.is_none());
+
+            let no_such_task = tx
+                .get_aggregation_job_lease::<VERIFY_KEY_LENGTH_PRIO3, TimeInterval, Prio3Count>(
+                    &random(),
+                    &random(),
+                )
+                .await
+                .unwrap();
+            assert!(no_such_task.is_none());
 
             Ok(())
         })
@@ -2165,6 +2252,69 @@ async fn aggregation_job_acquire_release(ephemeral_datastore: EphemeralDatastore
     assert_eq!(want_aggregation_jobs, got_aggregation_jobs);
 
     // Run: release a few jobs with a delay before reacquiry, then attempt to acquire jobs again.
+    // The leases having been acquired should be reflected when we get MaybeLeases.
+    ds.run_unnamed_tx(|tx| {
+        let (task, mut maybe_leased_aggregation_job_ids, leased_aggregation_job_ids) = (
+            leader_task.clone(),
+            leader_aggregation_job_ids
+                .clone()
+                .into_iter()
+                .chain(
+                    // When we get leases, we expect to see the finished job, but not the expired
+                    // job (because we advanced time).
+                    Vec::from([finished_aggregation_job_id]),
+                )
+                .collect::<Vec<_>>(),
+            leader_aggregation_job_ids.clone(),
+        );
+        Box::pin(async move {
+            let maybe_leases = tx
+                .get_aggregation_job_leases_by_task::<VERIFY_KEY_LENGTH_PRIO3, TimeInterval, Prio3Count>(
+                    task.id(),
+                )
+                .await
+                .unwrap();
+
+            let mut seen_aggregation_job_ids = Vec::new();
+            for maybe_lease in maybe_leases {
+                if leased_aggregation_job_ids.contains(maybe_lease.leased().aggregation_job_id()) {
+                    assert_ne!(maybe_lease.lease_expiry_time, Timestamp::NegInfinity);
+                    assert_ne!(maybe_lease.lease_expiry_time, Timestamp::PosInfinity);
+                    assert!(maybe_lease.lease_token.is_some());
+                    assert_eq!(maybe_lease.lease_attempts, 1);
+                } else {
+                    assert_eq!(maybe_lease.lease_expiry_time, Timestamp::NegInfinity);
+                    assert_eq!(maybe_lease.lease_token, None);
+                    assert_eq!(maybe_lease.lease_attempts, 0);
+                }
+
+                seen_aggregation_job_ids.push(*maybe_lease.leased().aggregation_job_id());
+            }
+
+            maybe_leased_aggregation_job_ids.sort();
+            seen_aggregation_job_ids.sort();
+            assert_eq!(maybe_leased_aggregation_job_ids, seen_aggregation_job_ids);
+
+            let maybe_lease = tx
+                .get_aggregation_job_lease::<VERIFY_KEY_LENGTH_PRIO3, TimeInterval, Prio3Count>(
+                    task.id(),
+                    &leased_aggregation_job_ids[0],
+                )
+                .await
+                .unwrap()
+                .unwrap();
+
+            assert_ne!(maybe_lease.lease_expiry_time, Timestamp::NegInfinity);
+            assert_ne!(maybe_lease.lease_expiry_time, Timestamp::PosInfinity);
+            assert!(maybe_lease.lease_token.is_some());
+            assert_eq!(maybe_lease.lease_attempts, 1);
+
+            Ok(())
+        })
+    })
+    .await
+    .unwrap();
+
     const RELEASE_COUNT: usize = 2;
     const REACQUIRE_DELAY: StdDuration = StdDuration::from_secs(10);
 
@@ -3850,6 +4000,418 @@ async fn run_collection_job_acquire_test_case<B: TestBatchModeExt>(
     })
     .await
     .unwrap()
+}
+
+#[rstest_reuse::apply(schema_versions_template)]
+#[tokio::test]
+async fn get_collection_job_maybe_leases(ephemeral_datastore: EphemeralDatastore) {
+    install_test_trace_subscriber();
+    let clock = MockClock::new(Time::from_seconds_since_epoch(0));
+    let ds = ephemeral_datastore.datastore(clock.clone()).await;
+
+    let task_id = random();
+    let other_task_id = random();
+    let tasks: Vec<_> = [task_id, other_task_id]
+        .iter()
+        .map(|task_id| {
+            TaskBuilder::new(
+                task::BatchMode::TimeInterval,
+                AggregationMode::Synchronous,
+                VdafInstance::Fake { rounds: 1 },
+            )
+            .with_id(*task_id)
+            .with_time_precision(Duration::from_seconds(1))
+            .with_report_expiry_age(Some(Duration::from_seconds(100)))
+            .build()
+        })
+        .collect();
+    let reports = Vec::from([
+        // First collection job
+        LeaderStoredReport::new_dummy(task_id, Time::from_seconds_since_epoch(0)),
+        // Second collection job
+        LeaderStoredReport::new_dummy(task_id, Time::from_seconds_since_epoch(300)),
+        // Other task collection job
+        LeaderStoredReport::new_dummy(other_task_id, Time::from_seconds_since_epoch(0)),
+    ]);
+    let batch_interval = Interval::new(
+        Time::from_seconds_since_epoch(0),
+        Duration::from_seconds(100),
+    )
+    .unwrap();
+    let second_batch_interval = Interval::new(
+        Time::from_seconds_since_epoch(300),
+        Duration::from_seconds(100),
+    )
+    .unwrap();
+    let aggregation_jobs = Vec::from([
+        // First collection job
+        AggregationJob::<0, TimeInterval, dummy::Vdaf>::new(
+            task_id,
+            random(),
+            dummy::AggregationParam(0),
+            (),
+            Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1)).unwrap(),
+            AggregationJobState::Finished,
+            AggregationJobStep::from(1),
+        ),
+        // Second collection job
+        AggregationJob::<0, TimeInterval, dummy::Vdaf>::new(
+            task_id,
+            random(),
+            dummy::AggregationParam(0),
+            (),
+            Interval::new(
+                Time::from_seconds_since_epoch(300),
+                Duration::from_seconds(1),
+            )
+            .unwrap(),
+            AggregationJobState::Finished,
+            AggregationJobStep::from(1),
+        ),
+        // Other task collection job
+        AggregationJob::<0, TimeInterval, dummy::Vdaf>::new(
+            other_task_id,
+            random(),
+            dummy::AggregationParam(0),
+            (),
+            Interval::new(Time::from_seconds_since_epoch(0), Duration::from_seconds(1)).unwrap(),
+            AggregationJobState::Finished,
+            AggregationJobStep::from(1),
+        ),
+    ]);
+    let report_aggregations = Vec::from([
+        // First collection job
+        ReportAggregation::<0, dummy::Vdaf>::new(
+            task_id,
+            *aggregation_jobs[0].id(),
+            *reports[0].metadata().id(),
+            *reports[0].metadata().time(),
+            0,
+            None,
+            ReportAggregationState::Finished, // Doesn't matter what state the report aggregation is in
+        ),
+        // Second collection job
+        ReportAggregation::<0, dummy::Vdaf>::new(
+            task_id,
+            *aggregation_jobs[1].id(),
+            *reports[1].metadata().id(),
+            *reports[1].metadata().time(),
+            0,
+            None,
+            ReportAggregationState::Finished,
+        ),
+        // Other task collection job
+        ReportAggregation::<0, dummy::Vdaf>::new(
+            other_task_id,
+            *aggregation_jobs[2].id(),
+            *reports[2].metadata().id(),
+            *reports[2].metadata().time(),
+            0,
+            None,
+            ReportAggregationState::Finished,
+        ),
+    ]);
+    let batch_aggregations = Vec::from([
+        // First collection job
+        BatchAggregation::<0, TimeInterval, dummy::Vdaf>::new(
+            task_id,
+            batch_interval,
+            dummy::AggregationParam(0),
+            0,
+            Interval::EMPTY,
+            BatchAggregationState::Scrubbed,
+        ),
+        // Second collection job
+        BatchAggregation::<0, TimeInterval, dummy::Vdaf>::new(
+            task_id,
+            second_batch_interval,
+            dummy::AggregationParam(0),
+            0,
+            Interval::EMPTY,
+            BatchAggregationState::Scrubbed,
+        ),
+        // Other task collection job
+        BatchAggregation::<0, TimeInterval, dummy::Vdaf>::new(
+            other_task_id,
+            batch_interval,
+            dummy::AggregationParam(0),
+            0,
+            Interval::EMPTY,
+            BatchAggregationState::Scrubbed,
+        ),
+    ]);
+    let collection_jobs = Vec::from([
+        // Job is in start state, so it can be acquired. With clock at time 0, the job is not
+        // expired. The job is expired once the clock is advanced by 200.
+        CollectionJob::<0, TimeInterval, dummy::Vdaf>::new(
+            task_id,
+            random(),
+            TimeInterval::query_for_batch_identifier(&batch_interval),
+            dummy::AggregationParam(0),
+            batch_interval,
+            CollectionJobState::Start,
+        ),
+        // Job is in finished state, so it cannot be acquired, but its MaybeLease should be gotten.
+        // With clock at time 0, the job is not expired. The job is also not expired once the clock
+        // is advanced by 200.
+        CollectionJob::<0, TimeInterval, dummy::Vdaf>::new(
+            task_id,
+            random(),
+            TimeInterval::query_for_batch_identifier(&second_batch_interval),
+            dummy::AggregationParam(0),
+            second_batch_interval,
+            CollectionJobState::Finished {
+                report_count: 1,
+                client_timestamp_interval: Interval::EMPTY,
+                encrypted_helper_aggregate_share: HpkeCiphertext::new(
+                    HpkeConfigId::from(0),
+                    Vec::new(),
+                    Vec::new(),
+                ),
+                leader_aggregate_share: dummy::AggregateShare(0),
+            },
+        ),
+        // Job for another task, so it should not be visible when querying for the first task.
+        CollectionJob::<0, TimeInterval, dummy::Vdaf>::new(
+            other_task_id,
+            random(),
+            TimeInterval::query_for_batch_identifier(&batch_interval),
+            dummy::AggregationParam(0),
+            batch_interval,
+            CollectionJobState::Start,
+        ),
+    ]);
+
+    ds.run_unnamed_tx(|tx| {
+        let (
+            tasks,
+            reports,
+            report_aggregations,
+            aggregation_jobs,
+            batch_aggregations,
+            collection_jobs,
+        ) = (
+            tasks.clone(),
+            reports.clone(),
+            report_aggregations.clone(),
+            aggregation_jobs.clone(),
+            batch_aggregations.clone(),
+            collection_jobs.clone(),
+        );
+        Box::pin(async move {
+            for task in &tasks {
+                tx.put_aggregator_task(&task.leader_view().unwrap())
+                    .await
+                    .unwrap();
+            }
+
+            for report in &reports {
+                tx.put_client_report(report).await.unwrap();
+            }
+            for aggregation_job in &aggregation_jobs {
+                tx.put_aggregation_job(aggregation_job).await.unwrap();
+            }
+
+            for report_aggregation in &report_aggregations {
+                tx.put_report_aggregation(report_aggregation).await.unwrap();
+            }
+
+            for batch_aggregation in batch_aggregations {
+                tx.put_batch_aggregation(&batch_aggregation).await.unwrap();
+            }
+
+            for collection_job in collection_jobs {
+                tx.put_collection_job(&collection_job).await.unwrap();
+            }
+
+            Ok(())
+        })
+    })
+    .await
+    .unwrap();
+
+    // Getting collection job leases should not acquire them and should not affect acquiring them
+    // later.
+    ds.run_unnamed_tx(|tx| {
+        let (task_id, mut maybe_leased_collection_job_ids) = (
+            task_id,
+            Vec::from([*collection_jobs[0].id(), *collection_jobs[1].id()]),
+        );
+        Box::pin(async move {
+            let maybe_leases = tx
+                .get_collection_job_leases_by_task::<0, TimeInterval, dummy::Vdaf>(&task_id)
+                .await
+                .unwrap();
+
+            let mut seen_collection_job_ids = Vec::new();
+            for maybe_lease in maybe_leases {
+                assert_eq!(maybe_lease.lease_expiry_time, Timestamp::NegInfinity);
+                assert_eq!(maybe_lease.lease_token, None);
+                assert_eq!(maybe_lease.lease_attempts, 0);
+
+                seen_collection_job_ids.push(*maybe_lease.leased().collection_job_id());
+            }
+
+            seen_collection_job_ids.sort();
+            maybe_leased_collection_job_ids.sort();
+            assert_eq!(seen_collection_job_ids, maybe_leased_collection_job_ids);
+
+            let no_such_task = tx
+                .get_collection_job_leases_by_task::<0, TimeInterval, dummy::Vdaf>(&random())
+                .await
+                .unwrap();
+            assert!(no_such_task.is_empty());
+
+            let maybe_lease = tx
+                .get_collection_job_lease::<0, TimeInterval, dummy::Vdaf>(
+                    &task_id,
+                    &maybe_leased_collection_job_ids[0],
+                )
+                .await
+                .unwrap()
+                .unwrap();
+
+            assert_eq!(maybe_lease.lease_expiry_time, Timestamp::NegInfinity);
+            assert_eq!(maybe_lease.lease_token, None);
+            assert_eq!(maybe_lease.lease_attempts, 0);
+
+            let no_such_task = tx
+                .get_collection_job_lease::<0, TimeInterval, dummy::Vdaf>(
+                    &random(),
+                    &maybe_leased_collection_job_ids[0],
+                )
+                .await
+                .unwrap();
+            assert!(no_such_task.is_none());
+
+            let no_such_collection_job = tx
+                .get_collection_job_lease::<0, TimeInterval, dummy::Vdaf>(&task_id, &random())
+                .await
+                .unwrap();
+            assert!(no_such_collection_job.is_none());
+
+            Ok(())
+        })
+    })
+    .await
+    .unwrap();
+
+    // Acquire incomplete collection jobs.
+    ds.run_unnamed_tx(|tx| {
+        let mut expected_collection_job_ids =
+            Vec::from([*collection_jobs[0].id(), *collection_jobs[2].id()]);
+        Box::pin(async move {
+            let acquired = tx
+                .acquire_incomplete_collection_jobs(&StdDuration::from_secs(100), 10)
+                .await
+                .unwrap();
+
+            let mut acquired_ids: Vec<_> = acquired
+                .iter()
+                .map(|j| *j.leased().collection_job_id())
+                .collect();
+
+            expected_collection_job_ids.sort();
+            acquired_ids.sort();
+            assert_eq!(expected_collection_job_ids, acquired_ids);
+            Ok(())
+        })
+    })
+    .await
+    .unwrap();
+
+    // Getting collection job leases should reflect that some of the jobs were acquired.
+    ds.run_unnamed_tx(|tx| {
+        let (task_id, acquired_job_id, non_acquired_job_id) =
+            (task_id, *collection_jobs[0].id(), *collection_jobs[1].id());
+        Box::pin(async move {
+            let maybe_leases = tx
+                .get_collection_job_leases_by_task::<0, TimeInterval, dummy::Vdaf>(&task_id)
+                .await
+                .unwrap();
+
+            let mut seen_collection_job_ids = Vec::new();
+            for maybe_lease in maybe_leases {
+                if maybe_lease.leased().collection_job_id() == &acquired_job_id {
+                    assert_ne!(maybe_lease.lease_expiry_time, Timestamp::NegInfinity);
+                    assert_ne!(maybe_lease.lease_expiry_time, Timestamp::PosInfinity);
+                    assert!(maybe_lease.lease_token.is_some());
+                    assert_eq!(maybe_lease.lease_attempts, 1);
+                } else {
+                    assert_eq!(maybe_lease.lease_expiry_time, Timestamp::NegInfinity);
+                    assert_eq!(maybe_lease.lease_token, None);
+                    assert_eq!(maybe_lease.lease_attempts, 0);
+                }
+
+                seen_collection_job_ids.push(*maybe_lease.leased().collection_job_id());
+            }
+
+            seen_collection_job_ids.sort();
+            let mut expected_collection_job_ids = Vec::from([acquired_job_id, non_acquired_job_id]);
+            expected_collection_job_ids.sort();
+            assert_eq!(expected_collection_job_ids, seen_collection_job_ids);
+
+            let maybe_lease = tx
+                .get_collection_job_lease::<0, TimeInterval, dummy::Vdaf>(
+                    &task_id,
+                    &acquired_job_id,
+                )
+                .await
+                .unwrap()
+                .unwrap();
+            assert_ne!(maybe_lease.lease_expiry_time, Timestamp::NegInfinity);
+            assert_ne!(maybe_lease.lease_expiry_time, Timestamp::PosInfinity);
+            assert!(maybe_lease.lease_token.is_some());
+            assert_eq!(maybe_lease.lease_attempts, 1);
+
+            Ok(())
+        })
+    })
+    .await
+    .unwrap();
+
+    // Advance time by the task expiry. We should no longer get the first maybe lease.
+    clock.advance(&Duration::from_seconds(200));
+    ds.run_unnamed_tx(|tx| {
+        let (task_id, acquired_job_id, non_acquired_job_id) =
+            (task_id, *collection_jobs[0].id(), *collection_jobs[1].id());
+        Box::pin(async move {
+            let maybe_leases = tx
+                .get_collection_job_leases_by_task::<0, TimeInterval, dummy::Vdaf>(&task_id)
+                .await
+                .unwrap();
+            assert_eq!(maybe_leases.len(), 1);
+
+            assert_eq!(maybe_leases[0].lease_expiry_time, Timestamp::NegInfinity);
+            assert_eq!(maybe_leases[0].lease_token, None);
+            assert_eq!(maybe_leases[0].lease_attempts, 0);
+
+            let maybe_lease = tx
+                .get_collection_job_lease::<0, TimeInterval, dummy::Vdaf>(
+                    &task_id,
+                    &acquired_job_id,
+                )
+                .await
+                .unwrap();
+            assert!(maybe_lease.is_none());
+
+            let maybe_lease = tx
+                .get_collection_job_lease::<0, TimeInterval, dummy::Vdaf>(
+                    &task_id,
+                    &non_acquired_job_id,
+                )
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(maybe_lease.lease_expiry_time, Timestamp::NegInfinity);
+            assert_eq!(maybe_lease.lease_token, None);
+            assert_eq!(maybe_lease.lease_attempts, 0);
+
+            Ok(())
+        })
+    })
+    .await
+    .unwrap();
 }
 
 #[rstest_reuse::apply(schema_versions_template)]


### PR DESCRIPTION
Adds new subcommands to `janus_cli` to enable easily getting information about aggregation and collection jobs and any leases on them.

Forward-port of #3934, #3944