### PR TITLE
Migrate to Axum [part 10]: Final(-ish) Trillium cleanup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,10 +41,6 @@ updates:
           - opentelemetry-*
           - opentelemetry_*
           - tracing-opentelemetry
-      trillium:
-        patterns:
-          - trillium
-          - trillium-*
       kube:
         patterns:
           - kube
@@ -126,10 +122,6 @@ updates:
           - opentelemetry-*
           - opentelemetry_*
           - tracing-opentelemetry
-      trillium:
-        patterns:
-          - trillium
-          - trillium-*
       kube:
         patterns:
           - kube

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,16 +221,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-dup"
-version = "1.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2886ab563af5038f79ec016dd7b87947ed138b794e8dd64992962c9cca0411"
-dependencies = [
- "async-lock 3.3.0",
- "futures-io",
-]
-
-[[package]]
 name = "async-executor"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2777,9 +2767,6 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-log",
- "trillium",
- "trillium-macros 0.0.6",
- "trillium-router",
  "url",
  "yaml_serde",
 ]
@@ -2883,8 +2870,6 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber",
- "trillium",
- "trillium-testing",
  "url",
  "yaml_serde",
 ]
@@ -4027,15 +4012,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "portpicker"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
-dependencies = [
- "rand 0.8.5",
-]
-
-[[package]]
 name = "postgres-derive"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4549,17 +4525,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3560f70f30a0f16d11d01ed078a07740fe6b489667abc7c7b029155d9f21c3d8"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "routefinder"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0971d3c8943a6267d6bd0d782fdc4afa7593e7381a92a3df950ff58897e066b5"
-dependencies = [
- "memchr",
- "smartcow",
- "smartstring",
 ]
 
 [[package]]
