### PR TITLE
Use constants for label values of counter metric

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -72,6 +72,10 @@ use crate::{
     },
     cache::HpkeKeypairCache,
     metrics::{
+        aggregate_step_failure_types::{
+            CONTINUE_MISMATCH, DUPLICATE_EXTENSION, FINISH_MISMATCH, HELPER_STEP_FAILURE,
+            PUBLIC_SHARE_ENCODE_FAILURE,
+        },
         aggregated_report_share_dimension_histogram, early_report_clock_skew_histogram,
         keypair_use_counter, past_report_clock_skew_histogram,
     },
@@ -496,7 +500,7 @@ where
                             "Received report with duplicate extensions"
                         );
                         aggregate_step_failure_counter
-                            .add(1, &[KeyValue::new("type", "duplicate_extension")]);
+                            .add(1, &[KeyValue::new("type", DUPLICATE_EXTENSION)]);
                         return ra_sender.send(WritableReportAggregation::new(
                             report_aggregation.with_state(ReportAggregationState::Failed {
                                 report_error: ReportError::InvalidMessage,
@@ -511,7 +515,7 @@ where
                         Err(err) => {
                             debug!(report_id = %report_aggregation.report_id(), ?err, "Could not encode public share");
                             aggregate_step_failure_counter
-                                .add(1, &[KeyValue::new("type", "public_share_encode_failure")]);
+                                .add(1, &[KeyValue::new("type", PUBLIC_SHARE_ENCODE_FAILURE)]);
                             return ra_sender.send(WritableReportAggregation::new(
                                 report_aggregation.with_state(ReportAggregationState::Failed {
                                     report_error: ReportError::InvalidMessage,
@@ -1282,7 +1286,7 @@ where
                                     "Helper continued but Leader did not",
                                 );
                                 aggregate_step_failure_counter
-                                    .add(1, &[KeyValue::new("type", "continue_mismatch")]);
+                                    .add(1, &[KeyValue::new("type", CONTINUE_MISMATCH)]);
                                 task_aggregation_counters
                                     .increment_with_report_error(ReportError::VdafVerifyError);
                                 (
@@ -1307,7 +1311,7 @@ where
                                     "Helper finished but Leader did not",
                                 );
                                 aggregate_step_failure_counter
-                                    .add(1, &[KeyValue::new("type", "finish_mismatch")]);
+                                    .add(1, &[KeyValue::new("type", FINISH_MISMATCH)]);
                                 task_aggregation_counters
                                     .increment_with_report_error(ReportError::VdafVerifyError);
                                 (
@@ -1330,7 +1334,7 @@ where
                                     "Helper couldn't step report aggregation",
                                 );
                                 aggregate_step_failure_counter
-                                    .add(1, &[KeyValue::new("type", "helper_step_failure")]);
+                                    .add(1, &[KeyValue::new("type", HELPER_STEP_FAILURE)]);
                                 task_aggregation_counters.increment_with_helper_report_error(*err);
                                 (ReportAggregationState::Failed { report_error: *err }, None)
                             }

--- a/aggregator/src/aggregator/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/aggregation_job_init.rs
@@ -36,6 +36,12 @@ use crate::{
         error::handle_ping_pong_error,
     },
     cache::HpkeKeypairCache,
+    metrics::aggregate_step_failure_types::{
+        DECRYPT_FAILURE, DUPLICATE_EXTENSION, INPUT_SHARE_AAD_ENCODE_FAILURE,
+        INPUT_SHARE_DECODE_FAILURE, MISSING_OR_MALFORMED_TASKBIND_EXTENSION,
+        PLAINTEXT_INPUT_SHARE_DECODE_FAILURE, PUBLIC_SHARE_DECODE_FAILURE,
+        UNEXPECTED_TASKBIND_EXTENSION, UNKNOWN_HPKE_CONFIG_ID, UNRECOGNIZED_EXTENSION,
+    },
 };
 
 #[derive(Clone)]
@@ -157,7 +163,7 @@ where
                             );
                             metrics
                                 .aggregate_step_failure_counter
-                                .add(1, &[KeyValue::new("type", "unknown_hpke_config_id")]);
+                                .add(1, &[KeyValue::new("type", UNKNOWN_HPKE_CONFIG_ID)]);
                             ReportError::HpkeUnknownConfigId
                         });
 
@@ -177,7 +183,7 @@ where
                                 );
                                 metrics.aggregate_step_failure_counter.add(
                                     1,
-                                    &[KeyValue::new("type", "input_share_aad_encode_failure")],
+                                    &[KeyValue::new("type", INPUT_SHARE_AAD_ENCODE_FAILURE)],
                                 );
                                 // HpkeDecryptError isn't strictly accurate, but given that this
                                 // fallible encoding is part of the HPKE decryption process, I think
@@ -218,7 +224,7 @@ where
                                 );
                                 metrics
                                     .aggregate_step_failure_counter
-                                    .add(1, &[KeyValue::new("type", "decrypt_failure")]);
+                                    .add(1, &[KeyValue::new("type", DECRYPT_FAILURE)]);
                                 ReportError::HpkeDecryptError
                             })
                         });
