### PR TITLE
Add an InstantClock trait and plumb it into the LIFOQueueHandler and Datastore

### DIFF
--- a/aggregator/src/binary_utils.rs
+++ b/aggregator/src/binary_utils.rs
@@ -139,7 +139,7 @@ pub async fn datastore<C: Clock>(
     datastore_keys: &[String],
     check_schema_version: bool,
     max_transaction_retries: u64,
-) -> Result<Datastore<C>> {
+) -> Result<Datastore<C, janus_core::time::RealInstantClock>> {
     let datastore_keys = datastore_keys
         .iter()
         .filter(|k| !k.is_empty())
@@ -165,21 +165,25 @@ pub async fn datastore<C: Clock>(
     }
 
     let datastore = if check_schema_version {
-        Datastore::new(
+        use janus_core::time::RealInstantClock;
+        Datastore::with_instant_clock(
             pool,
             Crypter::new(datastore_keys),
             clock,
             meter,
             max_transaction_retries,
+            RealInstantClock,
         )
         .await?
     } else {
+        use janus_core::time::RealInstantClock;
         Datastore::new_without_supported_versions(
             pool,
             Crypter::new(datastore_keys),
             clock,
             meter,
             max_transaction_retries,
+            RealInstantClock,
         )
         .await
     };

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -88,6 +88,7 @@ async fn reject_unsupported_schema_version(ephemeral_datastore: EphemeralDatasto
         &noop_meter(),
         &[0],
         TEST_DATASTORE_MAX_TRANSACTION_RETRIES,
+        janus_core::time::RealInstantClock,
     )
     .await
     .unwrap_err();


### PR DESCRIPTION
This doesn't _use_ the new capabilities yet, because it's not super natural to do so.

This also doesn't propagate it out to the `Datastore` and `Aggregator` types yet. I have that in-progress, but I keep not liking how it looks. Still working.

Follow-on to PR #4046
Resolves #4044

