### PR TITLE
Bypass RUSTSEC-2025-0012 and RUSTSEC-2025-0052 on 0.7

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -15,6 +15,14 @@ ignore = [
     # Janus never uses the protobuf format for exposing metrics, and in any case we would not be
     # handling untrusted input.
     "RUSTSEC-2024-0437",
+
+    # We've moved to `backon` in `main`, but as this is small and driven by internal logic, it is
+    # unlikely to have exploitable security vulnerabilities.
+    "RUSTSEC-2025-0012",
+
+    # `async-std` is only in our tree as the `opentelemetry_sdk/rt-async-std` feature, which we do
+    # not enable.
+    "RUSTSEC-2025-0052",
 ]
 
 [bans]


### PR DESCRIPTION
Clean up the "backoff" alert while we're at it.