@@ -235,7 +241,7 @@ where
                                         1,
                                         &[KeyValue::new(
                                             "type",
-                                            "plaintext_input_share_decode_failure",
+                                            PLAINTEXT_INPUT_SHARE_DECODE_FAILURE,
                                         )],
                                     );
                                     ReportError::InvalidMessage
@@ -258,7 +264,7 @@ where
                                     );
                                     metrics
                                         .aggregate_step_failure_counter
-                                        .add(1, &[KeyValue::new("type", "unrecognized_extension")]);
+                                        .add(1, &[KeyValue::new("type", UNRECOGNIZED_EXTENSION)]);
                                     return Err(ReportError::InvalidMessage);
                                 }
                                 if extensions
@@ -272,7 +278,7 @@ where
                                     );
                                     metrics
                                         .aggregate_step_failure_counter
-                                        .add(1, &[KeyValue::new("type", "duplicate_extension")]);
+                                        .add(1, &[KeyValue::new("type", DUPLICATE_EXTENSION)]);
                                     return Err(ReportError::InvalidMessage);
                                 }
                             }
@@ -293,7 +299,7 @@ where
                                         1,
                                         &[KeyValue::new(
                                             "type",
-                                            "missing_or_malformed_taskbind_extension",
+                                            MISSING_OR_MALFORMED_TASKBIND_EXTENSION,
                                         )],
                                     );
                                     return Err(ReportError::InvalidMessage);
@@ -308,7 +314,7 @@ where
                                 );
                                 metrics
                                     .aggregate_step_failure_counter
-                                    .add(1, &[KeyValue::new("type", "unexpected_taskbind_extension")]);
+                                    .add(1, &[KeyValue::new("type", UNEXPECTED_TASKBIND_EXTENSION)]);
                                 return Err(ReportError::InvalidMessage);
                             }
 
@@ -329,7 +335,7 @@ where
                                 );
                                 metrics
                                     .aggregate_step_failure_counter
-                                    .add(1, &[KeyValue::new("type", "input_share_decode_failure")]);
+                                    .add(1, &[KeyValue::new("type", INPUT_SHARE_DECODE_FAILURE)]);
                                 ReportError::InvalidMessage
                             })
                         });
@@ -346,7 +352,7 @@ where
                             );
                             metrics
                                 .aggregate_step_failure_counter
-                                .add(1, &[KeyValue::new("type", "public_share_decode_failure")]);
+                                .add(1, &[KeyValue::new("type", PUBLIC_SHARE_DECODE_FAILURE)]);
                             ReportError::InvalidMessage
                         });
 

--- a/aggregator/src/aggregator/aggregation_job_writer.rs
+++ b/aggregator/src/aggregator/aggregation_job_writer.rs
@@ -32,7 +32,7 @@ use rand::{RngExt, rng};
 use tokio::try_join;
 use tracing::{Level, warn};
 
-use crate::Operation;
+use crate::{Operation, metrics::aggregate_step_failure_types::ACCUMULATE_FAILURE};
 
 /// Buffers pending writes to aggregation jobs and their report aggregations.
 pub struct AggregationJobWriter<const SEED_SIZE: usize, B, A, WT, RA>
