### PR TITLE
Leader must reject reports with duplicate extensions

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1886,6 +1886,7 @@ impl VdafOps {
         // Check if any two extensions have the same extension type across public
         // and private extension fields. If so, the Aggregator MUST mark the input
         // share as invalid with error invalid_message. (§4.6.2.4 step 7)
+        //
         // Note at this point we can't provide Error::InvalidMessage here because
         // we're packaging this into a report rejection list.
         let mut extensions = HashMap::new();

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -99,7 +99,7 @@ use rand::{Rng, random, rng};
 use reqwest::Client;
 use std::{
     borrow::Cow,
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     fmt::Debug,
     panic,
     path::PathBuf,
@@ -1882,6 +1882,32 @@ impl VdafOps {
                 return Err(reject_report(ReportRejectionReason::DecodeFailure).await?);
             }
         };
+
+        // Check if any two extensions have the same extension type across public
+        // and private extension fields. If so, the Aggregator MUST mark the input
+        // share as invalid with error invalid_message. (§4.6.2.4 step 7)
+        // Note at this point we can't provide Error::InvalidMessage here because
+        // we're packaging this into a report rejection list.
+        let mut extensions = HashMap::new();
+        if !leader_private_extensions
+            .iter()
+            .chain(report.metadata().public_extensions())
+            .all(|extension| {
+                extensions
+                    .insert(*extension.extension_type(), extension.extension_data())
+                    .is_none()
+            })
+        {
+            debug!(
+                task_id = %task.id(),
+                report_id = ?report.metadata().id(),
+                "Received report share with duplicate extensions",
+            );
+            metrics
+                .upload_decode_failure_counter
+                .add(1, &[KeyValue::new("type", "duplicate_extension")]);
+            return Err(reject_report(ReportRejectionReason::DuplicateExtension).await?);
+        }
 
         let report = LeaderStoredReport::new(
             *task.id(),

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -315,6 +315,7 @@ impl<C: Clock> Aggregator<C> {
             .with_unit("{error}")
             .build();
         upload_decode_failure_counter.add(0, &[]);
+        upload_decode_failure_counter.add(0, &[KeyValue::new("type", "duplicate_extension")]);
 
         let report_aggregation_success_counter = report_aggregation_success_counter(meter);
         let aggregate_step_failure_counter = aggregate_step_failure_counter(meter);

--- a/aggregator/src/aggregator/error.rs
+++ b/aggregator/src/aggregator/error.rs
@@ -232,6 +232,7 @@ pub enum ReportRejectionReason {
     TooEarly,
     OutdatedHpkeConfig(HpkeConfigId),
     TaskNotStarted,
+    DuplicateExtension,
 }
 
 impl ReportRejectionReason {
@@ -249,6 +250,7 @@ impl ReportRejectionReason {
                 "Report is using an outdated HPKE configuration."
             }
             ReportRejectionReason::TaskNotStarted => "Task has not started.",
+            ReportRejectionReason::DuplicateExtension => "Report contains duplicate extensions.",
         }
     }
 }
@@ -284,6 +286,7 @@ impl Error {
             Error::ReportRejected(rejection) => match rejection.reason {
                 ReportRejectionReason::TooEarly => "report_too_early",
                 ReportRejectionReason::OutdatedHpkeConfig(_) => "outdated_hpke_config",
+                ReportRejectionReason::DuplicateExtension => "duplicate_extension",
                 _ => "report_rejected",
             },
             Error::InvalidMessage(_, _) => "unrecognized_message",

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -69,6 +69,11 @@ async fn run_error_handler(error: &Error, mut conn: Conn) -> Conn {
                 &ProblemDocument::new_dap(DapProblemType::ReportTooEarly)
                     .with_task_id(rejection.task_id()),
             ),
+            ReportRejectionReason::DuplicateExtension => conn.with_problem_document(
+                &ProblemDocument::new_dap(DapProblemType::InvalidMessage)
+                    .with_task_id(rejection.task_id())
+                    .with_detail(rejection.reason().detail()),
+            ),
             _ => conn.with_problem_document(
                 &ProblemDocument::new_dap(DapProblemType::ReportRejected)
                     .with_task_id(rejection.task_id())
@@ -158,7 +163,7 @@ async fn run_error_handler(error: &Error, mut conn: Conn) -> Conn {
         Error::Datastore(error @ datastoreError::TimeUnaligned { task_id, .. }) => conn
             .with_problem_document(
                 &ProblemDocument::new(
-                    "urn:ietf:params:ppm:dap:error:invalid_message",
+                    DapProblemType::InvalidMessage.type_uri(),
                     "Time unaligned.",
                     Status::BadRequest,
                 )

--- a/aggregator/src/aggregator/http_handlers/tests/report.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/report.rs
@@ -126,6 +126,9 @@ async fn upload_handler() {
         clock.now_aligned_to_precision(task.time_precision()),
         *accepted_report_id,
         &hpke_keypair,
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
     );
     let mut test_conn = post(task.report_upload_uri().unwrap().path())
         .with_request_header(KnownHeaderName::ContentType, Report::MEDIA_TYPE)
@@ -313,6 +316,9 @@ async fn upload_handler() {
         *accepted_report_id,
         // Encrypt report with some arbitrary key that has the same ID as an existing one.
         &HpkeKeypair::test_with_id(*hpke_keypair.config().id()),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
     );
     let mut test_conn = post(task.report_upload_uri().unwrap().path())
         .with_request_header(KnownHeaderName::ContentType, Report::MEDIA_TYPE)

--- a/aggregator/src/aggregator/report_writer.rs
+++ b/aggregator/src/aggregator/report_writer.rs
@@ -337,6 +337,7 @@ impl TaskUploadCounters {
             ReportRejectionReason::TooEarly => entry.increment_report_too_early(),
             ReportRejectionReason::OutdatedHpkeConfig(_) => entry.increment_report_outdated_key(),
             ReportRejectionReason::TaskNotStarted => entry.increment_task_not_started(),
+            ReportRejectionReason::DuplicateExtension => entry.increment_duplicate_extension(),
         }
     }
 

--- a/aggregator_api/src/tests.rs
+++ b/aggregator_api/src/tests.rs
@@ -911,7 +911,7 @@ async fn get_task_upload_metrics() {
     // Verify: requesting metrics on a task returns the correct result.
     ds.run_unnamed_tx(|tx| {
         Box::pin(async move {
-            TaskUploadCounter::new_with_values(0, 0, 2, 4, 6, 100, 25, 22, 12)
+            TaskUploadCounter::new_with_values(0, 0, 2, 4, 6, 100, 25, 22, 12, 0)
                 .flush(&task_id, tx, 1)
                 .await
         })
@@ -926,7 +926,7 @@ async fn get_task_upload_metrics() {
             .await,
         Status::Ok,
         serde_json::to_string(&GetTaskUploadMetricsResp(
-            TaskUploadCounter::new_with_values(0, 0, 2, 4, 6, 100, 25, 22, 12)
+            TaskUploadCounter::new_with_values(0, 0, 2, 4, 6, 100, 25, 22, 12, 0)
         ))
         .unwrap(),
     );
@@ -2146,7 +2146,7 @@ fn task_resp_serialization() {
 fn get_task_upload_metrics_serialization() {
     assert_ser_tokens(
         &GetTaskUploadMetricsResp(TaskUploadCounter::new_with_values(
-            0, 1, 2, 3, 4, 5, 6, 7, 8,
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
         )),
         &[
             Token::NewtypeStruct {
@@ -2154,7 +2154,7 @@ fn get_task_upload_metrics_serialization() {
             },
             Token::Struct {
                 name: "TaskUploadCounter",
-                len: 9,
+                len: 10,
             },
             Token::Str("interval_collected"),
             Token::U64(0),
@@ -2174,6 +2174,8 @@ fn get_task_upload_metrics_serialization() {
             Token::U64(7),
             Token::Str("task_ended"),
             Token::U64(8),
+            Token::Str("duplicate_extension"),
+            Token::U64(9),
             Token::StructEnd,
         ],
     )

--- a/aggregator_core/src/datastore/task_counters_tests.rs
+++ b/aggregator_core/src/datastore/task_counters_tests.rs
@@ -40,18 +40,18 @@ async fn roundtrip_task_upload_counter(ephemeral_datastore: EphemeralDatastore) 
                 assert_eq!(counter, Some(TaskUploadCounter::default()));
 
                 let ord = rng().random_range(0..32);
-                TaskUploadCounter::new_with_values(2, 4, 6, 8, 10, 100, 25, 22, 12)
+                TaskUploadCounter::new_with_values(2, 4, 6, 8, 10, 100, 25, 22, 12, 42)
                     .flush(&task_id, tx, ord)
                     .await
                     .unwrap();
 
                 let ord = rng().random_range(0..32);
-                TaskUploadCounter::new_with_values(0, 0, 0, 0, 0, 0, 0, 0, 8)
+                TaskUploadCounter::new_with_values(0, 0, 0, 0, 0, 0, 0, 0, 8, 0)
                     .flush(&task_id, tx, ord)
                     .await
                     .unwrap();
 
-                TaskUploadCounter::new_with_values(1, 1, 1, 1, 1, 1, 1, 1, 1)
+                TaskUploadCounter::new_with_values(1, 1, 1, 1, 1, 1, 1, 1, 1, 1)
                     // force conflict on (task_id, ord) to exercise the query's
                     // ON CONFLICT (task_id, ord) DO UPDATE SET clause
                     .flush(&task_id, tx, ord)
@@ -68,7 +68,7 @@ async fn roundtrip_task_upload_counter(ephemeral_datastore: EphemeralDatastore) 
                 assert_eq!(
                     counter,
                     Some(TaskUploadCounter::new_with_values(
-                        3, 5, 7, 9, 11, 101, 26, 23, 21,
+                        3, 5, 7, 9, 11, 101, 26, 23, 21, 43,
                     ))
                 );
 

--- a/db/00000000000001_initial_schema.up.sql
+++ b/db/00000000000001_initial_schema.up.sql
@@ -169,6 +169,7 @@ CREATE TABLE task_upload_counters(
     report_too_early       BIGINT NOT NULL DEFAULT 0, -- reports whose timestamp is too far in the future.
     task_not_started       BIGINT NOT NULL DEFAULT 0, -- reports sent to the task before it started.
     task_ended             BIGINT NOT NULL DEFAULT 0, -- reports sent to the task after it ended.
+    duplicate_extension    BIGINT NOT NULL DEFAULT 0, -- reports with duplicate extensions
 
     CONSTRAINT fk_task_id FOREIGN KEY(task_id) REFERENCES tasks(id) ON DELETE CASCADE,
     CONSTRAINT task_upload_counters_unique UNIQUE(task_id, ord)


### PR DESCRIPTION
Note there's an error response inconsistency between Helper and Leader -- Leader returns ReportRejectionReason::DuplicateExtension while Helper returns ReportError::InvalidMessage (line 235 in aggregation_job_init.rs).

Also note that this adds the telemetry to TaskUploadCounter, but we already have -- completely unused -- DuplicateExtension in TaskAggregationCounter.

Maybe this is putting the rejection in the wrong place for the Leader?

Fixes #3997