### PR TITLE
[DAP-17] Leader-side Collection Job Extensions support

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -53,10 +53,10 @@ use janus_core::{
 use janus_messages::{
     AggregateShare, AggregateShareAad, AggregateShareId, AggregateShareReq,
     AggregationJobContinueReq, AggregationJobId, AggregationJobInitializeReq, AggregationJobResp,
-    AggregationJobStep, BatchSelector, CollectionJobId, CollectionJobReq, CollectionJobResp,
-    Duration, ExtensionType, HpkeConfig, HpkeConfigList, InputShareAad, Interval,
-    PartialBatchSelector, PlaintextInputShare, Report, ReportError, ReportUploadStatus, Role,
-    TaskConfiguration, TaskId, UploadErrors, Url as DapUrl, VerifyResp,
+    AggregationJobStep, BatchSelector, CollectionJobExtensionType, CollectionJobId,
+    CollectionJobReq, CollectionJobResp, Duration, ExtensionType, HpkeConfig, HpkeConfigList,
+    InputShareAad, Interval, PartialBatchSelector, PlaintextInputShare, Report, ReportError,
+    ReportUploadStatus, Role, TaskConfiguration, TaskId, UploadErrors, Url as DapUrl, VerifyResp,
     batch_mode::{LeaderSelected, TimeInterval},
     extensions_are_strictly_increasing,
 };
@@ -3169,6 +3169,28 @@ impl VdafOps {
         collection_job_id: &CollectionJobId,
         req: Arc<CollectionJobReq<B>>,
     ) -> Result<Vec<u8>, Error> {
+        // Collection job extensions must be in strictly increasing order of extension type, and
+        // every extension type must be supported (DAP-19 §4.2.2).
+        if !req
+            .extensions()
+            .is_sorted_by(|a, b| a.extension_type() < b.extension_type())
+        {
+            return Err(Error::InvalidExtension(
+                Some(*task.id()),
+                "collection job extensions are not in strictly increasing order of extension type",
+            ));
+        }
+        if req
+            .extensions()
+            .iter()
+            .any(|extension| !extension.extension_type().is_supported())
+        {
+            return Err(Error::UnsupportedExtension(
+                Some(*task.id()),
+                "collection job contains an unsupported extension type",
+            ));
+        }
+
         let aggregation_param = Arc::new(
             A::AggregationParam::get_decoded(req.aggregation_parameter())
                 .map_err(Error::MessageDecode)?,
@@ -4197,6 +4219,18 @@ trait ExtensionTypeExt {
 impl ExtensionTypeExt for ExtensionType {
     fn is_supported(&self) -> bool {
         matches!(self, ExtensionType::Taskbind)
+    }
+}
+
+trait CollectionJobExtensionTypeExt {
+    /// Determines whether a collection job extension type is supported by this implementation.
+    fn is_supported(&self) -> bool;
+}
+
+impl CollectionJobExtensionTypeExt for CollectionJobExtensionType {
+    fn is_supported(&self) -> bool {
+        // No collection job extension types are defined yet, so none are supported.
+        false
     }
 }
 

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -53,10 +53,10 @@ use janus_core::{
 use janus_messages::{
     AggregateShare, AggregateShareAad, AggregateShareId, AggregateShareReq,
     AggregationJobContinueReq, AggregationJobId, AggregationJobInitializeReq, AggregationJobResp,
-    AggregationJobStep, BatchSelector, CollectionJobExtensionType, CollectionJobId,
-    CollectionJobReq, CollectionJobResp, Duration, ExtensionType, HpkeConfig, HpkeConfigList,
-    InputShareAad, Interval, PartialBatchSelector, PlaintextInputShare, Report, ReportError,
-    ReportUploadStatus, Role, TaskConfiguration, TaskId, UploadErrors, Url as DapUrl, VerifyResp,
+    AggregationJobStep, BatchSelector, CollectionJobId, CollectionJobReq, CollectionJobResp,
+    Duration, ExtensionType, HpkeConfig, HpkeConfigList, InputShareAad, Interval,
+    PartialBatchSelector, PlaintextInputShare, Report, ReportError, ReportUploadStatus, Role,
+    TaskConfiguration, TaskId, UploadErrors, Url as DapUrl, VerifyResp,
     batch_mode::{LeaderSelected, TimeInterval},
     extensions_are_strictly_increasing,
 };
@@ -3169,8 +3169,9 @@ impl VdafOps {
         collection_job_id: &CollectionJobId,
         req: Arc<CollectionJobReq<B>>,
     ) -> Result<Vec<u8>, Error> {
-        // Collection job extensions must be in strictly increasing order of extension type, and
-        // every extension type must be supported (DAP-19 §4.2.2).
+        // Collection job extensions must be in strictly increasing order of extension type, which
+        // also rejects duplicates, and every extension type must be supported (DAP-19 §4.6.2). No
+        // collection job extension types are defined yet, so any extension is unsupported.
         if !req
             .extensions()
             .is_sorted_by(|a, b| a.extension_type() < b.extension_type())
@@ -3180,11 +3181,7 @@ impl VdafOps {
                 "collection job extensions are not in strictly increasing order of extension type",
             ));
         }
-        if req
-            .extensions()
-            .iter()
-            .any(|extension| !extension.extension_type().is_supported())
-        {
+        if !req.extensions().is_empty() {
             return Err(Error::UnsupportedExtension(
                 Some(*task.id()),
                 "collection job contains an unsupported extension type",
@@ -4219,18 +4216,6 @@ trait ExtensionTypeExt {
 impl ExtensionTypeExt for ExtensionType {
     fn is_supported(&self) -> bool {
         matches!(self, ExtensionType::Taskbind)
-    }
-}
-
-trait CollectionJobExtensionTypeExt {
-    /// Determines whether a collection job extension type is supported by this implementation.
-    fn is_supported(&self) -> bool;
-}
-
-impl CollectionJobExtensionTypeExt for CollectionJobExtensionType {
-    fn is_supported(&self) -> bool {
-        // No collection job extension types are defined yet, so none are supported.
-        false
     }
 }
 

--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -349,7 +349,6 @@ async fn collection_job_success_leader_selected() {
     let request = CollectionJobReq::new(
         Query::new_leader_selected(),
         aggregation_param.get_encoded().unwrap(),
-        Vec::new(),
     );
 
     for _ in 0..2 {
@@ -538,7 +537,6 @@ async fn collection_job_put_idempotence_time_interval() {
             .unwrap(),
         ),
         dummy::AggregationParam::default().get_encoded().unwrap(),
-        Vec::new(),
     );
 
     for _ in 0..2 {
@@ -594,7 +592,6 @@ async fn collection_job_put_idempotence_time_interval_varied_collection_id() {
             .unwrap(),
         ),
         dummy::AggregationParam::default().get_encoded().unwrap(),
-        Vec::new(),
     );
 
     for collection_job_id in &collection_job_ids {
@@ -646,7 +643,6 @@ async fn collection_job_put_idempotence_time_interval_mutate_time_interval() {
     let request = CollectionJobReq::new(
         Query::new_time_interval(Interval::minimal(Time::from_time_precision_units(0)).unwrap()),
         dummy::AggregationParam::default().get_encoded().unwrap(),
-        Vec::new(),
     );
 
     let response = test_case
@@ -663,7 +659,6 @@ async fn collection_job_put_idempotence_time_interval_mutate_time_interval() {
             .unwrap(),
         ),
         dummy::AggregationParam::default().get_encoded().unwrap(),
-        Vec::new(),
     );
 
     let response = test_case
@@ -683,7 +678,6 @@ async fn collection_job_put_idempotence_time_interval_mutate_aggregation_param()
     let request = CollectionJobReq::new(
         Query::new_time_interval(Interval::minimal(Time::from_time_precision_units(0)).unwrap()),
         dummy::AggregationParam(0).get_encoded().unwrap(),
-        Vec::new(),
     );
 
     let response = test_case
@@ -694,7 +688,6 @@ async fn collection_job_put_idempotence_time_interval_mutate_aggregation_param()
     let mutated_request = CollectionJobReq::new(
         Query::new_time_interval(Interval::minimal(Time::from_time_precision_units(0)).unwrap()),
         dummy::AggregationParam(1).get_encoded().unwrap(),
-        Vec::new(),
     );
 
     let response = test_case
@@ -712,7 +705,6 @@ async fn collection_job_put_idempotence_leader_selected() {
     let request = CollectionJobReq::new(
         Query::new_leader_selected(),
         dummy::AggregationParam(0).get_encoded().unwrap(),
-        Vec::new(),
     );
     let mut seen_batch_id = None;
 
@@ -764,7 +756,6 @@ async fn collection_job_put_idempotence_leader_selected_mutate_aggregation_param
     let request = CollectionJobReq::new(
         Query::new_leader_selected(),
         dummy::AggregationParam(0).get_encoded().unwrap(),
-        Vec::new(),
     );
 
     let response = test_case
@@ -776,7 +767,6 @@ async fn collection_job_put_idempotence_leader_selected_mutate_aggregation_param
     let mutated_request = CollectionJobReq::new(
         Query::new_leader_selected(),
         dummy::AggregationParam(1).get_encoded().unwrap(),
-        Vec::new(),
     );
 
     let response = test_case
@@ -795,7 +785,6 @@ async fn collection_job_put_idempotence_leader_selected_no_extra_reports() {
     let request = CollectionJobReq::new(
         Query::new_leader_selected(),
         dummy::AggregationParam(0).get_encoded().unwrap(),
-        Vec::new(),
     );
 
     // Create the first collection job.
@@ -845,7 +834,6 @@ async fn collection_job_batch_mode_misaligned() {
     let request = CollectionJobReq::new(
         Query::new_leader_selected(),
         dummy::AggregationParam(0).get_encoded().unwrap(),
-        Vec::new(),
     );
 
     let mut response = test_case

--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -349,6 +349,7 @@ async fn collection_job_success_leader_selected() {
     let request = CollectionJobReq::new(
         Query::new_leader_selected(),
         aggregation_param.get_encoded().unwrap(),
+        Vec::new(),
     );
 
     for _ in 0..2 {
@@ -537,6 +538,7 @@ async fn collection_job_put_idempotence_time_interval() {
             .unwrap(),
         ),
         dummy::AggregationParam::default().get_encoded().unwrap(),
+        Vec::new(),
     );
 
     for _ in 0..2 {
@@ -592,6 +594,7 @@ async fn collection_job_put_idempotence_time_interval_varied_collection_id() {
             .unwrap(),
         ),
         dummy::AggregationParam::default().get_encoded().unwrap(),
+        Vec::new(),
     );
 
     for collection_job_id in &collection_job_ids {
@@ -643,6 +646,7 @@ async fn collection_job_put_idempotence_time_interval_mutate_time_interval() {
     let request = CollectionJobReq::new(
         Query::new_time_interval(Interval::minimal(Time::from_time_precision_units(0)).unwrap()),
         dummy::AggregationParam::default().get_encoded().unwrap(),
+        Vec::new(),
     );
 
     let response = test_case
@@ -659,6 +663,7 @@ async fn collection_job_put_idempotence_time_interval_mutate_time_interval() {
             .unwrap(),
         ),
         dummy::AggregationParam::default().get_encoded().unwrap(),
+        Vec::new(),
     );
 
     let response = test_case
@@ -678,6 +683,7 @@ async fn collection_job_put_idempotence_time_interval_mutate_aggregation_param()
     let request = CollectionJobReq::new(
         Query::new_time_interval(Interval::minimal(Time::from_time_precision_units(0)).unwrap()),
         dummy::AggregationParam(0).get_encoded().unwrap(),
+        Vec::new(),
     );
 
     let response = test_case
@@ -688,6 +694,7 @@ async fn collection_job_put_idempotence_time_interval_mutate_aggregation_param()
     let mutated_request = CollectionJobReq::new(
         Query::new_time_interval(Interval::minimal(Time::from_time_precision_units(0)).unwrap()),
         dummy::AggregationParam(1).get_encoded().unwrap(),
+        Vec::new(),
     );
 
     let response = test_case
@@ -705,6 +712,7 @@ async fn collection_job_put_idempotence_leader_selected() {
     let request = CollectionJobReq::new(
         Query::new_leader_selected(),
         dummy::AggregationParam(0).get_encoded().unwrap(),
+        Vec::new(),
     );
     let mut seen_batch_id = None;
 
@@ -756,6 +764,7 @@ async fn collection_job_put_idempotence_leader_selected_mutate_aggregation_param
     let request = CollectionJobReq::new(
         Query::new_leader_selected(),
         dummy::AggregationParam(0).get_encoded().unwrap(),
+        Vec::new(),
     );
 
     let response = test_case
@@ -767,6 +776,7 @@ async fn collection_job_put_idempotence_leader_selected_mutate_aggregation_param
     let mutated_request = CollectionJobReq::new(
         Query::new_leader_selected(),
         dummy::AggregationParam(1).get_encoded().unwrap(),
+        Vec::new(),
     );
 
     let response = test_case
@@ -785,6 +795,7 @@ async fn collection_job_put_idempotence_leader_selected_no_extra_reports() {
     let request = CollectionJobReq::new(
         Query::new_leader_selected(),
         dummy::AggregationParam(0).get_encoded().unwrap(),
+        Vec::new(),
     );
 
     // Create the first collection job.
@@ -834,6 +845,7 @@ async fn collection_job_batch_mode_misaligned() {
     let request = CollectionJobReq::new(
         Query::new_leader_selected(),
         dummy::AggregationParam(0).get_encoded().unwrap(),
+        Vec::new(),
     );
 
     let mut response = test_case

--- a/aggregator/src/aggregator/error.rs
+++ b/aggregator/src/aggregator/error.rs
@@ -51,6 +51,12 @@ pub enum Error {
     /// Corresponds to `invalidMessage` in DAP.
     #[error("task {0:?}: invalid message: {1}")]
     InvalidMessage(Option<TaskId>, &'static str),
+    /// Corresponds to `unsupportedExtension` in DAP.
+    #[error("task {0:?}: unsupported extension: {1}")]
+    UnsupportedExtension(Option<TaskId>, &'static str),
+    /// Corresponds to `invalidExtension` in DAP.
+    #[error("task {0:?}: invalid extension: {1}")]
+    InvalidExtension(Option<TaskId>, &'static str),
     /// Corresponds to `stepMismatch in DAP`
     #[error(
         "task {task_id}: unexpected step in aggregation job {aggregation_job_id} (expected \
@@ -314,6 +320,8 @@ impl Error {
                 _ => "report_rejected",
             },
             Error::InvalidMessage(_, _) => "unrecognized_message",
+            Error::UnsupportedExtension(_, _) => "unsupported_extension",
+            Error::InvalidExtension(_, _) => "invalid_extension",
             Error::StepMismatch { .. } => "step_mismatch",
             Error::UnrecognizedTask(_) => "unrecognized_task",
             Error::UnrecognizedAggregationJob(_, _) => "unrecognized_aggregation_job",

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -78,6 +78,26 @@ impl Error {
                 }
                 doc.into_response()
             }
+            Error::UnsupportedExtension(task_id, detail) => {
+                let mut doc = ProblemDocument::new_dap(DapProblemType::UnsupportedExtension);
+                if let Some(task_id) = task_id {
+                    doc = doc.with_task_id(task_id);
+                }
+                if !detail.is_empty() {
+                    doc = doc.with_detail(detail);
+                }
+                doc.into_response()
+            }
+            Error::InvalidExtension(task_id, detail) => {
+                let mut doc = ProblemDocument::new_dap(DapProblemType::InvalidExtension);
+                if let Some(task_id) = task_id {
+                    doc = doc.with_task_id(task_id);
+                }
+                if !detail.is_empty() {
+                    doc = doc.with_detail(detail);
+                }
+                doc.into_response()
+            }
             Error::StepMismatch { task_id, .. } => {
                 ProblemDocument::new_dap(DapProblemType::StepMismatch)
                     .with_task_id(task_id)

--- a/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
@@ -12,8 +12,9 @@ use janus_core::{
     vdaf::VdafInstance,
 };
 use janus_messages::{
-    AggregateShareAad, BatchSelector, CollectionJobId, CollectionJobReq, CollectionJobResp,
-    Duration, Interval, MediaType, Query, Role, Time, batch_mode::TimeInterval,
+    AggregateShareAad, BatchSelector, CollectionJobExtension, CollectionJobExtensionType,
+    CollectionJobId, CollectionJobReq, CollectionJobResp, Duration, Interval, MediaType, Query,
+    Role, Time, batch_mode::TimeInterval,
 };
 use prio::{
     codec::{Decode, Encode},
@@ -50,6 +51,7 @@ async fn collection_job_put_request_to_helper() {
             .unwrap(),
         ),
         dummy::AggregationParam::default().get_encoded().unwrap(),
+        Vec::new(),
     );
 
     let mut response = test_case
@@ -92,6 +94,7 @@ async fn collection_job_put_request_invalid_batch_interval() {
             .unwrap(),
         ),
         dummy::AggregationParam::default().get_encoded().unwrap(),
+        Vec::new(),
     );
 
     let mut response = test_case
@@ -132,6 +135,7 @@ async fn collection_job_put_request_invalid_aggregation_parameter() {
         // dummy::AggregationParam is a tuple struct wrapping a u8, so this is not a valid
         // encoding of an aggregation parameter.
         Vec::from([0u8, 0u8]),
+        Vec::new(),
     );
 
     let mut response = test_case
@@ -146,6 +150,76 @@ async fn collection_job_put_request_invalid_aggregation_parameter() {
             "status": StatusCode::BAD_REQUEST.as_u16(),
             "type": "urn:ietf:params:ppm:dap:error:invalidMessage",
             "title": "The message type for a response was incorrect or the payload was malformed.",
+        })
+    );
+}
+
+#[tokio::test]
+async fn collection_job_put_request_unsupported_extension() {
+    let test_case = setup_collection_job_test_case(Role::Leader, BatchMode::TimeInterval).await;
+
+    // No collection job extension types are defined, so any extension is unsupported.
+    let request = CollectionJobReq::new(
+        Query::new_time_interval(
+            Interval::minimal(Time::from_seconds_since_epoch(
+                0,
+                test_case.task.time_precision(),
+            ))
+            .unwrap(),
+        ),
+        dummy::AggregationParam::default().get_encoded().unwrap(),
+        Vec::from([CollectionJobExtension::new(
+            CollectionJobExtensionType::Unknown(0xffff),
+            Vec::new(),
+        )]),
+    );
+
+    let mut response = test_case.put_collection_job(&random(), &request).await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        take_problem_details(&mut response).await,
+        json!({
+            "status": StatusCode::BAD_REQUEST.as_u16(),
+            "type": "urn:ietf:params:ppm:dap:error:unsupportedExtension",
+            "title": "The message includes an unsupported extension.",
+            "detail": "collection job contains an unsupported extension type",
+            "taskid": format!("{}", test_case.task.id()),
+        })
+    );
+}
+
+#[tokio::test]
+async fn collection_job_put_request_invalid_extension_order() {
+    let test_case = setup_collection_job_test_case(Role::Leader, BatchMode::TimeInterval).await;
+
+    // Extension types 0x0002 then 0x0001 are not in strictly increasing order.
+    let request = CollectionJobReq::new(
+        Query::new_time_interval(
+            Interval::minimal(Time::from_seconds_since_epoch(
+                0,
+                test_case.task.time_precision(),
+            ))
+            .unwrap(),
+        ),
+        dummy::AggregationParam::default().get_encoded().unwrap(),
+        Vec::from([
+            CollectionJobExtension::new(CollectionJobExtensionType::Unknown(0x0002), Vec::new()),
+            CollectionJobExtension::new(CollectionJobExtensionType::Unknown(0x0001), Vec::new()),
+        ]),
+    );
+
+    let mut response = test_case.put_collection_job(&random(), &request).await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        take_problem_details(&mut response).await,
+        json!({
+            "status": StatusCode::BAD_REQUEST.as_u16(),
+            "type": "urn:ietf:params:ppm:dap:error:invalidExtension",
+            "title": "An extensions list is out of order or contains an invalid extension encoding.",
+            "detail": "collection job extensions are not in strictly increasing order of extension type",
+            "taskid": format!("{}", test_case.task.id()),
         })
     );
 }
@@ -174,6 +248,7 @@ async fn collection_job_put_request_invalid_batch_size() {
     let request = CollectionJobReq::new(
         Query::new_time_interval(Interval::minimal(Time::from_time_precision_units(0)).unwrap()),
         dummy::AggregationParam::default().get_encoded().unwrap(),
+        Vec::new(),
     );
 
     let mut response = router
@@ -225,6 +300,7 @@ async fn collection_job_put_request_unauthenticated() {
     let req = CollectionJobReq::new(
         Query::new_time_interval(batch_interval),
         dummy::AggregationParam::default().get_encoded().unwrap(),
+        Vec::new(),
     );
 
     // Incorrect authentication token.
@@ -270,6 +346,7 @@ async fn collection_job_get_request_unauthenticated_collection_jobs() {
     let request = CollectionJobReq::new(
         Query::new_time_interval(batch_interval),
         dummy::AggregationParam::default().get_encoded().unwrap(),
+        Vec::new(),
     );
 
     let response = test_case
@@ -321,6 +398,7 @@ async fn collection_job_success_time_interval() {
     let request = CollectionJobReq::new(
         Query::new_time_interval(batch_interval),
         aggregation_param.get_encoded().unwrap(),
+        Vec::new(),
     );
 
     let mut response = test_case
@@ -509,6 +587,7 @@ async fn collection_job_put_request_batch_queried_multiple_times() {
     let request = CollectionJobReq::new(
         Query::new_time_interval(interval),
         dummy::AggregationParam(0).get_encoded().unwrap(),
+        Vec::new(),
     );
 
     let response = test_case.put_collection_job(&random(), &request).await;
@@ -519,6 +598,7 @@ async fn collection_job_put_request_batch_queried_multiple_times() {
     let invalid_request = CollectionJobReq::new(
         Query::new_time_interval(interval),
         dummy::AggregationParam(1).get_encoded().unwrap(),
+        Vec::new(),
     );
 
     let mut response = test_case
@@ -557,6 +637,7 @@ async fn collection_job_put_request_batch_overlap() {
             .unwrap(),
         ),
         dummy::AggregationParam(0).get_encoded().unwrap(),
+        Vec::new(),
     );
 
     let response = test_case.put_collection_job(&random(), &request).await;
@@ -567,6 +648,7 @@ async fn collection_job_put_request_batch_overlap() {
     let invalid_request = CollectionJobReq::new(
         Query::new_time_interval(interval),
         dummy::AggregationParam(1).get_encoded().unwrap(),
+        Vec::new(),
     );
 
     let mut response = test_case
@@ -622,6 +704,7 @@ async fn delete_collection_job() {
     let request = CollectionJobReq::new(
         Query::new_time_interval(batch_interval),
         dummy::AggregationParam::default().get_encoded().unwrap(),
+        Vec::new(),
     );
 
     let response = test_case

--- a/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
@@ -51,7 +51,6 @@ async fn collection_job_put_request_to_helper() {
             .unwrap(),
         ),
         dummy::AggregationParam::default().get_encoded().unwrap(),
-        Vec::new(),
     );
 
     let mut response = test_case
@@ -94,7 +93,6 @@ async fn collection_job_put_request_invalid_batch_interval() {
             .unwrap(),
         ),
         dummy::AggregationParam::default().get_encoded().unwrap(),
-        Vec::new(),
     );
 
     let mut response = test_case
@@ -135,7 +133,6 @@ async fn collection_job_put_request_invalid_aggregation_parameter() {
         // dummy::AggregationParam is a tuple struct wrapping a u8, so this is not a valid
         // encoding of an aggregation parameter.
         Vec::from([0u8, 0u8]),
-        Vec::new(),
     );
 
     let mut response = test_case
@@ -168,11 +165,11 @@ async fn collection_job_put_request_unsupported_extension() {
             .unwrap(),
         ),
         dummy::AggregationParam::default().get_encoded().unwrap(),
-        Vec::from([CollectionJobExtension::new(
-            CollectionJobExtensionType::Unknown(0xffff),
-            Vec::new(),
-        )]),
-    );
+    )
+    .with_extensions(Vec::from([CollectionJobExtension::new(
+        CollectionJobExtensionType::Unknown(0xffff),
+        Vec::new(),
+    )]));
 
     let mut response = test_case.put_collection_job(&random(), &request).await;
 
@@ -203,11 +200,11 @@ async fn collection_job_put_request_invalid_extension_order() {
             .unwrap(),
         ),
         dummy::AggregationParam::default().get_encoded().unwrap(),
-        Vec::from([
-            CollectionJobExtension::new(CollectionJobExtensionType::Unknown(0x0002), Vec::new()),
-            CollectionJobExtension::new(CollectionJobExtensionType::Unknown(0x0001), Vec::new()),
-        ]),
-    );
+    )
+    .with_extensions(Vec::from([
+        CollectionJobExtension::new(CollectionJobExtensionType::Unknown(0x0002), Vec::new()),
+        CollectionJobExtension::new(CollectionJobExtensionType::Unknown(0x0001), Vec::new()),
+    ]));
 
     let mut response = test_case.put_collection_job(&random(), &request).await;
 
@@ -248,7 +245,6 @@ async fn collection_job_put_request_invalid_batch_size() {
     let request = CollectionJobReq::new(
         Query::new_time_interval(Interval::minimal(Time::from_time_precision_units(0)).unwrap()),
         dummy::AggregationParam::default().get_encoded().unwrap(),
-        Vec::new(),
     );
 
     let mut response = router
@@ -300,7 +296,6 @@ async fn collection_job_put_request_unauthenticated() {
     let req = CollectionJobReq::new(
         Query::new_time_interval(batch_interval),
         dummy::AggregationParam::default().get_encoded().unwrap(),
-        Vec::new(),
     );
 
     // Incorrect authentication token.
@@ -346,7 +341,6 @@ async fn collection_job_get_request_unauthenticated_collection_jobs() {
     let request = CollectionJobReq::new(
         Query::new_time_interval(batch_interval),
         dummy::AggregationParam::default().get_encoded().unwrap(),
-        Vec::new(),
     );
 
     let response = test_case
@@ -398,7 +392,6 @@ async fn collection_job_success_time_interval() {
     let request = CollectionJobReq::new(
         Query::new_time_interval(batch_interval),
         aggregation_param.get_encoded().unwrap(),
-        Vec::new(),
     );
 
     let mut response = test_case
@@ -587,7 +580,6 @@ async fn collection_job_put_request_batch_queried_multiple_times() {
     let request = CollectionJobReq::new(
         Query::new_time_interval(interval),
         dummy::AggregationParam(0).get_encoded().unwrap(),
-        Vec::new(),
     );
 
     let response = test_case.put_collection_job(&random(), &request).await;
@@ -598,7 +590,6 @@ async fn collection_job_put_request_batch_queried_multiple_times() {
     let invalid_request = CollectionJobReq::new(
         Query::new_time_interval(interval),
         dummy::AggregationParam(1).get_encoded().unwrap(),
-        Vec::new(),
     );
 
     let mut response = test_case
@@ -637,7 +628,6 @@ async fn collection_job_put_request_batch_overlap() {
             .unwrap(),
         ),
         dummy::AggregationParam(0).get_encoded().unwrap(),
-        Vec::new(),
     );
 
     let response = test_case.put_collection_job(&random(), &request).await;
@@ -648,7 +638,6 @@ async fn collection_job_put_request_batch_overlap() {
     let invalid_request = CollectionJobReq::new(
         Query::new_time_interval(interval),
         dummy::AggregationParam(1).get_encoded().unwrap(),
-        Vec::new(),
     );
 
     let mut response = test_case
@@ -704,7 +693,6 @@ async fn delete_collection_job() {
     let request = CollectionJobReq::new(
         Query::new_time_interval(batch_interval),
         dummy::AggregationParam::default().get_encoded().unwrap(),
-        Vec::new(),
     );
 
     let response = test_case

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -535,12 +535,10 @@ impl<V: vdaf::Collector> Collector<V> {
         aggregation_parameter: &V::AggregationParam,
         extensions: Vec<CollectionJobExtension>,
     ) -> Result<CollectionJob<V::AggregationParam, B>, Error> {
-        let collect_request = CollectionJobReq::new(
-            query.clone(),
-            aggregation_parameter.get_encoded()?,
-            extensions,
-        )
-        .get_encoded()?;
+        let collect_request =
+            CollectionJobReq::new(query.clone(), aggregation_parameter.get_encoded()?)
+                .with_extensions(extensions)
+                .get_encoded()?;
         let collection_job_url = self.collection_job_uri(collection_job_id)?;
 
         let response_res =

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -504,7 +504,7 @@ impl<V: vdaf::Collector> Collector<V> {
         ))?)
     }
 
-    /// Begin a collection request to the leader aggregator.
+    /// Construct a collection request to send to the leader aggregator.
     ///
     /// Returns a [`CollectionRequestBuilder`]; configure the optional collection job ID
     /// ([`CollectionRequestBuilder::with_id`]) and extensions

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -51,13 +51,14 @@
 //!
 //! // Make the requests and retrieve the aggregated statistic.
 //! let aggregation_result = collector
-//!     .collect(Query::new_time_interval(interval), &())
+//!     .collection(Query::new_time_interval(interval), &())
+//!     .collect()
 //!     .await
 //!     .unwrap();
 //!
 //! // Or if this is a leader-selected task, make a leader-selected query.
 //! let query = Query::new_leader_selected();
-//! let aggregation_result = collector.collect(query, &()).await.unwrap();
+//! let aggregation_result = collector.collection(query, &()).collect().await.unwrap();
 //! # }
 //! ```
 
@@ -85,8 +86,9 @@ use janus_core::{
     url_for_join,
 };
 use janus_messages::{
-    AggregateShareAad, BatchSelector, CollectionJobId, CollectionJobReq, CollectionJobResp,
-    MediaType, PartialBatchSelector, Query, Role, TaskId, TimePrecision, Url as DapUrl,
+    AggregateShareAad, BatchSelector, CollectionJobExtension, CollectionJobId, CollectionJobReq,
+    CollectionJobResp, MediaType, PartialBatchSelector, Query, Role, TaskId, TimePrecision,
+    Url as DapUrl,
     batch_mode::{BatchMode, TimeInterval},
 };
 use prio::{
@@ -207,6 +209,58 @@ impl<P, B: BatchMode> CollectionJob<P, B> {
     /// Gets the aggregation parameter used to create this collection job.
     pub fn aggregation_parameter(&self) -> &P {
         &self.aggregation_parameter
+    }
+}
+
+/// A builder for a collection request, returned by [`Collector::collection`].
+///
+/// Configure the optional collection job ID ([`Self::with_id`]) and extensions
+/// ([`Self::with_extensions`]), then send the request with [`Self::start`] or [`Self::collect`].
+pub struct CollectionRequestBuilder<'a, V: vdaf::Collector, B: BatchMode> {
+    collector: &'a Collector<V>,
+    query: Query<B>,
+    aggregation_parameter: &'a V::AggregationParam,
+    collection_job_id: Option<CollectionJobId>,
+    extensions: Vec<CollectionJobExtension>,
+}
+
+impl<'a, V: vdaf::Collector, B: BatchMode> CollectionRequestBuilder<'a, V, B> {
+    /// Use a caller-chosen collection job ID instead of a randomly generated one.
+    ///
+    /// Supplying a stable ID is recommended: a randomly generated ID is at risk of being lost if
+    /// the program crashes before [`Self::start`] or [`Self::collect`] returns.
+    pub fn with_id(mut self, collection_job_id: CollectionJobId) -> Self {
+        self.collection_job_id = Some(collection_job_id);
+        self
+    }
+
+    /// Set the collection job extensions.
+    pub fn with_extensions(mut self, extensions: Vec<CollectionJobExtension>) -> Self {
+        self.extensions = extensions;
+        self
+    }
+
+    /// Send the collection request to the leader aggregator and return an in-progress
+    /// [`CollectionJob`] that must be polled separately using [`Collector::poll_once`] or
+    /// [`Collector::poll_until_complete`].
+    pub async fn start(self) -> Result<CollectionJob<V::AggregationParam, B>, Error> {
+        let collection_job_id = self.collection_job_id.unwrap_or_else(random);
+        self.collector
+            .send_collection_request(
+                collection_job_id,
+                self.query,
+                self.aggregation_parameter,
+                self.extensions,
+            )
+            .await
+    }
+
+    /// Send the collection request to the leader aggregator, wait for it to complete, and return
+    /// the result of the aggregation.
+    pub async fn collect(self) -> Result<Collection<V::AggregateResult, B>, Error> {
+        let collector = self.collector;
+        let job = self.start().await?;
+        collector.poll_until_complete(&job).await
     }
 }
 
@@ -453,50 +507,43 @@ impl<V: vdaf::Collector> Collector<V> {
         ))?)
     }
 
-    /// Send a collection request to the leader aggregator, wait for it to complete, and return the
-    /// result of the aggregation.
-    pub async fn collect<B: BatchMode>(
-        &self,
+    /// Begin a collection request to the leader aggregator.
+    ///
+    /// Returns a [`CollectionRequestBuilder`]; configure the optional collection job ID
+    /// ([`CollectionRequestBuilder::with_id`]) and extensions
+    /// ([`CollectionRequestBuilder::with_extensions`]), then send the request with
+    /// [`CollectionRequestBuilder::start`] (returns a [`CollectionJob`] to poll) or
+    /// [`CollectionRequestBuilder::collect`] (sends and waits for the result).
+    pub fn collection<'a, B: BatchMode>(
+        &'a self,
         query: Query<B>,
-        aggregation_parameter: &V::AggregationParam,
-    ) -> Result<Collection<V::AggregateResult, B>, Error> {
-        let job = self.start_collection(query, aggregation_parameter).await?;
-        self.poll_until_complete(&job).await
+        aggregation_parameter: &'a V::AggregationParam,
+    ) -> CollectionRequestBuilder<'a, V, B> {
+        CollectionRequestBuilder {
+            collector: self,
+            query,
+            aggregation_parameter,
+            collection_job_id: None,
+            extensions: Vec::new(),
+        }
     }
 
-    /// Send a collection request to the leader aggregator, using a randomly generated
-    /// [`CollectionJobId`].
-    ///
-    /// This returns a [`CollectionJob`] that must be polled separately using [`Self::poll_once`] or
-    /// [`Self::poll_until_complete`].
-    ///
-    /// Since the collection job ID is randomly generated in this function, it is at risk of being
-    /// lost if the program crashes before the generated ID is returned to the caller. It is
-    /// recommended that collectors instead generate an ID themselves, store it to non-volatile
-    /// storage, then invoke [`Self::start_collection_with_id`].
-    #[tracing::instrument(skip(aggregation_parameter), err)]
-    pub async fn start_collection<B: BatchMode>(
-        &self,
-        query: Query<B>,
-        aggregation_parameter: &V::AggregationParam,
-    ) -> Result<CollectionJob<V::AggregationParam, B>, Error> {
-        self.start_collection_with_id(random(), query, aggregation_parameter)
-            .await
-    }
-
-    /// Send a collection request to the leader aggregator, with the given [`CollectionJobId`].
-    ///
-    /// This returns a [`CollectionJob`] that must be polled separately using [`Self::poll_once`] or
-    /// [`Self::poll_until_complete`].
-    pub async fn start_collection_with_id<B: BatchMode>(
+    /// Send a collection request to the leader aggregator with the given [`CollectionJobId`],
+    /// returning an in-progress [`CollectionJob`].
+    #[tracing::instrument(skip(self, aggregation_parameter, extensions), err)]
+    async fn send_collection_request<B: BatchMode>(
         &self,
         collection_job_id: CollectionJobId,
         query: Query<B>,
         aggregation_parameter: &V::AggregationParam,
+        extensions: Vec<CollectionJobExtension>,
     ) -> Result<CollectionJob<V::AggregationParam, B>, Error> {
-        let collect_request =
-            CollectionJobReq::new(query.clone(), aggregation_parameter.get_encoded()?)
-                .get_encoded()?;
+        let collect_request = CollectionJobReq::new(
+            query.clone(),
+            aggregation_parameter.get_encoded()?,
+            extensions,
+        )
+        .get_encoded()?;
         let collection_job_url = self.collection_job_uri(collection_job_id)?;
 
         let response_res =
@@ -982,7 +1029,8 @@ mod tests {
             .await;
 
         let job = collector
-            .start_collection(Query::new_time_interval(batch_interval), &())
+            .collection(Query::new_time_interval(batch_interval), &())
+            .start()
             .await;
 
         mocked_collect_start_error.assert_async().await;
@@ -1072,7 +1120,8 @@ mod tests {
             .await;
 
         let job = collector
-            .start_collection(Query::new_time_interval(batch_interval), &())
+            .collection(Query::new_time_interval(batch_interval), &())
+            .start()
             .await
             .unwrap();
         assert_eq!(job.query.batch_interval(), &batch_interval);
@@ -1141,7 +1190,8 @@ mod tests {
             .await;
 
         let job = collector
-            .start_collection(Query::new_time_interval(batch_interval), &())
+            .collection(Query::new_time_interval(batch_interval), &())
+            .start()
             .await
             .unwrap();
         assert_eq!(job.query.batch_interval(), &batch_interval);
@@ -1206,7 +1256,8 @@ mod tests {
             .await;
 
         let job = collector
-            .start_collection(Query::new_leader_selected(), &())
+            .collection(Query::new_leader_selected(), &())
+            .start()
             .await
             .unwrap();
 
@@ -1289,7 +1340,8 @@ mod tests {
             .await;
 
         let job = collector
-            .start_collection(Query::new_time_interval(batch_interval), &())
+            .collection(Query::new_time_interval(batch_interval), &())
+            .start()
             .await;
 
         mocked_collect_start_success.assert_async().await;
@@ -1356,7 +1408,8 @@ mod tests {
         )
         .unwrap();
         let error = collector
-            .start_collection(Query::new_time_interval(batch_interval), &())
+            .collection(Query::new_time_interval(batch_interval), &())
+            .start()
             .await
             .unwrap_err();
         assert_matches!(error, Error::Http(error_response) => {
@@ -1380,7 +1433,8 @@ mod tests {
             .await;
 
         let error = collector
-            .start_collection(Query::new_time_interval(batch_interval), &())
+            .collection(Query::new_time_interval(batch_interval), &())
+            .start()
             .await
             .unwrap_err();
         assert_matches!(error, Error::Http(error_response) => {
@@ -1409,7 +1463,8 @@ mod tests {
             .await;
 
         let error = collector
-            .start_collection(Query::new_time_interval(batch_interval), &())
+            .collection(Query::new_time_interval(batch_interval), &())
+            .start()
             .await
             .unwrap_err();
         assert_matches!(error, Error::Http(error_response) => {
@@ -1454,7 +1509,8 @@ mod tests {
         )
         .unwrap();
         let job = collector
-            .start_collection(Query::new_time_interval(batch_interval), &())
+            .collection(Query::new_time_interval(batch_interval), &())
+            .start()
             .await
             .unwrap();
         let error = collector.poll_once(&job).await.unwrap_err();
@@ -1703,7 +1759,8 @@ mod tests {
         )
         .unwrap();
         let job = collector
-            .start_collection(Query::new_time_interval(batch_interval), &())
+            .collection(Query::new_time_interval(batch_interval), &())
+            .start()
             .await
             .unwrap();
         mock_collect_start.assert_async().await;

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -226,9 +226,6 @@ pub struct CollectionRequestBuilder<'a, V: vdaf::Collector, B: BatchMode> {
 
 impl<'a, V: vdaf::Collector, B: BatchMode> CollectionRequestBuilder<'a, V, B> {
     /// Use a caller-chosen collection job ID instead of a randomly generated one.
-    ///
-    /// Supplying a stable ID is recommended: a randomly generated ID is at risk of being lost if
-    /// the program crashes before [`Self::start`] or [`Self::collect`] returns.
     pub fn with_id(mut self, collection_job_id: CollectionJobId) -> Self {
         self.collection_job_id = Some(collection_job_id);
         self

--- a/integration_tests/tests/integration/common.rs
+++ b/integration_tests/tests/integration/common.rs
@@ -151,7 +151,8 @@ where
         let query = query.clone();
         async move {
             collector
-                .collect(query.clone(), aggregation_parameter)
+                .collection(query.clone(), aggregation_parameter)
+                .collect()
                 .await
         }
     })

--- a/integration_tests/tests/integration/simulation/run.rs
+++ b/integration_tests/tests/integration/simulation/run.rs
@@ -441,7 +441,9 @@ impl Simulation {
                 match self
                     .components
                     .collector
-                    .start_collection_with_id(*collection_job_id, query, &())
+                    .collection(query, &())
+                    .with_id(*collection_job_id)
+                    .start()
                     .await
                 {
                     Ok(collection_job) => {
@@ -457,7 +459,9 @@ impl Simulation {
                 match self
                     .components
                     .collector
-                    .start_collection_with_id(*collection_job_id, query, &())
+                    .collection(query, &())
+                    .with_id(*collection_job_id)
+                    .start()
                     .await
                 {
                     Ok(collection_job) => {

--- a/interop_binaries/src/commands/janus_interop_collector.rs
+++ b/interop_binaries/src/commands/janus_interop_collector.rs
@@ -233,7 +233,7 @@ where
     .build()?;
     let agg_param = V::AggregationParam::get_decoded(agg_param_encoded)?;
     let handle = tokio::spawn(async move {
-        let collect_result = collector.collect(query, &agg_param).await?;
+        let collect_result = collector.collection(query, &agg_param).collect().await?;
         let (interval_start, interval_duration) = collect_result.interval();
         Ok(CollectResult {
             partial_batch_selector: batch_convert_fn(collect_result.partial_batch_selector()),

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -1716,6 +1716,116 @@ impl<B: BatchMode> Decode for Query<B> {
     }
 }
 
+/// DAP protocol message representing an extension included in a collection job request.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CollectionJobExtension {
+    extension_type: CollectionJobExtensionType,
+    extension_data: Vec<u8>,
+}
+
+impl CollectionJobExtension {
+    /// Construct a collection job extension from its type and payload.
+    pub fn new(
+        extension_type: CollectionJobExtensionType,
+        extension_data: Vec<u8>,
+    ) -> CollectionJobExtension {
+        CollectionJobExtension {
+            extension_type,
+            extension_data,
+        }
+    }
+
+    /// Returns the type of this extension.
+    pub fn extension_type(&self) -> CollectionJobExtensionType {
+        self.extension_type
+    }
+
+    /// Returns the unparsed data representing this extension.
+    pub fn extension_data(&self) -> &[u8] {
+        &self.extension_data
+    }
+}
+
+impl Encode for CollectionJobExtension {
+    fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
+        self.extension_type.encode(bytes)?;
+        encode_u16_items(bytes, &(), &self.extension_data)
+    }
+
+    fn encoded_len(&self) -> Option<usize> {
+        // Type, length prefix, and extension data.
+        Some(self.extension_type.encoded_len()? + 2 + self.extension_data.len())
+    }
+}
+
+impl Decode for CollectionJobExtension {
+    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        let extension_type = CollectionJobExtensionType::decode(bytes)?;
+        let extension_data = decode_u16_items(&(), bytes)?;
+
+        Ok(Self {
+            extension_type,
+            extension_data,
+        })
+    }
+}
+
+/// DAP protocol message representing the type of a collection job extension.
+///
+/// No extension types are defined yet, so every codepoint other than the reserved `0x0000` decodes
+/// to `Unknown`. Equality, ordering, and hashing are all defined in terms of the underlying
+/// codepoint.
+#[derive(Clone, Copy, Debug, FromPrimitive, IntoPrimitive)]
+#[repr(u16)]
+#[non_exhaustive]
+pub enum CollectionJobExtensionType {
+    Reserved = 0x0000,
+    #[num_enum(catch_all)]
+    Unknown(u16),
+}
+
+impl PartialEq for CollectionJobExtensionType {
+    fn eq(&self, other: &Self) -> bool {
+        u16::from(*self) == u16::from(*other)
+    }
+}
+
+impl Eq for CollectionJobExtensionType {}
+
+impl Hash for CollectionJobExtensionType {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        u16::from(*self).hash(state)
+    }
+}
+
+impl PartialOrd for CollectionJobExtensionType {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for CollectionJobExtensionType {
+    fn cmp(&self, other: &Self) -> Ordering {
+        u16::from(*self).cmp(&u16::from(*other))
+    }
+}
+
+impl Encode for CollectionJobExtensionType {
+    fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
+        u16::from(*self).encode(bytes)
+    }
+
+    fn encoded_len(&self) -> Option<usize> {
+        Some(2)
+    }
+}
+
+impl Decode for CollectionJobExtensionType {
+    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        Ok(Self::from(u16::decode(bytes)?))
+    }
+}
+
 /// DAP protocol message representing a request from the collector to the leader to provide
 /// aggregate shares for a given batch.
 #[derive(Clone, Educe, PartialEq, Eq)]
@@ -1724,14 +1834,20 @@ pub struct CollectionJobReq<B: BatchMode> {
     query: Query<B>,
     #[educe(Debug(ignore))]
     aggregation_parameter: Vec<u8>,
+    extensions: Vec<CollectionJobExtension>,
 }
 
 impl<B: BatchMode> CollectionJobReq<B> {
     /// Constructs a new collect request from its components.
-    pub fn new(query: Query<B>, aggregation_parameter: Vec<u8>) -> Self {
+    pub fn new(
+        query: Query<B>,
+        aggregation_parameter: Vec<u8>,
+        extensions: Vec<CollectionJobExtension>,
+    ) -> Self {
         Self {
             query,
             aggregation_parameter,
+            extensions,
         }
     }
 
@@ -1744,6 +1860,11 @@ impl<B: BatchMode> CollectionJobReq<B> {
     pub fn aggregation_parameter(&self) -> &[u8] {
         &self.aggregation_parameter
     }
+
+    /// Gets the extensions associated with this collect request.
+    pub fn extensions(&self) -> &[CollectionJobExtension] {
+        &self.extensions
+    }
 }
 
 impl<B: BatchMode> MediaType for CollectionJobReq<B> {
@@ -1753,11 +1874,16 @@ impl<B: BatchMode> MediaType for CollectionJobReq<B> {
 impl<B: BatchMode> Encode for CollectionJobReq<B> {
     fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
         self.query.encode(bytes)?;
-        encode_u32_items(bytes, &(), &self.aggregation_parameter)
+        encode_u32_items(bytes, &(), &self.aggregation_parameter)?;
+        encode_u16_items(bytes, &(), &self.extensions)
     }
 
     fn encoded_len(&self) -> Option<usize> {
-        Some(self.query.encoded_len()? + 4 + self.aggregation_parameter.len())
+        let mut len = self.query.encoded_len()? + 4 + self.aggregation_parameter.len() + 2;
+        for extension in &self.extensions {
+            len += extension.encoded_len()?;
+        }
+        Some(len)
     }
 }
 
@@ -1765,10 +1891,21 @@ impl<B: BatchMode> Decode for CollectionJobReq<B> {
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
         let query = Query::decode(bytes)?;
         let aggregation_parameter = decode_u32_items(&(), bytes)?;
+        let extensions: Vec<CollectionJobExtension> = decode_u16_items(&(), bytes)?;
+        if !extensions.is_sorted_by(|a, b| a.extension_type() < b.extension_type()) {
+            return Err(CodecError::Other(
+                anyhow!(
+                    "collection job extensions must be in strictly increasing order of \
+                     extension_type"
+                )
+                .into(),
+            ));
+        }
 
         Ok(Self {
             query,
             aggregation_parameter,
+            extensions,
         })
     }
 }

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -1753,7 +1753,7 @@ impl Encode for CollectionJobExtension {
     }
 
     fn encoded_len(&self) -> Option<usize> {
-        // Type, length prefix, and extension data.
+        // Extra 2 bytes for the data length prefix.
         Some(self.extension_type.encoded_len()? + 2 + self.extension_data.len())
     }
 }
@@ -1889,18 +1889,12 @@ impl<B: BatchMode> Encode for CollectionJobReq<B> {
 
 impl<B: BatchMode> Decode for CollectionJobReq<B> {
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        // Extension ordering and support are semantic checks the Leader performs while handling the
+        // request (producing the DAP `invalidExtension`/`unsupportedExtension` errors), so decoding
+        // here is purely structural.
         let query = Query::decode(bytes)?;
         let aggregation_parameter = decode_u32_items(&(), bytes)?;
-        let extensions: Vec<CollectionJobExtension> = decode_u16_items(&(), bytes)?;
-        if !extensions.is_sorted_by(|a, b| a.extension_type() < b.extension_type()) {
-            return Err(CodecError::Other(
-                anyhow!(
-                    "collection job extensions must be in strictly increasing order of \
-                     extension_type"
-                )
-                .into(),
-            ));
-        }
+        let extensions = decode_u16_items(&(), bytes)?;
 
         Ok(Self {
             query,

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -1838,17 +1838,20 @@ pub struct CollectionJobReq<B: BatchMode> {
 }
 
 impl<B: BatchMode> CollectionJobReq<B> {
-    /// Constructs a new collect request from its components.
-    pub fn new(
-        query: Query<B>,
-        aggregation_parameter: Vec<u8>,
-        extensions: Vec<CollectionJobExtension>,
-    ) -> Self {
+    /// Constructs a new collect request with no extensions. Use [`Self::with_extensions`] to add
+    /// them.
+    pub fn new(query: Query<B>, aggregation_parameter: Vec<u8>) -> Self {
         Self {
             query,
             aggregation_parameter,
-            extensions,
+            extensions: Vec::new(),
         }
+    }
+
+    /// Returns this collect request with its extensions set to the provided list.
+    pub fn with_extensions(mut self, extensions: Vec<CollectionJobExtension>) -> Self {
+        self.extensions = extensions;
+        self
     }
 
     /// Gets the query associated with this collect request.

--- a/messages/src/problem_type.rs
+++ b/messages/src/problem_type.rs
@@ -74,7 +74,9 @@ impl DapProblemType {
             DapProblemType::BatchOverlap => {
                 "The queried batch overlaps with a previously queried batch."
             }
-            DapProblemType::UnsupportedExtension => "The report includes an unsupported extension.",
+            DapProblemType::UnsupportedExtension => {
+                "The message includes an unsupported extension."
+            }
             DapProblemType::InvalidExtension => {
                 "An extensions list is out of order or contains an invalid extension encoding."
             }

--- a/messages/src/problem_type.rs
+++ b/messages/src/problem_type.rs
@@ -15,6 +15,7 @@ pub enum DapProblemType {
     StepMismatch,
     BatchOverlap,
     UnsupportedExtension,
+    InvalidExtension,
     /// A task defined via Taskprov was rejected by the aggregator. Error defined by
     /// draft-ietf-ppm-dap-taskprov ([1]).
     ///
@@ -42,6 +43,7 @@ impl DapProblemType {
             DapProblemType::UnsupportedExtension => {
                 "urn:ietf:params:ppm:dap:error:unsupportedExtension"
             }
+            DapProblemType::InvalidExtension => "urn:ietf:params:ppm:dap:error:invalidExtension",
             DapProblemType::InvalidTask => "urn:ietf:params:ppm:dap:error:invalidTask",
         }
     }
@@ -73,6 +75,9 @@ impl DapProblemType {
                 "The queried batch overlaps with a previously queried batch."
             }
             DapProblemType::UnsupportedExtension => "The report includes an unsupported extension.",
+            DapProblemType::InvalidExtension => {
+                "An extensions list is out of order or contains an invalid extension encoding."
+            }
             DapProblemType::InvalidTask => "Aggregator has opted out of the indicated task.",
         }
     }
@@ -103,6 +108,9 @@ impl FromStr for DapProblemType {
             "urn:ietf:params:ppm:dap:error:batchOverlap" => Ok(DapProblemType::BatchOverlap),
             "urn:ietf:params:ppm:dap:error:unsupportedExtension" => {
                 Ok(DapProblemType::UnsupportedExtension)
+            }
+            "urn:ietf:params:ppm:dap:error:invalidExtension" => {
+                Ok(DapProblemType::InvalidExtension)
             }
             "urn:ietf:params:ppm:dap:error:invalidTask" => Ok(DapProblemType::InvalidTask),
             _ => Err(DapProblemTypeParseError),

--- a/messages/src/tests/collection.rs
+++ b/messages/src/tests/collection.rs
@@ -1,10 +1,10 @@
 use prio::codec::Decode;
 
 use crate::{
-    AggregateShare, AggregateShareAad, AggregateShareReq, BatchId, BatchSelector, CollectionJobReq,
-    CollectionJobResp, Duration, HpkeCiphertext, HpkeConfigId, Interval, LeaderSelected,
-    PartialBatchSelector, Query, ReportIdChecksum, TaskId, Time, TimeInterval, TimePrecision,
-    roundtrip_encoding,
+    AggregateShare, AggregateShareAad, AggregateShareReq, BatchId, BatchSelector,
+    CollectionJobExtension, CollectionJobExtensionType, CollectionJobReq, CollectionJobResp,
+    Duration, HpkeCiphertext, HpkeConfigId, Interval, LeaderSelected, PartialBatchSelector, Query,
+    ReportIdChecksum, TaskId, Time, TimeInterval, TimePrecision, roundtrip_encoding,
 };
 
 const TEST_TIME_PRECISION: TimePrecision = TimePrecision::from_seconds(1);
@@ -23,6 +23,7 @@ fn roundtrip_collection_job_req() {
                     .unwrap(),
                 },
                 aggregation_parameter: Vec::new(),
+                extensions: Vec::new(),
             },
             concat!(
                 concat!(
@@ -40,6 +41,7 @@ fn roundtrip_collection_job_req() {
                     "00000000", // length
                     "",         // opaque data
                 ),
+                "0000", // extensions (empty)
             ),
         ),
         (
@@ -52,6 +54,7 @@ fn roundtrip_collection_job_req() {
                     .unwrap(),
                 },
                 aggregation_parameter: Vec::from("012345"),
+                extensions: Vec::new(),
             },
             concat!(
                 concat!(
@@ -69,6 +72,7 @@ fn roundtrip_collection_job_req() {
                     "00000006",     // length
                     "303132333435", // opaque data
                 ),
+                "0000", // extensions (empty)
             ),
         ),
     ]);
@@ -79,6 +83,7 @@ fn roundtrip_collection_job_req() {
             CollectionJobReq::<LeaderSelected> {
                 query: Query { query_body: () },
                 aggregation_parameter: Vec::new(),
+                extensions: Vec::new(),
             },
             concat!(
                 concat!(
@@ -91,12 +96,14 @@ fn roundtrip_collection_job_req() {
                     "00000000", // length
                     "",         // opaque data
                 ),
+                "0000", // extensions (empty)
             ),
         ),
         (
             CollectionJobReq::<LeaderSelected> {
                 query: Query { query_body: () },
                 aggregation_parameter: Vec::from("012345"),
+                extensions: Vec::new(),
             },
             concat!(
                 concat!(
@@ -109,9 +116,72 @@ fn roundtrip_collection_job_req() {
                     "00000006",     // length
                     "303132333435", // opaque data
                 ),
+                "0000", // extensions (empty)
+            ),
+        ),
+        (
+            // Two extensions, in strictly increasing order of extension_type.
+            CollectionJobReq::<LeaderSelected> {
+                query: Query { query_body: () },
+                aggregation_parameter: Vec::new(),
+                extensions: Vec::from([
+                    CollectionJobExtension::new(CollectionJobExtensionType::Reserved, Vec::new()),
+                    CollectionJobExtension::new(
+                        CollectionJobExtensionType::Unknown(0x0001),
+                        Vec::from("ext"),
+                    ),
+                ]),
+            },
+            concat!(
+                concat!(
+                    "02",   // batch_mode
+                    "0000", // length
+                    "",     // opaque data
+                ),
+                concat!(
+                    // aggregation_parameter
+                    "00000000", // length
+                    "",         // opaque data
+                ),
+                concat!(
+                    // extensions
+                    "000B", // length of extensions list
+                    concat!(
+                        "0000", // extension_type (Reserved)
+                        "0000", // extension_data length
+                        "",     // extension_data
+                    ),
+                    concat!(
+                        "0001",   // extension_type (0x0001)
+                        "0003",   // extension_data length
+                        "657874", // extension_data ("ext")
+                    ),
+                ),
             ),
         ),
     ]);
+}
+
+#[test]
+fn collection_job_req_rejects_unsorted_extensions() {
+    // extension_types 0x0002 then 0x0001 — not strictly increasing.
+    let encoded = hex::decode(concat!(
+        concat!(
+            "02",   // batch_mode (LeaderSelected)
+            "0000", // length
+        ),
+        "00000000", // aggregation_parameter length
+        concat!(
+            // extensions
+            "0008",                  // length of extensions list
+            concat!("0002", "0000"), // extension_type 0x0002, empty data
+            concat!("0001", "0000"), // extension_type 0x0001, empty data
+        ),
+    ))
+    .unwrap();
+
+    CollectionJobReq::<LeaderSelected>::get_decoded(&encoded)
+        .expect_err("unsorted collection job extensions must be rejected");
 }
 
 #[test]

--- a/messages/src/tests/collection.rs
+++ b/messages/src/tests/collection.rs
@@ -163,8 +163,9 @@ fn roundtrip_collection_job_req() {
 }
 
 #[test]
-fn collection_job_req_rejects_unsorted_extensions() {
-    // extension_types 0x0002 then 0x0001 — not strictly increasing.
+fn collection_job_req_decode_is_lenient_about_extension_order() {
+    // Unsorted extension_types (0x0002 before 0x0001) must still decode; ordering is enforced by
+    // the Leader, not here.
     let encoded = hex::decode(concat!(
         concat!(
             "02",   // batch_mode (LeaderSelected)
@@ -180,8 +181,9 @@ fn collection_job_req_rejects_unsorted_extensions() {
     ))
     .unwrap();
 
-    CollectionJobReq::<LeaderSelected>::get_decoded(&encoded)
-        .expect_err("unsorted collection job extensions must be rejected");
+    let req = CollectionJobReq::<LeaderSelected>::get_decoded(&encoded)
+        .expect("structurally valid collection job request must decode");
+    assert_eq!(req.extensions().len(), 2);
 }
 
 #[test]

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -544,7 +544,8 @@ where
     V::AggregateResult: Debug,
 {
     let collection = new_collector(options, vdaf, http_client)?
-        .collect(query, agg_param)
+        .collection(query, agg_param)
+        .collect()
         .await
         .map_err(|err| Error::Anyhow(err.into()))?;
     print_collection::<V, B>(collection)?;
@@ -563,7 +564,9 @@ where
     V::AggregateResult: Debug,
 {
     let collection = new_collector(options, vdaf, http_client)?
-        .start_collection_with_id(collection_job_id, query, agg_param)
+        .collection(query, agg_param)
+        .with_id(collection_job_id)
+        .start()
         .await
         .map_err(|err| Error::Anyhow(err.into()))?;
     println!("Job ID: {}", collection.collection_job_id());


### PR DESCRIPTION
This implements leader-side job extensions. Helper-side needs these extensions embedded in AggregateShareReq, which is part of the AAD work.

Since there _aren't_ any, I don't plumb this down to the database. Rather, the leader makes sure there aren't any, for now.

I'm really satisfied with the CollectionRequestBuilder, fwiw. I like those ergonomics.