### PR TITLE
Allow CDLA Permissive 2.0 license

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -43,6 +43,7 @@ allow = [
     "BSL-1.0",
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "CDLA-Permissive-2.0",
     "ISC",
     "Unicode-DFS-2016",
     "Unicode-3.0",


### PR DESCRIPTION
In newer versions of webpki-roots, the Mozilla root store is licensed under this license instead of the MPL.