@@ -6273,17 +6238,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trillium-router"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7aed20d63101d7dcd165fd047141423009a7f4ccfc75db5b875312d8127dbe"
-dependencies = [
- "log",
- "routefinder",
- "trillium",
-]
-
-[[package]]
 name = "trillium-rustls"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6312,27 +6266,6 @@ dependencies = [
  "rlimit",
  "trillium",
  "trillium-http",
- "url",
-]
-
-[[package]]
-name = "trillium-testing"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6c5d4d9d6f6844131f166cbe4d779894f09f9b846945ab2024272bcd6e198c"
-dependencies = [
- "async-channel 2.2.0",
- "async-dup",
- "cfg-if",
- "dashmap",
- "fastrand",
- "futures-lite",
- "once_cell",
- "portpicker",
- "trillium",
- "trillium-http",
- "trillium-macros 0.0.6",
- "trillium-server-common",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,16 +120,8 @@ tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 tokio-postgres-rustls = "0.13.0"
 tokio-stream = "0.1.18"
-trillium = "0.2.20"
-trillium-api = { version = "0.2.0-rc.12", default-features = false }
-trillium-head = "0.2.3"
-trillium-macros = "0.0.6"
-trillium-opentelemetry = "0.10.0"
-trillium-prometheus = "0.2.0"
-trillium-proxy = { version = "0.5.5", default-features = false }
-trillium-router = "0.4.1"
+# TODO: Remove once divviup-client is migrated off Trillium.
 trillium-rustls = "0.9"
-trillium-testing = "0.7.0"
 trillium-tokio = "0.4.0"
 trycmd = "1.2.0"
 url = { version = "2.5.8", features = ["serde"] }

--- a/aggregator/src/aggregator/error.rs
+++ b/aggregator/src/aggregator/error.rs
@@ -155,7 +155,7 @@ pub enum Error {
 }
 
 /// A newtype around `Arc<Error>`. This is needed to host a customized implementation of
-/// `trillium::Handler`.
+/// `IntoResponse`.
 #[derive(Clone)]
 pub(crate) struct ArcError(Arc<Error>);
 

--- a/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
@@ -488,12 +488,7 @@ async fn aggregate_share_request() {
                 "test case: {label:?}, iteration: {iteration}"
             );
             assert_eq!(
-                response
-                    .headers()
-                    .get(http::header::CONTENT_TYPE)
-                    .unwrap()
-                    .to_str()
-                    .unwrap(),
+                response.headers().get(http::header::CONTENT_TYPE).unwrap(),
                 AggregateShareMessage::MEDIA_TYPE,
             );
             let aggregate_share_resp: AggregateShareMessage =
@@ -834,12 +829,7 @@ async fn aggregate_share_request_get_poll_after_put() {
     assert_eq!(response.status(), StatusCode::OK);
 
     assert_eq!(
-        response
-            .headers()
-            .get(http::header::CONTENT_TYPE)
-            .unwrap()
-            .to_str()
-            .unwrap(),
+        response.headers().get(http::header::CONTENT_TYPE).unwrap(),
         AggregateShareMessage::MEDIA_TYPE,
     );
     let aggregate_share_resp: AggregateShareMessage = decode_response_body(&mut response).await;

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_get.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_get.rs
@@ -595,12 +595,7 @@ async fn get_aggregation_job_and_decode(
     let mut response = get_aggregation_job(task, aggregation_job_id, step, router).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response
-            .headers()
-            .get(http::header::CONTENT_TYPE)
-            .unwrap()
-            .to_str()
-            .unwrap(),
+        response.headers().get(http::header::CONTENT_TYPE).unwrap(),
         AggregationJobResp::MEDIA_TYPE
     );
     decode_response_body::<AggregationJobResp>(&mut response).await

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
@@ -603,12 +603,7 @@ async fn aggregate_init_sync() {
         let mut response = put_aggregation_job(&task, &aggregation_job_id, &request, &router).await;
         assert_eq!(response.status(), StatusCode::CREATED);
         assert_eq!(
-            response
-                .headers()
-                .get(http::header::CONTENT_TYPE)
-                .unwrap()
-                .to_str()
-                .unwrap(),
+            response.headers().get(http::header::CONTENT_TYPE).unwrap(),
             AggregationJobResp::MEDIA_TYPE
         );
         let aggregate_resp: AggregationJobResp = decode_response_body(&mut response).await;
@@ -1100,12 +1095,7 @@ async fn aggregate_init_prep_init_failed() {
     let mut response = put_aggregation_job(&task, &aggregation_job_id, &request, &router).await;
     assert_eq!(response.status(), StatusCode::CREATED);
     assert_eq!(
-        response
-            .headers()
-            .get(http::header::CONTENT_TYPE)
-            .unwrap()
-            .to_str()
-            .unwrap(),
+        response.headers().get(http::header::CONTENT_TYPE).unwrap(),
         AggregationJobResp::MEDIA_TYPE
     );
     let aggregate_resp: AggregationJobResp = decode_response_body(&mut response).await;
@@ -1170,12 +1160,7 @@ async fn aggregate_init_prep_step_failed() {
     let mut response = put_aggregation_job(&task, &aggregation_job_id, &request, &router).await;
     assert_eq!(response.status(), StatusCode::CREATED);
     assert_eq!(
-        response
-            .headers()
-            .get(http::header::CONTENT_TYPE)
-            .unwrap()
-            .to_str()
-            .unwrap(),
+        response.headers().get(http::header::CONTENT_TYPE).unwrap(),
         AggregationJobResp::MEDIA_TYPE
     );
     let aggregate_resp: AggregationJobResp = decode_response_body(&mut response).await;

--- a/aggregator/src/aggregator/problem_details.rs
+++ b/aggregator/src/aggregator/problem_details.rs
@@ -8,11 +8,15 @@ use http::{
 use janus_messages::{
     AggregateShareId, AggregationJobId, CollectionJobId, TaskId, problem_type::DapProblemType,
 };
-use serde::Serialize;
+use serde::{Serialize, Serializer};
 use tracing::warn;
 
 /// The media type for problem details formatted as a JSON document, per RFC 7807.
 static PROBLEM_DETAILS_JSON_MEDIA_TYPE: &str = "application/problem+json";
+
+fn serialize_status<S: Serializer>(status: &StatusCode, s: S) -> Result<S::Ok, S::Error> {
+    s.serialize_u16(status.as_u16())
+}
 
 /// Serialization helper struct for [DAP JSON problem details error responses][1].
 ///
@@ -22,7 +26,8 @@ pub struct ProblemDocument<'a> {
     #[serde(rename = "type")]
     type_: &'static str,
     title: &'static str,
-    status: u16,
+    #[serde(serialize_with = "serialize_status")]
+    status: StatusCode,
     #[serde(skip_serializing_if = "Option::is_none")]
     taskid: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -46,7 +51,7 @@ impl<'a> ProblemDocument<'a> {
         Self {
             type_,
             title,
-            status: status.as_u16(),
+            status,
             taskid: None,
             detail: None,
             aggregation_job_id: None,
@@ -106,7 +111,7 @@ impl<'a> ProblemDocument<'a> {
 
     /// Returns the HTTP status code for this problem document.
     pub fn status_code(&self) -> StatusCode {
-        StatusCode::from_u16(self.status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
+        self.status
     }
 
     /// Converts this problem document into an axum [`Response`].

--- a/aggregator/src/binary_utils.rs
+++ b/aggregator/src/binary_utils.rs
@@ -45,8 +45,7 @@ use crate::{
     trace::{TraceReloadHandle, install_trace_subscriber},
 };
 
-/// A cancellation token used to signal shutdown. Wraps `CancellationToken` and provides an API
-/// compatible with the former `trillium_tokio::Stopper`.
+/// A cancellation token used to signal shutdown. Wraps `CancellationToken`.
 #[derive(Clone, Debug)]
 pub struct Stopper(CancellationToken);
 

--- a/aggregator_core/Cargo.toml
+++ b/aggregator_core/Cargo.toml
@@ -60,9 +60,6 @@ tower-http = { workspace = true, features = ["trace"] }
 tokio-postgres = { workspace = true, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1", "array-impls"] }
 tracing = { workspace = true }
 tracing-log = { workspace = true }
-trillium.workspace = true
-trillium-macros = { workspace = true }
-trillium-router.workspace = true
 url.workspace = true
 
 [dev-dependencies]

--- a/aggregator_core/src/http_server.rs
+++ b/aggregator_core/src/http_server.rs
@@ -7,11 +7,7 @@ use opentelemetry::{
     metrics::{Counter, Histogram, Meter},
 };
 use tower_http::trace::TraceLayer;
-use tracing::{Instrument, Span, debug, info_span};
-use trillium::{Conn, Handler, Status};
-use trillium_macros::Handler;
-use trillium_router::RouterConnExt;
-
+use tracing::{Span, debug, info_span};
 /// These boundaries are intended to be able to capture the length of short-lived operations
 /// (e.g. HTTP requests) as well as longer-running operations.
 pub const TIME_HISTOGRAM_BOUNDARIES: &[f64] = &[
@@ -23,45 +19,6 @@ pub const BYTES_HISTOGRAM_BOUNDARIES: &[f64] = &[
     1024.0, 2048.0, 4096.0, 8192.0, 16384.0, 32768.0, 65536.0, 131072.0, 262144.0, 524288.0,
     1048576.0, 2097152.0, 4194304.0, 8388608.0, 16777216.0, 33554432.0,
 ];
-
-// -- Trillium --
-
-pub fn instrumented<H: Handler>(handler: H) -> impl Handler {
-    InstrumentedHandler(handler)
-}
-
-struct InstrumentedHandlerSpan(Span);
-
-#[derive(Handler)]
-struct InstrumentedHandler<H>(#[handler(except = [run, before_send])] H);
-
-impl<H: Handler> InstrumentedHandler<H> {
-    async fn run(&self, mut conn: Conn) -> Conn {
-        let route = conn.route().expect("no route in conn").to_string();
-        let method = conn.method();
-        let span = info_span!("endpoint", route, %method);
-        conn.insert_state(InstrumentedHandlerSpan(span.clone()));
-        self.0.run(conn).instrument(span).await
-    }
-
-    async fn before_send(&self, mut conn: Conn) -> Conn {
-        if let Some(span) = conn.take_state::<InstrumentedHandlerSpan>() {
-            let conn = self.0.before_send(conn).instrument(span.0.clone()).await;
-            span.0.in_scope(|| {
-                let status = conn
-                    .status()
-                    .as_ref()
-                    .map_or("unknown", Status::canonical_reason);
-                debug!(status, "Finished handling request");
-            });
-            conn
-        } else {
-            self.0.before_send(conn).await
-        }
-    }
-}
-
-// -- Axum --
 
 /// Newtype holding a textual error code, stored in response extensions for metrics.
 #[derive(Clone, Copy)]
@@ -109,7 +66,7 @@ impl HttpMetrics {
 }
 
 /// Extracts the matched route from an axum request and rewrites `{param}` to `:param`
-/// for metric label continuity with the existing Trillium convention.
+/// for metric label continuity.
 fn normalize_axum_route(request: &Request<Body>) -> String {
     request
         .extensions()
@@ -125,8 +82,8 @@ fn normalize_axum_route(request: &Request<Body>) -> String {
 
 /// Axum middleware that records HTTP server metrics (response counter, request duration,
 /// body sizes).
-// TODO(#4283): Replace with `opentelemetry-instrumentation-tower` once OpenTelemetry is
-// upgraded to 0.31 or later, which we can do after we're off Trillium.
+// TODO: Replace with `opentelemetry-instrumentation-tower` once OpenTelemetry is upgraded
+// to 0.31 or later.
 pub async fn http_metrics_middleware(
     axum::Extension(metrics): axum::Extension<Arc<HttpMetrics>>,
     request: Request<Body>,
@@ -196,8 +153,7 @@ pub async fn http_metrics_middleware(
     response
 }
 
-/// Returns a [`TraceLayer`] that instruments axum request handlers with tracing spans,
-/// mirroring the Trillium `instrumented` handler's span structure.
+/// Returns a [`TraceLayer`] that instruments axum request handlers with tracing spans.
 #[allow(clippy::type_complexity)]
 pub fn trace_layer() -> TraceLayer<
     tower_http::classify::SharedClassifier<tower_http::classify::ServerErrorsAsFailures>,

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,7 +26,6 @@ test-util = [
     "dep:tokio-stream",
     "dep:tracing-log",
     "dep:tracing-subscriber",
-    "dep:trillium-testing",
     "janus_messages/test-util",
     "kube/ws",
     "prio/test-util",
@@ -75,8 +74,6 @@ tokio-stream = { workspace = true, features = ["net"], optional = true }
 tracing = { workspace = true }
 tracing-log = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, features = ["std", "env-filter", "fmt"], optional = true }
-trillium.workspace = true
-trillium-testing = { workspace = true, optional = true }
 url = { workspace = true }
 
 [dev-dependencies]

--- a/core/src/auth_tokens.rs
+++ b/core/src/auth_tokens.rs
@@ -443,21 +443,11 @@ impl AsRef<[u8]> for AuthenticationTokenHash {
 pub mod test_util {
     use crate::auth_tokens::AuthenticationToken;
 
-    /// Extension trait to fluently add an auth token to a [`trillium_testing::TestConn`].
+    /// Extension trait to fluently add an auth token to an HTTP request.
     pub trait WithAuthenticationToken {
         /// Add the header and value obtained from
         /// [`AuthenticationToken::request_authentication`] to the request.
         fn with_authentication_token(self, auth_token: &AuthenticationToken) -> Self;
-    }
-
-    impl WithAuthenticationToken for trillium_testing::TestConn {
-        fn with_authentication_token(self, auth_token: &AuthenticationToken) -> Self {
-            let (header, value) = auth_token.request_authentication().unwrap();
-            self.with_request_header(
-                header.as_str().to_owned(),
-                value.to_str().unwrap().to_owned(),
-            )
-        }
     }
 
     impl WithAuthenticationToken for http::HeaderMap {

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -60,5 +60,6 @@ rustls-webpki = { version = "0.103.10", features = ["std"] }
 tempfile = { workspace = true }
 rustls.workspace = true
 tracing.workspace = true
+# TODO(divviup/divviup-api#...): Remove once divviup-client is migrated off Trillium.
 trillium-rustls.workspace = true
 trillium-tokio.workspace = true


### PR DESCRIPTION
Remove all remaining Trillium code and dependencies from crates other than integration_tests:

- Delete dead `instrumented` handler, `InstrumentedHandlerSpan`, and `InstrumentedHandler` from `aggregator_core::http_server`
- Delete dead `WithAuthenticationToken for trillium_testing::TestConn` impl from `core::auth_tokens`
- Remove `trillium`, `trillium-macros`, `trillium-router` deps from `aggregator_core`; `trillium`, `trillium-testing` deps from `core`
- Remove 9 unused trillium workspace dependencies (keep `trillium-rustls` and `trillium-tokio`, still needed by `integration_tests`)
- Remove trillium dependabot group from both branch configs

Additional cleanups:

- Change `ProblemDocument::status` from `u16` to `StatusCode` with a custom serde serializer, removing the (fallible) `from_u16` conversion
- Simplify content-type header assertions in tests by dropping unnecessary `.to_str().unwrap()` (`HeaderValue` implements `PartialEq<&str>`)
- Update stale comments referencing Trillium

NOTE: We have a few dangling uses because divviup-client still uses Trillium. We can get those after we update divviup-api.