### PR TITLE
[DAP-17] Require upload extensions in strictly increasing order

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -58,6 +58,7 @@ use janus_messages::{
     PartialBatchSelector, PlaintextInputShare, Report, ReportError, ReportUploadStatus, Role,
     TaskConfiguration, TaskId, UploadErrors, VerifyResp,
     batch_mode::{LeaderSelected, TimeInterval},
+    extensions_are_strictly_increasing,
 };
 use opentelemetry::{
     KeyValue,
@@ -95,7 +96,7 @@ use crate::{
         report_writer::{ReportWriteBatcher, WritableReport},
         upload_decode_failure_types::{
             DUPLICATE_EXTENSION, INPUT_SHARE_DECODE_FAILURE, PUBLIC_SHARE_DECODE_FAILURE,
-            UNRECOGNIZED_EXTENSION,
+            UNRECOGNIZED_EXTENSION, UNSORTED_EXTENSION,
         },
     },
     cache::{
@@ -320,6 +321,7 @@ impl<C: Clock> Aggregator<C> {
         upload_decode_failure_counter.add(0, &[KeyValue::new("type", PUBLIC_SHARE_DECODE_FAILURE)]);
         upload_decode_failure_counter.add(0, &[KeyValue::new("type", INPUT_SHARE_DECODE_FAILURE)]);
         upload_decode_failure_counter.add(0, &[KeyValue::new("type", DUPLICATE_EXTENSION)]);
+        upload_decode_failure_counter.add(0, &[KeyValue::new("type", UNSORTED_EXTENSION)]);
         upload_decode_failure_counter.add(0, &[KeyValue::new("type", UNRECOGNIZED_EXTENSION)]);
 
         let report_aggregation_success_counter = report_aggregation_success_counter(meter);
@@ -1930,6 +1932,20 @@ impl VdafOps {
                 return Err(reject_report(ReportRejectionReason::DecodeFailure).await?);
             }
         };
+
+        // Public extensions must be in strictly increasing order of extension type (DAP-18 §4.4.3);
+        // private extensions are validated when the plaintext input share is decoded.
+        if !extensions_are_strictly_increasing(report.metadata().public_extensions()) {
+            debug!(
+                task_id = %task.id(),
+                report_id = ?report.metadata().id(),
+                "Received report with unsorted public extensions",
+            );
+            metrics
+                .upload_decode_failure_counter
+                .add(1, &[KeyValue::new("type", UNSORTED_EXTENSION)]);
+            return Err(reject_report(ReportRejectionReason::DecodeFailure).await?);
+        }
 
         // Check for unrecognized extension types (§4.6.2.4 step 5 [dap-16]) and
         // duplicate extensions (§4.6.2.4 step 6 [dap-16]) in a single pass.
@@ -3919,6 +3935,7 @@ async fn send_request_to_helper(
 /// label.
 mod upload_decode_failure_types {
     pub(super) const DUPLICATE_EXTENSION: &str = "duplicate_extension";
+    pub(super) const UNSORTED_EXTENSION: &str = "unsorted_extension";
     pub(super) const UNRECOGNIZED_EXTENSION: &str = "unrecognized_extension";
     pub(super) const INPUT_SHARE_DECODE_FAILURE: &str = "input_share_decode_failure";
     pub(super) const PUBLIC_SHARE_DECODE_FAILURE: &str = "public_share_decode_failure";

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -37,6 +37,7 @@ use janus_messages::{
     PartialBatchSelector, ReportError, ReportMetadata, ReportShare, Role, VerifyContinue,
     VerifyInit, VerifyResp, VerifyStepResult,
     batch_mode::{LeaderSelected, TimeInterval},
+    extensions_are_strictly_increasing,
 };
 use opentelemetry::{
     KeyValue,
@@ -74,7 +75,7 @@ use crate::{
     metrics::{
         aggregate_step_failure_types::{
             CONTINUE_MISMATCH, DUPLICATE_EXTENSION, FINISH_MISMATCH, HELPER_STEP_FAILURE,
-            PUBLIC_SHARE_ENCODE_FAILURE,
+            PUBLIC_SHARE_ENCODE_FAILURE, UNSORTED_EXTENSION,
         },
         aggregated_report_share_dimension_histogram, early_report_clock_skew_histogram,
         keypair_use_counter, past_report_clock_skew_histogram,
@@ -487,6 +488,24 @@ where
                             report_aggregation.state()
                         ),
                     };
+
+                    // Public extensions must be in strictly increasing order of extension type
+                    // (DAP-18 §4.4.3); private extensions are validated when the plaintext input
+                    // share is decoded.
+                    if !extensions_are_strictly_increasing(public_extensions) {
+                        debug!(
+                            report_id = %report_aggregation.report_id(),
+                            "Received report with unsorted public extensions"
+                        );
+                        aggregate_step_failure_counter
+                            .add(1, &[KeyValue::new("type", UNSORTED_EXTENSION)]);
+                        return ra_sender.send(WritableReportAggregation::new(
+                            report_aggregation.with_state(ReportAggregationState::Failed {
+                                report_error: ReportError::InvalidMessage,
+                            }),
+                            None,
+                        )).map_err(|_| ());
+                    }
 
                     // Check for repeated extensions.
                     let mut extension_types = HashSet::new();

--- a/aggregator/src/aggregator/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/aggregation_job_init.rs
@@ -16,7 +16,7 @@ use janus_core::{
 };
 use janus_messages::{
     ExtensionType, InputShareAad, PlaintextInputShare, ReportError, Role, VerifyResp,
-    VerifyStepResult,
+    VerifyStepResult, extensions_are_strictly_increasing,
 };
 use opentelemetry::{
     KeyValue,
@@ -41,6 +41,7 @@ use crate::{
         INPUT_SHARE_DECODE_FAILURE, MISSING_OR_MALFORMED_TASKBIND_EXTENSION,
         PLAINTEXT_INPUT_SHARE_DECODE_FAILURE, PUBLIC_SHARE_DECODE_FAILURE,
         UNEXPECTED_TASKBIND_EXTENSION, UNKNOWN_HPKE_CONFIG_ID, UNRECOGNIZED_EXTENSION,
+        UNSORTED_EXTENSION,
     },
 };
 
@@ -246,6 +247,23 @@ where
                                     );
                                     ReportError::InvalidMessage
                                 })?;
+
+                            // Public extensions must be in strictly increasing order of extension
+                            // type (DAP-18 §4.4.3); private extensions are validated when the
+                            // plaintext input share is decoded.
+                            if !extensions_are_strictly_increasing(
+                                verify_init.report_share().metadata().public_extensions(),
+                            ) {
+                                debug!(
+                                    task_id = %task.id(),
+                                    report_id = ?verify_init.report_share().metadata().id(),
+                                    "Received report share with unsorted public extensions",
+                                );
+                                metrics
+                                    .aggregate_step_failure_counter
+                                    .add(1, &[KeyValue::new("type", UNSORTED_EXTENSION)]);
+                                return Err(ReportError::InvalidMessage);
+                            }
 
                             // Check for unrecognized extension types (§4.6.2.4 step 5 [dap-16]) and
                             // duplicate extensions (§4.6.2.4 step 6 [dap-16]) in a single pass.

--- a/aggregator/src/aggregator/upload_tests.rs
+++ b/aggregator/src/aggregator/upload_tests.rs
@@ -1047,6 +1047,83 @@ async fn upload_report_duplicate_extensions() {
 }
 
 #[tokio::test]
+async fn upload_report_unsorted_extensions() {
+    let mut runtime_manager = TestRuntimeManager::new();
+    let UploadTest {
+        aggregator,
+        clock,
+        datastore,
+        ephemeral_datastore: _ephemeral_datastore,
+        hpke_keypair,
+        ..
+    } = UploadTest::new_with_runtime(
+        default_aggregator_config(),
+        runtime_manager.with_label("aggregator"),
+    )
+    .await;
+
+    let time_precision = TimePrecision::from_seconds(100);
+    let task = TaskBuilder::new(
+        BatchMode::TimeInterval,
+        AggregationMode::Synchronous,
+        VdafInstance::Prio3Count,
+    )
+    .with_time_precision(time_precision)
+    .with_task_start(None)
+    .with_report_expiry_age(Some(Duration::from_seconds(60, &time_precision)))
+    .build()
+    .leader_view()
+    .unwrap();
+    datastore.put_aggregator_task(&task).await.unwrap();
+
+    // Distinct public extensions that are not in strictly increasing order of extension type
+    // (0xFF00 before 0x0000).
+    let report = create_report_custom(
+        &task,
+        clock.now().to_time(task.time_precision()),
+        random(),
+        &hpke_keypair,
+        /* public */
+        Vec::from([
+            Extension::new(ExtensionType::Taskbind, Vec::new()),
+            Extension::new(ExtensionType::Reserved, Vec::new()),
+        ]),
+        /* leader */ Vec::new(),
+        /* helper */ Vec::new(),
+    );
+
+    let upload_result = aggregator
+        .handle_upload(task.id(), report_stream(report.clone()))
+        .await
+        .unwrap();
+    let result_upload_status = &upload_result.status()[0];
+    assert_matches!(
+        result_upload_status.error(),
+        ReportError::InvalidMessage => {
+            assert_eq!(report.metadata().id(), &result_upload_status.report_id());
+        }
+    );
+
+    runtime_manager
+        .wait_for_completed_tasks("aggregator", 1)
+        .await;
+
+    let got_counters = datastore
+        .run_unnamed_tx(|tx| {
+            let task_id = *task.id();
+            Box::pin(async move { TaskUploadCounter::load(tx, &task_id).await })
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        got_counters,
+        Some(TaskUploadCounter::new_with_values(
+            0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+        ))
+    )
+}
+
+#[tokio::test]
 async fn upload_report_unrecognized_extension() {
     let mut runtime_manager = TestRuntimeManager::new();
     let UploadTest {

--- a/aggregator/src/metrics.rs
+++ b/aggregator/src/metrics.rs
@@ -342,6 +342,7 @@ pub(crate) mod aggregate_step_failure_types {
     pub(crate) const PLAINTEXT_INPUT_SHARE_DECODE_FAILURE: &str =
         "plaintext_input_share_decode_failure";
     pub(crate) const DUPLICATE_EXTENSION: &str = "duplicate_extension";
+    pub(crate) const UNSORTED_EXTENSION: &str = "unsorted_extension";
     pub(crate) const MISSING_OR_MALFORMED_TASKBIND_EXTENSION: &str =
         "missing_or_malformed_taskbind_extension";
     pub(crate) const UNEXPECTED_TASKBIND_EXTENSION: &str = "unexpected_taskbind_extension";
@@ -384,6 +385,7 @@ pub(crate) fn aggregate_step_failure_counter(meter: &Meter) -> Counter<u64> {
         HELPER_STEP_FAILURE,
         PLAINTEXT_INPUT_SHARE_DECODE_FAILURE,
         DUPLICATE_EXTENSION,
+        UNSORTED_EXTENSION,
         MISSING_OR_MALFORMED_TASKBIND_EXTENSION,
         UNEXPECTED_TASKBIND_EXTENSION,
         UNRECOGNIZED_EXTENSION,

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -7,7 +7,9 @@ use core::slice;
 #[cfg(test)]
 use std::borrow::Borrow;
 use std::{
+    cmp::Ordering,
     fmt::{self, Debug, Display, Formatter},
+    hash::{Hash, Hasher},
     io::{Cursor, Read},
     num::TryFromIntError,
     str::{self, FromStr},
@@ -856,8 +858,17 @@ impl Decode for Extension {
     }
 }
 
+/// Returns `true` if `extensions` are in strictly increasing order of `extension_type`, as required
+/// for report extensions by DAP-18 §4.4.3. This also rules out repeated extension types.
+pub fn extensions_are_strictly_increasing(extensions: &[Extension]) -> bool {
+    extensions.is_sorted_by(|a, b| a.extension_type() < b.extension_type())
+}
+
 /// DAP protocol message representing the type of an extension included in a client report.
-#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
+///
+/// Equality, ordering, and hashing are all defined in terms of the underlying codepoint, so
+/// `Unknown(0x0000)` compares and hashes equal to `Reserved`.
+#[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 pub enum ExtensionType {
     Reserved,
@@ -881,6 +892,32 @@ impl ExtensionType {
             Self::Taskbind => Self::TASKBIND,
             Self::Unknown(val) => val,
         }
+    }
+}
+
+impl PartialEq for ExtensionType {
+    fn eq(&self, other: &Self) -> bool {
+        self.to_u16() == other.to_u16()
+    }
+}
+
+impl Eq for ExtensionType {}
+
+impl Hash for ExtensionType {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.to_u16().hash(state)
+    }
+}
+
+impl PartialOrd for ExtensionType {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ExtensionType {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.to_u16().cmp(&other.to_u16())
     }
 }
 
@@ -1261,6 +1298,8 @@ impl Decode for ReportMetadata {
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
         let report_id = ReportId::decode(bytes)?;
         let time = Time::decode(bytes)?;
+        // Public extension ordering is validated per-report by the aggregator rather than here, so
+        // one malformed report doesn't fail decoding of a whole batched `AggregationJobInitReq`.
         let public_extensions = decode_u16_items(&(), bytes)?;
 
         Ok(Self {
@@ -1317,7 +1356,17 @@ impl Encode for PlaintextInputShare {
 
 impl Decode for PlaintextInputShare {
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        // Private extensions are decoded per-report after HPKE decryption, so a decode-time
+        // rejection fails only the offending report.
         let private_extensions = decode_u16_items(&(), bytes)?;
+        if !extensions_are_strictly_increasing(&private_extensions) {
+            return Err(CodecError::Other(
+                anyhow!(
+                    "private extensions must be in strictly increasing order of extension_type"
+                )
+                .into(),
+            ));
+        }
         let payload = decode_u32_items(&(), bytes)?;
 
         Ok(Self {

--- a/messages/src/tests/upload.rs
+++ b/messages/src/tests/upload.rs
@@ -103,6 +103,41 @@ fn roundtrip_report_metadata() {
 }
 
 #[test]
+fn plaintext_input_share_rejects_unordered_extensions() {
+    use prio::codec::Decode;
+
+    // A private_extensions list followed by an empty payload.
+    let payload = "00000000"; // payload length 0
+
+    // Strictly increasing order (0x0000 then 0xFF00) decodes successfully.
+    let ordered = concat!(
+        "0008", // length
+        "0000", "0000", // extension_type 0x0000, empty data
+        "FF00", "0000", // extension_type 0xFF00, empty data
+    );
+    PlaintextInputShare::get_decoded(&hex::decode([ordered, payload].concat()).unwrap())
+        .expect("strictly increasing extensions should decode");
+
+    // Out of order (0xFF00 then 0x0000) is rejected.
+    let unordered = concat!(
+        "0008", // length
+        "FF00", "0000", // extension_type 0xFF00, empty data
+        "0000", "0000", // extension_type 0x0000, empty data
+    );
+    PlaintextInputShare::get_decoded(&hex::decode([unordered, payload].concat()).unwrap())
+        .expect_err("out-of-order extensions should be rejected");
+
+    // Duplicate extension types (not strictly increasing) are rejected.
+    let duplicate = concat!(
+        "0008", // length
+        "0000", "0000", // extension_type 0x0000, empty data
+        "0000", "0000", // extension_type 0x0000, empty data
+    );
+    PlaintextInputShare::get_decoded(&hex::decode([duplicate, payload].concat()).unwrap())
+        .expect_err("duplicate extension types should be rejected");
+}
+
+#[test]
 fn roundtrip_plaintext_input_share() {
     roundtrip_encoding(&[
         (


### PR DESCRIPTION
Per DAP-18 §4.4.3, a report's public and private extensions must each appear in strictly increasing order of extension_type, which also rules out duplicates within a list.

Private extensions are validated in PlaintextInputShare::decode, since the input share is decrypted and decoded per-report. Public extensions live in plaintext ReportMetadata inside each batched ReportShare, so a decode-time rejection would fail the whole AggregationJobInitReq; they are instead validated per-report by the aggregator alongside the existing duplicate/unrecognized-extension checks, surfaced via a new unsorted_extension metric label.

ExtensionType now derives equality, hashing, and ordering from its codepoint so ordering matches the wire value.