### PR TITLE
Per-task counters for helper prep errors

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -2067,6 +2067,8 @@ impl VdafOps {
                 .map_err(Error::MessageDecode)?,
         );
 
+        let task_aggregation_counters = Arc::new(SyncMutex::new(TaskAggregationCounter::default()));
+
         // Check if this is a repeated request, and if it is the same as before, send
         // the same response as last time.
         if let Some(response) = datastore
@@ -2519,7 +2521,7 @@ impl VdafOps {
             .with_last_request_hash(request_hash),
         );
 
-        let (response, counters) = datastore
+        let response = datastore
             .run_tx("aggregate_init", |tx| {
                 let vdaf = Arc::clone(&vdaf);
                 let task = Arc::clone(&task);
@@ -2528,6 +2530,7 @@ impl VdafOps {
                 let report_share_data = Arc::clone(&report_share_data);
                 let req = Arc::clone(&req);
                 let log_forbidden_mutations = log_forbidden_mutations.clone();
+                let task_aggregation_counters = Arc::clone(&task_aggregation_counters);
 
                 Box::pin(async move {
                     // Check if this is a repeated request, and if it is the same as before, send
@@ -2544,7 +2547,7 @@ impl VdafOps {
                     )
                     .await?
                     {
-                        return Ok((response, TaskAggregationCounter::default()));
+                        return Ok(response);
                     }
 
                     // Write report shares, and ensure this isn't a repeated report aggregation.
@@ -2575,24 +2578,26 @@ impl VdafOps {
                             task,
                             batch_aggregation_shard_count,
                             Some(aggregation_job_writer_metrics),
+                            task_aggregation_counters,
                         );
                     aggregation_job_writer
                         .put(aggregation_job.as_ref().clone(), report_aggregations)?;
-                    let (mut prep_resps_by_agg_job, counters) =
-                        aggregation_job_writer.write(tx, vdaf).await?;
-                    Ok((
-                        AggregationJobResp::new(
-                            prep_resps_by_agg_job
-                                .remove(aggregation_job.id())
-                                .unwrap_or_default(),
-                        ),
-                        counters,
+                    let mut prep_resps_by_agg_job = aggregation_job_writer.write(tx, vdaf).await?;
+                    Ok(AggregationJobResp::new(
+                        prep_resps_by_agg_job
+                            .remove(aggregation_job.id())
+                            .unwrap_or_default(),
                     ))
                 })
             })
             .await?;
 
-        write_task_aggregation_counter(datastore, task_counter_shard_count, *task.id(), counters);
+        write_task_aggregation_counter(
+            datastore,
+            task_counter_shard_count,
+            *task.id(),
+            &task_aggregation_counters.lock().unwrap(),
+        );
 
         Ok(response)
     }
@@ -2630,16 +2635,18 @@ impl VdafOps {
                 "aggregation job cannot be advanced to step 0",
             ));
         }
+        let task_aggregation_counters = Arc::new(SyncMutex::new(TaskAggregationCounter::default()));
 
         // TODO(#224): don't hold DB transaction open while computing VDAF updates?
         // TODO(#1035): don't do O(n) network round-trips (where n is the number of prepare steps)
-        let (response, counters) = datastore
+        let response = datastore
             .run_tx("aggregate_continue", |tx| {
                 let vdaf = Arc::clone(&vdaf);
                 let metrics = metrics.clone();
                 let task = Arc::clone(&task);
                 let aggregation_job_id = *aggregation_job_id;
                 let req = Arc::clone(&req);
+                let task_aggregation_counters = Arc::clone(&task_aggregation_counters);
 
                 Box::pin(async move {
                     // Read existing state.
@@ -2695,15 +2702,12 @@ impl VdafOps {
                                 }
                             }
                         }
-                        return Ok((
-                            AggregationJobResp::new(
-                                report_aggregations
-                                    .iter()
-                                    .filter_map(ReportAggregation::last_prep_resp)
-                                    .cloned()
-                                    .collect(),
-                            ),
-                            TaskAggregationCounter::default(),
+                        return Ok(AggregationJobResp::new(
+                            report_aggregations
+                                .iter()
+                                .filter_map(ReportAggregation::last_prep_resp)
+                                .cloned()
+                                .collect(),
                         ));
                     } else if aggregation_job.step().increment() != req.step() {
                         // If this is not a replay, the leader should be advancing our state to the next
@@ -2731,13 +2735,19 @@ impl VdafOps {
                         req,
                         request_hash,
                         &metrics,
+                        task_aggregation_counters,
                     )
                     .await
                 })
             })
             .await?;
 
-        write_task_aggregation_counter(datastore, task_counter_shard_count, *task.id(), counters);
+        write_task_aggregation_counter(
+            datastore,
+            task_counter_shard_count,
+            *task.id(),
+            &task_aggregation_counters.lock().unwrap(),
+        );
 
         Ok(response)
     }
