### PR TITLE
update postgres-protocol and tokio-postgres

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4053,9 +4053,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
 dependencies = [
  "base64 0.22.1",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ tracing-opentelemetry = "0.25"
 tracing-stackdriver = "0.10.0"
 tracing-subscriber = "0.3"
 tokio = { version = "1.52", features = ["full", "tracing"] }
-tokio-postgres = "0.7.17"
+tokio-postgres = "0.7.18"
 tokio-postgres-rustls = "0.14.0"
 tokio-stream = "0.1.18"
 trillium = "0.2.20"


### PR DESCRIPTION
These dependency bumps address RUSTSEC-2026-0179, RUSTSEC-2026-0180 and RUSTSEC-2026-0178.

Backport of #4643