### PR TITLE
Move version check in make-release to right job

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -25,6 +25,15 @@ jobs:
           ref: '${{ matrix.target_branch }}'
           token: '${{ secrets.DIVVIUP_GITHUB_AUTOMATION_RELEASE_PAT }}'
 
+      - name: Check current version
+        # Check that the current version is not a pre-release version. Those
+        # must be bumped by hand, since the pre-release component of a version
+        # number is unstructured.
+        run: |
+          cargo metadata --no-deps --format-version 1 | \
+          jq -r '.packages | .[] | select(.name == "janus_aggregator") | .version' | \
+          grep '^\(0\|[1-9][0-9]*\)\.\(0\|[1-9][0-9]*\)\.\(0\|[1-9][0-9]*\)$'
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
@@ -67,15 +76,6 @@ jobs:
         with:
           ref: '${{ matrix.target_branch }}'
           token: '${{ secrets.DIVVIUP_GITHUB_AUTOMATION_RELEASE_PAT }}'
-
-      - name: Check current version
-        # Check that the current version is not a pre-release version. Those
-        # must be bumped by hand, since the pre-release component of a version
-        # number is unstructured.
-        run: |
-          cargo metadata --no-deps --format-version 1 | \
-          jq -r '.packages | .[] | select(.name == "janus_aggregator") | .version' | \
-          grep '^\(0\|[1-9][0-9]*\)\.\(0\|[1-9][0-9]*\)\.\(0\|[1-9][0-9]*\)$'
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
I noticed that this check was in the wrong job in this workflow. It needs to run before `cargo-edit`, otherwise `cargo-edit` will ensure that the version does not have a pre-release component.