### PR TITLE
Update Rust container images to 1.97.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.96.1-alpine AS chef
+FROM rust:1.97.1-alpine AS chef
 ENV CARGO_INCREMENTAL=0
 RUN apk add --no-cache libc-dev cmake make
 RUN cargo install cargo-chef --version 0.1.60 --locked && \

--- a/Dockerfile.interop
+++ b/Dockerfile.interop
@@ -1,7 +1,7 @@
 ARG BINARY
 ARG PROFILE=release
 
-FROM rust:1.96.1-alpine AS chef
+FROM rust:1.97.1-alpine AS chef
 ENV CARGO_INCREMENTAL=0
 RUN apk add --no-cache libc-dev cmake make
 RUN cargo install cargo-chef --version 0.1.60 --locked && \

--- a/Dockerfile.interop_aggregator
+++ b/Dockerfile.interop_aggregator
@@ -1,6 +1,6 @@
 ARG PROFILE=release
 
-FROM rust:1.96.1-alpine AS chef
+FROM rust:1.97.1-alpine AS chef
 ENV CARGO_INCREMENTAL=0
 RUN apk add --no-cache libc-dev cmake make
 RUN cargo install cargo-chef --version 0.1.60 --locked && \
@@ -60,7 +60,7 @@ COPY tools /src/tools
 COPY xtask /src/xtask
 RUN cargo build --features fpvec_bounded_l2 --profile $PROFILE -p janus_interop_binaries
 
-FROM rust:1.96.1-alpine AS sqlx
+FROM rust:1.97.1-alpine AS sqlx
 ENV CARGO_INCREMENTAL=0
 ARG SQLX_VERSION=0.7.2
 RUN apk add --no-cache libc-dev

--- a/Dockerfile.sqlx
+++ b/Dockerfile.sqlx
@@ -1,4 +1,4 @@
-FROM rust:1.96.1-alpine AS builder
+FROM rust:1.97.1-alpine AS builder
 ENV CARGO_INCREMENTAL=0
 ARG SQLX_VERSION
 RUN apk add libc-dev


### PR DESCRIPTION
Instead of updating to 1.97.0 in #4724, we should instead update to 1.97.1.