### PR TITLE
Make the integration tests use matching host:ports for all entities

### DIFF
--- a/integration_tests/src/client.rs
+++ b/integration_tests/src/client.rs
@@ -272,9 +272,9 @@ where
         (leader_port, helper_port): (u16, u16),
         vdaf: V,
     ) -> Result<ClientImplementation<V>, janus_client::Error> {
-        let (leader_aggregator_endpoint, helper_aggregator_endpoint) = task_parameters
+        let (leader_aggregator_endpoint, helper_aggregator_endpoint, http_client) = task_parameters
             .endpoint_fragments
-            .endpoints_for_host_client(leader_port, helper_port);
+            .in_process_config(leader_port, helper_port);
         let mut builder = Client::builder(
             task_parameters.task_id,
             leader_aggregator_endpoint.as_str().try_into().unwrap(),
@@ -293,6 +293,9 @@ where
         )
         .with_task_interval(task_parameters.task_interval);
 
+        if let Some(http_client) = http_client {
+            builder = builder.with_http_client(http_client);
+        }
         if let Some(ohttp_config) = &task_parameters.endpoint_fragments.ohttp_config {
             builder = builder.with_ohttp_config(ohttp_config.clone());
         }

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -42,9 +42,7 @@ use janus_interop_binaries::{
 #[cfg(feature = "testcontainer")]
 use janus_messages::Role;
 #[cfg(feature = "testcontainer")]
-use testcontainers::{
-    ContainerRequest, ImageExt, TestcontainersError, core::ContainerPort, runners::AsyncRunner,
-};
+use testcontainers::{ContainerRequest, ImageExt, runners::AsyncRunner};
 
 #[cfg(feature = "testcontainer")]
 use crate::interop_api;
@@ -92,56 +90,6 @@ impl JanusContainer {
             _container: container,
             port,
         }
-    }
-
-    /// Like [`Self::new`], but serves DAP on `port` both within the network and, via a fixed
-    /// `host:port -> container:port` mapping, from the host. The port is applied by injecting a
-    /// copy of the interop aggregator config with its `listen_address` rewritten. Returns an error
-    /// if the container fails to start, e.g. because the host port was taken between selection and
-    /// binding.
-    pub async fn new_on_port(
-        test_name: &str,
-        network: &str,
-        task: &Task,
-        role: Role,
-        port: u16,
-    ) -> Result<JanusContainer, TestcontainersError> {
-        const BASE_CONFIG: &str = include_str!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../interop_binaries/config/janus_interop_aggregator.yaml"
-        ));
-        let config = BASE_CONFIG.replace(
-            "listen_address: 0.0.0.0:8080",
-            &format!("listen_address: 0.0.0.0:{port}"),
-        );
-
-        let endpoint = match role {
-            Role::Leader => task.leader_aggregator_endpoint(),
-            Role::Helper => task.helper_aggregator_endpoint(),
-            _ => panic!("unexpected task role"),
-        };
-        let container = ContainerLogsDropGuard::new_janus(
-            test_name,
-            ContainerRequest::from(Aggregator::default())
-                .with_network(network)
-                .with_env_var("RUST_LOG", get_rust_log_level())
-                .with_container_name(endpoint.host_str().unwrap())
-                .with_copy_to(
-                    "/etc/janus/janus_interop_aggregator.yaml",
-                    config.into_bytes(),
-                )
-                .with_mapped_port(port, ContainerPort::Tcp(port))
-                .start()
-                .await?,
-        );
-
-        await_http_server(port).await;
-        interop_api::aggregator_add_task(port, task.clone(), role).await;
-
-        Ok(Self {
-            _container: container,
-            port,
-        })
     }
 
     /// Returns the port of the aggregator on the host.

