### PR TITLE
Don't opt out of task based on task expiry time

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -897,10 +897,6 @@ impl<C: Clock> Aggregator<C> {
             return Err(Error::UnauthorizedRequest(*task_id));
         }
 
-        if self.clock.now() > *task_config.task_expiration() {
-            return Err(Error::InvalidTask(*task_id, OptOutReason::TaskExpired));
-        }
-
         debug!(
             ?task_id,
             ?task_config,

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -579,15 +579,16 @@ async fn taskprov_aggregate_init_malformed_extension() {
     assert_eq!(test.task.taskprov_helper_view().unwrap(), got_task.unwrap());
 }
 
+/// The helper should not opt out of the task if the current time is past the task expiry time.
 #[tokio::test]
-async fn taskprov_opt_out_task_expired() {
+async fn taskprov_opt_out_task_expired_regression() {
     let test = TaskprovTestCase::new().await;
 
-    let (transcript, report_share, _) = test.next_report_share();
+    let (transcript, report_share, aggregation_param) = test.next_report_share();
 
     let batch_id = random();
     let request = AggregationJobInitializeReq::new(
-        ().get_encoded().unwrap(),
+        aggregation_param.get_encoded().unwrap(),
         PartialBatchSelector::new_fixed_size(batch_id),
         Vec::from([PrepareInit::new(
             report_share.clone(),
@@ -605,7 +606,7 @@ async fn taskprov_opt_out_task_expired() {
     // Advance clock past task expiry.
     test.clock.advance(&Duration::from_hours(48).unwrap());
 
-    let mut test_conn = put(test
+    let test_conn = put(test
         .task
         .aggregation_job_uri(&aggregation_job_id)
         .unwrap()
@@ -622,16 +623,7 @@ async fn taskprov_opt_out_task_expired() {
     .with_request_body(request.get_encoded().unwrap())
     .run_async(&test.handler)
     .await;
-    assert_eq!(test_conn.status(), Some(Status::BadRequest));
-    assert_eq!(
-        take_problem_details(&mut test_conn).await,
-        json!({
-            "status": Status::BadRequest as u16,
-            "type": "urn:ietf:params:ppm:dap:error:invalidTask",
-            "title": "Aggregator has opted out of the indicated task.",
-            "taskid": format!("{}", test.task_id),
-        })
-    );
+    assert_eq!(test_conn.status(), Some(Status::Ok));
 }
 
 #[tokio::test]


### PR DESCRIPTION
This fixes #3988 by removing an unnecessary check in Taskprov request authorization. I repurposed an existing test into a regression test for this issue.