@@ -753,7 +753,7 @@ where
                             self.writer.update_metrics(|metrics| {
                                 metrics
                                     .aggregate_step_failure_counter
-                                    .add(1, &[KeyValue::new("type", "accumulate_failure")])
+                                    .add(1, &[KeyValue::new("type", ACCUMULATE_FAILURE)])
                             });
                             self.writer
                                 .task_aggregation_counters

--- a/aggregator/src/aggregator/error.rs
+++ b/aggregator/src/aggregator/error.rs
@@ -5,7 +5,10 @@ use std::{
     sync::Arc,
 };
 
-use janus_aggregator_core::{datastore, task};
+use janus_aggregator_core::{
+    datastore::{self, models::AggregatorRole},
+    task,
+};
 use janus_core::http::HttpErrorResponse;
 use janus_messages::{
     AggregateShareId, AggregationJobId, AggregationJobStep, CollectionJobId, HpkeConfigId,
@@ -14,6 +17,13 @@ use janus_messages::{
 use opentelemetry::{KeyValue, metrics::Counter};
 use prio::{topology::ping_pong::PingPongError, vdaf::VdafError};
 use tracing::info;
+
+use crate::metrics::aggregate_step_failure_types::{
+    HELPER_PING_PONG_MESSAGE_MISMATCH, HELPER_VERIFY_MESSAGE_DECODE_FAILURE,
+    HELPER_VERIFY_SHARE_DECODE_FAILURE, LEADER_PING_PONG_MESSAGE_MISMATCH,
+    LEADER_VERIFY_MESSAGE_DECODE_FAILURE, LEADER_VERIFY_SHARE_DECODE_FAILURE, VERIFY_INIT_FAILURE,
+    VERIFY_MESSAGE_FAILURE, VERIFY_NEXT_FAILURE,
+};
 
 /// Errors returned by functions and methods in this module.
 ///
@@ -397,37 +407,46 @@ pub(crate) fn handle_ping_pong_error(
     aggregate_step_failure_counter: &Counter<u64>,
 ) -> ReportError {
     let peer_role = match role {
-        Role::Leader => Role::Helper,
-        Role::Helper => Role::Leader,
+        Role::Leader => AggregatorRole::Helper,
+        Role::Helper => AggregatorRole::Leader,
         // panic safety: role should be passed to this function as a literal, so passing a role that
         // isn't an aggregator is a straightforward programmer error and we want to fail noisily.
         _ => panic!("invalid role"),
     };
-    let (error_desc, value) = match ping_pong_error {
-        PingPongError::VdafVerifyInit(_) => (
+    let (error_desc, value) = match (&ping_pong_error, peer_role) {
+        (PingPongError::VdafVerifyInit(_), _) => (
             "Couldn't helper_initialize report share".to_string(),
-            "verify_init_failure".to_string(),
+            VERIFY_INIT_FAILURE,
         ),
-        PingPongError::VdafVerifierSharesToMessage(_) => (
+        (PingPongError::VdafVerifierSharesToMessage(_), _) => (
             "Couldn't compute verify message".to_string(),
-            "verify_message_failure".to_string(),
+            VERIFY_MESSAGE_FAILURE,
         ),
-        PingPongError::VdafVerifyNext(_) => (
-            "Verify next failed".to_string(),
-            "verify_next_failure".to_string(),
+        (PingPongError::VdafVerifyNext(_), _) => {
+            ("Verify next failed".to_string(), VERIFY_NEXT_FAILURE)
+        }
+        (PingPongError::CodecVerifierShare(_), AggregatorRole::Leader) => (
+            "Couldn't decode leader verify share".to_string(),
+            LEADER_VERIFY_SHARE_DECODE_FAILURE,
         ),
-        PingPongError::CodecVerifierShare(_) => (
-            format!("Couldn't decode {peer_role} verify share"),
-            format!("{peer_role}_verify_share_decode_failure"),
+        (PingPongError::CodecVerifierShare(_), AggregatorRole::Helper) => (
+            "Couldn't decode helper verify share".to_string(),
+            HELPER_VERIFY_SHARE_DECODE_FAILURE,
         ),
-        PingPongError::CodecVerifierMessage(_) => (
-            format!("Couldn't decode {peer_role} verify message"),
-            format!("{peer_role}_verify_message_decode_failure"),
+        (PingPongError::CodecVerifierMessage(_), AggregatorRole::Leader) => (
+            "Couldn't decode leader verify message".to_string(),
+            LEADER_VERIFY_MESSAGE_DECODE_FAILURE,
         ),
-        ref error @ PingPongError::PeerMessageMismatch { .. } => (
-            format!("{error}"),
-            format!("{peer_role}_ping_pong_message_mismatch"),
+        (PingPongError::CodecVerifierMessage(_), AggregatorRole::Helper) => (
+            "Couldn't decode helper verify message".to_string(),
+            HELPER_VERIFY_MESSAGE_DECODE_FAILURE,
         ),
+        (error @ PingPongError::PeerMessageMismatch { .. }, AggregatorRole::Leader) => {
+            (error.to_string(), LEADER_PING_PONG_MESSAGE_MISMATCH)
+        }
+        (error @ PingPongError::PeerMessageMismatch { .. }, AggregatorRole::Helper) => {
+            (error.to_string(), HELPER_PING_PONG_MESSAGE_MISMATCH)
+        }
         // enum PingPongError is non_exhaustive so we need a catch-all case
         error => panic!("unhandled PingPongError: {error:?}"),
     };

--- a/aggregator/src/metrics.rs
+++ b/aggregator/src/metrics.rs
@@ -314,7 +314,43 @@ pub(crate) fn aggregated_report_share_dimension_histogram(meter: &Meter) -> Hist
 pub(crate) const AGGREGATION_JOB_SIZE_HISTOGRAM_BOUNDARIES: &[f64] =
     &[1.0, 3.0, 10.0, 30.0, 100.0, 300.0, 1000.0];
 
+/// Constants specifying possible values of the `janus_step_failures` counter's `type` label.
+pub(crate) mod aggregate_step_failure_types {
+    pub(crate) const VERIFY_INIT_FAILURE: &str = "verify_init_failure";
+    pub(crate) const VERIFY_NEXT_FAILURE: &str = "verify_next_failure";
+    pub(crate) const VERIFY_MESSAGE_FAILURE: &str = "verify_message_failure";
+    pub(crate) const UNKNOWN_HPKE_CONFIG_ID: &str = "unknown_hpke_config_id";
+    pub(crate) const DECRYPT_FAILURE: &str = "decrypt_failure";
+    pub(crate) const INPUT_SHARE_DECODE_FAILURE: &str = "input_share_decode_failure";
+    pub(crate) const INPUT_SHARE_AAD_ENCODE_FAILURE: &str = "input_share_aad_encode_failure";
+    pub(crate) const PUBLIC_SHARE_DECODE_FAILURE: &str = "public_share_decode_failure";
+    pub(crate) const PUBLIC_SHARE_ENCODE_FAILURE: &str = "public_share_encode_failure";
+    pub(crate) const LEADER_VERIFY_MESSAGE_DECODE_FAILURE: &str =
+        "leader_verify_message_decode_failure";
+    pub(crate) const HELPER_VERIFY_MESSAGE_DECODE_FAILURE: &str =
+        "helper_verify_message_decode_failure";
+    pub(crate) const LEADER_VERIFY_SHARE_DECODE_FAILURE: &str =
+        "leader_verify_share_decode_failure";
+    pub(crate) const HELPER_VERIFY_SHARE_DECODE_FAILURE: &str =
+        "helper_verify_share_decode_failure";
+    pub(crate) const LEADER_PING_PONG_MESSAGE_MISMATCH: &str = "leader_ping_pong_message_mismatch";
+    pub(crate) const HELPER_PING_PONG_MESSAGE_MISMATCH: &str = "helper_ping_pong_message_mismatch";
+    pub(crate) const CONTINUE_MISMATCH: &str = "continue_mismatch";
+    pub(crate) const ACCUMULATE_FAILURE: &str = "accumulate_failure";
+    pub(crate) const FINISH_MISMATCH: &str = "finish_mismatch";
+    pub(crate) const HELPER_STEP_FAILURE: &str = "helper_step_failure";
+    pub(crate) const PLAINTEXT_INPUT_SHARE_DECODE_FAILURE: &str =
+        "plaintext_input_share_decode_failure";
+    pub(crate) const DUPLICATE_EXTENSION: &str = "duplicate_extension";
+    pub(crate) const MISSING_OR_MALFORMED_TASKBIND_EXTENSION: &str =
+        "missing_or_malformed_taskbind_extension";
+    pub(crate) const UNEXPECTED_TASKBIND_EXTENSION: &str = "unexpected_taskbind_extension";
+    pub(crate) const UNRECOGNIZED_EXTENSION: &str = "unrecognized_extension";
+}
+
 pub(crate) fn aggregate_step_failure_counter(meter: &Meter) -> Counter<u64> {
+    use aggregate_step_failure_types::*;
+
     let aggregate_step_failure_counter = meter
         .u64_counter("janus_step_failures")
         .with_description(concat!(
@@ -327,30 +363,30 @@ pub(crate) fn aggregate_step_failure_counter(meter: &Meter) -> Counter<u64> {
     // Initialize counters with desired status labels. This causes Prometheus to see the first
     // non-zero value we record.
     for failure_type in [
-        "verify_init_failure",
-        "verify_next_failure",
-        "verify_message_failure",
-        "unknown_hpke_config_id",
-        "decrypt_failure",
-        "input_share_decode_failure",
-        "input_share_aad_encode_failure",
-        "public_share_decode_failure",
-        "public_share_encode_failure",
-        "leader_verify_message_decode_failure",
-        "helper_verify_message_decode_failure",
-        "leader_verify_share_decode_failure",
-        "helper_verify_share_decode_failure",
-        "leader_ping_pong_message_mismatch",
-        "helper_ping_pong_message_mismatch",
-        "continue_mismatch",
-        "accumulate_failure",
-        "finish_mismatch",
-        "helper_step_failure",
-        "plaintext_input_share_decode_failure",
-        "duplicate_extension",
-        "missing_or_malformed_taskbind_extension",
-        "unexpected_taskbind_extension",
-        "unrecognized_extension",
+        VERIFY_INIT_FAILURE,
+        VERIFY_NEXT_FAILURE,
+        VERIFY_MESSAGE_FAILURE,
+        UNKNOWN_HPKE_CONFIG_ID,
+        DECRYPT_FAILURE,
+        INPUT_SHARE_DECODE_FAILURE,
+        INPUT_SHARE_AAD_ENCODE_FAILURE,
+        PUBLIC_SHARE_DECODE_FAILURE,
+        PUBLIC_SHARE_ENCODE_FAILURE,
+        LEADER_VERIFY_MESSAGE_DECODE_FAILURE,
+        HELPER_VERIFY_MESSAGE_DECODE_FAILURE,
+        LEADER_VERIFY_SHARE_DECODE_FAILURE,
+        HELPER_VERIFY_SHARE_DECODE_FAILURE,
+        LEADER_PING_PONG_MESSAGE_MISMATCH,
+        HELPER_PING_PONG_MESSAGE_MISMATCH,
+        CONTINUE_MISMATCH,
+        ACCUMULATE_FAILURE,
+        FINISH_MISMATCH,
+        HELPER_STEP_FAILURE,
+        PLAINTEXT_INPUT_SHARE_DECODE_FAILURE,
+        DUPLICATE_EXTENSION,
+        MISSING_OR_MALFORMED_TASKBIND_EXTENSION,
+        UNEXPECTED_TASKBIND_EXTENSION,
+        UNRECOGNIZED_EXTENSION,
     ] {
         aggregate_step_failure_counter.add(0, &[KeyValue::new("type", failure_type)]);
     }


### PR DESCRIPTION
This introduces constants for the values of the `type` label on `janus_step_failures`. This should make it easier to keep initialization and other code in sync during future changes, by inspecting references of each of these constants throughout the codebase. I also eliminated some runtime string formatting by adding the peer aggregator's role to a match block.