### PR TITLE
Increase cargo-deny severity for yanked crates

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,7 @@ all-features = true
 
 [advisories]
 version = 2
+yanked = "deny"
 ignore = [
     # Janus never uses the protobuf format for exposing metrics, and in any case we would not be
     # handling untrusted input.


### PR DESCRIPTION
This increases the severity for yanked crates in `cargo deny check advisories` from `warning` to `deny`. This will surface yanked crates with a red "x" in our non-blocking advisory workflow, if there isn't also a RustSec advisory for the same crate.