### PR TITLE
[DAP-17] TaskConf AAD Part 4: bind TaskConfiguration into HPKE AADs 

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -53,10 +53,10 @@ use janus_core::{
 use janus_messages::{
     AggregateShare, AggregateShareAad, AggregateShareId, AggregateShareReq,
     AggregationJobContinueReq, AggregationJobId, AggregationJobInitializeReq, AggregationJobResp,
-    AggregationJobStep, CollectionJobId, CollectionJobReq, CollectionJobResp, Duration,
-    ExtensionType, HpkeConfig, HpkeConfigList, InputShareAad, Interval, PartialBatchSelector,
-    PlaintextInputShare, Report, ReportError, ReportUploadStatus, Role, TaskConfiguration, TaskId,
-    UploadErrors, Url as DapUrl, VerifyResp,
+    AggregationJobStep, CollectionJobExtension, CollectionJobId, CollectionJobReq,
+    CollectionJobResp, Duration, ExtensionType, HpkeConfig, HpkeConfigList, InputShareAad,
+    Interval, PartialBatchSelector, PlaintextInputShare, Report, ReportError, ReportUploadStatus,
+    Role, TaskConfiguration, TaskId, UploadErrors, Url as DapUrl, VerifyResp,
     batch_mode::{LeaderSelected, TimeInterval},
     extensions_are_strictly_increasing,
 };
@@ -3178,24 +3178,7 @@ impl VdafOps {
         collection_job_id: &CollectionJobId,
         req: Arc<CollectionJobReq<B>>,
     ) -> Result<Vec<u8>, Error> {
-        // Collection job extensions must be in strictly increasing order of extension type, which
-        // also rejects duplicates, and every extension type must be supported (DAP-19 §4.6.2). No
-        // collection job extension types are defined yet, so any extension is unsupported.
-        if !req
-            .extensions()
-            .is_sorted_by(|a, b| a.extension_type() < b.extension_type())
-        {
-            return Err(Error::InvalidExtension(
-                Some(*task.id()),
-                "collection job extensions are not in strictly increasing order of extension type",
-            ));
-        }
-        if !req.extensions().is_empty() {
-            return Err(Error::UnsupportedExtension(
-                Some(*task.id()),
-                "collection job contains an unsupported extension type",
-            ));
-        }
+        validate_collection_job_extensions(task.id(), req.extensions())?;
 
         let aggregation_param = Arc::new(
             A::AggregationParam::get_decoded(req.aggregation_parameter())
@@ -3819,6 +3802,28 @@ impl VdafOps {
         aggregate_share_id: &AggregateShareId,
         dp_strategy: Arc<S>,
     ) -> Result<AggregateShare, Error> {
+        // DAP-19 §4.6.4: the Helper validates the Collector's extensions independently of the
+        // Leader.
+        validate_collection_job_extensions(
+            task.id(),
+            aggregate_share_req.collection_job_req().extensions(),
+        )?;
+
+        // DAP-19 §4.6.4: the Helper verifies the Leader-chosen batch selector against the query in
+        // the CollectionJobReq, which the AAD binds. The spec defines consistency per batch mode
+        // and would permit any time-interval selector within the queried interval, but we require
+        // exact round-tripping: the poll path rebuilds the AAD's query from the stored selector
+        // alone, so a narrower selector would decrypt here and fail there.
+        if B::query_for_collection_identifier(
+            aggregate_share_req.batch_selector().batch_identifier(),
+        ) != *aggregate_share_req.collection_job_req().query()
+        {
+            return Err(Error::InvalidMessage(
+                Some(*task.id()),
+                "batch selector is inconsistent with the collection job request's query",
+            ));
+        }
+
         // §4.4.4.3: check that the batch interval meets the requirements from §4.6
         if !B::validate_collection_identifier(
             aggregate_share_req.batch_selector().batch_identifier(),
@@ -4054,6 +4059,30 @@ impl VdafOps {
             })?;
         Ok(())
     }
+}
+
+/// Validates a collection job's extensions, per DAP-19 §4.6.2. Both the Leader (on collection job
+/// creation) and the Helper (on aggregate share requests, independently of the Leader) must apply
+/// this.
+fn validate_collection_job_extensions(
+    task_id: &TaskId,
+    extensions: &[CollectionJobExtension],
+) -> Result<(), Error> {
+    // Strictly increasing order also rejects duplicates.
+    if !extensions.is_sorted_by(|a, b| a.extension_type() < b.extension_type()) {
+        return Err(Error::InvalidExtension(
+            Some(*task_id),
+            "collection job extensions are not in strictly increasing order of extension type",
+        ));
+    }
+    // No collection job extension types are defined yet, so any extension is unsupported.
+    if !extensions.is_empty() {
+        return Err(Error::UnsupportedExtension(
+            Some(*task_id),
+            "collection job contains an unsupported extension type",
+        ));
+    }
+    Ok(())
 }
 
 fn write_task_aggregation_counter<C: Clock>(

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -53,10 +53,10 @@ use janus_core::{
 use janus_messages::{
     AggregateShare, AggregateShareAad, AggregateShareId, AggregateShareReq,
     AggregationJobContinueReq, AggregationJobId, AggregationJobInitializeReq, AggregationJobResp,
-    AggregationJobStep, BatchSelector, CollectionJobId, CollectionJobReq, CollectionJobResp,
-    Duration, ExtensionType, HpkeConfig, HpkeConfigList, InputShareAad, Interval,
-    PartialBatchSelector, PlaintextInputShare, Report, ReportError, ReportUploadStatus, Role,
-    TaskConfiguration, TaskId, UploadErrors, Url as DapUrl, VerifyResp,
+    AggregationJobStep, CollectionJobId, CollectionJobReq, CollectionJobResp, Duration,
+    ExtensionType, HpkeConfig, HpkeConfigList, InputShareAad, Interval, PartialBatchSelector,
+    PlaintextInputShare, Report, ReportError, ReportUploadStatus, Role, TaskConfiguration, TaskId,
+    UploadErrors, Url as DapUrl, VerifyResp,
     batch_mode::{LeaderSelected, TimeInterval},
     extensions_are_strictly_increasing,
 };
@@ -1945,6 +1945,8 @@ impl VdafOps {
 
         let input_share_aad = InputShareAad::new(
             *task.id(),
+            task.task_configuration()
+                .map_err(|e| UploadError::Internal(Arc::new(e.into())))?,
             report.metadata().clone(),
             report.public_share().to_vec(),
         )
@@ -3422,11 +3424,10 @@ impl VdafOps {
                         .map_err(Error::MessageEncode)?,
                     &AggregateShareAad::new(
                         *collection_job.task_id(),
+                        task.task_configuration()?,
                         collection_job
-                            .aggregation_parameter()
-                            .get_encoded()
+                            .to_collection_job_req()
                             .map_err(Error::MessageEncode)?,
-                        BatchSelector::<B>::new(collection_job.batch_identifier().clone()),
                     )
                     .get_encoded()
                     .map_err(Error::MessageEncode)?,
@@ -3651,11 +3652,18 @@ impl VdafOps {
                 .map_err(Error::MessageEncode)?,
             &AggregateShareAad::new(
                 *task.id(),
-                aggregate_share_job
-                    .aggregation_parameter()
-                    .get_encoded()
-                    .map_err(Error::MessageEncode)?,
-                BatchSelector::<B>::new(aggregate_share_job.batch_identifier().clone()),
+                task.task_configuration()?,
+                // On the poll path we no longer have the Collector's original CollectionJobReq
+                // (there is no incoming AggregateShareReq), so reconstruct it from the stored job.
+                // This must be byte-identical to the request the Collector sent; see
+                // `query_for_collection_identifier`.
+                CollectionJobReq::new(
+                    B::query_for_collection_identifier(aggregate_share_job.batch_identifier()),
+                    aggregate_share_job
+                        .aggregation_parameter()
+                        .get_encoded()
+                        .map_err(Error::MessageEncode)?,
+                ),
             )
             .get_encoded()
             .map_err(Error::MessageEncode)?,
@@ -4006,11 +4014,8 @@ impl VdafOps {
                 .map_err(Error::MessageEncode)?,
             &AggregateShareAad::new(
                 *task.id(),
-                aggregate_share_job
-                    .aggregation_parameter()
-                    .get_encoded()
-                    .map_err(Error::MessageEncode)?,
-                aggregate_share_req.batch_selector().clone(),
+                task.task_configuration()?,
+                aggregate_share_req.collection_job_req().clone(),
             )
             .get_encoded()
             .map_err(Error::MessageEncode)?,

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -3639,7 +3639,8 @@ impl VdafOps {
                 // On the poll path we no longer have the Collector's original CollectionJobReq
                 // (there is no incoming AggregateShareReq), so reconstruct it from the stored job.
                 // This must be byte-identical to the request the Collector sent; see
-                // `query_for_collection_identifier`.
+                // `query_for_collection_identifier`. When we support extensions (Issue #4715)
+                // this will need to change.
                 CollectionJobReq::new(
                     B::query_for_collection_identifier(aggregate_share_job.batch_identifier()),
                     aggregate_share_job
@@ -3811,9 +3812,9 @@ impl VdafOps {
 
         // DAP-19 §4.6.4: the Helper verifies the Leader-chosen batch selector against the query in
         // the CollectionJobReq, which the AAD binds. The spec defines consistency per batch mode
-        // and would permit any time-interval selector within the queried interval, but we require
-        // exact round-tripping: the poll path rebuilds the AAD's query from the stored selector
-        // alone, so a narrower selector would decrypt here and fail there.
+        // and would permit any time-interval selector within the queried interval, but Janus
+        // requires exact round-tripping, otherwise the poll path rebuilds the AAD's query from
+        // the stored selector alone, so a narrower selector would decrypt here and fail there.
         if B::query_for_collection_identifier(
             aggregate_share_req.batch_selector().batch_identifier(),
         ) != *aggregate_share_req.collection_job_req().query()
@@ -3882,7 +3883,8 @@ impl VdafOps {
                         .await?
                     {
                         // Duplicate aggregate share job found - verify the aggregate share ID
-                        // matches
+                        // matches. Note, when we add collection extensions, those will need
+                        // to be checked here as well. (Issue #4715)
                         if aggregate_share_job.aggregate_share_id() != &aggregate_share_id
                         {
                             // Mismatch here indicates a duplicate request with a different

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -3819,9 +3819,12 @@ impl VdafOps {
             aggregate_share_req.batch_selector().batch_identifier(),
         ) != *aggregate_share_req.collection_job_req().query()
         {
-            return Err(Error::InvalidMessage(
-                Some(*task.id()),
-                "batch selector is inconsistent with the collection job request's query",
+            return Err(Error::BatchInvalid(
+                *task.id(),
+                format!(
+                    "{}, which is inconsistent with the collection job request's query",
+                    aggregate_share_req.batch_selector().batch_identifier()
+                ),
             ));
         }
 

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -3639,8 +3639,8 @@ impl VdafOps {
                 // On the poll path we no longer have the Collector's original CollectionJobReq
                 // (there is no incoming AggregateShareReq), so reconstruct it from the stored job.
                 // This must be byte-identical to the request the Collector sent; see
-                // `query_for_collection_identifier`. When we support extensions (Issue #4715)
-                // this will need to change.
+                // `query_for_collection_identifier` (and Issue #4743). When we support
+                // extensions (Issue #4715) this will need to change.
                 CollectionJobReq::new(
                     B::query_for_collection_identifier(aggregate_share_job.batch_identifier()),
                     aggregate_share_job

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -970,6 +970,7 @@ mod tests {
         );
         let leader_report = Arc::new(LeaderStoredReport::generate(
             *leader_task.id(),
+            leader_task.task_configuration().unwrap(),
             leader_report_metadata,
             helper_hpke_keypair.config(),
             Vec::new(),
@@ -1175,6 +1176,7 @@ mod tests {
                 );
                 LeaderStoredReport::generate(
                     *task.id(),
+                    task.task_configuration().unwrap(),
                     report_metadata,
                     helper_hpke_keypair.config(),
                     Vec::new(),
@@ -1356,6 +1358,7 @@ mod tests {
         );
         let first_report = Arc::new(LeaderStoredReport::generate(
             *task.id(),
+            task.task_configuration().unwrap(),
             first_report_metadata,
             helper_hpke_keypair.config(),
             Vec::new(),
@@ -1373,6 +1376,7 @@ mod tests {
         );
         let second_report = Arc::new(LeaderStoredReport::generate(
             *task.id(),
+            task.task_configuration().unwrap(),
             second_report_metadata,
             helper_hpke_keypair.config(),
             Vec::new(),
@@ -1559,6 +1563,7 @@ mod tests {
         );
         let report = Arc::new(LeaderStoredReport::generate(
             *task.id(),
+            task.task_configuration().unwrap(),
             report_metadata,
             helper_hpke_keypair.config(),
             Vec::new(),
@@ -1724,6 +1729,7 @@ mod tests {
                 );
                 LeaderStoredReport::generate(
                     *task.id(),
+                    task.task_configuration().unwrap(),
                     report_metadata,
                     helper_hpke_keypair.config(),
                     Vec::new(),
@@ -1912,6 +1918,7 @@ mod tests {
                 );
                 LeaderStoredReport::generate(
                     *task.id(),
+                    task.task_configuration().unwrap(),
                     report_metadata,
                     helper_hpke_keypair.config(),
                     Vec::new(),
@@ -2112,6 +2119,7 @@ mod tests {
                 );
                 LeaderStoredReport::generate(
                     *task.id(),
+                    task.task_configuration().unwrap(),
                     report_metadata,
                     helper_hpke_keypair.config(),
                     Vec::new(),
@@ -2277,6 +2285,7 @@ mod tests {
                 );
                 LeaderStoredReport::generate(
                     *task.id(),
+                    task.task_configuration().unwrap(),
                     report_metadata,
                     helper_hpke_keypair.config(),
                     Vec::new(),
@@ -2392,6 +2401,7 @@ mod tests {
         );
         let last_report = Arc::new(LeaderStoredReport::generate(
             *task.id(),
+            task.task_configuration().unwrap(),
             last_report_metadata,
             helper_hpke_keypair.config(),
             Vec::new(),
@@ -2541,6 +2551,7 @@ mod tests {
                 );
                 LeaderStoredReport::generate(
                     *task.id(),
+                    task.task_configuration().unwrap(),
                     report_metadata,
                     helper_hpke_keypair.config(),
                     Vec::new(),
@@ -2659,6 +2670,7 @@ mod tests {
                 );
                 LeaderStoredReport::generate(
                     *task.id(),
+                    task.task_configuration().unwrap(),
                     report_metadata,
                     helper_hpke_keypair.config(),
                     Vec::new(),
@@ -2824,6 +2836,7 @@ mod tests {
                 );
                 LeaderStoredReport::generate(
                     *task.id(),
+                    task.task_configuration().unwrap(),
                     report_metadata,
                     helper_hpke_keypair.config(),
                     Vec::new(),
@@ -2845,6 +2858,7 @@ mod tests {
                 );
                 LeaderStoredReport::generate(
                     *task.id(),
+                    task.task_configuration().unwrap(),
                     report_metadata,
                     helper_hpke_keypair.config(),
                     Vec::new(),

--- a/aggregator/src/aggregator/aggregation_job_driver/tests.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver/tests.rs
@@ -113,6 +113,7 @@ async fn aggregation_job_driver() {
     );
     let accepted_report = LeaderStoredReport::generate(
         *task.id(),
+        task.leader_view().unwrap().task_configuration().unwrap(),
         accepted_report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -145,6 +146,7 @@ async fn aggregation_job_driver() {
             );
             let rejected_report = LeaderStoredReport::generate(
                 *task.id(),
+                task.leader_view().unwrap().task_configuration().unwrap(),
                 rejected_report_metadata,
                 helper_hpke_keypair.config(),
                 Vec::new(),
@@ -538,6 +540,7 @@ async fn leader_sync_time_interval_aggregation_job_init_single_step() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
+        task.leader_view().unwrap().task_configuration().unwrap(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -545,6 +548,7 @@ async fn leader_sync_time_interval_aggregation_job_init_single_step() {
     );
     let repeated_public_extension_report = LeaderStoredReport::generate(
         *task.id(),
+        task.leader_view().unwrap().task_configuration().unwrap(),
         ReportMetadata::new(
             random(),
             time,
@@ -559,6 +563,7 @@ async fn leader_sync_time_interval_aggregation_job_init_single_step() {
     );
     let repeated_private_extension_report = LeaderStoredReport::generate(
         *task.id(),
+        task.leader_view().unwrap().task_configuration().unwrap(),
         ReportMetadata::new(random(), time, Vec::new()),
         helper_hpke_keypair.config(),
         Vec::from([
@@ -569,6 +574,7 @@ async fn leader_sync_time_interval_aggregation_job_init_single_step() {
     );
     let repeated_public_private_extension_report = LeaderStoredReport::generate(
         *task.id(),
+        task.leader_view().unwrap().task_configuration().unwrap(),
         ReportMetadata::new(
             random(),
             time,
@@ -998,6 +1004,7 @@ async fn leader_sync_time_interval_aggregation_job_init_two_steps() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
+        task.leader_view().unwrap().task_configuration().unwrap(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -1308,6 +1315,7 @@ async fn leader_sync_time_interval_aggregation_job_init_partially_garbage_collec
     let helper_hpke_keypair = HpkeKeypair::test();
     let gc_eligible_report = LeaderStoredReport::generate(
         *task.id(),
+        task.leader_view().unwrap().task_configuration().unwrap(),
         gc_eligible_report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -1315,6 +1323,7 @@ async fn leader_sync_time_interval_aggregation_job_init_partially_garbage_collec
     );
     let gc_ineligible_report = LeaderStoredReport::generate(
         *task.id(),
+        task.leader_view().unwrap().task_configuration().unwrap(),
         gc_ineligible_report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -1697,6 +1706,7 @@ async fn leader_sync_leader_selected_aggregation_job_init_single_step() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
+        task.leader_view().unwrap().task_configuration().unwrap(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -2027,6 +2037,7 @@ async fn leader_sync_leader_selected_aggregation_job_init_two_steps() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
+        task.leader_view().unwrap().task_configuration().unwrap(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -2304,6 +2315,7 @@ async fn leader_sync_time_interval_aggregation_job_continue() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
+        task.leader_view().unwrap().task_configuration().unwrap(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -2658,6 +2670,7 @@ async fn leader_sync_leader_selected_aggregation_job_continue() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
+        task.leader_view().unwrap().task_configuration().unwrap(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -2952,6 +2965,7 @@ async fn leader_async_aggregation_job_init_to_pending() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
+        task.leader_view().unwrap().task_configuration().unwrap(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -3209,6 +3223,7 @@ async fn leader_async_aggregation_job_init_to_pending_two_step() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
+        task.leader_view().unwrap().task_configuration().unwrap(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -3467,6 +3482,7 @@ async fn leader_async_aggregation_job_continue_to_pending() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
+        task.leader_view().unwrap().task_configuration().unwrap(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -3728,6 +3744,7 @@ async fn leader_async_aggregation_job_init_poll_to_pending() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
+        task.leader_view().unwrap().task_configuration().unwrap(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -3972,6 +3989,7 @@ async fn leader_async_aggregation_job_init_poll_to_pending_two_step() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
+        task.leader_view().unwrap().task_configuration().unwrap(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -4216,6 +4234,7 @@ async fn leader_async_aggregation_job_init_poll_to_finished() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
+        task.leader_view().unwrap().task_configuration().unwrap(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -4477,6 +4496,7 @@ async fn leader_async_aggregation_job_init_poll_to_continue() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
+        task.leader_view().unwrap().task_configuration().unwrap(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -4738,6 +4758,7 @@ async fn leader_async_aggregation_job_continue_poll_to_pending() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
+        task.leader_view().unwrap().task_configuration().unwrap(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -4991,6 +5012,7 @@ async fn leader_async_aggregation_job_continue_poll_to_finished() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
+        task.leader_view().unwrap().task_configuration().unwrap(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -5247,6 +5269,7 @@ async fn helper_async_init_processing_to_finished() {
 
     let report_share = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
+        task.helper_view().unwrap().task_configuration().unwrap(),
         report_metadata,
         hpke_keypair.config(),
         &transcript.public_share,
@@ -5490,6 +5513,7 @@ async fn helper_async_init_processing_to_continue() {
 
     let report_share = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
+        task.helper_view().unwrap().task_configuration().unwrap(),
         report_metadata,
         hpke_keypair.config(),
         &transcript.public_share,
@@ -5730,6 +5754,7 @@ async fn helper_async_continue_processing_to_finished() {
 
     let report_share = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
+        task.helper_view().unwrap().task_configuration().unwrap(),
         report_metadata,
         hpke_keypair.config(),
         &transcript.public_share,
@@ -5983,6 +6008,7 @@ async fn setup_cancel_aggregation_job_test() -> CancelAggregationJobTestCase {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
+        task.task_configuration().unwrap(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -6265,6 +6291,7 @@ async fn abandon_failing_aggregation_job_with_retryable_error() {
     );
     let report = LeaderStoredReport::generate(
         *task.id(),
+        task.leader_view().unwrap().task_configuration().unwrap(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -6516,6 +6543,7 @@ async fn abandon_failing_aggregation_job_with_fatal_error() {
     );
     let report = LeaderStoredReport::generate(
         *task.id(),
+        task.leader_view().unwrap().task_configuration().unwrap(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),

--- a/aggregator/src/aggregator/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/aggregation_job_init.rs
@@ -111,6 +111,7 @@ where
     C: Clock,
 {
     let verify_key = task.vdaf_verify_key()?;
+    let task_configuration = task.task_configuration()?;
     let report_aggregation_count = report_aggregations.len();
     let now = clock.now();
     let report_deadline = now
@@ -170,6 +171,7 @@ where
                     let plaintext = hpke_keypair.and_then(|hpke_keypair| {
                         let input_share_aad = InputShareAad::new(
                             *task.id(),
+                            task_configuration.clone(),
                             verify_init.report_share().metadata().clone(),
                             verify_init.report_share().public_share().to_vec(),
                         )
@@ -677,6 +679,7 @@ pub mod test_util {
             );
             let report_share = generate_helper_report_share::<V>(
                 *self.task.id(),
+                self.task.task_configuration().unwrap(),
                 report_metadata,
                 &self.hpke_config,
                 &transcript.public_share,

--- a/aggregator/src/aggregator/collection_job_driver.rs
+++ b/aggregator/src/aggregator/collection_job_driver.rs
@@ -381,11 +381,10 @@ impl CollectionJobDriver {
                     content_type: AggregateShareReq::<B>::MEDIA_TYPE,
                     body: Bytes::from(
                         AggregateShareReq::<B>::new(
-                            BatchSelector::new(collection_job.batch_identifier().clone()),
                             collection_job
-                                .aggregation_parameter()
-                                .get_encoded()
+                                .to_collection_job_req()
                                 .map_err(Error::MessageEncode)?,
+                            BatchSelector::new(collection_job.batch_identifier().clone()),
                             leader_aggregate_share.report_count,
                             leader_aggregate_share.checksum,
                         )
@@ -952,9 +951,9 @@ mod tests {
         vdaf::VdafInstance,
     };
     use janus_messages::{
-        AggregateShare, AggregateShareReq, AggregationJobStep, BatchSelector, Duration, Interval,
-        MediaType, Query, ReportIdChecksum, TimePrecision, batch_mode::TimeInterval,
-        problem_type::DapProblemType,
+        AggregateShare, AggregateShareReq, AggregationJobStep, BatchSelector, CollectionJobReq,
+        Duration, Interval, MediaType, Query, ReportIdChecksum, TimePrecision,
+        batch_mode::TimeInterval, problem_type::DapProblemType,
     };
     use postgres_types::Timestamp;
     use prio::{
@@ -1402,8 +1401,11 @@ mod tests {
         assert_eq!(expected_aggregate_share_id, aggregate_share_id);
 
         let leader_request = AggregateShareReq::new(
+            CollectionJobReq::new(
+                Query::new_time_interval(batch_interval),
+                aggregation_param.get_encoded().unwrap(),
+            ),
             BatchSelector::new_time_interval(batch_interval),
-            aggregation_param.get_encoded().unwrap(),
             10,
             ReportIdChecksum::get_decoded(&[3 ^ 2; 32]).unwrap(),
         );
@@ -2110,8 +2112,11 @@ mod tests {
         let aggregation_param = dummy::AggregationParam(0);
 
         let leader_request = AggregateShareReq::new(
+            CollectionJobReq::new(
+                Query::new_time_interval(batch_interval),
+                aggregation_param.get_encoded().unwrap(),
+            ),
             BatchSelector::new_time_interval(batch_interval),
-            aggregation_param.get_encoded().unwrap(),
             10,
             ReportIdChecksum::get_decoded(&[3 ^ 2; 32]).unwrap(),
         );
@@ -2219,8 +2224,11 @@ mod tests {
         let aggregation_param = dummy::AggregationParam(0);
 
         let leader_request = AggregateShareReq::new(
+            CollectionJobReq::new(
+                Query::new_time_interval(batch_interval),
+                aggregation_param.get_encoded().unwrap(),
+            ),
             BatchSelector::new_time_interval(batch_interval),
-            aggregation_param.get_encoded().unwrap(),
             10,
             ReportIdChecksum::get_decoded(&[3 ^ 2; 32]).unwrap(),
         );

--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -26,8 +26,8 @@ use janus_core::{
     vdaf::VdafInstance,
 };
 use janus_messages::{
-    AggregateShareAad, AggregationJobStep, BatchId, BatchSelector, CollectionJobId,
-    CollectionJobReq, CollectionJobResp, Interval, MediaType, Query, Role, Time, TimePrecision,
+    AggregateShareAad, AggregationJobStep, BatchId, CollectionJobId, CollectionJobReq,
+    CollectionJobResp, Interval, MediaType, Query, Role, Time, TimePrecision,
     batch_mode::{BatchMode as BatchModeTrait, LeaderSelected, TimeInterval},
 };
 use prio::{
@@ -394,8 +394,11 @@ async fn collection_job_success_leader_selected() {
                         &helper_aggregate_share_bytes,
                         &AggregateShareAad::new(
                             *task.id(),
-                            aggregation_param.get_encoded().unwrap(),
-                            BatchSelector::new_leader_selected(batch_id),
+                            task.helper_view().unwrap().task_configuration().unwrap(),
+                            CollectionJobReq::new(
+                                Query::new_leader_selected(),
+                                aggregation_param.get_encoded().unwrap(),
+                            ),
                         )
                         .get_encoded()
                         .unwrap(),
@@ -465,8 +468,16 @@ async fn collection_job_success_leader_selected() {
             &leader_encrypted_aggregate_share,
             &AggregateShareAad::new(
                 *test_case.task.id(),
-                aggregation_param.get_encoded().unwrap(),
-                BatchSelector::new_leader_selected(batch_id),
+                test_case
+                    .task
+                    .leader_view()
+                    .unwrap()
+                    .task_configuration()
+                    .unwrap(),
+                CollectionJobReq::new(
+                    Query::new_leader_selected(),
+                    aggregation_param.get_encoded().unwrap(),
+                ),
             )
             .get_encoded()
             .unwrap(),
@@ -483,8 +494,16 @@ async fn collection_job_success_leader_selected() {
             &helper_encrypted_aggregate_share,
             &AggregateShareAad::new(
                 *test_case.task.id(),
-                aggregation_param.get_encoded().unwrap(),
-                BatchSelector::new_leader_selected(batch_id),
+                test_case
+                    .task
+                    .leader_view()
+                    .unwrap()
+                    .task_configuration()
+                    .unwrap(),
+                CollectionJobReq::new(
+                    Query::new_leader_selected(),
+                    aggregation_param.get_encoded().unwrap(),
+                ),
             )
             .get_encoded()
             .unwrap(),

--- a/aggregator/src/aggregator/collection_job_tests.rs
+++ b/aggregator/src/aggregator/collection_job_tests.rs
@@ -394,7 +394,7 @@ async fn collection_job_success_leader_selected() {
                         &helper_aggregate_share_bytes,
                         &AggregateShareAad::new(
                             *task.id(),
-                            task.helper_view().unwrap().task_configuration().unwrap(),
+                            task.task_configuration(),
                             CollectionJobReq::new(
                                 Query::new_leader_selected(),
                                 aggregation_param.get_encoded().unwrap(),
@@ -468,12 +468,7 @@ async fn collection_job_success_leader_selected() {
             &leader_encrypted_aggregate_share,
             &AggregateShareAad::new(
                 *test_case.task.id(),
-                test_case
-                    .task
-                    .leader_view()
-                    .unwrap()
-                    .task_configuration()
-                    .unwrap(),
+                test_case.task.task_configuration(),
                 CollectionJobReq::new(
                     Query::new_leader_selected(),
                     aggregation_param.get_encoded().unwrap(),
@@ -494,12 +489,7 @@ async fn collection_job_success_leader_selected() {
             &helper_encrypted_aggregate_share,
             &AggregateShareAad::new(
                 *test_case.task.id(),
-                test_case
-                    .task
-                    .leader_view()
-                    .unwrap()
-                    .task_configuration()
-                    .unwrap(),
+                test_case.task.task_configuration(),
                 CollectionJobReq::new(
                     Query::new_leader_selected(),
                     aggregation_param.get_encoded().unwrap(),

--- a/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
@@ -19,8 +19,9 @@ use janus_core::{
 };
 use janus_messages::{
     AggregateShare as AggregateShareMessage, AggregateShareAad, AggregateShareId,
-    AggregateShareReq, BatchId, BatchSelector, CollectionJobReq, Duration, Interval, MediaType,
-    Query, ReportIdChecksum, Role, Time, TimePrecision,
+    AggregateShareReq, BatchId, BatchSelector, CollectionJobExtension, CollectionJobExtensionType,
+    CollectionJobReq, Duration, Interval, MediaType, Query, ReportIdChecksum, Role, Time,
+    TimePrecision,
     batch_mode::{self, LeaderSelected, TimeInterval},
 };
 use prio::{
@@ -1297,6 +1298,140 @@ async fn aggregate_share_delete_nonexistant() {
             "title": "The aggregate share ID is not recognized.",
             "taskid": format!("{}", task.id()),
             "aggregate_share_id": format!("{}", nonexistent_aggregate_share_id),
+        })
+    );
+}
+
+#[tokio::test]
+async fn aggregate_share_request_batch_selector_inconsistent_with_query() {
+    let HttpHandlerTest {
+        clock: _,
+        ephemeral_datastore: _ephemeral_datastore,
+        datastore,
+        router,
+        ..
+    } = HttpHandlerTest::new().await;
+
+    let task = TaskBuilder::new(
+        BatchMode::TimeInterval,
+        AggregationMode::Synchronous,
+        VdafInstance::Fake { rounds: 1 },
+    )
+    .with_helper_aggregator_endpoint("https://helper.example.com/".parse().unwrap())
+    .build();
+    datastore
+        .put_aggregator_task(&task.helper_view().unwrap())
+        .await
+        .unwrap();
+
+    let interval = |start, duration| {
+        Interval::new(
+            Time::from_time_precision_units(start),
+            Duration::from_time_precision_units(duration),
+        )
+        .unwrap()
+    };
+    let queried_interval = interval(10, 10);
+
+    for selected_interval in [
+        interval(30, 10), // disjoint from the queried interval
+        // A strict sub-interval. This is permitted by DAP-19 4.6.4 but not by Janus.
+        interval(12, 5),
+        interval(5, 20), // a superset of the queried interval
+    ] {
+        let request = AggregateShareReq::new(
+            CollectionJobReq::new(
+                Query::new_time_interval(queried_interval),
+                dummy::AggregationParam(0).get_encoded().unwrap(),
+            ),
+            BatchSelector::new_time_interval(selected_interval),
+            0,
+            ReportIdChecksum::default(),
+        );
+
+        let mut response = put_aggregate_share_request(
+            &task,
+            &request,
+            &AggregateShareId::from([0u8; 16]),
+            &router,
+        )
+        .await;
+
+        assert_eq!(
+            response.status(),
+            StatusCode::BAD_REQUEST,
+            "selector {selected_interval} should be rejected"
+        );
+        assert_eq!(
+            take_problem_details(&mut response).await,
+            json!({
+                "status": StatusCode::BAD_REQUEST.as_u16(),
+                "type": "urn:ietf:params:ppm:dap:error:invalidMessage",
+                "title": "The message type for a response was incorrect or the payload was malformed.",
+                "detail": "batch selector is inconsistent with the collection job request's query",
+                "taskid": format!("{}", task.id()),
+            })
+        );
+    }
+}
+
+// The helper validates the collector's extensions itself rather than trusting the leader
+// (DAP-19 §4.6.4).
+#[tokio::test]
+async fn aggregate_share_request_unsupported_extension() {
+    let HttpHandlerTest {
+        clock: _,
+        ephemeral_datastore: _ephemeral_datastore,
+        datastore,
+        router,
+        ..
+    } = HttpHandlerTest::new().await;
+
+    let task = TaskBuilder::new(
+        BatchMode::TimeInterval,
+        AggregationMode::Synchronous,
+        VdafInstance::Fake { rounds: 1 },
+    )
+    .with_helper_aggregator_endpoint("https://helper.example.com/".parse().unwrap())
+    .build();
+    datastore
+        .put_aggregator_task(&task.helper_view().unwrap())
+        .await
+        .unwrap();
+
+    let batch_interval = Interval::new(
+        Time::from_time_precision_units(10),
+        Duration::from_time_precision_units(10),
+    )
+    .unwrap();
+
+    let request = AggregateShareReq::new(
+        CollectionJobReq::new(
+            Query::new_time_interval(batch_interval),
+            dummy::AggregationParam(0).get_encoded().unwrap(),
+        )
+        .with_extensions(Vec::from([CollectionJobExtension::new(
+            CollectionJobExtensionType::Unknown(0xbeef),
+            Vec::from([0]),
+        )])),
+        BatchSelector::new_time_interval(batch_interval),
+        0,
+        ReportIdChecksum::default(),
+    );
+
+    let mut response =
+        put_aggregate_share_request(&task, &request, &AggregateShareId::from([0u8; 16]), &router)
+            .await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        take_problem_details(&mut response).await,
+        json!({
+            "status": StatusCode::BAD_REQUEST.as_u16(),
+            "type": "urn:ietf:params:ppm:dap:error:unsupportedExtension",
+            "title": "The message includes an unsupported extension.",
+            "detail": "collection job contains an unsupported extension type",
+            "taskid": format!("{}", task.id()),
         })
     );
 }

--- a/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
@@ -1366,9 +1366,8 @@ async fn aggregate_share_request_batch_selector_inconsistent_with_query() {
             take_problem_details(&mut response).await,
             json!({
                 "status": StatusCode::BAD_REQUEST.as_u16(),
-                "type": "urn:ietf:params:ppm:dap:error:invalidMessage",
-                "title": "The message type for a response was incorrect or the payload was malformed.",
-                "detail": "batch selector is inconsistent with the collection job request's query",
+                "type": "urn:ietf:params:ppm:dap:error:batchInvalid",
+                "title": "The batch implied by the query is invalid.",
                 "taskid": format!("{}", task.id()),
             })
         );

--- a/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
@@ -19,9 +19,9 @@ use janus_core::{
 };
 use janus_messages::{
     AggregateShare as AggregateShareMessage, AggregateShareAad, AggregateShareId,
-    AggregateShareReq, BatchSelector, Duration, Interval, MediaType, ReportIdChecksum, Role, Time,
-    TimePrecision,
-    batch_mode::{self, TimeInterval},
+    AggregateShareReq, BatchId, BatchSelector, CollectionJobReq, Duration, Interval, MediaType,
+    Query, ReportIdChecksum, Role, Time, TimePrecision,
+    batch_mode::{self, LeaderSelected, TimeInterval},
 };
 use prio::{
     codec::{Decode, Encode},
@@ -78,10 +78,15 @@ async fn aggregate_share_request_to_leader() {
     datastore.put_aggregator_task(&leader_task).await.unwrap();
 
     let request = AggregateShareReq::new(
+        CollectionJobReq::new(
+            Query::new_time_interval(
+                Interval::minimal(Time::from_time_precision_units(0)).unwrap(),
+            ),
+            Vec::new(),
+        ),
         BatchSelector::new_time_interval(
             Interval::minimal(Time::from_time_precision_units(0)).unwrap(),
         ),
-        Vec::new(),
         0,
         ReportIdChecksum::default(),
     );
@@ -125,6 +130,17 @@ async fn aggregate_share_request_invalid_batch_interval() {
     datastore.put_aggregator_task(&helper_task).await.unwrap();
 
     let request = AggregateShareReq::new(
+        CollectionJobReq::new(
+            Query::new_time_interval(
+                Interval::new(
+                    clock.now().to_time(task.time_precision()),
+                    // Collect request will be rejected because batch interval is too small
+                    Duration::from_seconds(task.time_precision().as_seconds() - 1, &time_precision),
+                )
+                .unwrap(),
+            ),
+            Vec::new(),
+        ),
         BatchSelector::new_time_interval(
             Interval::new(
                 clock.now().to_time(task.time_precision()),
@@ -133,7 +149,6 @@ async fn aggregate_share_request_invalid_batch_interval() {
             )
             .unwrap(),
         ),
-        Vec::new(),
         0,
         ReportIdChecksum::default(),
     );
@@ -159,10 +174,15 @@ async fn aggregate_share_request_invalid_batch_interval() {
     let response = put_aggregate_share_request(
         &task,
         &AggregateShareReq::new(
+            CollectionJobReq::new(
+                Query::new_time_interval(
+                    Interval::minimal(Time::from_time_precision_units(0)).unwrap(),
+                ),
+                Vec::new(),
+            ),
             BatchSelector::new_time_interval(
                 Interval::minimal(Time::from_time_precision_units(0)).unwrap(),
             ),
-            Vec::new(),
             0,
             ReportIdChecksum::default(),
         ),
@@ -196,10 +216,15 @@ async fn aggregate_share_request() {
 
     // There are no batch aggregations in the datastore yet
     let request = AggregateShareReq::new(
+        CollectionJobReq::new(
+            Query::new_time_interval(
+                Interval::minimal(Time::from_time_precision_units(0)).unwrap(),
+            ),
+            dummy::AggregationParam(0).get_encoded().unwrap(),
+        ),
         BatchSelector::new_time_interval(
             Interval::minimal(Time::from_time_precision_units(0)).unwrap(),
         ),
-        dummy::AggregationParam(0).get_encoded().unwrap(),
         0,
         ReportIdChecksum::default(),
     );
@@ -329,6 +354,16 @@ async fn aggregate_share_request() {
 
     // Specified interval includes too few reports.
     let request = AggregateShareReq::new(
+        CollectionJobReq::new(
+            Query::new_time_interval(
+                Interval::new(
+                    Time::from_time_precision_units(0),
+                    Duration::from_seconds(1000, task.time_precision()),
+                )
+                .unwrap(),
+            ),
+            dummy::AggregationParam(0).get_encoded().unwrap(),
+        ),
         BatchSelector::new_time_interval(
             Interval::new(
                 Time::from_time_precision_units(0),
@@ -336,7 +371,6 @@ async fn aggregate_share_request() {
             )
             .unwrap(),
         ),
-        dummy::AggregationParam(0).get_encoded().unwrap(),
         5,
         ReportIdChecksum::default(),
     );
@@ -366,6 +400,16 @@ async fn aggregate_share_request() {
         MisalignedRequestTestCase {
             name: "Interval is big enough but the checksums don't match",
             request: AggregateShareReq::new(
+                CollectionJobReq::new(
+                    Query::new_time_interval(
+                        Interval::new(
+                            Time::from_time_precision_units(0),
+                            Duration::from_seconds(2000, task.time_precision()),
+                        )
+                        .unwrap(),
+                    ),
+                    dummy::AggregationParam(0).get_encoded().unwrap(),
+                ),
                 BatchSelector::new_time_interval(
                     Interval::new(
                         Time::from_time_precision_units(0),
@@ -373,7 +417,6 @@ async fn aggregate_share_request() {
                     )
                     .unwrap(),
                 ),
-                dummy::AggregationParam(0).get_encoded().unwrap(),
                 10,
                 ReportIdChecksum::get_decoded(&[3; 32]).unwrap(),
             ),
@@ -383,6 +426,16 @@ async fn aggregate_share_request() {
         MisalignedRequestTestCase {
             name: "Interval is big enough but report count doesn't match",
             request: AggregateShareReq::new(
+                CollectionJobReq::new(
+                    Query::new_time_interval(
+                        Interval::new(
+                            Time::from_seconds_since_epoch(2000, task.time_precision()),
+                            Duration::from_seconds(2000, task.time_precision()),
+                        )
+                        .unwrap(),
+                    ),
+                    dummy::AggregationParam(0).get_encoded().unwrap(),
+                ),
                 BatchSelector::new_time_interval(
                     Interval::new(
                         Time::from_seconds_since_epoch(2000, task.time_precision()),
@@ -390,7 +443,6 @@ async fn aggregate_share_request() {
                     )
                     .unwrap(),
                 ),
-                dummy::AggregationParam(0).get_encoded().unwrap(),
                 20,
                 ReportIdChecksum::get_decoded(&[4 ^ 8; 32]).unwrap(),
             ),
@@ -440,6 +492,16 @@ async fn aggregate_share_request() {
         (
             "first and second batchess",
             AggregateShareReq::new(
+                CollectionJobReq::new(
+                    Query::new_time_interval(
+                        Interval::new(
+                            Time::from_time_precision_units(0),
+                            Duration::from_seconds(2000, task.time_precision()),
+                        )
+                        .unwrap(),
+                    ),
+                    dummy::AggregationParam(0).get_encoded().unwrap(),
+                ),
                 BatchSelector::new_time_interval(
                     Interval::new(
                         Time::from_time_precision_units(0),
@@ -447,7 +509,6 @@ async fn aggregate_share_request() {
                     )
                     .unwrap(),
                 ),
-                dummy::AggregationParam(0).get_encoded().unwrap(),
                 10,
                 ReportIdChecksum::get_decoded(&[3 ^ 2; 32]).unwrap(),
             ),
@@ -456,6 +517,16 @@ async fn aggregate_share_request() {
         (
             "third and fourth batches",
             AggregateShareReq::new(
+                CollectionJobReq::new(
+                    Query::new_time_interval(
+                        Interval::new(
+                            Time::from_seconds_since_epoch(2000, task.time_precision()),
+                            Duration::from_seconds(2000, task.time_precision()),
+                        )
+                        .unwrap(),
+                    ),
+                    dummy::AggregationParam(0).get_encoded().unwrap(),
+                ),
                 BatchSelector::new_time_interval(
                     Interval::new(
                         Time::from_seconds_since_epoch(2000, task.time_precision()),
@@ -463,7 +534,6 @@ async fn aggregate_share_request() {
                     )
                     .unwrap(),
                 ),
-                dummy::AggregationParam(0).get_encoded().unwrap(),
                 10,
                 ReportIdChecksum::get_decoded(&[8 ^ 4; 32]).unwrap(),
             ),
@@ -500,8 +570,8 @@ async fn aggregate_share_request() {
                 aggregate_share_resp.encrypted_aggregate_share(),
                 &AggregateShareAad::new(
                     *task.id(),
-                    dummy::AggregationParam(0).get_encoded().unwrap(),
-                    request.batch_selector().clone(),
+                    task.helper_view().unwrap().task_configuration().unwrap(),
+                    request.collection_job_req().clone(),
                 )
                 .get_encoded()
                 .unwrap(),
@@ -570,6 +640,16 @@ async fn aggregate_share_request() {
     // Requests for collection intervals that overlap with but are not identical to previous
     // collection intervals fail.
     let all_batch_request = AggregateShareReq::new(
+        CollectionJobReq::new(
+            Query::new_time_interval(
+                Interval::new(
+                    Time::from_time_precision_units(0),
+                    Duration::from_seconds(4000, task.time_precision()),
+                )
+                .unwrap(),
+            ),
+            dummy::AggregationParam(0).get_encoded().unwrap(),
+        ),
         BatchSelector::new_time_interval(
             Interval::new(
                 Time::from_time_precision_units(0),
@@ -577,7 +657,6 @@ async fn aggregate_share_request() {
             )
             .unwrap(),
         ),
-        dummy::AggregationParam(0).get_encoded().unwrap(),
         20,
         ReportIdChecksum::get_decoded(&[8 ^ 4 ^ 3 ^ 2; 32]).unwrap(),
     );
@@ -603,6 +682,16 @@ async fn aggregate_share_request() {
     // for all the batches. Further requests for any batches will cause query count violations.
     for query_count_violation_request in [
         AggregateShareReq::new(
+            CollectionJobReq::new(
+                Query::new_time_interval(
+                    Interval::new(
+                        Time::from_time_precision_units(0),
+                        Duration::from_seconds(2000, task.time_precision()),
+                    )
+                    .unwrap(),
+                ),
+                dummy::AggregationParam(1).get_encoded().unwrap(),
+            ),
             BatchSelector::new_time_interval(
                 Interval::new(
                     Time::from_time_precision_units(0),
@@ -610,11 +699,20 @@ async fn aggregate_share_request() {
                 )
                 .unwrap(),
             ),
-            dummy::AggregationParam(1).get_encoded().unwrap(),
             10,
             ReportIdChecksum::get_decoded(&[3 ^ 2; 32]).unwrap(),
         ),
         AggregateShareReq::new(
+            CollectionJobReq::new(
+                Query::new_time_interval(
+                    Interval::new(
+                        Time::from_seconds_since_epoch(2000, task.time_precision()),
+                        Duration::from_seconds(2000, task.time_precision()),
+                    )
+                    .unwrap(),
+                ),
+                dummy::AggregationParam(1).get_encoded().unwrap(),
+            ),
             BatchSelector::new_time_interval(
                 Interval::new(
                     Time::from_seconds_since_epoch(2000, task.time_precision()),
@@ -622,7 +720,6 @@ async fn aggregate_share_request() {
                 )
                 .unwrap(),
             ),
-            dummy::AggregationParam(1).get_encoded().unwrap(),
             10,
             ReportIdChecksum::get_decoded(&[4 ^ 8; 32]).unwrap(),
         ),
@@ -705,8 +802,11 @@ async fn aggregate_share_request_duplicate_with_different_id() {
         .unwrap();
 
     let request = AggregateShareReq::new(
+        CollectionJobReq::new(
+            Query::new_time_interval(batch_interval),
+            aggregation_param.get_encoded().unwrap(),
+        ),
         BatchSelector::new_time_interval(batch_interval),
-        aggregation_param.get_encoded().unwrap(),
         report_count,
         checksum,
     );
@@ -784,8 +884,11 @@ async fn aggregate_share_request_get_poll_after_put() {
         .unwrap();
 
     let request = AggregateShareReq::new(
+        CollectionJobReq::new(
+            Query::new_time_interval(batch_interval),
+            aggregation_param.get_encoded().unwrap(),
+        ),
         BatchSelector::new_time_interval(batch_interval),
-        aggregation_param.get_encoded().unwrap(),
         report_count,
         checksum,
     );
@@ -844,8 +947,8 @@ async fn aggregate_share_request_get_poll_after_put() {
         aggregate_share_resp.encrypted_aggregate_share(),
         &AggregateShareAad::new(
             *task.id(),
-            dummy::AggregationParam(0).get_encoded().unwrap(),
-            request.batch_selector().clone(),
+            task.helper_view().unwrap().task_configuration().unwrap(),
+            request.collection_job_req().clone(),
         )
         .get_encoded()
         .unwrap(),
@@ -870,6 +973,222 @@ async fn aggregate_share_request_get_poll_after_put() {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::NO_CONTENT);
+}
+
+// Leader-selected counterpart of the above: the poll path's reconstructed query must be
+// byte-identical or the decrypt fails.
+#[tokio::test]
+async fn aggregate_share_request_get_poll_after_put_leader_selected() {
+    let HttpHandlerTest {
+        clock: _,
+        ephemeral_datastore: _ephemeral_datastore,
+        datastore,
+        router,
+        ..
+    } = HttpHandlerTest::new().await;
+
+    let task = TaskBuilder::new(
+        BatchMode::LeaderSelected {
+            batch_time_window_size: None,
+        },
+        AggregationMode::Synchronous,
+        VdafInstance::Fake { rounds: 1 },
+    )
+    .with_helper_aggregator_endpoint("https://helper.example.com/".parse().unwrap())
+    .build();
+
+    let helper_task = task.helper_view().unwrap();
+    datastore.put_aggregator_task(&helper_task).await.unwrap();
+
+    let batch_id = BatchId::from([9u8; 32]);
+    let client_timestamp_interval = Interval::minimal(Time::from_time_precision_units(0)).unwrap();
+    let aggregation_param = dummy::AggregationParam(0);
+    let report_count = 5;
+    let checksum = ReportIdChecksum::get_decoded(&[3; 32]).unwrap();
+
+    datastore
+        .run_unnamed_tx(|tx| {
+            let helper_task = helper_task.clone();
+
+            Box::pin(async move {
+                tx.put_batch_aggregation(&BatchAggregation::<0, LeaderSelected, dummy::Vdaf>::new(
+                    *helper_task.id(),
+                    batch_id,
+                    aggregation_param,
+                    0,
+                    client_timestamp_interval,
+                    BatchAggregationState::Aggregating {
+                        aggregate_share: Some(dummy::AggregateShare(16)),
+                        report_count,
+                        checksum,
+                        aggregation_jobs_created: 1,
+                        aggregation_jobs_terminated: 1,
+                    },
+                ))
+                .await
+                .unwrap();
+                tx.put_outstanding_batch(helper_task.id(), &batch_id, &None)
+                    .await
+                    .unwrap();
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
+
+    let request = AggregateShareReq::new(
+        CollectionJobReq::new(
+            Query::new_leader_selected(),
+            aggregation_param.get_encoded().unwrap(),
+        ),
+        BatchSelector::new_leader_selected(batch_id),
+        report_count,
+        checksum,
+    );
+
+    let aggregate_share_id = AggregateShareId::from([42u8; 16]);
+
+    // PUT binds the forwarded CollectionJobReq; poll (GET) reconstructs it from the stored job.
+    let response = put_aggregate_share_request(&task, &request, &aggregate_share_id, &router).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let mut response = router
+        .clone()
+        .oneshot(
+            Request::get(
+                task.aggregate_shares_uri(&aggregate_share_id)
+                    .unwrap()
+                    .path(),
+            )
+            .with_authentication_token(task.aggregator_auth_token())
+            .body(Body::empty())
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let aggregate_share_resp: AggregateShareMessage = decode_response_body(&mut response).await;
+    hpke::open(
+        task.collector_hpke_keypair(),
+        &HpkeApplicationInfo::new(&Label::AggregateShare, &Role::Helper, &Role::Collector),
+        aggregate_share_resp.encrypted_aggregate_share(),
+        &AggregateShareAad::new(
+            *task.id(),
+            task.helper_view().unwrap().task_configuration().unwrap(),
+            request.collection_job_req().clone(),
+        )
+        .get_encoded()
+        .unwrap(),
+    )
+    .unwrap();
+}
+
+// Proves the TaskConfiguration in the aggregate-share AAD works: a mismatched one must not open
+// the helper's share.
+#[tokio::test]
+async fn aggregate_share_aad_task_configuration_mismatch_fails() {
+    let HttpHandlerTest {
+        clock: _,
+        ephemeral_datastore: _ephemeral_datastore,
+        datastore,
+        router,
+        ..
+    } = HttpHandlerTest::new().await;
+
+    let task = TaskBuilder::new(
+        BatchMode::TimeInterval,
+        AggregationMode::Synchronous,
+        VdafInstance::Fake { rounds: 1 },
+    )
+    .with_helper_aggregator_endpoint("https://helper.example.com/".parse().unwrap())
+    .with_min_batch_size(1)
+    .build();
+    let helper_task = task.helper_view().unwrap();
+    datastore.put_aggregator_task(&helper_task).await.unwrap();
+
+    let batch_interval = Interval::minimal(Time::from_time_precision_units(0)).unwrap();
+    let aggregation_param = dummy::AggregationParam(0);
+    let report_count = 5;
+    let checksum = ReportIdChecksum::get_decoded(&[3; 32]).unwrap();
+
+    datastore
+        .run_unnamed_tx(|tx| {
+            let helper_task = helper_task.clone();
+            Box::pin(async move {
+                tx.put_batch_aggregation(&BatchAggregation::<0, TimeInterval, dummy::Vdaf>::new(
+                    *helper_task.id(),
+                    batch_interval,
+                    aggregation_param,
+                    0,
+                    batch_interval,
+                    BatchAggregationState::Aggregating {
+                        aggregate_share: Some(dummy::AggregateShare(16)),
+                        report_count,
+                        checksum,
+                        aggregation_jobs_created: 1,
+                        aggregation_jobs_terminated: 1,
+                    },
+                ))
+                .await
+                .unwrap();
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
+
+    let request = AggregateShareReq::new(
+        CollectionJobReq::new(
+            Query::new_time_interval(batch_interval),
+            aggregation_param.get_encoded().unwrap(),
+        ),
+        BatchSelector::new_time_interval(batch_interval),
+        report_count,
+        checksum,
+    );
+
+    let mut response =
+        put_aggregate_share_request(&task, &request, &AggregateShareId::from([7u8; 16]), &router)
+            .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let aggregate_share_resp: AggregateShareMessage = decode_response_body(&mut response).await;
+
+    // A task identical except for `min_batch_size` yields a different TaskConfiguration, so its AAD
+    // must not open the helper's share.
+    let mismatched_task_configuration = TaskBuilder::new(
+        BatchMode::TimeInterval,
+        AggregationMode::Synchronous,
+        VdafInstance::Fake { rounds: 1 },
+    )
+    .with_helper_aggregator_endpoint("https://helper.example.com/".parse().unwrap())
+    .with_min_batch_size(2)
+    .build()
+    .helper_view()
+    .unwrap()
+    .task_configuration()
+    .unwrap();
+    assert_ne!(
+        mismatched_task_configuration,
+        task.helper_view().unwrap().task_configuration().unwrap(),
+    );
+
+    let result = hpke::open(
+        task.collector_hpke_keypair(),
+        &HpkeApplicationInfo::new(&Label::AggregateShare, &Role::Helper, &Role::Collector),
+        aggregate_share_resp.encrypted_aggregate_share(),
+        &AggregateShareAad::new(
+            *task.id(),
+            mismatched_task_configuration,
+            request.collection_job_req().clone(),
+        )
+        .get_encoded()
+        .unwrap(),
+    );
+    assert!(
+        result.is_err(),
+        "mismatched TaskConfiguration must not decrypt"
+    );
 }
 
 #[tokio::test]

--- a/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
@@ -135,8 +135,8 @@ async fn aggregate_share_request_invalid_batch_interval() {
             Query::new_time_interval(
                 Interval::new(
                     clock.now().to_time(task.time_precision()),
-                    // Collect request will be rejected because batch interval is too small
-                    Duration::from_seconds(task.time_precision().as_seconds() - 1, &time_precision),
+                    // Collect request will be rejected because the batch interval is too small.
+                    Duration::ZERO,
                 )
                 .unwrap(),
             ),
@@ -145,8 +145,8 @@ async fn aggregate_share_request_invalid_batch_interval() {
         BatchSelector::new_time_interval(
             Interval::new(
                 clock.now().to_time(task.time_precision()),
-                // Collect request will be rejected because batch interval is too small
-                Duration::from_seconds(task.time_precision().as_seconds() - 1, &time_precision),
+                // Collect request will be rejected because the batch interval is too small.
+                Duration::ZERO,
             )
             .unwrap(),
         ),
@@ -571,7 +571,7 @@ async fn aggregate_share_request() {
                 aggregate_share_resp.encrypted_aggregate_share(),
                 &AggregateShareAad::new(
                     *task.id(),
-                    task.helper_view().unwrap().task_configuration().unwrap(),
+                    task.task_configuration(),
                     request.collection_job_req().clone(),
                 )
                 .get_encoded()
@@ -948,7 +948,7 @@ async fn aggregate_share_request_get_poll_after_put() {
         aggregate_share_resp.encrypted_aggregate_share(),
         &AggregateShareAad::new(
             *task.id(),
-            task.helper_view().unwrap().task_configuration().unwrap(),
+            task.task_configuration(),
             request.collection_job_req().clone(),
         )
         .get_encoded()
@@ -1076,7 +1076,7 @@ async fn aggregate_share_request_get_poll_after_put_leader_selected() {
         aggregate_share_resp.encrypted_aggregate_share(),
         &AggregateShareAad::new(
             *task.id(),
-            task.helper_view().unwrap().task_configuration().unwrap(),
+            task.task_configuration(),
             request.collection_job_req().clone(),
         )
         .get_encoded()
@@ -1165,14 +1165,8 @@ async fn aggregate_share_aad_task_configuration_mismatch_fails() {
     .with_helper_aggregator_endpoint("https://helper.example.com/".parse().unwrap())
     .with_min_batch_size(2)
     .build()
-    .helper_view()
-    .unwrap()
-    .task_configuration()
-    .unwrap();
-    assert_ne!(
-        mismatched_task_configuration,
-        task.helper_view().unwrap().task_configuration().unwrap(),
-    );
+    .task_configuration();
+    assert_ne!(mismatched_task_configuration, task.task_configuration(),);
 
     let result = hpke::open(
         task.collector_hpke_keypair(),

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_continue.rs
@@ -88,6 +88,7 @@ async fn aggregate_continue_sync() {
     let leader_verify_message_0 = transcript_0.leader_verify_transitions[1].message().unwrap();
     let report_share_0 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
+        task.helper_view().unwrap().task_configuration().unwrap(),
         report_metadata_0.clone(),
         hpke_key.config(),
         &transcript_0.public_share,
@@ -113,6 +114,7 @@ async fn aggregate_continue_sync() {
     let helper_verify_state_1 = transcript_1.helper_verify_transitions[0].verify_state();
     let report_share_1 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
+        task.helper_view().unwrap().task_configuration().unwrap(),
         report_metadata_1.clone(),
         hpke_key.config(),
         &transcript_1.public_share,
@@ -139,6 +141,7 @@ async fn aggregate_continue_sync() {
     let leader_verify_message_2 = transcript_2.leader_verify_transitions[1].message().unwrap();
     let report_share_2 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
+        task.helper_view().unwrap().task_configuration().unwrap(),
         report_metadata_2.clone(),
         hpke_key.config(),
         &transcript_2.public_share,
@@ -426,6 +429,7 @@ async fn aggregate_continue_async() {
     let leader_verify_message_0 = transcript_0.leader_verify_transitions[1].message().unwrap();
     let report_share_0 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
+        task.helper_view().unwrap().task_configuration().unwrap(),
         report_metadata_0.clone(),
         hpke_key.config(),
         &transcript_0.public_share,
@@ -451,6 +455,7 @@ async fn aggregate_continue_async() {
     let helper_verify_state_1 = transcript_1.helper_verify_transitions[0].verify_state();
     let report_share_1 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
+        task.helper_view().unwrap().task_configuration().unwrap(),
         report_metadata_1.clone(),
         hpke_key.config(),
         &transcript_1.public_share,
@@ -676,6 +681,7 @@ async fn aggregate_continue_accumulate_batch_aggregation() {
     let ping_pong_leader_message_0 = transcript_0.leader_verify_transitions[1].message().unwrap();
     let report_share_0 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
+        task.helper_view().unwrap().task_configuration().unwrap(),
         report_metadata_0.clone(),
         hpke_key.config(),
         &transcript_0.public_share,
@@ -701,6 +707,7 @@ async fn aggregate_continue_accumulate_batch_aggregation() {
     let ping_pong_leader_message_1 = transcript_1.leader_verify_transitions[1].message().unwrap();
     let report_share_1 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
+        task.helper_view().unwrap().task_configuration().unwrap(),
         report_metadata_1.clone(),
         hpke_key.config(),
         &transcript_1.public_share,
@@ -729,6 +736,7 @@ async fn aggregate_continue_accumulate_batch_aggregation() {
     let ping_pong_leader_message_2 = transcript_2.leader_verify_transitions[1].message().unwrap();
     let report_share_2 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
+        task.helper_view().unwrap().task_configuration().unwrap(),
         report_metadata_2.clone(),
         hpke_key.config(),
         &transcript_2.public_share,
@@ -1016,6 +1024,7 @@ async fn aggregate_continue_accumulate_batch_aggregation() {
     let ping_pong_leader_message_3 = transcript_3.leader_verify_transitions[1].message().unwrap();
     let report_share_3 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
+        task.helper_view().unwrap().task_configuration().unwrap(),
         report_metadata_3.clone(),
         hpke_key.config(),
         &transcript_3.public_share,
@@ -1044,6 +1053,7 @@ async fn aggregate_continue_accumulate_batch_aggregation() {
     let ping_pong_leader_message_4 = transcript_4.leader_verify_transitions[1].message().unwrap();
     let report_share_4 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
+        task.helper_view().unwrap().task_configuration().unwrap(),
         report_metadata_4.clone(),
         hpke_key.config(),
         &transcript_4.public_share,
@@ -1072,6 +1082,7 @@ async fn aggregate_continue_accumulate_batch_aggregation() {
     let ping_pong_leader_message_5 = transcript_5.leader_verify_transitions[1].message().unwrap();
     let report_share_5 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
+        task.helper_view().unwrap().task_configuration().unwrap(),
         report_metadata_5.clone(),
         hpke_key.config(),
         &transcript_5.public_share,
@@ -1441,6 +1452,7 @@ async fn aggregate_continue_verify_step_fails() {
     );
     let helper_report_share = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
+        task.helper_view().unwrap().task_configuration().unwrap(),
         report_metadata.clone(),
         hpke_key.config(),
         &transcript.public_share,

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_get.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_get.rs
@@ -186,6 +186,7 @@ async fn aggregation_job_get_unready() {
     let leader_message = transcript.leader_verify_transitions[0].message().unwrap();
     let report_share = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
+        task.helper_view().unwrap().task_configuration().unwrap(),
         report_metadata.clone(),
         hpke_keypair.config(),
         &transcript.public_share,

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
@@ -24,9 +24,9 @@ use janus_core::{
 };
 use janus_messages::{
     AggregateShareReq, AggregationJobId, AggregationJobInitializeReq, AggregationJobResp, BatchId,
-    BatchSelector, Extension, ExtensionType, HpkeCiphertext, HpkeConfigId, InputShareAad, Interval,
-    MediaType, PartialBatchSelector, ReportError, ReportIdChecksum, ReportMetadata, ReportShare,
-    Role, Time, VerifyInit, VerifyStepResult,
+    BatchSelector, CollectionJobReq, Extension, ExtensionType, HpkeCiphertext, HpkeConfigId,
+    InputShareAad, Interval, MediaType, PartialBatchSelector, Query, ReportError, ReportIdChecksum,
+    ReportMetadata, ReportShare, Role, Time, VerifyInit, VerifyStepResult,
     batch_mode::{LeaderSelected, TimeInterval},
 };
 use prio::{codec::Encode, vdaf::dummy};
@@ -275,6 +275,7 @@ async fn aggregate_init_sync() {
         &input_share_bytes,
         &InputShareAad::new(
             *task.id(),
+            task.helper_view().unwrap().task_configuration().unwrap(),
             verify_init_2.report_share().metadata().clone(),
             transcript_2.public_share.get_encoded().unwrap(),
         )
@@ -295,6 +296,7 @@ async fn aggregate_init_sync() {
 
     let report_share_3 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
+        task.helper_view().unwrap().task_configuration().unwrap(),
         verify_init_3.report_share().metadata().clone(),
         &wrong_hpke_config,
         &transcript_3.public_share,
@@ -325,6 +327,7 @@ async fn aggregate_init_sync() {
     );
     let report_share_5 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
+        task.helper_view().unwrap().task_configuration().unwrap(),
         report_metadata_5,
         hpke_keypair.config(),
         &transcript_5.public_share,
@@ -360,9 +363,14 @@ async fn aggregate_init_sync() {
         hpke_keypair.config(),
         public_share_6.clone(),
         &transcript_6.helper_input_share.get_encoded().unwrap(),
-        &InputShareAad::new(*task.id(), report_metadata_6, public_share_6)
-            .get_encoded()
-            .unwrap(),
+        &InputShareAad::new(
+            *task.id(),
+            task.helper_view().unwrap().task_configuration().unwrap(),
+            report_metadata_6,
+            public_share_6,
+        )
+        .get_encoded()
+        .unwrap(),
     );
 
     let verify_init_6 = VerifyInit::new(
@@ -392,6 +400,7 @@ async fn aggregate_init_sync() {
     );
     let report_share_7 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
+        task.helper_view().unwrap().task_configuration().unwrap(),
         report_metadata_7,
         hpke_keypair.config(),
         &transcript_7.public_share,
@@ -423,6 +432,7 @@ async fn aggregate_init_sync() {
     );
     let report_share_8 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
+        task.helper_view().unwrap().task_configuration().unwrap(),
         report_metadata_8,
         hpke_keypair.config(),
         &transcript_8.public_share,
@@ -458,6 +468,7 @@ async fn aggregate_init_sync() {
     );
     let report_share_9 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
+        task.helper_view().unwrap().task_configuration().unwrap(),
         report_metadata_9,
         hpke_keypair.config(),
         &transcript_9.public_share,
@@ -489,6 +500,7 @@ async fn aggregate_init_sync() {
     );
     let report_share_10 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
+        task.helper_view().unwrap().task_configuration().unwrap(),
         report_metadata_10,
         hpke_keypair.config(),
         &transcript_10.public_share,
@@ -520,6 +532,7 @@ async fn aggregate_init_sync() {
     );
     let report_share_11 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
+        task.helper_view().unwrap().task_configuration().unwrap(),
         report_metadata_11,
         hpke_keypair.config(),
         &transcript_11.public_share,
@@ -1382,8 +1395,8 @@ async fn aggregate_init_partially_replayed_aggregation_init() {
     }
 
     let request = AggregateShareReq::new(
+        CollectionJobReq::new(Query::new_leader_selected(), agg_param.clone()),
         BatchSelector::new_leader_selected(batch_id),
-        agg_param.clone(),
         5,
         ReportIdChecksum::from_report_ids(&report_ids),
     );

--- a/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
@@ -12,9 +12,9 @@ use janus_core::{
     vdaf::VdafInstance,
 };
 use janus_messages::{
-    AggregateShareAad, BatchSelector, CollectionJobExtension, CollectionJobExtensionType,
-    CollectionJobId, CollectionJobReq, CollectionJobResp, Duration, Interval, MediaType, Query,
-    Role, Time, batch_mode::TimeInterval,
+    AggregateShareAad, CollectionJobExtension, CollectionJobExtensionType, CollectionJobId,
+    CollectionJobReq, CollectionJobResp, Duration, Interval, MediaType, Query, Role, Time,
+    batch_mode::TimeInterval,
 };
 use prio::{
     codec::{Decode, Encode},
@@ -451,8 +451,11 @@ async fn collection_job_success_time_interval() {
                     &helper_aggregate_share_bytes,
                     &AggregateShareAad::new(
                         *task.id(),
-                        aggregation_param.get_encoded().unwrap(),
-                        BatchSelector::new_time_interval(batch_interval),
+                        task.helper_view().unwrap().task_configuration().unwrap(),
+                        CollectionJobReq::new(
+                            Query::new_time_interval(batch_interval),
+                            aggregation_param.get_encoded().unwrap(),
+                        ),
                     )
                     .get_encoded()
                     .unwrap(),
@@ -517,8 +520,16 @@ async fn collection_job_success_time_interval() {
         &leader_encrypted_aggregate_share,
         &AggregateShareAad::new(
             *test_case.task.id(),
-            aggregation_param.get_encoded().unwrap(),
-            BatchSelector::new_time_interval(batch_interval),
+            test_case
+                .task
+                .leader_view()
+                .unwrap()
+                .task_configuration()
+                .unwrap(),
+            CollectionJobReq::new(
+                Query::new_time_interval(batch_interval),
+                aggregation_param.get_encoded().unwrap(),
+            ),
         )
         .get_encoded()
         .unwrap(),
@@ -535,8 +546,16 @@ async fn collection_job_success_time_interval() {
         &helper_encrypted_aggregate_share,
         &AggregateShareAad::new(
             *test_case.task.id(),
-            aggregation_param.get_encoded().unwrap(),
-            BatchSelector::new_time_interval(batch_interval),
+            test_case
+                .task
+                .helper_view()
+                .unwrap()
+                .task_configuration()
+                .unwrap(),
+            CollectionJobReq::new(
+                Query::new_time_interval(batch_interval),
+                aggregation_param.get_encoded().unwrap(),
+            ),
         )
         .get_encoded()
         .unwrap(),

--- a/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/collection_job.rs
@@ -451,7 +451,7 @@ async fn collection_job_success_time_interval() {
                     &helper_aggregate_share_bytes,
                     &AggregateShareAad::new(
                         *task.id(),
-                        task.helper_view().unwrap().task_configuration().unwrap(),
+                        task.task_configuration(),
                         CollectionJobReq::new(
                             Query::new_time_interval(batch_interval),
                             aggregation_param.get_encoded().unwrap(),
@@ -520,12 +520,7 @@ async fn collection_job_success_time_interval() {
         &leader_encrypted_aggregate_share,
         &AggregateShareAad::new(
             *test_case.task.id(),
-            test_case
-                .task
-                .leader_view()
-                .unwrap()
-                .task_configuration()
-                .unwrap(),
+            test_case.task.task_configuration(),
             CollectionJobReq::new(
                 Query::new_time_interval(batch_interval),
                 aggregation_param.get_encoded().unwrap(),
@@ -546,12 +541,7 @@ async fn collection_job_success_time_interval() {
         &helper_encrypted_aggregate_share,
         &AggregateShareAad::new(
             *test_case.task.id(),
-            test_case
-                .task
-                .helper_view()
-                .unwrap()
-                .task_configuration()
-                .unwrap(),
+            test_case.task.task_configuration(),
             CollectionJobReq::new(
                 Query::new_time_interval(batch_interval),
                 aggregation_param.get_encoded().unwrap(),

--- a/aggregator/src/aggregator/http_handlers/tests/helper_e2e.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/helper_e2e.rs
@@ -4,8 +4,8 @@ use janus_aggregator_core::task::{AggregationMode, BatchMode, test_util::TaskBui
 use janus_core::{report_id::ReportIdChecksumExt, vdaf::VdafInstance};
 use janus_messages::{
     AggregateShareId, AggregateShareReq, AggregationJobInitializeReq, AggregationJobResp,
-    BatchSelector, PartialBatchSelector, ReportError, ReportIdChecksum, VerifyStepResult,
-    batch_mode::LeaderSelected,
+    BatchSelector, CollectionJobReq, PartialBatchSelector, Query, ReportError, ReportIdChecksum,
+    VerifyStepResult, batch_mode::LeaderSelected,
 };
 use prio::{
     codec::{Decode, Encode},
@@ -82,15 +82,21 @@ async fn helper_aggregation_report_share_replay() {
         ReportIdChecksum::for_report_id(replayed_report.report_share().metadata().id())
             .updated_with(other_report_1.report_share().metadata().id());
     let agg_share_req_1 = AggregateShareReq::<LeaderSelected>::new(
+        CollectionJobReq::new(
+            Query::new_leader_selected(),
+            agg_param.get_encoded().unwrap(),
+        ),
         BatchSelector::new(batch_id_1),
-        agg_param.get_encoded().unwrap(),
         2,
         checksum_1,
     );
     let checksum_2 = ReportIdChecksum::for_report_id(other_report_2.report_share().metadata().id());
     let agg_share_req_2 = AggregateShareReq::<LeaderSelected>::new(
+        CollectionJobReq::new(
+            Query::new_leader_selected(),
+            agg_param.get_encoded().unwrap(),
+        ),
         BatchSelector::new(batch_id_2),
-        agg_param.get_encoded().unwrap(),
         1,
         checksum_2,
     );

--- a/aggregator/src/aggregator/http_handlers/tests/report.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/report.rs
@@ -484,6 +484,7 @@ async fn upload_handler() {
                 .unwrap(),
             &InputShareAad::new(
                 *task.id(),
+                leader_task.task_configuration().unwrap(),
                 bad_leader_input_share_report.metadata().clone(),
                 bad_leader_input_share_report.public_share().to_vec(),
             )

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -34,10 +34,10 @@ use janus_core::{
 use janus_messages::{
     AggregateShare as AggregateShareMessage, AggregateShareAad, AggregateShareId,
     AggregateShareReq, AggregationJobContinueReq, AggregationJobId, AggregationJobInitializeReq,
-    AggregationJobResp, AggregationJobStep, BatchConfig, BatchSelector, Duration, Extension,
-    ExtensionType, Interval, MediaType, PartialBatchSelector, ReportError, ReportIdChecksum,
-    ReportShare, Role, TaskConfiguration, TaskConfigurationBuilder, TaskId, Time, TimePrecision,
-    VdafConfig, VerifyContinue, VerifyInit, VerifyResp, VerifyStepResult,
+    AggregationJobResp, AggregationJobStep, BatchConfig, BatchSelector, CollectionJobReq, Duration,
+    Extension, ExtensionType, Interval, MediaType, PartialBatchSelector, Query, ReportError,
+    ReportIdChecksum, ReportShare, Role, TaskConfiguration, TaskConfigurationBuilder, TaskId, Time,
+    TimePrecision, VdafConfig, VerifyContinue, VerifyInit, VerifyResp, VerifyStepResult,
     batch_mode::LeaderSelected,
     codec::{Decode, Encode},
 };
@@ -1165,14 +1165,20 @@ async fn taskprov_aggregate_share() {
     test.datastore
         .run_unnamed_tx(|tx| {
             let task = test.task.clone();
+            let task_config = test.task_config.clone();
             let interval =
                 Interval::minimal(Time::from_seconds_since_epoch(6000, task.time_precision()))
                     .unwrap();
             let transcript = transcript.clone();
 
             Box::pin(async move {
-                tx.put_aggregator_task(&task.taskprov_helper_view().unwrap())
-                    .await?;
+                tx.put_aggregator_task(
+                    &task
+                        .taskprov_helper_view()
+                        .unwrap()
+                        .with_taskprov_task_config(task_config),
+                )
+                .await?;
 
                 tx.put_batch_aggregation(&BatchAggregation::<0, LeaderSelected, dummy::Vdaf>::new(
                     *task.id(),
@@ -1197,8 +1203,11 @@ async fn taskprov_aggregate_share() {
         .unwrap();
 
     let request = AggregateShareReq::new(
+        CollectionJobReq::new(
+            Query::new_leader_selected(),
+            aggregation_param.get_encoded().unwrap(),
+        ),
         BatchSelector::new_leader_selected(batch_id),
-        aggregation_param.get_encoded().unwrap(),
         1,
         ReportIdChecksum::get_decoded(&[3; 32]).unwrap(),
     );
@@ -1272,8 +1281,8 @@ async fn taskprov_aggregate_share() {
         aggregate_share_resp.encrypted_aggregate_share(),
         &AggregateShareAad::new(
             test.task_id,
-            aggregation_param.get_encoded().unwrap(),
-            request.batch_selector().clone(),
+            test.task_config.clone(),
+            request.collection_job_req().clone(),
         )
         .get_encoded()
         .unwrap(),
@@ -1415,8 +1424,11 @@ async fn end_to_end() {
 
     let checksum = ReportIdChecksum::for_report_id(report_share.metadata().id());
     let aggregate_share_request = AggregateShareReq::new(
+        CollectionJobReq::new(
+            Query::new_leader_selected(),
+            aggregation_param.get_encoded().unwrap(),
+        ),
         BatchSelector::new_leader_selected(batch_id),
-        aggregation_param.get_encoded().unwrap(),
         1,
         checksum,
     );
@@ -1461,8 +1473,8 @@ async fn end_to_end() {
         aggregate_share_resp.encrypted_aggregate_share(),
         &AggregateShareAad::new(
             test.task_id,
-            aggregation_param.get_encoded().unwrap(),
-            aggregate_share_request.batch_selector().clone(),
+            test.task_config.clone(),
+            aggregate_share_request.collection_job_req().clone(),
         )
         .get_encoded()
         .unwrap(),
@@ -1556,8 +1568,11 @@ async fn end_to_end_sumvec_hmac() {
 
     let checksum = ReportIdChecksum::for_report_id(report_share.metadata().id());
     let aggregate_share_request = AggregateShareReq::new(
+        CollectionJobReq::new(
+            Query::new_leader_selected(),
+            aggregation_param.get_encoded().unwrap(),
+        ),
         BatchSelector::new_leader_selected(batch_id),
-        aggregation_param.get_encoded().unwrap(),
         1,
         checksum,
     );
@@ -1602,8 +1617,8 @@ async fn end_to_end_sumvec_hmac() {
         aggregate_share_resp.encrypted_aggregate_share(),
         &AggregateShareAad::new(
             test.task_id,
-            aggregation_param.get_encoded().unwrap(),
-            aggregate_share_request.batch_selector().clone(),
+            test.task_config.clone(),
+            aggregate_share_request.collection_job_req().clone(),
         )
         .get_encoded()
         .unwrap(),

--- a/aggregator/src/aggregator/test_util.rs
+++ b/aggregator/src/aggregator/test_util.rs
@@ -12,7 +12,8 @@ use janus_core::{
 };
 use janus_messages::{
     AggregateShare, Extension, HpkeCiphertext, HpkeConfig, HpkeConfigId, InputShareAad,
-    PlaintextInputShare, Report, ReportId, ReportMetadata, ReportShare, Role, TaskId, Time,
+    PlaintextInputShare, Report, ReportId, ReportMetadata, ReportShare, Role, TaskConfiguration,
+    TaskId, Time,
 };
 use prio::{
     codec::Encode,
@@ -85,6 +86,7 @@ pub fn create_report_custom(
 
     let associated_data = InputShareAad::new(
         *task.id(),
+        task.task_configuration().unwrap(),
         report_metadata.clone(),
         public_share.get_encoded().unwrap(),
     );
@@ -134,6 +136,7 @@ pub fn create_report(
 
 pub fn generate_helper_report_share<V: vdaf::Client<16>>(
     task_id: TaskId,
+    task_configuration: TaskConfiguration,
     report_metadata: ReportMetadata,
     cfg: &HpkeConfig,
     public_share: &V::PublicShare,
@@ -149,6 +152,7 @@ pub fn generate_helper_report_share<V: vdaf::Client<16>>(
             .unwrap(),
         &InputShareAad::new(
             task_id,
+            task_configuration,
             report_metadata,
             public_share.get_encoded().unwrap(),
         )

--- a/aggregator/src/aggregator/upload_tests.rs
+++ b/aggregator/src/aggregator/upload_tests.rs
@@ -151,7 +151,12 @@ async fn upload() {
         .await
         .unwrap()
         .unwrap();
-    assert!(got_report.eq_report(&vdaf, &hpke_keypair, &report));
+    assert!(got_report.eq_report(
+        &vdaf,
+        &hpke_keypair,
+        &task.leader_view().unwrap().task_configuration().unwrap(),
+        &report,
+    ));
 
     // Report uploads are idempotent.
     aggregator
@@ -192,7 +197,12 @@ async fn upload() {
         })
         .await
         .unwrap();
-    assert!(got_report.unwrap().eq_report(&vdaf, &hpke_keypair, &report));
+    assert!(got_report.unwrap().eq_report(
+        &vdaf,
+        &hpke_keypair,
+        &task.leader_view().unwrap().task_configuration().unwrap(),
+        &report,
+    ));
 
     assert_eq!(
         got_counter,
@@ -1011,6 +1021,7 @@ async fn upload_report_leader_input_share_decode_failure() {
                 .unwrap(),
             &InputShareAad::new(
                 *task.id(),
+                task.task_configuration().unwrap(),
                 report.metadata().clone(),
                 report.public_share().to_vec(),
             )

--- a/aggregator/src/aggregator/upload_tests.rs
+++ b/aggregator/src/aggregator/upload_tests.rs
@@ -151,12 +151,7 @@ async fn upload() {
         .await
         .unwrap()
         .unwrap();
-    assert!(got_report.eq_report(
-        &vdaf,
-        &hpke_keypair,
-        &task.leader_view().unwrap().task_configuration().unwrap(),
-        &report,
-    ));
+    assert!(got_report.eq_report(&vdaf, &hpke_keypair, &task.task_configuration(), &report,));
 
     // Report uploads are idempotent.
     aggregator
@@ -200,7 +195,7 @@ async fn upload() {
     assert!(got_report.unwrap().eq_report(
         &vdaf,
         &hpke_keypair,
-        &task.leader_view().unwrap().task_configuration().unwrap(),
+        &task.task_configuration(),
         &report,
     ));
 

--- a/aggregator_core/src/batch_mode.rs
+++ b/aggregator_core/src/batch_mode.rs
@@ -159,6 +159,15 @@ pub trait CollectableBatchMode: AccumulableBatchMode {
         query: &Query<Self>,
     ) -> Result<Option<Self::BatchIdentifier>, datastore::Error>;
 
+    /// Reconstructs the Collector's original collection [`Query`] from a stored batch identifier.
+    ///
+    /// The Helper serves aggregate shares on both the PUT path (where it has the forwarded
+    /// [`CollectionJobReq`](janus_messages::CollectionJobReq)) and the poll/GET path (where it only
+    /// has the stored [`AggregateShareJob`](crate::datastore::models::AggregateShareJob)). On the
+    /// latter it rebuilds the query with this method, which must be exact: the aggregate-share AAD
+    /// is byte-identical to the Collector's original or the decrypt fails.
+    fn query_for_collection_identifier(batch_identifier: &Self::BatchIdentifier) -> Query<Self>;
+
     /// Some batch modes (e.g. [`TimeInterval`]) can receive a batch identifier in collection
     /// requests which refers to multiple batches. This method takes a batch identifier received in
     /// a collection request and provides an iterator over the individual batches' identifiers.
@@ -262,6 +271,10 @@ impl CollectableBatchMode for TimeInterval {
         Ok(Some(*query.batch_interval()))
     }
 
+    fn query_for_collection_identifier(batch_interval: &Self::BatchIdentifier) -> Query<Self> {
+        Query::new_time_interval(*batch_interval)
+    }
+
     fn batch_identifiers_for_collection_identifier(
         batch_interval: &Self::BatchIdentifier,
     ) -> Self::Iter {
@@ -331,6 +344,10 @@ impl CollectableBatchMode for LeaderSelected {
             .await
     }
 
+    fn query_for_collection_identifier(_batch_id: &Self::BatchIdentifier) -> Query<Self> {
+        Query::new_leader_selected()
+    }
+
     fn batch_identifiers_for_collection_identifier(batch_id: &Self::BatchIdentifier) -> Self::Iter {
         iter::once(*batch_id)
     }
@@ -351,9 +368,20 @@ impl CollectableBatchMode for LeaderSelected {
 
 #[cfg(test)]
 mod tests {
-    use janus_messages::{Duration, Interval, Time, batch_mode::TimeInterval};
+    use janus_messages::{
+        BatchId, CollectionJobReq, Duration, Interval, Query, Time, TimePrecision,
+        batch_mode::{LeaderSelected, TimeInterval},
+    };
+    use prio::{
+        codec::Encode,
+        vdaf::dummy::{AggregationParam, Vdaf},
+    };
+    use rand::random;
 
-    use crate::batch_mode::CollectableBatchMode;
+    use crate::{
+        batch_mode::CollectableBatchMode,
+        datastore::models::{CollectionJob, CollectionJobState},
+    };
 
     #[test]
     fn reject_null_collection_intervals() {
@@ -368,5 +396,82 @@ mod tests {
             )
             .unwrap()
         ));
+    }
+
+    /// The Collector's original `CollectionJobReq`, the Leader's reconstruction from its stored
+    /// collection job ([`CollectionJob::to_collection_job_req`]), and the Helper's reconstruction
+    /// from a stored batch identifier ([`CollectableBatchMode::query_for_collection_identifier`])
+    /// must all encode to identical bytes, or aggregate-share AADs will silently mismatch and
+    /// decryption will fail. This locks that invariant for both batch modes.
+    #[test]
+    fn collection_job_req_reconstruction_is_byte_identical() {
+        let aggregation_parameter = AggregationParam(7);
+        let encoded_aggregation_parameter = aggregation_parameter.get_encoded().unwrap();
+
+        let interval = Interval::new(
+            Time::from_seconds_since_epoch(54321, &TimePrecision::from_seconds(1)),
+            Duration::from_seconds(12345, &TimePrecision::from_seconds(1)),
+        )
+        .unwrap();
+        let collector_request = CollectionJobReq::<TimeInterval>::new(
+            Query::new_time_interval(interval),
+            encoded_aggregation_parameter.clone(),
+        );
+        let helper_request = CollectionJobReq::new(
+            TimeInterval::query_for_collection_identifier(&interval),
+            encoded_aggregation_parameter.clone(),
+        );
+        let leader_job = CollectionJob::<0, TimeInterval, Vdaf>::new(
+            random(),
+            random(),
+            random(),
+            Query::new_time_interval(interval),
+            aggregation_parameter,
+            interval,
+            CollectionJobState::Start,
+        );
+        assert_eq!(
+            collector_request.get_encoded().unwrap(),
+            helper_request.get_encoded().unwrap(),
+        );
+        assert_eq!(
+            collector_request.get_encoded().unwrap(),
+            leader_job
+                .to_collection_job_req()
+                .unwrap()
+                .get_encoded()
+                .unwrap(),
+        );
+
+        let batch_id = BatchId::from([5u8; 32]);
+        let collector_request = CollectionJobReq::<LeaderSelected>::new(
+            Query::new_leader_selected(),
+            encoded_aggregation_parameter.clone(),
+        );
+        let helper_request = CollectionJobReq::new(
+            LeaderSelected::query_for_collection_identifier(&batch_id),
+            encoded_aggregation_parameter,
+        );
+        let leader_job = CollectionJob::<0, LeaderSelected, Vdaf>::new(
+            random(),
+            random(),
+            random(),
+            Query::new_leader_selected(),
+            aggregation_parameter,
+            batch_id,
+            CollectionJobState::Start,
+        );
+        assert_eq!(
+            collector_request.get_encoded().unwrap(),
+            helper_request.get_encoded().unwrap(),
+        );
+        assert_eq!(
+            collector_request.get_encoded().unwrap(),
+            leader_job
+                .to_collection_job_req()
+                .unwrap()
+                .get_encoded()
+                .unwrap(),
+        );
     }
 }

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -1849,9 +1849,10 @@ impl<const SEED_SIZE: usize, B: BatchMode, A: AsyncAggregator<SEED_SIZE>>
     /// collection job. The Leader forwards this to the Helper and binds it into aggregate-share
     /// AADs, where it must be byte-identical to the Collector's original request.
     ///
-    /// Collection job extensions are rejected unless empty (DAP-19 §4.6.2), so no extensions are
-    /// stored and the reconstruction carries none. If that enforcement ever relaxes, the original
-    /// extensions must be persisted and replayed here, or the AAD will silently mismatch.
+    /// Collection job extensions are rejected unless empty (DAP-19 §4.6.2), so no extensions
+    /// are stored and the reconstruction carries none. If that enforcement ever relaxes
+    /// (Issue #4715), the original extensions must be persisted and replayed here, or the AAD
+    /// will silently mismatch.
     pub fn to_collection_job_req(&self) -> Result<CollectionJobReq<B>, CodecError> {
         Ok(CollectionJobReq::new(
             self.query.clone(),

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -19,10 +19,10 @@ use janus_core::{
     vdaf::VdafInstance,
 };
 use janus_messages::{
-    AggregateShareId, AggregationJobId, AggregationJobStep, BatchId, CollectionJobId, Duration,
-    Extension, HpkeCiphertext, HpkeConfigId, Interval, Query, ReportError, ReportId,
-    ReportIdChecksum, ReportMetadata, Role, TaskId, Time, TimePrecision, VerifyContinue,
-    VerifyInit, VerifyResp,
+    AggregateShareId, AggregationJobId, AggregationJobStep, BatchId, CollectionJobId,
+    CollectionJobReq, Duration, Extension, HpkeCiphertext, HpkeConfigId, Interval, Query,
+    ReportError, ReportId, ReportIdChecksum, ReportMetadata, Role, TaskId, Time, TimePrecision,
+    VerifyContinue, VerifyInit, VerifyResp,
     batch_mode::{BatchMode, LeaderSelected, TimeInterval},
 };
 use postgres_protocol::types::{
@@ -30,7 +30,7 @@ use postgres_protocol::types::{
 };
 use postgres_types::{FromSql, ToSql, accepts, to_sql_checked};
 use prio::{
-    codec::{Encode, encode_u16_items},
+    codec::{CodecError, Encode, encode_u16_items},
     topology::ping_pong::PingPongContinuation,
     vdaf::Aggregatable,
 };
@@ -193,6 +193,7 @@ impl<const SEED_SIZE: usize, A: AsyncAggregator<SEED_SIZE>> LeaderStoredReport<S
         &self,
         vdaf: &A,
         leader_hpke_keypair: &hpke::HpkeKeypair,
+        task_configuration: &janus_messages::TaskConfiguration,
         report: &janus_messages::Report,
     ) -> bool {
         use janus_core::hpke::{self, HpkeApplicationInfo, Label};
@@ -210,6 +211,7 @@ impl<const SEED_SIZE: usize, A: AsyncAggregator<SEED_SIZE>> LeaderStoredReport<S
             report.leader_encrypted_input_share(),
             &InputShareAad::new(
                 self.task_id,
+                task_configuration.clone(),
                 report.metadata().clone(),
                 report.public_share().to_vec(),
             )
@@ -236,6 +238,7 @@ impl<const SEED_SIZE: usize, A: AsyncAggregator<SEED_SIZE>> LeaderStoredReport<S
     #[cfg(feature = "test-util")]
     pub fn generate(
         task_id: TaskId,
+        task_configuration: janus_messages::TaskConfiguration,
         report_metadata: ReportMetadata,
         helper_hpke_config: &janus_messages::HpkeConfig,
         leader_private_extensions: Vec<Extension>,
@@ -258,6 +261,7 @@ impl<const SEED_SIZE: usize, A: AsyncAggregator<SEED_SIZE>> LeaderStoredReport<S
             .unwrap(),
             &InputShareAad::new(
                 task_id,
+                task_configuration,
                 report_metadata.clone(),
                 transcript.public_share.get_encoded().unwrap(),
             )
@@ -1839,6 +1843,20 @@ impl<const SEED_SIZE: usize, B: BatchMode, A: AsyncAggregator<SEED_SIZE>>
     /// Returns the query that was sent to create this collection job.
     pub fn query(&self) -> &Query<B> {
         &self.query
+    }
+
+    /// Reconstructs the [`CollectionJobReq`] that the Collector originally sent to create this
+    /// collection job. The Leader forwards this to the Helper and binds it into aggregate-share
+    /// AADs, where it must be byte-identical to the Collector's original request.
+    ///
+    /// Collection job extensions are rejected unless empty (DAP-19 §4.6.2), so no extensions are
+    /// stored and the reconstruction carries none. If that enforcement ever relaxes, the original
+    /// extensions must be persisted and replayed here, or the AAD will silently mismatch.
+    pub fn to_collection_job_req(&self) -> Result<CollectionJobReq<B>, CodecError> {
+        Ok(CollectionJobReq::new(
+            self.query.clone(),
+            self.aggregation_parameter.get_encoded()?,
+        ))
     }
 
     /// Return the aggregate share's ID in use for this collection job.

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -23,10 +23,10 @@ use janus_core::{
     vdaf::{VERIFY_KEY_LENGTH_PRIO3, VdafInstance, vdaf_dp_strategies},
 };
 use janus_messages::{
-    AggregateShareAad, AggregationJobId, AggregationJobStep, BatchId, BatchSelector,
-    CollectionJobId, Duration, Extension, ExtensionType, HpkeCiphertext, HpkeConfigId, Interval,
-    Query, ReportError, ReportId, ReportIdChecksum, ReportMetadata, ReportShare, Role, TaskId,
-    Time, TimePrecision, VerifyContinue, VerifyInit, VerifyResp, VerifyStepResult,
+    AggregateShareAad, AggregationJobId, AggregationJobStep, BatchId, CollectionJobId, Duration,
+    Extension, ExtensionType, HpkeCiphertext, HpkeConfigId, Interval, Query, ReportError, ReportId,
+    ReportIdChecksum, ReportMetadata, ReportShare, Role, TaskId, Time, TimePrecision,
+    VerifyContinue, VerifyInit, VerifyResp, VerifyStepResult,
     batch_mode::{BatchMode, LeaderSelected, TimeInterval},
 };
 use postgres_types::Timestamp;
@@ -3655,8 +3655,8 @@ async fn get_collection_job(ephemeral_datastore: EphemeralDatastore) {
                 &[0, 1, 2, 3, 4, 5],
                 &AggregateShareAad::new(
                     *task.id(),
-                    ().get_encoded().unwrap(),
-                    BatchSelector::new_time_interval(first_batch_interval),
+                    task.task_configuration().unwrap(),
+                    first_collection_job.to_collection_job_req().unwrap(),
                 )
                 .get_encoded()
                 .unwrap(),

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -405,7 +405,7 @@ async fn roundtrip_taskprov_task_config(ephemeral_datastore: EphemeralDatastore)
     .build();
     // Source a TaskConfiguration to store from a non-taskprov view (synthesizing one for a taskprov
     // task is now rejected); any valid config exercises the column's byte round-trip.
-    let task_config = base.leader_view().unwrap().task_configuration().unwrap();
+    let task_config = base.task_configuration();
     let task = base
         .taskprov_helper_view()
         .unwrap()

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -962,7 +962,8 @@ pub mod test_util {
     };
     use janus_messages::{
         AggregateShareId, AggregationJobId, AggregationJobStep, CollectionJobId, Duration,
-        HpkeConfigId, Interval, Role, TaskId, Time, TimePrecision, Url as DapUrl,
+        HpkeConfigId, Interval, Role, TaskConfiguration, TaskId, Time, TimePrecision,
+        Url as DapUrl,
     };
     use rand::{RngExt, distr::StandardUniform, random, rng};
     use url::Url;
@@ -1252,6 +1253,13 @@ pub mod test_util {
                     aggregation_mode: self.helper_aggregation_mode,
                 },
             )
+        }
+
+        /// The task's [`TaskConfiguration`], as bound into HPKE AADs. Identical across aggregator
+        /// views, so this collapses the frequent
+        /// `helper_view().unwrap().task_configuration().unwrap()` chain in tests.
+        pub fn task_configuration(&self) -> TaskConfiguration {
+            self.leader_view().unwrap().task_configuration().unwrap()
         }
 
         /// Render a taskprov helper aggregator's view of this task.

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -572,6 +572,7 @@ impl<V: vdaf::Client<16>> Client<V> {
             Vec::new(), // No extensions supported yet.
         );
         let encoded_public_share = public_share.get_encoded()?;
+        let task_configuration = self.parameters.task_configuration()?;
 
         let (leader_encrypted_input_share, helper_encrypted_input_share) = [
             (leader_hpke_config, &Role::Leader),
@@ -590,6 +591,7 @@ impl<V: vdaf::Client<16>> Client<V> {
                 .get_encoded()?,
                 &InputShareAad::new(
                     self.parameters.task_id,
+                    task_configuration.clone(),
                     report_metadata.clone(),
                     encoded_public_share.clone(),
                 )

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -100,9 +100,9 @@ use janus_core::{
     url_for_join,
 };
 use janus_messages::{
-    AggregateShareAad, BatchConfig, BatchSelector, CollectionJobExtension, CollectionJobId,
-    CollectionJobReq, CollectionJobResp, Interval, MediaType, PartialBatchSelector, Query, Role,
-    TaskConfiguration, TaskId, TimePrecision, Url as DapUrl, VdafConfig,
+    AggregateShareAad, BatchConfig, CollectionJobExtension, CollectionJobId, CollectionJobReq,
+    CollectionJobResp, Interval, MediaType, PartialBatchSelector, Query, Role, TaskConfiguration,
+    TaskId, TimePrecision, Url as DapUrl, VdafConfig,
     batch_mode::{BatchMode, TimeInterval},
 };
 use prio::{
@@ -737,6 +737,13 @@ impl<V: vdaf::Collector> Collector<V> {
 
         let collect_response = CollectionJobResp::<B>::get_decoded(body)?;
 
+        let aggregate_share_aad = AggregateShareAad::new(
+            self.task_id,
+            self.task_configuration()?,
+            CollectionJobReq::new(job.query.clone(), job.aggregation_parameter.get_encoded()?),
+        )
+        .get_encoded()?;
+
         let aggregate_shares = [
             (Role::Leader, collect_response.leader_encrypted_agg_share),
             (Role::Helper, collect_response.helper_encrypted_agg_share),
@@ -747,15 +754,7 @@ impl<V: vdaf::Collector> Collector<V> {
                 &self.hpke_keypair,
                 &HpkeApplicationInfo::new(&hpke::Label::AggregateShare, &role, &Role::Collector),
                 &encrypted_aggregate_share,
-                &AggregateShareAad::new(
-                    self.task_id,
-                    job.aggregation_parameter.get_encoded()?,
-                    BatchSelector::<B>::new(B::batch_identifier_for_collection(
-                        &job.query,
-                        collect_response.partial_batch_selector.batch_identifier(),
-                    )),
-                )
-                .get_encoded()?,
+                &aggregate_share_aad,
             )?;
             V::AggregateShare::get_decoded_with_param(
                 &(&self.vdaf, &job.aggregation_parameter),
@@ -933,7 +932,7 @@ mod tests {
         test_util::{VdafTranscript, install_test_trace_subscriber, run_vdaf},
     };
     use janus_messages::{
-        AggregateShareAad, BatchConfig, BatchId, BatchSelector, CollectionJobId, CollectionJobReq,
+        AggregateShareAad, BatchConfig, BatchId, CollectionJobId, CollectionJobReq,
         CollectionJobResp, Duration, HpkeCiphertext, Interval, MediaType, PartialBatchSelector,
         Query, Role, TaskId, Time, TimePrecision, Url as DapUrl, VdafConfig,
         batch_mode::{LeaderSelected, TimeInterval},
@@ -998,8 +997,11 @@ mod tests {
     {
         let associated_data = AggregateShareAad::new(
             collector.task_id,
-            aggregation_parameter.get_encoded().unwrap(),
-            BatchSelector::new_time_interval(batch_interval),
+            collector.task_configuration().unwrap(),
+            CollectionJobReq::new(
+                Query::new_time_interval(batch_interval),
+                aggregation_parameter.get_encoded().unwrap(),
+            ),
         );
         CollectionJobResp {
             partial_batch_selector: PartialBatchSelector::new_time_interval(),
@@ -1034,8 +1036,11 @@ mod tests {
     {
         let associated_data = AggregateShareAad::new(
             collector.task_id,
-            aggregation_parameter.get_encoded().unwrap(),
-            BatchSelector::new_leader_selected(batch_id),
+            collector.task_configuration().unwrap(),
+            CollectionJobReq::new(
+                Query::new_leader_selected(),
+                aggregation_parameter.get_encoded().unwrap(),
+            ),
         );
         CollectionJobResp {
             partial_batch_selector: PartialBatchSelector::new_leader_selected(batch_id),
@@ -1756,8 +1761,11 @@ mod tests {
 
         let associated_data = AggregateShareAad::new(
             collector.task_id,
-            ().get_encoded().unwrap(),
-            BatchSelector::new_time_interval(batch_interval),
+            collector.task_configuration().unwrap(),
+            CollectionJobReq::new(
+                Query::new_time_interval(batch_interval),
+                ().get_encoded().unwrap(),
+            ),
         );
         let collect_resp = CollectionJobResp {
             partial_batch_selector: PartialBatchSelector::new_time_interval(),

--- a/core/src/vdaf.rs
+++ b/core/src/vdaf.rs
@@ -188,9 +188,12 @@ impl VdafInstance {
 
             #[cfg(feature = "test-util")]
             VdafInstance::Fake { rounds } => VdafConfig::Fake { rounds: *rounds },
+            // These test-only variants only differ from `Fake` in that they force a VDAF
+            // verification failure; for wire purposes (and the TaskConfiguration bound into HPKE
+            // AADs) they are represented as `Fake` so a config can be built at all.
             #[cfg(feature = "test-util")]
             VdafInstance::FakeFailsVerifyInit | VdafInstance::FakeFailsVerifyStep => {
-                return Err("VDAF instance has no VdafConfig representation");
+                VdafConfig::Fake { rounds: 1 }
             }
         })
     }
@@ -775,9 +778,14 @@ mod tests {
             .is_err()
         );
 
-        // The fake-failure VDAFs have no VdafConfig representation.
-        assert!(VdafInstance::FakeFailsVerifyInit.to_vdaf_config().is_err());
-        assert!(VdafInstance::FakeFailsVerifyStep.to_vdaf_config().is_err());
+        assert_eq!(
+            VdafInstance::FakeFailsVerifyInit.to_vdaf_config().unwrap(),
+            VdafConfig::Fake { rounds: 1 }
+        );
+        assert_eq!(
+            VdafInstance::FakeFailsVerifyStep.to_vdaf_config().unwrap(),
+            VdafConfig::Fake { rounds: 1 }
+        );
         assert_eq!(
             VdafInstance::Fake { rounds: 3 }.to_vdaf_config().unwrap(),
             VdafConfig::Fake { rounds: 3 }

--- a/integration_tests/src/client.rs
+++ b/integration_tests/src/client.rs
@@ -2,10 +2,14 @@ use std::env;
 
 use anyhow::anyhow;
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use janus_aggregator_core::task::BatchMode;
 use janus_client::Client;
 use janus_core::vdaf::{Prio3SumVecField64MultiproofHmacSha256Aes128, VdafInstance};
 use janus_interop_binaries::{ContainerLogsDropGuard, get_rust_log_level};
-use janus_messages::{TaskId, Time, TimePrecision};
+use janus_messages::{
+    TaskId, Time, TimePrecision,
+    batch_mode::{BatchMode as _, LeaderSelected, TimeInterval},
+};
 use prio::{
     codec::Encode,
     field::Field64,
@@ -245,6 +249,8 @@ where
     vdaf_instance: VdafInstance,
     host_port: u16,
     http_client: reqwest::Client,
+    min_batch_size: u64,
+    batch_mode: u8,
 }
 
 /// A DAP client implementation, specialized to work with a particular VDAF. See also
@@ -321,6 +327,10 @@ where
         let (leader_aggregator_endpoint, helper_aggregator_endpoint) = task_parameters
             .endpoint_fragments
             .endpoints_for_virtual_network_client();
+        let batch_mode = match task_parameters.batch_mode {
+            BatchMode::TimeInterval => TimeInterval::CODE as u8,
+            BatchMode::LeaderSelected { .. } => LeaderSelected::CODE as u8,
+        };
         ClientImplementation::Container(Box::new(ContainerClientImplementation {
             _container: container,
             leader: leader_aggregator_endpoint,
@@ -331,6 +341,8 @@ where
             vdaf_instance: task_parameters.vdaf.clone(),
             host_port,
             http_client,
+            min_batch_size: task_parameters.min_batch_size,
+            batch_mode,
         }))
     }
 
@@ -356,6 +368,8 @@ where
                         "measurement": inner.vdaf.json_encode_measurement(measurement),
                         "time": time.as_seconds_since_epoch(&inner.time_precision),
                         "time_precision": inner.time_precision.as_seconds(),
+                        "min_batch_size": inner.min_batch_size,
+                        "batch_mode": inner.batch_mode,
                     }))
                     .send()
                     .await?

--- a/integration_tests/tests/integration/common.rs
+++ b/integration_tests/tests/integration/common.rs
@@ -167,7 +167,7 @@ where
 
 pub async fn submit_measurements_and_verify_aggregate_generic<V>(
     task_parameters: &TaskParameters,
-    leader_port: u16,
+    (leader_port, helper_port): (u16, u16),
     vdaf: V,
     test_case: &AggregationTestCase<V>,
     client_implementation: &ClientImplementation<V>,
@@ -184,7 +184,7 @@ pub async fn submit_measurements_and_verify_aggregate_generic<V>(
 
     verify_aggregate_generic(
         task_parameters,
-        leader_port,
+        (leader_port, helper_port),
         vdaf,
         test_case,
         before_timestamp,
@@ -216,7 +216,7 @@ where
 
 pub async fn verify_aggregate_generic<V>(
     task_parameters: &TaskParameters,
-    leader_port: u16,
+    (leader_port, helper_port): (u16, u16),
     vdaf: V,
     test_case: &AggregationTestCase<V>,
     before_timestamp: Time,
@@ -226,7 +226,7 @@ pub async fn verify_aggregate_generic<V>(
 {
     let (report_count, aggregate_result) = collect_aggregate_result_generic(
         task_parameters,
-        leader_port,
+        (leader_port, helper_port),
         vdaf,
         before_timestamp,
         &test_case.aggregation_parameter,
@@ -242,7 +242,7 @@ pub async fn verify_aggregate_generic<V>(
 
 pub async fn collect_aggregate_result_generic<V>(
     task_parameters: &TaskParameters,
-    leader_port: u16,
+    (leader_port, helper_port): (u16, u16),
     vdaf: V,
     before_timestamp: Time,
     aggregation_parameter: &V::AggregationParam,
@@ -251,9 +251,9 @@ where
     V: vdaf::Client<16> + vdaf::Collector + InteropClientEncoding,
     V::AggregateResult: PartialEq,
 {
-    let leader_endpoint = task_parameters
+    let (leader_endpoint, helper_endpoint) = task_parameters
         .endpoint_fragments
-        .leader_endpoint_for_host(leader_port);
+        .endpoints_for_host_client(leader_port, helper_port);
     let collector = Collector::builder(
         task_parameters.task_id,
         leader_endpoint.as_str().try_into().unwrap(),
@@ -262,10 +262,9 @@ where
         vdaf,
         task_parameters.time_precision,
     )
-    // The helper endpoint and task_info are threaded through for AAD byte-identity in a later
-    // stage; placeholders for now.
-    .with_helper_endpoint("http://unused.helper.example/".try_into().unwrap())
-    .with_task_info(Vec::new())
+    .with_helper_endpoint(helper_endpoint.as_str().try_into().unwrap())
+    .with_task_info(task_parameters.task_info.clone())
+    .with_task_interval(task_parameters.task_interval)
     .with_min_batch_size(task_parameters.min_batch_size)
     .with_batch_config(task_parameters.batch_mode.to_batch_config())
     .with_vdaf_config(task_parameters.vdaf.to_vdaf_config().unwrap())
@@ -392,7 +391,7 @@ pub async fn submit_measurements_and_verify_aggregate(
 
             submit_measurements_and_verify_aggregate_generic(
                 task_parameters,
-                leader_port,
+                (leader_port, helper_port),
                 vdaf,
                 &test_case,
                 &client_implementation,
@@ -426,7 +425,7 @@ pub async fn submit_measurements_and_verify_aggregate(
 
             submit_measurements_and_verify_aggregate_generic(
                 task_parameters,
-                leader_port,
+                (leader_port, helper_port),
                 vdaf,
                 &test_case,
                 &client_implementation,
@@ -480,7 +479,7 @@ pub async fn submit_measurements_and_verify_aggregate(
 
             submit_measurements_and_verify_aggregate_generic(
                 task_parameters,
-                leader_port,
+                (leader_port, helper_port),
                 vdaf,
                 &test_case,
                 &client_implementation,
@@ -534,7 +533,7 @@ pub async fn submit_measurements_and_verify_aggregate(
 
             submit_measurements_and_verify_aggregate_generic(
                 task_parameters,
-                leader_port,
+                (leader_port, helper_port),
                 vdaf,
                 &test_case,
                 &client_implementation,
@@ -574,7 +573,7 @@ pub async fn submit_measurements_and_verify_aggregate(
 
             submit_measurements_and_verify_aggregate_generic(
                 task_parameters,
-                leader_port,
+                (leader_port, helper_port),
                 vdaf,
                 &test_case,
                 &client_implementation,
@@ -602,7 +601,7 @@ pub async fn submit_measurements_and_verify_aggregate(
 
             submit_measurements_and_verify_aggregate_generic(
                 task_parameters,
-                leader_port,
+                (leader_port, helper_port),
                 vdaf,
                 &test_case,
                 &client_implementation,

--- a/integration_tests/tests/integration/in_cluster.rs
+++ b/integration_tests/tests/integration/in_cluster.rs
@@ -986,7 +986,7 @@ async fn in_cluster_histogram_dp_noise() {
     .await;
     let (report_count, aggregate_result) = collect_aggregate_result_generic(
         &janus_pair.task_parameters,
-        janus_pair.leader.port(),
+        (janus_pair.leader.port(), janus_pair.helper.port()),
         vdaf,
         before_timestamp,
         &(),
@@ -1065,7 +1065,7 @@ async fn in_cluster_sumvec_dp_noise() {
     .await;
     let (report_count, aggregate_result) = collect_aggregate_result_generic(
         &janus_pair.task_parameters,
-        janus_pair.leader.port(),
+        (janus_pair.leader.port(), janus_pair.helper.port()),
         vdaf,
         before_timestamp,
         &(),

--- a/integration_tests/tests/integration/janus.rs
+++ b/integration_tests/tests/integration/janus.rs
@@ -176,6 +176,8 @@ async fn run_in_process_test(
 /// aggregation.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "testcontainer")]
+#[ignore = "host client/collector can't build byte-identical AADs against container aggregators; \
+            re-enabled by the follow-up PR that containerizes the client + collector"]
 async fn janus_janus_sync_count() {
     run_container_test(
         "janus_janus_sync_count",
@@ -190,6 +192,8 @@ async fn janus_janus_sync_count() {
 /// aggregation.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "testcontainer")]
+#[ignore = "host client/collector can't build byte-identical AADs against container aggregators; \
+            re-enabled by the follow-up PR that containerizes the client + collector"]
 async fn janus_janus_async_count() {
     // TODO(#3436): allow callers to specify asynchronous aggregation mode (requires updated
     // interop test design)
@@ -232,6 +236,8 @@ async fn janus_in_process_async_count() {
 /// aggregation.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "testcontainer")]
+#[ignore = "host client/collector can't build byte-identical AADs against container aggregators; \
+            re-enabled by the follow-up PR that containerizes the client + collector"]
 async fn janus_janus_sync_sum_16() {
     run_container_test(
         "janus_janus_sync_sum_16",
@@ -248,6 +254,8 @@ async fn janus_janus_sync_sum_16() {
 /// aggregation.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "testcontainer")]
+#[ignore = "host client/collector can't build byte-identical AADs against container aggregators; \
+            re-enabled by the follow-up PR that containerizes the client + collector"]
 async fn janus_janus_async_sum_16() {
     run_container_test(
         "janus_janus_async_sum_16",
@@ -294,6 +302,8 @@ async fn janus_in_process_async_sum_16() {
 /// synchronous aggregation.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "testcontainer")]
+#[ignore = "host client/collector can't build byte-identical AADs against container aggregators; \
+            re-enabled by the follow-up PR that containerizes the client + collector"]
 async fn janus_janus_sync_histogram_4_buckets() {
     run_container_test(
         "janus_janus_sync_histogram_4_buckets",
@@ -312,6 +322,8 @@ async fn janus_janus_sync_histogram_4_buckets() {
 /// asynchronous aggregation.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "testcontainer")]
+#[ignore = "host client/collector can't build byte-identical AADs against container aggregators; \
+            re-enabled by the follow-up PR that containerizes the client + collector"]
 async fn janus_janus_async_histogram_4_buckets() {
     run_container_test(
         "janus_janus_async_histogram_4_buckets",
@@ -364,6 +376,8 @@ async fn janus_in_process_async_histogram_4_buckets() {
 /// using synchronous aggregation.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "testcontainer")]
+#[ignore = "host client/collector can't build byte-identical AADs against container aggregators; \
+            re-enabled by the follow-up PR that containerizes the client + collector"]
 async fn janus_janus_leader_selected_sync() {
     run_container_test(
         "janus_janus_leader_selected_sync",
@@ -380,6 +394,8 @@ async fn janus_janus_leader_selected_sync() {
 /// using asynchronous aggregation.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "testcontainer")]
+#[ignore = "host client/collector can't build byte-identical AADs against container aggregators; \
+            re-enabled by the follow-up PR that containerizes the client + collector"]
 async fn janus_janus_leader_selected_async() {
     run_container_test(
         "janus_janus_leader_selected_async",
@@ -426,6 +442,8 @@ async fn janus_in_process_leader_selected_async() {
 /// aggregation.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "testcontainer")]
+#[ignore = "host client/collector can't build byte-identical AADs against container aggregators; \
+            re-enabled by the follow-up PR that containerizes the client + collector"]
 async fn janus_janus_sync_sum_vec() {
     run_container_test(
         "janus_janus_sync_sum_vec",
@@ -445,6 +463,8 @@ async fn janus_janus_sync_sum_vec() {
 /// aggregation.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "testcontainer")]
+#[ignore = "host client/collector can't build byte-identical AADs against container aggregators; \
+            re-enabled by the follow-up PR that containerizes the client + collector"]
 async fn janus_janus_async_sum_vec() {
     run_container_test(
         "janus_janus_async_sum_vec",
@@ -572,7 +592,7 @@ async fn janus_in_process_histogram_dp_noise() {
     .await;
     let (report_count, aggregate_result) = collect_aggregate_result_generic(
         &janus_pair.task_parameters,
-        janus_pair.leader.port(),
+        (janus_pair.leader.port(), janus_pair.helper.port()),
         vdaf,
         before_timestamp,
         &(),
@@ -646,7 +666,7 @@ async fn janus_in_process_sumvec_dp_noise() {
     .await;
     let (report_count, aggregate_result) = collect_aggregate_result_generic(
         &janus_pair.task_parameters,
-        janus_pair.leader.port(),
+        (janus_pair.leader.port(), janus_pair.helper.port()),
         vdaf,
         before_timestamp,
         &(),

--- a/integration_tests/tests/integration/simulation/bad_client.rs
+++ b/integration_tests/tests/integration/simulation/bad_client.rs
@@ -302,6 +302,7 @@ async fn prepare_report(
 
     let aad = InputShareAad::new(
         task_id,
+        task.leader_view().unwrap().task_configuration().unwrap(),
         report_metadata.clone(),
         encoded_public_share.clone(),
     )

--- a/integration_tests/tests/integration/simulation/bad_client.rs
+++ b/integration_tests/tests/integration/simulation/bad_client.rs
@@ -302,7 +302,7 @@ async fn prepare_report(
 
     let aad = InputShareAad::new(
         task_id,
-        task.leader_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata.clone(),
         encoded_public_share.clone(),
     )

--- a/interop_binaries/src/commands/janus_interop_aggregator.rs
+++ b/interop_binaries/src/commands/janus_interop_aggregator.rs
@@ -36,7 +36,7 @@ use tokio::net::TcpListener;
 use url::Url;
 
 use crate::{
-    AddTaskResponse, AggregatorAddTaskRequest, AggregatorRole,
+    AddTaskResponse, AggregatorAddTaskRequest, AggregatorRole, INTEROP_TASK_INFO,
     status::{ERROR, SUCCESS},
 };
 
@@ -66,14 +66,8 @@ async fn handle_add_task(
         AggregatorRole::Leader => (&request.helper, &request.leader),
         AggregatorRole::Helper => (&request.leader, &request.helper),
     };
-    let peer_aggregator_endpoint: DapUrl = peer_endpoint
-        .as_str()
-        .parse()
-        .context("invalid peer aggregator endpoint")?;
-    let own_aggregator_endpoint: DapUrl = own_endpoint
-        .as_str()
-        .parse()
-        .context("invalid own aggregator endpoint")?;
+    let peer_aggregator_endpoint: DapUrl = peer_endpoint.clone();
+    let own_aggregator_endpoint: DapUrl = own_endpoint.clone();
     let vdaf = request.vdaf.into();
     let leader_authentication_token =
         AuthenticationToken::new_dap_auth_token_from_string(request.leader_authentication_token)
@@ -162,8 +156,7 @@ async fn handle_add_task(
         time_precision,
         /* tolerable clock skew */
         Duration::ONE, // Since the clock skew must be a multiple of the precision, start at 1x
-        // The interop test API has no task_info concept, so use a fixed non-empty placeholder.
-        b"task-info".to_vec(),
+        INTEROP_TASK_INFO.to_vec(),
         aggregator_parameters,
     )
     .context("error constructing task")?;

--- a/interop_binaries/src/commands/janus_interop_client.rs
+++ b/interop_binaries/src/commands/janus_interop_client.rs
@@ -16,7 +16,7 @@ use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use clap::Parser;
 use educe::Educe;
 use janus_core::vdaf::{VdafInstance, new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128};
-use janus_messages::{BatchConfig, TaskId, Time, TimePrecision, Url as DapUrl};
+use janus_messages::{TaskId, Time, TimePrecision, Url as DapUrl};
 use prio::{
     codec::Decode,
     field::Field64,
@@ -27,7 +27,8 @@ use serde::{Deserialize, Serialize};
 use tokio::net::TcpListener;
 
 use crate::{
-    NumberAsString, VdafObject, install_tracing_subscriber,
+    INTEROP_TASK_INFO, NumberAsString, VdafObject, install_tracing_subscriber,
+    interop_batch_config,
     status::{ERROR, SUCCESS},
 };
 
@@ -67,6 +68,10 @@ struct UploadRequest {
     #[serde(default)]
     time: Option<u64>,
     time_precision: u64,
+    #[serde(default)]
+    min_batch_size: u64,
+    #[serde(default)]
+    batch_mode: u8,
 }
 
 #[derive(Debug, Serialize)]
@@ -100,12 +105,9 @@ async fn handle_upload_generic<V: prio::vdaf::Client<16>>(
         vdaf,
     )
     .with_http_client(http_client.clone())
-    // The interop upload request does not yet carry task_info, min_batch_size, batch_config, or
-    // task_interval; these placeholders make the client build, but interop AAD byte-identity needs
-    // test-design support to provide the real values.
-    .with_task_info(Vec::new())
-    .with_min_batch_size(0)
-    .with_batch_config(BatchConfig::TimeInterval)
+    .with_task_info(INTEROP_TASK_INFO.to_vec())
+    .with_min_batch_size(request.min_batch_size)
+    .with_batch_config(interop_batch_config(request.batch_mode)?)
     .with_vdaf_config(vdaf_config)
     .build()
     .await

--- a/interop_binaries/src/commands/janus_interop_collector.rs
+++ b/interop_binaries/src/commands/janus_interop_collector.rs
@@ -36,7 +36,8 @@ use serde::{Deserialize, Serialize};
 use tokio::{net::TcpListener, runtime::Runtime, sync::Mutex, task::JoinHandle};
 
 use crate::{
-    HpkeConfigRegistry, Keyring, NumberAsString, VdafObject, install_tracing_subscriber,
+    HpkeConfigRegistry, INTEROP_TASK_INFO, Keyring, NumberAsString, VdafObject,
+    install_tracing_subscriber, interop_batch_config,
     status::{COMPLETE, ERROR, IN_PROGRESS, SUCCESS},
 };
 
@@ -46,11 +47,22 @@ struct AddTaskRequest {
     task_id: String,
     #[educe(Debug(method(std::fmt::Display::fmt)))]
     leader: DapUrl,
+    // The collector never connects to the helper, but its endpoint is bound into the
+    // AggregateShareAad, so it must match the aggregators' byte-for-byte. Optional (serde default)
+    // so a non-Janus runner that omits it still parses. (See issue #4713)
+    #[educe(Debug(method(std::fmt::Display::fmt)))]
+    #[serde(default = "unused_helper_endpoint")]
+    helper: DapUrl,
     vdaf: VdafObject,
     collector_authentication_token: String,
-    #[serde(rename = "batch_mode")]
-    _batch_mode: u8,
+    batch_mode: u8,
+    #[serde(default)]
+    min_batch_size: u64,
     time_precision: u64,
+}
+
+fn unused_helper_endpoint() -> DapUrl {
+    "http://unused.helper.example/".try_into().unwrap()
 }
 
 #[derive(Debug, Serialize)]
@@ -127,9 +139,12 @@ struct TaskState {
     task_id: TaskId,
     keypair: HpkeKeypair,
     leader_url: DapUrl,
+    helper_url: DapUrl,
     vdaf: VdafObject,
     auth_token: AuthenticationToken,
     time_precision: TimePrecision,
+    min_batch_size: u64,
+    batch_config: BatchConfig,
 }
 
 /// A collection job handle.
@@ -179,13 +194,18 @@ async fn handle_add_task(
         AuthenticationToken::new_dap_auth_token_from_string(request.collector_authentication_token)
             .context("invalid header value in \"collector_authentication_token\"")?;
 
+    let batch_config = interop_batch_config(request.batch_mode)?;
+
     entry.or_insert(TaskState {
         task_id,
         keypair,
         leader_url: request.leader,
+        helper_url: request.helper,
         vdaf: request.vdaf,
         auth_token,
         time_precision: TimePrecision::from_seconds(request.time_precision),
+        min_batch_size: request.min_batch_size,
+        batch_config,
     });
 
     Ok(hpke_config)
@@ -217,14 +237,10 @@ where
         vdaf,
         time_precision,
     )
-    // The interop add-task request does not yet carry the helper endpoint, task_info,
-    // min_batch_size, batch_config, or task_interval; these placeholders make the collector
-    // build, but interop AAD byte-identity needs test-design support to provide the real
-    // values.
-    .with_helper_endpoint("http://unused.helper.example/".try_into().unwrap())
-    .with_task_info(Vec::new())
-    .with_min_batch_size(0)
-    .with_batch_config(BatchConfig::TimeInterval)
+    .with_helper_endpoint(task_state.helper_url.clone())
+    .with_task_info(INTEROP_TASK_INFO.to_vec())
+    .with_min_batch_size(task_state.min_batch_size)
+    .with_batch_config(task_state.batch_config.clone())
     .with_vdaf_config(vdaf_config)
     .with_http_client(http_client.clone())
     .with_http_request_backoff(

--- a/interop_binaries/src/commands/janus_interop_collector.rs
+++ b/interop_binaries/src/commands/janus_interop_collector.rs
@@ -48,21 +48,14 @@ struct AddTaskRequest {
     #[educe(Debug(method(std::fmt::Display::fmt)))]
     leader: DapUrl,
     // The collector never connects to the helper, but its endpoint is bound into the
-    // AggregateShareAad, so it must match the aggregators' byte-for-byte. Optional (serde default)
-    // so a non-Janus runner that omits it still parses. (See issue #4713)
+    // AggregateShareAad, so it must match the aggregators' byte-for-byte.
     #[educe(Debug(method(std::fmt::Display::fmt)))]
-    #[serde(default = "unused_helper_endpoint")]
     helper: DapUrl,
     vdaf: VdafObject,
     collector_authentication_token: String,
     batch_mode: u8,
-    #[serde(default)]
     min_batch_size: u64,
     time_precision: u64,
-}
-
-fn unused_helper_endpoint() -> DapUrl {
-    "http://unused.helper.example/".try_into().unwrap()
 }
 
 #[derive(Debug, Serialize)]

--- a/interop_binaries/src/lib.rs
+++ b/interop_binaries/src/lib.rs
@@ -20,7 +20,7 @@ use janus_core::{
     vdaf::{VdafInstance, vdaf_dp_strategies},
 };
 use janus_messages::{
-    HpkeAeadId, HpkeConfigId, HpkeKdfId, HpkeKemId, Role, TaskId,
+    BatchConfig, HpkeAeadId, HpkeConfigId, HpkeKdfId, HpkeKemId, Role, TaskId, Url as DapUrl,
     batch_mode::{BatchMode as _, LeaderSelected, TimeInterval},
 };
 use prio::codec::Encode;
@@ -30,9 +30,24 @@ use testcontainers::{ContainerAsync, Image};
 use tokio::sync::Mutex;
 use tracing_log::LogTracer;
 use tracing_subscriber::{EnvFilter, Registry, prelude::*};
-use url::Url;
 
 pub mod commands;
+
+/// The interop test API has no `task_info` concept, so every Janus interop binary (aggregator,
+/// client, and collector) uses this fixed, non-empty placeholder. It must be identical across all
+/// three so the `TaskConfiguration` bound into the HPKE AADs is byte-identical on every party.
+pub const INTEROP_TASK_INFO: &[u8] = b"task-info";
+
+/// Maps an interop-test batch-mode code to the [`BatchConfig`] that a Janus interop binary must
+/// bind into its `TaskConfiguration`. Mirrors `BatchMode::to_batch_config` so the client and
+/// collector agree byte-for-byte with the aggregator.
+pub fn interop_batch_config(batch_mode: u8) -> anyhow::Result<BatchConfig> {
+    match batch_mode {
+        code if code == TimeInterval::CODE as u8 => Ok(BatchConfig::TimeInterval),
+        code if code == LeaderSelected::CODE as u8 => Ok(BatchConfig::LeaderSelected),
+        _ => Err(anyhow::anyhow!("invalid batch mode: {batch_mode}")),
+    }
+}
 
 #[cfg(feature = "testcontainer")]
 pub mod testcontainer;
@@ -256,9 +271,9 @@ impl From<AggregatorRole> for Role {
 pub struct AggregatorAddTaskRequest {
     pub task_id: TaskId, // uses unpadded base64url
     #[educe(Debug(method(std::fmt::Display::fmt)))]
-    pub leader: Url,
+    pub leader: DapUrl,
     #[educe(Debug(method(std::fmt::Display::fmt)))]
-    pub helper: Url,
+    pub helper: DapUrl,
     pub vdaf: VdafObject,
     pub leader_authentication_token: String,
     #[serde(default)]
@@ -281,8 +296,16 @@ impl AggregatorAddTaskRequest {
         };
         Self {
             task_id: *task.id(),
-            leader: task.leader_aggregator_endpoint().clone(),
-            helper: task.helper_aggregator_endpoint().clone(),
+            leader: task
+                .leader_aggregator_endpoint()
+                .as_str()
+                .try_into()
+                .unwrap(),
+            helper: task
+                .helper_aggregator_endpoint()
+                .as_str()
+                .try_into()
+                .unwrap(),
             vdaf: task.vdaf().clone().into(),
             leader_authentication_token: String::from_utf8(
                 task.aggregator_auth_token().as_ref().to_vec(),

--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -246,9 +246,11 @@ async fn run(
         .json(&json!({
             "task_id": task_id_encoded,
             "leader": internal_leader_endpoint,
+            "helper": internal_helper_endpoint,
             "vdaf": vdaf_object,
             "collector_authentication_token": collector_auth_token,
             "batch_mode": batch_mode_json,
+            "min_batch_size": measurements.len(),
             "time_precision": TIME_PRECISION,
         }))
         .send()
@@ -386,6 +388,8 @@ async fn run(
                 "vdaf": vdaf_object,
                 "measurement": measurement,
                 "time_precision": TIME_PRECISION,
+                "batch_mode": batch_mode_json,
+                "min_batch_size": measurements.len(),
             }))
             .send()
             .await

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -2090,15 +2090,22 @@ impl<B: BatchMode> Decode for CollectionJobResp<B> {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct InputShareAad {
     task_id: TaskId,
+    task_configuration: TaskConfiguration,
     metadata: ReportMetadata,
     public_share: Vec<u8>,
 }
 
 impl InputShareAad {
     /// Constructs a new input share AAD.
-    pub fn new(task_id: TaskId, metadata: ReportMetadata, public_share: Vec<u8>) -> Self {
+    pub fn new(
+        task_id: TaskId,
+        task_configuration: TaskConfiguration,
+        metadata: ReportMetadata,
+        public_share: Vec<u8>,
+    ) -> Self {
         Self {
             task_id,
+            task_configuration,
             metadata,
             public_share,
         }
@@ -2107,6 +2114,11 @@ impl InputShareAad {
     /// Retrieves the task ID associated with this input share AAD.
     pub fn task_id(&self) -> &TaskId {
         &self.task_id
+    }
+
+    /// Retrieves the task configuration associated with this input share AAD.
+    pub fn task_configuration(&self) -> &TaskConfiguration {
+        &self.task_configuration
     }
 
     /// Retrieves the report metadata associated with this input share AAD.
@@ -2123,6 +2135,7 @@ impl InputShareAad {
 impl Encode for InputShareAad {
     fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
         self.task_id.encode(bytes)?;
+        self.task_configuration.encode(bytes)?;
         self.metadata.encode(bytes)?;
         encode_u32_items(bytes, &(), &self.public_share)
     }
@@ -2130,6 +2143,7 @@ impl Encode for InputShareAad {
     fn encoded_len(&self) -> Option<usize> {
         Some(
             self.task_id.encoded_len()?
+                + self.task_configuration.encoded_len()?
                 + self.metadata.encoded_len()?
                 + 4
                 + self.public_share.len(),
@@ -2140,11 +2154,13 @@ impl Encode for InputShareAad {
 impl Decode for InputShareAad {
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
         let task_id = TaskId::decode(bytes)?;
+        let task_configuration = TaskConfiguration::decode(bytes)?;
         let metadata = ReportMetadata::decode(bytes)?;
         let public_share = decode_u32_items(&(), bytes)?;
 
         Ok(Self {
             task_id,
+            task_configuration,
             metadata,
             public_share,
         })
@@ -2156,21 +2172,21 @@ impl Decode for InputShareAad {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AggregateShareAad<B: BatchMode> {
     task_id: TaskId,
-    aggregation_parameter: Vec<u8>,
-    batch_selector: BatchSelector<B>,
+    task_configuration: TaskConfiguration,
+    collection_job_req: CollectionJobReq<B>,
 }
 
 impl<B: BatchMode> AggregateShareAad<B> {
     /// Constructs a new aggregate share AAD.
     pub fn new(
         task_id: TaskId,
-        aggregation_parameter: Vec<u8>,
-        batch_selector: BatchSelector<B>,
+        task_configuration: TaskConfiguration,
+        collection_job_req: CollectionJobReq<B>,
     ) -> Self {
         Self {
             task_id,
-            aggregation_parameter,
-            batch_selector,
+            task_configuration,
+            collection_job_req,
         }
     }
 
@@ -2179,30 +2195,29 @@ impl<B: BatchMode> AggregateShareAad<B> {
         &self.task_id
     }
 
-    /// Retrieves the aggregation parameter associated with this aggregate share AAD.
-    pub fn aggregation_parameter(&self) -> &[u8] {
-        &self.aggregation_parameter
+    /// Retrieves the task configuration associated with this aggregate share AAD.
+    pub fn task_configuration(&self) -> &TaskConfiguration {
+        &self.task_configuration
     }
 
-    /// Retrieves the batch selector associated with this aggregate share AAD.
-    pub fn batch_selector(&self) -> &BatchSelector<B> {
-        &self.batch_selector
+    /// Retrieves the collection job request associated with this aggregate share AAD.
+    pub fn collection_job_req(&self) -> &CollectionJobReq<B> {
+        &self.collection_job_req
     }
 }
 
 impl<B: BatchMode> Encode for AggregateShareAad<B> {
     fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
         self.task_id.encode(bytes)?;
-        encode_u32_items(bytes, &(), &self.aggregation_parameter)?;
-        self.batch_selector.encode(bytes)
+        self.task_configuration.encode(bytes)?;
+        self.collection_job_req.encode(bytes)
     }
 
     fn encoded_len(&self) -> Option<usize> {
         Some(
             self.task_id.encoded_len()?
-                + 4
-                + self.aggregation_parameter.len()
-                + self.batch_selector.encoded_len()?,
+                + self.task_configuration.encoded_len()?
+                + self.collection_job_req.encoded_len()?,
         )
     }
 }
@@ -2210,13 +2225,13 @@ impl<B: BatchMode> Encode for AggregateShareAad<B> {
 impl<B: BatchMode> Decode for AggregateShareAad<B> {
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
         let task_id = TaskId::decode(bytes)?;
-        let aggregation_parameter = decode_u32_items(&(), bytes)?;
-        let batch_selector = BatchSelector::decode(bytes)?;
+        let task_configuration = TaskConfiguration::decode(bytes)?;
+        let collection_job_req = CollectionJobReq::decode(bytes)?;
 
         Ok(Self {
             task_id,
-            aggregation_parameter,
-            batch_selector,
+            task_configuration,
+            collection_job_req,
         })
     }
 }
@@ -2902,9 +2917,8 @@ impl<B: BatchMode> Decode for BatchSelector<B> {
 #[derive(Clone, Educe, PartialEq, Eq)]
 #[educe(Debug)]
 pub struct AggregateShareReq<B: BatchMode> {
+    collection_job_req: CollectionJobReq<B>,
     batch_selector: BatchSelector<B>,
-    #[educe(Debug(ignore))]
-    aggregation_parameter: Vec<u8>,
     report_count: u64,
     checksum: ReportIdChecksum,
 }
@@ -2912,17 +2926,22 @@ pub struct AggregateShareReq<B: BatchMode> {
 impl<B: BatchMode> AggregateShareReq<B> {
     /// Constructs a new aggregate share request from its components.
     pub fn new(
+        collection_job_req: CollectionJobReq<B>,
         batch_selector: BatchSelector<B>,
-        aggregation_parameter: Vec<u8>,
         report_count: u64,
         checksum: ReportIdChecksum,
     ) -> Self {
         Self {
+            collection_job_req,
             batch_selector,
-            aggregation_parameter,
             report_count,
             checksum,
         }
+    }
+
+    /// Gets the collection job request associated with this aggregate share request.
+    pub fn collection_job_req(&self) -> &CollectionJobReq<B> {
+        &self.collection_job_req
     }
 
     /// Gets the batch selector associated with this aggregate share request.
@@ -2932,7 +2951,7 @@ impl<B: BatchMode> AggregateShareReq<B> {
 
     /// Gets the aggregation parameter associated with this aggregate share request.
     pub fn aggregation_parameter(&self) -> &[u8] {
-        &self.aggregation_parameter
+        self.collection_job_req.aggregation_parameter()
     }
 
     /// Gets the report count associated with this aggregate share request.
@@ -2952,17 +2971,16 @@ impl<B: BatchMode> MediaType for AggregateShareReq<B> {
 
 impl<B: BatchMode> Encode for AggregateShareReq<B> {
     fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
+        self.collection_job_req.encode(bytes)?;
         self.batch_selector.encode(bytes)?;
-        encode_u32_items(bytes, &(), &self.aggregation_parameter)?;
         self.report_count.encode(bytes)?;
         self.checksum.encode(bytes)
     }
 
     fn encoded_len(&self) -> Option<usize> {
         Some(
-            self.batch_selector.encoded_len()?
-                + 4
-                + self.aggregation_parameter.len()
+            self.collection_job_req.encoded_len()?
+                + self.batch_selector.encoded_len()?
                 + self.report_count.encoded_len()?
                 + self.checksum.encoded_len()?,
         )
@@ -2971,14 +2989,14 @@ impl<B: BatchMode> Encode for AggregateShareReq<B> {
 
 impl<B: BatchMode> Decode for AggregateShareReq<B> {
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        let collection_job_req = CollectionJobReq::decode(bytes)?;
         let batch_selector = BatchSelector::decode(bytes)?;
-        let aggregation_parameter = decode_u32_items(&(), bytes)?;
         let report_count = u64::decode(bytes)?;
         let checksum = ReportIdChecksum::decode(bytes)?;
 
         Ok(Self {
+            collection_job_req,
             batch_selector,
-            aggregation_parameter,
             report_count,
             checksum,
         })

--- a/messages/src/tests/collection.rs
+++ b/messages/src/tests/collection.rs
@@ -1,5 +1,6 @@
 use prio::codec::Decode;
 
+use super::{TASK_CONFIGURATION_HEX, test_task_configuration};
 use crate::{
     AggregateShare, AggregateShareAad, AggregateShareReq, BatchId, BatchSelector,
     CollectionJobExtension, CollectionJobExtensionType, CollectionJobReq, CollectionJobResp,
@@ -551,6 +552,17 @@ fn roundtrip_aggregate_share_req() {
     roundtrip_encoding(&[
         (
             AggregateShareReq::<TimeInterval> {
+                collection_job_req: CollectionJobReq {
+                    query: Query {
+                        query_body: Interval::new(
+                            Time::from_seconds_since_epoch(54321, &TEST_TIME_PRECISION),
+                            Duration::from_seconds(12345, &TEST_TIME_PRECISION),
+                        )
+                        .unwrap(),
+                    },
+                    aggregation_parameter: Vec::new(),
+                    extensions: Vec::new(),
+                },
                 batch_selector: BatchSelector {
                     batch_identifier: Interval::new(
                         Time::from_seconds_since_epoch(54321, &TEST_TIME_PRECISION),
@@ -558,11 +570,28 @@ fn roundtrip_aggregate_share_req() {
                     )
                     .unwrap(),
                 },
-                aggregation_parameter: Vec::new(),
                 report_count: 439,
                 checksum: ReportIdChecksum::get_decoded(&[u8::MIN; 32]).unwrap(),
             },
             concat!(
+                concat!(
+                    // collection_job_req
+                    concat!(
+                        // query
+                        "01",   // batch_mode
+                        "0010", // length
+                        concat!(
+                            "000000000000D431", // start
+                            "0000000000003039", // duration
+                        ),
+                    ),
+                    concat!(
+                        // aggregation_parameter
+                        "00000000", // length
+                        "",         // opaque data
+                    ),
+                    "0000", // extensions (empty)
+                ),
                 concat!(
                     // batch_selector
                     "01",   // batch_mode
@@ -573,17 +602,23 @@ fn roundtrip_aggregate_share_req() {
                         "0000000000003039", // duration
                     ),
                 ),
-                concat!(
-                    // aggregation_parameter
-                    "00000000", // length
-                    "",         // opaque data
-                ),
                 "00000000000001B7", // report_count
                 "0000000000000000000000000000000000000000000000000000000000000000", // checksum
             ),
         ),
         (
             AggregateShareReq::<TimeInterval> {
+                collection_job_req: CollectionJobReq {
+                    query: Query {
+                        query_body: Interval::new(
+                            Time::from_seconds_since_epoch(50821, &TEST_TIME_PRECISION),
+                            Duration::from_seconds(84354, &TEST_TIME_PRECISION),
+                        )
+                        .unwrap(),
+                    },
+                    aggregation_parameter: Vec::from("012345"),
+                    extensions: Vec::new(),
+                },
                 batch_selector: BatchSelector {
                     batch_identifier: Interval::new(
                         Time::from_seconds_since_epoch(50821, &TEST_TIME_PRECISION),
@@ -591,11 +626,28 @@ fn roundtrip_aggregate_share_req() {
                     )
                     .unwrap(),
                 },
-                aggregation_parameter: Vec::from("012345"),
                 report_count: 8725,
                 checksum: ReportIdChecksum::get_decoded(&[u8::MAX; 32]).unwrap(),
             },
             concat!(
+                concat!(
+                    // collection_job_req
+                    concat!(
+                        // query
+                        "01",   // batch_mode
+                        "0010", // length
+                        concat!(
+                            "000000000000C685", // start
+                            "0000000000014982", // duration
+                        ),
+                    ),
+                    concat!(
+                        // aggregation_parameter
+                        "00000006",     // length
+                        "303132333435", // opaque data
+                    ),
+                    "0000", // extensions (empty)
+                ),
                 concat!(
                     // batch_selector
                     "01",   // batch_mode
@@ -605,11 +657,6 @@ fn roundtrip_aggregate_share_req() {
                         "000000000000C685", // start
                         "0000000000014982", // duration
                     ),
-                ),
-                concat!(
-                    // aggregation_parameter
-                    "00000006",     // length
-                    "303132333435", // opaque data
                 ),
                 "0000000000002215", // report_count
                 "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", // checksum
@@ -621,14 +668,32 @@ fn roundtrip_aggregate_share_req() {
     roundtrip_encoding(&[
         (
             AggregateShareReq::<LeaderSelected> {
+                collection_job_req: CollectionJobReq {
+                    query: Query { query_body: () },
+                    aggregation_parameter: Vec::new(),
+                    extensions: Vec::new(),
+                },
                 batch_selector: BatchSelector {
                     batch_identifier: BatchId::from([12u8; 32]),
                 },
-                aggregation_parameter: Vec::new(),
                 report_count: 439,
                 checksum: ReportIdChecksum::get_decoded(&[u8::MIN; 32]).unwrap(),
             },
             concat!(
+                concat!(
+                    // collection_job_req
+                    concat!(
+                        // query
+                        "02",   // batch_mode
+                        "0000", // length (empty body)
+                    ),
+                    concat!(
+                        // aggregation_parameter
+                        "00000000", // length
+                        "",         // opaque data
+                    ),
+                    "0000", // extensions (empty)
+                ),
                 concat!(
                     // batch_selector
                     "02",   // batch_mode
@@ -636,36 +701,44 @@ fn roundtrip_aggregate_share_req() {
                     // opaque data
                     "0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C",
                 ),
-                concat!(
-                    // aggregation_parameter
-                    "00000000", // length
-                    "",         // opaque data
-                ),
                 "00000000000001B7", // report_count
                 "0000000000000000000000000000000000000000000000000000000000000000", // checksum
             ),
         ),
         (
             AggregateShareReq::<LeaderSelected> {
+                collection_job_req: CollectionJobReq {
+                    query: Query { query_body: () },
+                    aggregation_parameter: Vec::from("012345"),
+                    extensions: Vec::new(),
+                },
                 batch_selector: BatchSelector {
                     batch_identifier: BatchId::from([7u8; 32]),
                 },
-                aggregation_parameter: Vec::from("012345"),
                 report_count: 8725,
                 checksum: ReportIdChecksum::get_decoded(&[u8::MAX; 32]).unwrap(),
             },
             concat!(
+                concat!(
+                    // collection_job_req
+                    concat!(
+                        // query
+                        "02",   // batch_mode
+                        "0000", // length (empty body)
+                    ),
+                    concat!(
+                        // aggregation_parameter
+                        "00000006",     // length
+                        "303132333435", // opaque data
+                    ),
+                    "0000", // extensions (empty)
+                ),
                 concat!(
                     // batch_selector
                     "02",   // batch_mode
                     "0020", // length
                     // opaque data
                     "0707070707070707070707070707070707070707070707070707070707070707",
-                ),
-                concat!(
-                    // aggregation_parameter
-                    "00000006",     // length
-                    "303132333435", // opaque data
                 ),
                 "0000000000002215", // report_count
                 "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", // checksum
@@ -727,61 +800,81 @@ fn roundtrip_aggregate_share() {
 
 #[test]
 fn roundtrip_aggregate_share_aad() {
+    // The embedded TaskConfiguration bytes are spliced in from `TASK_CONFIGURATION_HEX` (verified
+    // in `task::roundtrip_task_configuration`) via `format!`, since `concat!` cannot reference a
+    // const.
+
     // TimeInterval.
-    roundtrip_encoding(&[(
-        AggregateShareAad::<TimeInterval> {
-            task_id: TaskId::from([12u8; 32]),
-            aggregation_parameter: Vec::from([0, 1, 2, 3]),
-            batch_selector: BatchSelector {
-                batch_identifier: Interval::new(
-                    Time::from_seconds_since_epoch(54321, &TEST_TIME_PRECISION),
-                    Duration::from_seconds(12345, &TEST_TIME_PRECISION),
-                )
-                .unwrap(),
-            },
-        },
-        concat!(
-            "0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C", // task_id
+    let time_interval_encoding = format!(
+        "{task_id}{task_configuration}{collection_job_req}",
+        task_id = "0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C",
+        task_configuration = TASK_CONFIGURATION_HEX,
+        collection_job_req = concat!(
             concat!(
-                // aggregation_parameter
-                "00000004", // length
-                "00010203", //opaque data
-            ),
-            concat!(
-                // batch_selector
+                // query
                 "01",   // batch_mode
                 "0010", // length
                 concat!(
-                    // opaque data
                     "000000000000D431", // start
                     "0000000000003039", // duration
                 ),
             ),
-        ),
-    )]);
-
-    // LeaderSelected.
-    roundtrip_encoding(&[(
-        AggregateShareAad::<LeaderSelected> {
-            task_id: TaskId::from([u8::MIN; 32]),
-            aggregation_parameter: Vec::from([3, 2, 1, 0]),
-            batch_selector: BatchSelector {
-                batch_identifier: BatchId::from([7u8; 32]),
-            },
-        },
-        concat!(
-            "0000000000000000000000000000000000000000000000000000000000000000", // task_id
             concat!(
                 // aggregation_parameter
                 "00000004", // length
-                "03020100", //opaque data
+                "00010203", // opaque data
+            ),
+            "0000", // extensions (empty)
+        ),
+    );
+    roundtrip_encoding(&[(
+        AggregateShareAad::<TimeInterval> {
+            task_id: TaskId::from([12u8; 32]),
+            task_configuration: test_task_configuration(),
+            collection_job_req: CollectionJobReq {
+                query: Query {
+                    query_body: Interval::new(
+                        Time::from_seconds_since_epoch(54321, &TEST_TIME_PRECISION),
+                        Duration::from_seconds(12345, &TEST_TIME_PRECISION),
+                    )
+                    .unwrap(),
+                },
+                aggregation_parameter: Vec::from([0, 1, 2, 3]),
+                extensions: Vec::new(),
+            },
+        },
+        time_interval_encoding.as_str(),
+    )]);
+
+    // LeaderSelected.
+    let leader_selected_encoding = format!(
+        "{task_id}{task_configuration}{collection_job_req}",
+        task_id = "0000000000000000000000000000000000000000000000000000000000000000",
+        task_configuration = TASK_CONFIGURATION_HEX,
+        collection_job_req = concat!(
+            concat!(
+                // query
+                "02",   // batch_mode
+                "0000", // length (empty body)
             ),
             concat!(
-                // batch_selector
-                "02",                                                               // batch_mode
-                "0020",                                                             // length
-                "0707070707070707070707070707070707070707070707070707070707070707", // opaque data
+                // aggregation_parameter
+                "00000004", // length
+                "03020100", // opaque data
             ),
+            "0000", // extensions (empty)
         ),
+    );
+    roundtrip_encoding(&[(
+        AggregateShareAad::<LeaderSelected> {
+            task_id: TaskId::from([u8::MIN; 32]),
+            task_configuration: test_task_configuration(),
+            collection_job_req: CollectionJobReq {
+                query: Query { query_body: () },
+                aggregation_parameter: Vec::from([3, 2, 1, 0]),
+                extensions: Vec::new(),
+            },
+        },
+        leader_selected_encoding.as_str(),
     )])
 }

--- a/messages/src/tests/collection.rs
+++ b/messages/src/tests/collection.rs
@@ -1,6 +1,6 @@
 use prio::codec::Decode;
 
-use super::{TASK_CONFIGURATION_HEX, test_task_configuration};
+use super::{task_configuration_hex, test_task_configuration};
 use crate::{
     AggregateShare, AggregateShareAad, AggregateShareReq, BatchId, BatchSelector,
     CollectionJobExtension, CollectionJobExtensionType, CollectionJobReq, CollectionJobResp,
@@ -800,16 +800,16 @@ fn roundtrip_aggregate_share() {
 
 #[test]
 fn roundtrip_aggregate_share_aad() {
-    // The embedded TaskConfiguration bytes are spliced in from `TASK_CONFIGURATION_HEX` (verified
-    // in `task::roundtrip_task_configuration`) via `format!`, since `concat!` cannot reference a
-    // const.
+    // The embedded TaskConfiguration bytes are spliced in from `task_configuration_hex!` (verified
+    // in `task::roundtrip_task_configuration`).
 
     // TimeInterval.
-    let time_interval_encoding = format!(
-        "{task_id}{task_configuration}{collection_job_req}",
-        task_id = "0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C",
-        task_configuration = TASK_CONFIGURATION_HEX,
-        collection_job_req = concat!(
+    let time_interval_encoding = concat!(
+        // task_id
+        "0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C",
+        task_configuration_hex!(),
+        // collection_job_req
+        concat!(
             concat!(
                 // query
                 "01",   // batch_mode
@@ -843,15 +843,16 @@ fn roundtrip_aggregate_share_aad() {
                 extensions: Vec::new(),
             },
         },
-        time_interval_encoding.as_str(),
+        time_interval_encoding,
     )]);
 
     // LeaderSelected.
-    let leader_selected_encoding = format!(
-        "{task_id}{task_configuration}{collection_job_req}",
-        task_id = "0000000000000000000000000000000000000000000000000000000000000000",
-        task_configuration = TASK_CONFIGURATION_HEX,
-        collection_job_req = concat!(
+    let leader_selected_encoding = concat!(
+        // task_id
+        "0000000000000000000000000000000000000000000000000000000000000000",
+        task_configuration_hex!(),
+        // collection_job_req
+        concat!(
             concat!(
                 // query
                 "02",   // batch_mode
@@ -875,6 +876,6 @@ fn roundtrip_aggregate_share_aad() {
                 extensions: Vec::new(),
             },
         },
-        leader_selected_encoding.as_str(),
+        leader_selected_encoding,
     )])
 }

--- a/messages/src/tests/mod.rs
+++ b/messages/src/tests/mod.rs
@@ -5,3 +5,67 @@ mod hpke;
 mod query;
 mod task;
 mod upload;
+
+use crate::{
+    BatchConfig, Duration, TaskConfiguration, TaskConfigurationBuilder, Time, TimePrecision, Url,
+    VdafConfig,
+};
+
+/// A fixed [`TaskConfiguration`] reused by the AAD codec fixtures that embed one. Its encoding is
+/// verified independently in [`task::roundtrip_task_configuration`], so the AAD fixtures can splice
+/// in [`TASK_CONFIGURATION_HEX`] rather than recompute the whole config's bytes.
+pub(crate) fn test_task_configuration() -> TaskConfiguration {
+    let time_precision = TimePrecision::from_seconds(3600);
+    TaskConfigurationBuilder::new(
+        "foobar".as_bytes().to_vec(),
+        Url::try_from("https://example.com/").unwrap(),
+        Url::try_from("https://another.example.com/").unwrap(),
+        time_precision,
+        10000,
+        BatchConfig::TimeInterval,
+        VdafConfig::Prio3Count,
+    )
+    .with_task_interval(
+        Time::from_seconds_since_epoch(1000000, &time_precision),
+        Duration::from_time_precision_units(28),
+    )
+    .unwrap()
+    .build()
+    .unwrap()
+}
+
+/// The wire encoding of [`test_task_configuration`], mirroring
+/// [`task::roundtrip_task_configuration`].
+pub(crate) const TASK_CONFIGURATION_HEX: &str = concat!(
+    concat!(
+        // task_info
+        "06",           // length
+        "666F6F626172"  // opaque data
+    ),
+    concat!(
+        // leader_aggregator_url
+        "0014",                                     // length
+        "68747470733A2F2F6578616D706C652E636F6D2F"  // contents
+    ),
+    concat!(
+        // helper_aggregator_url
+        "001C",                                                     // length
+        "68747470733A2F2F616E6F746865722E6578616D706C652E636F6D2F"  // contents
+    ),
+    "0000000000000E10", // time_precision
+    "0000000000002710", // min_batch_size
+    "01",               // batch_mode
+    "0000",             // batch_config
+    "00000001",         // vdaf_type
+    "0000",             // vdaf_config
+    concat!(
+        // extensions (task_interval extension)
+        "0014", // length
+        concat!(
+            "0001",             // extension_type (TaskInterval)
+            "0010",             // extension_data length
+            "0000000000000115", // start
+            "000000000000001C", // duration
+        ),
+    ),
+);

--- a/messages/src/tests/mod.rs
+++ b/messages/src/tests/mod.rs
@@ -35,37 +35,43 @@ pub(crate) fn test_task_configuration() -> TaskConfiguration {
 }
 
 /// The wire encoding of [`test_task_configuration`], mirroring
-/// [`task::roundtrip_task_configuration`].
-pub(crate) const TASK_CONFIGURATION_HEX: &str = concat!(
-    concat!(
-        // task_info
-        "06",           // length
-        "666F6F626172"  // opaque data
-    ),
-    concat!(
-        // leader_aggregator_url
-        "0014",                                     // length
-        "68747470733A2F2F6578616D706C652E636F6D2F"  // contents
-    ),
-    concat!(
-        // helper_aggregator_url
-        "001C",                                                     // length
-        "68747470733A2F2F616E6F746865722E6578616D706C652E636F6D2F"  // contents
-    ),
-    "0000000000000E10", // time_precision
-    "0000000000002710", // min_batch_size
-    "01",               // batch_mode
-    "0000",             // batch_config
-    "00000001",         // vdaf_type
-    "0000",             // vdaf_config
-    concat!(
-        // extensions (task_interval extension)
-        "0014", // length
+/// [`task::roundtrip_task_configuration`]. A macro rather than a `const` so it can be spliced into
+/// other `concat!` fixtures, which only accept literals.
+macro_rules! task_configuration_hex {
+    () => {
         concat!(
-            "0001",             // extension_type (TaskInterval)
-            "0010",             // extension_data length
-            "0000000000000115", // start
-            "000000000000001C", // duration
-        ),
-    ),
-);
+            concat!(
+                // task_info
+                "06",           // length
+                "666F6F626172"  // opaque data
+            ),
+            concat!(
+                // leader_aggregator_url
+                "0014",                                     // length
+                "68747470733A2F2F6578616D706C652E636F6D2F"  // contents
+            ),
+            concat!(
+                // helper_aggregator_url
+                "001C",                                                     // length
+                "68747470733A2F2F616E6F746865722E6578616D706C652E636F6D2F"  // contents
+            ),
+            "0000000000000E10", // time_precision
+            "0000000000002710", // min_batch_size
+            "01",               // batch_mode
+            "0000",             // batch_config
+            "00000001",         // vdaf_type
+            "0000",             // vdaf_config
+            concat!(
+                // extensions (task_interval extension)
+                "0014", // length
+                concat!(
+                    "0001",             // extension_type (TaskInterval)
+                    "0010",             // extension_data length
+                    "0000000000000115", // start
+                    "000000000000001C", // duration
+                ),
+            ),
+        )
+    };
+}
+pub(crate) use task_configuration_hex;

--- a/messages/src/tests/upload.rs
+++ b/messages/src/tests/upload.rs
@@ -1,5 +1,6 @@
 use prio::codec::Encode;
 
+use super::{TASK_CONFIGURATION_HEX, test_task_configuration};
 use crate::{
     Extension, ExtensionType, HpkeCiphertext, HpkeConfigId, InputShareAad, PlaintextInputShare,
     Report, ReportError, ReportId, ReportMetadata, ReportUploadStatus, TaskId, Time, TimePrecision,
@@ -317,9 +318,38 @@ fn roundtrip_report() {
 
 #[test]
 fn roundtrip_input_share_aad() {
+    // The embedded TaskConfiguration bytes are spliced in from `TASK_CONFIGURATION_HEX` (verified
+    // in `task::roundtrip_task_configuration`) via `format!`, since `concat!` cannot reference a
+    // const.
+    let encoding = format!(
+        "{task_id}{task_configuration}{metadata}{public_share}",
+        task_id = "0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C",
+        task_configuration = TASK_CONFIGURATION_HEX,
+        metadata = concat!(
+            "0102030405060708090A0B0C0D0E0F10", // report_id
+            "000000000000D431",                 // time
+            concat!(
+                // public_extensions
+                "0008", // length
+                concat!(
+                    "0000", // extension_type
+                    concat!(
+                        // extension_data
+                        "0004",     // length
+                        "30313233", // opaque data
+                    ),
+                ),
+            ),
+        ),
+        public_share = concat!(
+            "00000004", // length
+            "30313233", // opaque data
+        ),
+    );
     roundtrip_encoding(&[(
         InputShareAad {
             task_id: TaskId::from([12u8; 32]),
+            task_configuration: test_task_configuration(),
             metadata: ReportMetadata::new(
                 ReportId::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
                 Time::from_seconds_since_epoch(54321, &TEST_TIME_PRECISION),
@@ -327,31 +357,7 @@ fn roundtrip_input_share_aad() {
             ),
             public_share: Vec::from("0123"),
         },
-        concat!(
-            "0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C", // task_id
-            concat!(
-                // metadata
-                "0102030405060708090A0B0C0D0E0F10", // report_id
-                "000000000000D431",                 // time
-                concat!(
-                    // public_extensions
-                    "0008", // length
-                    concat!(
-                        "0000", // extension_type
-                        concat!(
-                            // extension_data
-                            "0004",     // length
-                            "30313233", // opaque data
-                        ),
-                    ),
-                ),
-            ),
-            concat!(
-                // public_share
-                "00000004", // length
-                "30313233", // opaque data
-            ),
-        ),
+        encoding.as_str(),
     )])
 }
 

--- a/messages/src/tests/upload.rs
+++ b/messages/src/tests/upload.rs
@@ -1,6 +1,6 @@
 use prio::codec::Encode;
 
-use super::{TASK_CONFIGURATION_HEX, test_task_configuration};
+use super::{task_configuration_hex, test_task_configuration};
 use crate::{
     Extension, ExtensionType, HpkeCiphertext, HpkeConfigId, InputShareAad, PlaintextInputShare,
     Report, ReportError, ReportId, ReportMetadata, ReportUploadStatus, TaskId, Time, TimePrecision,
@@ -318,14 +318,14 @@ fn roundtrip_report() {
 
 #[test]
 fn roundtrip_input_share_aad() {
-    // The embedded TaskConfiguration bytes are spliced in from `TASK_CONFIGURATION_HEX` (verified
-    // in `task::roundtrip_task_configuration`) via `format!`, since `concat!` cannot reference a
-    // const.
-    let encoding = format!(
-        "{task_id}{task_configuration}{metadata}{public_share}",
-        task_id = "0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C",
-        task_configuration = TASK_CONFIGURATION_HEX,
-        metadata = concat!(
+    // The embedded TaskConfiguration bytes are spliced in from `task_configuration_hex!` (verified
+    // in `task::roundtrip_task_configuration`).
+    let encoding = concat!(
+        // task_id
+        "0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C",
+        task_configuration_hex!(),
+        // metadata
+        concat!(
             "0102030405060708090A0B0C0D0E0F10", // report_id
             "000000000000D431",                 // time
             concat!(
@@ -341,7 +341,8 @@ fn roundtrip_input_share_aad() {
                 ),
             ),
         ),
-        public_share = concat!(
+        // public_share
+        concat!(
             "00000004", // length
             "30313233", // opaque data
         ),
@@ -357,7 +358,7 @@ fn roundtrip_input_share_aad() {
             ),
             public_share: Vec::from("0123"),
         },
-        encoding.as_str(),
+        encoding,
     )])
 }
 

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, fs::File, path::PathBuf, process::exit, time::Duration as StdDuration};
 
-use anyhow::Context;
+use anyhow::{Context, anyhow};
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use clap::{
     Args, CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum,
@@ -54,6 +54,19 @@ impl From<clap::Error> for Error {
     fn from(error: clap::Error) -> Self {
         Error::Clap(error)
     }
+}
+
+/// Decrypting an aggregate share requires binding the task's `TaskConfiguration` into the AAD, but
+/// this tool does not yet accept the parameters needed to reconstruct it, so [`new_collector`]
+/// supplies placeholders. Refuse up front rather than decrypt against an AAD we know is wrong and
+/// fail with an opaque HPKE error.
+fn ensure_aggregate_share_decryption_supported() -> Result<(), Error> {
+    Err(Error::Anyhow(anyhow!(
+        "collecting an aggregate share is not yet supported: the helper endpoint, task info, \
+         minimum batch size, batch config, and VDAF config are needed to reconstruct the task's \
+         TaskConfiguration, and this tool does not yet accept them. The `new-job` subcommand still \
+         works. See https://github.com/divviup/janus/issues/4713."
+    )))
 }
 
 // Parsers for command-line arguments:
@@ -543,6 +556,7 @@ async fn run_collection<V: vdaf::Collector, B: BatchModeExt>(
 where
     V::AggregateResult: Debug,
 {
+    ensure_aggregate_share_decryption_supported()?;
     let collection = new_collector(options, vdaf, http_client)?
         .collection(query, agg_param)
         .collect()
@@ -584,6 +598,7 @@ async fn run_poll_job<V: vdaf::Collector, B: BatchModeExt>(
 where
     V::AggregateResult: Debug,
 {
+    ensure_aggregate_share_decryption_supported()?;
     let collection_job = CollectionJob::new(collection_job_id, query, agg_param.clone());
     let poll_result = new_collector(options, vdaf, http_client)?
         .poll_once(&collection_job)
@@ -623,9 +638,7 @@ fn new_collector<V: vdaf::Collector>(
         vdaf,
         time_precision,
     )
-    // The helper endpoint and remaining TaskConfiguration parameters are not yet exposed as CLI
-    // options; these placeholders make the collector build, but correct aggregate-share decryption
-    // will require real values once the TaskConfiguration is bound into the AAD.
+    // Placeholders (#4713). Only `new-job` gets this far, and it never computes an AAD.
     .with_helper_endpoint("http://unused.helper.example/".try_into().unwrap())
     .with_task_info(Vec::new())
     .with_min_batch_size(0)
@@ -721,7 +734,7 @@ mod tests {
         initialize_rustls,
         test_util::install_test_trace_subscriber,
     };
-    use janus_messages::{TaskId, Url as DapUrl};
+    use janus_messages::{CollectionJobId, TaskId, Url as DapUrl};
     use prio::codec::Encode;
     use rand::random;
     use tempfile::NamedTempFile;
@@ -745,6 +758,61 @@ mod tests {
     #[test]
     fn verify_app() {
         Options::command().debug_assert();
+    }
+
+    /// The paths that decrypt an aggregate share must refuse before contacting the leader, rather
+    /// than build an AAD from the placeholders in `new_collector` and fail to decrypt. See #4713.
+    #[tokio::test]
+    async fn aggregate_share_decryption_refused() {
+        install_test_trace_subscriber();
+        initialize_rustls();
+
+        let hpke_keypair = HpkeKeypair::test();
+        let task_id: TaskId = random();
+        let auth_token = AuthenticationToken::DapAuth(random());
+        let arguments = [
+            "collect".to_string(),
+            format!(
+                "--task-id={}",
+                URL_SAFE_NO_PAD.encode(task_id.get_encoded().unwrap())
+            ),
+            "--leader=https://example.com/dap/".to_string(),
+            format!("--dap-auth-token={}", auth_token.as_str()),
+            format!(
+                "--hpke-config={}",
+                URL_SAFE_NO_PAD.encode(hpke_keypair.config().get_encoded().unwrap())
+            ),
+            format!(
+                "--hpke-private-key={}",
+                URL_SAFE_NO_PAD.encode(hpke_keypair.private_key().as_ref())
+            ),
+            "--vdaf=count".to_string(),
+            "--batch-interval-start=1000000".to_string(),
+            "--batch-interval-duration=1000".to_string(),
+            "--time-precision=300".to_string(),
+        ];
+
+        let collection_job_id: CollectionJobId = random();
+
+        // The default (collect-and-wait) path, and the poll path.
+        for subcommand in [
+            Vec::new(),
+            Vec::from([
+                "poll-job".to_string(),
+                "--".to_string(),
+                collection_job_id.to_string(),
+            ]),
+        ] {
+            let options =
+                Options::try_parse_from(arguments.iter().cloned().chain(subcommand)).unwrap();
+            assert_matches!(
+                run(options).await.unwrap_err(),
+                Error::Anyhow(err) => assert!(
+                    err.to_string().contains("issues/4713"),
+                    "unexpected error: {err}"
+                )
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
I'm afraid this is another _draw the rest of the owl_ that can't split up worth a darn and have green tests. Except for the ones I'm marking to ignore!

This is broken into sub-commits which deal with these specific headings... but I feel like this one is just as easy to review as a big blob of ~crazy~ _high quality code_

## Bind each task's TaskConfiguration into the input-share and aggregate-share HPKE AADs.

Both ends recompute each AAD independently, so byte-identical encoding across every party is mandatory or everything errors out.

- `InputShareAad` gains `task_configuration` as field 2
- `AggregateShareAad` becomes `{task_id, task_configuration, collection_job_req}`,  dropping `aggregation_parameter + batch_selector`, now matching DAP-18
    - This requires the Helper to do more validations (they became MUST) which I add before the datastore transaction.
- `AggregateShareReq` becomes `{collection_job_req, batch_selector, report_count, checksum}`:
    - `collection_job_req` replaces the standalone `aggregation_parameter`
    - The Leader forwards its stored `CollectionJobReq` verbatim and the Helper binds it directly (no reconstruction)
    - the aggregation parameter is now reached via `req.collection_job_req().aggregation_parameter()`


> [!IMPORTANT]
> §4.6.4 defines consistency per batch mode, and for time-interval permits any selector within the queried interval (containment):
> `all batch buckets whose batch bucket identifiers are contained within the batch interval specified in the CollectionJobReq's query`
> Here I implement the stricter requirement that the selector reconstruct the query exactly (equality). The reason is that the `PUT` path stores `batch_selector().batch_identifier()`, and the poll/`GET` path rebuilds the AAD's query from that stored identifier alone via `query_for_collection_identifier`. That reconstruction is lossy for anything narrower than the query, so a strict sub-interval would decrypt on the `PUT` path and silently fail on the poll path. Equality fails with `batchInvalid` at `PUT`; containment would accept and fail silently later. (`invalidMessage` vs `batchInvalid` is a judgment call imo, I'm open to changing. I've already changed my mind once.)
> The consequence is that Janus rejects some spec-conformant sub-interval requests -- if we want true containment, the Helper needs to persist the query rather than re-derive it, which yet another big expansion of scope for this already big change. I'm erroring on YAGNI here, but if we think we want that, I want to file an issue and take it as a follow-on. I have a test for this, noting the choice.
> For leader-selected the check is trivially satisfied, since the query body is empty. (phew)

> [!NOTE]
> `core/src/vdaf.rs`: `to_vdaf_config()` (which is `#[cfg(test-util)]`) maps `FakeFailsVerifyInit` and `FakeFailsVerifyStep` to `VdafConfig::Fake`, so the Helper can build an `InputShareAad` before the intentional verify failure.

## Update the interop binaries to build a byte-identical `TaskConfiguration`.

- Flip AggregatorAddTaskRequest.leader/.helper to `janus_messages::Url` so endpoint bytes survive interop provisioning verbatim (no `url::Url` re-encoding); the interop aggregator binds them directly.
- Add a shared `INTEROP_TASK_INFO` placeholder (the interop test API has no `task_info` concept) and an `interop_batch_config()` helper, used identically by the interop aggregator, client, and collector.
- Carry `min_batch_size + batch_mode` in the interop upload request, and the helper `endpoint + min_batch_size` in the collector `add_task` request; new fields are serde-optional so a non-Janus runner still parses.
- Test harness: source real `task_info/task_interval/helper` endpoint into the collector (collect_aggregate_result_generic now takes a helper_port) and send  `min_batch_size + batch_mode` from the container client.
- Ignore the `janus_janus_*` container tests: a follow-up will re-enable them.... somehow.

## A Stake in `tools/collect` (see #4713)

`new_collector` fabricates its `TaskConfiguration` values to make things work. But now they're _actively_ wrong. I've made the two AAD-consuming paths (`run_collection` and `run_poll_job`) now fail fast with an error naming the missing parameters. #4713 (David's suggested `--task-config <blob>`) is probably The Way.

`new-job` is unaffected and still works as it never computes an AAD. Success through laziness!