### PR TITLE
Update arguments for docker/bake-action

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -176,7 +176,7 @@ jobs:
       uses: docker/bake-action@v7.3.0
       with:
         files: docker-bake.hcl
-        workdir: .
+        source: .
         targets: janus
         load: true
     # Independent smoke checks; run in parallel.
@@ -204,7 +204,7 @@ jobs:
       uses: docker/bake-action@v7.3.0
       with:
         files: docker-bake.hcl
-        workdir: .
+        source: .
         targets: interop_binaries_ci
 
   rustsec_advisories:

--- a/.github/workflows/push-docker-images-release.yml
+++ b/.github/workflows/push-docker-images-release.yml
@@ -31,7 +31,7 @@ jobs:
       uses: docker/bake-action@v7.3.0
       with:
         files: docker-bake.hcl
-        workdir: .
+        source: .
         targets: release
         load: true
         # Note that we can't push all tags simultaneously, since we use two


### PR DESCRIPTION
The arguments to the `docker/bake-action` changed in [version 7.0.0](https://github.com/docker/bake-action/releases/tag/v7.0.0). `workdir` has been subsumed into `source`, but we were using the default value in the first place, so everything kept working. This fixes an error flagged by my GitHub Actions syntax highlighting.