### PR TITLE
Taskprov: Plumb opt-out reason into opt-out errors

### DIFF
--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -150,8 +150,10 @@ async fn run_error_handler(error: &Error, mut conn: Conn) -> Conn {
         ),
         Error::ForbiddenMutation { .. } => conn.with_status(Status::Conflict),
         Error::BadRequest(_) => conn.with_status(Status::BadRequest),
-        Error::InvalidTask(task_id, _) => conn.with_problem_document(
-            &ProblemDocument::new_dap(DapProblemType::InvalidTask).with_task_id(task_id),
+        Error::InvalidTask(task_id, opt_out_reason) => conn.with_problem_document(
+            &ProblemDocument::new_dap(DapProblemType::InvalidTask)
+                .with_task_id(task_id)
+                .with_detail(&format!("{opt_out_reason}")),
         ),
         Error::DifferentialPrivacy(_) => conn.with_status(Status::InternalServerError),
         Error::ClientDisconnected => conn.with_status(Status::BadRequest),
@@ -161,10 +163,10 @@ async fn run_error_handler(error: &Error, mut conn: Conn) -> Conn {
                 "The server is currently overloaded.",
                 Status::TooManyRequests,
             )
-            .with_detail(concat!(
-                "The server is currently servicing too many requests, please try the request ",
-                "again later."
-            )),
+            .with_detail(
+                "The server is currently servicing too many requests, please try the request again \
+                later.",
+            ),
         ),
     };
 

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -783,6 +783,7 @@ async fn taskprov_opt_out_peer_aggregator_wrong_role() {
             "type": "urn:ietf:params:ppm:dap:error:invalidTask",
             "title": "Aggregator has opted out of the indicated task.",
             "taskid": format!("{another_task_id}"),
+            "detail": "this aggregator is not peered with the given leader aggregator",
         })
     );
 }
@@ -864,6 +865,7 @@ async fn taskprov_opt_out_peer_aggregator_does_not_exist() {
             "type": "urn:ietf:params:ppm:dap:error:invalidTask",
             "title": "Aggregator has opted out of the indicated task.",
             "taskid": format!("{another_task_id}"),
+            "detail": "this aggregator is not peered with the given leader aggregator",
         })
     );
 }


### PR DESCRIPTION
The problem documents served to the leader when a Janus helper opts out of a taskprov task will now include an unstructured description of the reason.