--- a/integration_tests/src/janus.rs
+++ b/integration_tests/src/janus.rs
@@ -42,7 +42,9 @@ use janus_interop_binaries::{
 #[cfg(feature = "testcontainer")]
 use janus_messages::Role;
 #[cfg(feature = "testcontainer")]
-use testcontainers::{ContainerRequest, ImageExt, runners::AsyncRunner};
+use testcontainers::{
+    ContainerRequest, ImageExt, TestcontainersError, core::ContainerPort, runners::AsyncRunner,
+};
 
 #[cfg(feature = "testcontainer")]
 use crate::interop_api;
@@ -90,6 +92,56 @@ impl JanusContainer {
             _container: container,
             port,
         }
+    }
+
+    /// Like [`Self::new`], but serves DAP on `port` both within the network and, via a fixed
+    /// `host:port -> container:port` mapping, from the host. The port is applied by injecting a
+    /// copy of the interop aggregator config with its `listen_address` rewritten. Returns an error
+    /// if the container fails to start, e.g. because the host port was taken between selection and
+    /// binding.
+    pub async fn new_on_port(
+        test_name: &str,
+        network: &str,
+        task: &Task,
+        role: Role,
+        port: u16,
+    ) -> Result<JanusContainer, TestcontainersError> {
+        const BASE_CONFIG: &str = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../interop_binaries/config/janus_interop_aggregator.yaml"
+        ));
+        let config = BASE_CONFIG.replace(
+            "listen_address: 0.0.0.0:8080",
+            &format!("listen_address: 0.0.0.0:{port}"),
+        );
+
+        let endpoint = match role {
+            Role::Leader => task.leader_aggregator_endpoint(),
+            Role::Helper => task.helper_aggregator_endpoint(),
+            _ => panic!("unexpected task role"),
+        };
+        let container = ContainerLogsDropGuard::new_janus(
+            test_name,
+            ContainerRequest::from(Aggregator::default())
+                .with_network(network)
+                .with_env_var("RUST_LOG", get_rust_log_level())
+                .with_container_name(endpoint.host_str().unwrap())
+                .with_copy_to(
+                    "/etc/janus/janus_interop_aggregator.yaml",
+                    config.into_bytes(),
+                )
+                .with_mapped_port(port, ContainerPort::Tcp(port))
+                .start()
+                .await?,
+        );
+
+        await_http_server(port).await;
+        interop_api::aggregator_add_task(port, task.clone(), role).await;
+
+        Ok(Self {
+            _container: container,
+            port,
+        })
     }
 
     /// Returns the port of the aggregator on the host.

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -36,18 +36,12 @@ pub struct TaskParameters {
 /// Components of one aggregator's DAP endpoint.
 #[derive(Debug)]
 pub enum AggregatorEndpointFragments {
-    /// The aggregator is in a Kind cluster.
-    ///
-    /// It is reached from the host via a port forward on localhost (ephemeral port, supplied
-    /// later) and from within the cluster at its service name on port 8080. The scheme is always
-    /// `http`.
-    VirtualNetwork { host: String, path: String },
-    /// The aggregator is in a Docker network.
+    /// The aggregator is in a virtual network: a Docker network or a Kind cluster.
     ///
     /// It serves on port 8080 at `host`. The single `http://{host}:8080{path}` URL is
-    /// byte-identical for all parties; the host reaches it through a per-aggregator forwarding
-    /// proxy (Docker assigns the host port dynamically). The scheme is always `http`.
-    DockerNetwork { host: String, path: String },
+    /// identical for all parties; the host reaches it through a per-aggregator forwarding
+    /// proxy that bridges to an ephemeral host port, and the scheme is always `http`.
+    VirtualNetwork { host: String, path: String },
     /// The aggregator is running on localhost.
     ///
     /// No port forwarding is involved, so the same URL is used in all circumstances. The port
@@ -61,19 +55,18 @@ pub enum AggregatorEndpointFragments {
 }
 
 impl AggregatorEndpointFragments {
-    /// Provides the URL for the aggregator's endpoint from the perspective of the host. If the
-    /// aggregator is in a virtual network, this will use a port forward, with the provided port
-    /// number. If the aggregator itself is running on the host, it will use the provided port
-    /// number as well. If the aggregator is running remotely, the port number is ignored and the
-    /// URL is returned.
+    /// Provides the URL for the aggregator's endpoint from the perspective of the host. A
+    /// virtual-network aggregator uses its byte-identical `http://{host}:8080` URL (the host
+    /// reaches it through a forwarding proxy, so the port number is ignored). An aggregator running
+    /// on the host uses the provided port number. A remote aggregator ignores the port number and
+    /// returns its URL.
     pub fn endpoint_for_host(&self, port: u16) -> Url {
         match self {
-            AggregatorEndpointFragments::VirtualNetwork { path, .. }
-            | AggregatorEndpointFragments::Localhost { path } => {
-                Url::parse(&format!("http://127.0.0.1:{port}{path}")).unwrap()
-            }
-            AggregatorEndpointFragments::DockerNetwork { host, path } => {
+            AggregatorEndpointFragments::VirtualNetwork { host, path } => {
                 Url::parse(&format!("http://{host}:8080{path}")).unwrap()
+            }
+            AggregatorEndpointFragments::Localhost { path } => {
+                Url::parse(&format!("http://127.0.0.1:{port}{path}")).unwrap()
             }
             AggregatorEndpointFragments::Remote { url } => url.clone(),
         }
@@ -86,9 +79,6 @@ impl AggregatorEndpointFragments {
     pub fn endpoint_for_virtual_network(&self) -> Url {
         match self {
             AggregatorEndpointFragments::VirtualNetwork { host, path } => {
-                Url::parse(&format!("http://{host}:8080{path}")).unwrap()
-            }
-            AggregatorEndpointFragments::DockerNetwork { host, path } => {
                 Url::parse(&format!("http://{host}:8080{path}")).unwrap()
             }
             AggregatorEndpointFragments::Localhost { .. } => panic!(
@@ -107,9 +97,6 @@ impl AggregatorEndpointFragments {
             AggregatorEndpointFragments::VirtualNetwork {
                 path: self_path, ..
             }
-            | AggregatorEndpointFragments::DockerNetwork {
-                path: self_path, ..
-            }
             | AggregatorEndpointFragments::Localhost { path: self_path } => *self_path = path,
             AggregatorEndpointFragments::Remote { .. } => {
                 panic!("cannot set path for remote aggregator")
@@ -124,7 +111,7 @@ pub struct EndpointFragments {
     pub helper: AggregatorEndpointFragments,
     pub ohttp_config: Option<OhttpConfig>,
     /// HTTP client an in-process client or collector should use to reach the aggregators, when
-    /// they are not directly reachable at their endpoint URLs (e.g. Docker-network aggregators
+    /// they are not directly reachable at their endpoint URLs (e.g. virtual-network aggregators
     /// reached through a forwarding proxy). `None` means connect directly.
     pub in_process_http_client: Option<reqwest::Client>,
 }
@@ -157,30 +144,17 @@ impl EndpointFragments {
     }
 
     /// Leader and helper endpoints, and the optional HTTP client, for an in-process client or
-    /// collector on the host. For [`AggregatorEndpointFragments::DockerNetwork`] aggregators this
-    /// returns the byte-identical virtual-network endpoints; otherwise the localhost port-forward
-    /// endpoints. The client is whatever was set on [`Self::in_process_http_client`].
+    /// collector on the host. Virtual-network aggregators use their service URLs via the
+    /// proxy in [`Self::in_process_http_client`] -- localhost aggregators use the given
+    /// ephemeral ports.
     pub fn in_process_config(
         &self,
         leader_port: u16,
         helper_port: u16,
     ) -> (Url, Url, Option<reqwest::Client>) {
-        let (leader_endpoint, helper_endpoint) = match (&self.leader, &self.helper) {
-            (
-                AggregatorEndpointFragments::DockerNetwork { .. },
-                AggregatorEndpointFragments::DockerNetwork { .. },
-            ) => (
-                self.leader.endpoint_for_virtual_network(),
-                self.helper.endpoint_for_virtual_network(),
-            ),
-            _ => (
-                self.leader.endpoint_for_host(leader_port),
-                self.helper.endpoint_for_host(helper_port),
-            ),
-        };
         (
-            leader_endpoint,
-            helper_endpoint,
+            self.leader.endpoint_for_host(leader_port),
+            self.helper.endpoint_for_host(helper_port),
             self.in_process_http_client.clone(),
         )
     }

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -36,20 +36,27 @@ pub struct TaskParameters {
 /// Components of one aggregator's DAP endpoint.
 #[derive(Debug)]
 pub enum AggregatorEndpointFragments {
-    /// The aggregator is in a Kind cluster, reached from the host via a port forward on localhost
-    /// (ephemeral port, supplied later) and from within the cluster at its service name on port
-    /// 8080. The scheme is always 'http:'.
+    /// The aggregator is in a Kind cluster.
+    ///
+    /// It is reached from the host via a port forward on localhost (ephemeral port, supplied
+    /// later) and from within the cluster at its service name on port 8080. The scheme is always
+    /// `http`.
     VirtualNetwork { host: String, path: String },
-    /// The aggregator is in a Docker network, serving on port 8080 at `host`. The single
-    /// `http://{host}:8080{path}` URL is byte-identical for all parties; the host reaches it
-    /// through a per-aggregator forwarding proxy (Docker assigns the host port dynamically).
+    /// The aggregator is in a Docker network.
+    ///
+    /// It serves on port 8080 at `host`. The single `http://{host}:8080{path}` URL is
+    /// byte-identical for all parties; the host reaches it through a per-aggregator forwarding
+    /// proxy (Docker assigns the host port dynamically). The scheme is always `http`.
     DockerNetwork { host: String, path: String },
-    /// The aggregator is running on localhost. No port forwarding is involved, so the same URL is
-    /// used in all circumstances. The port number will be supplied later. The scheme is assumed to
-    /// always be 'http:'.
+    /// The aggregator is running on localhost.
+    ///
+    /// No port forwarding is involved, so the same URL is used in all circumstances. The port
+    /// number is supplied later, and the scheme is always `http`.
     Localhost { path: String },
-    /// The aggregator is running remotely, accessible at some URL. No port forwarding is involved,
-    /// and the remote port and scheme are set by the URL.
+    /// The aggregator is running remotely.
+    ///
+    /// It is accessible at some URL. No port forwarding is involved, and the remote port and
+    /// scheme are set by the URL.
     Remote { url: Url },
 }
 

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -1,6 +1,9 @@
 //! This crate contains functionality useful for Janus integration tests.
 
-use std::time;
+use std::{
+    net::{Ipv4Addr, SocketAddr},
+    time,
+};
 
 use janus_aggregator_core::task::BatchMode;
 use janus_client::OhttpConfig;
@@ -36,12 +39,19 @@ pub struct TaskParameters {
 /// Components of one aggregator's DAP endpoint.
 #[derive(Debug)]
 pub enum AggregatorEndpointFragments {
-    /// The aggregator is in a virtual network, (a Docker network or a Kind cluster) so different
-    /// URLs must be used depending on whether it is accessed from within the same virtual network
-    /// or via a port forward on localhost. It is assumed that the port will always be 8080 within
-    /// the virtual network. The port number of forwarded ports will be supplied later. The scheme
-    /// is assumed to always be 'http:'.
+    /// The aggregator is in a Kind cluster, reached from the host via a port forward on localhost
+    /// (ephemeral port, supplied later) and from within the cluster at its service name on port
+    /// 8080. The scheme is always 'http:'.
     VirtualNetwork { host: String, path: String },
+    /// The aggregator is in a Docker network, serving on `port` both within the network (at `host`)
+    /// and from the host (via a fixed `host:port -> container:port` mapping). The single
+    /// `http://{host}:{port}{path}` URL is byte-identical for all parties; the host reaches it by
+    /// resolving `host` to loopback. The scheme is always 'http:'.
+    DockerNetwork {
+        host: String,
+        port: u16,
+        path: String,
+    },
     /// The aggregator is running on localhost. No port forwarding is involved, so the same URL is
     /// used in all circumstances. The port number will be supplied later. The scheme is assumed to
     /// always be 'http:'.
@@ -63,6 +73,9 @@ impl AggregatorEndpointFragments {
             | AggregatorEndpointFragments::Localhost { path } => {
                 Url::parse(&format!("http://127.0.0.1:{port}{path}")).unwrap()
             }
+            AggregatorEndpointFragments::DockerNetwork { host, port, path } => {
+                Url::parse(&format!("http://{host}:{port}{path}")).unwrap()
+            }
             AggregatorEndpointFragments::Remote { url } => url.clone(),
         }
     }
@@ -75,6 +88,9 @@ impl AggregatorEndpointFragments {
         match self {
             AggregatorEndpointFragments::VirtualNetwork { host, path } => {
                 Url::parse(&format!("http://{host}:8080{path}")).unwrap()
+            }
+            AggregatorEndpointFragments::DockerNetwork { host, port, path } => {
+                Url::parse(&format!("http://{host}:{port}{path}")).unwrap()
             }
             AggregatorEndpointFragments::Localhost { .. } => panic!(
                 "cannot combine an aggregator running on localhost with a client or leader running \
@@ -92,10 +108,23 @@ impl AggregatorEndpointFragments {
             AggregatorEndpointFragments::VirtualNetwork {
                 path: self_path, ..
             }
+            | AggregatorEndpointFragments::DockerNetwork {
+                path: self_path, ..
+            }
             | AggregatorEndpointFragments::Localhost { path: self_path } => *self_path = path,
             AggregatorEndpointFragments::Remote { .. } => {
                 panic!("cannot set path for remote aggregator")
             }
+        }
+    }
+
+    /// Set the serving port. Only valid for [`AggregatorEndpointFragments::DockerNetwork`].
+    pub fn set_port(&mut self, port: u16) {
+        match self {
+            AggregatorEndpointFragments::DockerNetwork {
+                port: self_port, ..
+            } => *self_port = port,
+            _ => panic!("only DockerNetwork endpoints have a settable port"),
         }
     }
 }
@@ -132,5 +161,52 @@ impl EndpointFragments {
             self.leader.endpoint_for_virtual_network(),
             self.helper.endpoint_for_virtual_network(),
         )
+    }
+
+    /// Leader and helper endpoints, and an optional HTTP client, for an in-process client or
+    /// collector on the host. For [`AggregatorEndpointFragments::DockerNetwork`] aggregators this
+    /// returns the byte-identical virtual-network endpoints plus a client that resolves their
+    /// hostnames to loopback; otherwise the localhost port-forward endpoints and no client.
+    pub fn in_process_config(
+        &self,
+        leader_port: u16,
+        helper_port: u16,
+    ) -> (Url, Url, Option<reqwest::Client>) {
+        match (&self.leader, &self.helper) {
+            (
+                AggregatorEndpointFragments::DockerNetwork {
+                    host: leader_host,
+                    port: leader_serving_port,
+                    ..
+                },
+                AggregatorEndpointFragments::DockerNetwork {
+                    host: helper_host,
+                    port: helper_serving_port,
+                    ..
+                },
+            ) => {
+                let http_client = reqwest::Client::builder()
+                    .resolve(
+                        leader_host,
+                        SocketAddr::from((Ipv4Addr::LOCALHOST, *leader_serving_port)),
+                    )
+                    .resolve(
+                        helper_host,
+                        SocketAddr::from((Ipv4Addr::LOCALHOST, *helper_serving_port)),
+                    )
+                    .build()
+                    .unwrap();
+                (
+                    self.leader.endpoint_for_virtual_network(),
+                    self.helper.endpoint_for_virtual_network(),
+                    Some(http_client),
+                )
+            }
+            _ => (
+                self.leader.endpoint_for_host(leader_port),
+                self.helper.endpoint_for_host(helper_port),
+                None,
+            ),
+        }
     }
 }

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -1,9 +1,6 @@
 //! This crate contains functionality useful for Janus integration tests.
 
-use std::{
-    net::{Ipv4Addr, SocketAddr},
-    time,
-};
+use std::time;
 
 use janus_aggregator_core::task::BatchMode;
 use janus_client::OhttpConfig;
@@ -43,15 +40,10 @@ pub enum AggregatorEndpointFragments {
     /// (ephemeral port, supplied later) and from within the cluster at its service name on port
     /// 8080. The scheme is always 'http:'.
     VirtualNetwork { host: String, path: String },
-    /// The aggregator is in a Docker network, serving on `port` both within the network (at `host`)
-    /// and from the host (via a fixed `host:port -> container:port` mapping). The single
-    /// `http://{host}:{port}{path}` URL is byte-identical for all parties; the host reaches it by
-    /// resolving `host` to loopback. The scheme is always 'http:'.
-    DockerNetwork {
-        host: String,
-        port: u16,
-        path: String,
-    },
+    /// The aggregator is in a Docker network, serving on port 8080 at `host`. The single
+    /// `http://{host}:8080{path}` URL is byte-identical for all parties; the host reaches it
+    /// through a per-aggregator forwarding proxy (Docker assigns the host port dynamically).
+    DockerNetwork { host: String, path: String },
     /// The aggregator is running on localhost. No port forwarding is involved, so the same URL is
     /// used in all circumstances. The port number will be supplied later. The scheme is assumed to
     /// always be 'http:'.
@@ -73,8 +65,8 @@ impl AggregatorEndpointFragments {
             | AggregatorEndpointFragments::Localhost { path } => {
                 Url::parse(&format!("http://127.0.0.1:{port}{path}")).unwrap()
             }
-            AggregatorEndpointFragments::DockerNetwork { host, port, path } => {
-                Url::parse(&format!("http://{host}:{port}{path}")).unwrap()
+            AggregatorEndpointFragments::DockerNetwork { host, path } => {
+                Url::parse(&format!("http://{host}:8080{path}")).unwrap()
             }
             AggregatorEndpointFragments::Remote { url } => url.clone(),
         }
@@ -89,8 +81,8 @@ impl AggregatorEndpointFragments {
             AggregatorEndpointFragments::VirtualNetwork { host, path } => {
                 Url::parse(&format!("http://{host}:8080{path}")).unwrap()
             }
-            AggregatorEndpointFragments::DockerNetwork { host, port, path } => {
-                Url::parse(&format!("http://{host}:{port}{path}")).unwrap()
+            AggregatorEndpointFragments::DockerNetwork { host, path } => {
+                Url::parse(&format!("http://{host}:8080{path}")).unwrap()
             }
             AggregatorEndpointFragments::Localhost { .. } => panic!(
                 "cannot combine an aggregator running on localhost with a client or leader running \
@@ -117,16 +109,6 @@ impl AggregatorEndpointFragments {
             }
         }
     }
-
-    /// Set the serving port. Only valid for [`AggregatorEndpointFragments::DockerNetwork`].
-    pub fn set_port(&mut self, port: u16) {
-        match self {
-            AggregatorEndpointFragments::DockerNetwork {
-                port: self_port, ..
-            } => *self_port = port,
-            _ => panic!("only DockerNetwork endpoints have a settable port"),
-        }
-    }
 }
 
 /// Components of DAP endpoints for a leader and helper aggregator.
@@ -134,6 +116,10 @@ pub struct EndpointFragments {
     pub leader: AggregatorEndpointFragments,
     pub helper: AggregatorEndpointFragments,
     pub ohttp_config: Option<OhttpConfig>,
+    /// HTTP client an in-process client or collector should use to reach the aggregators, when
+    /// they are not directly reachable at their endpoint URLs (e.g. Docker-network aggregators
+    /// reached through a forwarding proxy). `None` means connect directly.
+    pub in_process_http_client: Option<reqwest::Client>,
 }
 
 impl EndpointFragments {
@@ -163,50 +149,32 @@ impl EndpointFragments {
         )
     }
 
-    /// Leader and helper endpoints, and an optional HTTP client, for an in-process client or
+    /// Leader and helper endpoints, and the optional HTTP client, for an in-process client or
     /// collector on the host. For [`AggregatorEndpointFragments::DockerNetwork`] aggregators this
-    /// returns the byte-identical virtual-network endpoints plus a client that resolves their
-    /// hostnames to loopback; otherwise the localhost port-forward endpoints and no client.
+    /// returns the byte-identical virtual-network endpoints; otherwise the localhost port-forward
+    /// endpoints. The client is whatever was set on [`Self::in_process_http_client`].
     pub fn in_process_config(
         &self,
         leader_port: u16,
         helper_port: u16,
     ) -> (Url, Url, Option<reqwest::Client>) {
-        match (&self.leader, &self.helper) {
+        let (leader_endpoint, helper_endpoint) = match (&self.leader, &self.helper) {
             (
-                AggregatorEndpointFragments::DockerNetwork {
-                    host: leader_host,
-                    port: leader_serving_port,
-                    ..
-                },
-                AggregatorEndpointFragments::DockerNetwork {
-                    host: helper_host,
-                    port: helper_serving_port,
-                    ..
-                },
-            ) => {
-                let http_client = reqwest::Client::builder()
-                    .resolve(
-                        leader_host,
-                        SocketAddr::from((Ipv4Addr::LOCALHOST, *leader_serving_port)),
-                    )
-                    .resolve(
-                        helper_host,
-                        SocketAddr::from((Ipv4Addr::LOCALHOST, *helper_serving_port)),
-                    )
-                    .build()
-                    .unwrap();
-                (
-                    self.leader.endpoint_for_virtual_network(),
-                    self.helper.endpoint_for_virtual_network(),
-                    Some(http_client),
-                )
-            }
+                AggregatorEndpointFragments::DockerNetwork { .. },
+                AggregatorEndpointFragments::DockerNetwork { .. },
+            ) => (
+                self.leader.endpoint_for_virtual_network(),
+                self.helper.endpoint_for_virtual_network(),
+            ),
             _ => (
                 self.leader.endpoint_for_host(leader_port),
                 self.helper.endpoint_for_host(helper_port),
-                None,
             ),
-        }
+        };
+        (
+            leader_endpoint,
+            helper_endpoint,
+            self.in_process_http_client.clone(),
+        )
     }
 }

--- a/integration_tests/tests/integration/common.rs
+++ b/integration_tests/tests/integration/common.rs
@@ -29,9 +29,13 @@ use url::Url;
 /// Different contexts or test harnesses that integration tests may be run against, which require
 /// different configuration customizations.
 pub enum TestContext {
-    /// Aggregators are running in a virtual network, like a Docker network or a Kind cluster.
+    /// Aggregators are running in a Kind cluster, reached from the host via port forwards.
     #[allow(dead_code)]
     VirtualNetwork,
+    /// Aggregators are running in a Docker network, each on a distinct port reachable identically
+    /// from within the network and from the host.
+    #[allow(dead_code)]
+    DockerNetwork,
     /// Aggregators are running natively on the same host as the test driver.
     Host,
     /// Aggregators are running remotely, say in a staging environment.
@@ -60,6 +64,29 @@ pub fn build_test_task(
                     },
                     helper: AggregatorEndpointFragments::VirtualNetwork {
                         host: format!("helper-{endpoint_random_value}"),
+                        path: "/".to_string(),
+                    },
+                    ohttp_config: None,
+                },
+            )
+        }
+        // The port is a placeholder until the container pair assigns each aggregator a free port.
+        TestContext::DockerNetwork => {
+            let endpoint_random_value = hex::encode(random::<[u8; 4]>());
+            let leader_host = format!("leader-{endpoint_random_value}");
+            let helper_host = format!("helper-{endpoint_random_value}");
+            (
+                Url::parse(&format!("http://{leader_host}:8080/")).unwrap(),
+                Url::parse(&format!("http://{helper_host}:8080/")).unwrap(),
+                EndpointFragments {
+                    leader: AggregatorEndpointFragments::DockerNetwork {
+                        host: leader_host,
+                        port: 8080,
+                        path: "/".to_string(),
+                    },
+                    helper: AggregatorEndpointFragments::DockerNetwork {
+                        host: helper_host,
+                        port: 8080,
                         path: "/".to_string(),
                     },
                     ohttp_config: None,
@@ -251,10 +278,10 @@ where
     V: vdaf::Client<16> + vdaf::Collector + InteropClientEncoding,
     V::AggregateResult: PartialEq,
 {
-    let (leader_endpoint, helper_endpoint) = task_parameters
+    let (leader_endpoint, helper_endpoint, http_client) = task_parameters
         .endpoint_fragments
-        .endpoints_for_host_client(leader_port, helper_port);
-    let collector = Collector::builder(
+        .in_process_config(leader_port, helper_port);
+    let mut builder = Collector::builder(
         task_parameters.task_id,
         leader_endpoint.as_str().try_into().unwrap(),
         task_parameters.collector_auth_token.clone(),
@@ -264,10 +291,10 @@ where
     )
     .with_helper_endpoint(helper_endpoint.as_str().try_into().unwrap())
     .with_task_info(task_parameters.task_info.clone())
-    .with_task_interval(task_parameters.task_interval)
     .with_min_batch_size(task_parameters.min_batch_size)
     .with_batch_config(task_parameters.batch_mode.to_batch_config())
     .with_vdaf_config(task_parameters.vdaf.to_vdaf_config().unwrap())
+    .with_task_interval(task_parameters.task_interval)
     .with_http_request_backoff(test_http_request_exponential_backoff())
     .with_collect_poll_backoff(
         ExponentialWithTotalDelayBuilder::new()
@@ -275,9 +302,11 @@ where
             .with_max_delay(task_parameters.collector_max_interval)
             .without_max_times()
             .with_total_delay(Some(task_parameters.collector_max_elapsed_time)),
-    )
-    .build()
-    .unwrap();
+    );
+    if let Some(http_client) = http_client {
+        builder = builder.with_http_client(http_client);
+    }
+    let collector = builder.build().unwrap();
 
     // Send a collect request and verify that we got the correct result.
     let (report_count, aggregate_result) = match &task_parameters.batch_mode {

--- a/integration_tests/tests/integration/common.rs
+++ b/integration_tests/tests/integration/common.rs
@@ -67,10 +67,10 @@ pub fn build_test_task(
                         path: "/".to_string(),
                     },
                     ohttp_config: None,
+                    in_process_http_client: None,
                 },
             )
         }
-        // The port is a placeholder until the container pair assigns each aggregator a free port.
         TestContext::DockerNetwork => {
             let endpoint_random_value = hex::encode(random::<[u8; 4]>());
             let leader_host = format!("leader-{endpoint_random_value}");
@@ -81,15 +81,14 @@ pub fn build_test_task(
                 EndpointFragments {
                     leader: AggregatorEndpointFragments::DockerNetwork {
                         host: leader_host,
-                        port: 8080,
                         path: "/".to_string(),
                     },
                     helper: AggregatorEndpointFragments::DockerNetwork {
                         host: helper_host,
-                        port: 8080,
                         path: "/".to_string(),
                     },
                     ohttp_config: None,
+                    in_process_http_client: None,
                 },
             )
         }
@@ -104,6 +103,7 @@ pub fn build_test_task(
                     path: "/".to_string(),
                 },
                 ohttp_config: None,
+                in_process_http_client: None,
             },
         ),
         #[cfg(feature = "in-cluster")]
@@ -118,6 +118,7 @@ pub fn build_test_task(
                     url: task_builder.helper_aggregator_endpoint().clone(),
                 },
                 ohttp_config: None,
+                in_process_http_client: None,
             },
         ),
     };

--- a/integration_tests/tests/integration/common.rs
+++ b/integration_tests/tests/integration/common.rs
@@ -88,6 +88,7 @@ pub fn build_test_task(
                         path: "/".to_string(),
                     },
                     ohttp_config: None,
+                    // Filled in with `Some` later, once the containers' host ports are known.
                     in_process_http_client: None,
                 },
             )

--- a/integration_tests/tests/integration/common.rs
+++ b/integration_tests/tests/integration/common.rs
@@ -29,13 +29,11 @@ use url::Url;
 /// Different contexts or test harnesses that integration tests may be run against, which require
 /// different configuration customizations.
 pub enum TestContext {
-    /// Aggregators are running in a Kind cluster, reached from the host via port forwards.
+    /// Aggregators are running in a virtual network: a Docker network or a Kind cluster. Each
+    /// serves on port 8080, reachable at the same URL from within the network and from the host
+    /// (the host reaches it through a forwarding proxy).
     #[allow(dead_code)]
     VirtualNetwork,
-    /// Aggregators are running in a Docker network, each on a distinct port reachable identically
-    /// from within the network and from the host.
-    #[allow(dead_code)]
-    DockerNetwork,
     /// Aggregators are running natively on the same host as the test driver.
     Host,
     /// Aggregators are running remotely, say in a staging environment.
@@ -67,28 +65,8 @@ pub fn build_test_task(
                         path: "/".to_string(),
                     },
                     ohttp_config: None,
-                    in_process_http_client: None,
-                },
-            )
-        }
-        TestContext::DockerNetwork => {
-            let endpoint_random_value = hex::encode(random::<[u8; 4]>());
-            let leader_host = format!("leader-{endpoint_random_value}");
-            let helper_host = format!("helper-{endpoint_random_value}");
-            (
-                Url::parse(&format!("http://{leader_host}:8080/")).unwrap(),
-                Url::parse(&format!("http://{helper_host}:8080/")).unwrap(),
-                EndpointFragments {
-                    leader: AggregatorEndpointFragments::DockerNetwork {
-                        host: leader_host,
-                        path: "/".to_string(),
-                    },
-                    helper: AggregatorEndpointFragments::DockerNetwork {
-                        host: helper_host,
-                        path: "/".to_string(),
-                    },
-                    ohttp_config: None,
-                    // Filled in with `Some` later, once the containers' host ports are known.
+                    // Filled in with `Some` later, once the aggregators' host ports are known
+                    // (e.g. by `JanusContainerPair::new`).
                     in_process_http_client: None,
                 },
             )

--- a/integration_tests/tests/integration/janus.rs
+++ b/integration_tests/tests/integration/janus.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "testcontainer")]
-use std::net::{Ipv4Addr, Ipv6Addr};
 use std::{iter, time::Duration};
 
 use janus_aggregator_core::task::{AggregationMode, BatchMode, test_util::TaskBuilder};
