### PR TITLE
Use trusted publishing in yank-crates workflow

### DIFF
--- a/.github/workflows/yank-crates.yml
+++ b/.github/workflows/yank-crates.yml
@@ -8,9 +8,6 @@ on:
         required: true
         type: string
 
-env:
-  CARGO_REGISTRY_TOKEN: ${{ secrets.DIVVIUP_GITHUB_AUTOMATION_CRATES_IO_API_TOKEN }}
-
 jobs:
   yank:
     strategy:
@@ -21,8 +18,15 @@ jobs:
           - janus_client
           - janus_collector
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
     steps:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
+    - id: auth
+      uses: rust-lang/crates-io-auth-action@v1
     - name: "Yank"
       run: cargo yank --version ${{ inputs.version }} ${{ matrix.crate }}
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
This is a follow-up to #4203 to update the yank-crates workflow as well.