### PR TITLE
Use `cargo install --locked`

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -40,6 +40,7 @@ jobs:
           cargo install \
             --root ${{ runner.tool_cache }}/cargo-edit \
             --version ${{ env.CARGO_EDIT_VERSION }} \
+            --locked \
             cargo-edit
       
       - run: cargo set-version --bump patch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM rust:1.89.0-alpine AS chef
 ENV CARGO_INCREMENTAL=0
 RUN apk add --no-cache libc-dev cmake make
-RUN cargo install cargo-chef --version 0.1.71 && \
+RUN cargo install cargo-chef --version 0.1.71 --locked && \
     rm -r $CARGO_HOME/registry
 WORKDIR /src
 

--- a/Dockerfile.interop
+++ b/Dockerfile.interop
@@ -4,7 +4,7 @@ ARG PROFILE=release
 FROM rust:1.89.0-alpine AS chef
 ENV CARGO_INCREMENTAL=0
 RUN apk add --no-cache libc-dev cmake make
-RUN cargo install cargo-chef --version 0.1.71 && \
+RUN cargo install cargo-chef --version 0.1.71 --locked && \
     rm -r $CARGO_HOME/registry
 WORKDIR /src
 

--- a/Dockerfile.interop_aggregator
+++ b/Dockerfile.interop_aggregator
@@ -3,7 +3,7 @@ ARG PROFILE=release
 FROM rust:1.89.0-alpine AS chef
 ENV CARGO_INCREMENTAL=0
 RUN apk add --no-cache libc-dev cmake make
-RUN cargo install cargo-chef --version 0.1.71 && \
+RUN cargo install cargo-chef --version 0.1.71 --locked && \
     rm -r $CARGO_HOME/registry
 WORKDIR /src
 
@@ -66,6 +66,7 @@ ARG SQLX_VERSION=0.7.2
 RUN apk add --no-cache libc-dev
 RUN cargo install sqlx-cli \
     --version ${SQLX_VERSION} \
+    --locked \
     --no-default-features --features postgres
 
 FROM postgres:15-alpine AS final

--- a/Dockerfile.sqlx
+++ b/Dockerfile.sqlx
@@ -4,6 +4,7 @@ ARG SQLX_VERSION
 RUN apk add libc-dev
 RUN cargo install sqlx-cli \
     --version ${SQLX_VERSION} \
+    --locked \
     --no-default-features --features rustls,postgres
 
 FROM alpine:3.22.1


### PR DESCRIPTION
This passes `--locked` to invocations of `cargo install` in Dockerfiles and CI scripts, so that we use the crate's lock file when building and installing binaries. This will avoid surprises from untested dependency versions, such as the now-yanked `cfg-if@1.0.2`, which we ran into earlier today.