### PR TITLE
Put tracing-opentelemetry in OTel Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,12 +31,16 @@ updates:
       tracing:
         patterns:
           - tracing
-          - tracing-*
+          - tracing-chrome
+          - tracing-log
+          - tracing-stackdriver
+          - tracing-subscriber
       opentelemetry:
         patterns:
           - opentelemetry
           - opentelemetry-*
           - opentelemetry_*
+          - tracing-opentelemetry
       trillium:
         patterns:
           - trillium
@@ -112,12 +116,16 @@ updates:
       tracing:
         patterns:
           - tracing
-          - tracing-*
+          - tracing-chrome
+          - tracing-log
+          - tracing-stackdriver
+          - tracing-subscriber
       opentelemetry:
         patterns:
           - opentelemetry
           - opentelemetry-*
           - opentelemetry_*
+          - tracing-opentelemetry
       trillium:
         patterns:
           - trillium


### PR DESCRIPTION
This moves tracing-opentelemetry from the `tracing` Dependabot group to the `opentelemetry` group.