### PR TITLE
[DAP-17] TaskConf AAD Part 2B: Use janus_messages::Url 

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -56,7 +56,7 @@ use janus_messages::{
     AggregationJobStep, BatchSelector, CollectionJobId, CollectionJobReq, CollectionJobResp,
     Duration, ExtensionType, HpkeConfig, HpkeConfigList, InputShareAad, Interval,
     PartialBatchSelector, PlaintextInputShare, Report, ReportError, ReportUploadStatus, Role,
-    TaskConfiguration, TaskId, UploadErrors, VerifyResp,
+    TaskConfiguration, TaskId, UploadErrors, Url as DapUrl, VerifyResp,
     batch_mode::{LeaderSelected, TimeInterval},
     extensions_are_strictly_increasing,
 };
@@ -933,7 +933,7 @@ impl<C: Clock> Aggregator<C> {
         task_id: &TaskId,
         task_config: &TaskConfiguration,
         aggregator_auth_token: Option<&AuthenticationToken>,
-    ) -> Result<(&PeerAggregator, Url, Url), Error> {
+    ) -> Result<(&PeerAggregator, DapUrl, DapUrl), Error> {
         let peer_aggregator_url = match peer_role {
             Role::Leader => task_config.leader_aggregator_endpoint(),
             Role::Helper => task_config.helper_aggregator_endpoint(),
@@ -964,8 +964,9 @@ impl<C: Clock> Aggregator<C> {
         );
         Ok((
             peer_aggregator,
-            task_config.leader_aggregator_endpoint().try_into()?,
-            task_config.helper_aggregator_endpoint().try_into()?,
+            // Byte-preserving clones of the wire endpoints (no re-encoding, per DAP-18 §4.1).
+            task_config.leader_aggregator_endpoint().clone(),
+            task_config.helper_aggregator_endpoint().clone(),
         ))
     }
 

--- a/aggregator_api/src/models.rs
+++ b/aggregator_api/src/models.rs
@@ -15,7 +15,7 @@ use janus_core::{
 };
 use janus_messages::{
     Duration, HpkeAeadId, HpkeConfig, HpkeKdfId, HpkeKemId, Role, TaskId, Time, TimePrecision,
-    batch_mode::Code as SupportedBatchMode,
+    Url as DapUrl, batch_mode::Code as SupportedBatchMode,
 };
 use serde::{Deserialize, Deserializer, Serialize};
 use url::Url;
@@ -66,7 +66,7 @@ pub(crate) struct PostTaskReq {
     /// URL relative to which this task's peer aggregator's DAP API can be found. The peer
     /// aggregator plays the DAP role opposite to the one in the `role` field.
     #[educe(Debug(method(std::fmt::Display::fmt)))]
-    pub(crate) peer_aggregator_endpoint: Url,
+    pub(crate) peer_aggregator_endpoint: DapUrl,
     /// DAP batch mode for this task.
     pub(crate) batch_mode: BatchMode,
     /// Aggregation mode (e.g. synchronous vs asynchronous) for this task. Populated if and only if
@@ -120,7 +120,7 @@ pub(crate) struct TaskResp {
     /// URL relative to which this task's peer aggregator's DAP API can be found. The peer
     /// aggregator plays the DAP role opposite to the one in the `role` field.
     #[educe(Debug(method(std::fmt::Display::fmt)))]
-    pub(crate) peer_aggregator_endpoint: Url,
+    pub(crate) peer_aggregator_endpoint: DapUrl,
     /// DAP batch mode for this task.
     pub(crate) batch_mode: BatchMode,
     /// The VDAF being run by this task.

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -866,9 +866,9 @@ pub mod test_util {
 
     use educe::Educe;
     use janus_core::{
+        UrlExt,
         auth_tokens::{AuthenticationToken, AuthenticationTokenHash},
         hpke::HpkeKeypair,
-        url_ensure_trailing_slash,
         vdaf::VdafInstance,
     };
     use janus_messages::{
@@ -969,8 +969,8 @@ pub mod test_util {
                 // Ensure provided aggregator endpoints end with a slash, as we will be joining
                 // additional path segments into these endpoints & the Url::join implementation is
                 // persnickety about the slash at the end of the path.
-                leader_aggregator_endpoint: url_ensure_trailing_slash(leader_aggregator_endpoint),
-                helper_aggregator_endpoint: url_ensure_trailing_slash(helper_aggregator_endpoint),
+                leader_aggregator_endpoint: leader_aggregator_endpoint.ensure_trailing_slash(),
+                helper_aggregator_endpoint: helper_aggregator_endpoint.ensure_trailing_slash(),
                 helper_aggregation_mode,
                 aggregator_auth_token,
                 collector_auth_token,
@@ -1286,7 +1286,7 @@ pub mod test_util {
         /// Associates the eventual task with the given aggregator endpoint for the Leader.
         pub fn with_leader_aggregator_endpoint(self, leader_aggregator_endpoint: Url) -> Self {
             Self(Task {
-                leader_aggregator_endpoint: url_ensure_trailing_slash(leader_aggregator_endpoint),
+                leader_aggregator_endpoint: leader_aggregator_endpoint.ensure_trailing_slash(),
                 ..self.0
             })
         }
@@ -1294,7 +1294,7 @@ pub mod test_util {
         /// Associates the eventual task with the given aggregator endpoint for the Helper.
         pub fn with_helper_aggregator_endpoint(self, helper_aggregator_endpoint: Url) -> Self {
             Self(Task {
-                helper_aggregator_endpoint: url_ensure_trailing_slash(helper_aggregator_endpoint),
+                helper_aggregator_endpoint: helper_aggregator_endpoint.ensure_trailing_slash(),
                 ..self.0
             })
         }

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -8,11 +8,12 @@ use chrono::{DateTime, Utc};
 use educe::Educe;
 use janus_core::{
     auth_tokens::{AuthenticationToken, AuthenticationTokenHash},
+    url_for_join,
     vdaf::VdafInstance,
 };
 use janus_messages::{
     AggregateShareId, AggregationJobId, AggregationJobStep, BatchConfig, Duration, HpkeConfig,
-    Interval, Role, TaskId, Time, TimePrecision, batch_mode,
+    Interval, Role, TaskId, Time, TimePrecision, Url as DapUrl, batch_mode,
 };
 use postgres_types::{FromSql, ToSql};
 use rand::{RngExt, distr::StandardUniform, random, rng};
@@ -252,7 +253,7 @@ pub struct AggregatorTask {
     common_parameters: CommonTaskParameters,
     /// URL relative to which the peer aggregator's API endpoints are found.
     #[educe(Debug(method(std::fmt::Display::fmt)))]
-    peer_aggregator_endpoint: Url,
+    peer_aggregator_endpoint: DapUrl,
     /// Parameters specific to either aggregator role
     aggregator_parameters: AggregatorTaskParameters,
     /// Deactivation instant. When set and reached (per the aggregator's clock), the
@@ -265,7 +266,7 @@ impl AggregatorTask {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         task_id: TaskId,
-        peer_aggregator_endpoint: Url,
+        peer_aggregator_endpoint: DapUrl,
         batch_mode: BatchMode,
         vdaf: VdafInstance,
         vdaf_verify_key: SecretBytes,
@@ -298,7 +299,7 @@ impl AggregatorTask {
 
     fn new_with_common_parameters(
         common_parameters: CommonTaskParameters,
-        peer_aggregator_endpoint: Url,
+        peer_aggregator_endpoint: DapUrl,
         aggregator_parameters: AggregatorTaskParameters,
     ) -> Result<Self, Error> {
         if let BatchMode::LeaderSelected {
@@ -342,7 +343,7 @@ impl AggregatorTask {
     }
 
     /// Retrieves the peer aggregator endpoint associated with this task.
-    pub fn peer_aggregator_endpoint(&self) -> &Url {
+    pub fn peer_aggregator_endpoint(&self) -> &DapUrl {
         &self.peer_aggregator_endpoint
     }
 
@@ -446,7 +447,7 @@ impl AggregatorTask {
             self.aggregator_parameters,
             AggregatorTaskParameters::Leader { .. }
         ) {
-            let mut uri = self.peer_aggregator_endpoint().join(&format!(
+            let mut uri = url_for_join(self.peer_aggregator_endpoint())?.join(&format!(
                 "{}/aggregation_jobs/{aggregation_job_id}",
                 self.tasks_path()
             ))?;
@@ -471,11 +472,13 @@ impl AggregatorTask {
             self.aggregator_parameters,
             AggregatorTaskParameters::Leader { .. }
         ) {
-            Ok(Some(self.peer_aggregator_endpoint().join(&format!(
-                "{}/aggregate_shares/{}",
-                self.tasks_path(),
-                aggregate_share_id,
-            ))?))
+            Ok(Some(url_for_join(self.peer_aggregator_endpoint())?.join(
+                &format!(
+                    "{}/aggregate_shares/{}",
+                    self.tasks_path(),
+                    aggregate_share_id,
+                ),
+            )?))
         } else {
             Ok(None)
         }
@@ -675,7 +678,7 @@ impl AggregatorTaskParameters {
 #[derive(Clone, Serialize, Deserialize)]
 pub struct SerializedAggregatorTask {
     task_id: Option<TaskId>,
-    peer_aggregator_endpoint: Url,
+    peer_aggregator_endpoint: DapUrl,
     batch_mode: BatchMode,
     aggregation_mode: Option<AggregationMode>,
     vdaf: VdafInstance,
@@ -866,7 +869,7 @@ pub mod test_util {
     };
     use janus_messages::{
         AggregateShareId, AggregationJobId, AggregationJobStep, CollectionJobId, Duration,
-        HpkeConfigId, Interval, Role, TaskId, Time, TimePrecision,
+        HpkeConfigId, Interval, Role, TaskId, Time, TimePrecision, Url as DapUrl,
     };
     use rand::{RngExt, distr::StandardUniform, random, rng};
     use url::Url;
@@ -878,6 +881,12 @@ pub mod test_util {
             CommonTaskParameters, Error, VerifyKey,
         },
     };
+
+    /// Converts a routing [`url::Url`] into the [`janus_messages::Url`] the aggregator view stores.
+    /// Test-only: a `url::Url` always serializes to non-empty ASCII, so this cannot fail here.
+    fn to_dap_url(url: &Url) -> DapUrl {
+        DapUrl::try_from(url.as_str().as_bytes()).unwrap()
+    }
 
     /// All parameters and secrets for a task, for all participants.
     #[derive(Clone, Educe, PartialEq, Eq)]
@@ -1124,7 +1133,7 @@ pub mod test_util {
         pub fn leader_view(&self) -> Result<AggregatorTask, Error> {
             AggregatorTask::new_with_common_parameters(
                 self.common_parameters.clone(),
-                self.helper_aggregator_endpoint.clone(),
+                to_dap_url(&self.helper_aggregator_endpoint),
                 AggregatorTaskParameters::Leader {
                     aggregator_auth_token: self.aggregator_auth_token.clone(),
                     collector_auth_token_hash: AuthenticationTokenHash::from(
@@ -1139,7 +1148,7 @@ pub mod test_util {
         pub fn helper_view(&self) -> Result<AggregatorTask, Error> {
             AggregatorTask::new_with_common_parameters(
                 self.common_parameters.clone(),
-                self.leader_aggregator_endpoint.clone(),
+                to_dap_url(&self.leader_aggregator_endpoint),
                 AggregatorTaskParameters::Helper {
                     aggregator_auth_token_hash: AuthenticationTokenHash::from(
                         &self.aggregator_auth_token,
@@ -1154,7 +1163,7 @@ pub mod test_util {
         pub fn taskprov_helper_view(&self) -> Result<AggregatorTask, Error> {
             AggregatorTask::new_with_common_parameters(
                 self.common_parameters.clone(),
-                self.leader_aggregator_endpoint.clone(),
+                to_dap_url(&self.leader_aggregator_endpoint),
                 AggregatorTaskParameters::TaskprovHelper {
                     aggregation_mode: self.helper_aggregation_mode,
                 },

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -302,6 +302,10 @@ impl AggregatorTask {
         peer_aggregator_endpoint: DapUrl,
         aggregator_parameters: AggregatorTaskParameters,
     ) -> Result<Self, Error> {
+        // Reject an unparseable endpoint at construction. Without this check a
+        // malformed endpoint would persist and never surface a user-visible error.
+        Url::try_from(&peer_aggregator_endpoint)?;
+
         if let BatchMode::LeaderSelected {
             batch_time_window_size: Some(batch_time_window_size),
             ..
@@ -1452,7 +1456,7 @@ mod tests {
     };
     use janus_messages::{
         BatchConfig, Duration, HpkeAeadId, HpkeConfig, HpkeConfigId, HpkeKdfId, HpkeKemId,
-        HpkePublicKey, Interval, TaskId, Time, TimePrecision,
+        HpkePublicKey, Interval, TaskId, Time, TimePrecision, Url as DapUrl,
     };
     use rand::random;
     use serde_json::json;
@@ -1628,10 +1632,19 @@ mod tests {
     /// (which validates `task_info`), with a caller-supplied `task_info` and otherwise fixed
     /// values.
     fn aggregator_task_with_task_info(task_info: Vec<u8>) -> Result<AggregatorTask, Error> {
+        aggregator_task_with_endpoint("https://example.net/".parse().unwrap(), task_info)
+    }
+
+    /// Builds an [`AggregatorTask`] through the production [`AggregatorTask::new`] constructor,
+    /// with a caller-supplied peer endpoint and `task_info` and otherwise fixed values.
+    fn aggregator_task_with_endpoint(
+        peer_aggregator_endpoint: DapUrl,
+        task_info: Vec<u8>,
+    ) -> Result<AggregatorTask, Error> {
         let time_precision = TimePrecision::from_seconds(60);
         AggregatorTask::new(
             TaskId::from([0; 32]),
-            "https://example.net/".parse().unwrap(),
+            peer_aggregator_endpoint,
             BatchMode::TimeInterval,
             VdafInstance::Prio3Count,
             SecretBytes::new(b"1234567812345678".to_vec()),
@@ -1671,6 +1684,21 @@ mod tests {
         );
         aggregator_task_with_task_info(vec![b'a'; 255]).unwrap();
         aggregator_task_with_task_info(b"x".to_vec()).unwrap();
+    }
+
+    #[test]
+    fn rejects_unparseable_peer_endpoint() {
+        // The endpoint is ASCII (so it is a valid `DapUrl`) but not a parseable URL; construction
+        // must reject it rather than persist it to surface only at request time.
+        assert_matches!(
+            aggregator_task_with_endpoint("not a url".try_into().unwrap(), b"task-info".to_vec()),
+            Err(Error::Url(_))
+        );
+        aggregator_task_with_endpoint(
+            "https://example.net/".try_into().unwrap(),
+            b"task-info".to_vec(),
+        )
+        .unwrap();
     }
 
     #[test]

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -7,15 +7,14 @@
 //! # Examples
 //!
 //! ```no_run
-//! use url::Url;
 //! use prio::vdaf::prio3::Prio3Histogram;
-//! use janus_messages::{TimePrecision, TaskId};
+//! use janus_messages::{TimePrecision, TaskId, Url};
 //! use std::str::FromStr;
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     let leader_url = Url::parse("https://leader.example.com/").unwrap();
-//!     let helper_url = Url::parse("https://helper.example.com/").unwrap();
+//!     let leader_url = Url::try_from("https://leader.example.com/").unwrap();
+//!     let helper_url = Url::try_from("https://helper.example.com/").unwrap();
 //!     let vdaf = Prio3Histogram::new_histogram(
 //!         2,
 //!         12,
@@ -58,13 +57,13 @@ use janus_core::{
         ExponentialWithTotalDelayBuilder, http_request_exponential_backoff, retry_http_request,
     },
     time::{Clock, DateTimeExt, RealClock},
-    url_ensure_trailing_slash,
+    url_for_join,
     vdaf::vdaf_application_context,
 };
 use janus_messages::{
     HpkeConfig, HpkeConfigList, InputShareAad, MediaType, PlaintextInputShare, Report, ReportId,
     ReportMetadata, ReportUploadStatus, Role, TaskId, Time, TimePrecision, UploadErrors,
-    UploadRequest,
+    UploadRequest, Url as DapUrl,
 };
 #[cfg(feature = "ohttp")]
 use ohttp::{ClientRequest, KeyConfig};
@@ -163,10 +162,10 @@ struct ClientParameters {
     task_id: TaskId,
     /// URL relative to which the Leader's API endpoints are found.
     #[educe(Debug(method(std::fmt::Display::fmt)))]
-    leader_aggregator_endpoint: Url,
+    leader_aggregator_endpoint: DapUrl,
     /// URL relative to which the Helper's API endpoints are found.
     #[educe(Debug(method(std::fmt::Display::fmt)))]
-    helper_aggregator_endpoint: Url,
+    helper_aggregator_endpoint: DapUrl,
     /// The time precision of the task. This value is shared by all parties in the protocol, and is
     /// used to compute report timestamps.
     time_precision: TimePrecision,
@@ -178,14 +177,16 @@ impl ClientParameters {
     /// Creates a new set of client task parameters.
     pub fn new(
         task_id: TaskId,
-        leader_aggregator_endpoint: Url,
-        helper_aggregator_endpoint: Url,
+        leader_aggregator_endpoint: DapUrl,
+        helper_aggregator_endpoint: DapUrl,
         time_precision: TimePrecision,
     ) -> Self {
+        // Store the endpoints byte-for-byte; trailing-slash normalization happens at join time via
+        // `url_for_join`, so the bytes bound into HPKE AADs stay exactly as provisioned (DAP §4.1).
         Self {
             task_id,
-            leader_aggregator_endpoint: url_ensure_trailing_slash(leader_aggregator_endpoint),
-            helper_aggregator_endpoint: url_ensure_trailing_slash(helper_aggregator_endpoint),
+            leader_aggregator_endpoint,
+            helper_aggregator_endpoint,
             time_precision,
             http_request_retry_parameters: http_request_exponential_backoff(),
         }
@@ -193,7 +194,7 @@ impl ClientParameters {
 
     /// The URL relative to which the API endpoints for the aggregator may be found, if the role is
     /// an aggregator, or an error otherwise.
-    fn aggregator_endpoint(&self, role: &Role) -> Result<&Url, Error> {
+    fn aggregator_endpoint(&self, role: &Role) -> Result<&DapUrl, Error> {
         match role {
             Role::Leader => Ok(&self.leader_aggregator_endpoint),
             Role::Helper => Ok(&self.helper_aggregator_endpoint),
@@ -206,13 +207,12 @@ impl ClientParameters {
     ///
     /// [1]: https://www.ietf.org/archive/id/draft-ietf-ppm-dap-07.html#name-hpke-configuration-request
     fn hpke_config_endpoint(&self, role: &Role) -> Result<Url, Error> {
-        Ok(self.aggregator_endpoint(role)?.join("hpke_config")?)
+        Ok(url_for_join(self.aggregator_endpoint(role)?)?.join("hpke_config")?)
     }
 
     // URI to which reports may be uploaded for the provided task.
     fn reports_resource_uri(&self, task_id: &TaskId) -> Result<Url, Error> {
-        Ok(self
-            .leader_aggregator_endpoint
+        Ok(url_for_join(&self.leader_aggregator_endpoint)?
             .join(&format!("tasks/{task_id}/reports"))?)
     }
 }
@@ -258,8 +258,8 @@ impl<V: vdaf::Client<16>> ClientBuilder<V> {
     /// Construct a [`ClientBuilder`] from its required DAP task parameters.
     pub fn new(
         task_id: TaskId,
-        leader_aggregator_endpoint: Url,
-        helper_aggregator_endpoint: Url,
+        leader_aggregator_endpoint: DapUrl,
+        helper_aggregator_endpoint: DapUrl,
         time_precision: TimePrecision,
         vdaf: V,
     ) -> Self {
@@ -390,7 +390,7 @@ impl<V: vdaf::Client<16>> ClientBuilder<V> {
     /// ```no_run
     /// # use url::Url;
     /// # use prio::vdaf::prio3::Prio3Count;
-    /// # use janus_messages::{TimePrecision, TaskId};
+    /// # use janus_messages::{TimePrecision, TaskId, Url as DapUrl};
     /// # use rand::random;
     /// # use std::str::FromStr;
     ///
@@ -400,8 +400,8 @@ impl<V: vdaf::Client<16>> ClientBuilder<V> {
     ///
     ///     let client = janus_client::Client::builder(
     ///         task_id,
-    ///         Url::parse("https://leader.example.com/").unwrap(),
-    ///         Url::parse("https://helper.example.com/").unwrap(),
+    ///         DapUrl::try_from("https://leader.example.com/").unwrap(),
+    ///         DapUrl::try_from("https://helper.example.com/").unwrap(),
     ///         TimePrecision::from_seconds(1),
     ///         Prio3Count::new_count(2).unwrap(),
     ///     )
@@ -440,8 +440,8 @@ impl<V: vdaf::Client<16>> Client<V> {
     /// Construct a new client from the required set of DAP task parameters.
     pub async fn new(
         task_id: TaskId,
-        leader_aggregator_endpoint: Url,
-        helper_aggregator_endpoint: Url,
+        leader_aggregator_endpoint: DapUrl,
+        helper_aggregator_endpoint: DapUrl,
         time_precision: TimePrecision,
         vdaf: V,
     ) -> Result<Self, Error> {
@@ -468,8 +468,8 @@ impl<V: vdaf::Client<16>> Client<V> {
     )]
     pub fn with_hpke_configs(
         task_id: TaskId,
-        leader_aggregator_endpoint: Url,
-        helper_aggregator_endpoint: Url,
+        leader_aggregator_endpoint: DapUrl,
+        helper_aggregator_endpoint: DapUrl,
         time_precision: TimePrecision,
         vdaf: V,
         leader_hpke_config: HpkeConfig,
@@ -490,8 +490,8 @@ impl<V: vdaf::Client<16>> Client<V> {
     /// parameters.
     pub fn builder(
         task_id: TaskId,
-        leader_aggregator_endpoint: Url,
-        helper_aggregator_endpoint: Url,
+        leader_aggregator_endpoint: DapUrl,
+        helper_aggregator_endpoint: DapUrl,
         time_precision: TimePrecision,
         vdaf: V,
     ) -> ClientBuilder<V> {

--- a/client/src/tests/mod.rs
+++ b/client/src/tests/mod.rs
@@ -8,14 +8,13 @@ use janus_core::{
 };
 use janus_messages::{
     HpkeConfigList, MediaType, ReportError, ReportUploadStatus, Role, Time, TimePrecision,
-    UploadErrors, UploadRequest,
+    UploadErrors, UploadRequest, Url as DapUrl,
 };
 use prio::{
     codec::Encode,
     vdaf::{self, prio3::Prio3},
 };
 use rand::random;
-use url::Url;
 
 use crate::{Client, ClientParameters, Error, HpkeConfiguration, UploadStats, default_http_client};
 
@@ -23,7 +22,7 @@ use crate::{Client, ClientParameters, Error, HpkeConfiguration, UploadStats, def
 mod ohttp;
 
 async fn setup_client<V: vdaf::Client<16>>(server: &mockito::Server, vdaf: V) -> Client<V> {
-    let server_url = Url::parse(&server.url()).unwrap();
+    let server_url = DapUrl::try_from(server.url().as_str()).unwrap();
     Client::builder(
         random(),
         server_url.clone(),
@@ -40,21 +39,40 @@ async fn setup_client<V: vdaf::Client<16>>(server: &mockito::Server, vdaf: V) ->
 }
 
 #[test]
-fn aggregator_endpoints_end_in_slash() {
+fn endpoints_preserved_and_joined() {
+    let task_id = random();
     let client_parameters = ClientParameters::new(
-        random(),
-        "http://leader_endpoint/foo/bar".parse().unwrap(),
-        "http://helper_endpoint".parse().unwrap(),
+        task_id,
+        "http://leader_endpoint/foo/bar".try_into().unwrap(),
+        "http://helper_endpoint".try_into().unwrap(),
         TimePrecision::from_seconds(100),
     );
 
+    // Endpoints are stored verbatim (no trailing slash added), so the bytes bound into HPKE AADs
+    // match what was provisioned (DAP §4.1).
     assert_eq!(
-        client_parameters.leader_aggregator_endpoint,
-        "http://leader_endpoint/foo/bar/".parse().unwrap()
+        client_parameters.leader_aggregator_endpoint.as_str(),
+        "http://leader_endpoint/foo/bar"
     );
     assert_eq!(
-        client_parameters.helper_aggregator_endpoint,
-        "http://helper_endpoint/".parse().unwrap()
+        client_parameters.helper_aggregator_endpoint.as_str(),
+        "http://helper_endpoint"
+    );
+
+    // Joining for requests still applies the trailing slash.
+    assert_eq!(
+        client_parameters
+            .hpke_config_endpoint(&Role::Helper)
+            .unwrap()
+            .as_str(),
+        "http://helper_endpoint/hpke_config"
+    );
+    assert_eq!(
+        client_parameters
+            .reports_resource_uri(&task_id)
+            .unwrap()
+            .as_str(),
+        format!("http://leader_endpoint/foo/bar/tasks/{task_id}/reports")
     );
 }
 
@@ -223,7 +241,7 @@ async fn unsupported_hpke_algorithms() {
     initialize_rustls();
 
     let mut server = mockito::Server::new_async().await;
-    let server_url = Url::parse(&server.url()).unwrap();
+    let server_url = DapUrl::try_from(server.url().as_str()).unwrap();
     let http_client = default_http_client().unwrap();
     let mut client_parameters = ClientParameters::new(
         random(),

--- a/client/src/tests/ohttp.rs
+++ b/client/src/tests/ohttp.rs
@@ -10,7 +10,7 @@ use janus_core::{
     retries::test_util::test_http_request_exponential_backoff,
     test_util::install_test_trace_subscriber,
 };
-use janus_messages::{MediaType, Report, TimePrecision, UploadRequest};
+use janus_messages::{MediaType, Report, TimePrecision, UploadRequest, Url as DapUrl};
 use ohttp::{
     KeyConfig, SymmetricSuite,
     hpke::{Aead, Kdf},
@@ -29,7 +29,7 @@ use crate::{
 
 async fn build_client(server: &mockito::ServerGuard) -> Result<Client<Prio3Count>, Error> {
     let task_id = random();
-    let server_url = Url::parse(&server.url()).unwrap();
+    let server_url = DapUrl::try_from(server.url().as_str()).unwrap();
     let keys_endpoint = Url::parse(format!("{}/ohttp-keys", server.url()).as_str()).unwrap();
     let relay = Url::parse(format!("{}/relay", server.url()).as_str()).unwrap();
 

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -12,9 +12,8 @@
 //! use std::{fs::File, str::FromStr};
 //!
 //! use janus_collector::{Collector, PrivateCollectorCredential};
-//! use janus_messages::{Duration, Interval, Query, TaskId, Time, TimePrecision};
+//! use janus_messages::{Duration, Interval, Query, TaskId, Time, TimePrecision, Url};
 //! use prio::vdaf::prio3::Prio3;
-//! use url::Url;
 //!
 //! # async fn run() {
 //! # const TIME_PRECISION: u64 = 3600;
@@ -83,11 +82,11 @@ use janus_core::{
         ExponentialWithTotalDelayBuilder, http_request_exponential_backoff, retry_http_request,
     },
     time::TimeExt,
-    url_ensure_trailing_slash,
+    url_for_join,
 };
 use janus_messages::{
     AggregateShareAad, BatchSelector, CollectionJobId, CollectionJobReq, CollectionJobResp,
-    MediaType, PartialBatchSelector, Query, Role, TaskId, TimePrecision,
+    MediaType, PartialBatchSelector, Query, Role, TaskId, TimePrecision, Url as DapUrl,
     batch_mode::{BatchMode, TimeInterval},
 };
 use prio::{
@@ -290,7 +289,7 @@ pub struct CollectorBuilder<V: vdaf::Collector> {
     /// Unique identifier for the task.
     task_id: TaskId,
     /// The base URL of the leader's aggregator API endpoints.
-    leader_endpoint: Url,
+    leader_endpoint: DapUrl,
     /// The authentication information needed to communicate with the leader aggregator.
     authentication: AuthenticationToken,
     /// HPKE keypair used for decryption of aggregate shares.
@@ -313,7 +312,7 @@ impl<V: vdaf::Collector> CollectorBuilder<V> {
     /// the task's VDAF.
     pub fn new(
         task_id: TaskId,
-        leader_endpoint: Url,
+        leader_endpoint: DapUrl,
         authentication: AuthenticationToken,
         hpke_keypair: HpkeKeypair,
         vdaf: V,
@@ -344,7 +343,9 @@ impl<V: vdaf::Collector> CollectorBuilder<V> {
         };
         Ok(Collector {
             task_id: self.task_id,
-            leader_endpoint: url_ensure_trailing_slash(self.leader_endpoint),
+            // Stored verbatim; the trailing slash is applied at join time via `url_for_join`, so
+            // the bytes bound into HPKE AADs stay exactly as provisioned (DAP §4.1).
+            leader_endpoint: self.leader_endpoint,
             authentication: self.authentication,
             hpke_keypair: self.hpke_keypair,
             vdaf: self.vdaf,
@@ -382,7 +383,7 @@ pub struct Collector<V: vdaf::Collector> {
     task_id: TaskId,
     /// The base URL of the leader's aggregator API endpoints.
     #[educe(Debug(method(std::fmt::Display::fmt)))]
-    leader_endpoint: Url,
+    leader_endpoint: DapUrl,
     /// The authentication information needed to communicate with the leader aggregator.
     authentication: AuthenticationToken,
     /// HPKE keypair used for decryption of aggregate shares.
@@ -407,7 +408,7 @@ impl<V: vdaf::Collector> Collector<V> {
     /// implementation of the task's VDAF.
     pub fn new(
         task_id: TaskId,
-        leader_endpoint: Url,
+        leader_endpoint: DapUrl,
         authentication: AuthenticationToken,
         hpke_keypair: HpkeKeypair,
         vdaf: V,
@@ -428,7 +429,7 @@ impl<V: vdaf::Collector> Collector<V> {
     /// the task's VDAF.
     pub fn builder(
         task_id: TaskId,
-        leader_endpoint: Url,
+        leader_endpoint: DapUrl,
         authentication: AuthenticationToken,
         hpke_keypair: HpkeKeypair,
         vdaf: V,
@@ -446,7 +447,7 @@ impl<V: vdaf::Collector> Collector<V> {
 
     /// Construct a URI for a collection.
     fn collection_job_uri(&self, collection_job_id: CollectionJobId) -> Result<Url, Error> {
-        Ok(self.leader_endpoint.join(&format!(
+        Ok(url_for_join(&self.leader_endpoint)?.join(&format!(
             "tasks/{}/collection_jobs/{collection_job_id}",
             self.task_id
         ))?)
@@ -785,7 +786,7 @@ mod tests {
     use janus_messages::{
         AggregateShareAad, BatchId, BatchSelector, CollectionJobId, CollectionJobReq,
         CollectionJobResp, Duration, HpkeCiphertext, Interval, MediaType, PartialBatchSelector,
-        Query, Role, TaskId, Time, TimePrecision,
+        Query, Role, TaskId, Time, TimePrecision, Url as DapUrl,
         batch_mode::{LeaderSelected, TimeInterval},
         problem_type::DapProblemType,
     };
@@ -797,7 +798,7 @@ mod tests {
     };
     use rand::random;
     use reqwest::{
-        StatusCode, Url,
+        StatusCode,
         header::{AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE},
     };
     use retry_after::RetryAfter;
@@ -807,7 +808,7 @@ mod tests {
     const TEST_TIME_PRECISION: TimePrecision = TimePrecision::from_seconds(100);
 
     fn setup_collector<V: vdaf::Collector>(server: &mut mockito::Server, vdaf: V) -> Collector<V> {
-        let server_url = Url::parse(&server.url()).unwrap();
+        let server_url = DapUrl::try_from(server.url().as_str()).unwrap();
         let hpke_keypair = HpkeKeypair::test();
         Collector::builder(
             random(),
@@ -904,36 +905,40 @@ mod tests {
     }
 
     #[test]
-    fn leader_endpoint_end_in_slash() {
+    fn leader_endpoint_preserved_and_joined() {
         install_test_trace_subscriber();
         initialize_rustls();
         let hpke_keypair = HpkeKeypair::test();
-        let collector = Collector::new(
-            random(),
-            "http://example.com/dap".parse().unwrap(),
-            AuthenticationToken::new_bearer_token_from_string("Y29sbGVjdG9yIHRva2Vu").unwrap(),
-            hpke_keypair.clone(),
-            dummy::Vdaf::new(1),
-            TEST_TIME_PRECISION,
-        )
-        .unwrap();
+        let collection_job_id: CollectionJobId = random();
 
-        assert_eq!(
-            collector.leader_endpoint.as_str(),
-            "http://example.com/dap/",
-        );
+        for (endpoint, joined_base) in [
+            ("http://example.com/dap", "http://example.com/dap/"),
+            ("http://example.com", "http://example.com/"),
+        ] {
+            let collector = Collector::new(
+                random(),
+                endpoint.try_into().unwrap(),
+                AuthenticationToken::new_bearer_token_from_string("Y29sbGVjdG9yIHRva2Vu").unwrap(),
+                hpke_keypair.clone(),
+                dummy::Vdaf::new(1),
+                TEST_TIME_PRECISION,
+            )
+            .unwrap();
 
-        let collector = Collector::new(
-            random(),
-            "http://example.com".parse().unwrap(),
-            AuthenticationToken::new_bearer_token_from_string("Y29sbGVjdG9yIHRva2Vu").unwrap(),
-            hpke_keypair,
-            dummy::Vdaf::new(1),
-            TEST_TIME_PRECISION,
-        )
-        .unwrap();
-
-        assert_eq!(collector.leader_endpoint.as_str(), "http://example.com/");
+            // Stored verbatim (no trailing slash added) for byte-identical HPKE AADs (DAP §4.1),
+            // while the request URI is still joined against a slash-terminated base.
+            assert_eq!(collector.leader_endpoint.as_str(), endpoint);
+            assert_eq!(
+                collector
+                    .collection_job_uri(collection_job_id)
+                    .unwrap()
+                    .as_str(),
+                format!(
+                    "{joined_base}tasks/{}/collection_jobs/{collection_job_id}",
+                    collector.task_id
+                ),
+            );
+        }
     }
 
     #[tokio::test]
@@ -1247,7 +1252,7 @@ mod tests {
         let mut server = mockito::Server::new_async().await;
         let vdaf = Prio3::new_count(2).unwrap();
         let transcript = run_vdaf(&vdaf, &random(), &random(), &(), &random(), &true);
-        let server_url = Url::parse(&server.url()).unwrap();
+        let server_url = DapUrl::try_from(server.url().as_str()).unwrap();
         let hpke_keypair = HpkeKeypair::test();
         let collector = Collector::builder(
             random(),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -50,16 +50,21 @@ pub mod taskprov {
 /// implemented.
 const DAP_VERSION_IDENTIFIER: &str = "dap-18";
 
-/// Returns the given [`Url`], possibly modified to end with a slash.
-///
-/// Aggregator endpoint URLs should end with a slash if they will be used with [`Url::join`],
-/// because that method will drop the last path component of the base URL if it does not end with a
-/// slash.
-pub fn url_ensure_trailing_slash(mut url: Url) -> Url {
-    if !url.as_str().ends_with('/') {
-        url.set_path(&format!("{}/", url.path()));
+/// Extends [`Url`] with a helper for making a URL safe to use as a [`Url::join`] base.
+pub trait UrlExt {
+    /// Returns this URL, modified to end with a slash if it does not already.
+    ///
+    /// A base URL must end with a slash for [`Url::join`] to preserve its last path component.
+    fn ensure_trailing_slash(self) -> Self;
+}
+
+impl UrlExt for Url {
+    fn ensure_trailing_slash(mut self) -> Self {
+        if !self.as_str().ends_with('/') {
+            self.set_path(&format!("{}/", self.path()));
+        }
+        self
     }
-    url
 }
 
 /// Converts a [`janus_messages::Url`] into a [`url::Url`] ready for [`Url::join`], ensuring a
@@ -69,7 +74,7 @@ pub fn url_ensure_trailing_slash(mut url: Url) -> Url {
 /// [`janus_messages::Url`] — its exact bytes are bound into HPKE AADs and must not be re-encoded
 /// (DAP-18 §4.1).
 pub fn url_for_join(url: &janus_messages::Url) -> Result<Url, url::ParseError> {
-    Ok(url_ensure_trailing_slash(Url::try_from(url)?))
+    Ok(Url::try_from(url)?.ensure_trailing_slash())
 }
 
 /// Choose aws-lc-rs as the default rustls crypto provider. This is what's currently enabled by the

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -62,6 +62,16 @@ pub fn url_ensure_trailing_slash(mut url: Url) -> Url {
     url
 }
 
+/// Converts a [`janus_messages::Url`] into a [`url::Url`] ready for [`Url::join`], ensuring a
+/// trailing slash so `join` does not drop the last path component.
+///
+/// The trailing-slash fixup applies only to this routing copy, never to the stored
+/// [`janus_messages::Url`] — its exact bytes are bound into HPKE AADs and must not be re-encoded
+/// (DAP-18 §4.1).
+pub fn url_for_join(url: &janus_messages::Url) -> Result<Url, url::ParseError> {
+    Ok(url_ensure_trailing_slash(Url::try_from(url)?))
+}
+
 /// Choose aws-lc-rs as the default rustls crypto provider. This is what's currently enabled by the
 /// default Cargo feature. Specifying a default provider here prevents runtime errors if another
 /// dependency also enables the ring feature.

--- a/integration_tests/src/client.rs
+++ b/integration_tests/src/client.rs
@@ -271,8 +271,8 @@ where
             .endpoints_for_host_client(leader_port, helper_port);
         let mut builder = Client::builder(
             task_parameters.task_id,
-            leader_aggregator_endpoint,
-            helper_aggregator_endpoint,
+            leader_aggregator_endpoint.as_str().try_into().unwrap(),
+            helper_aggregator_endpoint.as_str().try_into().unwrap(),
             task_parameters.time_precision,
             vdaf,
         );

--- a/integration_tests/tests/integration/common.rs
+++ b/integration_tests/tests/integration/common.rs
@@ -253,7 +253,7 @@ where
         .leader_endpoint_for_host(leader_port);
     let collector = Collector::builder(
         task_parameters.task_id,
-        leader_endpoint,
+        leader_endpoint.as_str().try_into().unwrap(),
         task_parameters.collector_auth_token.clone(),
         task_parameters.collector_hpke_keypair.clone(),
         vdaf,

--- a/integration_tests/tests/integration/simulation/setup.rs
+++ b/integration_tests/tests/integration/simulation/setup.rs
@@ -219,8 +219,14 @@ impl Components {
         let http_client = default_http_client().unwrap();
         let client = Client::builder(
             *task.id(),
-            task.leader_aggregator_endpoint().clone(),
-            task.helper_aggregator_endpoint().clone(),
+            task.leader_aggregator_endpoint()
+                .as_str()
+                .try_into()
+                .unwrap(),
+            task.helper_aggregator_endpoint()
+                .as_str()
+                .try_into()
+                .unwrap(),
             *task.time_precision(),
             state.vdaf.clone(),
         )
@@ -327,7 +333,10 @@ impl Components {
 
         let collector = Collector::builder(
             *task.id(),
-            task.leader_aggregator_endpoint().clone(),
+            task.leader_aggregator_endpoint()
+                .as_str()
+                .try_into()
+                .unwrap(),
             task.collector_auth_token().clone(),
             task.collector_hpke_keypair().clone(),
             state.vdaf.clone(),

--- a/interop_binaries/src/commands/janus_interop_aggregator.rs
+++ b/interop_binaries/src/commands/janus_interop_aggregator.rs
@@ -28,7 +28,7 @@ use janus_core::{
     auth_tokens::{AuthenticationToken, AuthenticationTokenHash},
     time::RealClock,
 };
-use janus_messages::{Duration, HpkeConfig, Interval, Time, TimePrecision};
+use janus_messages::{Duration, HpkeConfig, Interval, Time, TimePrecision, Url as DapUrl};
 use prio::codec::Decode;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -62,10 +62,13 @@ async fn handle_add_task(
     datastore: &Datastore<RealClock>,
     request: AggregatorAddTaskRequest,
 ) -> anyhow::Result<()> {
-    let peer_aggregator_endpoint = match request.role {
+    let peer_aggregator_endpoint: DapUrl = match request.role {
         AggregatorRole::Leader => request.helper,
         AggregatorRole::Helper => request.leader,
-    };
+    }
+    .as_str()
+    .parse()
+    .context("invalid peer aggregator endpoint")?;
     let vdaf = request.vdaf.into();
     let leader_authentication_token =
         AuthenticationToken::new_dap_auth_token_from_string(request.leader_authentication_token)

--- a/interop_binaries/src/commands/janus_interop_client.rs
+++ b/interop_binaries/src/commands/janus_interop_client.rs
@@ -16,7 +16,7 @@ use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use clap::Parser;
 use educe::Educe;
 use janus_core::vdaf::{VdafInstance, new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128};
-use janus_messages::{TaskId, Time, TimePrecision};
+use janus_messages::{TaskId, Time, TimePrecision, Url as DapUrl};
 use prio::{
     codec::Decode,
     field::Field64,
@@ -25,7 +25,6 @@ use prio::{
 };
 use serde::{Deserialize, Serialize};
 use tokio::net::TcpListener;
-use url::Url;
 
 use crate::{
     NumberAsString, VdafObject, install_tracing_subscriber,
@@ -60,9 +59,9 @@ where
 struct UploadRequest {
     task_id: String,
     #[educe(Debug(method(std::fmt::Display::fmt)))]
-    leader: Url,
+    leader: DapUrl,
     #[educe(Debug(method(std::fmt::Display::fmt)))]
-    helper: Url,
+    helper: DapUrl,
     vdaf: VdafObject,
     measurement: serde_json::Value,
     #[serde(default)]

--- a/interop_binaries/src/commands/janus_interop_collector.rs
+++ b/interop_binaries/src/commands/janus_interop_collector.rs
@@ -24,7 +24,7 @@ use janus_core::{
 };
 use janus_messages::{
     BatchId, Duration, HpkeConfig, Interval, PartialBatchSelector, Query, TaskId, Time,
-    TimePrecision, batch_mode::BatchMode,
+    TimePrecision, Url as DapUrl, batch_mode::BatchMode,
 };
 use prio::{
     codec::{Decode, Encode},
@@ -32,7 +32,6 @@ use prio::{
     vdaf::{self, prio3::Prio3},
 };
 use rand::{RngExt, distr::StandardUniform, prelude::Distribution, random};
-use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use tokio::{net::TcpListener, runtime::Runtime, sync::Mutex, task::JoinHandle};
 
@@ -46,7 +45,7 @@ use crate::{
 struct AddTaskRequest {
     task_id: String,
     #[educe(Debug(method(std::fmt::Display::fmt)))]
-    leader: Url,
+    leader: DapUrl,
     vdaf: VdafObject,
     collector_authentication_token: String,
     #[serde(rename = "batch_mode")]
@@ -127,7 +126,7 @@ struct CollectPollResponse {
 struct TaskState {
     task_id: TaskId,
     keypair: HpkeKeypair,
-    leader_url: Url,
+    leader_url: DapUrl,
     vdaf: VdafObject,
     auth_token: AuthenticationToken,
     time_precision: TimePrecision,

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -71,6 +71,12 @@ pub struct Url(Vec<u8>);
 
 impl Url {
     const MAX_LEN: usize = 2usize.pow(16) - 1;
+
+    /// Returns the URL as a string slice.
+    pub fn as_str(&self) -> &str {
+        // Unwrap safety: the constructor validates that the contents are ASCII.
+        str::from_utf8(&self.0).unwrap()
+    }
 }
 
 impl Encode for Url {
@@ -85,7 +91,7 @@ impl Encode for Url {
 
 impl Decode for Url {
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
-        Url::try_from(decode_u16_items(&(), bytes)?.as_ref())
+        Url::try_from(decode_u16_items(&(), bytes)?.as_slice())
     }
 }
 
@@ -131,6 +137,14 @@ impl TryFrom<&[u8]> for Url {
     }
 }
 
+impl FromStr for Url {
+    type Err = CodecError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Url::try_from(s.as_bytes())
+    }
+}
+
 impl TryFrom<&Url> for url::Url {
     type Error = url::ParseError;
 
@@ -138,6 +152,43 @@ impl TryFrom<&Url> for url::Url {
         // Unwrap safety: this type can't be constructed without being validated
         // as consisting only of ASCII.
         url::Url::parse(str::from_utf8(&value.0).unwrap())
+    }
+}
+
+/// Serializes as the URL's ASCII string, so serde formats (e.g. the aggregator API's JSON) carry
+/// the exact bytes rather than a re-encoded form.
+impl Serialize for Url {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+struct UrlVisitor;
+
+impl Visitor<'_> for UrlVisitor {
+    type Value = Url;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("an ASCII-encoded URL string")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Url, E>
+    where
+        E: de::Error,
+    {
+        Url::try_from(value.as_bytes()).map_err(E::custom)
+    }
+}
+
+impl<'de> Deserialize<'de> for Url {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_str(UrlVisitor)
     }
 }
 

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -137,6 +137,14 @@ impl TryFrom<&[u8]> for Url {
     }
 }
 
+impl TryFrom<&str> for Url {
+    type Error = CodecError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Url::try_from(value.as_bytes())
+    }
+}
+
 impl FromStr for Url {
     type Err = CodecError;
 

--- a/messages/src/tests/common.rs
+++ b/messages/src/tests/common.rs
@@ -38,6 +38,21 @@ fn roundtrip_url() {
 }
 
 #[test]
+fn url_string_conversions_preserve_bytes() {
+    // Deliberately non-canonical: mixed-case host, no trailing slash. `url::Url` would normalize
+    // these; `janus_messages::Url` must preserve the exact bytes so the value bound into HPKE AADs
+    // is byte-identical to what was provisioned.
+    let raw = "HTTPS://Example.COM/Path";
+    let url = Url::try_from(raw.as_bytes()).unwrap();
+
+    assert_eq!(url.as_str(), raw);
+    assert_eq!(raw.parse::<Url>().unwrap(), url);
+
+    // serde carries the exact string, unchanged.
+    assert_tokens(&url, &[Token::Str(raw)]);
+}
+
+#[test]
 #[should_panic]
 fn time_precision_zero() {
     TimePrecision::from_seconds(0);

--- a/messages/src/tests/common.rs
+++ b/messages/src/tests/common.rs
@@ -19,7 +19,7 @@ fn roundtrip_url() {
         ),
     ] {
         roundtrip_encoding(&[(
-            Url::try_from(test.as_ref()).unwrap(),
+            Url::try_from(test).unwrap(),
             (hex::encode(len) + &hex::encode(test)).as_str(),
         )])
     }

--- a/messages/src/tests/task.rs
+++ b/messages/src/tests/task.rs
@@ -15,8 +15,8 @@ fn roundtrip_task_configuration() {
         (
             TaskConfigurationBuilder::new(
                 "foobar".as_bytes().to_vec(),
-                Url::try_from("https://example.com/".as_ref()).unwrap(),
-                Url::try_from("https://another.example.com/".as_ref()).unwrap(),
+                Url::try_from("https://example.com/").unwrap(),
+                Url::try_from("https://another.example.com/").unwrap(),
                 time_precision,
                 10000,
                 BatchConfig::TimeInterval,
@@ -72,8 +72,8 @@ fn roundtrip_task_configuration() {
         (
             TaskConfigurationBuilder::new(
                 "f".as_bytes().to_vec(),
-                Url::try_from("https://example.com/".as_ref()).unwrap(),
-                Url::try_from("https://another.example.com/".as_ref()).unwrap(),
+                Url::try_from("https://example.com/").unwrap(),
+                Url::try_from("https://another.example.com/").unwrap(),
                 TimePrecision::from_seconds(1000),
                 1000,
                 BatchConfig::LeaderSelected,
@@ -489,8 +489,8 @@ fn task_configuration_task_interval() {
 
     let config = TaskConfigurationBuilder::new(
         "test".as_bytes().to_vec(),
-        Url::try_from("https://leader.example.com/".as_ref()).unwrap(),
-        Url::try_from("https://helper.example.com/".as_ref()).unwrap(),
+        Url::try_from("https://leader.example.com/").unwrap(),
+        Url::try_from("https://helper.example.com/").unwrap(),
         time_precision,
         10,
         BatchConfig::TimeInterval,
@@ -508,8 +508,8 @@ fn task_configuration_task_interval() {
     // TaskConfiguration without task_interval extension.
     let config_no_interval = TaskConfigurationBuilder::new(
         "test".as_bytes().to_vec(),
-        Url::try_from("https://leader.example.com/".as_ref()).unwrap(),
-        Url::try_from("https://helper.example.com/".as_ref()).unwrap(),
+        Url::try_from("https://leader.example.com/").unwrap(),
+        Url::try_from("https://helper.example.com/").unwrap(),
         time_precision,
         10,
         BatchConfig::TimeInterval,
@@ -532,8 +532,8 @@ fn task_configuration_rejects_duplicate_extensions() {
     assert!(
         TaskConfiguration::new(
             "test".as_bytes().to_vec(),
-            Url::try_from("https://leader.example.com/".as_ref()).unwrap(),
-            Url::try_from("https://helper.example.com/".as_ref()).unwrap(),
+            Url::try_from("https://leader.example.com/").unwrap(),
+            Url::try_from("https://helper.example.com/").unwrap(),
             time_precision,
             10,
             BatchConfig::TimeInterval,
@@ -551,8 +551,8 @@ fn task_configuration_rejects_duplicate_extensions() {
     assert!(
         TaskConfigurationBuilder::new(
             "test".as_bytes().to_vec(),
-            Url::try_from("https://leader.example.com/".as_ref()).unwrap(),
-            Url::try_from("https://helper.example.com/".as_ref()).unwrap(),
+            Url::try_from("https://leader.example.com/").unwrap(),
+            Url::try_from("https://helper.example.com/").unwrap(),
             time_precision,
             10,
             BatchConfig::TimeInterval,
@@ -579,8 +579,8 @@ fn task_configuration_rejects_out_of_order_extensions() {
     assert!(
         TaskConfiguration::new(
             "test".as_bytes().to_vec(),
-            Url::try_from("https://leader.example.com/".as_ref()).unwrap(),
-            Url::try_from("https://helper.example.com/".as_ref()).unwrap(),
+            Url::try_from("https://leader.example.com/").unwrap(),
+            Url::try_from("https://helper.example.com/").unwrap(),
             TimePrecision::from_seconds(60),
             10,
             BatchConfig::TimeInterval,
@@ -607,8 +607,8 @@ fn with_task_interval_inserts_in_sorted_order() {
     // TaskInterval extension before it, maintaining strictly increasing order.
     let config = TaskConfigurationBuilder::new(
         "test".as_bytes().to_vec(),
-        Url::try_from("https://leader.example.com/".as_ref()).unwrap(),
-        Url::try_from("https://helper.example.com/".as_ref()).unwrap(),
+        Url::try_from("https://leader.example.com/").unwrap(),
+        Url::try_from("https://helper.example.com/").unwrap(),
         time_precision,
         10,
         BatchConfig::TimeInterval,
@@ -648,8 +648,8 @@ fn with_task_interval_rejects_unsorted_caller_extensions() {
     assert!(
         TaskConfigurationBuilder::new(
             "test".as_bytes().to_vec(),
-            Url::try_from("https://leader.example.com/".as_ref()).unwrap(),
-            Url::try_from("https://helper.example.com/".as_ref()).unwrap(),
+            Url::try_from("https://leader.example.com/").unwrap(),
+            Url::try_from("https://helper.example.com/").unwrap(),
             time_precision,
             10,
             BatchConfig::TimeInterval,
@@ -675,8 +675,8 @@ fn task_configuration_rejects_oversized_task_info() {
     let builder = |task_info: Vec<u8>| {
         TaskConfigurationBuilder::new(
             task_info,
-            Url::try_from("https://leader.example.com/".as_ref()).unwrap(),
-            Url::try_from("https://helper.example.com/".as_ref()).unwrap(),
+            Url::try_from("https://leader.example.com/").unwrap(),
+            Url::try_from("https://helper.example.com/").unwrap(),
             TimePrecision::from_seconds(60),
             10,
             BatchConfig::TimeInterval,
@@ -750,8 +750,8 @@ fn unknown_vdaf_config_decodes_from_wire() {
 fn unknown_task_extension_type_in_task_configuration_roundtrips() {
     let config = TaskConfiguration::new(
         "test".as_bytes().to_vec(),
-        Url::try_from("https://leader.example.com/".as_ref()).unwrap(),
-        Url::try_from("https://helper.example.com/".as_ref()).unwrap(),
+        Url::try_from("https://leader.example.com/").unwrap(),
+        Url::try_from("https://helper.example.com/").unwrap(),
         TimePrecision::from_seconds(60),
         10,
         BatchConfig::TimeInterval,
@@ -777,8 +777,8 @@ fn with_task_interval_inserts_after_lower_extensions() {
     // Caller passes [Reserved] (< TaskInterval). Result should be [Reserved, TaskInterval].
     let config = TaskConfigurationBuilder::new(
         "test".as_bytes().to_vec(),
-        Url::try_from("https://leader.example.com/".as_ref()).unwrap(),
-        Url::try_from("https://helper.example.com/".as_ref()).unwrap(),
+        Url::try_from("https://leader.example.com/").unwrap(),
+        Url::try_from("https://helper.example.com/").unwrap(),
         time_precision,
         10,
         BatchConfig::TimeInterval,
@@ -812,8 +812,8 @@ fn builder_task_interval_survives_later_with_extensions() {
     // is tracked separately and inserted at build time regardless of call order.
     let config = TaskConfigurationBuilder::new(
         "test".as_bytes().to_vec(),
-        Url::try_from("https://leader.example.com/".as_ref()).unwrap(),
-        Url::try_from("https://helper.example.com/".as_ref()).unwrap(),
+        Url::try_from("https://leader.example.com/").unwrap(),
+        Url::try_from("https://helper.example.com/").unwrap(),
         time_precision,
         10,
         BatchConfig::TimeInterval,

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -27,6 +27,7 @@ use prio::{
 use rand::random;
 use tracing_log::LogTracer;
 use tracing_subscriber::{EnvFilter, Registry, prelude::*};
+use url::Url;
 
 /// Enum to propagate errors through this program. Clap errors are handled separately from all
 /// others because [`clap::Error::exit`] takes care of its own error formatting, command-line help,
@@ -135,6 +136,14 @@ fn private_collector_credential_parser(
     s: &str,
 ) -> Result<PrivateCollectorCredential, serde_json::Error> {
     serde_json::from_str(s)
+}
+
+/// Parses an endpoint into a byte-preserving [`DapUrl`], rejecting a value that is not a parseable
+/// URL. The exact bytes are kept for later HPKE AAD binding (`DapUrl` alone only checks ASCII); the
+/// `url::Url` parse is a discarded validity gate.
+fn leader_endpoint_parser(s: &str) -> Result<DapUrl, anyhow::Error> {
+    Url::parse(s)?;
+    Ok(DapUrl::try_from(s)?)
 }
 
 #[derive(Debug, Args, PartialEq, Eq)]
@@ -286,7 +295,12 @@ struct Options {
     #[clap(long, help_heading = "DAP Task Parameters", display_order = 0)]
     task_id: TaskId,
     /// The leader aggregator's endpoint URL
-    #[clap(long, help_heading = "DAP Task Parameters", display_order = 1)]
+    #[clap(
+        long,
+        value_parser = leader_endpoint_parser,
+        help_heading = "DAP Task Parameters",
+        display_order = 1
+    )]
     leader: DapUrl,
     /// The task's time precision, in seconds
     #[clap(long, help_heading = "DAP Task Parameters", display_order = 2)]

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -17,7 +17,7 @@ use janus_core::{
 };
 use janus_messages::{
     CollectionJobId, Duration, HpkeConfig, Interval, PartialBatchSelector, Query, TaskId, Time,
-    TimePrecision,
+    TimePrecision, Url as DapUrl,
     batch_mode::{BatchMode, LeaderSelected, TimeInterval},
 };
 use prio::{
@@ -27,7 +27,6 @@ use prio::{
 use rand::random;
 use tracing_log::LogTracer;
 use tracing_subscriber::{EnvFilter, Registry, prelude::*};
-use url::Url;
 
 /// Enum to propagate errors through this program. Clap errors are handled separately from all
 /// others because [`clap::Error::exit`] takes care of its own error formatting, command-line help,
@@ -288,7 +287,7 @@ struct Options {
     task_id: TaskId,
     /// The leader aggregator's endpoint URL
     #[clap(long, help_heading = "DAP Task Parameters", display_order = 1)]
-    leader: Url,
+    leader: DapUrl,
     /// The task's time precision, in seconds
     #[clap(long, help_heading = "DAP Task Parameters", display_order = 2)]
     time_precision: u64,
@@ -697,10 +696,9 @@ mod tests {
         initialize_rustls,
         test_util::install_test_trace_subscriber,
     };
-    use janus_messages::TaskId;
+    use janus_messages::{TaskId, Url as DapUrl};
     use prio::codec::Encode;
     use rand::random;
-    use reqwest::Url;
     use tempfile::NamedTempFile;
 
     use crate::{
@@ -735,7 +733,7 @@ mod tests {
         let encoded_private_key = URL_SAFE_NO_PAD.encode(hpke_keypair.private_key().as_ref());
 
         let task_id = random();
-        let leader = Url::parse("https://example.com/dap/").unwrap();
+        let leader = DapUrl::try_from("https://example.com/dap/").unwrap();
         let auth_token = AuthenticationToken::DapAuth(random());
 
         let expected = Options {
@@ -906,7 +904,7 @@ mod tests {
         let task_id: TaskId = random();
         let task_id_encoded = URL_SAFE_NO_PAD.encode(task_id.get_encoded().unwrap());
 
-        let leader = Url::parse("https://example.com/dap/").unwrap();
+        let leader = DapUrl::try_from("https://example.com/dap/").unwrap();
 
         let hpke_keypair = HpkeKeypair::test();
         let encoded_hpke_config =
@@ -1184,7 +1182,7 @@ mod tests {
     fn hpke_config() {
         let task_id: TaskId = random();
         let task_id_encoded = URL_SAFE_NO_PAD.encode(task_id.get_encoded().unwrap());
-        let leader = Url::parse("https://example.com/dap/").unwrap();
+        let leader = DapUrl::try_from("https://example.com/dap/").unwrap();
         let hpke_keypair = HpkeKeypair::test();
         let encoded_hpke_config =
             URL_SAFE_NO_PAD.encode(hpke_keypair.config().get_encoded().unwrap());
@@ -1257,7 +1255,7 @@ mod tests {
         let encoded_private_key = URL_SAFE_NO_PAD.encode(hpke_keypair.private_key().as_ref());
 
         let task_id = random();
-        let leader = Url::parse("https://example.com/dap/").unwrap();
+        let leader = DapUrl::try_from("https://example.com/dap/").unwrap();
         let auth_token = AuthenticationToken::DapAuth(random());
 
         let mut expected = Options {
@@ -1345,7 +1343,7 @@ mod tests {
         let encoded_private_key = URL_SAFE_NO_PAD.encode(hpke_keypair.private_key().as_ref());
 
         let task_id = random();
-        let leader = Url::parse("https://example.com/dap/").unwrap();
+        let leader = DapUrl::try_from("https://example.com/dap/").unwrap();
         let auth_token = AuthenticationToken::DapAuth(random());
         let collection_job_id = random();
         let expected = Options {


### PR DESCRIPTION
This set of commits changes the endpoint URLs to a byte-preserving `janus_messages::Url` form instead of `url::Url`. This is largely mechanical, and I left it in four commits for ease of review... though it's not that bad to go through as one.

Note that one of the final commits, https://github.com/divviup/janus/pull/4692/commits/c2d58781d62ca04be428c659543a925eb1c02ff1, adds the "fast fail" functionality, for purely code-compilation reasons. So when you see by commit 2 that we'd store a bad URL, uh, I do fix that.
