### PR TITLE
[DAP-18] Add verification key ID field to AggregationJobInitReq

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/aggregation_job_continue.rs
@@ -920,6 +920,7 @@ mod tests {
         // Subsequent attempts to initialize the job should fail.
         let (verify_init_msg, _) = test_case.verify_init_generator.next(&13);
         let init_req = AggregationJobInitializeReq::new(
+            0,
             test_case.aggregation_parameter.get_encoded().unwrap(),
             PartialBatchSelector::new_time_interval(),
             Vec::from([verify_init_msg]),

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -618,6 +618,8 @@ where
         let (resp, retry_after) = if !verify_inits.is_empty() {
             // Construct request, send it to the helper, and process the response.
             let request = AggregationJobInitializeReq::<B>::new(
+                // Janus uses a single verification key per task.
+                0,
                 aggregation_job
                     .aggregation_parameter()
                     .get_encoded()

--- a/aggregator/src/aggregator/aggregation_job_driver/tests.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver/tests.rs
@@ -674,6 +674,7 @@ async fn leader_sync_time_interval_aggregation_job_init_single_step() {
     // It would be nicer to retrieve the request bytes from the mock, then do our own parsing &
     // verification -- but mockito does not expose this functionality at time of writing.)
     let leader_request = AggregationJobInitializeReq::new(
+        0,
         ().get_encoded().unwrap(),
         PartialBatchSelector::new_time_interval(),
         Vec::from([VerifyInit::new(
@@ -1060,6 +1061,7 @@ async fn leader_sync_time_interval_aggregation_job_init_two_steps() {
     // It would be nicer to retrieve the request bytes from the mock, then do our own parsing &
     // verification -- but mockito does not expose this functionality at time of writing.)
     let leader_request = AggregationJobInitializeReq::new(
+        0,
         aggregation_param.get_encoded().unwrap(),
         PartialBatchSelector::new_time_interval(),
         Vec::from([VerifyInit::new(
@@ -1432,6 +1434,7 @@ async fn leader_sync_time_interval_aggregation_job_init_partially_garbage_collec
 
     // Setup: prepare mocked HTTP response.
     let leader_request = AggregationJobInitializeReq::new(
+        0,
         ().get_encoded().unwrap(),
         PartialBatchSelector::new_time_interval(),
         Vec::from([
@@ -1761,6 +1764,7 @@ async fn leader_sync_leader_selected_aggregation_job_init_single_step() {
     // It would be nicer to retrieve the request bytes from the mock, then do our own parsing &
     // verification -- but mockito does not expose this functionality at time of writing.)
     let leader_request = AggregationJobInitializeReq::new(
+        0,
         ().get_encoded().unwrap(),
         PartialBatchSelector::new_leader_selected(batch_id),
         Vec::from([VerifyInit::new(
@@ -2079,6 +2083,7 @@ async fn leader_sync_leader_selected_aggregation_job_init_two_steps() {
     // It would be nicer to retrieve the request bytes from the mock, then do our own parsing &
     // verification -- but mockito does not expose this functionality at time of writing.)
     let leader_request = AggregationJobInitializeReq::new(
+        0,
         aggregation_param.get_encoded().unwrap(),
         PartialBatchSelector::new_leader_selected(batch_id),
         Vec::from([VerifyInit::new(
@@ -2998,6 +3003,7 @@ async fn leader_async_aggregation_job_init_to_pending() {
 
     // Setup: prepare mocked HTTP response.
     let leader_request = AggregationJobInitializeReq::new(
+        0,
         aggregation_param.get_encoded().unwrap(),
         PartialBatchSelector::new_time_interval(),
         Vec::from([VerifyInit::new(
@@ -3254,6 +3260,7 @@ async fn leader_async_aggregation_job_init_to_pending_two_step() {
 
     // Setup: prepare mocked HTTP response.
     let leader_request = AggregationJobInitializeReq::new(
+        0,
         aggregation_param.get_encoded().unwrap(),
         PartialBatchSelector::new_time_interval(),
         Vec::from([VerifyInit::new(

--- a/aggregator/src/aggregator/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/aggregation_job_init.rs
@@ -871,6 +871,7 @@ mod tests {
 
         let aggregation_job_id = random();
         let aggregation_job_init_req = AggregationJobInitializeReq::new(
+            0,
             aggregation_param.get_encoded().unwrap(),
             PartialBatchSelector::new_time_interval(),
             verify_inits.clone(),
@@ -997,6 +998,7 @@ mod tests {
             .0;
         let report_id = *verify_init.report_share().metadata().id();
         let aggregation_job_init_req = AggregationJobInitializeReq::new(
+            0,
             dummy::AggregationParam(1).get_encoded().unwrap(),
             PartialBatchSelector::new_time_interval(),
             Vec::from([verify_init]),
@@ -1028,6 +1030,7 @@ mod tests {
 
         // Put the aggregation job again, but with a different aggregation parameter.
         let mutated_aggregation_job_init_req = AggregationJobInitializeReq::new(
+            0,
             dummy::AggregationParam(1).get_encoded().unwrap(),
             PartialBatchSelector::new_time_interval(),
             test_case.aggregation_job_init_req.verify_inits().to_vec(),
@@ -1066,6 +1069,7 @@ mod tests {
             verify_inits.iter().rev().cloned().collect(),
         ] {
             let mutated_aggregation_job_init_req = AggregationJobInitializeReq::new(
+                0,
                 test_case.aggregation_param.get_encoded().unwrap(),
                 PartialBatchSelector::new_time_interval(),
                 mutated_verify_inits,
@@ -1103,6 +1107,7 @@ mod tests {
             .collect();
 
         let mutated_aggregation_job_init_req = AggregationJobInitializeReq::new(
+            0,
             test_case.aggregation_param.get_encoded().unwrap(),
             PartialBatchSelector::new_time_interval(),
             mutated_verify_inits,
@@ -1130,6 +1135,7 @@ mod tests {
         .await;
 
         test_case.aggregation_job_init_req = AggregationJobInitializeReq::new(
+            0,
             test_case.aggregation_param.get_encoded().unwrap(),
             PartialBatchSelector::new_time_interval(),
             Vec::from([
@@ -1248,6 +1254,7 @@ mod tests {
         let aggregation_job_id = random();
 
         let aggregation_job_init_req = AggregationJobInitializeReq::new(
+            0,
             aggregation_param.get_encoded().unwrap(),
             PartialBatchSelector::new_time_interval(),
             Vec::from([
@@ -1389,6 +1396,7 @@ mod tests {
         let aggregation_job_id = random();
 
         let aggregation_job_init_req = AggregationJobInitializeReq::new(
+            0,
             aggregation_param.get_encoded().unwrap(),
             PartialBatchSelector::new_time_interval(),
             Vec::from([
@@ -1449,6 +1457,7 @@ mod tests {
         // setup_aggregate_init_test sets up a task with a time interval query. We send a
         // leader-selected query which should yield an error.
         let wrong_query = AggregationJobInitializeReq::new(
+            0,
             test_case.aggregation_param.get_encoded().unwrap(),
             PartialBatchSelector::new_leader_selected(random()),
             test_case.aggregation_job_init_req.verify_inits().to_vec(),

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
@@ -70,6 +70,7 @@ async fn aggregate_leader() {
         .unwrap();
 
     let request = AggregationJobInitializeReq::new(
+        0,
         Vec::new(),
         PartialBatchSelector::new_time_interval(),
         Vec::new(),
@@ -163,6 +164,7 @@ async fn aggregate_wrong_agg_auth_token() {
         .unwrap();
 
     let request = AggregationJobInitializeReq::new(
+        0,
         Vec::new(),
         PartialBatchSelector::new_time_interval(),
         Vec::new(),
@@ -582,6 +584,7 @@ async fn aggregate_init_sync() {
 
     let aggregation_param = dummy::AggregationParam(0);
     let request = AggregationJobInitializeReq::new(
+        0,
         aggregation_param.get_encoded().unwrap(),
         PartialBatchSelector::new_time_interval(),
         Vec::from([
@@ -848,6 +851,7 @@ async fn aggregate_init_async() {
 
     let aggregation_param = dummy::AggregationParam(0);
     let request = AggregationJobInitializeReq::new(
+        0,
         aggregation_param.get_encoded().unwrap(),
         PartialBatchSelector::new_time_interval(),
         Vec::from([verify_init_0.clone(), verify_init_1.clone()]),
@@ -980,6 +984,7 @@ async fn aggregate_init_batch_already_collected() {
     let aggregation_param = dummy::AggregationParam(0);
     let batch_id = random();
     let request = AggregationJobInitializeReq::new(
+        0,
         aggregation_param.get_encoded().unwrap(),
         PartialBatchSelector::new_leader_selected(batch_id),
         Vec::from([verify_init.clone()]),
@@ -1088,6 +1093,7 @@ async fn aggregate_init_verify_init_failed() {
 
     let (verify_init, _) = verify_init_generator.next(&0);
     let request = AggregationJobInitializeReq::new(
+        0,
         dummy::AggregationParam(0).get_encoded().unwrap(),
         PartialBatchSelector::new_time_interval(),
         Vec::from([verify_init.clone()]),
@@ -1154,6 +1160,7 @@ async fn aggregate_init_verify_step_failed() {
 
     let (verify_init, _) = verify_init_generator.next(&0);
     let request = AggregationJobInitializeReq::new(
+        0,
         dummy::AggregationParam(0).get_encoded().unwrap(),
         PartialBatchSelector::new_time_interval(),
         Vec::from([verify_init.clone()]),
@@ -1221,6 +1228,7 @@ async fn aggregate_init_duplicated_report_id() {
     let (verify_init, _) = verify_init_generator.next(&0);
 
     let request = AggregationJobInitializeReq::new(
+        0,
         dummy::AggregationParam(0).get_encoded().unwrap(),
         PartialBatchSelector::new_time_interval(),
         Vec::from([verify_init.clone(), verify_init]),
@@ -1306,6 +1314,7 @@ async fn aggregate_init_partially_replayed_aggregation_init() {
     .collect();
 
     let request = AggregationJobInitializeReq::new(
+        0,
         agg_param.clone(),
         partial_batch_selector.clone(),
         Vec::from([verify_init_1.clone(), verify_init_2.clone()]),
@@ -1330,6 +1339,7 @@ async fn aggregate_init_partially_replayed_aggregation_init() {
     }
 
     let request = AggregationJobInitializeReq::new(
+        0,
         agg_param.clone(),
         partial_batch_selector,
         Vec::from([

--- a/aggregator/src/aggregator/http_handlers/tests/helper_e2e.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/helper_e2e.rs
@@ -66,11 +66,13 @@ async fn helper_aggregation_report_share_replay() {
     let aggregation_job_id_2 = random();
 
     let agg_init_req_1 = AggregationJobInitializeReq::new(
+        0,
         agg_param.get_encoded().unwrap(),
         PartialBatchSelector::new_leader_selected(batch_id_1),
         Vec::from([replayed_report.clone(), other_report_1.clone()]),
     );
     let agg_init_req_2 = AggregationJobInitializeReq::new(
+        0,
         agg_param.get_encoded().unwrap(),
         PartialBatchSelector::new_leader_selected(batch_id_2),
         Vec::from([replayed_report.clone(), other_report_2.clone()]),

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -283,6 +283,7 @@ async fn taskprov_aggregate_init() {
     let (transcript_1, report_share_1, aggregation_param_1) = test.next_report_share();
     let batch_id_1 = random();
     let request_1 = AggregationJobInitializeReq::new(
+        0,
         aggregation_param_1.get_encoded().unwrap(),
         PartialBatchSelector::new_leader_selected(batch_id_1),
         Vec::from([VerifyInit::new(
@@ -298,6 +299,7 @@ async fn taskprov_aggregate_init() {
     let (transcript_2, report_share_2, aggregation_param_2) = test.next_report_share();
     let batch_id_2 = random();
     let request_2 = AggregationJobInitializeReq::new(
+        0,
         aggregation_param_2.get_encoded().unwrap(),
         PartialBatchSelector::new_leader_selected(batch_id_2),
         Vec::from([VerifyInit::new(
@@ -450,6 +452,7 @@ async fn taskprov_aggregate_init_without_task_interval() {
     let (transcript, report_share, aggregation_param) = test.next_report_share();
     let batch_id = random();
     let request = AggregationJobInitializeReq::new(
+        0,
         aggregation_param.get_encoded().unwrap(),
         PartialBatchSelector::new_leader_selected(batch_id),
         Vec::from([VerifyInit::new(
@@ -512,6 +515,7 @@ async fn taskprov_aggregate_init_missing_extension() {
         test.next_report_share_with_private_extensions(Vec::new());
     let batch_id = random();
     let request = AggregationJobInitializeReq::new(
+        0,
         aggregation_param.get_encoded().unwrap(),
         PartialBatchSelector::new_leader_selected(batch_id),
         Vec::from([VerifyInit::new(
@@ -606,6 +610,7 @@ async fn taskprov_aggregate_init_malformed_extension() {
         test.next_report_share_with_private_extensions(Vec::new());
     let batch_id = random();
     let request = AggregationJobInitializeReq::new(
+        0,
         aggregation_param.get_encoded().unwrap(),
         PartialBatchSelector::new_leader_selected(batch_id),
         Vec::from([VerifyInit::new(
@@ -701,6 +706,7 @@ async fn taskprov_opt_out_task_ended_regression() {
 
     let batch_id = random();
     let request = AggregationJobInitializeReq::new(
+        0,
         aggregation_param.get_encoded().unwrap(),
         PartialBatchSelector::new_leader_selected(batch_id),
         Vec::from([VerifyInit::new(
@@ -753,6 +759,7 @@ async fn taskprov_opt_out_mismatched_task_id() {
     let (transcript, report_share, _) = test.next_report_share();
     let batch_id = random();
     let request = AggregationJobInitializeReq::new(
+        0,
         ().get_encoded().unwrap(),
         PartialBatchSelector::new_leader_selected(batch_id),
         Vec::from([VerifyInit::new(
@@ -831,6 +838,7 @@ async fn taskprov_opt_out_peer_aggregator_wrong_role() {
     let (transcript, report_share, _) = test.next_report_share();
     let batch_id = random();
     let request = AggregationJobInitializeReq::new(
+        0,
         ().get_encoded().unwrap(),
         PartialBatchSelector::new_leader_selected(batch_id),
         Vec::from([VerifyInit::new(
@@ -907,6 +915,7 @@ async fn taskprov_opt_out_peer_aggregator_does_not_exist() {
     let (transcript, report_share, _) = test.next_report_share();
     let batch_id = random();
     let request = AggregationJobInitializeReq::new(
+        0,
         ().get_encoded().unwrap(),
         PartialBatchSelector::new_leader_selected(batch_id),
         Vec::from([VerifyInit::new(
@@ -1269,6 +1278,7 @@ async fn end_to_end() {
 
     let (transcript, report_share, aggregation_param) = test.next_report_share();
     let aggregation_job_init_request = AggregationJobInitializeReq::new(
+        0,
         aggregation_param.get_encoded().unwrap(),
         PartialBatchSelector::new_leader_selected(batch_id),
         Vec::from([VerifyInit::new(
@@ -1468,6 +1478,7 @@ async fn end_to_end_sumvec_hmac() {
     let aggregate_share_id = random();
     let (transcript, report_share, aggregation_param) = test.next_report_share();
     let aggregation_job_init_request = AggregationJobInitializeReq::new(
+        0,
         aggregation_param.get_encoded().unwrap(),
         PartialBatchSelector::new_leader_selected(batch_id),
         Vec::from([VerifyInit::new(

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -2351,6 +2351,7 @@ impl Distribution<AggregationJobId> for StandardUniform {
 #[derive(Clone, Educe, PartialEq, Eq)]
 #[educe(Debug)]
 pub struct AggregationJobInitializeReq<B: BatchMode> {
+    verification_key_id: u8,
     #[educe(Debug(ignore))]
     aggregation_parameter: Vec<u8>,
     partial_batch_selector: PartialBatchSelector<B>,
@@ -2360,15 +2361,22 @@ pub struct AggregationJobInitializeReq<B: BatchMode> {
 impl<B: BatchMode> AggregationJobInitializeReq<B> {
     /// Constructs an aggregate initialization request from its components.
     pub fn new(
+        verification_key_id: u8,
         aggregation_parameter: Vec<u8>,
         partial_batch_selector: PartialBatchSelector<B>,
         verify_inits: Vec<VerifyInit>,
     ) -> Self {
         Self {
+            verification_key_id,
             aggregation_parameter,
             partial_batch_selector,
             verify_inits,
         }
+    }
+
+    /// Gets the identifier for the VDAF verification key nominated by the leader.
+    pub fn verification_key_id(&self) -> u8 {
+        self.verification_key_id
     }
 
     /// Gets the aggregation parameter associated with this aggregate initialization request.
@@ -2394,13 +2402,15 @@ impl<B: BatchMode> MediaType for AggregationJobInitializeReq<B> {
 
 impl<B: BatchMode> Encode for AggregationJobInitializeReq<B> {
     fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
+        self.verification_key_id.encode(bytes)?;
         encode_u32_items(bytes, &(), &self.aggregation_parameter)?;
         self.partial_batch_selector.encode(bytes)?;
         encode_u32_items(bytes, &(), &self.verify_inits)
     }
 
     fn encoded_len(&self) -> Option<usize> {
-        let mut length = 4 + self.aggregation_parameter.len();
+        let mut length = 1;
+        length += 4 + self.aggregation_parameter.len();
         length += self.partial_batch_selector.encoded_len()?;
         length += 4;
         for verify_init in &self.verify_inits {
@@ -2412,11 +2422,13 @@ impl<B: BatchMode> Encode for AggregationJobInitializeReq<B> {
 
 impl<B: BatchMode> Decode for AggregationJobInitializeReq<B> {
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        let verification_key_id = u8::decode(bytes)?;
         let aggregation_parameter = decode_u32_items(&(), bytes)?;
         let partial_batch_selector = PartialBatchSelector::decode(bytes)?;
         let verify_inits = decode_u32_items(&(), bytes)?;
 
         Ok(Self {
+            verification_key_id,
             aggregation_parameter,
             partial_batch_selector,
             verify_inits,

--- a/messages/src/tests/aggregation.rs
+++ b/messages/src/tests/aggregation.rs
@@ -328,6 +328,7 @@ fn roundtrip_aggregation_job_initialize_req() {
     // TimeInterval.
     roundtrip_encoding(&[(
         AggregationJobInitializeReq {
+            verification_key_id: 7,
             aggregation_parameter: Vec::from("012345"),
             partial_batch_selector: PartialBatchSelector::new_time_interval(),
             verify_inits: Vec::from([
@@ -370,6 +371,7 @@ fn roundtrip_aggregation_job_initialize_req() {
             ]),
         },
         concat!(
+            "07", // verification_key_id
             concat!(
                 // aggregation_parameter
                 "00000006",     // length
@@ -482,6 +484,7 @@ fn roundtrip_aggregation_job_initialize_req() {
     // LeaderSelected.
     roundtrip_encoding(&[(
         AggregationJobInitializeReq::<LeaderSelected> {
+            verification_key_id: 255,
             aggregation_parameter: Vec::from("012345"),
             partial_batch_selector: PartialBatchSelector::new_leader_selected(BatchId::from(
                 [2u8; 32],
@@ -526,6 +529,7 @@ fn roundtrip_aggregation_job_initialize_req() {
             ]),
         },
         concat!(
+            "ff", // verification_key_id
             concat!(
                 // aggregation_parameter
                 "00000006",     // length


### PR DESCRIPTION
DAP-18 adds a leading `uint8 verification_key_id` field to `AggregationJobInitReq`, identifying which prearranged VDAF verification key the leader nominated.

- Add `verification_key_id: u8` to `AggregationJobInitializeReq`, encoded and decoded first per the new wire order
- The leader always nominates key 0, since Janus uses a single verification key per task
- The helper decodes and ignores the field for now

The `extensions` field and strictly-increasing-order rules from the same draft revision are [tracked separately](https://github.com/divviup/janus/issues/4402).