### PR TITLE
[DAP-17] TaskConf AAD Part 2A: Mandatory task_info and Interval task validity

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1892,6 +1892,15 @@ impl VdafOps {
             }
         }
 
+        // Reject reports once the task has been deactivated. This is Janus-specific
+        // (not part of the task's TaskConfiguration/AAD) and is compared against the
+        // aggregator's current clock, not the report timestamp.
+        if let Some(deactivate_at) = task.deactivate_at() {
+            if now >= deactivate_at {
+                return Err(reject_report(ReportRejectionReason::TaskDeactivated).await?);
+            }
+        }
+
         // Reject reports that would be eligible for garbage collection, to prevent replay attacks.
         if let Some(report_expiry_age) = task.report_expiry_age() {
             let report_expiry_time = report
@@ -1899,10 +1908,7 @@ impl VdafOps {
                 .time()
                 .add_duration(report_expiry_age)
                 .map_err(|err| UploadError::Internal(Arc::new(Error::from(err))))?;
-            if clock
-                .now()
-                .is_after(&report_expiry_time, task.time_precision())
-            {
+            if now.is_after(&report_expiry_time, task.time_precision()) {
                 return Err(reject_report(ReportRejectionReason::Expired).await?);
             }
         }

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -862,16 +862,9 @@ impl<C: Clock> Aggregator<C> {
 
         let vdaf_verify_key = peer_aggregator.derive_vdaf_verify_key(task_id, &vdaf_instance);
 
-        let (task_start, task_end) = match task_config.task_interval() {
-            Some(interval) => {
-                let start = interval.start();
-                (Some(start), Some(start.add_duration(&interval.duration())?))
-            }
-            // task_interval is optional per DAP-18 §4.2.3; when absent the task has no time
-            // bounds, so time-based report rejection is skipped (the same behavior as
-            // API-provisioned tasks created without task_start/task_end).
-            None => (None, None),
-        };
+        // task_interval is optional per DAP-18 §4.2.3; when absent the task has no time bounds, so
+        // time-based report rejection is skipped.
+        let task_interval = task_config.task_interval();
 
         let report_expiry_age = peer_aggregator
             .report_expiry_age()
@@ -884,13 +877,13 @@ impl<C: Clock> Aggregator<C> {
                 BatchMode::try_from(task_config.batch_config())?,
                 vdaf_instance,
                 vdaf_verify_key,
-                task_start,
-                task_end,
+                task_interval,
                 report_expiry_age,
                 task_config.min_batch_size(),
                 *task_config.time_precision(),
                 /* tolerable clock skew */
                 Duration::ONE,
+                task_config.task_info().to_vec(),
                 task::AggregatorTaskParameters::TaskprovHelper {
                     aggregation_mode: peer_aggregator.aggregation_mode().copied().ok_or_else(
                         || {
@@ -901,8 +894,7 @@ impl<C: Clock> Aggregator<C> {
                     )?,
                 },
             )
-            .map_err(|err| Error::InvalidTask(*task_id, OptOutReason::TaskParameters(err)))?
-            .with_task_info(task_config.task_info().to_vec()),
+            .map_err(|err| Error::InvalidTask(*task_id, OptOutReason::TaskParameters(err)))?,
         );
         self.datastore
             .run_tx("taskprov_put_task", |tx| {
@@ -1888,14 +1880,14 @@ impl VdafOps {
 
         // Reject reports before a task has started. (§4.6.2.4 step 3 [dap-16])
         if let Some(task_start) = task.task_start() {
-            if report.metadata().time().is_before(task_start) {
+            if report.metadata().time().is_before(&task_start) {
                 return Err(reject_report(ReportRejectionReason::TaskNotStarted).await?);
             }
         }
 
         // Reject reports after a task has ended. (§4.6.2.4 step 4 [dap-16])
         if let Some(task_end) = task.task_end() {
-            if report.metadata().time().ge(task_end) {
+            if report.metadata().time().ge(&task_end) {
                 return Err(reject_report(ReportRejectionReason::TaskEnded).await?);
             }
         }

--- a/aggregator/src/aggregator/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/aggregation_job_init.rs
@@ -428,6 +428,18 @@ where
                         Ok(shares)
                     });
 
+                    // Reject reports once the task has been deactivated. This is Janus-specific
+                    // (not part of the task's TaskConfiguration/AAD) and is compared against
+                    // theaggregator's current clock, not the report timestamp.
+                    let shares = shares.and_then(|shares| {
+                        if let Some(deactivate_at) = task.deactivate_at() {
+                            if now >= deactivate_at {
+                                return Err(ReportError::TaskExpired);
+                            }
+                        }
+                        Ok(shares)
+                    });
+
                     // Next, the aggregator runs the verification-state initialization algorithm
                     // for the VDAF associated with the task and computes the first state
                     // transition. [...] If either step fails, then the aggregator MUST fail

--- a/aggregator/src/aggregator/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/aggregation_job_init.rs
@@ -430,7 +430,7 @@ where
 
                     // Reject reports once the task has been deactivated. This is Janus-specific
                     // (not part of the task's TaskConfiguration/AAD) and is compared against
-                    // theaggregator's current clock, not the report timestamp.
+                    // the aggregator's current clock, not the report timestamp.
                     let shares = shares.and_then(|shares| {
                         if let Some(deactivate_at) = task.deactivate_at() {
                             if now >= deactivate_at {

--- a/aggregator/src/aggregator/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/aggregation_job_init.rs
@@ -409,7 +409,7 @@ where
                                 .report_share()
                                 .metadata()
                                 .time()
-                                .is_before(task_start)
+                                .is_before(&task_start)
                             {
                                 return Err(ReportError::TaskNotStarted);
                             }
@@ -421,7 +421,7 @@ where
                     // of the task_end time. (§4.6.2.4 step 4 [dap-16])
                     let shares = shares.and_then(|shares| {
                         if let Some(task_end) = task.task_end() {
-                            if verify_init.report_share().metadata().time().ge(task_end) {
+                            if verify_init.report_share().metadata().time().ge(&task_end) {
                                 return Err(ReportError::TaskExpired);
                             }
                         }
@@ -723,8 +723,8 @@ mod tests {
     };
     use janus_messages::{
         AggregationJobId, AggregationJobInitializeReq, AggregationJobResp, Duration, Extension,
-        ExtensionType, MediaType, PartialBatchSelector, ReportError, ReportMetadata, TimePrecision,
-        VerifyResp, VerifyStepResult, batch_mode::TimeInterval,
+        ExtensionType, Interval, MediaType, PartialBatchSelector, ReportError, ReportMetadata,
+        TimePrecision, VerifyResp, VerifyStepResult, batch_mode::TimeInterval,
     };
     use prio::{
         codec::Encode,
@@ -1225,7 +1225,15 @@ mod tests {
         .with_time_precision(time_precision)
         .with_tolerable_clock_skew(Duration::from_seconds(500, &time_precision))
         .with_aggregator_auth_token(AuthenticationToken::Bearer(random()))
-        .with_task_end(Some(task_end_time))
+        .with_task_interval(Some(
+            Interval::new(
+                task_end_time
+                    .sub_duration(&Duration::from_seconds(1000, &time_precision))
+                    .unwrap(),
+                Duration::from_seconds(1000, &time_precision),
+            )
+            .unwrap(),
+        ))
         .build();
         let helper_task = task.helper_view().unwrap();
         let ephemeral_datastore = ephemeral_datastore().await;
@@ -1367,7 +1375,13 @@ mod tests {
         .with_time_precision(time_precision)
         .with_tolerable_clock_skew(Duration::from_seconds(500, &time_precision))
         .with_aggregator_auth_token(AuthenticationToken::Bearer(random()))
-        .with_task_start(Some(task_start_time))
+        .with_task_interval(Some(
+            Interval::new(
+                task_start_time,
+                Duration::from_seconds(2000, &time_precision),
+            )
+            .unwrap(),
+        ))
         .build();
         let helper_task = task.helper_view().unwrap();
         let ephemeral_datastore = ephemeral_datastore().await;

--- a/aggregator/src/aggregator/error.rs
+++ b/aggregator/src/aggregator/error.rs
@@ -246,6 +246,9 @@ pub enum ReportRejectionReason {
     OutdatedHpkeConfig(HpkeConfigId),
     TaskNotStarted,
     DuplicateExtension,
+    /// The task has been operationally deactivated (implementation-specific state, distinct from
+    /// the DAP validity interval ending).
+    TaskDeactivated,
 }
 
 impl ReportRejectionReason {
@@ -260,6 +263,7 @@ impl ReportRejectionReason {
             ReportRejectionReason::OutdatedHpkeConfig(_) => ReportError::HpkeUnknownConfigId,
             ReportRejectionReason::TaskNotStarted => ReportError::TaskNotStarted,
             ReportRejectionReason::DuplicateExtension => ReportError::InvalidMessage,
+            ReportRejectionReason::TaskDeactivated => ReportError::TaskExpired,
         }
     }
 }

--- a/aggregator/src/aggregator/http_handlers/tests/report.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/report.rs
@@ -16,9 +16,9 @@ use janus_core::{
     vdaf::VdafInstance,
 };
 use janus_messages::{
-    Duration, Extension, ExtensionType, HpkeCiphertext, HpkeConfigId, InputShareAad, MediaType,
-    PlaintextInputShare, Report, ReportError, ReportId, ReportMetadata, Role, TimePrecision,
-    UploadErrors, UploadRequest,
+    Duration, Extension, ExtensionType, HpkeCiphertext, HpkeConfigId, InputShareAad, Interval,
+    MediaType, PlaintextInputShare, Report, ReportError, ReportId, ReportMetadata, Role,
+    TimePrecision, UploadErrors, UploadRequest,
 };
 use opentelemetry::Key;
 use opentelemetry_sdk::metrics::data::{Histogram, Sum};
@@ -348,12 +348,8 @@ async fn upload_handler() {
     // advance it, and we have to instead tolerate skew.
     .with_tolerable_clock_skew(Duration::from_time_precision_units(2))
     .with_time_precision(*task.time_precision())
-    .with_task_end(Some(
-        clock
-            .now()
-            .to_time(task.time_precision())
-            .add_duration(&Duration::ONE)
-            .unwrap(),
+    .with_task_interval(Some(
+        Interval::new(clock.now().to_time(task.time_precision()), Duration::ONE).unwrap(),
     ))
     .build();
     let leader_task_end_soon = task_end_soon.leader_view().unwrap();
@@ -788,14 +784,18 @@ async fn upload_handler_task_not_started() {
         VdafInstance::Prio3Count,
     )
     .with_time_precision(time_precision)
-    .with_task_start(Some(
-        clock
-            .now()
-            .to_time(&time_precision)
-            .add_duration(&Duration::ONE) // Add one time precision interval
-            .unwrap()
-            .add_duration(&Duration::ONE) // Add another to be clearly in the future
-            .unwrap(),
+    .with_task_interval(Some(
+        Interval::new(
+            clock
+                .now()
+                .to_time(&time_precision)
+                .add_duration(&Duration::ONE)
+                .unwrap()
+                .add_duration(&Duration::ONE) // two precision units, clearly in the future
+                .unwrap(),
+            Duration::from_time_precision_units(10),
+        )
+        .unwrap(),
     ))
     // Need to allow clock skew so the handler doesn't reject for being "too far in the future"
     .with_tolerable_clock_skew(Duration::from_seconds(

--- a/aggregator/src/aggregator/report_writer.rs
+++ b/aggregator/src/aggregator/report_writer.rs
@@ -348,6 +348,9 @@ impl TaskUploadCounters {
             ReportRejectionReason::OutdatedHpkeConfig(_) => entry.increment_report_outdated_key(),
             ReportRejectionReason::TaskNotStarted => entry.increment_task_not_started(),
             ReportRejectionReason::DuplicateExtension => entry.increment_duplicate_extension(),
+            // Operational deactivation reuses the "task ended" counter; it is the same outcome
+            // (the task is no longer accepting reports) from an operator's perspective.
+            ReportRejectionReason::TaskDeactivated => entry.increment_task_ended(),
         }
     }
 

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -28,7 +28,7 @@ use janus_core::{
     report_id::ReportIdChecksumExt,
     taskprov::TASKPROV_HEADER,
     test_util::{VdafTranscript, install_test_trace_subscriber, runtime::TestRuntime},
-    time::{Clock, DateTimeExt, MockClock, TimeExt},
+    time::{Clock, DateTimeExt, MockClock},
     vdaf::new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128,
 };
 use janus_messages::{
@@ -195,33 +195,30 @@ where
         let vdaf_instance = task_config.vdaf_config().try_into().unwrap();
         let vdaf_verify_key = peer_aggregator.derive_vdaf_verify_key(&task_id, &vdaf_instance);
 
-        let task = TaskBuilder::new(
-            BatchMode::LeaderSelected {
-                batch_time_window_size: None,
-            },
-            AggregationMode::Synchronous,
-            vdaf_instance,
-        )
-        .with_id(task_id)
-        .with_leader_aggregator_endpoint(Url::parse("https://leader.example.com/").unwrap())
-        .with_helper_aggregator_endpoint(Url::parse("https://helper.example.com/").unwrap())
-        .with_vdaf_verify_key(vdaf_verify_key)
-        .with_task_start(include_task_interval.then(|| task_start.to_time(&time_precision)))
-        .with_task_end(include_task_interval.then(|| {
-            task_start
-                .to_time(&time_precision)
-                .add_duration(&task_duration)
-                .unwrap()
-        }))
-        .with_report_expiry_age(
-            peer_aggregator
-                .report_expiry_age()
-                .map(|d| Duration::from_chrono(d, &time_precision)),
-        )
-        .with_min_batch_size(min_batch_size)
-        .with_time_precision(time_precision)
-        .with_task_info(task_config.task_info().to_vec())
-        .build();
+        let task =
+            TaskBuilder::new(
+                BatchMode::LeaderSelected {
+                    batch_time_window_size: None,
+                },
+                AggregationMode::Synchronous,
+                vdaf_instance,
+            )
+            .with_id(task_id)
+            .with_leader_aggregator_endpoint(Url::parse("https://leader.example.com/").unwrap())
+            .with_helper_aggregator_endpoint(Url::parse("https://helper.example.com/").unwrap())
+            .with_vdaf_verify_key(vdaf_verify_key)
+            .with_task_interval(include_task_interval.then(|| {
+                Interval::new(task_start.to_time(&time_precision), task_duration).unwrap()
+            }))
+            .with_report_expiry_age(
+                peer_aggregator
+                    .report_expiry_age()
+                    .map(|d| Duration::from_chrono(d, &time_precision)),
+            )
+            .with_min_batch_size(min_batch_size)
+            .with_time_precision(time_precision)
+            .with_task_info(task_config.task_info().to_vec())
+            .build();
 
         Self {
             _ephemeral_datastore: ephemeral_datastore,
@@ -435,7 +432,7 @@ async fn taskprov_aggregate_init() {
     );
     let got_task = got_task.unwrap();
     assert_eq!(test.task.taskprov_helper_view().unwrap(), got_task);
-    assert_eq!(got_task.task_info(), Some(b"foobar".as_slice()));
+    assert_eq!(got_task.task_info(), b"foobar".as_slice());
 }
 
 /// A `TaskConfiguration` may omit the optional `task_interval` extension (DAP-18

--- a/aggregator/src/aggregator/upload_tests.rs
+++ b/aggregator/src/aggregator/upload_tests.rs
@@ -677,6 +677,87 @@ async fn upload_report_task_ended() {
 }
 
 #[tokio::test]
+async fn upload_report_task_deactivated() {
+    let mut runtime_manager = TestRuntimeManager::new();
+    let UploadTest {
+        aggregator,
+        clock,
+        datastore,
+        ephemeral_datastore: _ephemeral_datastore,
+        hpke_keypair,
+        ..
+    } = UploadTest::new_with_runtime(
+        default_aggregator_config(),
+        runtime_manager.with_label("aggregator"),
+    )
+    .await;
+
+    let precision = TimePrecision::from_seconds(100);
+    let report_time = clock.now().to_time(&precision);
+
+    // A task with no validity interval; only its deactivation will stop uploads.
+    let task = TaskBuilder::new(
+        BatchMode::TimeInterval,
+        AggregationMode::Synchronous,
+        VdafInstance::Prio3Count,
+    )
+    .with_time_precision(precision)
+    .with_task_interval(None)
+    .build()
+    .leader_view()
+    .unwrap();
+    datastore.put_aggregator_task(&task).await.unwrap();
+
+    // Deactivate the task as of now.
+    let task_id = *task.id();
+    let deactivate_at = clock.now();
+    datastore
+        .run_unnamed_tx(|tx| {
+            Box::pin(async move {
+                tx.set_task_deactivate_at(&task_id, Some(&deactivate_at))
+                    .await
+            })
+        })
+        .await
+        .unwrap();
+
+    let report = create_report(&task, &hpke_keypair, report_time);
+
+    // Try to upload the report; verify that the deactivated task rejects it.
+    let upload_result = aggregator
+        .handle_upload(task.id(), report_stream(report.clone()))
+        .await
+        .unwrap();
+    let result_upload_status = &upload_result.status()[0];
+    assert_matches!(
+        result_upload_status.error(),
+        ReportError::TaskExpired => {
+            assert_eq!(report.metadata().id(), &result_upload_status.report_id());
+        }
+    );
+
+    // Wait for the report writer to have completed one write task.
+    runtime_manager
+        .wait_for_completed_tasks("aggregator", 1)
+        .await;
+
+    // Deactivation reuses the "task ended" upload counter.
+    let got_counters = datastore
+        .run_unnamed_tx(|tx| {
+            let task_id = *task.id();
+            Box::pin(async move { TaskUploadCounter::load(tx, &task_id).await })
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        got_counters,
+        Some(TaskUploadCounter::new_with_values(
+            0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+        ))
+    )
+}
+
+#[tokio::test]
 async fn upload_report_report_expired() {
     let mut runtime_manager = TestRuntimeManager::new();
     let UploadTest {

--- a/aggregator/src/aggregator/upload_tests.rs
+++ b/aggregator/src/aggregator/upload_tests.rs
@@ -23,7 +23,7 @@ use janus_core::{
         install_test_trace_subscriber,
         runtime::{TestRuntime, TestRuntimeManager},
     },
-    time::{Clock, DateTimeExt, MockClock},
+    time::{Clock, DateTimeExt, MockClock, TimeExt},
     vdaf::{VERIFY_KEY_LENGTH_PRIO3, VdafInstance},
 };
 use janus_messages::{
@@ -544,24 +544,21 @@ async fn upload_report_task_not_started() {
     )
     .await;
 
-    // Set the task start time to the future, and generate & upload a report from before that time.
+    // Task starts an hour from now; report is from before then.
     let time_precision = TimePrecision::from_seconds(100);
+    let hour = Duration::from_seconds(3600, &time_precision);
+    let task_start = clock
+        .now()
+        .add_duration(&hour, &time_precision)
+        .unwrap()
+        .to_time(&time_precision);
     let task = TaskBuilder::new(
         BatchMode::TimeInterval,
         AggregationMode::Synchronous,
         VdafInstance::Prio3Count,
     )
     .with_time_precision(time_precision)
-    .with_task_start(Some(
-        clock
-            .now()
-            .add_duration(
-                &Duration::from_seconds(3600, &time_precision),
-                &time_precision,
-            )
-            .unwrap()
-            .to_time(&time_precision),
-    ))
+    .with_task_interval(Some(Interval::new(task_start, hour).unwrap()))
     .build()
     .leader_view()
     .unwrap();
@@ -623,15 +620,19 @@ async fn upload_report_task_ended() {
     .await;
 
     let precision = TimePrecision::from_seconds(100);
+    let hour = Duration::from_seconds(3600, &precision);
     let task_end_time = clock.now().to_time(&precision);
 
+    // Task started an hour ago and has just ended.
     let task = TaskBuilder::new(
         BatchMode::TimeInterval,
         AggregationMode::Synchronous,
         VdafInstance::Prio3Count,
     )
     .with_time_precision(precision)
-    .with_task_end(Some(task_end_time))
+    .with_task_interval(Some(
+        Interval::new(task_end_time.sub_duration(&hour).unwrap(), hour).unwrap(),
+    ))
     .build()
     .leader_view()
     .unwrap();
@@ -995,7 +996,6 @@ async fn upload_report_duplicate_extensions() {
         VdafInstance::Prio3Count,
     )
     .with_time_precision(time_precision)
-    .with_task_start(None)
     .with_report_expiry_age(Some(Duration::from_seconds(60, &time_precision)))
     .build()
     .leader_view()
@@ -1069,7 +1069,6 @@ async fn upload_report_unsorted_extensions() {
         VdafInstance::Prio3Count,
     )
     .with_time_precision(time_precision)
-    .with_task_start(None)
     .with_report_expiry_age(Some(Duration::from_seconds(60, &time_precision)))
     .build()
     .leader_view()
@@ -1151,7 +1150,6 @@ async fn upload_report_unrecognized_extension() {
             VdafInstance::Prio3Count,
         )
         .with_time_precision(time_precision)
-        .with_task_start(None)
         .with_report_expiry_age(Some(Duration::from_seconds(60, &time_precision)))
         .build()
         .leader_view()

--- a/aggregator/src/binaries/janus_cli.rs
+++ b/aggregator/src/binaries/janus_cli.rs
@@ -1624,7 +1624,9 @@ mod tests {
     max_measurement: 4096
   role: Leader
   vdaf_verify_key:
-  task_end: 9000000000
+  task_info: dGFzay1pbmZv
+  task_start: 0
+  task_duration: 9000000000
   min_batch_size: 10
   time_precision: 300
   tolerable_clock_skew: 600
@@ -1648,7 +1650,9 @@ mod tests {
     max_measurement: 4096
   role: Helper
   vdaf_verify_key:
-  task_end: 9000000000
+  task_info: dGFzay1pbmZv
+  task_start: 0
+  task_duration: 9000000000
   min_batch_size: 10
   time_precision: 300
   tolerable_clock_skew: 600

--- a/aggregator/src/cache.rs
+++ b/aggregator/src/cache.rs
@@ -307,7 +307,7 @@ mod tests {
         time::MockClock,
         vdaf::VdafInstance,
     };
-    use janus_messages::{Time, TimePrecision};
+    use janus_messages::{Interval, Time, TimePrecision};
     use tokio::time::sleep;
 
     use crate::{
@@ -387,6 +387,7 @@ mod tests {
             VdafInstance::Prio3Count,
         )
         .with_time_precision(TimePrecision::from_seconds(100))
+        .with_task_interval(Some(Interval::EMPTY))
         .build()
         .leader_view()
         .unwrap();
@@ -418,7 +419,7 @@ mod tests {
         let task_aggregator = task_aggregators.get(task.id()).await.unwrap().unwrap();
         assert!(
             (task_aggregator.task.task_end() == task.task_end())
-                || (task_aggregator.task.task_end() == Some(&new_end))
+                || (task_aggregator.task.task_end() == Some(new_end))
         );
 
         // Unfortunately, because moka doesn't provide any facility for a fake clock, we have to
@@ -426,7 +427,7 @@ mod tests {
         sleep(Duration::from_secs(1)).await;
 
         let task_aggregator = task_aggregators.get(task.id()).await.unwrap().unwrap();
-        assert_eq!(task_aggregator.task.task_end(), Some(&new_end));
+        assert_eq!(task_aggregator.task.task_end(), Some(new_end));
     }
 
     #[tokio::test]
@@ -457,6 +458,7 @@ mod tests {
             VdafInstance::Prio3Count,
         )
         .with_time_precision(TimePrecision::from_seconds(100))
+        .with_task_interval(Some(Interval::EMPTY))
         .build()
         .leader_view()
         .unwrap();
@@ -492,12 +494,12 @@ mod tests {
         let task_aggregator = task_aggregators.get(task.id()).await.unwrap().unwrap();
         assert!(
             (task_aggregator.task.task_end() == task.task_end())
-                || (task_aggregator.task.task_end() == Some(&new_end))
+                || (task_aggregator.task.task_end() == Some(new_end))
         );
 
         sleep(Duration::from_secs(1)).await;
 
         let task_aggregator = task_aggregators.get(task.id()).await.unwrap().unwrap();
-        assert_eq!(task_aggregator.task.task_end(), Some(&new_end));
+        assert_eq!(task_aggregator.task.task_end(), Some(new_end));
     }
 }

--- a/aggregator/src/cache.rs
+++ b/aggregator/src/cache.rs
@@ -296,6 +296,7 @@ impl<C: Clock> TaskAggregatorCache<C> {
 mod tests {
     use std::{sync::Arc, time::Duration};
 
+    use chrono::{DateTime, Utc};
     use janus_aggregator_core::{
         datastore::{models::HpkeKeyState, test_util::ephemeral_datastore},
         task::{AggregationMode, BatchMode, test_util::TaskBuilder},
@@ -307,7 +308,7 @@ mod tests {
         time::MockClock,
         vdaf::VdafInstance,
     };
-    use janus_messages::{Interval, Time, TimePrecision};
+    use janus_messages::{Interval, TimePrecision};
     use tokio::time::sleep;
 
     use crate::{
@@ -402,12 +403,14 @@ mod tests {
         assert_eq!(task_aggregator.task.id(), task.id());
 
         // Modify the task.
-        let new_end = Time::from_seconds_since_epoch(100, task.time_precision());
+        let deactivate_at = DateTime::<Utc>::from_timestamp(100, 0).unwrap();
         datastore
             .run_unnamed_tx(|tx| {
                 let task_id = *task.id();
                 Box::pin(async move {
-                    tx.update_task_end(&task_id, Some(&new_end)).await.unwrap();
+                    tx.set_task_deactivate_at(&task_id, Some(&deactivate_at))
+                        .await
+                        .unwrap();
                     Ok(())
                 })
             })
@@ -418,8 +421,8 @@ mod tests {
         // previous task.
         let task_aggregator = task_aggregators.get(task.id()).await.unwrap().unwrap();
         assert!(
-            (task_aggregator.task.task_end() == task.task_end())
-                || (task_aggregator.task.task_end() == Some(new_end))
+            (task_aggregator.task.deactivate_at() == task.deactivate_at())
+                || (task_aggregator.task.deactivate_at() == Some(deactivate_at))
         );
 
         // Unfortunately, because moka doesn't provide any facility for a fake clock, we have to
@@ -427,7 +430,7 @@ mod tests {
         sleep(Duration::from_secs(1)).await;
 
         let task_aggregator = task_aggregators.get(task.id()).await.unwrap().unwrap();
-        assert_eq!(task_aggregator.task.task_end(), Some(new_end));
+        assert_eq!(task_aggregator.task.deactivate_at(), Some(deactivate_at));
     }
 
     #[tokio::test]
@@ -477,12 +480,14 @@ mod tests {
         assert_eq!(task_aggregator.task.id(), task.id());
 
         // Modify the task.
-        let new_end = Time::from_seconds_since_epoch(100, task.time_precision());
+        let deactivate_at = DateTime::<Utc>::from_timestamp(100, 0).unwrap();
         datastore
             .run_unnamed_tx(|tx| {
                 let task_id = *task.id();
                 Box::pin(async move {
-                    tx.update_task_end(&task_id, Some(&new_end)).await.unwrap();
+                    tx.set_task_deactivate_at(&task_id, Some(&deactivate_at))
+                        .await
+                        .unwrap();
                     Ok(())
                 })
             })
@@ -493,13 +498,13 @@ mod tests {
         // previous value.
         let task_aggregator = task_aggregators.get(task.id()).await.unwrap().unwrap();
         assert!(
-            (task_aggregator.task.task_end() == task.task_end())
-                || (task_aggregator.task.task_end() == Some(new_end))
+            (task_aggregator.task.deactivate_at() == task.deactivate_at())
+                || (task_aggregator.task.deactivate_at() == Some(deactivate_at))
         );
 
         sleep(Duration::from_secs(1)).await;
 
         let task_aggregator = task_aggregators.get(task.id()).await.unwrap().unwrap();
-        assert_eq!(task_aggregator.task.task_end(), Some(new_end));
+        assert_eq!(task_aggregator.task.deactivate_at(), Some(deactivate_at));
     }
 }

--- a/aggregator_api/Cargo.toml
+++ b/aggregator_api/Cargo.toml
@@ -13,7 +13,7 @@ anyhow.workspace = true
 aws-lc-rs = { workspace = true }
 axum.workspace = true
 base64.workspace = true
-chrono.workspace = true
+chrono = { workspace = true, features = ["serde"] }
 educe.workspace = true
 git-version.workspace = true
 http.workspace = true

--- a/aggregator_api/src/models.rs
+++ b/aggregator_api/src/models.rs
@@ -1,4 +1,5 @@
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use chrono::{DateTime, Utc};
 use educe::Educe;
 use janus_aggregator_core::{
     datastore::{
@@ -79,7 +80,7 @@ pub(crate) struct PostTaskReq {
     /// derived from the verify key.
     pub(crate) vdaf_verify_key: String,
     /// The `task_info` byte string from the task's `TaskConfiguration`, as unpadded base64url.
-    /// Must be non-empty and at most 255 bytes.
+    /// Must be at most 255 bytes.
     pub(crate) task_info: String,
     /// The start of the task's validity interval. Must be set together with `task_duration` (both
     /// present or both absent); a half-open interval is rejected.
@@ -104,8 +105,11 @@ pub(crate) struct PostTaskReq {
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct PatchTaskReq {
+    /// The task's operational deactivation instant. `Some(Some(_))` sets it, `Some(None)`
+    /// clears it, and an absent field leaves it unchanged. This is Janus-specific state, not
+    /// part of the task's `TaskConfiguration`, so changing it does not affect HPKE AADs.
     #[serde(default, deserialize_with = "deserialize_some")]
-    pub(crate) task_end: Option<Option<Time>>,
+    pub(crate) deactivate_at: Option<Option<DateTime<Utc>>>,
 }
 
 #[derive(Clone, Educe, PartialEq, Eq, Serialize, Deserialize)]
@@ -149,6 +153,9 @@ pub(crate) struct TaskResp {
     pub(crate) aggregator_auth_token: Option<AuthenticationToken>,
     /// HPKE configuration used by the collector to decrypt aggregate shares.
     pub(crate) collector_hpke_config: HpkeConfig,
+    /// The task's operational deactivation instant, if set. Janus-specific state, not part of
+    /// the `TaskConfiguration`.
+    pub(crate) deactivate_at: Option<DateTime<Utc>>,
 }
 
 impl TryFrom<&AggregatorTask> for TaskResp {
@@ -174,6 +181,7 @@ impl TryFrom<&AggregatorTask> for TaskResp {
                 .collector_hpke_config()
                 .ok_or("collector_hpke_config is required")?
                 .clone(),
+            deactivate_at: task.deactivate_at(),
         })
     }
 }

--- a/aggregator_api/src/models.rs
+++ b/aggregator_api/src/models.rs
@@ -78,10 +78,14 @@ pub(crate) struct PostTaskReq {
     /// The VDAF verification key used for this DAP task, as Base64 encoded bytes. Task ID is
     /// derived from the verify key.
     pub(crate) vdaf_verify_key: String,
-    /// The time before which the task is considered invalid.
+    /// The `task_info` byte string from the task's `TaskConfiguration`, as unpadded base64url.
+    /// Must be non-empty and at most 255 bytes.
+    pub(crate) task_info: String,
+    /// The start of the task's validity interval. Must be set together with `task_duration` (both
+    /// present or both absent); a half-open interval is rejected.
     pub(crate) task_start: Option<Time>,
-    /// The time after which the task is considered invalid.
-    pub(crate) task_end: Option<Time>,
+    /// The length of the task's validity interval. Must be set together with `task_start`.
+    pub(crate) task_duration: Option<Duration>,
     /// The minimum number of reports in a batch to allow it to be collected.
     pub(crate) min_batch_size: u64,
     /// The duration to which clients should round their reported timestamps, as seconds since
@@ -122,10 +126,13 @@ pub(crate) struct TaskResp {
     /// The VDAF verification key used for this DAP task, as Base64 encoded bytes. Task ID is
     /// derived from the verify key.
     pub(crate) vdaf_verify_key: String,
-    /// The time before which the task is considered invalid.
+    /// The `task_info` byte string from the task's `TaskConfiguration`, as unpadded base64url.
+    pub(crate) task_info: String,
+    /// The start of the task's validity interval. Set together with `task_duration` (both present
+    /// or both absent).
     pub(crate) task_start: Option<Time>,
-    /// The time after which the task is considered invalid.
-    pub(crate) task_end: Option<Time>,
+    /// The length of the task's validity interval. Set together with `task_start`.
+    pub(crate) task_duration: Option<Duration>,
     /// The age after which a report is considered to be "expired" and will be considered a
     /// candidate for garbage collection.
     pub(crate) report_expiry_age: Option<Duration>,
@@ -155,8 +162,9 @@ impl TryFrom<&AggregatorTask> for TaskResp {
             vdaf: task.vdaf().clone(),
             role: *task.role(),
             vdaf_verify_key: URL_SAFE_NO_PAD.encode(task.opaque_vdaf_verify_key().as_ref()),
-            task_start: task.task_start().copied(),
-            task_end: task.task_end().copied(),
+            task_info: URL_SAFE_NO_PAD.encode(task.task_info()),
+            task_start: task.task_start(),
+            task_duration: task.task_interval().map(|i| i.duration()),
             report_expiry_age: task.report_expiry_age().cloned(),
             min_batch_size: task.min_batch_size(),
             time_precision: task.time_precision().to_owned(),

--- a/aggregator_api/src/routes.rs
+++ b/aggregator_api/src/routes.rs
@@ -316,25 +316,11 @@ pub(super) async fn patch_task<C: Clock>(
         .datastore
         .run_tx("patch_task", |tx| {
             Box::pin(async move {
-                if let Some(task_end) = req.task_end {
-                    // Setting a concrete end requires an existing task_start that is not after the
-                    // new end. PATCH cannot create a half-open interval, and an end before the start
-                    // would be a negative (unrepresentable) duration.
-                    if let Some(end) = task_end {
-                        if let Some(existing) = tx.get_aggregator_task(&task_id).await? {
-                            if existing.task_start().is_none_or(|start| start > end) {
-                                return Err(datastore::Error::User(
-                                    Error::BadRequest(
-                                        "task_end requires an existing task_start that is not after \
-                                         it"
-                                        .into(),
-                                    )
-                                    .into(),
-                                ));
-                            }
-                        }
-                    }
-                    tx.update_task_end(&task_id, task_end.as_ref()).await?;
+                // deactivate_at is Janus-specific operational state flag (not part of the
+                // task's TaskConfiguration/AAD), so we can set (or clear) it at any time.
+                if let Some(deactivate_at) = req.deactivate_at {
+                    tx.set_task_deactivate_at(&task_id, deactivate_at.as_ref())
+                        .await?;
                 }
                 tx.get_aggregator_task(&task_id).await
             })

--- a/aggregator_api/src/routes.rs
+++ b/aggregator_api/src/routes.rs
@@ -18,7 +18,7 @@ use janus_aggregator_core::{
         self,
         task_counters::{TaskAggregationCounter, TaskUploadCounter},
     },
-    task::{AggregatorTask, AggregatorTaskParameters},
+    task::{AggregatorTask, AggregatorTaskParameters, reconstruct_task_interval},
     taskprov::PeerAggregator,
 };
 use janus_core::{
@@ -139,6 +139,11 @@ pub(super) async fn post_task<C: Clock>(
 
     let vdaf_verify_key = SecretBytes::new(vdaf_verify_key_bytes);
 
+    let task_info = URL_SAFE_NO_PAD
+        .decode(&req.task_info)
+        .context("Invalid base64 value for task_info")
+        .map_err(|err| Error::BadRequest(err.into()))?;
+
     let (aggregator_auth_token, aggregator_parameters) = match req.role {
         Role::Leader => {
             let aggregator_auth_token = req.aggregator_auth_token.ok_or_else(|| {
@@ -191,6 +196,11 @@ pub(super) async fn post_task<C: Clock>(
         _ => unreachable!(),
     };
 
+    // The task's validity interval is supplied as a separate start and duration, which must both be
+    // present or both absent; a half-open interval is rejected.
+    let task_interval = reconstruct_task_interval(req.task_start, req.task_duration)
+        .map_err(|err| Error::BadRequest(err.into()))?;
+
     let task = Arc::new(
         AggregatorTask::new(
             task_id,
@@ -198,8 +208,7 @@ pub(super) async fn post_task<C: Clock>(
             /* batch_mode */ req.batch_mode,
             /* vdaf */ req.vdaf,
             vdaf_verify_key,
-            /* task_start */ req.task_start,
-            /* task_end */ req.task_end,
+            /* task_interval */ task_interval,
             /* report_expiry_age */
             Some(Duration::from_seconds(
                 3600 * 24 * 7 * 2,
@@ -209,6 +218,7 @@ pub(super) async fn post_task<C: Clock>(
             /* time_precision */ req.time_precision,
             /* tolerable_clock_skew */
             Duration::ONE,
+            task_info,
             aggregator_parameters,
         )
         .context("Error constructing task")
@@ -228,8 +238,8 @@ pub(super) async fn post_task<C: Clock>(
                         && existing_task.vdaf() == task.vdaf()
                         && existing_task.opaque_vdaf_verify_key() == task.opaque_vdaf_verify_key()
                         && existing_task.role() == task.role()
-                        && existing_task.task_start() == task.task_start()
-                        && existing_task.task_end() == task.task_end()
+                        && existing_task.task_info() == task.task_info()
+                        && existing_task.task_interval() == task.task_interval()
                         && existing_task.min_batch_size() == task.min_batch_size()
                         && existing_task.time_precision() == task.time_precision()
                         && existing_task.tolerable_clock_skew() == task.tolerable_clock_skew()
@@ -307,6 +317,23 @@ pub(super) async fn patch_task<C: Clock>(
         .run_tx("patch_task", |tx| {
             Box::pin(async move {
                 if let Some(task_end) = req.task_end {
+                    // Setting a concrete end requires an existing task_start that is not after the
+                    // new end. PATCH cannot create a half-open interval, and an end before the start
+                    // would be a negative (unrepresentable) duration.
+                    if let Some(end) = task_end {
+                        if let Some(existing) = tx.get_aggregator_task(&task_id).await? {
+                            if existing.task_start().is_none_or(|start| start > end) {
+                                return Err(datastore::Error::User(
+                                    Error::BadRequest(
+                                        "task_end requires an existing task_start that is not after \
+                                         it"
+                                        .into(),
+                                    )
+                                    .into(),
+                                ));
+                            }
+                        }
+                    }
                     tx.update_task_end(&task_id, task_end.as_ref()).await?;
                 }
                 tx.get_aggregator_task(&task_id).await

--- a/aggregator_api/src/routes.rs
+++ b/aggregator_api/src/routes.rs
@@ -141,7 +141,7 @@ pub(super) async fn post_task<C: Clock>(
 
     let task_info = URL_SAFE_NO_PAD
         .decode(&req.task_info)
-        .context("Invalid base64 value for task_info")
+        .context("Invalid base64url value for task_info")
         .map_err(|err| Error::BadRequest(err.into()))?;
 
     let (aggregator_auth_token, aggregator_parameters) = match req.role {

--- a/aggregator_api/src/tests.rs
+++ b/aggregator_api/src/tests.rs
@@ -28,8 +28,8 @@ use janus_core::{
     vdaf::{VERIFY_KEY_LENGTH_PRIO3, VdafInstance, vdaf_dp_strategies},
 };
 use janus_messages::{
-    Duration, HpkeAeadId, HpkeConfig, HpkeConfigId, HpkeKdfId, HpkeKemId, HpkePublicKey, Role,
-    TaskId, Time, TimePrecision,
+    Duration, HpkeAeadId, HpkeConfig, HpkeConfigId, HpkeKdfId, HpkeKemId, HpkePublicKey, Interval,
+    Role, TaskId, Time, TimePrecision,
 };
 use rand::{RngExt, distr::StandardUniform, random, rng};
 use serde_test::{Token, assert_ser_tokens, assert_tokens};
@@ -303,8 +303,9 @@ async fn post_task_bad_role() {
         vdaf: VdafInstance::Prio3Count,
         role: Role::Collector,
         vdaf_verify_key: URL_SAFE_NO_PAD.encode(&vdaf_verify_key),
+        task_info: URL_SAFE_NO_PAD.encode(b"task-info"),
         task_start: Some(Time::from_seconds_since_epoch(12300, &time_precision)),
-        task_end: Some(Time::from_seconds_since_epoch(12360, &time_precision)),
+        task_duration: Some(Duration::from_seconds(60, &time_precision)),
         min_batch_size: 223,
         time_precision,
         collector_hpke_config: HpkeKeypair::test().config().clone(),
@@ -347,8 +348,9 @@ async fn post_task_unauthorized() {
         vdaf: VdafInstance::Prio3Count,
         role: Role::Helper,
         vdaf_verify_key: URL_SAFE_NO_PAD.encode(&vdaf_verify_key),
+        task_info: URL_SAFE_NO_PAD.encode(b"task-info"),
         task_start: None,
-        task_end: Some(Time::from_seconds_since_epoch(12300, &time_precision)),
+        task_duration: None,
         min_batch_size: 223,
         time_precision,
         collector_hpke_config: HpkeKeypair::test().config().clone(),
@@ -391,8 +393,9 @@ async fn post_task_helper_no_optional_fields() {
         vdaf: VdafInstance::Prio3Count,
         role: Role::Helper,
         vdaf_verify_key: URL_SAFE_NO_PAD.encode(&vdaf_verify_key),
+        task_info: URL_SAFE_NO_PAD.encode(b"task-info"),
         task_start: None,
-        task_end: None,
+        task_duration: None,
         min_batch_size: 223,
         time_precision: TimePrecision::from_seconds(60),
         collector_hpke_config: HpkeKeypair::test().config().clone(),
@@ -443,7 +446,7 @@ async fn post_task_helper_no_optional_fields() {
     assert_eq!(&req.batch_mode, got_task.batch_mode());
     assert_eq!(&req.vdaf, got_task.vdaf());
     assert_eq!(&req.role, got_task.role());
-    assert_eq!(req.task_end.as_ref(), got_task.task_end());
+    assert_eq!(got_task.task_interval(), None);
     assert_eq!(req.min_batch_size, got_task.min_batch_size());
     assert_eq!(&req.time_precision, got_task.time_precision());
     assert!(got_task.aggregator_auth_token().is_none());
@@ -481,8 +484,9 @@ async fn post_task_helper_with_aggregator_auth_token() {
         vdaf: VdafInstance::Prio3Count,
         role: Role::Helper,
         vdaf_verify_key: URL_SAFE_NO_PAD.encode(&vdaf_verify_key),
-        task_start: None,
-        task_end: Some(Time::from_seconds_since_epoch(12360, &time_precision)),
+        task_info: URL_SAFE_NO_PAD.encode(b"task-info"),
+        task_start: Some(Time::from_seconds_since_epoch(12300, &time_precision)),
+        task_duration: Some(Duration::from_seconds(60, &time_precision)),
         min_batch_size: 223,
         time_precision,
         collector_hpke_config: HpkeKeypair::test().config().clone(),
@@ -527,8 +531,9 @@ async fn post_task_idempotence() {
         vdaf: VdafInstance::Prio3Count,
         role: Role::Leader,
         vdaf_verify_key: URL_SAFE_NO_PAD.encode(&vdaf_verify_key),
+        task_info: URL_SAFE_NO_PAD.encode(b"task-info"),
         task_start: Some(Time::from_seconds_since_epoch(12300, &time_precision)),
-        task_end: Some(Time::from_seconds_since_epoch(12360, &time_precision)),
+        task_duration: Some(Duration::from_seconds(60, &time_precision)),
         min_batch_size: 223,
         time_precision,
         collector_hpke_config: HpkeKeypair::test().config().clone(),
@@ -615,8 +620,9 @@ async fn post_task_leader_all_optional_fields() {
         vdaf: VdafInstance::Prio3Count,
         role: Role::Leader,
         vdaf_verify_key: URL_SAFE_NO_PAD.encode(&vdaf_verify_key),
-        task_start: None,
-        task_end: Some(Time::from_seconds_since_epoch(12360, &time_precision)),
+        task_info: URL_SAFE_NO_PAD.encode(b"task-info"),
+        task_start: Some(Time::from_seconds_since_epoch(12300, &time_precision)),
+        task_duration: Some(Duration::from_seconds(60, &time_precision)),
         min_batch_size: 223,
         time_precision,
         collector_hpke_config: HpkeKeypair::test().config().clone(),
@@ -661,7 +667,11 @@ async fn post_task_leader_all_optional_fields() {
     assert_eq!(&req.vdaf, got_task.vdaf());
     assert_eq!(&req.role, got_task.role());
     assert_eq!(&vdaf_verify_key, got_task.opaque_vdaf_verify_key());
-    assert_eq!(req.task_end.as_ref(), got_task.task_end());
+    assert_eq!(req.task_start, got_task.task_start());
+    assert_eq!(
+        req.task_duration,
+        got_task.task_interval().map(|i| i.duration())
+    );
     assert_eq!(req.min_batch_size, got_task.min_batch_size());
     assert_eq!(&req.time_precision, got_task.time_precision());
     assert_eq!(
@@ -703,8 +713,9 @@ async fn post_task_leader_no_aggregator_auth_token() {
         vdaf: VdafInstance::Prio3Count,
         role: Role::Leader,
         vdaf_verify_key: URL_SAFE_NO_PAD.encode(&vdaf_verify_key),
+        task_info: URL_SAFE_NO_PAD.encode(b"task-info"),
         task_start: Some(Time::from_seconds_since_epoch(12300, &time_precision)),
-        task_end: Some(Time::from_seconds_since_epoch(12360, &time_precision)),
+        task_duration: Some(Duration::from_seconds(60, &time_precision)),
         min_batch_size: 223,
         time_precision,
         collector_hpke_config: HpkeKeypair::test().config().clone(),
@@ -901,7 +912,15 @@ async fn patch_task(#[case] role: Role) {
         VdafInstance::Fake { rounds: 1 },
     )
     .with_time_precision(time_precision)
-    .with_task_end(Some(Time::from_time_precision_units(10)))
+    // The task starts at the epoch and ends at 10 time-precision units; patching the end recomputes
+    // the duration against this start.
+    .with_task_interval(Some(
+        Interval::new(
+            Time::from_time_precision_units(0),
+            Duration::from_time_precision_units(10),
+        )
+        .unwrap(),
+    ))
     .build()
     .view_for_role(role)
     .unwrap();
@@ -937,38 +956,11 @@ async fn patch_task(#[case] role: Role) {
         .unwrap();
     assert_eq!(
         task.unwrap().task_end(),
-        Some(&Time::from_seconds_since_epoch(1000, &time_precision))
+        Some(Time::from_seconds_since_epoch(1000, &time_precision))
     );
 
-    // Verify: patching the task with a null task end time returns the expected result.
-    let response = handler
-        .clone()
-        .oneshot(
-            Request::patch(format!("/tasks/{task_id}"))
-                .header("authorization", format!("Bearer {AUTH_TOKEN}"))
-                .header("accept", CONTENT_TYPE)
-                .header("content-type", CONTENT_TYPE)
-                .body(Body::from(r#"{"task_end": null}"#))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(response.status(), StatusCode::OK);
-    let got_task_resp: TaskResp = serde_json::from_slice(
-        &axum::body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .unwrap(),
-    )
-    .unwrap();
-    assert_eq!(got_task_resp.task_end, None);
-    let task = ds
-        .run_unnamed_tx(|tx| Box::pin(async move { tx.get_aggregator_task(&task_id).await }))
-        .await
-        .unwrap();
-    assert_eq!(task.unwrap().task_end(), None);
-
-    // Verify: patching the task with a task end time returns the expected result.
-    let expected_time = Some(Time::from_seconds_since_epoch(2000, &time_precision));
+    // Verify: patching the task with a new task end time recomputes the duration against the
+    // existing start (still the epoch).
     let response = handler
         .clone()
         .oneshot(
@@ -988,12 +980,50 @@ async fn patch_task(#[case] role: Role) {
             .unwrap(),
     )
     .unwrap();
-    assert_eq!(got_task_resp.task_end, expected_time);
+    assert_eq!(
+        got_task_resp.task_start,
+        Some(Time::from_time_precision_units(0))
+    );
+    assert_eq!(
+        got_task_resp.task_duration,
+        Some(Duration::from_time_precision_units(20))
+    );
     let task = ds
         .run_unnamed_tx(|tx| Box::pin(async move { tx.get_aggregator_task(&task_id).await }))
         .await
         .unwrap();
-    assert_eq!(task.unwrap().task_end(), expected_time.as_ref());
+    assert_eq!(
+        task.unwrap().task_end(),
+        Some(Time::from_seconds_since_epoch(2000, &time_precision))
+    );
+
+    // Verify: patching the task with a null task end time clears the whole validity interval.
+    let response = handler
+        .clone()
+        .oneshot(
+            Request::patch(format!("/tasks/{task_id}"))
+                .header("authorization", format!("Bearer {AUTH_TOKEN}"))
+                .header("accept", CONTENT_TYPE)
+                .header("content-type", CONTENT_TYPE)
+                .body(Body::from(r#"{"task_end": null}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let got_task_resp: TaskResp = serde_json::from_slice(
+        &axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(got_task_resp.task_start, None);
+    assert_eq!(got_task_resp.task_duration, None);
+    let task = ds
+        .run_unnamed_tx(|tx| Box::pin(async move { tx.get_aggregator_task(&task_id).await }))
+        .await
+        .unwrap();
+    assert_eq!(task.unwrap().task_end(), None);
 
     // Verify: patching a nonexistent task returns NotFound.
     let response = handler
@@ -1023,6 +1053,83 @@ async fn patch_task(#[case] role: Role) {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn patch_task_rejects_end_before_start() {
+    let (handler, _ephemeral_datastore, ds) = setup_api_test().await;
+
+    // A task whose validity interval starts at 100 time-precision units.
+    let task = TaskBuilder::new(
+        BatchMode::TimeInterval,
+        AggregationMode::Synchronous,
+        VdafInstance::Fake { rounds: 1 },
+    )
+    .with_task_interval(Some(
+        Interval::new(
+            Time::from_time_precision_units(100),
+            Duration::from_time_precision_units(10),
+        )
+        .unwrap(),
+    ))
+    .build()
+    .leader_view()
+    .unwrap();
+    ds.put_aggregator_task(&task).await.unwrap();
+
+    // Patching an end earlier than the start must be rejected, not stored as a negative duration.
+    let response = handler
+        .oneshot(
+            Request::patch(format!("/tasks/{}", task.id()))
+                .header("authorization", format!("Bearer {AUTH_TOKEN}"))
+                .header("accept", CONTENT_TYPE)
+                .header("content-type", CONTENT_TYPE)
+                .body(Body::from(r#"{"task_end": 50}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    // The stored task is unchanged.
+    let task_id = *task.id();
+    let stored = ds
+        .run_unnamed_tx(|tx| Box::pin(async move { tx.get_aggregator_task(&task_id).await }))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.task_interval(), task.task_interval());
+}
+
+#[tokio::test]
+async fn patch_task_rejects_end_without_start() {
+    let (handler, _ephemeral_datastore, ds) = setup_api_test().await;
+
+    // A task with no validity interval at all.
+    let task = TaskBuilder::new(
+        BatchMode::TimeInterval,
+        AggregationMode::Synchronous,
+        VdafInstance::Fake { rounds: 1 },
+    )
+    .with_task_interval(None)
+    .build()
+    .leader_view()
+    .unwrap();
+    ds.put_aggregator_task(&task).await.unwrap();
+
+    // Setting an end is rejected: PATCH cannot create a half-open interval (it has no start).
+    let response = handler
+        .oneshot(
+            Request::patch(format!("/tasks/{}", task.id()))
+                .header("authorization", format!("Bearer {AUTH_TOKEN}"))
+                .header("accept", CONTENT_TYPE)
+                .header("content-type", CONTENT_TYPE)
+                .body(Body::from(r#"{"task_end": 50}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
 #[tokio::test]
@@ -2023,8 +2130,9 @@ fn post_task_req_serialization() {
             },
             role: Role::Helper,
             vdaf_verify_key: "encoded".to_owned(),
+            task_info: "dGFzay1pbmZv".to_owned(),
             task_start: None,
-            task_end: None,
+            task_duration: None,
             min_batch_size: 100,
             time_precision,
             collector_hpke_config: HpkeConfig::new(
@@ -2040,7 +2148,7 @@ fn post_task_req_serialization() {
         &[
             Token::Struct {
                 name: "PostTaskReq",
-                len: 13,
+                len: 14,
             },
             Token::Str("peer_aggregator_endpoint"),
             Token::Str("https://example.com/"),
@@ -2087,9 +2195,11 @@ fn post_task_req_serialization() {
             },
             Token::Str("vdaf_verify_key"),
             Token::Str("encoded"),
+            Token::Str("task_info"),
+            Token::Str("dGFzay1pbmZv"),
             Token::Str("task_start"),
             Token::None,
-            Token::Str("task_end"),
+            Token::Str("task_duration"),
             Token::None,
             Token::Str("min_batch_size"),
             Token::U64(100),
@@ -2150,8 +2260,9 @@ fn post_task_req_serialization() {
             },
             role: Role::Leader,
             vdaf_verify_key: "encoded".to_owned(),
+            task_info: "dGFzay1pbmZv".to_owned(),
             task_start: Some(Time::from_time_precision_units(42)),
-            task_end: Some(Time::from_time_precision_units(67)),
+            task_duration: Some(Duration::from_time_precision_units(25)),
             min_batch_size: 100,
             time_precision,
             collector_hpke_config: HpkeConfig::new(
@@ -2171,7 +2282,7 @@ fn post_task_req_serialization() {
         &[
             Token::Struct {
                 name: "PostTaskReq",
-                len: 13,
+                len: 14,
             },
             Token::Str("peer_aggregator_endpoint"),
             Token::Str("https://example.com/"),
@@ -2214,14 +2325,16 @@ fn post_task_req_serialization() {
             },
             Token::Str("vdaf_verify_key"),
             Token::Str("encoded"),
+            Token::Str("task_info"),
+            Token::Str("dGFzay1pbmZv"),
             Token::Str("task_start"),
             Token::Some,
             Token::NewtypeStruct { name: "Time" },
             Token::U64(42),
-            Token::Str("task_end"),
+            Token::Str("task_duration"),
             Token::Some,
-            Token::NewtypeStruct { name: "Time" },
-            Token::U64(67),
+            Token::NewtypeStruct { name: "Duration" },
+            Token::U64(25),
             Token::Str("min_batch_size"),
             Token::U64(100),
             Token::Str("time_precision"),
@@ -2306,12 +2419,12 @@ fn task_resp_serialization() {
             dp_strategy: vdaf_dp_strategies::Prio3SumVec::NoDifferentialPrivacy,
         },
         SecretBytes::new(b"vdaf verify key!".to_vec()),
-        None,
-        None,
-        None,
+        /* task_interval */ None,
+        /* report_expiry_age */ None,
         100,
         time_precision,
         Duration::from_time_precision_units(11),
+        b"task-info".to_vec(),
         AggregatorTaskParameters::Leader {
             aggregator_auth_token: AuthenticationToken::new_dap_auth_token_from_string(
                 "Y29sbGVjdG9yLWFiY2RlZjAw",
@@ -2336,7 +2449,7 @@ fn task_resp_serialization() {
         &[
             Token::Struct {
                 name: "TaskResp",
-                len: 14,
+                len: 15,
             },
             Token::Str("task_id"),
             Token::Str("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
@@ -2379,9 +2492,11 @@ fn task_resp_serialization() {
             },
             Token::Str("vdaf_verify_key"),
             Token::Str("dmRhZiB2ZXJpZnkga2V5IQ"),
+            Token::Str("task_info"),
+            Token::Str("dGFzay1pbmZv"),
             Token::Str("task_start"),
             Token::None,
-            Token::Str("task_end"),
+            Token::Str("task_duration"),
             Token::None,
             Token::Str("report_expiry_age"),
             Token::None,

--- a/aggregator_api/src/tests.rs
+++ b/aggregator_api/src/tests.rs
@@ -3,6 +3,7 @@ use std::{iter, sync::Arc};
 use assert_matches::assert_matches;
 use axum::body::Body;
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use chrono::{DateTime, Utc};
 use futures::future::try_join_all;
 use http::{Request, StatusCode};
 use janus_aggregator_core::{
@@ -912,8 +913,8 @@ async fn patch_task(#[case] role: Role) {
         VdafInstance::Fake { rounds: 1 },
     )
     .with_time_precision(time_precision)
-    // The task starts at the epoch and ends at 10 time-precision units; patching the end recomputes
-    // the duration against this start.
+    // The task has a fixed validity interval. PATCH only changes the deactivation
+    // instant, which is independent of (and does not mutate!) this interval.
     .with_task_interval(Some(
         Interval::new(
             Time::from_time_precision_units(0),
@@ -954,13 +955,16 @@ async fn patch_task(#[case] role: Role) {
         .run_unnamed_tx(|tx| Box::pin(async move { tx.get_aggregator_task(&task_id).await }))
         .await
         .unwrap();
+    let unwrapped = task.unwrap();
     assert_eq!(
-        task.unwrap().task_end(),
+        unwrapped.task_end(),
         Some(Time::from_seconds_since_epoch(1000, &time_precision))
     );
+    assert_eq!(unwrapped.deactivate_at(), None);
 
-    // Verify: patching the task with a new task end time recomputes the duration against the
-    // existing start (still the epoch).
+    // Verify: patching the task with a deactivation instant disables it, leaving the
+    // validity interval untouched.
+    let deactivate_at = DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap();
     let response = handler
         .clone()
         .oneshot(
@@ -968,7 +972,10 @@ async fn patch_task(#[case] role: Role) {
                 .header("authorization", format!("Bearer {AUTH_TOKEN}"))
                 .header("accept", CONTENT_TYPE)
                 .header("content-type", CONTENT_TYPE)
-                .body(Body::from(r#"{"task_end": 20}"#))
+                .body(Body::from(format!(
+                    r#"{{"deactivate_at": "{}"}}"#,
+                    deactivate_at.to_rfc3339()
+                )))
                 .unwrap(),
         )
         .await
@@ -980,24 +987,24 @@ async fn patch_task(#[case] role: Role) {
             .unwrap(),
     )
     .unwrap();
+    assert_eq!(got_task_resp.deactivate_at, Some(deactivate_at));
+    // The validity interval is unchanged.
     assert_eq!(
         got_task_resp.task_start,
         Some(Time::from_time_precision_units(0))
     );
     assert_eq!(
         got_task_resp.task_duration,
-        Some(Duration::from_time_precision_units(20))
+        Some(Duration::from_time_precision_units(10))
     );
     let task = ds
         .run_unnamed_tx(|tx| Box::pin(async move { tx.get_aggregator_task(&task_id).await }))
         .await
         .unwrap();
-    assert_eq!(
-        task.unwrap().task_end(),
-        Some(Time::from_seconds_since_epoch(2000, &time_precision))
-    );
+    assert_eq!(task.unwrap().deactivate_at(), Some(deactivate_at));
 
-    // Verify: patching the task with a null task end time clears the whole validity interval.
+    // Verify: patching the task with a null deactivation clears it, still leaving the
+    // validity interval untouched.
     let response = handler
         .clone()
         .oneshot(
@@ -1005,7 +1012,7 @@ async fn patch_task(#[case] role: Role) {
                 .header("authorization", format!("Bearer {AUTH_TOKEN}"))
                 .header("accept", CONTENT_TYPE)
                 .header("content-type", CONTENT_TYPE)
-                .body(Body::from(r#"{"task_end": null}"#))
+                .body(Body::from(r#"{"deactivate_at": null}"#))
                 .unwrap(),
         )
         .await
@@ -1017,13 +1024,16 @@ async fn patch_task(#[case] role: Role) {
             .unwrap(),
     )
     .unwrap();
-    assert_eq!(got_task_resp.task_start, None);
-    assert_eq!(got_task_resp.task_duration, None);
+    assert_eq!(got_task_resp.deactivate_at, None);
+    assert_eq!(
+        got_task_resp.task_start,
+        Some(Time::from_time_precision_units(0))
+    );
     let task = ds
         .run_unnamed_tx(|tx| Box::pin(async move { tx.get_aggregator_task(&task_id).await }))
         .await
         .unwrap();
-    assert_eq!(task.unwrap().task_end(), None);
+    assert_eq!(task.unwrap().deactivate_at(), None);
 
     // Verify: patching a nonexistent task returns NotFound.
     let response = handler
@@ -1056,56 +1066,11 @@ async fn patch_task(#[case] role: Role) {
 }
 
 #[tokio::test]
-async fn patch_task_rejects_end_before_start() {
+async fn patch_task_deactivate_at_without_interval() {
     let (handler, _ephemeral_datastore, ds) = setup_api_test().await;
 
-    // A task whose validity interval starts at 100 time-precision units.
-    let task = TaskBuilder::new(
-        BatchMode::TimeInterval,
-        AggregationMode::Synchronous,
-        VdafInstance::Fake { rounds: 1 },
-    )
-    .with_task_interval(Some(
-        Interval::new(
-            Time::from_time_precision_units(100),
-            Duration::from_time_precision_units(10),
-        )
-        .unwrap(),
-    ))
-    .build()
-    .leader_view()
-    .unwrap();
-    ds.put_aggregator_task(&task).await.unwrap();
-
-    // Patching an end earlier than the start must be rejected, not stored as a negative duration.
-    let response = handler
-        .oneshot(
-            Request::patch(format!("/tasks/{}", task.id()))
-                .header("authorization", format!("Bearer {AUTH_TOKEN}"))
-                .header("accept", CONTENT_TYPE)
-                .header("content-type", CONTENT_TYPE)
-                .body(Body::from(r#"{"task_end": 50}"#))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-
-    // The stored task is unchanged.
-    let task_id = *task.id();
-    let stored = ds
-        .run_unnamed_tx(|tx| Box::pin(async move { tx.get_aggregator_task(&task_id).await }))
-        .await
-        .unwrap()
-        .unwrap();
-    assert_eq!(stored.task_interval(), task.task_interval());
-}
-
-#[tokio::test]
-async fn patch_task_rejects_end_without_start() {
-    let (handler, _ephemeral_datastore, ds) = setup_api_test().await;
-
-    // A task with no validity interval at all.
+    // A task with no validity interval at all: deactivation is independent of the interval,
+    // so it can still be set.
     let task = TaskBuilder::new(
         BatchMode::TimeInterval,
         AggregationMode::Synchronous,
@@ -1117,19 +1082,32 @@ async fn patch_task_rejects_end_without_start() {
     .unwrap();
     ds.put_aggregator_task(&task).await.unwrap();
 
-    // Setting an end is rejected: PATCH cannot create a half-open interval (it has no start).
+    let deactivate_at = DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap();
     let response = handler
         .oneshot(
             Request::patch(format!("/tasks/{}", task.id()))
                 .header("authorization", format!("Bearer {AUTH_TOKEN}"))
                 .header("accept", CONTENT_TYPE)
                 .header("content-type", CONTENT_TYPE)
-                .body(Body::from(r#"{"task_end": 50}"#))
+                .body(Body::from(format!(
+                    r#"{{"deactivate_at": "{}"}}"#,
+                    deactivate_at.to_rfc3339()
+                )))
                 .unwrap(),
         )
         .await
         .unwrap();
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let task_id = *task.id();
+    let stored = ds
+        .run_unnamed_tx(|tx| Box::pin(async move { tx.get_aggregator_task(&task_id).await }))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.deactivate_at(), Some(deactivate_at));
+    // The (absent) validity interval is unchanged.
+    assert_eq!(stored.task_interval(), task.task_interval());
 }
 
 #[tokio::test]
@@ -2449,7 +2427,7 @@ fn task_resp_serialization() {
         &[
             Token::Struct {
                 name: "TaskResp",
-                len: 15,
+                len: 16,
             },
             Token::Str("task_id"),
             Token::Str("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
@@ -2540,6 +2518,8 @@ fn task_resp_serialization() {
             Token::Str("public_key"),
             Token::Str("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
             Token::StructEnd,
+            Token::Str("deactivate_at"),
+            Token::None,
             Token::StructEnd,
         ],
     );

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -715,13 +715,13 @@ INSERT INTO tasks (
     task_id, aggregator_role, aggregation_mode, peer_aggregator_endpoint,
     batch_mode, vdaf, task_start, task_duration, report_expiry_age, min_batch_size,
     time_precision, tolerable_clock_skew, collector_hpke_config,
-    vdaf_verify_key, task_info, aggregator_auth_token_type,
+    vdaf_verify_key, task_info, deactivate_at, aggregator_auth_token_type,
     aggregator_auth_token, aggregator_auth_token_hash,
     collector_auth_token_type, collector_auth_token_hash, created_at,
     updated_at, updated_by)
 VALUES (
     $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18,
-    $19, $20, $21, $22, $23
+    $19, $20, $21, $22, $23, $24
 )
 ON CONFLICT DO NOTHING",
             )
@@ -775,6 +775,8 @@ ON CONFLICT DO NOTHING",
                     )?,
                     /* task_info */
                     &task.task_info(),
+                    /* deactivate_at */
+                    &task.deactivate_at(),
                     /* aggregator_auth_token_type */
                     &task
                         .aggregator_auth_token()
@@ -836,27 +838,23 @@ DELETE FROM tasks WHERE task_id = $1",
         Ok(())
     }
 
-    /// Sets or unsets the end date of a task.
+    /// Sets or clears a task's operational deactivation instant.
     ///
-    /// Because the task's validity interval is stored as a (start, duration) pair and a half-open
-    /// interval is not representable, the requested end is translated into a new `task_duration`:
-    ///
-    /// * `Some(end)`: `task_duration` is recomputed as `end - task_start`, leaving `task_start`
-    ///   unchanged. If the task has no `task_start`, both columns remain NULL (the interval cannot
-    ///   be set without a start), which is a no-op.
-    /// * `None`: both `task_start` and `task_duration` are cleared, removing the interval entirely.
+    /// This is implementation-specific state and is deliberately *not* part of the task's
+    /// `TaskConfiguration`, so (unlike the validity interval) changing it does not affect HPKE
+    /// AADs. When set and reached (per the aggregator's clock), the aggregator stops accepting
+    /// reports for the task; `None` clears the deactivation.
     #[tracing::instrument(skip(self), err(level = Level::DEBUG))]
-    pub async fn update_task_end(
+    pub async fn set_task_deactivate_at(
         &self,
         task_id: &TaskId,
-        task_end: Option<&Time>,
+        deactivate_at: Option<&DateTime<Utc>>,
     ) -> Result<(), Error> {
         let stmt = self
             .prepare_cached(
-                "-- update_task_end()
+                "-- set_task_deactivate_at()
 UPDATE tasks SET
-    task_start = CASE WHEN $1::BIGINT IS NULL THEN NULL ELSE task_start END,
-    task_duration = CASE WHEN $1::BIGINT IS NULL THEN NULL ELSE $1 - task_start END,
+    deactivate_at = $1,
     updated_at = $2,
     updated_by = $3
    WHERE task_id = $4",
@@ -867,10 +865,7 @@ UPDATE tasks SET
             self.execute(
                 &stmt,
                 &[
-                    /* task_end */
-                    &task_end
-                        .map(|t| t.as_signed_time_precision_units())
-                        .transpose()?,
+                    /* deactivate_at */ &deactivate_at,
                     /* updated_at */ &self.clock.now(),
                     /* updated_by */ &self.name,
                     /* task_id */ &task_id.as_ref(),
@@ -894,7 +889,7 @@ SELECT
     aggregator_role, aggregation_mode, peer_aggregator_endpoint, batch_mode,
     vdaf, task_start, task_duration, report_expiry_age, min_batch_size,
     time_precision, tolerable_clock_skew, collector_hpke_config,
-    vdaf_verify_key, task_info, aggregator_auth_token_type,
+    vdaf_verify_key, task_info, deactivate_at, aggregator_auth_token_type,
     aggregator_auth_token, aggregator_auth_token_hash,
     collector_auth_token_type, collector_auth_token_hash
 FROM tasks WHERE task_id = $1",
@@ -917,7 +912,7 @@ SELECT
     task_id, aggregator_role, aggregation_mode, peer_aggregator_endpoint,
     batch_mode, vdaf, task_start, task_duration, report_expiry_age, min_batch_size,
     time_precision, tolerable_clock_skew, collector_hpke_config,
-    vdaf_verify_key, task_info, aggregator_auth_token_type,
+    vdaf_verify_key, task_info, deactivate_at, aggregator_auth_token_type,
     aggregator_auth_token, aggregator_auth_token_hash,
     collector_auth_token_type, collector_auth_token_hash
 FROM tasks",
@@ -972,6 +967,7 @@ FROM tasks",
             )
             .map(SecretBytes::new)?;
         let task_info: Vec<u8> = row.get("task_info");
+        let deactivate_at: Option<DateTime<Utc>> = row.get("deactivate_at");
 
         let aggregator_auth_token_type: Option<AuthenticationTokenType> =
             row.get("aggregator_auth_token_type");
@@ -1056,7 +1052,8 @@ FROM tasks",
             tolerable_clock_skew,
             task_info,
             aggregator_parameters,
-        )?;
+        )?
+        .with_deactivate_at(deactivate_at);
         Ok(task)
     }
 

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -17,7 +17,7 @@ use std::{
 };
 
 use aws_lc_rs::aead::{self, AES_128_GCM, LessSafeKey};
-use chrono::{DateTime, TimeDelta, Utc};
+use chrono::{DateTime, NaiveDateTime, TimeDelta, Utc};
 use futures::future::try_join_all;
 use janus_core::{
     auth_tokens::AuthenticationToken,
@@ -776,7 +776,8 @@ ON CONFLICT DO NOTHING",
                     /* task_info */
                     &task.task_info(),
                     /* deactivate_at */
-                    &task.deactivate_at(),
+                    // Stored as a naive UTC timestamp.
+                    &task.deactivate_at().map(|dt| dt.naive_utc()),
                     /* aggregator_auth_token_type */
                     &task
                         .aggregator_auth_token()
@@ -861,6 +862,8 @@ UPDATE tasks SET
             )
             .await?;
 
+        // Stored as a naive UTC timestamp.
+        let deactivate_at = deactivate_at.map(|dt| dt.naive_utc());
         check_single_row_mutation(
             self.execute(
                 &stmt,
@@ -967,7 +970,10 @@ FROM tasks",
             )
             .map(SecretBytes::new)?;
         let task_info: Vec<u8> = row.get("task_info");
-        let deactivate_at: Option<DateTime<Utc>> = row.get("deactivate_at");
+        // Stored as a naive UTC timestamp.
+        let deactivate_at = row
+            .get::<_, Option<NaiveDateTime>>("deactivate_at")
+            .map(|dt| dt.and_utc());
 
         let aggregator_auth_token_type: Option<AuthenticationTokenType> =
             row.get("aggregator_auth_token_type");

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -22,7 +22,7 @@ use futures::future::try_join_all;
 use janus_core::{
     auth_tokens::AuthenticationToken,
     hpke::{self, HpkePrivateKey},
-    time::{Clock, IntervalExt, TimeExt},
+    time::{Clock, TimeExt},
     vdaf::VdafInstance,
 };
 use janus_messages::{
@@ -713,7 +713,7 @@ WHERE success = TRUE ORDER BY version DESC LIMIT(1)",
                 "-- put_aggregator_task()
 INSERT INTO tasks (
     task_id, aggregator_role, aggregation_mode, peer_aggregator_endpoint,
-    batch_mode, vdaf, task_start, task_end, report_expiry_age, min_batch_size,
+    batch_mode, vdaf, task_start, task_duration, report_expiry_age, min_batch_size,
     time_precision, tolerable_clock_skew, collector_hpke_config,
     vdaf_verify_key, task_info, aggregator_auth_token_type,
     aggregator_auth_token, aggregator_auth_token_hash,
@@ -742,10 +742,10 @@ ON CONFLICT DO NOTHING",
                         .task_start()
                         .map(|t| t.as_signed_time_precision_units())
                         .transpose()?,
-                    /* task_end */
+                    /* task_duration */
                     &task
-                        .task_end()
-                        .map(|t| t.as_signed_time_precision_units())
+                        .task_interval()
+                        .map(|i| i.duration().as_signed_time_precision_units())
                         .transpose()?,
                     /* report_expiry_age */
                     &task
@@ -837,6 +837,14 @@ DELETE FROM tasks WHERE task_id = $1",
     }
 
     /// Sets or unsets the end date of a task.
+    ///
+    /// Because the task's validity interval is stored as a (start, duration) pair and a half-open
+    /// interval is not representable, the requested end is translated into a new `task_duration`:
+    ///
+    /// * `Some(end)`: `task_duration` is recomputed as `end - task_start`, leaving `task_start`
+    ///   unchanged. If the task has no `task_start`, both columns remain NULL (the interval cannot
+    ///   be set without a start), which is a no-op.
+    /// * `None`: both `task_start` and `task_duration` are cleared, removing the interval entirely.
     #[tracing::instrument(skip(self), err(level = Level::DEBUG))]
     pub async fn update_task_end(
         &self,
@@ -846,7 +854,11 @@ DELETE FROM tasks WHERE task_id = $1",
         let stmt = self
             .prepare_cached(
                 "-- update_task_end()
-UPDATE tasks SET task_end = $1, updated_at = $2, updated_by = $3
+UPDATE tasks SET
+    task_start = CASE WHEN $1::BIGINT IS NULL THEN NULL ELSE task_start END,
+    task_duration = CASE WHEN $1::BIGINT IS NULL THEN NULL ELSE $1 - task_start END,
+    updated_at = $2,
+    updated_by = $3
    WHERE task_id = $4",
             )
             .await?;
@@ -880,7 +892,7 @@ UPDATE tasks SET task_end = $1, updated_at = $2, updated_by = $3
                 "-- get_aggregator_task()
 SELECT
     aggregator_role, aggregation_mode, peer_aggregator_endpoint, batch_mode,
-    vdaf, task_start, task_end, report_expiry_age, min_batch_size,
+    vdaf, task_start, task_duration, report_expiry_age, min_batch_size,
     time_precision, tolerable_clock_skew, collector_hpke_config,
     vdaf_verify_key, task_info, aggregator_auth_token_type,
     aggregator_auth_token, aggregator_auth_token_hash,
@@ -903,7 +915,7 @@ FROM tasks WHERE task_id = $1",
                 "-- get_aggregator_tasks()
 SELECT
     task_id, aggregator_role, aggregation_mode, peer_aggregator_endpoint,
-    batch_mode, vdaf, task_start, task_end, report_expiry_age, min_batch_size,
+    batch_mode, vdaf, task_start, task_duration, report_expiry_age, min_batch_size,
     time_precision, tolerable_clock_skew, collector_hpke_config,
     vdaf_verify_key, task_info, aggregator_auth_token_type,
     aggregator_auth_token, aggregator_auth_token_hash,
@@ -932,9 +944,11 @@ FROM tasks",
         let task_start = row
             .get_nullable_bigint_and_convert("task_start")?
             .map(Time::from_time_precision_units);
-        let task_end = row
-            .get_nullable_bigint_and_convert("task_end")?
-            .map(Time::from_time_precision_units);
+        let task_duration = row
+            .get_nullable_bigint_and_convert("task_duration")?
+            .map(Duration::from_time_precision_units);
+        let task_interval = task::reconstruct_task_interval(task_start, task_duration)
+            .map_err(|e| Error::DbState(format!("task row has invalid validity interval: {e}")))?;
         let report_expiry_age = row
             .get_nullable_bigint_and_convert("report_expiry_age")?
             .map(|s| Duration::from_seconds(s, &time_precision));
@@ -957,7 +971,7 @@ FROM tasks",
                 &encrypted_vdaf_verify_key,
             )
             .map(SecretBytes::new)?;
-        let task_info: Option<Vec<u8>> = row.get("task_info");
+        let task_info: Vec<u8> = row.get("task_info");
 
         let aggregator_auth_token_type: Option<AuthenticationTokenType> =
             row.get("aggregator_auth_token_type");
@@ -1029,23 +1043,20 @@ FROM tasks",
             }
         };
 
-        let mut task = AggregatorTask::new(
+        let task = AggregatorTask::new(
             *task_id,
             peer_aggregator_endpoint,
             batch_mode,
             vdaf,
             vdaf_verify_key,
-            task_start,
-            task_end,
+            task_interval,
             report_expiry_age,
             min_batch_size,
             time_precision,
             tolerable_clock_skew,
+            task_info,
             aggregator_parameters,
         )?;
-        if let Some(task_info) = task_info {
-            task = task.with_task_info(task_info);
-        }
         Ok(task)
     }
 

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -343,7 +343,7 @@ async fn roundtrip_task(ephemeral_datastore: EphemeralDatastore) {
 
 #[rstest_reuse::apply(schema_versions_template)]
 #[tokio::test]
-async fn update_task_end(ephemeral_datastore: EphemeralDatastore) {
+async fn set_task_deactivate_at(ephemeral_datastore: EphemeralDatastore) {
     install_test_trace_subscriber();
     let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
@@ -369,33 +369,28 @@ async fn update_task_end(ephemeral_datastore: EphemeralDatastore) {
         let task_id = *task.id();
         Box::pin(async move {
             let task = tx.get_aggregator_task(&task_id).await.unwrap().unwrap();
-            assert_eq!(
-                task.task_end(),
-                Some(Time::from_seconds_since_epoch(1000, &TIME_PRECISION))
-            );
+            assert_eq!(task.deactivate_at(), None);
+            let task_end = task.task_end();
 
-            tx.update_task_end(
-                &task_id,
-                Some(&Time::from_seconds_since_epoch(2000, &TIME_PRECISION)),
-            )
-            .await
-            .unwrap();
+            let deactivate_at = DateTime::<Utc>::from_timestamp(2000, 0).unwrap();
+            tx.set_task_deactivate_at(&task_id, Some(&deactivate_at))
+                .await
+                .unwrap();
 
             let task = tx.get_aggregator_task(&task_id).await.unwrap().unwrap();
-            assert_eq!(
-                task.task_end(),
-                Some(Time::from_seconds_since_epoch(2000, &TIME_PRECISION))
-            );
+            assert_eq!(task.deactivate_at(), Some(deactivate_at));
+            // Deactivation is independent of the (immutable) validity interval.
+            assert_eq!(task.task_end(), task_end);
 
-            tx.update_task_end(&task_id, None).await.unwrap();
+            tx.set_task_deactivate_at(&task_id, None).await.unwrap();
 
             let task = tx.get_aggregator_task(&task_id).await.unwrap().unwrap();
-            assert_eq!(task.task_end(), None);
+            assert_eq!(task.deactivate_at(), None);
 
             let result = tx
-                .update_task_end(
+                .set_task_deactivate_at(
                     &random(),
-                    Some(&Time::from_seconds_since_epoch(2000, &TIME_PRECISION)),
+                    Some(&DateTime::<Utc>::from_timestamp(2000, 0).unwrap()),
                 )
                 .await;
             assert_matches!(result, Err(Error::MutationTargetNotFound));

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -242,8 +242,13 @@ async fn roundtrip_task(ephemeral_datastore: EphemeralDatastore) {
             AggregationMode::Synchronous,
             vdaf,
         )
-        .with_task_start(Some(Time::from_seconds_since_epoch(1000, &TIME_PRECISION)))
-        .with_task_end(Some(Time::from_seconds_since_epoch(4000, &TIME_PRECISION)))
+        .with_task_interval(Some(
+            Interval::new(
+                Time::from_seconds_since_epoch(1000, &TIME_PRECISION),
+                Duration::from_seconds(3000, &TIME_PRECISION),
+            )
+            .unwrap(),
+        ))
         .with_time_precision(TIME_PRECISION)
         .with_report_expiry_age(Some(Duration::from_seconds(3600, &TIME_PRECISION)))
         .build()
@@ -348,7 +353,13 @@ async fn update_task_end(ephemeral_datastore: EphemeralDatastore) {
         VdafInstance::Prio3Count,
     )
     .with_time_precision(TIME_PRECISION)
-    .with_task_end(Some(Time::from_seconds_since_epoch(1000, &TIME_PRECISION)))
+    .with_task_interval(Some(
+        Interval::new(
+            Time::from_seconds_since_epoch(0, &TIME_PRECISION),
+            Duration::from_seconds(1000, &TIME_PRECISION),
+        )
+        .unwrap(),
+    ))
     .build()
     .leader_view()
     .unwrap();
@@ -359,7 +370,7 @@ async fn update_task_end(ephemeral_datastore: EphemeralDatastore) {
         Box::pin(async move {
             let task = tx.get_aggregator_task(&task_id).await.unwrap().unwrap();
             assert_eq!(
-                task.task_end().cloned(),
+                task.task_end(),
                 Some(Time::from_seconds_since_epoch(1000, &TIME_PRECISION))
             );
 
@@ -372,14 +383,14 @@ async fn update_task_end(ephemeral_datastore: EphemeralDatastore) {
 
             let task = tx.get_aggregator_task(&task_id).await.unwrap().unwrap();
             assert_eq!(
-                task.task_end().cloned(),
+                task.task_end(),
                 Some(Time::from_seconds_since_epoch(2000, &TIME_PRECISION))
             );
 
             tx.update_task_end(&task_id, None).await.unwrap();
 
             let task = tx.get_aggregator_task(&task_id).await.unwrap().unwrap();
-            assert_eq!(task.task_end().cloned(), None);
+            assert_eq!(task.task_end(), None);
 
             let result = tx
                 .update_task_end(

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -4,6 +4,7 @@ use std::{array::TryFromSliceError, str::FromStr};
 
 use anyhow::anyhow;
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use chrono::{DateTime, Utc};
 use educe::Educe;
 use janus_core::{
     auth_tokens::{AuthenticationToken, AuthenticationTokenHash},
@@ -254,6 +255,9 @@ pub struct AggregatorTask {
     peer_aggregator_endpoint: Url,
     /// Parameters specific to either aggregator role
     aggregator_parameters: AggregatorTaskParameters,
+    /// Deactivation instant. When set and reached (per the aggregator's clock), the
+    /// aggregator stops accepting reports for this task. This is Janus-specific state.
+    deactivate_at: Option<DateTime<Utc>>,
 }
 
 impl AggregatorTask {
@@ -318,6 +322,7 @@ impl AggregatorTask {
             common_parameters,
             peer_aggregator_endpoint,
             aggregator_parameters,
+            deactivate_at: None,
         })
     }
 
@@ -369,6 +374,17 @@ impl AggregatorTask {
     /// Retrieves the task end time (the end of the validity interval), if any.
     pub fn task_end(&self) -> Option<Time> {
         self.common_parameters.task_interval.map(|i| i.end())
+    }
+
+    /// Retrieves the deactivation instant, if set. (Janus-specific)
+    pub fn deactivate_at(&self) -> Option<DateTime<Utc>> {
+        self.deactivate_at
+    }
+
+    /// Returns this task with its deactivation instant set. (Janus-specific)
+    pub fn with_deactivate_at(mut self, deactivate_at: Option<DateTime<Utc>>) -> Self {
+        self.deactivate_at = deactivate_at;
+        self
     }
 
     /// Retrieves the report expiry age associated with this task.

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -11,7 +11,7 @@ use janus_core::{
 };
 use janus_messages::{
     AggregateShareId, AggregationJobId, AggregationJobStep, BatchConfig, Duration, HpkeConfig,
-    Role, TaskId, Time, TimePrecision, batch_mode,
+    Interval, Role, TaskId, Time, TimePrecision, batch_mode,
 };
 use postgres_types::{FromSql, ToSql};
 use rand::{RngExt, distr::StandardUniform, random, rng};
@@ -136,10 +136,10 @@ struct CommonTaskParameters {
     vdaf: VdafInstance,
     /// Secret verification key shared by the aggregators.
     vdaf_verify_key: SecretBytes,
-    /// The time before which the task is considered invalid.
-    task_start: Option<Time>,
-    /// The time after which the task is considered invalid.
-    task_end: Option<Time>,
+    /// The interval of time during which the task is valid. Reports with timestamps before the
+    /// interval's start or at-or-after its end are rejected. `None` indicates that the task has no
+    /// time bounds.
+    task_interval: Option<Interval>,
     /// The age after which a report is considered to be "expired" and will be considered a
     /// candidate for garbage collection. A value of `None` indicates that garbage collection is
     /// disabled.
@@ -152,10 +152,9 @@ struct CommonTaskParameters {
     /// How much clock skew to allow between client and aggregator. Reports from
     /// farther than this duration into the future will be rejected.
     tolerable_clock_skew: Duration,
-    /// The `task_info` byte string from a `TaskConfiguration` struct. `None` for API-provisioned
-    /// tasks, which have no `TaskConfiguration`; used to distinguish tasks with otherwise
-    /// equivalent DAP task parameters.
-    task_info: Option<Vec<u8>>,
+    /// The `task_info` byte string from a `TaskConfiguration` struct, used to distinguish tasks
+    /// with otherwise equivalent DAP task parameters. Must be non-empty and at most 255 bytes.
+    task_info: Vec<u8>,
 }
 
 impl CommonTaskParameters {
@@ -166,15 +165,22 @@ impl CommonTaskParameters {
         batch_mode: BatchMode,
         vdaf: VdafInstance,
         vdaf_verify_key: SecretBytes,
-        task_start: Option<Time>,
-        task_end: Option<Time>,
+        task_interval: Option<Interval>,
         report_expiry_age: Option<Duration>,
         min_batch_size: u64,
         time_precision: TimePrecision,
         tolerable_clock_skew: Duration,
+        task_info: Vec<u8>,
     ) -> Result<Self, Error> {
         if min_batch_size == 0 {
             return Err(Error::InvalidParameter("min_batch_size"));
+        }
+
+        // task_info may be empty: DAP-19 (draft-ietf-ppm-dap#787) relaxes the bound to <0..255>.
+        if task_info.len() > u8::MAX as usize {
+            return Err(Error::InvalidParameter(
+                "task_info must not exceed 255 bytes",
+            ));
         }
 
         if let BatchMode::LeaderSelected {
@@ -194,20 +200,17 @@ impl CommonTaskParameters {
                 .as_signed_time_precision_units()
                 .map_err(|_| Error::InvalidParameter("report_expiry_age too large"))?;
         }
-        if let Some(task_start) = task_start {
-            task_start
+        // The interval's ordering and half-open-ness are already enforced by `Interval` itself; we
+        // only need to range-check that the start and duration fit in the signed 64-bit DB columns.
+        if let Some(task_interval) = task_interval {
+            task_interval
+                .start()
                 .as_signed_time_precision_units()
-                .map_err(|_| Error::InvalidParameter("task_start out of range"))?;
-        }
-        if let Some(task_end) = task_end {
-            task_end
+                .map_err(|_| Error::InvalidParameter("task_interval start out of range"))?;
+            task_interval
+                .duration()
                 .as_signed_time_precision_units()
-                .map_err(|_| Error::InvalidParameter("task_end out of range"))?;
-        }
-        if let (Some(task_start), Some(task_end)) = (task_start, task_end) {
-            if task_end < task_start {
-                return Err(Error::InvalidParameter("task_end before task_start"));
-            }
+                .map_err(|_| Error::InvalidParameter("task_interval duration out of range"))?;
         }
 
         if time_precision.as_seconds() == 0 {
@@ -219,13 +222,12 @@ impl CommonTaskParameters {
             batch_mode,
             vdaf,
             vdaf_verify_key,
-            task_start,
-            task_end,
+            task_interval,
             report_expiry_age,
             min_batch_size,
             time_precision,
             tolerable_clock_skew,
-            task_info: None,
+            task_info,
         })
     }
 
@@ -263,12 +265,12 @@ impl AggregatorTask {
         batch_mode: BatchMode,
         vdaf: VdafInstance,
         vdaf_verify_key: SecretBytes,
-        task_start: Option<Time>,
-        task_end: Option<Time>,
+        task_interval: Option<Interval>,
         report_expiry_age: Option<Duration>,
         min_batch_size: u64,
         time_precision: TimePrecision,
         tolerable_clock_skew: Duration,
+        task_info: Vec<u8>,
         aggregator_parameters: AggregatorTaskParameters,
     ) -> Result<Self, Error> {
         let common_parameters = CommonTaskParameters::new(
@@ -276,12 +278,12 @@ impl AggregatorTask {
             batch_mode,
             vdaf,
             vdaf_verify_key,
-            task_start,
-            task_end,
+            task_interval,
             report_expiry_age,
             min_batch_size,
             time_precision,
             tolerable_clock_skew,
+            task_info,
         )?;
         Self::new_with_common_parameters(
             common_parameters,
@@ -354,14 +356,19 @@ impl AggregatorTask {
         &self.common_parameters.vdaf_verify_key
     }
 
-    /// Retrieves the task start time associated with this task.
-    pub fn task_start(&self) -> Option<&Time> {
-        self.common_parameters.task_start.as_ref()
+    /// Retrieves the validity interval associated with this task, if any.
+    pub fn task_interval(&self) -> Option<&Interval> {
+        self.common_parameters.task_interval.as_ref()
     }
 
-    /// Retrieves the task end time associated with this task.
-    pub fn task_end(&self) -> Option<&Time> {
-        self.common_parameters.task_end.as_ref()
+    /// Retrieves the task start time (the start of the validity interval), if any.
+    pub fn task_start(&self) -> Option<Time> {
+        self.common_parameters.task_interval.map(|i| i.start())
+    }
+
+    /// Retrieves the task end time (the end of the validity interval), if any.
+    pub fn task_end(&self) -> Option<Time> {
+        self.common_parameters.task_interval.map(|i| i.end())
     }
 
     /// Retrieves the report expiry age associated with this task.
@@ -507,15 +514,9 @@ impl AggregatorTask {
             .unwrap_or(false)
     }
 
-    /// Set the `task_info` field for this task.
-    pub fn with_task_info(mut self, task_info: Vec<u8>) -> Self {
-        self.common_parameters.task_info = Some(task_info);
-        self
-    }
-
     /// Return the `task_info` field for this task.
-    pub fn task_info(&self) -> Option<&[u8]> {
-        self.common_parameters.task_info.as_deref()
+    pub fn task_info(&self) -> &[u8] {
+        &self.common_parameters.task_info
     }
 }
 
@@ -664,8 +665,9 @@ pub struct SerializedAggregatorTask {
     vdaf: VdafInstance,
     role: Role,
     vdaf_verify_key: Option<String>, // in unpadded base64url
+    task_info: String,               // in unpadded base64url
     task_start: Option<Time>,
-    task_end: Option<Time>,
+    task_duration: Option<Duration>,
     report_expiry_age: Option<Duration>,
     min_batch_size: u64,
     time_precision: TimePrecision,
@@ -723,8 +725,9 @@ impl Serialize for AggregatorTask {
             vdaf: self.vdaf().clone(),
             role: *self.role(),
             vdaf_verify_key: Some(URL_SAFE_NO_PAD.encode(self.opaque_vdaf_verify_key())),
-            task_start: self.task_start().copied(),
-            task_end: self.task_end().copied(),
+            task_info: URL_SAFE_NO_PAD.encode(self.task_info()),
+            task_start: self.task_start(),
+            task_duration: self.task_interval().map(|i| i.duration()),
             report_expiry_age: self.report_expiry_age().copied(),
             min_batch_size: self.min_batch_size(),
             time_precision: *self.time_precision(),
@@ -745,6 +748,27 @@ impl Serialize for AggregatorTask {
                 .cloned(),
         }
         .serialize(serializer)
+    }
+}
+
+/// Reconstructs an optional task validity [`Interval`] from a separately-stored start and duration.
+///
+/// Both must be present (yielding `Some(Interval)`) or both absent (yielding `None`); a lone bound
+/// is rejected, as a half-open task interval is not representable.
+pub fn reconstruct_task_interval(
+    task_start: Option<Time>,
+    task_duration: Option<Duration>,
+) -> Result<Option<Interval>, Error> {
+    match (task_start, task_duration) {
+        (Some(start), Some(duration)) => {
+            Ok(Some(Interval::new(start, duration).map_err(|_| {
+                Error::InvalidParameter("task interval start + duration overflows")
+            })?))
+        }
+        (None, None) => Ok(None),
+        _ => Err(Error::InvalidParameter(
+            "task_start and task_duration must both be set or both be unset",
+        )),
     }
 }
 
@@ -784,18 +808,21 @@ impl TryFrom<SerializedAggregatorTask> for AggregatorTask {
             _ => return Err(Error::InvalidParameter("unexpected role")),
         };
 
+        let task_interval =
+            reconstruct_task_interval(serialized_task.task_start, serialized_task.task_duration)?;
+
         AggregatorTask::new(
             task_id,
             serialized_task.peer_aggregator_endpoint,
             serialized_task.batch_mode,
             serialized_task.vdaf,
             SecretBytes::new(URL_SAFE_NO_PAD.decode(vdaf_verify_key)?),
-            serialized_task.task_start,
-            serialized_task.task_end,
+            task_interval,
             serialized_task.report_expiry_age,
             serialized_task.min_batch_size,
             serialized_task.time_precision,
             serialized_task.tolerable_clock_skew,
+            URL_SAFE_NO_PAD.decode(serialized_task.task_info)?,
             aggregator_parameters,
         )
     }
@@ -823,7 +850,7 @@ pub mod test_util {
     };
     use janus_messages::{
         AggregateShareId, AggregationJobId, AggregationJobStep, CollectionJobId, Duration,
-        HpkeConfigId, Role, TaskId, Time, TimePrecision,
+        HpkeConfigId, Interval, Role, TaskId, Time, TimePrecision,
     };
     use rand::{RngExt, distr::StandardUniform, random, rng};
     use url::Url;
@@ -875,8 +902,7 @@ pub mod test_util {
             helper_aggregation_mode: AggregationMode,
             vdaf: VdafInstance,
             vdaf_verify_key: SecretBytes,
-            task_start: Option<Time>,
-            task_end: Option<Time>,
+            task_interval: Option<Interval>,
             report_expiry_age: Option<Duration>,
             min_batch_size: u64,
             time_precision: TimePrecision,
@@ -904,13 +930,12 @@ pub mod test_util {
                     batch_mode,
                     vdaf,
                     vdaf_verify_key,
-                    task_start,
-                    task_end,
+                    task_interval,
                     report_expiry_age,
                     min_batch_size,
                     time_precision,
                     tolerable_clock_skew,
-                    task_info: None,
+                    task_info: b"task-info".to_vec(),
                 },
                 // Ensure provided aggregator endpoints end with a slash, as we will be joining
                 // additional path segments into these endpoints & the Url::join implementation is
@@ -960,14 +985,19 @@ pub mod test_util {
             &self.common_parameters.vdaf_verify_key
         }
 
-        /// Retrieves the task start time associated with this task.
-        pub fn task_start(&self) -> Option<&Time> {
-            self.common_parameters.task_start.as_ref()
+        /// Retrieves the validity interval associated with this task, if any.
+        pub fn task_interval(&self) -> Option<&Interval> {
+            self.common_parameters.task_interval.as_ref()
         }
 
-        /// Retrieves the task end time associated with this task.
-        pub fn task_end(&self) -> Option<&Time> {
-            self.common_parameters.task_end.as_ref()
+        /// Retrieves the task start time (the start of the validity interval), if any.
+        pub fn task_start(&self) -> Option<Time> {
+            self.common_parameters.task_interval.map(|i| i.start())
+        }
+
+        /// Retrieves the task end time (the end of the validity interval), if any.
+        pub fn task_end(&self) -> Option<Time> {
+            self.common_parameters.task_interval.map(|i| i.end())
         }
 
         /// Retrieves the report expiry age associated with this task.
@@ -1168,9 +1198,8 @@ pub mod test_util {
                 helper_aggregation_mode,
                 vdaf,
                 vdaf_verify_key,
-                None,
-                None,
-                None,
+                /* task_interval */ None,
+                /* report_expiry_age */ None,
                 /* Min batch size */ 1,
                 /* Time precision */
                 TimePrecision::from_hours(8),
@@ -1337,22 +1366,11 @@ pub mod test_util {
             })
         }
 
-        /// Sets the task start time.
-        pub fn with_task_start(self, task_start: Option<Time>) -> Self {
+        /// Sets the task validity interval.
+        pub fn with_task_interval(self, task_interval: Option<Interval>) -> Self {
             Self(Task {
                 common_parameters: CommonTaskParameters {
-                    task_start,
-                    ..self.0.common_parameters
-                },
-                ..self.0
-            })
-        }
-
-        /// Sets the task end time.
-        pub fn with_task_end(self, task_end: Option<Time>) -> Self {
-            Self(Task {
-                common_parameters: CommonTaskParameters {
-                    task_end,
+                    task_interval,
                     ..self.0.common_parameters
                 },
                 ..self.0
@@ -1372,7 +1390,7 @@ pub mod test_util {
 
         /// Set the `task_info` field for this task.
         pub fn with_task_info(mut self, task_info: Vec<u8>) -> Self {
-            self.0.common_parameters.task_info = Some(task_info);
+            self.0.common_parameters.task_info = task_info;
             self
         }
 
@@ -1409,7 +1427,7 @@ mod tests {
     };
     use janus_messages::{
         BatchConfig, Duration, HpkeAeadId, HpkeConfig, HpkeConfigId, HpkeKdfId, HpkeKemId,
-        HpkePublicKey, TaskId, Time, TimePrecision,
+        HpkePublicKey, Interval, TaskId, Time, TimePrecision,
     };
     use rand::random;
     use serde_json::json;
@@ -1418,8 +1436,8 @@ mod tests {
     use crate::{
         SecretBytes,
         task::{
-            AggregationMode, AggregatorTask, AggregatorTaskParameters, BatchMode, VdafInstance,
-            test_util::TaskBuilder,
+            AggregationMode, AggregatorTask, AggregatorTaskParameters, BatchMode, Error,
+            VdafInstance, test_util::TaskBuilder,
         },
     };
 
@@ -1581,45 +1599,64 @@ mod tests {
         assert!(!helper_task.check_aggregator_auth_token(Some(&incorrect_auth_token)));
     }
 
+    /// Builds an [`AggregatorTask`] through the production [`AggregatorTask::new`] constructor
+    /// (which validates `task_info`), with a caller-supplied `task_info` and otherwise fixed
+    /// values.
+    fn aggregator_task_with_task_info(task_info: Vec<u8>) -> Result<AggregatorTask, Error> {
+        let time_precision = TimePrecision::from_seconds(60);
+        AggregatorTask::new(
+            TaskId::from([0; 32]),
+            "https://example.net/".parse().unwrap(),
+            BatchMode::TimeInterval,
+            VdafInstance::Prio3Count,
+            SecretBytes::new(b"1234567812345678".to_vec()),
+            None,
+            None,
+            10,
+            time_precision,
+            Duration::from_seconds(60, &time_precision),
+            task_info,
+            AggregatorTaskParameters::Leader {
+                aggregator_auth_token: AuthenticationToken::new_dap_auth_token_from_string(
+                    "YWdncmVnYXRvciB0b2tlbg",
+                )
+                .unwrap(),
+                collector_auth_token_hash: AuthenticationTokenHash::from(
+                    &AuthenticationToken::new_bearer_token_from_string("Y29sbGVjdG9yIHRva2Vu")
+                        .unwrap(),
+                ),
+                collector_hpke_config: HpkeConfig::new(
+                    HpkeConfigId::from(8),
+                    HpkeKemId::X25519HkdfSha256,
+                    HpkeKdfId::HkdfSha256,
+                    HpkeAeadId::Aes128Gcm,
+                    HpkePublicKey::from(b"collector hpke public key".to_vec()),
+                ),
+            },
+        )
+    }
+
+    #[test]
+    fn task_info_validation() {
+        // Empty is accepted (DAP-19, draft-ietf-ppm-dap#787); oversized rejected; boundaries OK.
+        aggregator_task_with_task_info(Vec::new()).unwrap();
+        assert_matches!(
+            aggregator_task_with_task_info(vec![b'a'; 256]),
+            Err(Error::InvalidParameter(_))
+        );
+        aggregator_task_with_task_info(vec![b'a'; 255]).unwrap();
+        aggregator_task_with_task_info(b"x".to_vec()).unwrap();
+    }
+
     #[test]
     fn aggregator_task_serde() {
         let time_precision = TimePrecision::from_seconds(60);
         assert_tokens(
-            &AggregatorTask::new(
-                TaskId::from([0; 32]),
-                "https://example.net/".parse().unwrap(),
-                BatchMode::TimeInterval,
-                VdafInstance::Prio3Count,
-                SecretBytes::new(b"1234567812345678".to_vec()),
-                None,
-                None,
-                None,
-                10,
-                time_precision,
-                Duration::from_seconds(60, &time_precision),
-                AggregatorTaskParameters::Leader {
-                    aggregator_auth_token: AuthenticationToken::new_dap_auth_token_from_string(
-                        "YWdncmVnYXRvciB0b2tlbg",
-                    )
-                    .unwrap(),
-                    collector_auth_token_hash: AuthenticationTokenHash::from(
-                        &AuthenticationToken::new_bearer_token_from_string("Y29sbGVjdG9yIHRva2Vu")
-                            .unwrap(),
-                    ),
-                    collector_hpke_config: HpkeConfig::new(
-                        HpkeConfigId::from(8),
-                        HpkeKemId::X25519HkdfSha256,
-                        HpkeKdfId::HkdfSha256,
-                        HpkeAeadId::Aes128Gcm,
-                        HpkePublicKey::from(b"collector hpke public key".to_vec()),
-                    ),
-                },
-            )
-            .unwrap(),
+            &aggregator_task_with_task_info(b"task-info".to_vec()).unwrap(),
             &[
                 Token::Struct {
                     name: "SerializedAggregatorTask",
-                    len: 17,
+                    len: 18,
                 },
                 Token::Str("task_id"),
                 Token::Some,
@@ -1646,9 +1683,11 @@ mod tests {
                 Token::Str("vdaf_verify_key"),
                 Token::Some,
                 Token::Str("MTIzNDU2NzgxMjM0NTY3OA"),
+                Token::Str("task_info"),
+                Token::Str("dGFzay1pbmZv"),
                 Token::Str("task_start"),
                 Token::None,
-                Token::Str("task_end"),
+                Token::Str("task_duration"),
                 Token::None,
                 Token::Str("report_expiry_age"),
                 Token::None,
@@ -1738,12 +1777,18 @@ mod tests {
                     dp_strategy: vdaf_dp_strategies::Prio3SumVec::NoDifferentialPrivacy,
                 },
                 SecretBytes::new(b"1234567812345678".to_vec()),
-                Some(Time::from_seconds_since_epoch(1000, &time_precision)),
-                Some(Time::from_seconds_since_epoch(2000, &time_precision)),
+                Some(
+                    Interval::new(
+                        Time::from_seconds_since_epoch(1000, &time_precision),
+                        Duration::from_time_precision_units(17),
+                    )
+                    .unwrap(),
+                ),
                 Some(Duration::from_seconds(1800, &time_precision)),
                 10,
                 time_precision,
                 Duration::from_seconds(60, &time_precision),
+                b"task-info".to_vec(),
                 AggregatorTaskParameters::Helper {
                     aggregator_auth_token_hash: AuthenticationTokenHash::from(
                         &AuthenticationToken::new_bearer_token_from_string(
@@ -1765,7 +1810,7 @@ mod tests {
             &[
                 Token::Struct {
                     name: "SerializedAggregatorTask",
-                    len: 17,
+                    len: 18,
                 },
                 Token::Str("task_id"),
                 Token::Some,
@@ -1816,14 +1861,16 @@ mod tests {
                 Token::Str("vdaf_verify_key"),
                 Token::Some,
                 Token::Str("MTIzNDU2NzgxMjM0NTY3OA"),
+                Token::Str("task_info"),
+                Token::Str("dGFzay1pbmZv"),
                 Token::Str("task_start"),
                 Token::Some,
                 Token::NewtypeStruct { name: "Time" },
                 Token::U64(16),
-                Token::Str("task_end"),
+                Token::Str("task_duration"),
                 Token::Some,
-                Token::NewtypeStruct { name: "Time" },
-                Token::U64(33),
+                Token::NewtypeStruct { name: "Duration" },
+                Token::U64(17),
                 Token::Str("report_expiry_age"),
                 Token::Some,
                 Token::NewtypeStruct { name: "Duration" },

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -153,7 +153,7 @@ struct CommonTaskParameters {
     /// farther than this duration into the future will be rejected.
     tolerable_clock_skew: Duration,
     /// The `task_info` byte string from a `TaskConfiguration` struct, used to distinguish tasks
-    /// with otherwise equivalent DAP task parameters. Must be non-empty and at most 255 bytes.
+    /// with otherwise equivalent DAP task parameters. Must be at most 255 bytes.
     task_info: Vec<u8>,
 }
 

--- a/core/src/task_config.rs
+++ b/core/src/task_config.rs
@@ -44,9 +44,8 @@ pub fn build_task_configuration(
 
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
     use janus_messages::{
-        BatchConfig, Duration, Error, Interval, Time, TimePrecision, Url as DapUrl, VdafConfig,
+        BatchConfig, Duration, Interval, Time, TimePrecision, Url as DapUrl, VdafConfig,
     };
     use prio::codec::Encode as _;
 
@@ -124,20 +123,20 @@ mod tests {
     }
 
     #[test]
-    fn rejects_empty_task_info() {
-        assert_matches!(
-            build_task_configuration(
-                Vec::new(),
-                leader(),
-                helper(),
-                TimePrecision::from_seconds(3600),
-                100,
-                BatchConfig::TimeInterval,
-                VdafConfig::Prio3Count,
-                None,
-            ),
-            Err(Error::InvalidParameter(_))
-        );
+    fn allows_empty_task_info() {
+        // task_info may be empty per DAP-19 (draft-ietf-ppm-dap#787).
+        let config = build_task_configuration(
+            Vec::new(),
+            leader(),
+            helper(),
+            TimePrecision::from_seconds(3600),
+            100,
+            BatchConfig::TimeInterval,
+            VdafConfig::Prio3Count,
+            None,
+        )
+        .unwrap();
+        assert!(config.task_info().is_empty());
     }
 
     /// Pins the exact encoded bytes produced by the canonical builder. Because DAP implementations

--- a/db/00000000000001_initial_schema.up.sql
+++ b/db/00000000000001_initial_schema.up.sql
@@ -107,15 +107,18 @@ CREATE TABLE tasks(
     batch_mode                  JSONB NOT NULL,            -- the batch mode in use for this task, along with its parameters
     aggregation_mode            AGGREGATION_MODE,          -- the aggregation mode in use for this task (populated for Helper only)
     vdaf                        JSON NOT NULL,             -- the VDAF instance in use for this task, along with its parameters
+    -- The task's validity interval, stored as a start instant and a duration, both in time
+    -- precision increments. A half-open interval is not representable: task_start and task_duration
+    -- are either both NULL (no time bounds) or both set.
     task_start                  BIGINT,                    -- the time before which client reports are not accepted, in time precision increments
-    task_end                    BIGINT,                    -- the time after which client reports are no longer accepted, in time precision increments
+    task_duration               BIGINT,                    -- the length of the task's validity interval, in time precision increments
     report_expiry_age           BIGINT,                    -- the maximum age of a report before it is considered expired (and acceptable for garbage collection), in seconds. NULL means that GC is disabled.
     min_batch_size              BIGINT NOT NULL,           -- the minimum number of reports in a batch to allow it to be collected
     time_precision              BIGINT NOT NULL,           -- the duration to which clients are expected to round their report timestamps, in seconds
     tolerable_clock_skew        BIGINT NOT NULL,           -- the maximum acceptable clock skew to allow between client and aggregator, in seconds
     collector_hpke_config       BYTEA,                     -- the HPKE config of the collector (encoded HpkeConfig message)
     vdaf_verify_key             BYTEA NOT NULL,            -- the VDAF verification key (encrypted)
-    task_info                   BYTEA,                     -- the task_info field of a TaskConfiguration structure; NULL for API-provisioned tasks, which have no TaskConfiguration
+    task_info                   BYTEA NOT NULL,            -- the task_info field of a TaskConfiguration structure; non-empty and at most 255 bytes
 
     -- Authentication token used to authenticate messages to/from the other aggregator.
     -- These columns are NULL if the task was provisioned by taskprov.
@@ -137,6 +140,13 @@ CREATE TABLE tasks(
     collector_auth_token_hash   BYTEA,              -- hash of the token
     -- The collector_auth_token columns must either both be NULL or both be non-NULL
     CONSTRAINT collector_auth_token_null CHECK ((collector_auth_token_type IS NULL) = (collector_auth_token_hash IS NULL)),
+
+    -- The task's validity interval is all-or-nothing, and its duration is non-negative.
+    CONSTRAINT task_interval_null CHECK ((task_start IS NULL) = (task_duration IS NULL)),
+    CONSTRAINT task_duration_non_negative CHECK (task_duration IS NULL OR task_duration >= 0),
+    -- task_info is the at-most-255-byte task_info field of a TaskConfiguration; it may be empty
+    -- (DAP-19, draft-ietf-ppm-dap#787 relaxes the bound to <0..255>).
+    CONSTRAINT task_info_length CHECK (octet_length(task_info) <= 255),
 
     -- creation/update records
     created_at TIMESTAMP WITH TIME ZONE NOT NULL,  -- when the row was created

--- a/db/00000000000001_initial_schema.up.sql
+++ b/db/00000000000001_initial_schema.up.sql
@@ -118,7 +118,7 @@ CREATE TABLE tasks(
     tolerable_clock_skew        BIGINT NOT NULL,           -- the maximum acceptable clock skew to allow between client and aggregator, in seconds
     collector_hpke_config       BYTEA,                     -- the HPKE config of the collector (encoded HpkeConfig message)
     vdaf_verify_key             BYTEA NOT NULL,            -- the VDAF verification key (encrypted)
-    task_info                   BYTEA NOT NULL,            -- the task_info field of a TaskConfiguration structure; non-empty and at most 255 bytes
+    task_info                   BYTEA NOT NULL,            -- the task_info field of a TaskConfiguration structure; at most 255 bytes
 
     -- Authentication token used to authenticate messages to/from the other aggregator.
     -- These columns are NULL if the task was provisioned by taskprov.

--- a/db/00000000000001_initial_schema.up.sql
+++ b/db/00000000000001_initial_schema.up.sql
@@ -119,7 +119,7 @@ CREATE TABLE tasks(
     collector_hpke_config       BYTEA,                     -- the HPKE config of the collector (encoded HpkeConfig message)
     vdaf_verify_key             BYTEA NOT NULL,            -- the VDAF verification key (encrypted)
     task_info                   BYTEA NOT NULL,            -- the task_info field of a TaskConfiguration structure; at most 255 bytes
-    deactivate_at               TIMESTAMP WITH TIME ZONE,  -- stop accepting reports at this time (or null). (Janus-specific)
+    deactivate_at               TIMESTAMP,                 -- stop accepting reports at this time (or null). (Janus-specific)
 
     -- Authentication token used to authenticate messages to/from the other aggregator.
     -- These columns are NULL if the task was provisioned by taskprov.

--- a/db/00000000000001_initial_schema.up.sql
+++ b/db/00000000000001_initial_schema.up.sql
@@ -119,6 +119,7 @@ CREATE TABLE tasks(
     collector_hpke_config       BYTEA,                     -- the HPKE config of the collector (encoded HpkeConfig message)
     vdaf_verify_key             BYTEA NOT NULL,            -- the VDAF verification key (encrypted)
     task_info                   BYTEA NOT NULL,            -- the task_info field of a TaskConfiguration structure; at most 255 bytes
+    deactivate_at               TIMESTAMP WITH TIME ZONE,  -- stop accepting reports at this time (or null). (Janus-specific)
 
     -- Authentication token used to authenticate messages to/from the other aggregator.
     -- These columns are NULL if the task was provisioned by taskprov.

--- a/docs/samples/tasks.yaml
+++ b/docs/samples/tasks.yaml
@@ -24,13 +24,21 @@
   # determined by the task's VDAF.
   vdaf_verify_key: "1CmuYNtBLYIoXN8bU0T_XA"
 
+  # The task_info field of the task's TaskConfiguration, in base64url-encoded
+  # form. Must be non-empty and at most 255 bytes. Distinguishes tasks with
+  # otherwise equivalent DAP parameters.
+  task_info: "dGFzay1pbmZv"
+
   # The DAP task's time precision. This determines how clients round report
   # timestamps, and sets the minimum duration of any batch interval for time
   # interval queries.
   time_precision: 1800
 
-  # The task's end time, as a number of time_precision units since the UNIX epoch
-  task_end: 946716
+  # The task's validity interval, expressed as a start instant and a duration, both
+  # in time_precision units. Either both fields are set or both are omitted; a
+  # half-open interval is not allowed. (Here the interval ends at 946716.)
+  task_start: 0
+  task_duration: 946716
 
   # Time in time_precision units after which reports expire and may be garbage collected.
   # This is a Janus-specific parameter. Garbage collection for a task may
@@ -100,7 +108,9 @@
   vdaf: Prio3Count
   role: Helper
   vdaf_verify_key: "ZXtE4kLqtsCOr8h_pNUeoQ"
-  task_end: 5680296
+  task_info: "dGFzay1pbmZv"
+  task_start: 0
+  task_duration: 5680296
   report_expiry_age: null
   min_batch_size: 100
   time_precision: 300

--- a/interop_binaries/src/commands/janus_interop_aggregator.rs
+++ b/interop_binaries/src/commands/janus_interop_aggregator.rs
@@ -28,7 +28,7 @@ use janus_core::{
     auth_tokens::{AuthenticationToken, AuthenticationTokenHash},
     time::RealClock,
 };
-use janus_messages::{Duration, HpkeConfig, Time, TimePrecision};
+use janus_messages::{Duration, HpkeConfig, Interval, Time, TimePrecision};
 use prio::codec::Decode;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -120,23 +120,41 @@ async fn handle_add_task(
         }
     };
 
+    // The interop API supplies task_start and task_end (both seconds since the epoch); a task is
+    // valid only if both or neither are present, mirroring the all-or-nothing validity interval.
+    let task_interval = match (request.task_start, request.task_end) {
+        (Some(start), Some(end)) => {
+            let start = Time::from_seconds_since_epoch(start, &time_precision);
+            let end = Time::from_seconds_since_epoch(end, &time_precision);
+            let duration = Duration::from_time_precision_units(
+                end.as_time_precision_units()
+                    .checked_sub(start.as_time_precision_units())
+                    .context("task_end must not be before task_start")?,
+            );
+            Some(Interval::new(start, duration).context("error constructing task interval")?)
+        }
+        (None, None) => None,
+        _ => {
+            return Err(anyhow::anyhow!(
+                "task_start and task_end must both be set or both be unset"
+            ));
+        }
+    };
+
     let task = AggregatorTask::new(
         request.task_id,
         peer_aggregator_endpoint,
         batch_mode,
         vdaf,
         vdaf_verify_key,
-        request
-            .task_start
-            .map(|t| Time::from_seconds_since_epoch(t, &time_precision)),
-        request
-            .task_end
-            .map(|t| Time::from_seconds_since_epoch(t, &time_precision)),
-        None,
+        task_interval,
+        /* report_expiry_age */ None,
         request.min_batch_size,
         time_precision,
         /* tolerable clock skew */
         Duration::ONE, // Since the clock skew must be a multiple of the precision, start at 1x
+        // The interop test API has no task_info concept, so use a fixed non-empty placeholder.
+        b"task-info".to_vec(),
         aggregator_parameters,
     )
     .context("error constructing task")?;

--- a/messages/src/task.rs
+++ b/messages/src/task.rs
@@ -57,9 +57,7 @@ impl TaskConfiguration {
         vdaf_config: VdafConfig,
         extensions: Vec<TaskExtension>,
     ) -> Result<Self, Error> {
-        if task_info.is_empty() {
-            return Err(Error::InvalidParameter("task_info must not be empty"));
-        }
+        // task_info may be empty: DAP-19 (draft-ietf-ppm-dap#787) relaxes the bound to <0..255>.
         if task_info.len() > u8::MAX as usize {
             return Err(Error::InvalidParameter(
                 "task_info must not exceed 255 bytes",
@@ -155,12 +153,8 @@ impl Encode for TaskConfiguration {
 
 impl Decode for TaskConfiguration {
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        // task_info may be empty: DAP-19 (draft-ietf-ppm-dap#787) relaxes the bound to <0..255>.
         let task_info = decode_u8_items(&(), bytes)?;
-        if task_info.is_empty() {
-            return Err(CodecError::Other(
-                anyhow!("task_info must not be empty").into(),
-            ));
-        }
         let leader_aggregator_endpoint = Url::decode(bytes)?;
         let helper_aggregator_endpoint = Url::decode(bytes)?;
         let time_precision = TimePrecision::decode(bytes)?;

--- a/messages/src/tests/task.rs
+++ b/messages/src/tests/task.rs
@@ -129,46 +129,45 @@ fn roundtrip_task_configuration() {
         ),
     ]);
 
-    // Empty task_info.
-    assert_matches!(
-        TaskConfiguration::get_decoded(
-            &hex::decode(concat!(
-                concat!(
-                    // task_info
-                    "00", // length
-                    ""    // opaque data
-                ),
-                concat!(
-                    // leader_aggregator_url
-                    "0014",                                     // length
-                    "68747470733A2F2F6578616D706C652E636F6D2F"  // contents
-                ),
-                concat!(
-                    // helper_aggregator_url
-                    "001C",                                                     // length
-                    "68747470733A2F2F616E6F746865722E6578616D706C652E636F6D2F"  // contents
-                ),
-                "0000000000000E10", // time_precision
-                "0000000000002710", // min_batch_size (u64)
-                "01",               // batch_mode
-                concat!(
-                    // batch_config
-                    "0000", // length
-                ),
-                "00000001", // vdaf_type
-                concat!(
-                    // vdaf_config
-                    "0000", // length
-                ),
-                concat!(
-                    // extensions
-                    "0000", // length
-                ),
-            ))
-            .unwrap(),
-        ),
-        Err(CodecError::Other(_))
-    );
+    // Empty task_info is allowed (DAP-19, draft-ietf-ppm-dap#787).
+    let config = TaskConfiguration::get_decoded(
+        &hex::decode(concat!(
+            concat!(
+                // task_info
+                "00", // length
+                ""    // opaque data
+            ),
+            concat!(
+                // leader_aggregator_url
+                "0014",                                     // length
+                "68747470733A2F2F6578616D706C652E636F6D2F"  // contents
+            ),
+            concat!(
+                // helper_aggregator_url
+                "001C",                                                     // length
+                "68747470733A2F2F616E6F746865722E6578616D706C652E636F6D2F"  // contents
+            ),
+            "0000000000000E10", // time_precision
+            "0000000000002710", // min_batch_size (u64)
+            "01",               // batch_mode
+            concat!(
+                // batch_config
+                "0000", // length
+            ),
+            "00000001", // vdaf_type
+            concat!(
+                // vdaf_config
+                "0000", // length
+            ),
+            concat!(
+                // extensions
+                "0000", // length
+            ),
+        ))
+        .unwrap(),
+    )
+    .unwrap();
+    assert!(config.task_info().is_empty());
 }
 
 #[test]

--- a/messages/src/time.rs
+++ b/messages/src/time.rs
@@ -370,6 +370,14 @@ impl Interval {
     pub fn duration(&self) -> Duration {
         self.duration
     }
+
+    /// Returns a [`Time`] representing the excluded end of this interval (`start + duration`).
+    ///
+    /// This is infallible because [`Interval::new`] already guaranteed that `start + duration` does
+    /// not overflow.
+    pub fn end(&self) -> Time {
+        Time::from_time_precision_units(self.start.0 + self.duration.0)
+    }
 }
 
 impl Encode for Interval {


### PR DESCRIPTION
Provisions the task data the HPKE-AAD TaskConfiguration will need (Part 3), with no AAD changes yet.

- task_info is now a mandatory, persisted `Vec<u8>` (non-empty, <=255 bytes) rather than an `Option` that serde silently dropped. In the DB it's `BYTEA NOT NULL`; serde/API forms carry it as an unpadded base64url; taskprov passes the real value from its `TaskConfiguration`.

- Task validity is represented as a single `Option<Interval>` all the way to the DB: the `task_end` column becomes `task_duration,` and the API/serde forms are `task_start + task_duration`. Half-open intervals are now unrepresentable, as we all wanted.  Report-admission checks derive start/end from the interval, and just for safety I added that the `PATCH` task-end path returns 400 when end is `< task_start`.

Part 2B will change `url::Url` to `janus_messages::Url` for our in-DB representations, to keep from causing AAD errors with URL normalization business. That turns out to be a nice standalone task.

Closes #4625.