### PR TITLE
Extension traits for fluent request auth

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -63,6 +63,7 @@ use janus_core::{
     Runtime,
     auth_tokens::AuthenticationToken,
     hpke::{self, HpkeApplicationInfo, Label},
+    http::ReqwestAuthenticationToken,
     retries::{HttpResponse, retry_http_request_notify},
     time::{Clock, DurationExt, IntervalExt, TimeExt},
     vdaf::{
@@ -3724,7 +3725,6 @@ async fn send_request_to_helper(
     auth_token: &AuthenticationToken,
     http_request_duration_histogram: &Histogram<f64>,
 ) -> Result<HttpResponse, Error> {
-    let (auth_header, auth_value) = auth_token.request_authentication();
     let domain = Arc::from(url.domain().unwrap_or_default());
     let method_str = Arc::from(method.as_str());
     let timer = RequestTimer::new(
@@ -3741,7 +3741,7 @@ async fn send_request_to_helper(
             timer.start_attempt();
             let mut request = http_client
                 .request(method.clone(), url.clone())
-                .header(auth_header, auth_value.as_str());
+                .authentication_token(auth_token);
             if let Some(request_body) = request_body.clone() {
                 request = request
                     .header(CONTENT_TYPE, request_body.content_type)

--- a/aggregator/src/aggregator/aggregation_job_driver/tests.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver/tests.rs
@@ -32,6 +32,7 @@ use janus_aggregator_core::{
 };
 use janus_core::{
     Runtime,
+    auth_tokens::test_util::MatchAuthenticationToken,
     hpke::HpkeKeypair,
     initialize_rustls,
     report_id::ReportIdChecksumExt,
@@ -285,7 +286,6 @@ async fn aggregation_job_driver() {
     ]);
     let mocked_aggregates = join_all(helper_responses.iter().map(
         |(req_method, req_content_type, resp_content_type, resp_body)| {
-            let (header, value) = agg_auth_token.request_authentication();
             server
                 .mock(
                     req_method,
@@ -293,7 +293,7 @@ async fn aggregation_job_driver() {
                         .unwrap()
                         .path(),
                 )
-                .match_header(header, value.as_str())
+                .match_authentication_token(&agg_auth_token)
                 .match_header(CONTENT_TYPE.as_str(), *req_content_type)
                 .with_status(200)
                 .with_header(CONTENT_TYPE.as_str(), resp_content_type)
@@ -716,7 +716,6 @@ async fn leader_sync_time_interval_aggregation_job_init_single_step() {
         .with_body("{\"type\": \"urn:ietf:params:ppm:dap:error:unauthorizedRequest\"}")
         .create_async()
         .await;
-    let (header, value) = agg_auth_token.request_authentication();
     let mocked_aggregate_success = server
         .mock(
             "PUT",
@@ -724,7 +723,7 @@ async fn leader_sync_time_interval_aggregation_job_init_single_step() {
                 .unwrap()
                 .path(),
         )
-        .match_header(header, value.as_str())
+        .match_authentication_token(agg_auth_token)
         .match_header(
             CONTENT_TYPE.as_str(),
             AggregationJobInitializeReq::<TimeInterval>::MEDIA_TYPE,
@@ -1091,7 +1090,6 @@ async fn leader_sync_time_interval_aggregation_job_init_two_steps() {
             },
         )]),
     };
-    let (header, value) = agg_auth_token.request_authentication();
     let mocked_aggregate_success = server
         .mock(
             "PUT",
@@ -1099,7 +1097,7 @@ async fn leader_sync_time_interval_aggregation_job_init_two_steps() {
                 .unwrap()
                 .path(),
         )
-        .match_header(header, value.as_str())
+        .match_authentication_token(agg_auth_token)
         .match_header(
             CONTENT_TYPE.as_str(),
             AggregationJobInitializeReq::<TimeInterval>::MEDIA_TYPE,
@@ -1477,7 +1475,6 @@ async fn leader_sync_time_interval_aggregation_job_init_partially_garbage_collec
             ),
         ]),
     };
-    let (header, value) = agg_auth_token.request_authentication();
     let mocked_aggregate_init = server
         .mock(
             "PUT",
@@ -1485,7 +1482,7 @@ async fn leader_sync_time_interval_aggregation_job_init_partially_garbage_collec
                 .unwrap()
                 .path(),
         )
-        .match_header(header, value.as_str())
+        .match_authentication_token(agg_auth_token)
         .match_header(
             CONTENT_TYPE.as_str(),
             AggregationJobInitializeReq::<TimeInterval>::MEDIA_TYPE,
@@ -1792,7 +1789,6 @@ async fn leader_sync_leader_selected_aggregation_job_init_single_step() {
         .with_body("{\"type\": \"urn:ietf:params:ppm:dap:error:invalidMessage\"}")
         .create_async()
         .await;
-    let (header, value) = agg_auth_token.request_authentication();
     let mocked_aggregate_success = server
         .mock(
             "PUT",
@@ -1800,7 +1796,7 @@ async fn leader_sync_leader_selected_aggregation_job_init_single_step() {
                 .unwrap()
                 .path(),
         )
-        .match_header(header, value.as_str())
+        .match_authentication_token(agg_auth_token)
         .match_header(
             CONTENT_TYPE.as_str(),
             AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
@@ -2095,7 +2091,6 @@ async fn leader_sync_leader_selected_aggregation_job_init_two_steps() {
             },
         )]),
     };
-    let (header, value) = agg_auth_token.request_authentication();
     let mocked_aggregate_success = server
         .mock(
             "PUT",
@@ -2103,7 +2098,7 @@ async fn leader_sync_leader_selected_aggregation_job_init_two_steps() {
                 .unwrap()
                 .path(),
         )
-        .match_header(header, value.as_str())
+        .match_authentication_token(agg_auth_token)
         .match_header(
             CONTENT_TYPE.as_str(),
             AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
@@ -2411,7 +2406,6 @@ async fn leader_sync_time_interval_aggregation_job_continue() {
         .with_body("{\"type\": \"urn:ietf:params:ppm:dap:error:unrecognizedTask\"}")
         .create_async()
         .await;
-    let (header, value) = agg_auth_token.request_authentication();
     let mocked_aggregate_success = server
         .mock(
             "POST",
@@ -2419,7 +2413,7 @@ async fn leader_sync_time_interval_aggregation_job_continue() {
                 .unwrap()
                 .path(),
         )
-        .match_header(header, value.as_str())
+        .match_authentication_token(agg_auth_token)
         .match_header(CONTENT_TYPE.as_str(), AggregationJobContinueReq::MEDIA_TYPE)
         .match_body(leader_request.get_encoded().unwrap())
         .with_status(202)
@@ -2744,7 +2738,6 @@ async fn leader_sync_leader_selected_aggregation_job_continue() {
         .with_body("{\"type\": \"urn:ietf:params:ppm:dap:error:unrecognizedTask\"}")
         .create_async()
         .await;
-    let (header, value) = agg_auth_token.request_authentication();
     let mocked_aggregate_success = server
         .mock(
             "POST",
@@ -2752,7 +2745,7 @@ async fn leader_sync_leader_selected_aggregation_job_continue() {
                 .unwrap()
                 .path(),
         )
-        .match_header(header, value.as_str())
+        .match_authentication_token(agg_auth_token)
         .match_header(CONTENT_TYPE.as_str(), AggregationJobContinueReq::MEDIA_TYPE)
         .match_body(leader_request.get_encoded().unwrap())
         .with_status(202)
@@ -3011,7 +3004,6 @@ async fn leader_async_aggregation_job_init_to_pending() {
                 .clone(),
         )]),
     );
-    let (header, value) = agg_auth_token.request_authentication();
     let mocked_aggregate_request = server
         .mock(
             "PUT",
@@ -3019,7 +3011,7 @@ async fn leader_async_aggregation_job_init_to_pending() {
                 .unwrap()
                 .path(),
         )
-        .match_header(header, value.as_str())
+        .match_authentication_token(agg_auth_token)
         .match_header(
             CONTENT_TYPE.as_str(),
             AggregationJobInitializeReq::<TimeInterval>::MEDIA_TYPE,
@@ -3268,7 +3260,6 @@ async fn leader_async_aggregation_job_init_to_pending_two_step() {
                 .clone(),
         )]),
     );
-    let (header, value) = agg_auth_token.request_authentication();
     let mocked_aggregate_request = server
         .mock(
             "PUT",
@@ -3276,7 +3267,7 @@ async fn leader_async_aggregation_job_init_to_pending_two_step() {
                 .unwrap()
                 .path(),
         )
-        .match_header(header, value.as_str())
+        .match_authentication_token(agg_auth_token)
         .match_header(
             CONTENT_TYPE.as_str(),
             AggregationJobInitializeReq::<TimeInterval>::MEDIA_TYPE,
@@ -3531,7 +3522,6 @@ async fn leader_async_aggregation_job_continue_to_pending() {
                 .clone(),
         )]),
     );
-    let (header, value) = agg_auth_token.request_authentication();
     let mocked_aggregate_request = server
         .mock(
             "POST",
@@ -3539,7 +3529,7 @@ async fn leader_async_aggregation_job_continue_to_pending() {
                 .unwrap()
                 .path(),
         )
-        .match_header(header, value.as_str())
+        .match_authentication_token(agg_auth_token)
         .match_header(CONTENT_TYPE.as_str(), AggregationJobContinueReq::MEDIA_TYPE)
         .match_body(leader_request.get_encoded().unwrap())
         .with_status(202)
@@ -3780,8 +3770,6 @@ async fn leader_async_aggregation_job_init_poll_to_pending() {
     assert_eq!(lease.leased().aggregation_job_id(), &aggregation_job_id);
 
     // Setup: prepare mocked HTTP response.
-    let (header, value) = agg_auth_token.request_authentication();
-
     let mocked_aggregate_request = server
         .mock(
             "GET",
@@ -3790,7 +3778,7 @@ async fn leader_async_aggregation_job_init_poll_to_pending() {
                 .path(),
         )
         .match_query("step=0")
-        .match_header(header, value.as_str())
+        .match_authentication_token(agg_auth_token)
         .with_status(200)
         .create_async()
         .await;
@@ -4026,8 +4014,6 @@ async fn leader_async_aggregation_job_init_poll_to_pending_two_step() {
     assert_eq!(lease.leased().aggregation_job_id(), &aggregation_job_id);
 
     // Setup: prepare mocked HTTP response.
-    let (header, value) = agg_auth_token.request_authentication();
-
     let mocked_aggregate_request = server
         .mock(
             "GET",
@@ -4036,7 +4022,7 @@ async fn leader_async_aggregation_job_init_poll_to_pending_two_step() {
                 .path(),
         )
         .match_query("step=0")
-        .match_header(header, value.as_str())
+        .match_authentication_token(agg_auth_token)
         .with_status(200)
         .create_async()
         .await;
@@ -4283,7 +4269,6 @@ async fn leader_async_aggregation_job_init_poll_to_finished() {
             },
         )]),
     };
-    let (header, value) = agg_auth_token.request_authentication();
 
     let mocked_aggregate_request = server
         .mock(
@@ -4293,7 +4278,7 @@ async fn leader_async_aggregation_job_init_poll_to_finished() {
                 .path(),
         )
         .match_query("step=0")
-        .match_header(header, value.as_str())
+        .match_authentication_token(agg_auth_token)
         .with_status(200)
         .with_header(CONTENT_TYPE.as_str(), AggregationJobResp::MEDIA_TYPE)
         .with_body(helper_response.get_encoded().unwrap())
@@ -4545,7 +4530,6 @@ async fn leader_async_aggregation_job_init_poll_to_continue() {
             },
         )]),
     };
-    let (header, value) = agg_auth_token.request_authentication();
 
     let mocked_aggregate_request = server
         .mock(
@@ -4555,7 +4539,7 @@ async fn leader_async_aggregation_job_init_poll_to_continue() {
                 .path(),
         )
         .match_query("step=0")
-        .match_header(header, value.as_str())
+        .match_authentication_token(agg_auth_token)
         .with_status(200)
         .with_header(CONTENT_TYPE.as_str(), AggregationJobResp::MEDIA_TYPE)
         .with_body(helper_response.get_encoded().unwrap())
@@ -4804,7 +4788,6 @@ async fn leader_async_aggregation_job_continue_poll_to_pending() {
     assert_eq!(lease.leased().aggregation_job_id(), &aggregation_job_id);
 
     // Setup: prepare mocked HTTP responses.
-    let (header, value) = agg_auth_token.request_authentication();
     let mocked_aggregate_success = server
         .mock(
             "GET",
@@ -4813,7 +4796,7 @@ async fn leader_async_aggregation_job_continue_poll_to_pending() {
                 .path(),
         )
         .match_query("step=1")
-        .match_header(header, value.as_str())
+        .match_authentication_token(agg_auth_token)
         .with_status(200)
         .create_async()
         .await;
@@ -5065,7 +5048,6 @@ async fn leader_async_aggregation_job_continue_poll_to_finished() {
             PrepareStepResult::Finished,
         )]),
     };
-    let (header, value) = agg_auth_token.request_authentication();
     let mocked_aggregate_success = server
         .mock(
             "GET",
@@ -5074,7 +5056,7 @@ async fn leader_async_aggregation_job_continue_poll_to_finished() {
                 .path(),
         )
         .match_query("step=1")
-        .match_header(header, value.as_str())
+        .match_authentication_token(agg_auth_token)
         .with_status(200)
         .with_header(CONTENT_TYPE.as_str(), AggregationJobResp::MEDIA_TYPE)
         .with_body(helper_response.get_encoded().unwrap())
@@ -6350,7 +6332,6 @@ async fn abandon_failing_aggregation_job_with_retryable_error() {
 
     // Set up three error responses from our mock helper. These will cause errors in the
     // leader, because the response body is empty and cannot be decoded.
-    let (header, value) = agg_auth_token.request_authentication();
     let failure_mock = server
         .mock(
             "PUT",
@@ -6358,7 +6339,7 @@ async fn abandon_failing_aggregation_job_with_retryable_error() {
                 .unwrap()
                 .path(),
         )
-        .match_header(header, value.as_str())
+        .match_authentication_token(agg_auth_token)
         .match_header(
             CONTENT_TYPE.as_str(),
             AggregationJobInitializeReq::<TimeInterval>::MEDIA_TYPE,
@@ -6377,7 +6358,7 @@ async fn abandon_failing_aggregation_job_with_retryable_error() {
                 .unwrap()
                 .path(),
         )
-        .match_header(header, value.as_str())
+        .match_authentication_token(agg_auth_token)
         .match_header(
             CONTENT_TYPE.as_str(),
             AggregationJobInitializeReq::<TimeInterval>::MEDIA_TYPE,
@@ -6602,7 +6583,6 @@ async fn abandon_failing_aggregation_job_with_fatal_error() {
 
     // Set up one fatal error response from our mock helper. These will cause errors in the
     // leader, because the response body is empty and cannot be decoded.
-    let (header, value) = agg_auth_token.request_authentication();
     let failure_mock = server
         .mock(
             "PUT",
@@ -6610,7 +6590,7 @@ async fn abandon_failing_aggregation_job_with_fatal_error() {
                 .unwrap()
                 .path(),
         )
-        .match_header(header, value.as_str())
+        .match_authentication_token(agg_auth_token)
         .match_header(
             CONTENT_TYPE.as_str(),
             AggregationJobInitializeReq::<TimeInterval>::MEDIA_TYPE,
@@ -6629,7 +6609,7 @@ async fn abandon_failing_aggregation_job_with_fatal_error() {
                 .unwrap()
                 .path(),
         )
-        .match_header(header, value.as_str())
+        .match_authentication_token(agg_auth_token)
         .match_header(
             CONTENT_TYPE.as_str(),
             AggregationJobInitializeReq::<TimeInterval>::MEDIA_TYPE,

--- a/aggregator/src/aggregator/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/aggregation_job_init.rs
@@ -452,6 +452,7 @@ pub mod test_util {
         task::{AggregatorTask, test_util::Task},
     };
     use janus_core::{
+        auth_tokens::test_util::WithAuthenticationToken,
         test_util::{VdafTranscript, run_vdaf},
         time::{Clock, MockClock, TimeExt as _},
     };
@@ -591,13 +592,11 @@ pub mod test_util {
         aggregation_job: &AggregationJobInitializeReq<B>,
         handler: &impl Handler,
     ) -> TestConn {
-        let (header, value) = task.aggregator_auth_token().request_authentication();
-
         put(task
             .aggregation_job_uri(aggregation_job_id, None)
             .unwrap()
             .path())
-        .with_request_header(header, value)
+        .with_authentication_token(task.aggregator_auth_token())
         .with_request_header(
             KnownHeaderName::ContentType,
             AggregationJobInitializeReq::<B>::MEDIA_TYPE,
@@ -630,7 +629,7 @@ mod tests {
         test_util::noop_meter,
     };
     use janus_core::{
-        auth_tokens::{AuthenticationToken, DAP_AUTH_HEADER},
+        auth_tokens::{AuthenticationToken, DAP_AUTH_HEADER, test_util::WithAuthenticationToken},
         test_util::{install_test_trace_subscriber, runtime::TestRuntime},
         time::{Clock, MockClock, TimeExt as _},
         vdaf::VdafInstance,
@@ -815,17 +814,12 @@ mod tests {
         )
         .await;
 
-        let (auth_header, auth_value) = test_case
-            .task
-            .aggregator_auth_token()
-            .request_authentication();
-
         let response = put(test_case
             .task
             .aggregation_job_uri(&test_case.aggregation_job_id, None)
             .unwrap()
             .path())
-        .with_request_header(auth_header, auth_value)
+        .with_authentication_token(test_case.task.aggregator_auth_token())
         .with_request_header(
             KnownHeaderName::ContentType,
             AggregationJobInitializeReq::<TimeInterval>::MEDIA_TYPE,
@@ -1138,17 +1132,12 @@ mod tests {
             test_case.aggregation_job_init_req.prepare_inits().to_vec(),
         );
 
-        let (header, value) = test_case
-            .task
-            .aggregator_auth_token()
-            .request_authentication();
-
         let mut response = put(test_case
             .task
             .aggregation_job_uri(&random(), None)
             .unwrap()
             .path())
-        .with_request_header(header, value)
+        .with_authentication_token(test_case.task.aggregator_auth_token())
         .with_request_header(
             KnownHeaderName::ContentType,
             AggregationJobInitializeReq::<TimeInterval>::MEDIA_TYPE,

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -893,7 +893,9 @@ mod tests {
         test_util::noop_meter,
     };
     use janus_core::{
-        Runtime, initialize_rustls,
+        Runtime,
+        auth_tokens::test_util::MatchAuthenticationToken,
+        initialize_rustls,
         retries::test_util::LimitedRetryer,
         test_util::{install_test_trace_subscriber, runtime::TestRuntimeManager},
         time::{Clock, MockClock, TimeExt},
@@ -1329,7 +1331,6 @@ mod tests {
         );
 
         // Simulate helper failing to service the aggregate share request.
-        let (header, value) = agg_auth_token.request_authentication();
         let mocked_failed_aggregate_share = server
             .mock(
                 "PUT",
@@ -1337,7 +1338,7 @@ mod tests {
                     .unwrap()
                     .path(),
             )
-            .match_header(header, value.as_str())
+            .match_authentication_token(agg_auth_token)
             .match_header(
                 CONTENT_TYPE.as_str(),
                 AggregateShareReq::<TimeInterval>::MEDIA_TYPE,
@@ -1402,7 +1403,6 @@ mod tests {
 
         // Helper aggregate share is opaque to the leader, so no need to construct a real one
         let helper_response = fake_aggregate_share();
-        let (header, value) = agg_auth_token.request_authentication();
         let mocked_aggregate_share = server
             .mock(
                 "PUT",
@@ -1410,7 +1410,7 @@ mod tests {
                     .unwrap()
                     .path(),
             )
-            .match_header(header, value.as_str())
+            .match_authentication_token(agg_auth_token)
             .match_header(
                 CONTENT_TYPE.as_str(),
                 AggregateShareReq::<TimeInterval>::MEDIA_TYPE,

--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -21,7 +21,7 @@ use janus_aggregator_core::{
     test_util::noop_meter,
 };
 use janus_core::{
-    auth_tokens::AuthenticationToken,
+    auth_tokens::{AuthenticationToken, test_util::WithAuthenticationToken},
     hpke::{self, HpkeApplicationInfo, Label},
     test_util::{install_test_trace_subscriber, runtime::TestRuntime},
     time::{Clock, IntervalExt, MockClock},
@@ -68,8 +68,7 @@ impl CollectionJobTestCase {
             .unwrap()
             .path());
         if let Some(auth) = auth_token {
-            let (header, value) = auth.request_authentication();
-            test_conn = test_conn.with_request_header(header, value);
+            test_conn = test_conn.with_authentication_token(auth);
         }
 
         test_conn
@@ -106,8 +105,7 @@ impl CollectionJobTestCase {
             .unwrap()
             .path());
         if let Some(auth) = auth_token {
-            let (header, value) = auth.request_authentication();
-            test_conn = test_conn.with_request_header(header, value);
+            test_conn = test_conn.with_authentication_token(auth);
         }
         test_conn.run_async(&self.handler).await
     }

--- a/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
@@ -13,6 +13,7 @@ use janus_aggregator_core::{
     },
 };
 use janus_core::{
+    auth_tokens::test_util::WithAuthenticationToken,
     hpke::{self, HpkeApplicationInfo, Label},
     report_id::ReportIdChecksumExt,
     time::Clock,
@@ -40,12 +41,11 @@ pub(crate) async fn put_aggregate_share_request<B: batch_mode::BatchMode>(
     aggregate_share_id: &AggregateShareId,
     handler: &impl Handler,
 ) -> TestConn {
-    let (header, value) = task.aggregator_auth_token().request_authentication();
     put(task
         .aggregate_shares_uri(aggregate_share_id)
         .unwrap()
         .path())
-    .with_request_header(header, value)
+    .with_authentication_token(task.aggregator_auth_token())
     .with_request_header(
         KnownHeaderName::ContentType,
         AggregateShareReq::<B>::MEDIA_TYPE,

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_get.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_get.rs
@@ -12,6 +12,7 @@ use janus_aggregator_core::{
     },
 };
 use janus_core::{
+    auth_tokens::test_util::WithAuthenticationToken,
     test_util::run_vdaf,
     time::{Clock as _, TimeExt as _},
     vdaf::VdafInstance,
@@ -595,9 +596,8 @@ async fn get_aggregation_job(
         None => uri.path().to_string(),
     };
 
-    let (header, value) = task.aggregator_auth_token().request_authentication();
     get(uri)
-        .with_request_header(header, value)
+        .with_authentication_token(task.aggregator_auth_token())
         .run_async(handler)
         .await
 }

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
@@ -21,7 +21,7 @@ use janus_aggregator_core::{
     task::{AggregationMode, BatchMode, VerifyKey, test_util::TaskBuilder},
 };
 use janus_core::{
-    auth_tokens::AuthenticationToken,
+    auth_tokens::{AuthenticationToken, test_util::WithAuthenticationToken},
     hpke::HpkeKeypair,
     report_id::ReportIdChecksumExt,
     test_util::run_vdaf,
@@ -925,12 +925,11 @@ async fn aggregate_init_batch_already_collected() {
         .unwrap();
 
     let aggregation_job_id: AggregationJobId = random();
-    let (header, value) = task.aggregator_auth_token().request_authentication();
     let mut test_conn = put(task
         .aggregation_job_uri(&aggregation_job_id, None)
         .unwrap()
         .path())
-    .with_request_header(header, value)
+    .with_authentication_token(task.aggregator_auth_token())
     .with_request_header(
         KnownHeaderName::ContentType,
         AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,6 +18,7 @@ fpvec_bounded_l2 = ["dep:fixed", "prio/experimental"]
 test-util = [
     "dep:assert_matches",
     "dep:k8s-openapi",
+    "dep:mockito",
     "dep:quickcheck",
     "dep:serde_json",
     "dep:stopper",
@@ -26,6 +27,7 @@ test-util = [
     "dep:tokio-stream",
     "dep:tracing-log",
     "dep:tracing-subscriber",
+    "dep:trillium-testing",
     "janus_messages/test-util",
     "kube/ws",
     "prio/test-util",
@@ -55,6 +57,7 @@ janus_messages.workspace = true
 k8s-openapi = { workspace = true, optional = true }
 kube = { workspace = true, optional = true, features = ["rustls-tls"] }
 mime.workspace = true
+mockito = { workspace = true, optional = true }
 prio = { workspace = true, default-features = true, features = ["experimental"] }
 quickcheck = { workspace = true, optional = true }
 rand.workspace = true
@@ -75,14 +78,13 @@ tracing = { workspace = true }
 tracing-log = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, features = ["std", "env-filter", "fmt"], optional = true }
 trillium.workspace = true
+trillium-testing = { workspace = true, optional = true }
 url = { workspace = true }
 
 [dev-dependencies]
 fixed = { workspace = true }
 hex = { workspace = true, features = ["serde"] }  # ensure this remains compatible with the non-dev dependency
 janus_core = { workspace = true, features = ["test-util"] }
-mockito = { workspace = true }
 rstest.workspace = true
 rustls.workspace = true
 serde_test.workspace = true
-trillium-testing.workspace = true

--- a/core/src/auth_tokens.rs
+++ b/core/src/auth_tokens.rs
@@ -428,6 +428,39 @@ impl AsRef<[u8]> for AuthenticationTokenHash {
     }
 }
 
+#[cfg(feature = "test-util")]
+pub mod test_util {
+    use crate::auth_tokens::AuthenticationToken;
+
+    /// Extension trait to fluently add an auth token to a [`trillium_testing::TestConn`].
+    pub trait WithAuthenticationToken {
+        /// Add the header and value obtained from [`AuthenticationToken::request_authentication`] to
+        /// the request.
+        fn with_authentication_token(self, auth_token: &AuthenticationToken) -> Self;
+    }
+
+    impl WithAuthenticationToken for trillium_testing::TestConn {
+        fn with_authentication_token(self, auth_token: &AuthenticationToken) -> Self {
+            let (header, value) = auth_token.request_authentication();
+            self.with_request_header(header, value)
+        }
+    }
+
+    /// Extension trait to fluently match on authentication tokens with a [`mockito::Mock`].
+    pub trait MatchAuthenticationToken {
+        /// Matches on requests which include a header and value matching
+        /// [`AuthenticationToken::request_authentication`].
+        fn match_authentication_token(self, auth_token: &AuthenticationToken) -> Self;
+    }
+
+    impl MatchAuthenticationToken for mockito::Mock {
+        fn match_authentication_token(self, auth_token: &AuthenticationToken) -> Self {
+            let (header, value) = auth_token.request_authentication();
+            self.match_header(header, value.as_str())
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::auth_tokens::{AuthenticationToken, AuthenticationTokenHash};

--- a/core/src/http.rs
+++ b/core/src/http.rs
@@ -184,6 +184,18 @@ pub fn parse_retry_after(headers: &http::HeaderMap) -> Result<Option<RetryAfter>
         .map_err(|e| anyhow!("Unable to parse Retry-After: {}", e))
 }
 
+/// Extension trait on [`reqwest::RequestBuilder`] to fluently add request authentication.
+pub trait ReqwestAuthenticationToken {
+    fn authentication_token(self, auth_token: &AuthenticationToken) -> Self;
+}
+
+impl ReqwestAuthenticationToken for reqwest::RequestBuilder {
+    fn authentication_token(self, auth_token: &AuthenticationToken) -> Self {
+        let (header, value) = auth_token.request_authentication();
+        self.header(header, value)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;


### PR DESCRIPTION
Adds extension traits on `reqwest::Builder`, `mockito::Mock` and `trillium_testing::TestConn` so that we can insert or expect an `Authorization: Bearer <blah>` header more fluently when working with a `janus_core::auth_token::AuthenticationToken`.