### PR TITLE
rustfmt: Enable error_on_line_overflow

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1334,7 +1334,18 @@ enum VdafOps {
 /// specify the VDAF's type, and the name of a const that will be set to the VDAF's verify key
 /// length, also for explicitly specifying type parameters.
 macro_rules! vdaf_ops_dispatch {
-    ($vdaf_ops:expr, ($vdaf:pat_param, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident, $dp_strategy:ident, $DpStrategy:ident) => $body:tt) => {
+    (
+        $vdaf_ops:expr,
+        (
+            $vdaf:pat_param,
+            $Vdaf:ident,
+            $VERIFY_KEY_LENGTH:ident,
+            $dp_strategy:ident,
+            $DpStrategy:ident
+        )
+        =>
+        $body:tt
+    ) => {
         match $vdaf_ops {
             crate::aggregator::VdafOps::Prio3Count(vdaf) => {
                 let $vdaf = vdaf;
@@ -1376,7 +1387,10 @@ macro_rules! vdaf_ops_dispatch {
                 }
             }
 
-            crate::aggregator::VdafOps::Prio3SumVecField64MultiproofHmacSha256Aes128(vdaf, _dp_strategy) => {
+            crate::aggregator::VdafOps::Prio3SumVecField64MultiproofHmacSha256Aes128(
+                vdaf,
+                _dp_strategy
+            ) => {
                 let $vdaf = vdaf;
                 type $Vdaf = ::janus_core::vdaf::Prio3SumVecField64MultiproofHmacSha256Aes128<
                     ::prio::flp::gadgets::ParallelSum<
@@ -1435,8 +1449,29 @@ macro_rules! vdaf_ops_dispatch {
         }
     };
 
-    ($vdaf_ops:expr, ($vdaf:pat_param, $Vdaf:ident, $VERIFY_KEY_LENGTH:ident) => $body:tt) => {
-        vdaf_ops_dispatch!($vdaf_ops, ($vdaf, $Vdaf, $VERIFY_KEY_LENGTH, _unused, _Unused) => $body)};
+    (
+        $vdaf_ops:expr,
+        (
+            $vdaf:pat_param,
+            $Vdaf:ident,
+            $VERIFY_KEY_LENGTH:ident
+        )
+        =>
+        $body:tt
+    ) => {
+        vdaf_ops_dispatch!(
+            $vdaf_ops,
+            (
+                $vdaf,
+                $Vdaf,
+                $VERIFY_KEY_LENGTH,
+                _unused,
+                _Unused
+            )
+            =>
+            $body
+        )
+    };
 }
 
 impl VdafOps {
@@ -1506,7 +1541,12 @@ impl VdafOps {
         match task.batch_mode() {
             task::BatchMode::TimeInterval => {
                 vdaf_ops_dispatch!(self, (vdaf, VdafType, VERIFY_KEY_LENGTH) => {
-                    Self::handle_aggregate_init_generic::<VERIFY_KEY_LENGTH, TimeInterval, VdafType, _>(
+                    Self::handle_aggregate_init_generic::<
+                        VERIFY_KEY_LENGTH,
+                        TimeInterval,
+                        VdafType,
+                        _,
+                    >(
                         datastore,
                         hpke_keypairs,
                         Arc::clone(vdaf),
@@ -1524,7 +1564,12 @@ impl VdafOps {
             }
             task::BatchMode::LeaderSelected { .. } => {
                 vdaf_ops_dispatch!(self, (vdaf, VdafType, VERIFY_KEY_LENGTH) => {
-                    Self::handle_aggregate_init_generic::<VERIFY_KEY_LENGTH, LeaderSelected, VdafType, _>(
+                    Self::handle_aggregate_init_generic::<
+                        VERIFY_KEY_LENGTH,
+                        LeaderSelected,
+                        VdafType,
+                        _,
+                    >(
                         datastore,
                         hpke_keypairs,
                         Arc::clone(vdaf),
@@ -1562,7 +1607,12 @@ impl VdafOps {
         match task.batch_mode() {
             task::BatchMode::TimeInterval => {
                 vdaf_ops_dispatch!(self, (vdaf, VdafType, VERIFY_KEY_LENGTH) => {
-                    Self::handle_aggregate_continue_generic::<VERIFY_KEY_LENGTH, TimeInterval, VdafType, _>(
+                    Self::handle_aggregate_continue_generic::<
+                        VERIFY_KEY_LENGTH,
+                        TimeInterval,
+                        VdafType,
+                        _,
+                    >(
                         datastore,
                         Arc::clone(vdaf),
                         metrics,
@@ -1578,7 +1628,12 @@ impl VdafOps {
             }
             task::BatchMode::LeaderSelected { .. } => {
                 vdaf_ops_dispatch!(self, (vdaf, VdafType, VERIFY_KEY_LENGTH) => {
-                    Self::handle_aggregate_continue_generic::<VERIFY_KEY_LENGTH, LeaderSelected, VdafType, _>(
+                    Self::handle_aggregate_continue_generic::<
+                        VERIFY_KEY_LENGTH,
+                        LeaderSelected,
+                        VdafType,
+                        _,
+                    >(
                         datastore,
                         Arc::clone(vdaf),
                         metrics,
@@ -1595,7 +1650,11 @@ impl VdafOps {
         }
     }
 
-    #[tracing::instrument(skip(self, datastore), fields(task_id = ?task.id()), err(level = Level::DEBUG))]
+    #[tracing::instrument(
+        skip(self, datastore),
+        fields(task_id = ?task.id()),
+        err(level = Level::DEBUG)
+    )]
     async fn handle_aggregate_get<C: Clock>(
         &self,
         datastore: Arc<Datastore<C>>,
@@ -1606,7 +1665,12 @@ impl VdafOps {
         match task.batch_mode() {
             task::BatchMode::TimeInterval => {
                 vdaf_ops_dispatch!(self, (vdaf, VdafType, VERIFY_KEY_LENGTH) => {
-                    Self::handle_aggregate_get_generic::<VERIFY_KEY_LENGTH, TimeInterval, VdafType, _>(
+                    Self::handle_aggregate_get_generic::<
+                        VERIFY_KEY_LENGTH,
+                        TimeInterval,
+                        VdafType,
+                        _,
+                    >(
                         datastore,
                         Arc::clone(vdaf),
                         task,
@@ -1618,7 +1682,12 @@ impl VdafOps {
 
             task::BatchMode::LeaderSelected { .. } => {
                 vdaf_ops_dispatch!(self, (vdaf, VdafType, VERIFY_KEY_LENGTH) => {
-                    Self::handle_aggregate_get_generic::<VERIFY_KEY_LENGTH, LeaderSelected, VdafType, _>(
+                    Self::handle_aggregate_get_generic::<
+                        VERIFY_KEY_LENGTH,
+                        LeaderSelected,
+                        VdafType,
+                        _,
+                    >(
                         datastore,
                         Arc::clone(vdaf),
                         task,
@@ -1630,7 +1699,11 @@ impl VdafOps {
         }
     }
 
-    #[tracing::instrument(skip(self, datastore), fields(task_id = ?task.id()), err(level = Level::DEBUG))]
+    #[tracing::instrument(
+        skip(self, datastore),
+        fields(task_id = ?task.id()),
+        err(level = Level::DEBUG)
+    )]
     async fn handle_aggregate_delete<C: Clock>(
         &self,
         datastore: &Datastore<C>,
@@ -1640,7 +1713,12 @@ impl VdafOps {
         match task.batch_mode() {
             task::BatchMode::TimeInterval => {
                 vdaf_ops_dispatch!(self, (_, VdafType, VERIFY_KEY_LENGTH) => {
-                    Self::handle_aggregate_delete_generic::<VERIFY_KEY_LENGTH, TimeInterval, VdafType, _>(
+                    Self::handle_aggregate_delete_generic::<
+                        VERIFY_KEY_LENGTH,
+                        TimeInterval,
+                        VdafType,
+                        _,
+                    >(
                         datastore,
                         task,
                         aggregation_job_id,
@@ -1649,7 +1727,12 @@ impl VdafOps {
             }
             task::BatchMode::LeaderSelected { .. } => {
                 vdaf_ops_dispatch!(self, (_, VdafType, VERIFY_KEY_LENGTH) => {
-                    Self::handle_aggregate_delete_generic::<VERIFY_KEY_LENGTH, LeaderSelected, VdafType, _>(
+                    Self::handle_aggregate_delete_generic::<
+                        VERIFY_KEY_LENGTH,
+                        LeaderSelected,
+                        VdafType,
+                        _,
+                    >(
                         datastore,
                         task,
                         aggregation_job_id,
@@ -2601,14 +2684,14 @@ impl VdafOps {
                                         .cloned()
                                         .collect(),
                                 })
-                            },
-                            Some(AggregationMode::Asynchronous) =>
-                                AggregationJobContinueResult::Async(aggregation_job.step()),
+                            }
+                            Some(AggregationMode::Asynchronous) => {
+                                AggregationJobContinueResult::Async(aggregation_job.step())
+                            }
                             None => {
                                 return Err(datastore::Error::User(
-                                    Error::Internal("task has no aggregation mode".into())
-                                        .into(),
-                                ))
+                                    Error::Internal("task has no aggregation mode".into()).into(),
+                                ));
                             }
                         };
 
@@ -2631,20 +2714,23 @@ impl VdafOps {
 
                     // Pair incoming verification continuation messages with existing report
                     // aggregations.
-                    let mut report_aggregations_to_write = Vec::with_capacity(report_aggregations.len());
+                    let mut report_aggregations_to_write =
+                        Vec::with_capacity(report_aggregations.len());
                     let mut report_aggregations_iter = report_aggregations.into_iter();
                     let mut report_aggregations = Vec::with_capacity(req.verify_continues().len());
                     for verify_continue in req.verify_continues() {
                         let report_aggregation = loop {
-                            let report_aggregation = report_aggregations_iter.next().ok_or_else(|| {
-                                datastore::Error::User(
-                                    Error::InvalidMessage(
-                                        Some(*task.id()),
-                                        "leader sent unexpected, duplicate, or out-of-order verify steps",
+                            let report_aggregation =
+                                report_aggregations_iter.next().ok_or_else(|| {
+                                    datastore::Error::User(
+                                        Error::InvalidMessage(
+                                            Some(*task.id()),
+                                            "leader sent unexpected, duplicate, or out-of-order \
+                                             verify steps",
+                                        )
+                                        .into(),
                                     )
-                                    .into(),
-                                )
-                            })?;
+                                })?;
                             if report_aggregation.report_id() != verify_continue.report_id() {
                                 // This report was omitted by the leader because of a prior failure.
                                 // Note that the report was dropped (if it's not already in an error
@@ -2653,38 +2739,45 @@ impl VdafOps {
                                     report_aggregation.state(),
                                     ReportAggregationState::HelperContinue { .. }
                                 ) {
-                                    report_aggregations_to_write.push(WritableReportAggregation::new(
-                                        report_aggregation
-                                            .with_state(ReportAggregationState::Failed {
-                                                report_error: ReportError::ReportDropped,
-                                            })
-                                            .with_last_verify_resp(None),
-                                        None,
-                                    ));
+                                    report_aggregations_to_write.push(
+                                        WritableReportAggregation::new(
+                                            report_aggregation
+                                                .with_state(ReportAggregationState::Failed {
+                                                    report_error: ReportError::ReportDropped,
+                                                })
+                                                .with_last_verify_resp(None),
+                                            None,
+                                        ),
+                                    );
                                 }
                                 continue;
                             }
                             break report_aggregation;
                         };
 
-                        let verify_state = if let ReportAggregationState::HelperContinue{ verify_state } = report_aggregation.state() {
-                            verify_state.clone()
-                        } else {
-                            return Err(datastore::Error::User(
-                                Error::InvalidMessage(
-                                    Some(*task.id()),
-                                    "leader sent verify step for non-CONTINUE report aggregation",
-                                )
-                                .into(),
-                            ))
+                        let verify_state = match report_aggregation.state() {
+                            ReportAggregationState::HelperContinue { verify_state } => {
+                                verify_state.clone()
+                            }
+                            _ => {
+                                return Err(datastore::Error::User(
+                                    Error::InvalidMessage(
+                                        Some(*task.id()),
+                                        "leader sent verify step for non-CONTINUE report \
+                                         aggregation",
+                                    )
+                                    .into(),
+                                ));
+                            }
                         };
 
-                        report_aggregations.push(report_aggregation
-                            .with_state(ReportAggregationState::HelperContinueProcessing {
-                                verify_state,
-                                verify_continue: verify_continue.clone(),
-                            })
-                            .with_last_verify_resp(None)
+                        report_aggregations.push(
+                            report_aggregation
+                                .with_state(ReportAggregationState::HelperContinueProcessing {
+                                    verify_state,
+                                    verify_continue: verify_continue.clone(),
+                                })
+                                .with_last_verify_resp(None),
                         );
                     }
 
@@ -2712,32 +2805,39 @@ impl VdafOps {
                         .with_last_request_hash(request_hash);
 
                     match task.aggregation_mode() {
-                        Some(AggregationMode::Synchronous) => Self::handle_aggregate_continue_generic_sync(
-                            tx,
-                            task,
-                            vdaf,
-                            batch_aggregation_shard_count,
-                            &metrics,
-                            task_aggregation_counters,
-                            report_aggregations_to_write,
-                            aggregation_job,
-                            report_aggregations,
-                        ).await,
+                        Some(AggregationMode::Synchronous) => {
+                            Self::handle_aggregate_continue_generic_sync(
+                                tx,
+                                task,
+                                vdaf,
+                                batch_aggregation_shard_count,
+                                &metrics,
+                                task_aggregation_counters,
+                                report_aggregations_to_write,
+                                aggregation_job,
+                                report_aggregations,
+                            )
+                            .await
+                        }
 
-                        Some(AggregationMode::Asynchronous) => Self::handle_aggregate_continue_generic_async(
-                            tx,
-                            task,
-                            vdaf,
-                            batch_aggregation_shard_count,
-                            &metrics,
-                            task_aggregation_counters,
-                            report_aggregations_to_write,
-                            aggregation_job,
-                            report_aggregations,
-                        ).await,
+                        Some(AggregationMode::Asynchronous) => {
+                            Self::handle_aggregate_continue_generic_async(
+                                tx,
+                                task,
+                                vdaf,
+                                batch_aggregation_shard_count,
+                                &metrics,
+                                task_aggregation_counters,
+                                report_aggregations_to_write,
+                                aggregation_job,
+                                report_aggregations,
+                            )
+                            .await
+                        }
 
                         None => Err(Error::Internal("task has no aggregation mode".into())),
-                    }.map_err(|err| datastore::Error::User(err.into()))
+                    }
+                    .map_err(|err| datastore::Error::User(err.into()))
                 })
             })
             .await?;
@@ -3176,7 +3276,11 @@ impl VdafOps {
     /// Handle GET requests to the leader's `tasks/{task-id}/collection_jobs/{collection-job-id}`
     /// endpoint. The return value is an encoded `CollectResp<Q>`.
     /// <https://www.ietf.org/archive/id/draft-ietf-ppm-dap-07.html#name-collecting-results>
-    #[tracing::instrument(skip(self, datastore, task), fields(task_id = ?task.id()), err(level = Level::DEBUG))]
+    #[tracing::instrument(
+        skip(self, datastore, task),
+        fields(task_id = ?task.id()),
+        err(level = Level::DEBUG)
+    )]
     async fn handle_get_collection_job<C: Clock>(
         &self,
         datastore: &Datastore<C>,
@@ -3240,12 +3344,20 @@ impl VdafOps {
 
         match collection_job.state() {
             CollectionJobState::Start => {
-                debug!(%collection_job_id, task_id = %task.id(), "collection job has not run yet");
+                debug!(
+                    %collection_job_id,
+                    task_id = %task.id(),
+                    "collection job has not run yet"
+                );
                 Ok(vec![0; 0])
             }
 
             CollectionJobState::Poll => {
-                debug!(%collection_job_id, task_id = %task.id(), "collection job has not completed yet");
+                debug!(
+                    %collection_job_id,
+                    task_id = %task.id(),
+                    "collection job has not completed yet"
+                );
                 Ok(vec![0; 0])
             }
 
@@ -3319,7 +3431,11 @@ impl VdafOps {
         }
     }
 
-    #[tracing::instrument(skip(self, datastore, task), fields(task_id = ?task.id()), err(level = Level::DEBUG))]
+    #[tracing::instrument(
+        skip(self, datastore, task),
+        fields(task_id = ?task.id()),
+        err(level = Level::DEBUG)
+    )]
     async fn handle_delete_collection_job<C: Clock>(
         &self,
         datastore: &Datastore<C>,
@@ -3410,38 +3526,56 @@ impl VdafOps {
     ) -> Result<AggregateShare, Error> {
         match task.batch_mode() {
             task::BatchMode::TimeInterval => {
-                vdaf_ops_dispatch!(self, (vdaf, VdafType, VERIFY_KEY_LENGTH, _dp_strategy, DpStrategyType) => {
-                    Self::handle_get_aggregate_share_generic::<
-                        VERIFY_KEY_LENGTH,
-                        TimeInterval,
-                        DpStrategyType,
+                vdaf_ops_dispatch!(
+                    self,
+                    (
+                        vdaf,
                         VdafType,
-                        _,
-                    >(
-                        datastore,
-                        task,
-                        Arc::clone(vdaf),
-                        collector_hpke_config,
-                        aggregate_share_id
-                    ).await
-                })
+                        VERIFY_KEY_LENGTH,
+                        _dp_strategy,
+                        DpStrategyType
+                    ) => {
+                        Self::handle_get_aggregate_share_generic::<
+                            VERIFY_KEY_LENGTH,
+                            TimeInterval,
+                            DpStrategyType,
+                            VdafType,
+                            _,
+                        >(
+                            datastore,
+                            task,
+                            Arc::clone(vdaf),
+                            collector_hpke_config,
+                            aggregate_share_id
+                        ).await
+                    }
+                )
             }
             task::BatchMode::LeaderSelected { .. } => {
-                vdaf_ops_dispatch!(self, (vdaf, VdafType, VERIFY_KEY_LENGTH, _dp_strategy, DpStrategyType) => {
-                    Self::handle_get_aggregate_share_generic::<
-                        VERIFY_KEY_LENGTH,
-                        LeaderSelected,
-                        DpStrategyType,
+                vdaf_ops_dispatch!(
+                    self,
+                    (
+                        vdaf,
                         VdafType,
-                        _,
-                    >(
-                        datastore,
-                        task,
-                        Arc::clone(vdaf),
-                        collector_hpke_config,
-                        aggregate_share_id,
-                    ).await
-                })
+                        VERIFY_KEY_LENGTH,
+                        _dp_strategy,
+                        DpStrategyType
+                    ) => {
+                        Self::handle_get_aggregate_share_generic::<
+                            VERIFY_KEY_LENGTH,
+                            LeaderSelected,
+                            DpStrategyType,
+                            VdafType,
+                            _,
+                        >(
+                            datastore,
+                            task,
+                            Arc::clone(vdaf),
+                            collector_hpke_config,
+                            aggregate_share_id,
+                        ).await
+                    }
+                )
             }
         }
     }
@@ -3525,48 +3659,66 @@ impl VdafOps {
     ) -> Result<AggregateShare, Error> {
         match task.batch_mode() {
             task::BatchMode::TimeInterval => {
-                vdaf_ops_dispatch!(self, (vdaf, VdafType, VERIFY_KEY_LENGTH, dp_strategy, DpStrategyType) => {
-                    Self::handle_aggregate_share_generic::<
-                        VERIFY_KEY_LENGTH,
-                        TimeInterval,
-                        DpStrategyType,
+                vdaf_ops_dispatch!(
+                    self,
+                    (
+                        vdaf,
                         VdafType,
-                        _,
-                    >(
-                        datastore,
-                        clock,
-                        task,
-                        Arc::clone(vdaf),
-                        req_bytes,
-                        batch_aggregation_shard_count,
-                        max_future_concurrency,
-                        collector_hpke_config,
-                        aggregate_share_id,
-                        Arc::clone(dp_strategy)
-                    ).await
-                })
+                        VERIFY_KEY_LENGTH,
+                        dp_strategy,
+                        DpStrategyType
+                    ) => {
+                        Self::handle_aggregate_share_generic::<
+                            VERIFY_KEY_LENGTH,
+                            TimeInterval,
+                            DpStrategyType,
+                            VdafType,
+                            _,
+                        >(
+                            datastore,
+                            clock,
+                            task,
+                            Arc::clone(vdaf),
+                            req_bytes,
+                            batch_aggregation_shard_count,
+                            max_future_concurrency,
+                            collector_hpke_config,
+                            aggregate_share_id,
+                            Arc::clone(dp_strategy)
+                        ).await
+                    }
+                )
             }
             task::BatchMode::LeaderSelected { .. } => {
-                vdaf_ops_dispatch!(self, (vdaf, VdafType, VERIFY_KEY_LENGTH, dp_strategy, DpStrategyType) => {
-                    Self::handle_aggregate_share_generic::<
-                        VERIFY_KEY_LENGTH,
-                        LeaderSelected,
-                        DpStrategyType,
+                vdaf_ops_dispatch!(
+                    self,
+                    (
+                        vdaf,
                         VdafType,
-                        _,
-                    >(
-                        datastore,
-                        clock,
-                        task,
-                        Arc::clone(vdaf),
-                        req_bytes,
-                        batch_aggregation_shard_count,
-                        max_future_concurrency,
-                        collector_hpke_config,
-                        aggregate_share_id,
-                        Arc::clone(dp_strategy)
-                    ).await
-                })
+                        VERIFY_KEY_LENGTH,
+                        dp_strategy,
+                        DpStrategyType
+                    ) => {
+                        Self::handle_aggregate_share_generic::<
+                            VERIFY_KEY_LENGTH,
+                            LeaderSelected,
+                            DpStrategyType,
+                            VdafType,
+                            _,
+                        >(
+                            datastore,
+                            clock,
+                            task,
+                            Arc::clone(vdaf),
+                            req_bytes,
+                            batch_aggregation_shard_count,
+                            max_future_concurrency,
+                            collector_hpke_config,
+                            aggregate_share_id,
+                            Arc::clone(dp_strategy)
+                        ).await
+                    }
+                )
             }
         }
     }

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -310,13 +310,19 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
         match (task.batch_mode(), task.vdaf()) {
             (task::BatchMode::TimeInterval, VdafInstance::Prio3Count) => {
                 let vdaf = Arc::new(Prio3::new_count(2)?);
-                self.create_aggregation_jobs_for_time_interval_task_no_param::<VERIFY_KEY_LENGTH_PRIO3, Prio3Count>(task, vdaf)
+                self.create_aggregation_jobs_for_time_interval_task_no_param::<
+                    VERIFY_KEY_LENGTH_PRIO3,
+                    Prio3Count,
+                >(task, vdaf)
                     .await
             }
 
             (task::BatchMode::TimeInterval, VdafInstance::Prio3Sum { max_measurement }) => {
                 let vdaf = Arc::new(Prio3::new_sum(2, *max_measurement)?);
-                self.create_aggregation_jobs_for_time_interval_task_no_param::<VERIFY_KEY_LENGTH_PRIO3, Prio3Sum>(task, vdaf)
+                self.create_aggregation_jobs_for_time_interval_task_no_param::<
+                    VERIFY_KEY_LENGTH_PRIO3,
+                    Prio3Sum,
+                >(task, vdaf)
                     .await
             }
 
@@ -335,7 +341,10 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                     *length,
                     *chunk_length,
                 )?);
-                self.create_aggregation_jobs_for_time_interval_task_no_param::<VERIFY_KEY_LENGTH_PRIO3, Prio3SumVec>(task, vdaf)
+                self.create_aggregation_jobs_for_time_interval_task_no_param::<
+                    VERIFY_KEY_LENGTH_PRIO3,
+                    Prio3SumVec,
+                >(task, vdaf)
                     .await
             }
 
@@ -369,7 +378,10 @@ impl<C: Clock + 'static> AggregationJobCreator<C> {
                 },
             ) => {
                 let vdaf = Arc::new(Prio3::new_histogram(2, *length, *chunk_length)?);
-                self.create_aggregation_jobs_for_time_interval_task_no_param::<VERIFY_KEY_LENGTH_PRIO3, Prio3Histogram>(task, vdaf)
+                self.create_aggregation_jobs_for_time_interval_task_no_param::<
+                    VERIFY_KEY_LENGTH_PRIO3,
+                    Prio3Histogram,
+                >(task, vdaf)
                     .await
             }
 
@@ -3325,7 +3337,7 @@ mod tests {
                     .await
                     .unwrap()
                     .into_iter()
-                    .map(|agg_job| async {
+                    .map(|agg_job: AggregationJob<SEED_SIZE, B, A>| async {
                         let agg_job_id = *agg_job.id();
                         let report_aggs = tx
                             .get_report_aggregations_for_aggregation_job(
@@ -3338,16 +3350,15 @@ mod tests {
                             .unwrap();
 
                         for ra in &report_aggs {
-                            // AggregationJob<_, _, A>::aggregation_parameter returns
-                            // &A::AggregationParam, but we nonetheless need this cast or the
-                            // compiler won't let us call clone
-                            let agg_param = (agg_job.aggregation_parameter() as &A::AggregationParam).clone();
+                            let agg_param = agg_job.aggregation_parameter().clone();
                             let want_ra_state = want_ra_states
                                 .get(&(*ra.report_id(), agg_param))
                                 .unwrap_or_else(|| {
                                     panic!(
-                                        "found report aggregation for unknown report {} aggregation param {:?}",
-                                        ra.report_id(), agg_job.aggregation_parameter(),
+                                        "found report aggregation for unknown report {} \
+                                         aggregation param {:?}",
+                                        ra.report_id(),
+                                        agg_job.aggregation_parameter(),
                                     )
                                 });
                             assert_eq!(want_ra_state, ra.state());

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -191,7 +191,12 @@ where
         match lease.leased().batch_mode() {
             task::BatchMode::TimeInterval => {
                 vdaf_dispatch!(lease.leased().vdaf(), (vdaf, VdafType, VERIFY_KEY_LENGTH) => {
-                    self.step_aggregation_job_generic::<VERIFY_KEY_LENGTH, C, TimeInterval, VdafType>(
+                    self.step_aggregation_job_generic::<
+                        VERIFY_KEY_LENGTH,
+                        C,
+                        TimeInterval,
+                        VdafType,
+                    >(
                         datastore,
                         hpke_keypairs,
                         Arc::new(vdaf),
@@ -201,7 +206,12 @@ where
             }
             task::BatchMode::LeaderSelected { .. } => {
                 vdaf_dispatch!(lease.leased().vdaf(), (vdaf, VdafType, VERIFY_KEY_LENGTH) => {
-                    self.step_aggregation_job_generic::<VERIFY_KEY_LENGTH, C, LeaderSelected, VdafType>(
+                    self.step_aggregation_job_generic::<
+                        VERIFY_KEY_LENGTH,
+                        C,
+                        LeaderSelected,
+                        VdafType,
+                    >(
                         datastore,
                         hpke_keypairs,
                         Arc::new(vdaf),

--- a/aggregator/src/aggregator/aggregation_job_driver/tests.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver/tests.rs
@@ -850,9 +850,12 @@ async fn leader_sync_time_interval_aggregation_job_init_single_step() {
             let vdaf = Arc::clone(&vdaf);
             let task = task.clone();
             let report_id = *report.metadata().id();
-            let repeated_public_extension_report_id = *repeated_public_extension_report.metadata().id();
-            let repeated_private_extension_report_id = *repeated_private_extension_report.metadata().id();
-            let repeated_public_private_extension_report_id = *repeated_public_private_extension_report.metadata().id();
+            let repeated_public_extension_report_id =
+                *repeated_public_extension_report.metadata().id();
+            let repeated_private_extension_report_id =
+                *repeated_private_extension_report.metadata().id();
+            let repeated_public_private_extension_report_id =
+                *repeated_public_private_extension_report.metadata().id();
 
             Box::pin(async move {
                 let aggregation_job = tx
@@ -908,7 +911,11 @@ async fn leader_sync_time_interval_aggregation_job_init_single_step() {
                     .unwrap()
                     .unwrap();
                 let batch_aggregations = merge_batch_aggregations_by_batch(
-                    tx.get_batch_aggregations_for_task::<VERIFY_KEY_LENGTH_PRIO3, TimeInterval, Prio3Count>(&vdaf, task.id())
+                    tx.get_batch_aggregations_for_task::<
+                        VERIFY_KEY_LENGTH_PRIO3,
+                        TimeInterval,
+                        Prio3Count,
+                    >(&vdaf, task.id())
                         .await
                         .unwrap(),
                 );
@@ -1621,7 +1628,11 @@ async fn leader_sync_time_interval_aggregation_job_init_partially_garbage_collec
                     .await
                     .unwrap();
                 let batch_aggregations = merge_batch_aggregations_by_batch(
-                    tx.get_batch_aggregations_for_task::<VERIFY_KEY_LENGTH_PRIO3, TimeInterval, Prio3Count>(&vdaf, task.id())
+                    tx.get_batch_aggregations_for_task::<
+                        VERIFY_KEY_LENGTH_PRIO3,
+                        TimeInterval,
+                        Prio3Count,
+                    >(&vdaf, task.id())
                         .await
                         .unwrap(),
                 );
@@ -1938,7 +1949,11 @@ async fn leader_sync_leader_selected_aggregation_job_init_single_step() {
                     .unwrap()
                     .unwrap();
                 let batch_aggregations = merge_batch_aggregations_by_batch(
-                    tx.get_batch_aggregations_for_task::<VERIFY_KEY_LENGTH_PRIO3, LeaderSelected, Prio3Count>(
+                    tx.get_batch_aggregations_for_task::<
+                        VERIFY_KEY_LENGTH_PRIO3,
+                        LeaderSelected,
+                        Prio3Count,
+                    >(
                         &vdaf,
                         task.id(),
                     )
@@ -2468,7 +2483,10 @@ async fn leader_sync_time_interval_aggregation_job_continue() {
         error,
         Error::Http(error_response) => {
             assert_eq!(error_response.status(), StatusCode::INTERNAL_SERVER_ERROR);
-            assert_eq!(*error_response.dap_problem_type().unwrap(), DapProblemType::UnrecognizedTask);
+            assert_eq!(
+                *error_response.dap_problem_type().unwrap(),
+                DapProblemType::UnrecognizedTask
+            );
         }
     );
     aggregation_job_driver
@@ -6108,7 +6126,7 @@ async fn cancel_aggregation_job() {
         },
     )]);
 
-    let (got_aggregation_job, got_report_aggregation, got_batch_aggregations, got_leases) = test_case
+    let (got_aggregation_job, got_report_aggregation, got_batch_aggs, got_leases) = test_case
         .datastore
         .run_unnamed_tx(|tx| {
             let (vdaf, task, report_id, aggregation_job) = (
@@ -6138,7 +6156,11 @@ async fn cancel_aggregation_job() {
                     .unwrap()
                     .unwrap();
                 let batch_aggregations = merge_batch_aggregations_by_batch(
-                    tx.get_batch_aggregations_for_task::<VERIFY_KEY_LENGTH_PRIO3, TimeInterval, Prio3Count>(&vdaf, task.id())
+                    tx.get_batch_aggregations_for_task::<
+                        VERIFY_KEY_LENGTH_PRIO3,
+                        TimeInterval,
+                        Prio3Count,
+                    >(&vdaf, task.id())
                         .await
                         .unwrap(),
                 );
@@ -6146,14 +6168,19 @@ async fn cancel_aggregation_job() {
                     .acquire_incomplete_aggregation_jobs(&StdDuration::from_secs(60), 1)
                     .await
                     .unwrap();
-                Ok((aggregation_job, report_aggregation, batch_aggregations, leases))
+                Ok((
+                    aggregation_job,
+                    report_aggregation,
+                    batch_aggregations,
+                    leases,
+                ))
             })
         })
         .await
         .unwrap();
     assert_eq!(want_aggregation_job, got_aggregation_job);
     assert_eq!(test_case.report_aggregation, got_report_aggregation);
-    assert_eq!(want_batch_aggregations, got_batch_aggregations);
+    assert_eq!(want_batch_aggregations, got_batch_aggs);
     assert!(got_leases.is_empty());
 }
 
@@ -6404,7 +6431,11 @@ async fn abandon_failing_aggregation_job_with_retryable_error() {
                     .unwrap()
                     .unwrap();
                 let got_batch_aggregations = merge_batch_aggregations_by_batch(
-                    tx.get_batch_aggregations_for_task::<VERIFY_KEY_LENGTH_PRIO3, TimeInterval, Prio3Count>(&vdaf, task.id())
+                    tx.get_batch_aggregations_for_task::<
+                        VERIFY_KEY_LENGTH_PRIO3,
+                        TimeInterval,
+                        Prio3Count,
+                    >(&vdaf, task.id())
                         .await
                         .unwrap(),
                 );
@@ -6645,7 +6676,11 @@ async fn abandon_failing_aggregation_job_with_fatal_error() {
                     .unwrap()
                     .unwrap();
                 let got_batch_aggregations = merge_batch_aggregations_by_batch(
-                    tx.get_batch_aggregations_for_task::<VERIFY_KEY_LENGTH_PRIO3, TimeInterval, Prio3Count>(&vdaf, task.id())
+                    tx.get_batch_aggregations_for_task::<
+                        VERIFY_KEY_LENGTH_PRIO3,
+                        TimeInterval,
+                        Prio3Count,
+                    >(&vdaf, task.id())
                         .await
                         .unwrap(),
                 );

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -106,28 +106,46 @@ impl CollectionJobDriver {
     ) -> Result<(), Error> {
         match lease.leased().batch_mode() {
             task::BatchMode::TimeInterval => {
-                vdaf_dispatch!(lease.leased().vdaf(), (vdaf, VdafType, VERIFY_KEY_LENGTH, dp_strategy, DpStrategy) => {
-                    self.step_collection_job_generic::<
+                vdaf_dispatch!(
+                    lease.leased().vdaf(),
+                    (
+                        vdaf,
+                        VdafType,
                         VERIFY_KEY_LENGTH,
-                        C,
-                        TimeInterval,
-                        DpStrategy,
-                        VdafType
-                    >(datastore, clock, Arc::new(vdaf), lease, dp_strategy)
-                    .await
-                })
+                        dp_strategy,
+                        DpStrategy
+                    ) => {
+                        self.step_collection_job_generic::<
+                            VERIFY_KEY_LENGTH,
+                            C,
+                            TimeInterval,
+                            DpStrategy,
+                            VdafType,
+                        >(datastore, clock, Arc::new(vdaf), lease, dp_strategy)
+                        .await
+                    }
+                )
             }
             task::BatchMode::LeaderSelected { .. } => {
-                vdaf_dispatch!(lease.leased().vdaf(), (vdaf, VdafType, VERIFY_KEY_LENGTH, dp_strategy, DpStrategy) => {
-                    self.step_collection_job_generic::<
+                vdaf_dispatch!(
+                    lease.leased().vdaf(),
+                    (
+                        vdaf,
+                        VdafType,
                         VERIFY_KEY_LENGTH,
-                        C,
-                        LeaderSelected,
-                        DpStrategy,
-                        VdafType
-                    >(datastore, clock, Arc::new(vdaf), lease, dp_strategy)
-                    .await
-                })
+                        dp_strategy,
+                        DpStrategy
+                    ) => {
+                        self.step_collection_job_generic::<
+                            VERIFY_KEY_LENGTH,
+                            C,
+                            LeaderSelected,
+                            DpStrategy,
+                            VdafType,
+                        >(datastore, clock, Arc::new(vdaf), lease, dp_strategy)
+                        .await
+                    }
+                )
             }
         }
     }
@@ -584,7 +602,12 @@ impl CollectionJobDriver {
         match lease.leased().batch_mode() {
             task::BatchMode::TimeInterval => {
                 vdaf_dispatch!(lease.leased().vdaf(), (vdaf, VdafType, VERIFY_KEY_LENGTH) => {
-                    self.abandon_collection_job_generic::<VERIFY_KEY_LENGTH, C, TimeInterval, VdafType>(
+                    self.abandon_collection_job_generic::<
+                        VERIFY_KEY_LENGTH,
+                        C,
+                        TimeInterval,
+                        VdafType,
+                    >(
                         datastore,
                         Arc::new(vdaf),
                         lease,
@@ -594,7 +617,12 @@ impl CollectionJobDriver {
             }
             task::BatchMode::LeaderSelected { .. } => {
                 vdaf_dispatch!(lease.leased().vdaf(), (vdaf, VdafType, VERIFY_KEY_LENGTH) => {
-                    self.abandon_collection_job_generic::<VERIFY_KEY_LENGTH, C, LeaderSelected, VdafType>(
+                    self.abandon_collection_job_generic::<
+                        VERIFY_KEY_LENGTH,
+                        C,
+                        LeaderSelected,
+                        VdafType,
+                    >(
                         datastore,
                         Arc::new(vdaf),
                         lease,
@@ -1407,7 +1435,10 @@ mod tests {
         assert_matches!(
             error,
             Error::Http(error_response) => {
-                assert_matches!(error_response.dap_problem_type(), Some(DapProblemType::InvalidMessage));
+                assert_matches!(
+                    error_response.dap_problem_type(),
+                    Some(DapProblemType::InvalidMessage)
+                );
                 assert_eq!(error_response.status(), StatusCode::BAD_REQUEST);
             }
         );
@@ -1497,20 +1528,35 @@ mod tests {
                     .unwrap()
                     .unwrap();
 
-                assert_matches!(collection_job.state(), CollectionJobState::Finished{ report_count, client_timestamp_interval, encrypted_helper_aggregate_share, leader_aggregate_share } => {
-                    assert_eq!(report_count, &10);
-                    assert_eq!(
+                assert_matches!(
+                    collection_job.state(),
+                    CollectionJobState::Finished {
+                        report_count,
                         client_timestamp_interval,
-                        &Interval::new(
-                            clock.now().to_time(&time_precision),
-                            Duration::from_time_precision_units(3),
-                        ).unwrap()
-                    );
-                    assert_eq!(encrypted_helper_aggregate_share, &helper_aggregate_share);
-                    assert_eq!(leader_aggregate_share, &dummy::AggregateShare(0));
-                });
+                        encrypted_helper_aggregate_share,
+                        leader_aggregate_share,
+                    } => {
+                        assert_eq!(report_count, &10);
+                        assert_eq!(
+                            client_timestamp_interval,
+                            &Interval::new(
+                                clock.now().to_time(&time_precision),
+                                Duration::from_time_precision_units(3),
+                            )
+                            .unwrap()
+                        );
+                        assert_eq!(encrypted_helper_aggregate_share, &helper_aggregate_share);
+                        assert_eq!(leader_aggregate_share, &dummy::AggregateShare(0));
+                    }
+                );
 
-                let batch_aggregations = tx.get_batch_aggregations_for_task::<0, TimeInterval, dummy::Vdaf>(&dummy::Vdaf::new(1), &task_id).await.unwrap();
+                let batch_aggregations = tx
+                    .get_batch_aggregations_for_task::<0, TimeInterval, dummy::Vdaf>(
+                        &dummy::Vdaf::new(1),
+                        &task_id,
+                    )
+                    .await
+                    .unwrap();
                 assert_eq!(batch_aggregations.len(), 128);
                 for batch_aggregation in batch_aggregations {
                     assert_matches!(batch_aggregation.state(), BatchAggregationState::Scrubbed);
@@ -1579,18 +1625,27 @@ mod tests {
                     .unwrap()
                     .unwrap();
 
-                assert_matches!(collection_job.state(), CollectionJobState::Finished{ report_count, client_timestamp_interval, encrypted_helper_aggregate_share, leader_aggregate_share } => {
-                    assert_eq!(report_count, &10);
-                    assert_eq!(
+                assert_matches!(
+                    collection_job.state(),
+                    CollectionJobState::Finished {
+                        report_count,
                         client_timestamp_interval,
-                        &Interval::new(
-                            clock.now().to_time(&time_precision),
-                            Duration::from_time_precision_units(3),
-                        ).unwrap()
-                    );
-                    assert_eq!(encrypted_helper_aggregate_share, &helper_aggregate_share);
-                    assert_eq!(leader_aggregate_share, &dummy::AggregateShare(0));
-                });
+                        encrypted_helper_aggregate_share,
+                        leader_aggregate_share,
+                    } => {
+                        assert_eq!(report_count, &10);
+                        assert_eq!(
+                            client_timestamp_interval,
+                            &Interval::new(
+                                clock.now().to_time(&time_precision),
+                                Duration::from_time_precision_units(3),
+                            )
+                            .unwrap()
+                        );
+                        assert_eq!(encrypted_helper_aggregate_share, &helper_aggregate_share);
+                        assert_eq!(leader_aggregate_share, &dummy::AggregateShare(0));
+                    }
+                );
 
                 Ok(())
             })
@@ -2269,8 +2324,11 @@ mod tests {
                     .unwrap()
                     .unwrap();
 
-                assert_matches!(collection_job.state(), CollectionJobState::Finished{
-                    report_count, leader_aggregate_share, encrypted_helper_aggregate_share, client_timestamp_interval: _
+                assert_matches!(collection_job.state(), CollectionJobState::Finished {
+                    report_count,
+                    leader_aggregate_share,
+                    encrypted_helper_aggregate_share,
+                    client_timestamp_interval: _,
                 } => {
                     assert_eq!(report_count, &10);
                     assert_eq!(leader_aggregate_share, &dummy::AggregateShare(0));

--- a/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
@@ -532,7 +532,11 @@ async fn aggregate_share_request() {
                                 let task_id = *task.id();
 
                                 async move {
-                                    tx.get_batch_aggregations_for_batch::<0, TimeInterval, dummy::Vdaf>(
+                                    tx.get_batch_aggregations_for_batch::<
+                                        0,
+                                        TimeInterval,
+                                        dummy::Vdaf,
+                                    >(
                                         &dummy::Vdaf::new(1),
                                         &task_id,
                                         &batch_identifier,

--- a/aggregator/src/aggregator/problem_details.rs
+++ b/aggregator/src/aggregator/problem_details.rs
@@ -246,10 +246,7 @@ mod tests {
                     Box::new(|| Error::UnrecognizedAggregationJob(random(), random())),
                     Some(DapProblemType::UnrecognizedAggregationJob),
                 ),
-                TestCase::new(
-                    Box::new(|| Error::UnauthorizedRequest(random())),
-                    None,
-                ),
+                TestCase::new(Box::new(|| Error::UnauthorizedRequest(random())), None),
                 TestCase::new(
                     Box::new(|| Error::InvalidBatchSize(random(), 8)),
                     Some(DapProblemType::InvalidBatchSize),
@@ -261,7 +258,9 @@ mod tests {
                             format!(
                                 "{}",
                                 Interval::new(
-                                    RealClock::default().now().to_time(&TimePrecision::from_seconds(1)),
+                                    RealClock::default()
+                                        .now()
+                                        .to_time(&TimePrecision::from_seconds(1)),
                                     Duration::from_seconds(3600, &TimePrecision::from_seconds(1))
                                 )
                                 .unwrap()
@@ -274,8 +273,13 @@ mod tests {
                     Box::new(|| {
                         Error::BatchOverlap(
                             random(),
-                            Interval::new(RealClock::default().now().to_time(&TimePrecision::from_seconds(1)), Duration::from_seconds(3600, &TimePrecision::from_seconds(1)))
-                                .unwrap(),
+                            Interval::new(
+                                RealClock::default()
+                                    .now()
+                                    .to_time(&TimePrecision::from_seconds(1)),
+                                Duration::from_seconds(3600, &TimePrecision::from_seconds(1)),
+                            )
+                            .unwrap(),
                         )
                     }),
                     Some(DapProblemType::BatchOverlap),
@@ -292,14 +296,8 @@ mod tests {
                     }),
                     Some(DapProblemType::BatchMismatch),
                 ),
-                TestCase::new(
-                    Box::new(|| Error::TooManyRequests),
-                    None,
-                ),
-                TestCase::new(
-                    Box::new(|| Error::RequestTimeout),
-                    None,
-                ),
+                TestCase::new(Box::new(|| Error::TooManyRequests), None),
+                TestCase::new(Box::new(|| Error::RequestTimeout), None),
             ]
             .into_iter()
             .map(|test_case| {
@@ -344,7 +342,10 @@ mod tests {
                     assert_matches!(
                         actual_error,
                         Error::Http(error_response) => {
-                            assert_eq!(error_response.dap_problem_type(), test_case.expected_problem_type.as_ref());
+                            assert_eq!(
+                                error_response.dap_problem_type(),
+                                test_case.expected_problem_type.as_ref()
+                            );
                         }
                     );
                 }

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -5305,11 +5305,12 @@ ord, type, token FROM taskprov_collector_auth_tokens AS a
             .await?;
         let collector_auth_token_rows = self.query(&stmt, &[]);
 
-        let (peer_aggregator_rows, aggregator_auth_token_rows, collector_auth_token_rows) = try_join!(
+        let rows = try_join!(
             peer_aggregator_rows,
             aggregator_auth_token_rows,
             collector_auth_token_rows,
         )?;
+        let (peer_aggregator_rows, aggregator_auth_token_rows, collector_auth_token_rows) = rows;
 
         let mut aggregator_auth_token_rows_by_peer_id: HashMap<i64, Vec<Row>> = HashMap::new();
         for row in aggregator_auth_token_rows {
@@ -5386,11 +5387,12 @@ SELECT ord, type, token FROM taskprov_collector_auth_tokens
             .await?;
         let collector_auth_token_rows = self.query(&stmt, params);
 
-        let (peer_aggregator_row, aggregator_auth_token_rows, collector_auth_token_rows) = try_join!(
+        let rows = try_join!(
             peer_aggregator_row,
             aggregator_auth_token_rows,
             collector_auth_token_rows,
         )?;
+        let (peer_aggregator_row, aggregator_auth_token_rows, collector_auth_token_rows) = rows;
         peer_aggregator_row
             .map(|peer_aggregator_row| {
                 self.taskprov_peer_aggregator_from_rows(

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -2087,16 +2087,24 @@ async fn aggregation_job_acquire_release(ephemeral_datastore: EphemeralDatastore
     ds.run_unnamed_tx(|tx| {
         let (task, mut maybe_leased_aggregation_job_ids) = (
             leader_task.clone(),
-            leader_aggregation_job_ids.clone().into_iter().chain(
-                // When we get leases, we expect to see the finished and expired jobs (because we
-                // haven't advanced time yet), but not the helper job (because we query on the
-                // leader task).
-                Vec::from([finished_aggregation_job_id, expired_aggregation_job_id])).collect::<Vec<_>>(),
-
+            leader_aggregation_job_ids
+                .clone()
+                .into_iter()
+                .chain(
+                    // When we get leases, we expect to see the finished and expired jobs (because
+                    // we haven't advanced time yet), but not the helper job
+                    // (because we query on the leader task).
+                    Vec::from([finished_aggregation_job_id, expired_aggregation_job_id]),
+                )
+                .collect::<Vec<_>>(),
         );
         Box::pin(async move {
             let maybe_leases = tx
-                .get_aggregation_job_leases_by_task::<VERIFY_KEY_LENGTH_PRIO3, TimeInterval, Prio3Count>(
+                .get_aggregation_job_leases_by_task::<
+                    VERIFY_KEY_LENGTH_PRIO3,
+                    TimeInterval,
+                    Prio3Count,
+                >(
                     task.id(),
                 )
                 .await
@@ -2116,7 +2124,11 @@ async fn aggregation_job_acquire_release(ephemeral_datastore: EphemeralDatastore
             assert_eq!(maybe_leased_aggregation_job_ids, seen_aggregation_job_ids);
 
             let no_such_task = tx
-                .get_aggregation_job_leases_by_task::<VERIFY_KEY_LENGTH_PRIO3, TimeInterval, Prio3Count>(
+                .get_aggregation_job_leases_by_task::<
+                    VERIFY_KEY_LENGTH_PRIO3,
+                    TimeInterval,
+                    Prio3Count,
+                >(
                     &random(),
                 )
                 .await
@@ -2270,7 +2282,11 @@ async fn aggregation_job_acquire_release(ephemeral_datastore: EphemeralDatastore
         );
         Box::pin(async move {
             let maybe_leases = tx
-                .get_aggregation_job_leases_by_task::<VERIFY_KEY_LENGTH_PRIO3, TimeInterval, Prio3Count>(
+                .get_aggregation_job_leases_by_task::<
+                    VERIFY_KEY_LENGTH_PRIO3,
+                    TimeInterval,
+                    Prio3Count,
+                >(
                     task.id(),
                 )
                 .await
@@ -2955,20 +2971,19 @@ SELECT updated_at, updated_by FROM report_aggregations
         // Make a "new" report aggregation with the same ID, but which is not expired. It should get
         // upserted, replacing the effectively GCed report aggregation.
         ds.run_unnamed_tx(|tx| {
-            let unexpired_report_aggregation = report_aggregation.clone().with_time(clock.now().to_time(&TIME_PRECISION));
+            let unexpired_report_aggregation = report_aggregation
+                .clone()
+                .with_time(clock.now().to_time(&TIME_PRECISION));
             Box::pin(async move {
                 tx.put_report_aggregation(&unexpired_report_aggregation)
                     .await
                     .unwrap();
 
-                let row = tx
-                    .query_one(
-                        "SELECT client_timestamp FROM report_aggregations WHERE client_report_id = $1",
-                        &[&report_id.as_ref()],
-                    )
-                    .await
-                    .unwrap();
-                let client_timestamp = Time::from_date_time(row.get("client_timestamp"), TIME_PRECISION);
+                let sql =
+                    "SELECT client_timestamp FROM report_aggregations WHERE client_report_id = $1";
+                let row = tx.query_one(sql, &[&report_id.as_ref()]).await.unwrap();
+                let client_timestamp =
+                    Time::from_date_time(row.get("client_timestamp"), TIME_PRECISION);
 
                 assert_eq!(unexpired_report_aggregation.time(), &client_timestamp);
 
@@ -5737,7 +5752,10 @@ async fn roundtrip_batch_aggregation_time_interval(ephemeral_datastore: Ephemera
                     task.id(),
                     &vdaf,
                     &Interval::new(
-                        Time::from_seconds_since_epoch(START_TIMESTAMP + 100, task.time_precision()),
+                        Time::from_seconds_since_epoch(
+                            START_TIMESTAMP + 100,
+                            task.time_precision(),
+                        ),
                         Duration::from_time_precision_units(4)
                     )
                     .unwrap(),
@@ -5764,8 +5782,11 @@ async fn roundtrip_batch_aggregation_time_interval(ephemeral_datastore: Ephemera
                 *first_batch_aggregation.batch_interval(),
                 *first_batch_aggregation.aggregation_parameter(),
                 first_batch_aggregation.ord(),
-                Interval::minimal(Time::from_seconds_since_epoch(START_TIMESTAMP + 100, task.time_precision()))
-                    .unwrap(),
+                Interval::minimal(Time::from_seconds_since_epoch(
+                    START_TIMESTAMP + 100,
+                    task.time_precision(),
+                ))
+                .unwrap(),
                 BatchAggregationState::Aggregating {
                     aggregate_share: Some(dummy::AggregateShare(92)),
                     report_count: 1,
@@ -5788,7 +5809,10 @@ async fn roundtrip_batch_aggregation_time_interval(ephemeral_datastore: Ephemera
                     task.id(),
                     &vdaf,
                     &Interval::new(
-                        Time::from_seconds_since_epoch(START_TIMESTAMP + 100, task.time_precision()),
+                        Time::from_seconds_since_epoch(
+                            START_TIMESTAMP + 100,
+                            task.time_precision(),
+                        ),
                         Duration::from_time_precision_units(4),
                     )
                     .unwrap(),
@@ -5834,7 +5858,10 @@ async fn roundtrip_batch_aggregation_time_interval(ephemeral_datastore: Ephemera
                     task.id(),
                     &vdaf,
                     &Interval::new(
-                        Time::from_seconds_since_epoch(START_TIMESTAMP + 100, task.time_precision()),
+                        Time::from_seconds_since_epoch(
+                            START_TIMESTAMP + 100,
+                            task.time_precision(),
+                        ),
                         Duration::from_time_precision_units(3)
                     )
                     .unwrap(),

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -1940,7 +1940,12 @@ mod tests {
             ),
             Ok(BatchMode::LeaderSelected {
                 batch_time_window_size: Some(duration),
-            }) => assert_eq!(duration, Duration::from_seconds(3600, &TimePrecision::from_seconds(1)))
+            }) => {
+                assert_eq!(
+                    duration,
+                    Duration::from_seconds(3600, &TimePrecision::from_seconds(1))
+                );
+            }
         );
     }
 }

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -1531,7 +1531,9 @@ mod tests {
         let poll_result = collector.poll_once(&job).await.unwrap();
         assert_matches!(
             poll_result,
-            PollResult::NotReady(Some(RetryAfter::Delay(duration))) => assert_eq!(duration, std::time::Duration::from_secs(65535))
+            PollResult::NotReady(Some(RetryAfter::Delay(duration))) => {
+                assert_eq!(duration, std::time::Duration::from_secs(65535));
+            }
         );
 
         mock_collection_job_empty_body_with_retry
@@ -1727,7 +1729,9 @@ mod tests {
             .await;
         assert_matches!(
             collector.poll_once(&job).await.unwrap(),
-            PollResult::NotReady(Some(RetryAfter::Delay(duration))) => assert_eq!(duration, std::time::Duration::from_secs(60))
+            PollResult::NotReady(Some(RetryAfter::Delay(duration))) => {
+                assert_eq!(duration, std::time::Duration::from_secs(60));
+            }
         );
         mock_collect_poll_retry_after_60s.assert_async().await;
 
@@ -1741,7 +1745,9 @@ mod tests {
         let ref_date_time = Utc.with_ymd_and_hms(2015, 10, 21, 7, 28, 0).unwrap();
         assert_matches!(
             collector.poll_once(&job).await.unwrap(),
-            PollResult::NotReady(Some(RetryAfter::DateTime(system_time))) => assert_eq!(system_time, SystemTime::from(ref_date_time))
+            PollResult::NotReady(Some(RetryAfter::DateTime(system_time))) => {
+                assert_eq!(system_time, SystemTime::from(ref_date_time));
+            }
         );
         mock_collect_poll_retry_after_date_time.assert_async().await;
     }

--- a/core/src/vdaf.rs
+++ b/core/src/vdaf.rs
@@ -212,7 +212,21 @@ pub fn new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128<
 /// Internal implementation details of [`vdaf_dispatch`](crate::vdaf_dispatch).
 #[macro_export]
 macro_rules! vdaf_dispatch_impl_base {
-    (impl match base $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LEN:ident, $dp_strategy:ident, $DpStrategy:ident) => $body:tt) => {
+    (
+        impl
+        match
+        base
+        $vdaf_instance:expr,
+        (
+            $vdaf:ident,
+            $Vdaf:ident,
+            $VERIFY_KEY_LEN:ident,
+            $dp_strategy:ident,
+            $DpStrategy:ident
+        )
+        =>
+        $body:tt
+    ) => {
         match $vdaf_instance {
             ::janus_core::vdaf::VdafInstance::Prio3Count => {
                 let $vdaf = ::prio::vdaf::prio3::Prio3::new_count(2)?;
@@ -238,8 +252,12 @@ macro_rules! vdaf_dispatch_impl_base {
                 chunk_length,
                 dp_strategy,
             } => {
-                let $vdaf =
-                    ::prio::vdaf::prio3::Prio3::new_sum_vec(2, *max_measurement as u128, *length, *chunk_length)?;
+                let $vdaf = ::prio::vdaf::prio3::Prio3::new_sum_vec(
+                    2,
+                    *max_measurement as u128,
+                    *length,
+                    *chunk_length,
+                )?;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3SumVec;
                 const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH_PRIO3;
                 match dp_strategy.clone() {
@@ -301,16 +319,18 @@ macro_rules! vdaf_dispatch_impl_base {
                 chunk_length,
                 dp_strategy,
             } => {
+                use ::janus_core::vdaf::vdaf_dp_strategies;
+
                 let $vdaf = ::prio::vdaf::prio3::Prio3::new_histogram(2, *length, *chunk_length)?;
                 type $Vdaf = ::prio::vdaf::prio3::Prio3Histogram;
                 const $VERIFY_KEY_LEN: usize = ::janus_core::vdaf::VERIFY_KEY_LENGTH_PRIO3;
                 match dp_strategy.clone() {
-                    ::janus_core::vdaf::vdaf_dp_strategies::Prio3Histogram::NoDifferentialPrivacy => {
+                    vdaf_dp_strategies::Prio3Histogram::NoDifferentialPrivacy => {
                         type $DpStrategy = janus_core::dp::NoDifferentialPrivacy;
                         let $dp_strategy = janus_core::dp::NoDifferentialPrivacy;
                         $body
                     }
-                    ::janus_core::vdaf::vdaf_dp_strategies::Prio3Histogram::PureDpDiscreteLaplace(_strategy) => {
+                    vdaf_dp_strategies::Prio3Histogram::PureDpDiscreteLaplace(_strategy) => {
                         type $DpStrategy = ::prio::dp::distributions::PureDpDiscreteLaplace;
                         let $dp_strategy = _strategy;
                         $body
@@ -327,7 +347,19 @@ macro_rules! vdaf_dispatch_impl_base {
 #[cfg(feature = "test-util")]
 #[macro_export]
 macro_rules! vdaf_dispatch_impl_test_util {
-    (impl match test_util $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LEN:ident, $dp_strategy:ident, $DpStrategy:ident) => $body:tt) => {
+    (
+        impl
+        match
+        test_util
+        $vdaf_instance:expr,
+        (
+            $vdaf:ident,
+            $Vdaf:ident,
+            $VERIFY_KEY_LEN:ident,
+            $dp_strategy:ident,
+            $DpStrategy:ident
+        ) => $body:tt
+    ) => {
         match $vdaf_instance {
             ::janus_core::vdaf::VdafInstance::Fake { rounds } => {
                 let $vdaf = ::prio::vdaf::dummy::Vdaf::new(*rounds);
@@ -373,20 +405,61 @@ macro_rules! vdaf_dispatch_impl_test_util {
 #[cfg(feature = "test-util")]
 #[macro_export]
 macro_rules! vdaf_dispatch_impl {
-    (impl match all $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LEN:ident, $dp_strategy:ident, $DpStrategy:ident) => $body:tt) => {
+    (
+        impl
+        match
+        all
+        $vdaf_instance:expr,
+        (
+            $vdaf:ident,
+            $Vdaf:ident,
+            $VERIFY_KEY_LEN:ident,
+            $dp_strategy:ident,
+            $DpStrategy:ident
+        ) =>
+        $body:tt
+    ) => {
         match $vdaf_instance {
             ::janus_core::vdaf::VdafInstance::Prio3Count
             | ::janus_core::vdaf::VdafInstance::Prio3Sum { .. }
             | ::janus_core::vdaf::VdafInstance::Prio3SumVec { .. }
             | ::janus_core::vdaf::VdafInstance::Prio3SumVecField64MultiproofHmacSha256Aes128 { .. }
             | ::janus_core::vdaf::VdafInstance::Prio3Histogram { .. } => {
-                ::janus_core::vdaf_dispatch_impl_base!(impl match base $vdaf_instance, ($vdaf, $Vdaf, $VERIFY_KEY_LEN, $dp_strategy, $DpStrategy) => $body)
+                ::janus_core::vdaf_dispatch_impl_base!(
+                    impl
+                    match
+                    base
+                    $vdaf_instance,
+                    (
+                        $vdaf,
+                        $Vdaf,
+                        $VERIFY_KEY_LEN,
+                        $dp_strategy,
+                        $DpStrategy
+                    )
+                    =>
+                    $body
+                )
             }
 
             ::janus_core::vdaf::VdafInstance::Fake { .. }
             | ::janus_core::vdaf::VdafInstance::FakeFailsVerifyInit
             | ::janus_core::vdaf::VdafInstance::FakeFailsVerifyStep => {
-                ::janus_core::vdaf_dispatch_impl_test_util!(impl match test_util $vdaf_instance, ($vdaf, $Vdaf, $VERIFY_KEY_LEN, $dp_strategy, $DpStrategy) => $body)
+                ::janus_core::vdaf_dispatch_impl_test_util!(
+                    impl
+                    match
+                    test_util
+                    $vdaf_instance,
+                    (
+                        $vdaf,
+                        $Vdaf,
+                        $VERIFY_KEY_LEN,
+                        $dp_strategy,
+                        $DpStrategy
+                    )
+                    =>
+                    $body
+                )
             }
 
             _ => panic!("VDAF {:?} is not yet supported", $vdaf_instance),
@@ -398,14 +471,42 @@ macro_rules! vdaf_dispatch_impl {
 #[cfg(not(feature = "test-util"))]
 #[macro_export]
 macro_rules! vdaf_dispatch_impl {
-    (impl match all $vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LEN:ident, $dp_strategy:ident, $DpStrategy:ident) => $body:tt) => {
+    (
+        impl
+        match
+        all
+        $vdaf_instance:expr,
+        (
+            $vdaf:ident,
+            $Vdaf:ident,
+            $VERIFY_KEY_LEN:ident,
+            $dp_strategy:ident,
+            $DpStrategy:ident
+        )
+        =>
+        $body:tt
+    ) => {
         match $vdaf_instance {
             ::janus_core::vdaf::VdafInstance::Prio3Count
             | ::janus_core::vdaf::VdafInstance::Prio3Sum { .. }
             | ::janus_core::vdaf::VdafInstance::Prio3SumVec { .. }
             | ::janus_core::vdaf::VdafInstance::Prio3SumVecField64MultiproofHmacSha256Aes128 { .. }
             | ::janus_core::vdaf::VdafInstance::Prio3Histogram { .. } => {
-                ::janus_core::vdaf_dispatch_impl_base!(impl match base $vdaf_instance, ($vdaf, $Vdaf, $VERIFY_KEY_LEN, $dp_strategy, $DpStrategy) => $body)
+                ::janus_core::vdaf_dispatch_impl_base!(
+                    impl
+                    match
+                    base
+                    $vdaf_instance,
+                    (
+                        $vdaf,
+                        $Vdaf,
+                        $VERIFY_KEY_LEN,
+                        $dp_strategy,
+                        $DpStrategy
+                    )
+                    =>
+                    $body
+                )
             }
 
             _ => panic!("VDAF {:?} is not yet supported", $vdaf_instance),
@@ -443,17 +544,68 @@ macro_rules! vdaf_dispatch_impl {
 macro_rules! vdaf_dispatch {
     // Provide the dispatched type only, don't construct a VDAF instance.
     ($vdaf_instance:expr, (_, $Vdaf:ident, $VERIFY_KEY_LEN:ident) => $body:tt) => {
-        ::janus_core::vdaf_dispatch_impl!(impl match all $vdaf_instance, (_, $Vdaf, $VERIFY_KEY_LEN) => $body)
+        ::janus_core::vdaf_dispatch_impl!(
+            impl
+            match
+            all
+            $vdaf_instance,
+            (
+                _,
+                $Vdaf,
+                $VERIFY_KEY_LEN
+            )
+            =>
+            $body
+        )
     };
 
     // Construct a VDAF instance, and provide that to the block as well.
     ($vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LEN:ident) => $body:tt) => {
-        ::janus_core::vdaf_dispatch_impl!(impl match all $vdaf_instance, ($vdaf, $Vdaf, $VERIFY_KEY_LEN, _unused, _Unused) => $body)
+        ::janus_core::vdaf_dispatch_impl!(
+            impl
+            match
+            all
+            $vdaf_instance,
+            (
+                $vdaf,
+                $Vdaf,
+                $VERIFY_KEY_LEN,
+                _unused,
+                _Unused
+            )
+            =>
+            $body
+        )
     };
 
     // Construct a VDAF instance and DP strategy, and provide them to the block as well.
-    ($vdaf_instance:expr, ($vdaf:ident, $Vdaf:ident, $VERIFY_KEY_LEN:ident, $dp_strategy:ident, $DpStrategy:ident) => $body:tt) => {
-        ::janus_core::vdaf_dispatch_impl!(impl match all $vdaf_instance, ($vdaf, $Vdaf, $VERIFY_KEY_LEN, $dp_strategy, $DpStrategy) => $body)
+    (
+        $vdaf_instance:expr,
+        (
+            $vdaf:ident,
+            $Vdaf:ident,
+            $VERIFY_KEY_LEN:ident,
+            $dp_strategy:ident,
+            $DpStrategy:ident
+        )
+        =>
+        $body:tt
+    ) => {
+        ::janus_core::vdaf_dispatch_impl!(
+            impl
+            match
+            all
+            $vdaf_instance,
+            (
+                $vdaf,
+                $Vdaf,
+                $VERIFY_KEY_LEN,
+                $dp_strategy,
+                $DpStrategy
+            )
+            =>
+            $body
+        )
     };
 }
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -9,6 +9,7 @@ comment_width = 100
 # Unstable features
 imports_granularity = "Crate"
 group_imports = "StdExternalCrate"
+error_on_line_overflow = true
 
 # Note: format_code_in_doc_comments is NOT enabled due to known issues
 # with block comment conversion and trailing comment alignment.

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -143,7 +143,9 @@ struct AuthenticationOptions {
     /// Authentication token for the DAP-Auth-Token HTTP header
     #[clap(
         long,
-        value_parser = StringValueParser::new().try_map(AuthenticationToken::new_dap_auth_token_from_string),
+        value_parser = StringValueParser::new().try_map(
+            AuthenticationToken::new_dap_auth_token_from_string,
+        ),
         env,
         hide_env_values = true,
         help_heading = "Authorization",
@@ -155,7 +157,9 @@ struct AuthenticationOptions {
     /// Authentication token for the "Authorization: Bearer ..." HTTP header
     #[clap(
         long,
-        value_parser = StringValueParser::new().try_map(AuthenticationToken::new_bearer_token_from_string),
+        value_parser = StringValueParser::new().try_map(
+            AuthenticationToken::new_bearer_token_from_string,
+        ),
         env,
         hide_env_values = true,
         help_heading = "Authorization",


### PR DESCRIPTION
This enables [`error_on_line_overflow`](https://rust-lang.github.io/rustfmt/?version=v1.9.0&search=#error_on_line_overflow), which makes rustfmt throw an error on long lines it can't reformat, with exceptions for long strings and comments. I manually reformatted or rewrote code to fix the issues this found. This resulted in some other automatic formatting changes shaking out from running rustfmt again. The issues broke down as follows:

* Long lines in macro calls. These do not get reformatted because each macro makes its own DSL.
* A combination of long method names and turbofishes. In these cases I wrapped the turbofish across multiple lines. This transformation isn't typically performed by rustfmt AFAIK, but we do so frequently throughout the codebase.
* Long string literals. While a line with a long string literal itself doesn't result in an error being raised, it can prevent rustfmt from reformatting nearby code with long lines. I fixed these cases by extracting a variable or adding an escaped newline.
* Long patterns. I turned one long if-let into a match, thus moving the pattern onto a second line. I added some intermediate variables or renamed a variable in cases where a tuple destructuring got too long.