### PR TITLE
Replace git-version with a custom build script

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -41,6 +41,7 @@ jobs:
       id: os-version
       run: echo "release=$(lsb_release --release --short)" >> $GITHUB_OUTPUT
     - uses: actions/checkout@v7
+    - run: echo "GIT_REVISION=$(git describe --always --dirty=-modified)" >> $GITHUB_ENV
     - name: Setup Go toolchain
       uses: actions/setup-go@v7.0.0
     - name: Install Kind
@@ -195,6 +196,7 @@ jobs:
       DOCKER_BUILDKIT: 1
     steps:
     - uses: actions/checkout@v7
+    - run: echo "GIT_REVISION=$(git describe --always --dirty=-modified)" >> $GITHUB_ENV
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4.2.0
       with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1945,26 +1945,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "git-version"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
-dependencies = [
- "git-version-macro",
-]
-
-[[package]]
-name = "git-version-macro"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2683,7 +2663,6 @@ dependencies = [
  "chrono",
  "educe 0.7.4",
  "futures",
- "git-version",
  "http",
  "janus_aggregator_core",
  "janus_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ deadpool-postgres = "0.14.1"
 divviup-client = "0.4"
 educe = { version = "0.7.4", default-features = false, features = ["Debug", "PartialEq", "Eq"] }
 futures = "0.3.32"
-git-version = "0.3.9"
 hex = "0.4.3"
 hex-literal = "1.1.0"
 hpke-dispatch = "0.8.0"

--- a/Dockerfile.interop
+++ b/Dockerfile.interop
@@ -40,11 +40,15 @@ COPY interop_binaries /src/interop_binaries
 COPY messages /src/messages
 COPY tools /src/tools
 COPY xtask /src/xtask
+ARG GIT_REVISION=unknown
+ENV GIT_REVISION=${GIT_REVISION}
 RUN cargo build --profile $PROFILE -p janus_interop_binaries
 
 FROM alpine:3.24.1 AS final
 ARG BINARY
 ARG PROFILE
+ARG GIT_REVISION=unknown
+LABEL revision=${GIT_REVISION}
 RUN mkdir /logs
 COPY --from=builder /src/target/$PROFILE/janus_interop /janus_interop
 RUN ln -s /janus_interop /janus_interop_client && \

--- a/Dockerfile.interop_aggregator
+++ b/Dockerfile.interop_aggregator
@@ -39,6 +39,8 @@ COPY interop_binaries /src/interop_binaries
 COPY messages /src/messages
 COPY tools /src/tools
 COPY xtask /src/xtask
+ARG GIT_REVISION=unknown
+ENV GIT_REVISION=${GIT_REVISION}
 RUN cargo build --profile $PROFILE -p janus_aggregator
 
 FROM chef AS builder-interop
@@ -58,6 +60,8 @@ COPY interop_binaries /src/interop_binaries
 COPY messages /src/messages
 COPY tools /src/tools
 COPY xtask /src/xtask
+ARG GIT_REVISION=unknown
+ENV GIT_REVISION=${GIT_REVISION}
 RUN cargo build --profile $PROFILE -p janus_interop_binaries
 
 FROM rust:1.97.0-alpine AS sqlx
@@ -70,6 +74,8 @@ RUN cargo install sqlx-cli \
     --no-default-features --features postgres
 
 FROM postgres:15-alpine AS final
+ARG GIT_REVISION=unknown
+LABEL revision=${GIT_REVISION}
 RUN mkdir /logs && mkdir /etc/janus
 RUN apk add --no-cache supervisor && rm -rf /tmp/* /var/cache/apk/*
 COPY db /etc/janus/migrations

--- a/aggregator_api/Cargo.toml
+++ b/aggregator_api/Cargo.toml
@@ -15,7 +15,6 @@ axum.workspace = true
 base64.workspace = true
 chrono = { workspace = true, features = ["serde"] }
 educe.workspace = true
-git-version.workspace = true
 http.workspace = true
 janus_aggregator_core.workspace = true
 janus_core.workspace = true

--- a/aggregator_api/build.rs
+++ b/aggregator_api/build.rs
@@ -1,0 +1,107 @@
+use std::{
+    borrow::Cow,
+    env::{self, VarError},
+    error::Error,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+};
+
+/// Get the current git commit, and pass it to rustc via an environment variable.
+///
+/// This build script replaces our previous use of `git-version`, in order to conditionally reduce
+/// spurious rebuilds when internal git files change.
+///
+/// The environment variable GIT_REVISION can be used to supply a revision when git is not
+/// available, i.e. in container builds. The same environment variable name is used both for
+/// communication from build tooling to this build script and from this build script to rustc.
+fn main() {
+    // Check for an environment variable input first. This is provided by a Dockerfile or CI build
+    // script. This allows us to short-circuit running `git describe`, and lets us avoid file
+    // dependencies.
+    println!("cargo::rerun-if-env-changed=GIT_REVISION");
+    match env::var("GIT_REVISION") {
+        Ok(git_revision) => {
+            println!("cargo::rustc-env=GIT_REVISION={git_revision}");
+            return;
+        }
+        Err(VarError::NotPresent) => {}
+        Err(VarError::NotUnicode(_)) => {
+            panic!("invalid value of GIT_REVISION environment variable")
+        }
+    }
+
+    // Get the path of the current package.
+    //
+    // We don't need to print "cargo::rerun-if-env-changed=CARGO_MANIFEST_DIR" because "it is not
+    // possible to use this for environment variables like TARGET that Cargo sets for build
+    // scripts." See
+    // https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-env-changed.
+    let manifest_dir = PathBuf::from(
+        env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR must be set by Cargo"),
+    );
+
+    // Run git describe.
+    let revision = match git_describe(&manifest_dir) {
+        Ok(output) => Cow::Owned(output),
+        Err((message, error)) => {
+            println!("cargo::warning=Could not determine git revision: {message}, {error}");
+            // Use this fallback value if there is no environment variable and using git fails.
+            Cow::Borrowed("unknown")
+        }
+    };
+
+    // Set environment variable for rustc compilation.
+    println!("cargo::rustc-env=GIT_REVISION={revision}");
+}
+
+/// Run git describe and return the result.
+fn git_describe(manifest_dir: &Path) -> Result<String, (&'static str, Box<dyn Error>)> {
+    // Locate the git directory.
+    let git_dir = run_command(
+        Command::new("git")
+            .arg("-C")
+            .arg(manifest_dir)
+            .args(["rev-parse", "--git-dir"]),
+    )?;
+
+    // Print file dependencies for git describe.
+    println!("cargo::rerun-if-changed={git_dir}/index");
+    println!("cargo::rerun-if-changed={git_dir}/logs/HEAD");
+
+    run_command(Command::new("git").arg("-C").arg(manifest_dir).args([
+        "describe",
+        "--always",
+        "--dirty=-modified",
+    ]))
+}
+
+/// Runs a git command, captures the output, and returns it.
+///
+/// This uses a tuple as the error type, instead of `anyhow::Error` and `anyhow::Context`, to keep
+/// this build script dependency-light, since it is on the critical path.
+fn run_command(command: &mut Command) -> Result<String, (&'static str, Box<dyn Error>)> {
+    let output = command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| ("Failed to execute git", e.into()))?
+        .wait_with_output()
+        .map_err(|e| ("Failed to wait for git", e.into()))?;
+
+    if !output.status.success() {
+        return Err((
+            "git subcommand failed",
+            format!(
+                "status code {}: {:?}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr)
+            )
+            .into(),
+        ));
+    }
+
+    let mut output = String::from_utf8(output.stdout)
+        .map_err(|e| ("Output from git is invalid UTF-8", e.into()))?;
+    output.truncate(output.trim_end().len());
+    Ok(output)
+}

--- a/aggregator_api/src/lib.rs
+++ b/aggregator_api/src/lib.rs
@@ -13,7 +13,6 @@ use axum::{
     response::{IntoResponse, Response},
     routing::{get, post},
 };
-use git_version::git_version;
 use http::{HeaderValue, StatusCode, header::CONTENT_TYPE as CONTENT_TYPE_HEADER};
 use janus_aggregator_core::{
     datastore::{self, Datastore},
@@ -235,14 +234,8 @@ fn parse_hpke_config_id_param(config_id: &str) -> Result<HpkeConfigId, Error> {
     )?))
 }
 
-/// Returns the git revision used to build this crate, using `git describe` if available, or the
-/// environment variable `GIT_REVISION`. Returns `"unknown"` instead if neither is available.
+/// Returns the git revision used to build this crate.
 pub fn git_revision() -> &'static str {
-    let mut git_revision: &'static str = git_version!(fallback = "unknown");
-    if git_revision == "unknown" {
-        if let Some(value) = option_env!("GIT_REVISION") {
-            git_revision = value;
-        }
-    }
-    git_revision
+    // This is always set by the build script.
+    env!("GIT_REVISION")
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -230,6 +230,7 @@ target "janus_db_migrator_release" {
 target "janus_interop_client" {
   args = {
     BINARY = "janus_interop_client"
+    GIT_REVISION = "${GIT_REVISION}"
   }
   dockerfile = "Dockerfile.interop"
   cache-from = [
@@ -249,6 +250,9 @@ target "janus_interop_client_release" {
 }
 
 target "janus_interop_aggregator" {
+  args = {
+    GIT_REVISION = "${GIT_REVISION}"
+  }
   dockerfile = "Dockerfile.interop_aggregator"
   cache-from = [
     "type=gha,scope=main-interop",
@@ -270,6 +274,7 @@ target "janus_interop_aggregator_release" {
 target "janus_interop_collector" {
   args = {
     BINARY = "janus_interop_collector"
+    GIT_REVISION = "${GIT_REVISION}"
   }
   dockerfile = "Dockerfile.interop"
   cache-from = [
@@ -292,6 +297,7 @@ target "janus_interop_client_small" {
   args = {
     PROFILE = "small"
     BINARY  = "janus_interop_client"
+    GIT_REVISION = "${GIT_REVISION}"
   }
   cache-from = [
     "type=gha,scope=main-interop-small",
@@ -304,6 +310,7 @@ target "janus_interop_client_small" {
 target "janus_interop_aggregator_small" {
   args = {
     PROFILE = "small"
+    GIT_REVISION = "${GIT_REVISION}"
   }
   cache-from = [
     "type=gha,scope=main-interop-small",
@@ -318,6 +325,7 @@ target "janus_interop_collector_small" {
   args = {
     PROFILE = "small"
     BINARY  = "janus_interop_collector"
+    GIT_REVISION = "${GIT_REVISION}"
   }
   cache-from = [
     "type=gha,scope=main-interop-small",
@@ -331,6 +339,7 @@ target "janus_interop_client_ci" {
   args = {
     PROFILE = "ci"
     BINARY  = "janus_interop_client"
+    GIT_REVISION = "${GIT_REVISION}"
   }
   cache-from = [
     "type=gha,scope=main-interop-ci",
@@ -343,6 +352,7 @@ target "janus_interop_client_ci" {
 target "janus_interop_aggregator_ci" {
   args = {
     PROFILE = "ci"
+    GIT_REVISION = "${GIT_REVISION}"
   }
   cache-from = [
     "type=gha,scope=main-interop-ci",
@@ -357,6 +367,7 @@ target "janus_interop_collector_ci" {
   args = {
     PROFILE = "ci"
     BINARY  = "janus_interop_collector"
+    GIT_REVISION = "${GIT_REVISION}"
   }
   cache-from = [
     "type=gha,scope=main-interop-ci",


### PR DESCRIPTION
This replaces our use of `git-version` with a custom build script. Per m-ou-se/rust-git-version#26, spurious rebuilds can be triggered when the `.git/index` file is changed, and this seems to explain the rebuilds we've sometimes seen between running `cargo test --no-run` and `cargo test`. We can't eliminate this dependency entirely without introducing a build tool other than Cargo, but we can make it conditional. We already use the `GIT_REVISION` environment variable as a fallback source for the truncated commit hash, for use in container build environments with no git executable or .git directory. The main idea of this PR is to switch the order in which we check these, and omit the dependency on `.git/index` when the environment variable is in use. Then we can set the environment variable in non-Docker CI builds, and hopefully avoid spurious rebuilds there.

A second benefit of this PR is that it prints a warning message when it uses the fallback "unknown" value. This directed me to add the `GIT_REVISION` environment variable to our interop test container builds.