### PR TITLE
Add timeout support to LIFO request queue (main)

### DIFF
--- a/aggregator/src/aggregator/error.rs
+++ b/aggregator/src/aggregator/error.rs
@@ -149,6 +149,8 @@ pub enum Error {
     ClientDisconnected,
     #[error("too many requests")]
     TooManyRequests,
+    #[error("request timed out waiting in queue")]
+    RequestTimeout,
 }
 
 /// A newtype around `Arc<Error>`. This is needed to host a customized implementation of
@@ -320,6 +322,7 @@ impl Error {
             Error::DifferentialPrivacy(_) => "differential_privacy",
             Error::ClientDisconnected => "client_disconnected",
             Error::TooManyRequests => "too_many_requests",
+            Error::RequestTimeout => "request_timeout",
             Error::BadContentType(_) => "bad_content_type",
         }
     }

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -210,6 +210,14 @@ async fn run_error_handler(error: &Error, mut conn: Conn) -> Conn {
                 later.",
             ),
         ),
+        Error::RequestTimeout => conn.with_problem_document(
+            &ProblemDocument::new(
+                "https://docs.divviup.org/references/janus-errors#request-timeout",
+                "Request timed out waiting in queue.",
+                Status::TooManyRequests,
+            )
+            .with_detail("The request spent too long waiting to be processed."),
+        ),
     };
 
     if matches!(conn.status(), Some(status) if status.is_server_error()) {
@@ -384,6 +392,9 @@ pub(crate) static AGGREGATE_SHARES_ROUTE: &str =
 pub struct HelperAggregationRequestQueue {
     pub depth: usize,
     pub concurrency: u32,
+    /// Maximum lifespan, in milliseconds, of requests in the Request Queue.
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
 }
 
 pub struct AggregatorHandlerBuilder<'a, C>
@@ -434,9 +445,21 @@ where
     pub fn build(self) -> Result<impl Handler, Error> {
         let helper_queue = self
             .helper_aggregation_request_queue
-            .map(|HelperAggregationRequestQueue { depth, concurrency }| {
-                LIFORequestQueue::new(concurrency, depth, self.meter, "janus_helper")
-            })
+            .map(
+                |HelperAggregationRequestQueue {
+                     depth,
+                     concurrency,
+                     timeout_ms,
+                 }| {
+                    LIFORequestQueue::new(
+                        concurrency,
+                        depth,
+                        self.meter,
+                        "janus_helper",
+                        timeout_ms.map(StdDuration::from_millis),
+                    )
+                },
+            )
             .transpose()?
             .map(Arc::new);
 
@@ -1129,6 +1152,7 @@ pub mod test_util {
             .with_helper_aggregation_request_queue(super::HelperAggregationRequestQueue {
                 depth: 16,
                 concurrency: 2,
+                timeout_ms: None,
             })
             .build()
             .unwrap();

--- a/aggregator/src/aggregator/queue.rs
+++ b/aggregator/src/aggregator/queue.rs
@@ -2,7 +2,7 @@ use itertools::Itertools;
 use janus_aggregator_core::TIME_HISTOGRAM_BOUNDARIES;
 use opentelemetry::{
     KeyValue,
-    metrics::{Histogram, Meter},
+    metrics::{Counter, Histogram, Meter},
 };
 use opentelemetry_sdk::metrics::MetricError;
 use std::{
@@ -11,7 +11,7 @@ use std::{
         Arc,
         atomic::{AtomicU64, Ordering},
     },
-    time::Instant,
+    time::{Duration, Instant},
 };
 use tokio::{
     select,
@@ -48,6 +48,10 @@ pub struct LIFORequestQueue {
     /// counter.
     id_counter: AtomicU64,
 
+    /// Maximum time a request can wait in the queue.
+    request_timeout: Option<Duration>,
+
+    /// Metrics for monitoring queue behavior.
     metrics: Metrics,
 }
 
@@ -58,11 +62,14 @@ impl LIFORequestQueue {
     ///
     /// `meter_prefix` is a string to disambiguate one queue from another in the metrics, while
     /// using the same meter. All metric names will be prefixed with this string.
+    ///
+    /// `request_timeout` specifies the maximum time a request can wait in the queue.
     pub fn new(
         concurrency: u32,
         depth: usize,
         meter: &Meter,
         meter_prefix: &str,
+        request_timeout: Option<Duration>,
     ) -> Result<Self, Error> {
         if concurrency < 1 {
             return Err(Error::InvalidConfiguration(
@@ -81,6 +88,7 @@ impl LIFORequestQueue {
         Ok(Self {
             id_counter,
             dispatcher_tx: message_tx,
+            request_timeout,
             metrics,
         })
     }
@@ -125,22 +133,27 @@ impl LIFORequestQueue {
                                 match message {
                                     DispatcherMessage::Enqueue(id, permit_tx) => {
                                         if let Some(permit) = permits.split(1) {
-                                            permit_tx.send(Ok(permit))
+                                            permit_tx.send(Ok(permit));
+                                            metrics.requests_processed_immediately.add(1, &[]);
                                         } else if stack.len() < depth {
-                                            let result = stack.insert(id, permit_tx);
-                                            if result.is_some() {
+                                            if stack.insert(id, permit_tx).is_some() {
                                                 // Avoid panicking on this bug, since if this
                                                 // process dies, request processing stops.
                                                 error!(?id, "bug: overwrote existing request in the queue");
+                                                metrics.requests_queued.add(1, &[KeyValue::new("status", "overwrote")]);
+                                            } else {
+                                                metrics.requests_queued.add(1, &[]);
                                             }
                                         } else {
                                             permit_tx.send(Err(Error::TooManyRequests));
+                                            metrics.requests_rejected.add(1, &[]);
                                         }
                                     },
                                     DispatcherMessage::Cancel(id) => {
-                                        debug!(?id, "removing from the queue");
+                                        debug!(?id, "removing request from the queue");
                                         stack.remove(&id);
-                                     },
+                                        metrics.requests_cancelled.add(1, &[]);
+                                    },
                                 }
                             }
                             // The receiver is held open for at least the life of the LIFORequestQueue
@@ -168,14 +181,18 @@ impl LIFORequestQueue {
                     }
                 }
 
+                let stack_len = stack.len();
                 // Unwrap safety: only fails on architectures where usize is less than 32 bits, or
                 // greater than 64 bits.
                 metrics.outstanding_requests.store(
-                    (stack.len() + usize::try_from(concurrency).unwrap() - permits.num_permits())
+                    (stack_len + usize::try_from(concurrency).unwrap() - permits.num_permits())
                         .try_into()
                         .unwrap(),
                     Ordering::Relaxed,
                 );
+                metrics
+                    .stacked_requests
+                    .store(u64::try_from(stack_len).unwrap(), Ordering::Relaxed);
             }
         })
     }
@@ -243,19 +260,35 @@ impl LIFORequestQueue {
             self.metrics.clone(),
             enqueue_time,
         );
-        let permit = permit_rx.await;
-        drop_guard.disarm();
 
-        self.metrics.wait_time_histogram.record(
-            enqueue_time.elapsed().as_secs_f64(),
-            &[KeyValue::new("status", "dequeued")],
-        );
+        let permit_future = async {
+            let permit = permit_rx.await;
+            drop_guard.disarm();
 
-        // If the rx channel is prematurely dropped, we'll reach this error, indicating that
-        // something has gone wrong with the dispatcher task or it has shutdown. If the drop guard
-        // causes the rx channel to be dropped, we shouldn't reach this error because the overall
-        // future would have been dropped.
-        permit.map_err(|_| Error::Internal("rx channel dropped".into()))?
+            self.metrics.wait_time_histogram.record(
+                enqueue_time.elapsed().as_secs_f64(),
+                &[KeyValue::new("status", "dequeued")],
+            );
+
+            // If the rx channel is prematurely dropped, we'll reach this error, indicating that
+            // something has gone wrong with the dispatcher task or it has shutdown. If the drop guard
+            // causes the rx channel to be dropped, we shouldn't reach this error because the overall
+            // future would have been dropped.
+            permit.map_err(|_| {
+                Error::Internal("permit channel dropped; dispatcher may have shut down?".into())
+            })?
+        };
+
+        // If a request timeout is provided, impose it.
+        match self.request_timeout {
+            Some(timeout) => tokio::time::timeout(timeout, permit_future)
+                .await
+                .map_err(|_| {
+                    self.metrics.requests_timeout_queue.add(1, &[]);
+                    Error::RequestTimeout
+                })?,
+            None => permit_future.await,
+        }
     }
 }
 
@@ -323,14 +356,39 @@ struct Metrics {
     /// tests.
     outstanding_requests: Arc<AtomicU64>,
 
+    /// Number of requests currently waiting in the queue.
+    stacked_requests: Arc<AtomicU64>,
+
     /// Histogram measuring how long a queue item waited before being dequeued.
     wait_time_histogram: Histogram<f64>,
+
+    /// Counter for requests processed immediately without queueing.
+    requests_processed_immediately: Counter<u64>,
+
+    /// Counter for requests that were queued.
+    requests_queued: Counter<u64>,
+
+    /// Counter for requests that were rejected due to queue being full.
+    requests_rejected: Counter<u64>,
+
+    /// Counter for requests that were cancelled.
+    requests_cancelled: Counter<u64>,
+
+    /// Counter for requests that timed out while waiting in the queue.
+    requests_timeout_queue: Counter<u64>,
 }
 
 impl Metrics {
     const OUTSTANDING_REQUESTS_METRIC_NAME: &'static str = "outstanding_requests";
     const MAX_OUTSTANDING_REQUESTS_METRIC_NAME: &'static str = "max_outstanding_requests";
+    const STACKED_REQUESTS_METRIC_NAME: &'static str = "stacked_requests";
     const WAIT_TIME_METRIC_NAME: &'static str = "lifo_queue_wait_time";
+    const REQUESTS_PROCESSED_IMMEDIATELY_METRIC_NAME: &'static str =
+        "requests_processed_immediately";
+    const REQUESTS_QUEUED_METRIC_NAME: &'static str = "requests_queued";
+    const REQUESTS_REJECTED_METRIC_NAME: &'static str = "requests_rejected";
+    const REQUESTS_CANCELLED_METRIC_NAME: &'static str = "requests_cancelled";
+    const REQUESTS_TIMEOUT_QUEUE_METRIC_NAME: &'static str = "requests_timeout_queue";
 
     fn metric_name(prefix: &str, name: &str) -> String {
         [prefix, name].into_iter().join("_")
@@ -342,6 +400,8 @@ impl Metrics {
         max_outstanding_requests: u64,
     ) -> Result<Self, MetricError> {
         let outstanding_requests = Arc::new(AtomicU64::new(0));
+        let stacked_requests = Arc::new(AtomicU64::new(0));
+
         let _outstanding_requests_gauge = meter
             .u64_observable_gauge(Self::metric_name(
                 prefix,
@@ -367,6 +427,18 @@ impl Metrics {
             .with_unit("{request}")
             .with_callback(move |observer| observer.observe(max_outstanding_requests, &[]))
             .build();
+        let _stacked_requests_gauge = meter
+            .u64_observable_gauge(Self::metric_name(
+                prefix,
+                Self::STACKED_REQUESTS_METRIC_NAME,
+            ))
+            .with_description("Number of requests currently waiting in the LIFO queue.")
+            .with_unit("{request}")
+            .with_callback({
+                let stacked_requests = Arc::clone(&stacked_requests);
+                move |observer| observer.observe(stacked_requests.load(Ordering::Relaxed), &[])
+            })
+            .build();
 
         let wait_time_histogram = meter
             .f64_histogram(Self::metric_name(prefix, Self::WAIT_TIME_METRIC_NAME))
@@ -375,9 +447,58 @@ impl Metrics {
             .with_unit("s")
             .build();
 
+        // Counters for different request lifecycle events
+        let requests_processed_immediately = meter
+            .u64_counter(Self::metric_name(
+                prefix,
+                Self::REQUESTS_PROCESSED_IMMEDIATELY_METRIC_NAME,
+            ))
+            .with_description("Number of requests processed immediately without queueing")
+            .with_unit("{request}")
+            .build();
+
+        let requests_queued = meter
+            .u64_counter(Self::metric_name(prefix, Self::REQUESTS_QUEUED_METRIC_NAME))
+            .with_description("Number of requests that were queued")
+            .with_unit("{request}")
+            .build();
+
+        let requests_rejected = meter
+            .u64_counter(Self::metric_name(
+                prefix,
+                Self::REQUESTS_REJECTED_METRIC_NAME,
+            ))
+            .with_description("Number of requests rejected due to queue being full")
+            .with_unit("{request}")
+            .build();
+
+        let requests_cancelled = meter
+            .u64_counter(Self::metric_name(
+                prefix,
+                Self::REQUESTS_CANCELLED_METRIC_NAME,
+            ))
+            .with_description("Number of requests that were cancelled")
+            .with_unit("{request}")
+            .build();
+
+        let requests_timeout_queue = meter
+            .u64_counter(Self::metric_name(
+                prefix,
+                Self::REQUESTS_TIMEOUT_QUEUE_METRIC_NAME,
+            ))
+            .with_description("Number of requests that timed out while waiting in the queue")
+            .with_unit("{request}")
+            .build();
+
         Ok(Self {
             outstanding_requests,
+            stacked_requests,
             wait_time_histogram,
+            requests_processed_immediately,
+            requests_queued,
+            requests_rejected,
+            requests_cancelled,
+            requests_timeout_queue,
         })
     }
 }
@@ -389,7 +510,7 @@ mod tests {
             Arc,
             atomic::{AtomicU32, Ordering},
         },
-        time::Duration,
+        time::{Duration, Instant},
     };
 
     use async_trait::async_trait;
@@ -397,7 +518,7 @@ mod tests {
     use futures::{Future, future::join_all};
     use janus_aggregator_core::test_util::noop_meter;
     use janus_core::test_util::install_test_trace_subscriber;
-    use opentelemetry_sdk::metrics::data::Gauge;
+    use opentelemetry_sdk::metrics::data::{Gauge, Sum};
     use quickcheck::{Arbitrary, TestResult, quickcheck};
     use tokio::{
         runtime::Builder as RuntimeBuilder,
@@ -497,10 +618,12 @@ mod tests {
                     (|| async {
                         let handler = Arc::clone(&handler);
                         let request = get("/").run_async(&handler).await;
-                        if request.status().unwrap() == Status::Ok {
-                            Ok(())
-                        } else {
-                            Err(Error::Internal("Test error".into()))
+                        match request.status().unwrap() {
+                            Status::Ok => Ok(()),
+                            Status::TooManyRequests => Ok(()), // Timeouts and queue full are fine during filling
+                            status => Err(Error::Internal(
+                                format!("Unexpected status: {status}").into(),
+                            )),
                         }
                     })
                     .retry(backoff)
@@ -523,6 +646,8 @@ mod tests {
         depth: usize,
         concurrency: u32,
         requests: usize,
+        /// Request timeout in milliseconds. None means no timeout. Only used in the _full test.
+        request_timeout_ms: Option<u64>,
     }
 
     impl Arbitrary for Parameters {
@@ -536,6 +661,12 @@ mod tests {
                 depth: u8::arbitrary(g) as usize,
                 concurrency: u8::arbitrary(g) as u32 + 1,
                 requests: (u16::arbitrary(g) / 10) as usize + 1,
+                request_timeout_ms: if bool::arbitrary(g) {
+                    // Between 10 and 2000ms
+                    Some(10u64 + u64::arbitrary(g) % 1990)
+                } else {
+                    None
+                },
             }
         }
     }
@@ -591,12 +722,21 @@ mod tests {
                 depth,
                 concurrency,
                 requests,
+                request_timeout_ms,
             } = parameters;
 
             runtime_flavor.run(async move {
                 let meter_prefix = "test";
+                let request_timeout = request_timeout_ms.map(Duration::from_millis);
                 let queue = Arc::new(
-                    LIFORequestQueue::new(concurrency, depth, &noop_meter(), meter_prefix).unwrap(),
+                    LIFORequestQueue::new(
+                        concurrency,
+                        depth,
+                        &noop_meter(),
+                        meter_prefix,
+                        request_timeout,
+                    )
+                    .unwrap(),
                 );
                 let handler = Arc::new(queued_lifo(
                     Arc::clone(&queue),
@@ -636,7 +776,7 @@ mod tests {
                 let metrics = InMemoryMetricInfrastructure::new();
                 let unhang = Arc::new(Notify::new());
                 let queue = Arc::new(
-                    LIFORequestQueue::new(concurrency, depth, &metrics.meter, meter_prefix)
+                    LIFORequestQueue::new(concurrency, depth, &metrics.meter, meter_prefix, None)
                         .unwrap(),
                 );
                 let handler = Arc::new(queued_lifo(
@@ -709,6 +849,7 @@ mod tests {
                 runtime_flavor,
                 depth,
                 concurrency,
+                request_timeout_ms,
                 ..
             } = parameters;
 
@@ -716,9 +857,16 @@ mod tests {
                 let unhang = Arc::new(Notify::new());
                 let meter_prefix = "test";
                 let metrics = InMemoryMetricInfrastructure::new();
+                let request_timeout = request_timeout_ms.map(Duration::from_millis);
                 let queue = Arc::new(
-                    LIFORequestQueue::new(concurrency, depth, &metrics.meter, meter_prefix)
-                        .unwrap(),
+                    LIFORequestQueue::new(
+                        concurrency,
+                        depth,
+                        &metrics.meter,
+                        meter_prefix,
+                        request_timeout,
+                    )
+                    .unwrap(),
                 );
                 let handler = Arc::new(queued_lifo(
                     Arc::clone(&queue),
@@ -782,7 +930,7 @@ mod tests {
                 let meter_prefix = "test";
                 let metrics = InMemoryMetricInfrastructure::new();
                 let queue = Arc::new(
-                    LIFORequestQueue::new(concurrency, depth, &metrics.meter, meter_prefix)
+                    LIFORequestQueue::new(concurrency, depth, &metrics.meter, meter_prefix, None)
                         .unwrap(),
                 );
                 let handler = Arc::new(queued_lifo(
@@ -845,5 +993,92 @@ mod tests {
 
         install_test_trace_subscriber();
         quickcheck(qc as fn(Parameters) -> TestResult);
+    }
+
+    #[test]
+    fn test_request_timeout() {
+        install_test_trace_subscriber();
+
+        tokio::runtime::Runtime::new().unwrap().block_on(async {
+            let meter_prefix = "test";
+            let metrics = InMemoryMetricInfrastructure::new();
+            let concurrency = 1;
+            let depth = 1;
+            let timeout = Duration::from_millis(100);
+
+            let queue = Arc::new(
+                LIFORequestQueue::new(
+                    concurrency,
+                    depth,
+                    &metrics.meter,
+                    meter_prefix,
+                    Some(timeout),
+                )
+                .unwrap(),
+            );
+
+            // Create a hanging handler that never releases requests
+            let unhang = Arc::new(Notify::new());
+            let handler = Arc::new(queued_lifo(
+                Arc::clone(&queue),
+                HangingHandler {
+                    unhang: Arc::clone(&unhang),
+                },
+            ));
+
+            // Fill up the active slots (concurrency) but leave queue empty
+            let mut requests = Vec::new();
+            for _ in 0..concurrency {
+                let handler = Arc::clone(&handler);
+                requests.push(tokio::spawn(
+                    async move { get("/").run_async(&handler).await },
+                ));
+            }
+
+            // Wait for all active slots to be filled
+            wait_for(&metrics, meter_prefix, |q| q == concurrency as usize).await;
+
+            // Now make a request that will be queued and should timeout
+            let start = Instant::now();
+            let result = get("/").run_async(&handler).await;
+            let elapsed = start.elapsed();
+
+            // Should have timed out with TooManyRequests status
+            assert_eq!(
+                result.status().unwrap(),
+                Status::TooManyRequests,
+                "Expected TooManyRequests (429) but got {:?}",
+                result.status().unwrap()
+            );
+            // Should have taken approximately the timeout duration (with some tolerance)
+            assert!(
+                elapsed >= timeout && elapsed < timeout + Duration::from_millis(200),
+                "Request took {elapsed:?}, expected around {timeout:?}"
+            );
+
+            // Check timeout metric was incremented
+            let timeout_count = metrics
+                .collect()
+                .await
+                .get(&Metrics::metric_name(
+                    meter_prefix,
+                    Metrics::REQUESTS_TIMEOUT_QUEUE_METRIC_NAME,
+                ))
+                .unwrap()
+                .data
+                .as_any()
+                .downcast_ref::<Sum<u64>>()
+                .unwrap()
+                .data_points[0]
+                .value;
+            assert_eq!(timeout_count, 1);
+
+            // Clean up: cancel the hanging requests
+            for request in requests {
+                request.abort();
+            }
+
+            metrics.shutdown().await;
+        });
     }
 }

--- a/docs/samples/advanced_config/aggregator.yaml
+++ b/docs/samples/advanced_config/aggregator.yaml
@@ -225,3 +225,8 @@ helper_aggregation_request_queue:
   # concurrency slot to become available. Excess requests are rejected with HTTP
   # status 429 Too Many Requests.
   depth: 24
+
+  # The maximum lifespan, in milliseconds, of requests in the queue. Requests
+  # that timeout are rejected with HTTP status 429 Too Many Requests.
+  # (optional; experimental, can be disabled by omitting or setting to null).
+  timeout_ms: 300000


### PR DESCRIPTION
Differences vs. `release/0.7`:
- Removed `requests_dequeued`
- Switched to using `wait_for` in `test_request_timeout`

Forward port of PR #4032
Closes #4032