@@ -21,11 +19,6 @@ use prio::{
     field::{Field128, FieldElementWithInteger},
     vdaf::prio3::Prio3,
 };
-#[cfg(feature = "testcontainer")]
-use tokio::{
-    io::copy_bidirectional,
-    net::{TcpListener, TcpStream},
-};
 
 use crate::{
     common::{
@@ -46,11 +39,6 @@ struct JanusContainerPair {
     leader: JanusContainer,
     /// Handle to the helper's resources, which are released on drop.
     helper: JanusContainer,
-
-    /// Proxies giving the host-side client and collector a stable address for each container's
-    /// Docker-assigned host port. Released on drop.
-    _leader_proxy: SpliceProxy,
-    _helper_proxy: SpliceProxy,
 }
 
 #[cfg(feature = "testcontainer")]
@@ -77,10 +65,9 @@ impl JanusContainerPair {
         let leader = JanusContainer::new(test_name, &network, &task, Role::Leader).await;
         let helper = JanusContainer::new(test_name, &network, &task, Role::Helper).await;
 
-        // Forward each aggregator's virtual-network hostname to its Docker-assigned host port, and
-        // route the client/collector's requests to those proxies.
-        let leader_proxy = SpliceProxy::spawn(leader.port()).await;
-        let helper_proxy = SpliceProxy::spawn(helper.port()).await;
+        // The host reaches each aggregator by pointing reqwest's per-request proxy at the
+        // container's Docker-assigned host port; the aggregator serves the absolute-form request
+        // reqwest sends through a proxy, so no forwarding process of our own is needed.
         let leader_host = task
             .leader_aggregator_endpoint()
             .host_str()
@@ -91,12 +78,13 @@ impl JanusContainerPair {
             .host_str()
             .unwrap()
             .to_string();
-        let (leader_proxy_url, helper_proxy_url) = (leader_proxy.url(), helper_proxy.url());
+        let leader_proxy = format!("http://127.0.0.1:{}", leader.port());
+        let helper_proxy = format!("http://127.0.0.1:{}", helper.port());
         task_parameters.endpoint_fragments.in_process_http_client = Some(
             reqwest::Client::builder()
                 .proxy(reqwest::Proxy::custom(move |url| match url.host_str() {
-                    Some(host) if host == leader_host => Some(leader_proxy_url.clone()),
-                    Some(host) if host == helper_host => Some(helper_proxy_url.clone()),
+                    Some(host) if host == leader_host => Some(leader_proxy.clone()),
+                    Some(host) if host == helper_host => Some(helper_proxy.clone()),
                     _ => None,
                 }))
                 .build()
@@ -107,54 +95,7 @@ impl JanusContainerPair {
             task_parameters,
             leader,
             helper,
-            _leader_proxy: leader_proxy,
-            _helper_proxy: helper_proxy,
         }
-    }
-}
-
-/// A loopback TCP proxy that forwards every connection to a fixed upstream port byte-for-byte,
-/// giving a host client a stable address for a container whose host port Docker assigns
-/// dynamically. Aborts its accept loop on drop.
-#[cfg(feature = "testcontainer")]
-struct SpliceProxy {
-    port: u16,
-    task: tokio::task::JoinHandle<()>,
-}
-
-#[cfg(feature = "testcontainer")]
-impl SpliceProxy {
-    async fn spawn(upstream_port: u16) -> Self {
-        let listener = TcpListener::bind((Ipv6Addr::LOCALHOST, 0)).await.unwrap();
-        let port = listener.local_addr().unwrap().port();
-        let task = tokio::spawn(async move {
-            while let Ok((mut inbound, _)) = listener.accept().await {
-                tokio::spawn(async move {
-                    // Docker publishes the container's port over IPv4, so dial the upstream there.
-                    match TcpStream::connect((Ipv4Addr::LOCALHOST, upstream_port)).await {
-                        Ok(mut upstream) => {
-                            let _ = copy_bidirectional(&mut inbound, &mut upstream).await;
-                        }
-                        Err(error) => {
-                            tracing::warn!(?error, "splice proxy failed to reach upstream")
-                        }
-                    }
-                });
-            }
-        });
-        Self { port, task }
-    }
-
-    /// The proxy URL to hand to `reqwest::Proxy`.
-    fn url(&self) -> String {
-        format!("http://[::1]:{}", self.port)
-    }
-}
-
-#[cfg(feature = "testcontainer")]
-impl Drop for SpliceProxy {
-    fn drop(&mut self) {
-        self.task.abort();
     }
 }
 

--- a/integration_tests/tests/integration/janus.rs
+++ b/integration_tests/tests/integration/janus.rs
@@ -45,8 +45,8 @@ struct JanusContainerPair {
 impl JanusContainerPair {
     /// Set up a new pair of containerized Janus test instances, and set up a new task in each using
     /// the given VDAF and batch mode. Each aggregator serves on port 8080; the host-side in-process
-    /// client and collector reach them through per-aggregator forwarding proxies, so all parties
-    /// use the same endpoint strings.
+    /// client and collector reach them by using the Docker port forwards as HTTP  proxies, so all
+    /// parties use the same endpoint strings.
     pub async fn new(
         test_name: &str,
         batch_mode: BatchMode,
@@ -66,8 +66,7 @@ impl JanusContainerPair {
         let helper = JanusContainer::new(test_name, &network, &task, Role::Helper).await;
 
         // The host reaches each aggregator by pointing reqwest's per-request proxy at the
-        // container's Docker-assigned host port; the aggregator serves the absolute-form request
-        // reqwest sends through a proxy, so no forwarding process of our own is needed.
+        // container's Docker-assigned host port.
         let leader_host = task
             .leader_aggregator_endpoint()
             .host_str()

--- a/integration_tests/tests/integration/janus.rs
+++ b/integration_tests/tests/integration/janus.rs
@@ -85,7 +85,12 @@ impl JanusContainerPair {
                 .proxy(reqwest::Proxy::custom(move |url| match url.host_str() {
                     Some(host) if host == leader_host => Some(leader_proxy.clone()),
                     Some(host) if host == helper_host => Some(helper_proxy.clone()),
-                    _ => None,
+                    // This client only ever talks to the leader and helper, so any other host is a
+                    // misconfiguration we want to catch noisily.
+                    other => panic!(
+                        "in-process HTTP client reached unexpected host {other:?}; only the \
+                         leader ({leader_host}) and helper ({helper_host}) are proxied"
+                    ),
                 }))
                 .build()
                 .unwrap(),

--- a/integration_tests/tests/integration/janus.rs
+++ b/integration_tests/tests/integration/janus.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "testcontainer")]
+use std::net::{Ipv4Addr, TcpListener};
 use std::{iter, time::Duration};
 
 use janus_aggregator_core::task::{AggregationMode, BatchMode, test_util::TaskBuilder};
@@ -19,6 +21,8 @@ use prio::{
     field::{Field128, FieldElementWithInteger},
     vdaf::prio3::Prio3,
 };
+#[cfg(feature = "testcontainer")]
+use testcontainers::TestcontainersError;
 
 use crate::{
     common::{
@@ -44,31 +48,94 @@ struct JanusContainerPair {
 #[cfg(feature = "testcontainer")]
 impl JanusContainerPair {
     /// Set up a new pair of containerized Janus test instances, and set up a new task in each using
-    /// the given VDAF and batch mode.
+    /// the given VDAF and batch mode. Each aggregator serves on a distinct port, so the host-side
+    /// in-process client and collector reach them at the same virtual-network endpoint strings the
+    /// aggregators use among themselves.
     pub async fn new(
         test_name: &str,
         batch_mode: BatchMode,
         aggregation_mode: AggregationMode,
         vdaf: VdafInstance,
     ) -> JanusContainerPair {
-        let (task_parameters, task_builder) = build_test_task(
+        // Each aggregator publishes a host port chosen just before its container starts, so that
+        // port is occasionally taken in the interim (under parallel tests). Retry the whole pair
+        // with fresh ports on such a failure.
+        const MAX_ATTEMPTS: usize = 5;
+        for attempt in 1..=MAX_ATTEMPTS {
+            match Self::try_new(test_name, batch_mode, aggregation_mode, vdaf.clone()).await {
+                Ok(pair) => return pair,
+                Err(error) if attempt < MAX_ATTEMPTS => {
+                    tracing::warn!(?error, attempt, "containerized Janus pair failed to start")
+                }
+                Err(error) => panic!("containerized Janus pair failed to start: {error}"),
+            }
+        }
+        unreachable!()
+    }
+
+    async fn try_new(
+        test_name: &str,
+        batch_mode: BatchMode,
+        aggregation_mode: AggregationMode,
+        vdaf: VdafInstance,
+    ) -> Result<JanusContainerPair, TestcontainersError> {
+        let (mut task_parameters, task_builder) = build_test_task(
             TaskBuilder::new(batch_mode, aggregation_mode, vdaf),
-            TestContext::VirtualNetwork,
+            TestContext::DockerNetwork,
             Duration::from_millis(500),
             Duration::from_secs(60),
         );
-        let task = task_builder.build();
+
+        let leader_port = reserve_ephemeral_port();
+        let helper_port = reserve_ephemeral_port();
+        task_parameters
+            .endpoint_fragments
+            .leader
+            .set_port(leader_port);
+        task_parameters
+            .endpoint_fragments
+            .helper
+            .set_port(helper_port);
+
+        let task = task_builder
+            .with_leader_aggregator_endpoint(
+                task_parameters
+                    .endpoint_fragments
+                    .leader
+                    .endpoint_for_virtual_network(),
+            )
+            .with_helper_aggregator_endpoint(
+                task_parameters
+                    .endpoint_fragments
+                    .helper
+                    .endpoint_for_virtual_network(),
+            )
+            .build();
 
         let network = generate_network_name();
-        let leader = JanusContainer::new(test_name, &network, &task, Role::Leader).await;
-        let helper = JanusContainer::new(test_name, &network, &task, Role::Helper).await;
+        let leader =
+            JanusContainer::new_on_port(test_name, &network, &task, Role::Leader, leader_port)
+                .await?;
+        let helper =
+            JanusContainer::new_on_port(test_name, &network, &task, Role::Helper, helper_port)
+                .await?;
 
-        Self {
+        Ok(Self {
             task_parameters,
             leader,
             helper,
-        }
+        })
     }
+}
+
+/// Reserve a free ephemeral TCP port on loopback for a container to publish.
+#[cfg(feature = "testcontainer")]
+fn reserve_ephemeral_port() -> u16 {
+    TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
 }
 
 /// A pair of Janus instances, running in-process, against which integration tests may be run.
@@ -176,8 +243,6 @@ async fn run_in_process_test(
 /// aggregation.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "testcontainer")]
-#[ignore = "host client/collector can't build byte-identical AADs against container aggregators; \
-            re-enabled by the follow-up PR that containerizes the client + collector"]
 async fn janus_janus_sync_count() {
     run_container_test(
         "janus_janus_sync_count",
@@ -192,8 +257,6 @@ async fn janus_janus_sync_count() {
 /// aggregation.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "testcontainer")]
-#[ignore = "host client/collector can't build byte-identical AADs against container aggregators; \
-            re-enabled by the follow-up PR that containerizes the client + collector"]
 async fn janus_janus_async_count() {
     // TODO(#3436): allow callers to specify asynchronous aggregation mode (requires updated
     // interop test design)
@@ -236,8 +299,6 @@ async fn janus_in_process_async_count() {
 /// aggregation.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "testcontainer")]
-#[ignore = "host client/collector can't build byte-identical AADs against container aggregators; \
-            re-enabled by the follow-up PR that containerizes the client + collector"]
 async fn janus_janus_sync_sum_16() {
     run_container_test(
         "janus_janus_sync_sum_16",
@@ -254,8 +315,6 @@ async fn janus_janus_sync_sum_16() {
 /// aggregation.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "testcontainer")]
-#[ignore = "host client/collector can't build byte-identical AADs against container aggregators; \
-            re-enabled by the follow-up PR that containerizes the client + collector"]
 async fn janus_janus_async_sum_16() {
     run_container_test(
         "janus_janus_async_sum_16",
@@ -302,8 +361,6 @@ async fn janus_in_process_async_sum_16() {
 /// synchronous aggregation.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "testcontainer")]
-#[ignore = "host client/collector can't build byte-identical AADs against container aggregators; \
-            re-enabled by the follow-up PR that containerizes the client + collector"]
 async fn janus_janus_sync_histogram_4_buckets() {
     run_container_test(
         "janus_janus_sync_histogram_4_buckets",
@@ -322,8 +379,6 @@ async fn janus_janus_sync_histogram_4_buckets() {
 /// asynchronous aggregation.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "testcontainer")]
-#[ignore = "host client/collector can't build byte-identical AADs against container aggregators; \
-            re-enabled by the follow-up PR that containerizes the client + collector"]
 async fn janus_janus_async_histogram_4_buckets() {
     run_container_test(
         "janus_janus_async_histogram_4_buckets",
@@ -376,8 +431,6 @@ async fn janus_in_process_async_histogram_4_buckets() {
 /// using synchronous aggregation.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "testcontainer")]
-#[ignore = "host client/collector can't build byte-identical AADs against container aggregators; \
-            re-enabled by the follow-up PR that containerizes the client + collector"]
 async fn janus_janus_leader_selected_sync() {
     run_container_test(
         "janus_janus_leader_selected_sync",
@@ -394,8 +447,6 @@ async fn janus_janus_leader_selected_sync() {
 /// using asynchronous aggregation.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "testcontainer")]
-#[ignore = "host client/collector can't build byte-identical AADs against container aggregators; \
-            re-enabled by the follow-up PR that containerizes the client + collector"]
 async fn janus_janus_leader_selected_async() {
     run_container_test(
         "janus_janus_leader_selected_async",
@@ -442,8 +493,6 @@ async fn janus_in_process_leader_selected_async() {
 /// aggregation.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "testcontainer")]
-#[ignore = "host client/collector can't build byte-identical AADs against container aggregators; \
-            re-enabled by the follow-up PR that containerizes the client + collector"]
 async fn janus_janus_sync_sum_vec() {
     run_container_test(
         "janus_janus_sync_sum_vec",
@@ -463,8 +512,6 @@ async fn janus_janus_sync_sum_vec() {
 /// aggregation.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "testcontainer")]
-#[ignore = "host client/collector can't build byte-identical AADs against container aggregators; \
-            re-enabled by the follow-up PR that containerizes the client + collector"]
 async fn janus_janus_async_sum_vec() {
     run_container_test(
         "janus_janus_async_sum_vec",

--- a/integration_tests/tests/integration/janus.rs
+++ b/integration_tests/tests/integration/janus.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "testcontainer")]
-use std::net::{Ipv4Addr, TcpListener};
+use std::net::{Ipv4Addr, Ipv6Addr};
 use std::{iter, time::Duration};
 
 use janus_aggregator_core::task::{AggregationMode, BatchMode, test_util::TaskBuilder};
@@ -22,7 +22,10 @@ use prio::{
     vdaf::prio3::Prio3,
 };
 #[cfg(feature = "testcontainer")]
-use testcontainers::TestcontainersError;
+use tokio::{
+    io::copy_bidirectional,
+    net::{TcpListener, TcpStream},
+};
 
 use crate::{
     common::{
@@ -43,99 +46,116 @@ struct JanusContainerPair {
     leader: JanusContainer,
     /// Handle to the helper's resources, which are released on drop.
     helper: JanusContainer,
+
+    /// Proxies giving the host-side client and collector a stable address for each container's
+    /// Docker-assigned host port. Released on drop.
+    _leader_proxy: SpliceProxy,
+    _helper_proxy: SpliceProxy,
 }
 
 #[cfg(feature = "testcontainer")]
 impl JanusContainerPair {
     /// Set up a new pair of containerized Janus test instances, and set up a new task in each using
-    /// the given VDAF and batch mode. Each aggregator serves on a distinct port, so the host-side
-    /// in-process client and collector reach them at the same virtual-network endpoint strings the
-    /// aggregators use among themselves.
+    /// the given VDAF and batch mode. Each aggregator serves on port 8080; the host-side in-process
+    /// client and collector reach them through per-aggregator forwarding proxies, so all parties
+    /// use the same endpoint strings.
     pub async fn new(
         test_name: &str,
         batch_mode: BatchMode,
         aggregation_mode: AggregationMode,
         vdaf: VdafInstance,
     ) -> JanusContainerPair {
-        // Each aggregator publishes a host port chosen just before its container starts, so that
-        // port is occasionally taken in the interim (under parallel tests). Retry the whole pair
-        // with fresh ports on such a failure.
-        const MAX_ATTEMPTS: usize = 5;
-        for attempt in 1..=MAX_ATTEMPTS {
-            match Self::try_new(test_name, batch_mode, aggregation_mode, vdaf.clone()).await {
-                Ok(pair) => return pair,
-                Err(error) if attempt < MAX_ATTEMPTS => {
-                    tracing::warn!(?error, attempt, "containerized Janus pair failed to start")
-                }
-                Err(error) => panic!("containerized Janus pair failed to start: {error}"),
-            }
-        }
-        unreachable!()
-    }
-
-    async fn try_new(
-        test_name: &str,
-        batch_mode: BatchMode,
-        aggregation_mode: AggregationMode,
-        vdaf: VdafInstance,
-    ) -> Result<JanusContainerPair, TestcontainersError> {
         let (mut task_parameters, task_builder) = build_test_task(
             TaskBuilder::new(batch_mode, aggregation_mode, vdaf),
             TestContext::DockerNetwork,
             Duration::from_millis(500),
             Duration::from_secs(60),
         );
-
-        let leader_port = reserve_ephemeral_port();
-        let helper_port = reserve_ephemeral_port();
-        task_parameters
-            .endpoint_fragments
-            .leader
-            .set_port(leader_port);
-        task_parameters
-            .endpoint_fragments
-            .helper
-            .set_port(helper_port);
-
-        let task = task_builder
-            .with_leader_aggregator_endpoint(
-                task_parameters
-                    .endpoint_fragments
-                    .leader
-                    .endpoint_for_virtual_network(),
-            )
-            .with_helper_aggregator_endpoint(
-                task_parameters
-                    .endpoint_fragments
-                    .helper
-                    .endpoint_for_virtual_network(),
-            )
-            .build();
+        let task = task_builder.build();
 
         let network = generate_network_name();
-        let leader =
-            JanusContainer::new_on_port(test_name, &network, &task, Role::Leader, leader_port)
-                .await?;
-        let helper =
-            JanusContainer::new_on_port(test_name, &network, &task, Role::Helper, helper_port)
-                .await?;
+        let leader = JanusContainer::new(test_name, &network, &task, Role::Leader).await;
+        let helper = JanusContainer::new(test_name, &network, &task, Role::Helper).await;
 
-        Ok(Self {
+        // Forward each aggregator's virtual-network hostname to its Docker-assigned host port, and
+        // route the client/collector's requests to those proxies.
+        let leader_proxy = SpliceProxy::spawn(leader.port()).await;
+        let helper_proxy = SpliceProxy::spawn(helper.port()).await;
+        let leader_host = task
+            .leader_aggregator_endpoint()
+            .host_str()
+            .unwrap()
+            .to_string();
+        let helper_host = task
+            .helper_aggregator_endpoint()
+            .host_str()
+            .unwrap()
+            .to_string();
+        let (leader_proxy_url, helper_proxy_url) = (leader_proxy.url(), helper_proxy.url());
+        task_parameters.endpoint_fragments.in_process_http_client = Some(
+            reqwest::Client::builder()
+                .proxy(reqwest::Proxy::custom(move |url| match url.host_str() {
+                    Some(host) if host == leader_host => Some(leader_proxy_url.clone()),
+                    Some(host) if host == helper_host => Some(helper_proxy_url.clone()),
+                    _ => None,
+                }))
+                .build()
+                .unwrap(),
+        );
+
+        Self {
             task_parameters,
             leader,
             helper,
-        })
+            _leader_proxy: leader_proxy,
+            _helper_proxy: helper_proxy,
+        }
     }
 }
 
-/// Reserve a free ephemeral TCP port on loopback for a container to publish.
+/// A loopback TCP proxy that forwards every connection to a fixed upstream port byte-for-byte,
+/// giving a host client a stable address for a container whose host port Docker assigns
+/// dynamically. Aborts its accept loop on drop.
 #[cfg(feature = "testcontainer")]
-fn reserve_ephemeral_port() -> u16 {
-    TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
-        .unwrap()
-        .local_addr()
-        .unwrap()
-        .port()
+struct SpliceProxy {
+    port: u16,
+    task: tokio::task::JoinHandle<()>,
+}
+
+#[cfg(feature = "testcontainer")]
+impl SpliceProxy {
+    async fn spawn(upstream_port: u16) -> Self {
+        let listener = TcpListener::bind((Ipv6Addr::LOCALHOST, 0)).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let task = tokio::spawn(async move {
+            while let Ok((mut inbound, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    // Docker publishes the container's port over IPv4, so dial the upstream there.
+                    match TcpStream::connect((Ipv4Addr::LOCALHOST, upstream_port)).await {
+                        Ok(mut upstream) => {
+                            let _ = copy_bidirectional(&mut inbound, &mut upstream).await;
+                        }
+                        Err(error) => {
+                            tracing::warn!(?error, "splice proxy failed to reach upstream")
+                        }
+                    }
+                });
+            }
+        });
+        Self { port, task }
+    }
+
+    /// The proxy URL to hand to `reqwest::Proxy`.
+    fn url(&self) -> String {
+        format!("http://[::1]:{}", self.port)
+    }
+}
+
+#[cfg(feature = "testcontainer")]
+impl Drop for SpliceProxy {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
 }
 
 /// A pair of Janus instances, running in-process, against which integration tests may be run.

--- a/integration_tests/tests/integration/janus.rs
+++ b/integration_tests/tests/integration/janus.rs
@@ -55,7 +55,7 @@ impl JanusContainerPair {
     ) -> JanusContainerPair {
         let (mut task_parameters, task_builder) = build_test_task(
             TaskBuilder::new(batch_mode, aggregation_mode, vdaf),
-            TestContext::DockerNetwork,
+            TestContext::VirtualNetwork,
             Duration::from_millis(500),
             Duration::from_secs(60),
         );


### PR DESCRIPTION
While each container aggregator is assigned a random port by Docker, we can use reqwest shenanigans to capture and proxy all the traffic from the client and collector to reach the right places, all using the same host:port strings, ensuring that all parties end up with the same AAD bytes.