### PR TITLE
[DAP-17] TaskConf AAD Part 1: Add canonical TaskConfiguration builder and conversions

### DIFF
--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -60,9 +60,8 @@ impl BatchMode {
     ///
     /// This is the inverse of [`BatchMode::try_from(&BatchConfig)`](TryFrom). The
     /// `batch_time_window_size` of [`BatchMode::LeaderSelected`] is a Janus-specific parameter that
-    /// is not part of the DAP batch configuration, and is silently dropped; both aggregators must
-    /// drop it identically for the synthesized task configuration (and therefore the HPKE AAD it is
-    /// bound into) to match.
+    /// is not part of the DAP batch configuration, and is silently dropped. Therefore, the HPKE AAD
+    /// does not force the aggregators to agree on the `batch_time_window_size`.
     pub fn to_batch_config(&self) -> BatchConfig {
         match self {
             BatchMode::TimeInterval => BatchConfig::TimeInterval,

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -54,6 +54,23 @@ pub enum BatchMode {
     },
 }
 
+impl BatchMode {
+    /// Returns the [`BatchConfig`] message representation of this batch mode, for inclusion in a
+    /// [`TaskConfiguration`](janus_messages::TaskConfiguration).
+    ///
+    /// This is the inverse of [`BatchMode::try_from(&BatchConfig)`](TryFrom). The
+    /// `batch_time_window_size` of [`BatchMode::LeaderSelected`] is a Janus-specific parameter that
+    /// is not part of the DAP batch configuration, and is silently dropped; both aggregators must
+    /// drop it identically for the synthesized task configuration (and therefore the HPKE AAD it is
+    /// bound into) to match.
+    pub fn to_batch_config(&self) -> BatchConfig {
+        match self {
+            BatchMode::TimeInterval => BatchConfig::TimeInterval,
+            BatchMode::LeaderSelected { .. } => BatchConfig::LeaderSelected,
+        }
+    }
+}
+
 impl TryFrom<batch_mode::Code> for BatchMode {
     type Error = Error;
 
@@ -1392,8 +1409,8 @@ mod tests {
         vdaf::vdaf_dp_strategies,
     };
     use janus_messages::{
-        Duration, HpkeAeadId, HpkeConfig, HpkeConfigId, HpkeKdfId, HpkeKemId, HpkePublicKey,
-        TaskId, Time, TimePrecision,
+        BatchConfig, Duration, HpkeAeadId, HpkeConfig, HpkeConfigId, HpkeKdfId, HpkeKemId,
+        HpkePublicKey, TaskId, Time, TimePrecision,
     };
     use rand::random;
     use serde_json::json;
@@ -1406,6 +1423,33 @@ mod tests {
             test_util::TaskBuilder,
         },
     };
+
+    #[test]
+    fn batch_mode_to_batch_config() {
+        assert_eq!(
+            BatchMode::TimeInterval.to_batch_config(),
+            BatchConfig::TimeInterval
+        );
+        // The Janus-specific batch_time_window_size is dropped, so both leader-selected variants
+        // map to the same BatchConfig.
+        assert_eq!(
+            BatchMode::LeaderSelected {
+                batch_time_window_size: None,
+            }
+            .to_batch_config(),
+            BatchConfig::LeaderSelected
+        );
+        assert_eq!(
+            BatchMode::LeaderSelected {
+                batch_time_window_size: Some(Duration::from_seconds(
+                    3600,
+                    &TimePrecision::from_seconds(3600)
+                )),
+            }
+            .to_batch_config(),
+            BatchConfig::LeaderSelected
+        );
+    }
 
     #[test]
     fn leader_task_serialization() {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod hpke;
 pub mod http;
 pub mod report_id;
 pub mod retries;
+pub mod task_config;
 #[cfg(feature = "test-util")]
 #[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
 pub mod test_util;

--- a/core/src/task_config.rs
+++ b/core/src/task_config.rs
@@ -140,8 +140,8 @@ mod tests {
         );
     }
 
-    /// Pins the exact encoded bytes produced by the canonical builder. Because DAP implementations can
-    /// be non-Janus, this synthesized encoding is a cross-implementation wire-compatibility
+    /// Pins the exact encoded bytes produced by the canonical builder. Because DAP implementations
+    /// can be non-Janus, this synthesized encoding is a cross-implementation wire-compatibility
     /// contract, so we assert the bytes directly rather than only round-tripping.
     #[test]
     fn encoded_test_vector() {

--- a/core/src/task_config.rs
+++ b/core/src/task_config.rs
@@ -1,0 +1,209 @@
+//! Construction of canonical [`TaskConfiguration`] messages from a task's internal parameters.
+//!
+//! In DAP-18, the task's [`TaskConfiguration`] is bound into the HPKE additional authenticated data
+//! (AAD) for input shares and aggregate shares. Every party (both aggregators, the client, and the
+//! collector) must independently reconstruct *byte-identical* [`TaskConfiguration`] bytes, or all
+//! decryption fails. [`build_task_configuration`] is the single canonical construction path, so
+//! that normalization (e.g. of aggregator endpoint URLs) and the mapping of internal
+//! representations onto the wire format happen in exactly one place.
+
+use janus_messages::{
+    BatchConfig, Error, Interval, TaskConfiguration, TaskExtension, TimePrecision, Url as DapUrl,
+    VdafConfig,
+};
+use url::Url;
+
+use crate::url_ensure_trailing_slash;
+
+/// Construct a canonical [`TaskConfiguration`] from a task's parameters, normalizing the inputs so
+/// that every party reconstructs byte-identical bytes.
+#[allow(clippy::too_many_arguments)]
+pub fn build_task_configuration(
+    task_info: Vec<u8>,
+    leader_aggregator_endpoint: Url,
+    helper_aggregator_endpoint: Url,
+    time_precision: TimePrecision,
+    min_batch_size: u64,
+    batch_config: BatchConfig,
+    vdaf_config: VdafConfig,
+    task_interval: Option<Interval>,
+) -> Result<TaskConfiguration, Error> {
+    let leader_aggregator_endpoint = normalize_endpoint(leader_aggregator_endpoint)?;
+    let helper_aggregator_endpoint = normalize_endpoint(helper_aggregator_endpoint)?;
+
+    // The optional task_interval becomes the lone extension, or none.
+    let extensions = Vec::from_iter(task_interval.map(TaskExtension::TaskInterval));
+
+    TaskConfiguration::new(
+        task_info,
+        leader_aggregator_endpoint,
+        helper_aggregator_endpoint,
+        time_precision,
+        min_batch_size,
+        batch_config,
+        vdaf_config,
+        extensions,
+    )
+}
+
+/// Normalize an aggregator endpoint and convert it to the DAP wire [`DapUrl`] representation.
+fn normalize_endpoint(endpoint: Url) -> Result<DapUrl, Error> {
+    let endpoint = url_ensure_trailing_slash(endpoint);
+    DapUrl::try_from(endpoint.as_str().as_bytes())
+        .map_err(|_| Error::InvalidParameter("aggregator endpoint is not a valid DAP URL"))
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches::assert_matches;
+    use janus_messages::{BatchConfig, Duration, Error, Interval, Time, TimePrecision, VdafConfig};
+    use prio::codec::Encode as _;
+    use url::Url;
+
+    use super::build_task_configuration;
+
+    fn leader() -> Url {
+        Url::parse("https://leader.example.com").unwrap()
+    }
+
+    fn helper() -> Url {
+        Url::parse("https://helper.example.com").unwrap()
+    }
+
+    #[test]
+    fn normalizes_endpoints() {
+        // Neither input URL ends with a slash; the synthesized configuration must.
+        let config = build_task_configuration(
+            b"task".to_vec(),
+            leader(),
+            helper(),
+            TimePrecision::from_seconds(3600),
+            100,
+            BatchConfig::TimeInterval,
+            VdafConfig::Prio3Count,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            config.leader_aggregator_endpoint().to_string(),
+            "https://leader.example.com/"
+        );
+        assert_eq!(
+            config.helper_aggregator_endpoint().to_string(),
+            "https://helper.example.com/"
+        );
+    }
+
+    #[test]
+    fn no_task_interval() {
+        let config = build_task_configuration(
+            b"task".to_vec(),
+            leader(),
+            helper(),
+            TimePrecision::from_seconds(3600),
+            100,
+            BatchConfig::TimeInterval,
+            VdafConfig::Prio3Count,
+            None,
+        )
+        .unwrap();
+        assert!(config.extensions().is_empty());
+        assert_eq!(config.task_interval(), None);
+    }
+
+    #[test]
+    fn carries_task_interval() {
+        let interval = Interval::new(
+            Time::from_time_precision_units(1000),
+            Duration::from_time_precision_units(28),
+        )
+        .unwrap();
+        let config = build_task_configuration(
+            b"task".to_vec(),
+            leader(),
+            helper(),
+            TimePrecision::from_seconds(3600),
+            100,
+            BatchConfig::TimeInterval,
+            VdafConfig::Prio3Count,
+            Some(interval),
+        )
+        .unwrap();
+        assert_eq!(config.task_interval(), Some(interval));
+    }
+
+    #[test]
+    fn rejects_empty_task_info() {
+        assert_matches!(
+            build_task_configuration(
+                Vec::new(),
+                leader(),
+                helper(),
+                TimePrecision::from_seconds(3600),
+                100,
+                BatchConfig::TimeInterval,
+                VdafConfig::Prio3Count,
+                None,
+            ),
+            Err(Error::InvalidParameter(_))
+        );
+    }
+
+    /// Pins the exact encoded bytes produced by the canonical builder. Because taskprov clients can
+    /// be non-Janus, this synthesized encoding is a cross-implementation wire-compatibility
+    /// contract, so we assert the bytes directly rather than only round-tripping.
+    #[test]
+    fn encoded_test_vector() {
+        let time_precision = TimePrecision::from_seconds(3600);
+        let config = build_task_configuration(
+            b"foobar".to_vec(),
+            Url::parse("https://example.com").unwrap(),
+            Url::parse("https://another.example.com").unwrap(),
+            time_precision,
+            10000,
+            BatchConfig::TimeInterval,
+            VdafConfig::Prio3Count,
+            Some(
+                Interval::new(
+                    Time::from_time_precision_units(1000000),
+                    Duration::from_time_precision_units(28),
+                )
+                .unwrap(),
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(
+            hex::encode(config.get_encoded().unwrap()),
+            concat!(
+                // task_info: length 0x06, "foobar"
+                "06",
+                "666f6f626172",
+                // leader_aggregator_endpoint: length 0x0014, "https://example.com/"
+                "0014",
+                "68747470733a2f2f6578616d706c652e636f6d2f",
+                // helper_aggregator_endpoint: length 0x001c, "https://another.example.com/"
+                "001c",
+                "68747470733a2f2f616e6f746865722e6578616d706c652e636f6d2f",
+                // time_precision: 3600
+                "0000000000000e10",
+                // min_batch_size: 10000
+                "0000000000002710",
+                // batch_config: TimeInterval (mode 0x01, empty config)
+                "01",
+                "0000",
+                // vdaf_config: Prio3Count (type 0x00000001, empty config)
+                "00000001",
+                "0000",
+                // extensions: u16 length prefix, then one task_interval extension
+                "0014",
+                // extension_type: task_interval (0x0001)
+                "0001",
+                // extension_data: u16 length 0x10, Interval{start: 1000000, duration: 28}
+                "0010",
+                "00000000000f4240",
+                "000000000000001c",
+            )
+        );
+    }
+}

--- a/core/src/task_config.rs
+++ b/core/src/task_config.rs
@@ -3,34 +3,30 @@
 //! In DAP-18, the task's [`TaskConfiguration`] is bound into the HPKE additional authenticated data
 //! (AAD) for input shares and aggregate shares. Every party (both aggregators, the client, and the
 //! collector) must independently reconstruct *byte-identical* [`TaskConfiguration`] bytes, or all
-//! decryption fails. [`build_task_configuration`] is the single canonical construction path, so
-//! that normalization (e.g. of aggregator endpoint URLs) and the mapping of internal
-//! representations onto the wire format happen in exactly one place.
+//! decryption fails. [`build_task_configuration`] is the single canonical construction path that
+//! maps internal representations onto the wire format in exactly one place.
+//!
+//! Endpoint URLs are kept as [`janus_messages::Url`] — the raw bytes from the wire — and
+//! bound directly, per DAP-18 §4.1.
 
 use janus_messages::{
     BatchConfig, Error, Interval, TaskConfiguration, TaskExtension, TimePrecision, Url as DapUrl,
     VdafConfig,
 };
-use url::Url;
 
-use crate::url_ensure_trailing_slash;
-
-/// Construct a canonical [`TaskConfiguration`] from a task's parameters, normalizing the inputs so
-/// that every party reconstructs byte-identical bytes.
+/// Construct a canonical [`TaskConfiguration`] from a task's parameters. Endpoints are bound
+/// verbatim from their wire bytes (no normalization — see the module docs).
 #[allow(clippy::too_many_arguments)]
 pub fn build_task_configuration(
     task_info: Vec<u8>,
-    leader_aggregator_endpoint: Url,
-    helper_aggregator_endpoint: Url,
+    leader_aggregator_endpoint: DapUrl,
+    helper_aggregator_endpoint: DapUrl,
     time_precision: TimePrecision,
     min_batch_size: u64,
     batch_config: BatchConfig,
     vdaf_config: VdafConfig,
     task_interval: Option<Interval>,
 ) -> Result<TaskConfiguration, Error> {
-    let leader_aggregator_endpoint = normalize_endpoint(leader_aggregator_endpoint)?;
-    let helper_aggregator_endpoint = normalize_endpoint(helper_aggregator_endpoint)?;
-
     // The optional task_interval becomes the lone extension, or none.
     let extensions = Vec::from_iter(task_interval.map(TaskExtension::TaskInterval));
 
@@ -46,37 +42,32 @@ pub fn build_task_configuration(
     )
 }
 
-/// Normalize an aggregator endpoint and convert it to the DAP wire [`DapUrl`] representation.
-fn normalize_endpoint(endpoint: Url) -> Result<DapUrl, Error> {
-    let endpoint = url_ensure_trailing_slash(endpoint);
-    DapUrl::try_from(endpoint.as_str().as_bytes())
-        .map_err(|_| Error::InvalidParameter("aggregator endpoint is not a valid DAP URL"))
-}
-
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
-    use janus_messages::{BatchConfig, Duration, Error, Interval, Time, TimePrecision, VdafConfig};
+    use janus_messages::{
+        BatchConfig, Duration, Error, Interval, Time, TimePrecision, Url as DapUrl, VdafConfig,
+    };
     use prio::codec::Encode as _;
-    use url::Url;
 
     use super::build_task_configuration;
 
-    fn leader() -> Url {
-        Url::parse("https://leader.example.com").unwrap()
+    fn leader() -> DapUrl {
+        DapUrl::try_from("https://leader.example.com/".as_bytes()).unwrap()
     }
 
-    fn helper() -> Url {
-        Url::parse("https://helper.example.com").unwrap()
+    fn helper() -> DapUrl {
+        DapUrl::try_from("https://helper.example.com/".as_bytes()).unwrap()
     }
 
     #[test]
-    fn normalizes_endpoints() {
-        // Neither input URL ends with a slash; the synthesized configuration must.
+    fn endpoints_bound_verbatim() {
+        // A path-bearing endpoint with no trailing slash must be bound exactly as given: this code
+        // performs no normalization (forbidden by DAP-18 §4.1).
         let config = build_task_configuration(
             b"task".to_vec(),
-            leader(),
-            helper(),
+            DapUrl::try_from("https://leader.example.com/dap".as_bytes()).unwrap(),
+            DapUrl::try_from("https://helper.example.com/dap".as_bytes()).unwrap(),
             TimePrecision::from_seconds(3600),
             100,
             BatchConfig::TimeInterval,
@@ -86,11 +77,11 @@ mod tests {
         .unwrap();
         assert_eq!(
             config.leader_aggregator_endpoint().to_string(),
-            "https://leader.example.com/"
+            "https://leader.example.com/dap"
         );
         assert_eq!(
             config.helper_aggregator_endpoint().to_string(),
-            "https://helper.example.com/"
+            "https://helper.example.com/dap"
         );
     }
 
@@ -157,8 +148,8 @@ mod tests {
         let time_precision = TimePrecision::from_seconds(3600);
         let config = build_task_configuration(
             b"foobar".to_vec(),
-            Url::parse("https://example.com").unwrap(),
-            Url::parse("https://another.example.com").unwrap(),
+            DapUrl::try_from("https://example.com/".as_bytes()).unwrap(),
+            DapUrl::try_from("https://another.example.com/".as_bytes()).unwrap(),
             time_precision,
             10000,
             BatchConfig::TimeInterval,

--- a/core/src/task_config.rs
+++ b/core/src/task_config.rs
@@ -140,7 +140,7 @@ mod tests {
         );
     }
 
-    /// Pins the exact encoded bytes produced by the canonical builder. Because taskprov clients can
+    /// Pins the exact encoded bytes produced by the canonical builder. Because DAP implementations can
     /// be non-Janus, this synthesized encoding is a cross-implementation wire-compatibility
     /// contract, so we assert the bytes directly rather than only round-tripping.
     #[test]

--- a/core/src/vdaf.rs
+++ b/core/src/vdaf.rs
@@ -133,6 +133,67 @@ impl VdafInstance {
             _ => VERIFY_KEY_LENGTH_PRIO3,
         }
     }
+
+    /// Returns the [`VdafConfig`] message representation of this VDAF instance, for inclusion in a
+    /// [`TaskConfiguration`](janus_messages::TaskConfiguration).
+    ///
+    /// This is the inverse of [`VdafInstance::try_from(&VdafConfig)`](TryFrom). It is an inherent
+    /// method rather than a `From`/`TryFrom` impl because the orphan rules forbid implementing a
+    /// foreign trait to produce the foreign [`VdafConfig`] type from this crate.
+    ///
+    /// The differential privacy strategy is **not** representable in [`VdafConfig`] and is silently
+    /// dropped. Both aggregators must drop it identically for the synthesized task configuration
+    /// (and therefore the HPKE AAD it is bound into) to match.
+    pub fn to_vdaf_config(&self) -> Result<VdafConfig, &'static str> {
+        // VDAF length parameters are `usize` here but `u32` on the wire.
+        fn to_u32(value: usize) -> Result<u32, &'static str> {
+            u32::try_from(value).map_err(|_| "VDAF length parameter exceeds u32::MAX")
+        }
+
+        Ok(match self {
+            VdafInstance::Prio3Count => VdafConfig::Prio3Count,
+            VdafInstance::Prio3Sum { max_measurement } => VdafConfig::Prio3Sum {
+                max_measurement: *max_measurement,
+            },
+            VdafInstance::Prio3SumVec {
+                max_measurement,
+                length,
+                chunk_length,
+                dp_strategy: _,
+            } => VdafConfig::Prio3SumVec {
+                length: to_u32(*length)?,
+                max_measurement: *max_measurement,
+                chunk_length: to_u32(*chunk_length)?,
+            },
+            VdafInstance::Prio3SumVecField64MultiproofHmacSha256Aes128 {
+                proofs,
+                max_measurement,
+                length,
+                chunk_length,
+                dp_strategy: _,
+            } => VdafConfig::Prio3SumVecField64MultiproofHmacSha256Aes128 {
+                length: to_u32(*length)?,
+                max_measurement: *max_measurement,
+                chunk_length: to_u32(*chunk_length)?,
+                proofs: *proofs,
+            },
+            VdafInstance::Prio3Histogram {
+                length,
+                chunk_length,
+                dp_strategy: _,
+            } => VdafConfig::Prio3Histogram {
+                length: to_u32(*length)?,
+                chunk_length: to_u32(*chunk_length)?,
+            },
+
+            #[cfg(feature = "test-util")]
+            VdafInstance::Fake { rounds } => VdafConfig::Fake { rounds: *rounds },
+            #[cfg(feature = "test-util")]
+            VdafInstance::FakeFailsVerifyInit | VdafInstance::FakeFailsVerifyStep => {
+                return Err("VDAF instance has no VdafConfig representation");
+            }
+        })
+    }
 }
 
 impl TryFrom<&VdafConfig> for VdafInstance {
@@ -460,6 +521,7 @@ macro_rules! vdaf_dispatch {
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
+    use janus_messages::VdafConfig;
     use prio::dp::{
         DifferentialPrivacyStrategy, PureDpBudget, Rational,
         distributions::{DiscreteLaplaceDpStrategy, PureDpDiscreteLaplace},
@@ -467,6 +529,108 @@ mod tests {
     use serde_test::{Token, assert_tokens};
 
     use crate::vdaf::{VdafInstance, vdaf_dp_strategies};
+
+    #[test]
+    fn vdaf_instance_to_vdaf_config() {
+        // Simple variants.
+        assert_eq!(
+            VdafInstance::Prio3Count.to_vdaf_config().unwrap(),
+            VdafConfig::Prio3Count
+        );
+        assert_eq!(
+            VdafInstance::Prio3Sum {
+                max_measurement: 4096
+            }
+            .to_vdaf_config()
+            .unwrap(),
+            VdafConfig::Prio3Sum {
+                max_measurement: 4096
+            }
+        );
+        assert_eq!(
+            VdafInstance::Prio3Histogram {
+                length: 6,
+                chunk_length: 2,
+                dp_strategy: vdaf_dp_strategies::Prio3Histogram::NoDifferentialPrivacy,
+            }
+            .to_vdaf_config()
+            .unwrap(),
+            VdafConfig::Prio3Histogram {
+                length: 6,
+                chunk_length: 2,
+            }
+        );
+        assert_eq!(
+            VdafInstance::Prio3SumVecField64MultiproofHmacSha256Aes128 {
+                proofs: 2,
+                max_measurement: 7,
+                length: 8,
+                chunk_length: 3,
+                dp_strategy: vdaf_dp_strategies::Prio3SumVec::NoDifferentialPrivacy,
+            }
+            .to_vdaf_config()
+            .unwrap(),
+            VdafConfig::Prio3SumVecField64MultiproofHmacSha256Aes128 {
+                length: 8,
+                max_measurement: 7,
+                chunk_length: 3,
+                proofs: 2,
+            }
+        );
+
+        // The differential privacy strategy is dropped: a DP and a non-DP instance map to the same
+        // VdafConfig.
+        let with_dp = VdafInstance::Prio3SumVec {
+            max_measurement: 1,
+            length: 8,
+            chunk_length: 3,
+            dp_strategy: vdaf_dp_strategies::Prio3SumVec::PureDpDiscreteLaplace(
+                prio::dp::distributions::PureDpDiscreteLaplace::from_budget(
+                    prio::dp::PureDpBudget::new(
+                        prio::dp::Rational::from_unsigned(2u128, 1u128).unwrap(),
+                    )
+                    .unwrap(),
+                ),
+            ),
+        };
+        let without_dp = VdafInstance::Prio3SumVec {
+            max_measurement: 1,
+            length: 8,
+            chunk_length: 3,
+            dp_strategy: vdaf_dp_strategies::Prio3SumVec::NoDifferentialPrivacy,
+        };
+        assert_eq!(
+            with_dp.to_vdaf_config().unwrap(),
+            without_dp.to_vdaf_config().unwrap()
+        );
+        assert_eq!(
+            without_dp.to_vdaf_config().unwrap(),
+            VdafConfig::Prio3SumVec {
+                length: 8,
+                max_measurement: 1,
+                chunk_length: 3,
+            }
+        );
+
+        // Length parameters that overflow u32 are rejected.
+        assert!(
+            VdafInstance::Prio3Histogram {
+                length: (u32::MAX as usize) + 1,
+                chunk_length: 2,
+                dp_strategy: vdaf_dp_strategies::Prio3Histogram::NoDifferentialPrivacy,
+            }
+            .to_vdaf_config()
+            .is_err()
+        );
+
+        // The fake-failure VDAFs have no VdafConfig representation.
+        assert!(VdafInstance::FakeFailsVerifyInit.to_vdaf_config().is_err());
+        assert!(VdafInstance::FakeFailsVerifyStep.to_vdaf_config().is_err());
+        assert_eq!(
+            VdafInstance::Fake { rounds: 3 }.to_vdaf_config().unwrap(),
+            VdafConfig::Fake { rounds: 3 }
+        );
+    }
 
     #[test]
     fn vdaf_serialization() {

--- a/core/src/vdaf.rs
+++ b/core/src/vdaf.rs
@@ -142,8 +142,8 @@ impl VdafInstance {
     /// foreign trait to produce the foreign [`VdafConfig`] type from this crate.
     ///
     /// The differential privacy strategy is **not** representable in [`VdafConfig`] and is silently
-    /// dropped. Both aggregators must drop it identically for the synthesized task configuration
-    /// (and therefore the HPKE AAD it is bound into) to match.
+    /// dropped. It is anticipated that future task extensions will allow for agreement on differential
+    /// privacy mechanisms.
     pub fn to_vdaf_config(&self) -> Result<VdafConfig, &'static str> {
         // VDAF length parameters are `usize` here but `u32` on the wire.
         fn to_u32(value: usize) -> Result<u32, &'static str> {

--- a/core/src/vdaf.rs
+++ b/core/src/vdaf.rs
@@ -142,8 +142,8 @@ impl VdafInstance {
     /// foreign trait to produce the foreign [`VdafConfig`] type from this crate.
     ///
     /// The differential privacy strategy is **not** representable in [`VdafConfig`] and is silently
-    /// dropped. It is anticipated that future task extensions will allow for agreement on differential
-    /// privacy mechanisms.
+    /// dropped. It is anticipated that future task extensions will allow for agreement on
+    /// differential privacy mechanisms.
     pub fn to_vdaf_config(&self) -> Result<VdafConfig, &'static str> {
         // VDAF length parameters are `usize` here but `u32` on the wire.
         fn to_u32(value: usize) -> Result<u32, &'static str> {


### PR DESCRIPTION
Foundation for binding TaskConfiguration into HPKE AADs:

- `VdafInstance::to_vdaf_config` and `BatchMode::to_batch_config` forward conversions (inherent methods, since orphan rules block `From` impls).
- `janus_core::task_config::build_task_configuration`, the single (prod, at least) path that touches endpoint URLs and the `task_interval` extension, with an encoded test vector. We'll be using this elsewhere.

Part plan:
- Part 2 is database changes, including switching database to the un-normalized URLs  (https://github.com/divviup/janus/issues/4625)
- Part 3 is message definitions
- Part 4 is aggregator
- Part 5 is client
- Part 6 is collector

This is part of https://github.com/divviup/janus/issues/4402