@@ -3433,8 +3443,9 @@ fn write_task_aggregation_counter<C: Clock>(
     datastore: Arc<Datastore<C>>,
     shard_count: u64,
     task_id: TaskId,
-    counters: TaskAggregationCounter,
+    counters: &TaskAggregationCounter,
 ) {
+    let counters = *counters;
     // We write task aggregation counters back in a separate tokio task & datastore transaction,
     // so that any slowness induced by writing the counters (e.g. due to transaction retry) does
     // not slow the main processing. The lack of transactionality between writing the updated

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -19,7 +19,7 @@ use janus_aggregator_core::{
         self,
         models::{
             AggregationJob, AggregationJobState, ReportAggregationMetadata,
-            ReportAggregationMetadataState,
+            ReportAggregationMetadataState, TaskAggregationCounter,
         },
         Datastore,
     },
@@ -59,7 +59,7 @@ use rand::{random, thread_rng, Rng};
 use std::{
     cmp::{max, min},
     collections::{HashMap, HashSet},
-    sync::Arc,
+    sync::{Arc, Mutex},
     time::Duration,
 };
 use tokio::{
@@ -609,6 +609,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                             Arc::clone(&task),
                             batch_aggregation_shard_count,
                             None,
+                            Arc::new(Mutex::new(TaskAggregationCounter::default())),
                         );
                     let mut report_ids_to_scrub = HashSet::new();
                     let mut outstanding_reports = Vec::new();
@@ -823,6 +824,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                                 Arc::clone(&task),
                                 batch_aggregation_shard_count,
                                 None,
+                                Arc::new(Mutex::new(TaskAggregationCounter::default())),
                             );
                         for agg_job_reports in report_ids_and_times.chunks(max_aggregation_job_size)
                         {
@@ -941,6 +943,7 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                         Arc::clone(&task),
                         batch_aggregation_shard_count,
                         None,
+                        Arc::new(Mutex::new(TaskAggregationCounter::default())),
                     );
                     let mut batch_creator = BatchCreator::new(
                         this.min_aggregation_job_size,

--- a/aggregator/src/aggregator/aggregation_job_driver/tests.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver/tests.rs
@@ -84,48 +84,94 @@ async fn aggregation_job_driver() {
         .to_batch_interval_start(task.time_precision())
         .unwrap();
     let batch_identifier = TimeInterval::to_batch_identifier(&leader_task, &(), &time).unwrap();
-    let report_metadata = ReportMetadata::new(random(), time);
     let verify_key: VerifyKey<VERIFY_KEY_LENGTH> = task.vdaf_verify_key().unwrap();
     let measurement = IdpfInput::from_bools(&[true]);
     let aggregation_param =
         Poplar1AggregationParam::try_from_prefixes(Vec::from([IdpfInput::from_bools(&[true])]))
             .unwrap();
+    let agg_auth_token = task.aggregator_auth_token().clone();
+    let helper_hpke_keypair = HpkeKeypair::test();
 
-    let transcript = run_vdaf(
+    let accepted_report_metadata = ReportMetadata::new(random(), time);
+    let accepted_transcript = run_vdaf(
         vdaf.as_ref(),
         verify_key.as_bytes(),
         &aggregation_param,
-        report_metadata.id(),
+        accepted_report_metadata.id(),
         &measurement,
     );
-
-    let agg_auth_token = task.aggregator_auth_token().clone();
-    let helper_hpke_keypair = HpkeKeypair::test();
-    let report = LeaderStoredReport::generate(
+    let accepted_report = LeaderStoredReport::generate(
         *task.id(),
-        report_metadata,
+        accepted_report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
-        &transcript,
+        &accepted_transcript,
     );
+
+    let prepare_errors = [
+        PrepareError::BatchCollected,
+        PrepareError::ReportReplayed,
+        PrepareError::ReportDropped,
+        PrepareError::HpkeUnknownConfigId,
+        PrepareError::HpkeDecryptError,
+        PrepareError::VdafPrepError,
+        PrepareError::BatchSaturated,
+        PrepareError::TaskExpired,
+        PrepareError::InvalidMessage,
+        PrepareError::ReportTooEarly,
+    ];
+    let mut rejected_reports: Vec<_> = prepare_errors
+        .into_iter()
+        .map(|prepare_error| {
+            let rejected_report_metadata = ReportMetadata::new(random(), time);
+            let rejected_transcript = run_vdaf(
+                vdaf.as_ref(),
+                verify_key.as_bytes(),
+                &aggregation_param,
+                rejected_report_metadata.id(),
+                &measurement,
+            );
+            let rejected_report = LeaderStoredReport::generate(
+                *task.id(),
+                rejected_report_metadata,
+                helper_hpke_keypair.config(),
+                Vec::new(),
+                &rejected_transcript,
+            );
+
+            (rejected_report, prepare_error)
+        })
+        .collect();
+    rejected_reports.sort_by_key(|(report, _)| *report.metadata().id());
 
     let aggregation_job_id = random();
 
     ds.run_unnamed_tx(|tx| {
-        let (task, report, aggregation_param) = (
+        let (task, accepted_report, rejected_reports, aggregation_param) = (
             leader_task.clone(),
-            report.clone(),
+            accepted_report.clone(),
+            rejected_reports.clone(),
             aggregation_param.clone(),
         );
         Box::pin(async move {
             tx.put_aggregator_task(&task).await.unwrap();
-            tx.put_client_report(&report).await.unwrap();
-            tx.scrub_client_report(report.task_id(), report.metadata().id())
+            tx.put_client_report(&accepted_report).await.unwrap();
+            tx.scrub_client_report(accepted_report.task_id(), accepted_report.metadata().id())
                 .await
                 .unwrap();
-            tx.mark_report_aggregated(task.id(), report.metadata().id())
+            tx.mark_report_aggregated(task.id(), accepted_report.metadata().id())
                 .await
                 .unwrap();
+
+            for (rejected_report, _) in &rejected_reports {
+                tx.put_client_report(rejected_report).await.unwrap();
+                tx.scrub_client_report(rejected_report.task_id(), rejected_report.metadata().id())
+                    .await
+                    .unwrap();
+                tx.mark_report_aggregated(task.id(), rejected_report.metadata().id())
+                    .await
+                    .unwrap();
+            }
 
             tx.put_aggregation_job(&AggregationJob::<
                 VERIFY_KEY_LENGTH,
@@ -144,10 +190,19 @@ async fn aggregation_job_driver() {
             .await
             .unwrap();
             tx.put_report_aggregation(
-                &report.as_start_leader_report_aggregation(aggregation_job_id, 0),
+                &accepted_report.as_start_leader_report_aggregation(aggregation_job_id, 0),
             )
             .await
             .unwrap();
+
+            for (ord, (rejected_report, _)) in rejected_reports.iter().enumerate() {
+                tx.put_report_aggregation(
+                    &rejected_report
+                        .as_start_leader_report_aggregation(aggregation_job_id, ord as u64 + 1),
+                )
+                .await
+                .unwrap();
+            }
 
             tx.put_batch_aggregation(&BatchAggregation::<
                 VERIFY_KEY_LENGTH,
@@ -182,12 +237,29 @@ async fn aggregation_job_driver() {
             "PUT",
             AggregationJobInitializeReq::<TimeInterval>::MEDIA_TYPE,
             AggregationJobResp::MEDIA_TYPE,
-            AggregationJobResp::new(Vec::from([PrepareResp::new(
-                *report.metadata().id(),
-                PrepareStepResult::Continue {
-                    message: transcript.helper_prepare_transitions[0].message.clone(),
-                },
-            )]))
+            AggregationJobResp::new(
+                Vec::from([PrepareResp::new(
+                    *accepted_report.metadata().id(),
+                    PrepareStepResult::Continue {
+                        message: accepted_transcript.helper_prepare_transitions[0]
+                            .message
+                            .clone(),
+                    },
+                )])
+                .into_iter()
+                .chain(
+                    // Simulate helper rejecting the remaining reports due to various PrepareErrors
+                    rejected_reports
+                        .iter()
+                        .map(|(rejected_report, prepare_error)| {
+                            PrepareResp::new(
+                                *rejected_report.metadata().id(),
+                                PrepareStepResult::Reject(*prepare_error),
+                            )
+                        }),
+                )
+                .collect(),
+            )
             .get_encoded()
             .unwrap(),
         ),
@@ -196,7 +268,7 @@ async fn aggregation_job_driver() {
             AggregationJobContinueReq::MEDIA_TYPE,
             AggregationJobResp::MEDIA_TYPE,
             AggregationJobResp::new(Vec::from([PrepareResp::new(
-                *report.metadata().id(),
+                *accepted_report.metadata().id(),
                 PrepareStepResult::Finished,
             )]))
             .get_encoded()
@@ -282,12 +354,12 @@ async fn aggregation_job_driver() {
             AggregationJobState::Finished,
             AggregationJobStep::from(2),
         );
-    let want_report_aggregation =
+    let want_accepted_report_aggregation =
         ReportAggregation::<VERIFY_KEY_LENGTH, Poplar1<XofTurboShake128, 16>>::new(
             *task.id(),
             aggregation_job_id,
-            *report.metadata().id(),
-            *report.metadata().time(),
+            *accepted_report.metadata().id(),
+            *accepted_report.metadata().time(),
             0,
             None,
             ReportAggregationState::Finished,
@@ -303,19 +375,20 @@ async fn aggregation_job_driver() {
         0,
         Interval::from_time(&time).unwrap(),
         BatchAggregationState::Aggregating {
-            aggregate_share: Some(transcript.leader_output_share.clone()),
+            aggregate_share: Some(accepted_transcript.leader_output_share.clone()),
             report_count: 1,
-            checksum: ReportIdChecksum::for_report_id(report.metadata().id()),
+            checksum: ReportIdChecksum::for_report_id(accepted_report.metadata().id()),
             aggregation_jobs_created: 1,
             aggregation_jobs_terminated: 1,
         },
     )]);
 
-    let (got_aggregation_job, got_report_aggregation, got_batch_aggregations) = ds
+    let (got_aggregation_job, got_accepted_report_aggregation, got_rejected_report_aggregations, got_batch_aggregations) = ds
         .run_unnamed_tx(|tx| {
             let vdaf = Arc::clone(&vdaf);
             let task = task.clone();
-            let report_id = *report.metadata().id();
+            let accepted_report_id = *accepted_report.metadata().id();
+            let rejected_reports = rejected_reports.clone();
 
             Box::pin(async move {
                 let aggregation_job = tx
@@ -325,33 +398,116 @@ async fn aggregation_job_driver() {
                     )
                     .await.unwrap()
                     .unwrap();
-                let report_aggregation = tx
+                let accepted_report_aggregation = tx
                     .get_report_aggregation_by_report_id(
                         vdaf.as_ref(),
                         &Role::Leader,
                         task.id(),
                         &aggregation_job_id,
-                        &report_id,
+                        &accepted_report_id,
                     )
-                    .await.unwrap()
+                    .await
+                    .unwrap()
                     .unwrap();
+
+                let mut rejected_report_aggregations = Vec::new();
+                for (rejected_report, _) in rejected_reports {
+                    let rejected_report_aggregation = tx
+                        .get_report_aggregation_by_report_id(
+                            vdaf.as_ref(),
+                            &Role::Leader,
+                            task.id(),
+                            &aggregation_job_id,
+                            rejected_report.metadata().id(),
+                        )
+                        .await
+                        .unwrap()
+                        .unwrap();
+                    rejected_report_aggregations.push(rejected_report_aggregation);
+                }
+
+                rejected_report_aggregations.sort_by_key(|ra| *ra.report_id());
+
                 let batch_aggregations = merge_batch_aggregations_by_batch(
-                    tx.get_batch_aggregations_for_task::<VERIFY_KEY_LENGTH, TimeInterval, Poplar1<XofTurboShake128, 16>>(&vdaf, task.id())
+                    tx.get_batch_aggregations_for_task::<
+                        VERIFY_KEY_LENGTH,
+                        TimeInterval,
+                        Poplar1<XofTurboShake128, 16>,
+                    >(&vdaf, task.id())
                         .await
                         .unwrap(),
                 );
-                Ok((aggregation_job, report_aggregation, batch_aggregations))
+                Ok((
+                    aggregation_job,
+                    accepted_report_aggregation,
+                    rejected_report_aggregations,
+                    batch_aggregations,
+                ))
             })
         })
         .await
         .unwrap();
 
     assert_eq!(want_aggregation_job, got_aggregation_job);
-    assert_eq!(want_report_aggregation, got_report_aggregation);
+    assert_eq!(
+        want_accepted_report_aggregation,
+        got_accepted_report_aggregation
+    );
+
+    for (ord, ((rejected_report, prepare_error), got_rejected_report_aggregation)) in
+        rejected_reports
+            .iter()
+            .zip(got_rejected_report_aggregations)
+            .enumerate()
+    {
+        let want_rejected_report_aggregation =
+            ReportAggregation::<VERIFY_KEY_LENGTH, Poplar1<XofTurboShake128, 16>>::new(
+                *task.id(),
+                aggregation_job_id,
+                *rejected_report.metadata().id(),
+                *rejected_report.metadata().time(),
+                1 + ord as u64,
+                None,
+                ReportAggregationState::Failed {
+                    prepare_error: *prepare_error,
+                },
+            );
+        assert_eq!(
+            want_rejected_report_aggregation,
+            got_rejected_report_aggregation
+        );
+    }
+
     assert_eq!(want_batch_aggregations, got_batch_aggregations);
 
-    assert_task_aggregation_counter(&ds, *task.id(), TaskAggregationCounter::new_with_values(1))
-        .await;
+    assert_task_aggregation_counter(
+        &ds,
+        *task.id(),
+        TaskAggregationCounter {
+            success: 1,
+            helper_hpke_decrypt_failure: 1,
+            helper_batch_collected: 1,
+            helper_report_replayed: 1,
+            helper_report_dropped: 1,
+            helper_hpke_unknown_config_id: 1,
+            helper_vdaf_prep_error: 1,
+            helper_task_expired: 1,
+            helper_invalid_message: 1,
+            helper_report_too_early: 1,
+            duplicate_extension: 0,
+            public_share_encode_failure: 0,
+            batch_collected: 0,
+            report_replayed: 0,
+            report_dropped: 0,
+            hpke_unknown_config_id: 0,
+            hpke_decrypt_failure: 0,
+            vdaf_prep_error: 0,
+            task_expired: 0,
+            invalid_message: 0,
+            report_too_early: 0,
+        },
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -679,8 +835,15 @@ async fn step_time_interval_aggregation_job_init_single_step() {
     );
     assert_eq!(want_batch_aggregations, got_batch_aggregations);
 
-    assert_task_aggregation_counter(&ds, *task.id(), TaskAggregationCounter::new_with_values(1))
-        .await;
+    assert_task_aggregation_counter(
+        &ds,
+        *task.id(),
+        TaskAggregationCounter {
+            success: 1,
+            ..Default::default()
+        },
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -939,8 +1102,15 @@ async fn step_time_interval_aggregation_job_init_two_steps() {
     assert_eq!(want_report_aggregation, got_report_aggregation);
     assert_eq!(want_batch_aggregations, got_batch_aggregations);
 
-    assert_task_aggregation_counter(&ds, *task.id(), TaskAggregationCounter::new_with_values(0))
-        .await;
+    assert_task_aggregation_counter(
+        &ds,
+        *task.id(),
+        TaskAggregationCounter {
+            success: 0,
+            ..Default::default()
+        },
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -1305,8 +1475,15 @@ async fn step_time_interval_aggregation_job_init_partially_garbage_collected() {
     assert_eq!(want_report_aggregations, got_report_aggregations);
     assert_eq!(want_batch_aggregations, got_batch_aggregations);
 
-    assert_task_aggregation_counter(&ds, *task.id(), TaskAggregationCounter::new_with_values(2))
-        .await;
+    assert_task_aggregation_counter(
+        &ds,
+        *task.id(),
+        TaskAggregationCounter {
+            success: 2,
+            ..Default::default()
+        },
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -1588,8 +1765,15 @@ async fn step_fixed_size_aggregation_job_init_single_step() {
     assert_eq!(want_report_aggregation, got_report_aggregation);
     assert_eq!(want_batch_aggregations, got_batch_aggregations);
 
-    assert_task_aggregation_counter(&ds, *task.id(), TaskAggregationCounter::new_with_values(1))
-        .await;
+    assert_task_aggregation_counter(
+        &ds,
+        *task.id(),
+        TaskAggregationCounter {
+            success: 1,
+            ..Default::default()
+        },
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -1856,8 +2040,15 @@ async fn step_fixed_size_aggregation_job_init_two_steps() {
     assert_eq!(want_report_aggregation, got_report_aggregation);
     assert_eq!(want_batch_aggregations, got_batch_aggregations);
 
-    assert_task_aggregation_counter(&ds, *task.id(), TaskAggregationCounter::new_with_values(0))
-        .await;
+    assert_task_aggregation_counter(
+        &ds,
+        *task.id(),
+        TaskAggregationCounter {
+            success: 0,
+            ..Default::default()
+        },
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -2196,8 +2387,15 @@ async fn step_time_interval_aggregation_job_continue() {
     assert_eq!(want_report_aggregation, got_report_aggregation);
     assert_eq!(want_batch_aggregations, got_batch_aggregations);
 
-    assert_task_aggregation_counter(&ds, *task.id(), TaskAggregationCounter::new_with_values(1))
-        .await;
+    assert_task_aggregation_counter(
+        &ds,
+        *task.id(),
+        TaskAggregationCounter {
+            success: 1,
+            ..Default::default()
+        },
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -2495,8 +2693,15 @@ async fn step_fixed_size_aggregation_job_continue() {
     assert_eq!(want_report_aggregation, got_report_aggregation);
     assert_eq!(want_batch_aggregations, got_batch_aggregations);
 
-    assert_task_aggregation_counter(&ds, *task.id(), TaskAggregationCounter::new_with_values(1))
-        .await;
+    assert_task_aggregation_counter(
+        &ds,
+        *task.id(),
+        TaskAggregationCounter {
+            success: 1,
+            ..Default::default()
+        },
+    )
+    .await;
 }
 
 struct CancelAggregationJobTestCase {

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_continue.rs
@@ -379,7 +379,10 @@ async fn aggregate_continue() {
     assert_task_aggregation_counter(
         &datastore,
         *task.id(),
-        TaskAggregationCounter::new_with_values(1),
+        TaskAggregationCounter {
+            success: 1,
+            ..Default::default()
+        },
     )
     .await;
 }
@@ -773,7 +776,10 @@ async fn aggregate_continue_accumulate_batch_aggregation() {
     assert_task_aggregation_counter(
         &datastore,
         *task.id(),
-        TaskAggregationCounter::new_with_values(2),
+        TaskAggregationCounter {
+            success: 2,
+            ..Default::default()
+        },
     )
     .await;
 
@@ -1073,7 +1079,10 @@ async fn aggregate_continue_accumulate_batch_aggregation() {
     assert_task_aggregation_counter(
         &datastore,
         *task.id(),
-        TaskAggregationCounter::new_with_values(3),
+        TaskAggregationCounter {
+            success: 3,
+            ..Default::default()
+        },
     )
     .await;
 }
@@ -1193,12 +1202,8 @@ async fn aggregate_continue_leader_sends_non_continue_or_finish_transition() {
         )
     );
 
-    assert_task_aggregation_counter(
-        &datastore,
-        *task.id(),
-        TaskAggregationCounter::new_with_values(0),
-    )
-    .await;
+    assert_task_aggregation_counter(&datastore, *task.id(), TaskAggregationCounter::default())
+        .await;
 }
 
 #[tokio::test]
@@ -1374,12 +1379,8 @@ async fn aggregate_continue_prep_step_fails() {
         )
     );
 
-    assert_task_aggregation_counter(
-        &datastore,
-        *task.id(),
-        TaskAggregationCounter::new_with_values(0),
-    )
-    .await;
+    assert_task_aggregation_counter(&datastore, *task.id(), TaskAggregationCounter::default())
+        .await;
 }
 
 #[tokio::test]
@@ -1497,12 +1498,8 @@ async fn aggregate_continue_unexpected_transition() {
     )
     .await;
 
-    assert_task_aggregation_counter(
-        &datastore,
-        *task.id(),
-        TaskAggregationCounter::new_with_values(0),
-    )
-    .await;
+    assert_task_aggregation_counter(&datastore, *task.id(), TaskAggregationCounter::default())
+        .await;
 }
 
 #[tokio::test]
@@ -1679,12 +1676,8 @@ async fn aggregate_continue_out_of_order_transition() {
     )
     .await;
 
-    assert_task_aggregation_counter(
-        &datastore,
-        *task.id(),
-        TaskAggregationCounter::new_with_values(0),
-    )
-    .await;
+    assert_task_aggregation_counter(&datastore, *task.id(), TaskAggregationCounter::default())
+        .await;
 }
 
 #[tokio::test]
@@ -1777,10 +1770,6 @@ async fn aggregate_continue_for_non_waiting_aggregation() {
     )
     .await;
 
-    assert_task_aggregation_counter(
-        &datastore,
-        *task.id(),
-        TaskAggregationCounter::new_with_values(0),
-    )
-    .await;
+    assert_task_aggregation_counter(&datastore, *task.id(), TaskAggregationCounter::default())
+        .await;
 }

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
@@ -606,7 +606,10 @@ async fn aggregate_init() {
     assert_task_aggregation_counter(
         &datastore,
         *task.id(),
-        TaskAggregationCounter::new_with_values(1),
+        TaskAggregationCounter {
+            success: 1,
+            ..Default::default()
+        },
     )
     .await;
 }
@@ -716,12 +719,8 @@ async fn aggregate_init_batch_already_collected() {
         &PrepareStepResult::Reject(PrepareError::BatchCollected)
     );
 
-    assert_task_aggregation_counter(
-        &datastore,
-        *task.id(),
-        TaskAggregationCounter::new_with_values(0),
-    )
-    .await;
+    assert_task_aggregation_counter(&datastore, *task.id(), TaskAggregationCounter::default())
+        .await;
 }
 
 #[tokio::test]
@@ -808,7 +807,10 @@ async fn aggregate_init_with_reports_encrypted_by_task_specific_key() {
     assert_task_aggregation_counter(
         &datastore,
         *task.id(),
-        TaskAggregationCounter::new_with_values(1),
+        TaskAggregationCounter {
+            success: 1,
+            ..Default::default()
+        },
     )
     .await;
 }
@@ -866,12 +868,8 @@ async fn aggregate_init_prep_init_failed() {
         &PrepareStepResult::Reject(PrepareError::VdafPrepError)
     );
 
-    assert_task_aggregation_counter(
-        &datastore,
-        *task.id(),
-        TaskAggregationCounter::new_with_values(0),
-    )
-    .await;
+    assert_task_aggregation_counter(&datastore, *task.id(), TaskAggregationCounter::default())
+        .await;
 }
 
 #[tokio::test]
@@ -926,12 +924,8 @@ async fn aggregate_init_prep_step_failed() {
         &PrepareStepResult::Reject(PrepareError::VdafPrepError)
     );
 
-    assert_task_aggregation_counter(
-        &datastore,
-        *task.id(),
-        TaskAggregationCounter::new_with_values(0),
-    )
-    .await;
+    assert_task_aggregation_counter(&datastore, *task.id(), TaskAggregationCounter::default())
+        .await;
 }
 
 #[tokio::test]
@@ -981,10 +975,6 @@ async fn aggregate_init_duplicated_report_id() {
     );
     assert_eq!(want_status, test_conn.status().unwrap());
 
-    assert_task_aggregation_counter(
-        &datastore,
-        *task.id(),
-        TaskAggregationCounter::new_with_values(0),
-    )
-    .await;
+    assert_task_aggregation_counter(&datastore, *task.id(), TaskAggregationCounter::default())
+        .await;
 }

--- a/aggregator_api/src/routes.rs
+++ b/aggregator_api/src/routes.rs
@@ -60,6 +60,7 @@ pub(super) async fn get_config(
             "UploadMetrics",
             "TimeBucketedFixedSize",
             "PureDpDiscreteLaplace",
+            "AggregationJobMetrics",
         ],
         software_name: "Janus",
         software_version,

--- a/aggregator_api/src/tests.rs
+++ b/aggregator_api/src/tests.rs
@@ -78,7 +78,7 @@ async fn get_config() {
             r#""protocol":"DAP-09","dap_url":"https://dap.url/","role":"Either","vdafs":"#,
             r#"["Prio3Count","Prio3Sum","Prio3Histogram","Prio3SumVec"],"#,
             r#""query_types":["TimeInterval","FixedSize"],"#,
-            r#""features":["TokenHash","UploadMetrics","TimeBucketedFixedSize","PureDpDiscreteLaplace"],"#,
+            r#""features":["TokenHash","UploadMetrics","TimeBucketedFixedSize","PureDpDiscreteLaplace","AggregationJobMetrics"],"#,
             r#""software_name":"Janus","software_version":""#,
         )
     );
@@ -924,7 +924,11 @@ async fn get_task_aggregation_metrics() {
             tx.increment_task_aggregation_counter(
                 &task_id,
                 5,
-                &TaskAggregationCounter::new_with_values(15),
+                &TaskAggregationCounter {
+                    success: 15,
+                    helper_hpke_decrypt_failure: 100,
+                    ..Default::default()
+                },
             )
             .await
         })
@@ -938,9 +942,11 @@ async fn get_task_aggregation_metrics() {
             .run_async(&handler)
             .await,
         Status::Ok,
-        serde_json::to_string(&GetTaskAggregationMetricsResp(
-            TaskAggregationCounter::new_with_values(15)
-        ))
+        serde_json::to_string(&GetTaskAggregationMetricsResp(TaskAggregationCounter {
+            success: 15,
+            helper_hpke_decrypt_failure: 100,
+            ..Default::default()
+        },))
         .unwrap(),
     );
 

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -2372,20 +2372,84 @@ impl TaskUploadCounter {
 }
 
 /// Per-task counts of aggregated reports.
+///
+/// The intended scope of this structure is a single operation, e.g., a single step of a single
+/// aggregation job. What that means is:
+///   - The counter values in this structure will not represent the current totals for the task, but
+///     rather just the contribution that the particular operation is making to the task total;
+///   - Callers must flush the counter values to the datastore by calling
+///     `Transaction::increment_task_aggregation_counter`. Callers must avoid double counting: any
+///     operation's counters should only be flushed to datastore once.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TaskAggregationCounter {
     /// The number of successfully-aggregated reports.
-    pub(crate) success: u64,
+    pub success: u64,
+
+    /// The number of reports rejected due to duplicate extensions.
+    pub duplicate_extension: u64,
+    /// The number of reports rejected due to failure to encode the public share.
+    pub public_share_encode_failure: u64,
+    /// The number of reports rejected due to the batch being collected.
+    pub batch_collected: u64,
+    /// The number of reports rejected due to the report replay.
+    pub report_replayed: u64,
+    /// The number of reports rejected due to the leader dropping the report.
+    pub report_dropped: u64,
+    /// The number of reports rejected due to unknown HPKE config ID.
+    pub hpke_unknown_config_id: u64,
+    /// The number of reports rejected due to HPKE decryption failure.
+    pub hpke_decrypt_failure: u64,
+    /// The number of reports rejected due to VDAF preparation error.
+    pub vdaf_prep_error: u64,
+    /// The number of reports rejected due to task expiration.
+    pub task_expired: u64,
+    /// The number of reports rejected due to an invalid message.
+    pub invalid_message: u64,
+    /// The number of reports rejected due to a report arriving too early.
+    pub report_too_early: u64,
+
+    /// The number of reports rejected by the helper due to the batch being collected.
+    pub helper_batch_collected: u64,
+    /// The number of reports rejected by the helper due to the report replay.
+    pub helper_report_replayed: u64,
+    /// The number of reports rejected by the helper due to the leader dropping the report.
+    pub helper_report_dropped: u64,
+    /// The number of reports rejected by the helper due to unknown HPKE config ID.
+    pub helper_hpke_unknown_config_id: u64,
+    /// The number of reports rejected by the helper due to HPKE decryption failure.
+    pub helper_hpke_decrypt_failure: u64,
+    /// The number of reports rejected by the helper due to VDAF preparation error.
+    pub helper_vdaf_prep_error: u64,
+    /// The number of reports rejected by the helper due to task expiration.
+    pub helper_task_expired: u64,
+    /// The number of reports rejected by the helper due to an invalid message.
+    pub helper_invalid_message: u64,
+    /// The number of reports rejected by the helper due to a report arriving too early.
+    pub helper_report_too_early: u64,
 }
 
 impl TaskAggregationCounter {
-    #[cfg(feature = "test-util")]
-    pub fn new_with_values(success: u64) -> Self {
-        Self { success }
-    }
-
     /// Increments the counter of successfully-aggregated reports.
     pub fn increment_success(&mut self) {
         self.success += 1
+    }
+
+    /// Increments the appropriate counter based on the helper prepare failure
+    pub fn increment_with_helper_prepare_error(&mut self, helper_error: PrepareError) {
+        match helper_error {
+            PrepareError::BatchCollected => self.helper_batch_collected += 1,
+            PrepareError::ReportReplayed => self.helper_report_replayed += 1,
+            PrepareError::ReportDropped => self.helper_report_dropped += 1,
+            PrepareError::HpkeUnknownConfigId => self.helper_hpke_unknown_config_id += 1,
+            PrepareError::HpkeDecryptError => self.helper_hpke_decrypt_failure += 1,
+            PrepareError::VdafPrepError => self.helper_vdaf_prep_error += 1,
+            PrepareError::TaskExpired => self.helper_task_expired += 1,
+            PrepareError::InvalidMessage => self.helper_invalid_message += 1,
+            PrepareError::ReportTooEarly => self.helper_report_too_early += 1,
+            // PrepareError::BatchSaturated corresponds to draft-ietf-ppm-dap-09's batch_saturated,
+            // but it's not used anywhere and is dropped from later DAP drafts, so we don't bother
+            // representing it in counters.
+            _ => tracing::debug!(?helper_error, "unexpected prepare error from helper"),
+        }
     }
 }

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -8190,7 +8190,11 @@ async fn roundtrip_task_aggregation_counter(ephemeral_datastore: EphemeralDatast
                 tx.increment_task_aggregation_counter(
                     task.id(),
                     ord,
-                    &TaskAggregationCounter { success: 4 },
+                    &TaskAggregationCounter {
+                        success: 4,
+                        helper_hpke_decrypt_failure: 102,
+                        ..Default::default()
+                    },
                 )
                 .await
                 .unwrap();
@@ -8199,7 +8203,12 @@ async fn roundtrip_task_aggregation_counter(ephemeral_datastore: EphemeralDatast
                 tx.increment_task_aggregation_counter(
                     task.id(),
                     ord,
-                    &TaskAggregationCounter { success: 6 },
+                    &TaskAggregationCounter {
+                        success: 6,
+                        helper_hpke_decrypt_failure: 98,
+                        helper_task_expired: 1,
+                        ..Default::default()
+                    },
                 )
                 .await
                 .unwrap();
@@ -8214,7 +8223,15 @@ async fn roundtrip_task_aggregation_counter(ephemeral_datastore: EphemeralDatast
                 .unwrap();
 
                 let counter = tx.get_task_aggregation_counter(task.id()).await.unwrap();
-                assert_eq!(counter, Some(TaskAggregationCounter { success: 10 }));
+                assert_eq!(
+                    counter,
+                    Some(TaskAggregationCounter {
+                        success: 10,
+                        helper_hpke_decrypt_failure: 200,
+                        helper_task_expired: 1,
+                        ..Default::default()
+                    })
+                );
 
                 Ok(())
             })


### PR DESCRIPTION
Expands `TaskAggregationCounter` so that the leader can report the various `PrepareError`s that a helper might indicate during handling of an aggregation job.

This change was previously made in https://github.com/divviup/janus/pull/3958 but partially reverted in PR https://github.com/divviup/janus/pull/3972.

Part of https://github.com/divviup/janus/issues/3798