### PR TITLE
Persist CollectionJobReq on the Helper, and allow narrower batch selectors

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -3894,6 +3894,27 @@ impl VdafOps {
                         return Ok(aggregate_share_job);
                     }
 
+                    // No job exists for this batch & aggregation parameter, so any job already
+                    // using this aggregate share ID is for a different batch. Reject it: the poll
+                    // path looks jobs up by ID alone and cannot disambiguate.
+                    if tx
+                        .get_aggregate_share_job_by_id::<SEED_SIZE, B, A>(
+                            vdaf.as_ref(),
+                            task.id(),
+                            aggregate_share_id,
+                        )
+                        .await?
+                        .is_some()
+                    {
+                        return Err(datastore::Error::User(
+                            Error::ForbiddenMutation {
+                                resource_type: "aggregate share job",
+                                identifier: aggregate_share_id.to_string(),
+                            }
+                            .into(),
+                        ));
+                    }
+
                     // This is a new aggregate share request, compute & validate the response.
                     debug!(
                         ?aggregate_share_req,

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -3873,25 +3873,16 @@ impl VdafOps {
                     {
                         // DAP requires duplicate requests to be identical.
                         if aggregate_share_job.aggregate_share_id() != &aggregate_share_id
+                            || aggregate_share_job.collection_job_req()
+                                != aggregate_share_req.collection_job_req()
                         {
                             return Err(datastore::Error::User(
-                                Error::AggregateShareRequestRejected(
-                                    *task.id(),
-                                    "aggregate share request is a duplicate but uses a different aggregate share ID"
+                                Error::ForbiddenMutation {
+                                    resource_type: "aggregate share job",
+                                    identifier: aggregate_share_job
+                                        .aggregate_share_id()
                                         .to_string(),
-                                )
-                                .into(),
-                            ));
-                        }
-                        if aggregate_share_job.collection_job_req()
-                            != aggregate_share_req.collection_job_req()
-                        {
-                            return Err(datastore::Error::User(
-                                Error::AggregateShareRequestRejected(
-                                    *task.id(),
-                                    "aggregate share request is a duplicate but carries a different collection job request"
-                                        .to_string(),
-                                )
+                                }
                                 .into(),
                             ));
                         }

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -3636,18 +3636,7 @@ impl VdafOps {
             &AggregateShareAad::new(
                 *task.id(),
                 task.task_configuration()?,
-                // On the poll path we no longer have the Collector's original CollectionJobReq
-                // (there is no incoming AggregateShareReq), so reconstruct it from the stored job.
-                // This must be byte-identical to the request the Collector sent; see
-                // `query_for_collection_identifier` (and Issue #4743). When we support
-                // extensions (Issue #4715) this will need to change.
-                CollectionJobReq::new(
-                    B::query_for_collection_identifier(aggregate_share_job.batch_identifier()),
-                    aggregate_share_job
-                        .aggregation_parameter()
-                        .get_encoded()
-                        .map_err(Error::MessageEncode)?,
-                ),
+                aggregate_share_job.collection_job_req().clone(),
             )
             .get_encoded()
             .map_err(Error::MessageEncode)?,
@@ -3811,14 +3800,11 @@ impl VdafOps {
         )?;
 
         // DAP-19 §4.6.4: the Helper verifies the Leader-chosen batch selector against the query in
-        // the CollectionJobReq, which the AAD binds. The spec defines consistency per batch mode
-        // and would permit any time-interval selector within the queried interval, but Janus
-        // requires exact round-tripping, otherwise the poll path rebuilds the AAD's query from
-        // the stored selector alone, so a narrower selector would decrypt here and fail there.
-        if B::query_for_collection_identifier(
+        // the CollectionJobReq, which the AAD binds.
+        if !B::is_batch_identifier_consistent_with_query(
             aggregate_share_req.batch_selector().batch_identifier(),
-        ) != *aggregate_share_req.collection_job_req().query()
-        {
+            aggregate_share_req.collection_job_req().query(),
+        ) {
             return Err(Error::BatchInvalid(
                 *task.id(),
                 format!(
@@ -3885,18 +3871,25 @@ impl VdafOps {
                         )
                         .await?
                     {
-                        // Duplicate aggregate share job found - verify the aggregate share ID
-                        // matches. Note, when we add collection extensions, those will need
-                        // to be checked here as well. (Issue #4715)
+                        // DAP requires duplicate requests to be identical.
                         if aggregate_share_job.aggregate_share_id() != &aggregate_share_id
                         {
-                            // Mismatch here indicates a duplicate request with a different
-                            // aggregate share ID. This violates the DAP protocol requirement
-                            // that duplicate requests must be identical.
                             return Err(datastore::Error::User(
                                 Error::AggregateShareRequestRejected(
                                     *task.id(),
                                     "aggregate share request is a duplicate but uses a different aggregate share ID"
+                                        .to_string(),
+                                )
+                                .into(),
+                            ));
+                        }
+                        if aggregate_share_job.collection_job_req()
+                            != aggregate_share_req.collection_job_req()
+                        {
+                            return Err(datastore::Error::User(
+                                Error::AggregateShareRequestRejected(
+                                    *task.id(),
+                                    "aggregate share request is a duplicate but carries a different collection job request"
                                         .to_string(),
                                 )
                                 .into(),
@@ -3988,6 +3981,7 @@ impl VdafOps {
                         aggregate_share_id,
                         aggregate_share.report_count,
                         aggregate_share.checksum,
+                        aggregate_share_req.collection_job_req().clone(),
                     );
 
                     tx.put_aggregate_share_job(&aggregate_share_job).await?;

--- a/aggregator/src/aggregator/garbage_collector.rs
+++ b/aggregator/src/aggregator/garbage_collector.rs
@@ -195,11 +195,11 @@ mod tests {
         vdaf::VdafInstance,
     };
     use janus_messages::{
-        AggregationJobStep, Duration, HpkeCiphertext, HpkeConfigId, Interval, Query,
-        ReportIdChecksum, ReportMetadata, ReportShare, Role, TimePrecision,
+        AggregationJobStep, CollectionJobReq, Duration, HpkeCiphertext, HpkeConfigId, Interval,
+        Query, ReportIdChecksum, ReportMetadata, ReportShare, Role, TimePrecision,
         batch_mode::{LeaderSelected, TimeInterval},
     };
-    use prio::vdaf::dummy;
+    use prio::{codec::Encode, vdaf::dummy};
     use rand::random;
 
     use crate::aggregator::garbage_collector::GarbageCollector;
@@ -495,6 +495,10 @@ mod tests {
                             random(),
                             0,
                             ReportIdChecksum::default(),
+                            CollectionJobReq::new(
+                                Query::new_time_interval(batch_identifier),
+                                dummy::AggregationParam(0).get_encoded().unwrap(),
+                            ),
                         ),
                     )
                     .await
@@ -889,6 +893,10 @@ mod tests {
                             random(),
                             0,
                             ReportIdChecksum::default(),
+                            CollectionJobReq::new(
+                                Query::new_leader_selected(),
+                                dummy::AggregationParam(0).get_encoded().unwrap(),
+                            ),
                         ),
                     )
                     .await

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -186,7 +186,6 @@ impl Error {
             | Error::HttpClient(_)
             | Error::Http { .. }
             | Error::TaskParameters(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
-            // Note: DAP defines no error for this.
             Error::AggregateShareRequestRejected(task_id, detail) => ProblemDocument::new(
                 "https://docs.divviup.org/references/janus-errors#aggregate-share-request-rejected",
                 "Aggregate share request rejected.",

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -186,10 +186,9 @@ impl Error {
             | Error::HttpClient(_)
             | Error::Http { .. }
             | Error::TaskParameters(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
-            // Note: DAP defines no error for this; `batchOverlap` may kinda fit the dupe
-            // cases, but it does not cover the too-late rejection that shares this variant.
+            // Note: DAP defines no error for this.
             Error::AggregateShareRequestRejected(task_id, detail) => ProblemDocument::new(
-                "about:blank",
+                "https://docs.divviup.org/references/janus-errors#aggregate-share-request-rejected",
                 "Aggregate share request rejected.",
                 StatusCode::BAD_REQUEST,
             )
@@ -201,7 +200,19 @@ impl Error {
                     .with_task_id(task_id)
                     .into_response()
             }
-            Error::ForbiddenMutation { .. } => StatusCode::CONFLICT.into_response(),
+            Error::ForbiddenMutation {
+                resource_type,
+                identifier,
+            } => ProblemDocument::new(
+                "https://docs.divviup.org/references/janus-errors#forbidden-mutation",
+                "Forbidden mutation of an immutable resource.",
+                StatusCode::CONFLICT,
+            )
+            .with_detail(&format!(
+                "The {resource_type} {identifier} already exists and cannot be modified. Use a new \
+                 identifier instead of re-sending this one with changed parameters."
+            ))
+            .into_response(),
             Error::BadContentType(_) => StatusCode::UNSUPPORTED_MEDIA_TYPE.into_response(),
             Error::BadRequest(detail) => ProblemDocument::new(
                 "about:blank",

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -186,7 +186,16 @@ impl Error {
             | Error::HttpClient(_)
             | Error::Http { .. }
             | Error::TaskParameters(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
-            Error::AggregateShareRequestRejected(_, _) => StatusCode::BAD_REQUEST.into_response(),
+            // Note: DAP defines no error for this; `batchOverlap` may kinda fit the dupe
+            // cases, but it does not cover the too-late rejection that shares this variant.
+            Error::AggregateShareRequestRejected(task_id, detail) => ProblemDocument::new(
+                "about:blank",
+                "Aggregate share request rejected.",
+                StatusCode::BAD_REQUEST,
+            )
+            .with_task_id(task_id)
+            .with_detail(detail)
+            .into_response(),
             Error::EmptyAggregation(task_id) => {
                 ProblemDocument::new_dap(DapProblemType::InvalidMessage)
                     .with_task_id(task_id)

--- a/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
@@ -4,7 +4,10 @@ use futures::future::try_join_all;
 use http::{Request, StatusCode};
 use janus_aggregator_core::{
     batch_mode::CollectableBatchMode,
-    datastore::models::{BatchAggregation, BatchAggregationState},
+    datastore::{
+        Datastore,
+        models::{BatchAggregation, BatchAggregationState},
+    },
     task::{
         AggregationMode, BatchMode,
         test_util::{Task, TaskBuilder},
@@ -14,7 +17,7 @@ use janus_core::{
     auth_tokens::test_util::WithAuthenticationToken,
     hpke::{self, HpkeApplicationInfo, Label},
     report_id::ReportIdChecksumExt,
-    time::{Clock, DateTimeExt},
+    time::{Clock, DateTimeExt, MockClock},
     vdaf::VdafInstance,
 };
 use janus_messages::{
@@ -822,10 +825,20 @@ async fn aggregate_share_request_duplicate_with_different_id() {
     assert_eq!(response.status(), StatusCode::OK);
 
     // Second request with same parameters but different aggregate share ID should fail
-    let response =
+    let mut response =
         put_aggregate_share_request(&task, &request, &aggregate_share_id_2, &router).await;
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        take_problem_details(&mut response).await,
+        json!({
+            "status": StatusCode::BAD_REQUEST.as_u16(),
+            "type": "about:blank",
+            "title": "Aggregate share request rejected.",
+            "taskid": format!("{}", task.id()),
+            "detail": "aggregate share request is a duplicate but uses a different aggregate share ID",
+        })
+    );
 }
 
 #[tokio::test]
@@ -976,8 +989,6 @@ async fn aggregate_share_request_get_poll_after_put() {
     assert_eq!(response.status(), StatusCode::NO_CONTENT);
 }
 
-// Leader-selected counterpart of the above: the poll path's reconstructed query must be
-// byte-identical or the decrypt fails.
 #[tokio::test]
 async fn aggregate_share_request_get_poll_after_put_leader_selected() {
     let HttpHandlerTest {
@@ -1049,7 +1060,7 @@ async fn aggregate_share_request_get_poll_after_put_leader_selected() {
 
     let aggregate_share_id = AggregateShareId::from([42u8; 16]);
 
-    // PUT binds the forwarded CollectionJobReq; poll (GET) reconstructs it from the stored job.
+    // PUT binds the forwarded CollectionJobReq; poll (GET) reuses the stored copy.
     let response = put_aggregate_share_request(&task, &request, &aggregate_share_id, &router).await;
     assert_eq!(response.status(), StatusCode::OK);
 
@@ -1083,6 +1094,218 @@ async fn aggregate_share_request_get_poll_after_put_leader_selected() {
         .unwrap(),
     )
     .unwrap();
+}
+
+async fn setup_time_interval_task_with_batch_aggregation(
+    datastore: &Datastore<MockClock>,
+    batch_interval: Interval,
+    aggregation_param: dummy::AggregationParam,
+    report_count: u64,
+    checksum: ReportIdChecksum,
+) -> Task {
+    let task = TaskBuilder::new(
+        BatchMode::TimeInterval,
+        AggregationMode::Synchronous,
+        VdafInstance::Fake { rounds: 1 },
+    )
+    .with_helper_aggregator_endpoint("https://helper.example.com/".parse().unwrap())
+    .build();
+
+    let helper_task = task.helper_view().unwrap();
+    datastore.put_aggregator_task(&helper_task).await.unwrap();
+    datastore
+        .run_unnamed_tx(|tx| {
+            let helper_task = helper_task.clone();
+            Box::pin(async move {
+                tx.put_batch_aggregation(&BatchAggregation::<0, TimeInterval, dummy::Vdaf>::new(
+                    *helper_task.id(),
+                    batch_interval,
+                    aggregation_param,
+                    0,
+                    batch_interval,
+                    BatchAggregationState::Aggregating {
+                        aggregate_share: Some(dummy::AggregateShare(16)),
+                        report_count,
+                        checksum,
+                        aggregation_jobs_created: 1,
+                        aggregation_jobs_terminated: 1,
+                    },
+                ))
+                .await
+                .unwrap();
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
+
+    task
+}
+
+// DAP-19 §4.6.4 only requires the batch selector to be contained in the collector's query, and the
+// AAD binds the query, not the selector.
+#[tokio::test]
+async fn aggregate_share_request_narrower_selector_than_query() {
+    let HttpHandlerTest {
+        clock: _,
+        ephemeral_datastore: _ephemeral_datastore,
+        datastore,
+        router,
+        ..
+    } = HttpHandlerTest::new().await;
+
+    let selected_interval = Interval::minimal(Time::from_time_precision_units(3)).unwrap();
+    let queried_interval = Interval::new(
+        Time::from_time_precision_units(0),
+        Duration::from_time_precision_units(10),
+    )
+    .unwrap();
+    let aggregation_param = dummy::AggregationParam(0);
+    let report_count = 5;
+    let checksum = ReportIdChecksum::get_decoded(&[3; 32]).unwrap();
+
+    let task = setup_time_interval_task_with_batch_aggregation(
+        &datastore,
+        selected_interval,
+        aggregation_param,
+        report_count,
+        checksum,
+    )
+    .await;
+
+    let request = AggregateShareReq::new(
+        CollectionJobReq::new(
+            Query::new_time_interval(queried_interval),
+            aggregation_param.get_encoded().unwrap(),
+        ),
+        BatchSelector::new_time_interval(selected_interval),
+        report_count,
+        checksum,
+    );
+
+    let aggregate_share_id = AggregateShareId::from([42u8; 16]);
+    let response = put_aggregate_share_request(&task, &request, &aggregate_share_id, &router).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let mut response = router
+        .clone()
+        .oneshot(
+            Request::get(
+                task.aggregate_shares_uri(&aggregate_share_id)
+                    .unwrap()
+                    .path(),
+            )
+            .with_authentication_token(task.aggregator_auth_token())
+            .body(Body::empty())
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let aggregate_share_resp: AggregateShareMessage = decode_response_body(&mut response).await;
+    hpke::open(
+        task.collector_hpke_keypair(),
+        &HpkeApplicationInfo::new(&Label::AggregateShare, &Role::Helper, &Role::Collector),
+        aggregate_share_resp.encrypted_aggregate_share(),
+        &AggregateShareAad::new(
+            *task.id(),
+            task.task_configuration(),
+            request.collection_job_req().clone(),
+        )
+        .get_encoded()
+        .unwrap(),
+    )
+    .unwrap();
+
+    // The AAD must come from the stored request, not from a query derived from the selector.
+    assert!(
+        hpke::open(
+            task.collector_hpke_keypair(),
+            &HpkeApplicationInfo::new(&Label::AggregateShare, &Role::Helper, &Role::Collector),
+            aggregate_share_resp.encrypted_aggregate_share(),
+            &AggregateShareAad::new(
+                *task.id(),
+                task.task_configuration(),
+                // selected_interval should be different than queried_interval. If it
+                // isn't, then we might have "simplified" in the Helper (probably) to
+                // make selected interval === queried, which isn't what DAP-19 says.
+                CollectionJobReq::new(
+                    Query::new_time_interval(selected_interval),
+                    aggregation_param.get_encoded().unwrap(),
+                ),
+            )
+            .get_encoded()
+            .unwrap(),
+        )
+        .is_err()
+    );
+}
+
+// Two requests to the same aggregate share resource that differ in their query are rejected
+// as conflicting dupes.
+#[tokio::test]
+async fn aggregate_share_request_duplicate_with_different_query() {
+    let HttpHandlerTest {
+        clock: _,
+        ephemeral_datastore: _ephemeral_datastore,
+        datastore,
+        router,
+        ..
+    } = HttpHandlerTest::new().await;
+
+    let selected_interval = Interval::minimal(Time::from_time_precision_units(3)).unwrap();
+    let aggregation_param = dummy::AggregationParam(0);
+    let report_count = 5;
+    let checksum = ReportIdChecksum::get_decoded(&[3; 32]).unwrap();
+
+    let task = setup_time_interval_task_with_batch_aggregation(
+        &datastore,
+        selected_interval,
+        aggregation_param,
+        report_count,
+        checksum,
+    )
+    .await;
+
+    let aggregate_share_id = AggregateShareId::from([42u8; 16]);
+    let request_for_query = |duration| {
+        AggregateShareReq::new(
+            CollectionJobReq::new(
+                Query::new_time_interval(
+                    Interval::new(
+                        Time::from_time_precision_units(0),
+                        Duration::from_time_precision_units(duration),
+                    )
+                    .unwrap(),
+                ),
+                aggregation_param.get_encoded().unwrap(),
+            ),
+            BatchSelector::new_time_interval(selected_interval),
+            report_count,
+            checksum,
+        )
+    };
+
+    let response =
+        put_aggregate_share_request(&task, &request_for_query(10), &aggregate_share_id, &router)
+            .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let mut response =
+        put_aggregate_share_request(&task, &request_for_query(20), &aggregate_share_id, &router)
+            .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        take_problem_details(&mut response).await,
+        json!({
+            "status": StatusCode::BAD_REQUEST.as_u16(),
+            "type": "about:blank",
+            "title": "Aggregate share request rejected.",
+            "taskid": format!("{}", task.id()),
+            "detail": "aggregate share request is a duplicate but carries a different collection job request",
+        })
+    );
 }
 
 // Proves the TaskConfiguration in the aggregate-share AAD works: a mismatched one must not open
@@ -1329,9 +1552,8 @@ async fn aggregate_share_request_batch_selector_inconsistent_with_query() {
 
     for selected_interval in [
         interval(30, 10), // disjoint from the queried interval
-        // A strict sub-interval. This is permitted by DAP-19 4.6.4 but not by Janus.
-        interval(12, 5),
-        interval(5, 20), // a superset of the queried interval
+        interval(15, 10), // overruns the end of the queried interval
+        interval(5, 20),  // a superset of the queried interval
     ] {
         let request = AggregateShareReq::new(
             CollectionJobReq::new(

--- a/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
@@ -396,6 +396,9 @@ async fn aggregate_share_request() {
     // Make requests that will fail because the checksum or report counts don't match.
     struct MisalignedRequestTestCase<B: janus_messages::batch_mode::BatchMode> {
         name: &'static str,
+        // Each case needs its own ID: a batch mismatch still persists the job, so reusing one
+        // would bind a single ID to two batches.
+        aggregate_share_id: AggregateShareId,
         request: AggregateShareReq<B>,
         expected_checksum: ReportIdChecksum,
         expected_report_count: u64,
@@ -403,6 +406,7 @@ async fn aggregate_share_request() {
     for misaligned_request in [
         MisalignedRequestTestCase {
             name: "Interval is big enough but the checksums don't match",
+            aggregate_share_id: AggregateShareId::from([1u8; 16]),
             request: AggregateShareReq::new(
                 CollectionJobReq::new(
                     Query::new_time_interval(
@@ -429,6 +433,7 @@ async fn aggregate_share_request() {
         },
         MisalignedRequestTestCase {
             name: "Interval is big enough but report count doesn't match",
+            aggregate_share_id: AggregateShareId::from([2u8; 16]),
             request: AggregateShareReq::new(
                 CollectionJobReq::new(
                     Query::new_time_interval(
@@ -457,7 +462,7 @@ async fn aggregate_share_request() {
         let mut response = put_aggregate_share_request(
             &task,
             &misaligned_request.request,
-            &AggregateShareId::from([0u8; 16]),
+            &misaligned_request.aggregate_share_id,
             &router,
         )
         .await;
@@ -492,9 +497,12 @@ async fn aggregate_share_request() {
 
     // Valid requests: intervals are big enough, do not overlap, checksum and report count are
     // good.
-    for (label, request, expected_result) in [
+    // These cover the same batches as the misaligned requests above, so they address the same
+    // aggregate share resources and reuse their IDs.
+    for (label, aggregate_share_id, request, expected_result) in [
         (
             "first and second batchess",
+            AggregateShareId::from([1u8; 16]),
             AggregateShareReq::new(
                 CollectionJobReq::new(
                     Query::new_time_interval(
@@ -520,6 +528,7 @@ async fn aggregate_share_request() {
         ),
         (
             "third and fourth batches",
+            AggregateShareId::from([2u8; 16]),
             AggregateShareReq::new(
                 CollectionJobReq::new(
                     Query::new_time_interval(
@@ -548,13 +557,8 @@ async fn aggregate_share_request() {
         // Request the aggregate share multiple times. If the request parameters don't change,
         // then there is no query count violation and all requests should succeed.
         for iteration in 0..3 {
-            let mut response = put_aggregate_share_request(
-                &task,
-                &request,
-                &AggregateShareId::from([0u8; 16]),
-                &router,
-            )
-            .await;
+            let mut response =
+                put_aggregate_share_request(&task, &request, &aggregate_share_id, &router).await;
 
             assert_eq!(
                 response.status(),
@@ -667,7 +671,7 @@ async fn aggregate_share_request() {
     let mut response = put_aggregate_share_request(
         &task,
         &all_batch_request,
-        &AggregateShareId::from([0u8; 16]),
+        &AggregateShareId::from([5u8; 16]),
         &router,
     )
     .await;
@@ -731,7 +735,7 @@ async fn aggregate_share_request() {
         let mut response = put_aggregate_share_request(
             &task,
             &query_count_violation_request,
-            &AggregateShareId::from([0u8; 16]),
+            &AggregateShareId::from([6u8; 16]),
             &router,
         )
         .await;
@@ -1298,6 +1302,112 @@ async fn aggregate_share_request_duplicate_with_different_query() {
     let mut response =
         put_aggregate_share_request(&task, &request_for_query(20), &aggregate_share_id, &router)
             .await;
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+    assert_eq!(
+        take_problem_details(&mut response).await,
+        json!({
+            "status": StatusCode::CONFLICT.as_u16(),
+            "type": "https://docs.divviup.org/references/janus-errors#forbidden-mutation",
+            "title": "Forbidden mutation of an immutable resource.",
+            "detail": format!(
+                "The aggregate share job {aggregate_share_id} already exists and cannot be \
+                 modified. Use a new identifier instead of re-sending this one with changed \
+                 parameters."
+            ),
+        })
+    );
+}
+
+// One aggregate share ID must not be bound to two batches: the poll path looks jobs up by ID
+// alone and cannot disambiguate. Narrower-than-query selectors make this easy to hit, since one
+// query now admits several batches.
+#[tokio::test]
+async fn aggregate_share_request_same_id_different_batch() {
+    let HttpHandlerTest {
+        clock: _,
+        ephemeral_datastore: _ephemeral_datastore,
+        datastore,
+        router,
+        ..
+    } = HttpHandlerTest::new().await;
+
+    let first_interval = Interval::minimal(Time::from_time_precision_units(3)).unwrap();
+    let second_interval = Interval::minimal(Time::from_time_precision_units(5)).unwrap();
+    let queried_interval = Interval::new(
+        Time::from_time_precision_units(0),
+        Duration::from_time_precision_units(10),
+    )
+    .unwrap();
+    let aggregation_param = dummy::AggregationParam(0);
+    let report_count = 5;
+    let checksum = ReportIdChecksum::get_decoded(&[3; 32]).unwrap();
+
+    let task = setup_time_interval_task_with_batch_aggregation(
+        &datastore,
+        first_interval,
+        aggregation_param,
+        report_count,
+        checksum,
+    )
+    .await;
+
+    // A second batch, also contained in the collector's query.
+    let helper_task = task.helper_view().unwrap();
+    datastore
+        .run_unnamed_tx(|tx| {
+            let helper_task = helper_task.clone();
+            Box::pin(async move {
+                tx.put_batch_aggregation(&BatchAggregation::<0, TimeInterval, dummy::Vdaf>::new(
+                    *helper_task.id(),
+                    second_interval,
+                    aggregation_param,
+                    0,
+                    second_interval,
+                    BatchAggregationState::Aggregating {
+                        aggregate_share: Some(dummy::AggregateShare(16)),
+                        report_count,
+                        checksum,
+                        aggregation_jobs_created: 1,
+                        aggregation_jobs_terminated: 1,
+                    },
+                ))
+                .await
+                .unwrap();
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
+
+    let aggregate_share_id = AggregateShareId::from([42u8; 16]);
+    let request_for_batch = |batch_interval| {
+        AggregateShareReq::new(
+            CollectionJobReq::new(
+                Query::new_time_interval(queried_interval),
+                aggregation_param.get_encoded().unwrap(),
+            ),
+            BatchSelector::new_time_interval(batch_interval),
+            report_count,
+            checksum,
+        )
+    };
+
+    let response = put_aggregate_share_request(
+        &task,
+        &request_for_batch(first_interval),
+        &aggregate_share_id,
+        &router,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let mut response = put_aggregate_share_request(
+        &task,
+        &request_for_batch(second_interval),
+        &aggregate_share_id,
+        &router,
+    )
+    .await;
     assert_eq!(response.status(), StatusCode::CONFLICT);
     assert_eq!(
         take_problem_details(&mut response).await,

--- a/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregate_share.rs
@@ -828,15 +828,18 @@ async fn aggregate_share_request_duplicate_with_different_id() {
     let mut response =
         put_aggregate_share_request(&task, &request, &aggregate_share_id_2, &router).await;
 
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::CONFLICT);
     assert_eq!(
         take_problem_details(&mut response).await,
         json!({
-            "status": StatusCode::BAD_REQUEST.as_u16(),
-            "type": "about:blank",
-            "title": "Aggregate share request rejected.",
-            "taskid": format!("{}", task.id()),
-            "detail": "aggregate share request is a duplicate but uses a different aggregate share ID",
+            "status": StatusCode::CONFLICT.as_u16(),
+            "type": "https://docs.divviup.org/references/janus-errors#forbidden-mutation",
+            "title": "Forbidden mutation of an immutable resource.",
+            "detail": format!(
+                "The aggregate share job {aggregate_share_id_1} already exists and cannot be \
+                 modified. Use a new identifier instead of re-sending this one with changed \
+                 parameters."
+            ),
         })
     );
 }
@@ -1295,15 +1298,18 @@ async fn aggregate_share_request_duplicate_with_different_query() {
     let mut response =
         put_aggregate_share_request(&task, &request_for_query(20), &aggregate_share_id, &router)
             .await;
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::CONFLICT);
     assert_eq!(
         take_problem_details(&mut response).await,
         json!({
-            "status": StatusCode::BAD_REQUEST.as_u16(),
-            "type": "about:blank",
-            "title": "Aggregate share request rejected.",
-            "taskid": format!("{}", task.id()),
-            "detail": "aggregate share request is a duplicate but carries a different collection job request",
+            "status": StatusCode::CONFLICT.as_u16(),
+            "type": "https://docs.divviup.org/references/janus-errors#forbidden-mutation",
+            "title": "Forbidden mutation of an immutable resource.",
+            "detail": format!(
+                "The aggregate share job {aggregate_share_id} already exists and cannot be \
+                 modified. Use a new identifier instead of re-sending this one with changed \
+                 parameters."
+            ),
         })
     );
 }

--- a/aggregator/src/aggregator/http_handlers/tests/helper_e2e.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/helper_e2e.rs
@@ -152,7 +152,7 @@ async fn helper_aggregation_report_share_replay() {
     let response = put_aggregate_share_request(
         &task,
         &agg_share_req_2,
-        &AggregateShareId::from([0u8; 16]),
+        &AggregateShareId::from([1u8; 16]),
         &router,
     )
     .await;

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -1060,6 +1060,10 @@ async fn taskprov_aggregate_continue() {
                         aggregate_share_id,
                         0,
                         ReportIdChecksum::default(),
+                        CollectionJobReq::new(
+                            Query::new_leader_selected(),
+                            aggregation_param.get_encoded().unwrap(),
+                        ),
                     ),
                 )
                 .await

--- a/aggregator_core/src/batch_mode.rs
+++ b/aggregator_core/src/batch_mode.rs
@@ -489,6 +489,7 @@ mod tests {
         for selector in [
             interval(99, 10),  // starts before the query
             interval(105, 10), // ends after the query
+            interval(90, 5),   // entirely before the query
             interval(110, 1),  // entirely after the query
             interval(90, 100), // contains the query
         ] {

--- a/aggregator_core/src/batch_mode.rs
+++ b/aggregator_core/src/batch_mode.rs
@@ -159,14 +159,12 @@ pub trait CollectableBatchMode: AccumulableBatchMode {
         query: &Query<Self>,
     ) -> Result<Option<Self::BatchIdentifier>, datastore::Error>;
 
-    /// Reconstructs the Collector's original collection [`Query`] from a stored batch identifier.
-    ///
-    /// The Helper serves aggregate shares on both the PUT path (where it has the forwarded
-    /// [`CollectionJobReq`](janus_messages::CollectionJobReq)) and the poll/GET path (where it only
-    /// has the stored [`AggregateShareJob`](crate::datastore::models::AggregateShareJob)). On the
-    /// latter it rebuilds the query with this method, which must be exact: the aggregate-share AAD
-    /// is byte-identical to the Collector's original or the decrypt fails.
-    fn query_for_collection_identifier(batch_identifier: &Self::BatchIdentifier) -> Query<Self>;
+    /// Returns whether the Leader-chosen batch identifier is consistent with the Collector's
+    /// query, per DAP's "Batch Selector Configuration".
+    fn is_batch_identifier_consistent_with_query(
+        batch_identifier: &Self::BatchIdentifier,
+        query: &Query<Self>,
+    ) -> bool;
 
     /// Some batch modes (e.g. [`TimeInterval`]) can receive a batch identifier in collection
     /// requests which refers to multiple batches. This method takes a batch identifier received in
@@ -271,8 +269,12 @@ impl CollectableBatchMode for TimeInterval {
         Ok(Some(*query.batch_interval()))
     }
 
-    fn query_for_collection_identifier(batch_interval: &Self::BatchIdentifier) -> Query<Self> {
-        Query::new_time_interval(*batch_interval)
+    fn is_batch_identifier_consistent_with_query(
+        batch_interval: &Self::BatchIdentifier,
+        query: &Query<Self>,
+    ) -> bool {
+        query.batch_interval().start() <= batch_interval.start()
+            && batch_interval.end() <= query.batch_interval().end()
     }
 
     fn batch_identifiers_for_collection_identifier(
@@ -344,8 +346,12 @@ impl CollectableBatchMode for LeaderSelected {
             .await
     }
 
-    fn query_for_collection_identifier(_batch_id: &Self::BatchIdentifier) -> Query<Self> {
-        Query::new_leader_selected()
+    fn is_batch_identifier_consistent_with_query(
+        _batch_id: &Self::BatchIdentifier,
+        _query: &Query<Self>,
+    ) -> bool {
+        // A leader-selected query has an empty body, so any batch ID is consistent with it.
+        true
     }
 
     fn batch_identifiers_for_collection_identifier(batch_id: &Self::BatchIdentifier) -> Self::Iter {
@@ -398,11 +404,10 @@ mod tests {
         ));
     }
 
-    /// The Collector's original `CollectionJobReq`, the Leader's reconstruction from its stored
-    /// collection job ([`CollectionJob::to_collection_job_req`]), and the Helper's reconstruction
-    /// from a stored batch identifier ([`CollectableBatchMode::query_for_collection_identifier`])
-    /// must all encode to identical bytes, or aggregate-share AADs will silently mismatch and
-    /// decryption will fail. This locks that invariant for both batch modes.
+    /// The Collector's original `CollectionJobReq` and the Leader's reconstruction from its stored
+    /// collection job ([`CollectionJob::to_collection_job_req`]) must encode to identical bytes, or
+    /// aggregate-share AADs will silently mismatch and decryption will fail. This locks that
+    /// invariant for both batch modes.
     #[test]
     fn collection_job_req_reconstruction_is_byte_identical() {
         let aggregation_parameter = AggregationParam(7);
@@ -417,10 +422,6 @@ mod tests {
             Query::new_time_interval(interval),
             encoded_aggregation_parameter.clone(),
         );
-        let helper_request = CollectionJobReq::new(
-            TimeInterval::query_for_collection_identifier(&interval),
-            encoded_aggregation_parameter.clone(),
-        );
         let leader_job = CollectionJob::<0, TimeInterval, Vdaf>::new(
             random(),
             random(),
@@ -429,10 +430,6 @@ mod tests {
             aggregation_parameter,
             interval,
             CollectionJobState::Start,
-        );
-        assert_eq!(
-            collector_request.get_encoded().unwrap(),
-            helper_request.get_encoded().unwrap(),
         );
         assert_eq!(
             collector_request.get_encoded().unwrap(),
@@ -446,10 +443,6 @@ mod tests {
         let batch_id = BatchId::from([5u8; 32]);
         let collector_request = CollectionJobReq::<LeaderSelected>::new(
             Query::new_leader_selected(),
-            encoded_aggregation_parameter.clone(),
-        );
-        let helper_request = CollectionJobReq::new(
-            LeaderSelected::query_for_collection_identifier(&batch_id),
             encoded_aggregation_parameter,
         );
         let leader_job = CollectionJob::<0, LeaderSelected, Vdaf>::new(
@@ -463,15 +456,45 @@ mod tests {
         );
         assert_eq!(
             collector_request.get_encoded().unwrap(),
-            helper_request.get_encoded().unwrap(),
-        );
-        assert_eq!(
-            collector_request.get_encoded().unwrap(),
             leader_job
                 .to_collection_job_req()
                 .unwrap()
                 .get_encoded()
                 .unwrap(),
         );
+    }
+
+    #[test]
+    fn time_interval_batch_identifier_consistency() {
+        let interval = |start, duration| {
+            Interval::new(
+                Time::from_time_precision_units(start),
+                Duration::from_time_precision_units(duration),
+            )
+            .unwrap()
+        };
+        let query = Query::new_time_interval(interval(100, 10));
+
+        for selector in [
+            interval(100, 10), // equal to the query
+            interval(100, 1),  // flush with the start
+            interval(103, 4),  // strictly inside
+            interval(109, 1),  // flush with the end
+        ] {
+            assert!(TimeInterval::is_batch_identifier_consistent_with_query(
+                &selector, &query
+            ));
+        }
+
+        for selector in [
+            interval(99, 10),  // starts before the query
+            interval(105, 10), // ends after the query
+            interval(110, 1),  // entirely after the query
+            interval(90, 100), // contains the query
+        ] {
+            assert!(!TimeInterval::is_batch_identifier_consistent_with_query(
+                &selector, &query
+            ));
+        }
     }
 }

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -26,10 +26,10 @@ use janus_core::{
     vdaf::VdafInstance,
 };
 use janus_messages::{
-    AggregateShareId, AggregationJobId, BatchId, CollectionJobId, Duration, Extension,
-    HpkeCiphertext, HpkeConfig, HpkeConfigId, Interval, Query, ReportId, ReportIdChecksum,
-    ReportMetadata, Role, TaskConfiguration, TaskId, Time, TimePrecision, VerifyContinue,
-    VerifyInit, VerifyResp,
+    AggregateShareId, AggregationJobId, BatchId, CollectionJobId, CollectionJobReq, Duration,
+    Extension, HpkeCiphertext, HpkeConfig, HpkeConfigId, Interval, Query, ReportId,
+    ReportIdChecksum, ReportMetadata, Role, TaskConfiguration, TaskId, Time, TimePrecision,
+    VerifyContinue, VerifyInit, VerifyResp,
     batch_mode::{BatchMode, LeaderSelected, TimeInterval},
 };
 use leases::{acquired_aggregation_job_from_row, acquired_collection_job_from_row};
@@ -4282,7 +4282,7 @@ WHERE task_id = $10
         let stmt = self
             .prepare_cached(
                 "-- get_aggregate_share_job()
-SELECT helper_aggregate_share, report_count, checksum, aggregate_share_id
+SELECT helper_aggregate_share, report_count, checksum, aggregate_share_id, collection_job_req
 FROM aggregate_share_jobs
 WHERE task_id = $1
   AND batch_identifier = $2
@@ -4342,8 +4342,8 @@ WHERE task_id = $1
             .prepare_cached(
                 "-- get_aggregate_share_job_by_id()
 SELECT 
-    helper_aggregate_share, batch_identifier, aggregation_param, report_count, 
-    checksum, aggregate_share_id
+    helper_aggregate_share, batch_identifier, aggregation_param, report_count,
+    checksum, aggregate_share_id, collection_job_req
 FROM aggregate_share_jobs
 WHERE task_id = $1
   AND aggregate_share_id = $2
@@ -4403,7 +4403,7 @@ WHERE task_id = $1
                 "-- get_aggregate_share_jobs_intersecting_interval()
 SELECT
     batch_identifier, aggregation_param, helper_aggregate_share, report_count,
-    checksum, aggregate_share_id
+    checksum, aggregate_share_id, collection_job_req
 FROM aggregate_share_jobs
 WHERE task_id = $1
   AND batch_interval && $2
@@ -4457,7 +4457,8 @@ WHERE task_id = $1
             .prepare_cached(
                 "-- get_aggregate_share_jobs_by_batch_id()
 SELECT
-    aggregation_param, helper_aggregate_share, report_count, checksum, aggregate_share_id
+    aggregation_param, helper_aggregate_share, report_count, checksum, aggregate_share_id,
+    collection_job_req
 FROM aggregate_share_jobs
 WHERE task_id = $1
   AND batch_identifier = $2
@@ -4508,7 +4509,7 @@ WHERE task_id = $1
                 "-- get_aggregate_share_jobs_for_task()
 SELECT
     batch_identifier, aggregation_param, helper_aggregate_share, report_count,
-    checksum, aggregate_share_id
+    checksum, aggregate_share_id, collection_job_req
 FROM aggregate_share_jobs
 WHERE task_id = $1
   AND COALESCE(
@@ -4567,6 +4568,7 @@ WHERE task_id = $1
             aggregate_share_id,
             row.get_bigint_and_convert("report_count")?,
             ReportIdChecksum::get_decoded(row.get("checksum"))?,
+            CollectionJobReq::<B>::get_decoded(row.get("collection_job_req"))?,
         ))
     }
 
@@ -4594,16 +4596,17 @@ WHERE task_id = $1
 INSERT INTO aggregate_share_jobs (
     task_id, batch_identifier, batch_interval, aggregation_param,
     helper_aggregate_share, aggregate_share_id, report_count, checksum,
-    created_at, updated_by
+    collection_job_req, created_at, updated_by
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 ON CONFLICT(task_id, batch_identifier, aggregation_param) DO UPDATE
     SET (
-        helper_aggregate_share, aggregate_share_id, report_count, checksum, 
-        created_at, updated_by
+        helper_aggregate_share, aggregate_share_id, report_count, checksum,
+        collection_job_req, created_at, updated_by
     ) = (
-        excluded.helper_aggregate_share, excluded.aggregate_share_id, 
-        excluded.report_count, excluded.checksum, excluded.created_at, excluded.updated_by
+        excluded.helper_aggregate_share, excluded.aggregate_share_id,
+        excluded.report_count, excluded.checksum, excluded.collection_job_req,
+        excluded.created_at, excluded.updated_by
     )
     WHERE COALESCE(
               LOWER(aggregate_share_jobs.batch_interval),
@@ -4612,7 +4615,7 @@ ON CONFLICT(task_id, batch_identifier, aggregation_param) DO UPDATE
                WHERE ba.task_id = aggregate_share_jobs.task_id
                  AND ba.batch_identifier = aggregate_share_jobs.batch_identifier
                  AND ba.aggregation_param = aggregate_share_jobs.aggregation_param),
-              0) < $11",
+              0) < $12",
             )
             .await?;
         check_insert(
@@ -4631,6 +4634,8 @@ ON CONFLICT(task_id, batch_identifier, aggregation_param) DO UPDATE
                     &aggregate_share_job.aggregate_share_id().get_encoded()?,
                     /* report_count */ &i64::try_from(aggregate_share_job.report_count())?,
                     /* checksum */ &aggregate_share_job.checksum().get_encoded()?,
+                    /* collection_job_req */
+                    &aggregate_share_job.collection_job_req().get_encoded()?,
                     /* created_at */ &now,
                     /* updated_by */ &self.name,
                     /* threshold */

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -2038,12 +2038,16 @@ pub struct AggregateShareJob<const SEED_SIZE: usize, B: BatchMode, A: AsyncAggre
     /// Checksum over the aggregated report shares, as described in §4.4.4.3.
     #[educe(Debug(ignore))]
     checksum: ReportIdChecksum,
+    /// The collector's request, as forwarded by the leader. Retained verbatim because the
+    /// aggregate share AAD binds it, and the poll path has to rebuild that AAD.
+    collection_job_req: CollectionJobReq<B>,
 }
 
 impl<const SEED_SIZE: usize, B: BatchMode, A: AsyncAggregator<SEED_SIZE>>
     AggregateShareJob<SEED_SIZE, B, A>
 {
     /// Creates a new [`AggregateShareJob`].
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         task_id: TaskId,
         batch_identifier: B::BatchIdentifier,
@@ -2052,6 +2056,7 @@ impl<const SEED_SIZE: usize, B: BatchMode, A: AsyncAggregator<SEED_SIZE>>
         aggregate_share_id: AggregateShareId,
         report_count: u64,
         checksum: ReportIdChecksum,
+        collection_job_req: CollectionJobReq<B>,
     ) -> Self {
         Self {
             task_id,
@@ -2061,6 +2066,7 @@ impl<const SEED_SIZE: usize, B: BatchMode, A: AsyncAggregator<SEED_SIZE>>
             aggregate_share_id,
             report_count,
             checksum,
+            collection_job_req,
         }
     }
 
@@ -2102,6 +2108,11 @@ impl<const SEED_SIZE: usize, B: BatchMode, A: AsyncAggregator<SEED_SIZE>>
     /// Gets the checksum associated with this aggregate share job.
     pub fn checksum(&self) -> &ReportIdChecksum {
         &self.checksum
+    }
+
+    /// Gets the collector's request associated with this aggregate share job.
+    pub fn collection_job_req(&self) -> &CollectionJobReq<B> {
+        &self.collection_job_req
     }
 }
 

--- a/aggregator_core/src/datastore/models.rs
+++ b/aggregator_core/src/datastore/models.rs
@@ -2038,8 +2038,10 @@ pub struct AggregateShareJob<const SEED_SIZE: usize, B: BatchMode, A: AsyncAggre
     /// Checksum over the aggregated report shares, as described in §4.4.4.3.
     #[educe(Debug(ignore))]
     checksum: ReportIdChecksum,
-    /// The collector's request, as forwarded by the leader. Retained verbatim because the
-    /// aggregate share AAD binds it, and the poll path has to rebuild that AAD.
+    /// The collector's request, as forwarded by the leader.
+    ///
+    /// Retained verbatim because the aggregate share AAD binds it, and the poll path has to
+    /// rebuild that AAD.
     collection_job_req: CollectionJobReq<B>,
 }
 

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -23,8 +23,9 @@ use janus_core::{
     vdaf::{VERIFY_KEY_LENGTH_PRIO3, VdafInstance, vdaf_dp_strategies},
 };
 use janus_messages::{
-    AggregateShareAad, AggregationJobId, AggregationJobStep, BatchId, CollectionJobId, Duration,
-    Extension, ExtensionType, HpkeCiphertext, HpkeConfigId, Interval, Query, ReportError, ReportId,
+    AggregateShareAad, AggregationJobId, AggregationJobStep, BatchId, CollectionJobExtension,
+    CollectionJobExtensionType, CollectionJobId, CollectionJobReq, Duration, Extension,
+    ExtensionType, HpkeCiphertext, HpkeConfigId, Interval, Query, ReportError, ReportId,
     ReportIdChecksum, ReportMetadata, ReportShare, Role, TaskId, Time, TimePrecision,
     VerifyContinue, VerifyInit, VerifyResp, VerifyStepResult,
     batch_mode::{BatchMode, LeaderSelected, TimeInterval},
@@ -6223,6 +6224,20 @@ async fn roundtrip_aggregate_share_job_time_interval(ephemeral_datastore: Epheme
                     random(),
                     10,
                     ReportIdChecksum::get_decoded(&[1; 32]).unwrap(),
+                    // A query wider than the batch identifier, with an extension, so the round
+                    // trip has to preserve more than the stored batch
+                    // identifier can reconstruct.
+                    CollectionJobReq::new(
+                        Query::new_time_interval(
+                            Interval::new(START_TIME, Duration::from_time_precision_units(10))
+                                .unwrap(),
+                        ),
+                        dummy::AggregationParam(11).get_encoded().unwrap(),
+                    )
+                    .with_extensions(Vec::from([CollectionJobExtension::new(
+                        CollectionJobExtensionType::Unknown(0x0001),
+                        Vec::from("ext"),
+                    )])),
                 );
 
                 tx.put_aggregate_share_job::<0, TimeInterval, dummy::Vdaf>(&aggregate_share_job)
@@ -6286,6 +6301,28 @@ async fn roundtrip_aggregate_share_job_time_interval(ephemeral_datastore: Epheme
                 .await
                 .unwrap();
             assert_eq!(got_aggregate_share_jobs, want_aggregate_share_jobs);
+
+            assert_eq!(
+                tx.get_aggregate_share_job_by_id::<0, TimeInterval, dummy::Vdaf>(
+                    &vdaf,
+                    want_aggregate_share_job.task_id(),
+                    *want_aggregate_share_job.aggregate_share_id(),
+                )
+                .await
+                .unwrap()
+                .unwrap(),
+                want_aggregate_share_job,
+            );
+
+            assert_eq!(
+                tx.get_aggregate_share_jobs_for_task::<0, TimeInterval, dummy::Vdaf>(
+                    &vdaf,
+                    want_aggregate_share_job.task_id(),
+                )
+                .await
+                .unwrap(),
+                want_aggregate_share_jobs,
+            );
 
             Ok(())
         })
@@ -6386,6 +6423,14 @@ async fn roundtrip_aggregate_share_job_leader_selected(ephemeral_datastore: Ephe
                     random(),
                     10,
                     ReportIdChecksum::get_decoded(&[1; 32]).unwrap(),
+                    CollectionJobReq::new(
+                        Query::new_leader_selected(),
+                        dummy::AggregationParam(11).get_encoded().unwrap(),
+                    )
+                    .with_extensions(Vec::from([CollectionJobExtension::new(
+                        CollectionJobExtensionType::Unknown(0x0001),
+                        Vec::from("ext"),
+                    )])),
                 );
 
                 tx.put_aggregate_share_job::<0, LeaderSelected, dummy::Vdaf>(&aggregate_share_job)
@@ -6441,6 +6486,28 @@ async fn roundtrip_aggregate_share_job_leader_selected(ephemeral_datastore: Ephe
                 .await
                 .unwrap();
             assert_eq!(got_aggregate_share_jobs, want_aggregate_share_jobs);
+
+            assert_eq!(
+                tx.get_aggregate_share_job_by_id::<0, LeaderSelected, dummy::Vdaf>(
+                    &vdaf,
+                    want_aggregate_share_job.task_id(),
+                    *want_aggregate_share_job.aggregate_share_id(),
+                )
+                .await
+                .unwrap()
+                .unwrap(),
+                want_aggregate_share_job,
+            );
+
+            assert_eq!(
+                tx.get_aggregate_share_jobs_for_task::<0, LeaderSelected, dummy::Vdaf>(
+                    &vdaf,
+                    want_aggregate_share_job.task_id(),
+                )
+                .await
+                .unwrap(),
+                want_aggregate_share_jobs,
+            );
 
             Ok(())
         })
@@ -7595,6 +7662,10 @@ async fn delete_expired_collection_artifacts(ephemeral_datastore: EphemeralDatas
                 random(),
                 client_timestamps.len().try_into().unwrap(),
                 random(),
+                CollectionJobReq::new(
+                    B::query_for_batch_identifier(&batch_identifier),
+                    dummy::AggregationParam(0).get_encoded().unwrap(),
+                ),
             ))
             .await
             .unwrap();

--- a/db/00000000000001_initial_schema.up.sql
+++ b/db/00000000000001_initial_schema.up.sql
@@ -465,6 +465,7 @@ CREATE TABLE aggregate_share_jobs(
     report_count                    BIGINT NOT NULL,    -- the count of reports included helper_aggregate_share
     checksum                        BYTEA NOT NULL,     -- the checksum over the reports included in helper_aggregate_share
     aggregate_share_id              BYTEA NOT NULL,     -- the 16-byte AggregateShareID as defined by DAP
+    collection_job_req              BYTEA NOT NULL,     -- the collector's verbatim CollectionJobReq
 
     -- creation/update records
     created_at TIMESTAMP WITH TIME ZONE NOT NULL,  -- when the row was created

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -3111,6 +3111,13 @@ pub(crate) fn roundtrip_encoding_parameterized<'a, T, P, TB, PB, I>(
             val,
             "Couldn't roundtrip (decoded value differs): {val:?}"
         );
+        // Re-encoding must reproduce the input bytes. Equality above is not sufficient: a type
+        // whose Eq ignores a field that affects encoding would pass it and fail here.
+        pretty_assertions::assert_eq!(
+            Wrapper(decoded_val.get_encoded().unwrap()),
+            expected,
+            "Couldn't roundtrip (re-encoded value differs): {val:?}"
+        );
         pretty_assertions::assert_eq!(
             encoded_val.0.len(),
             val.encoded_len().expect("No encoded length hint"),

--- a/messages/src/tests/collection.rs
+++ b/messages/src/tests/collection.rs
@@ -1,4 +1,4 @@
-use prio::codec::Decode;
+use prio::codec::{Decode, Encode};
 
 use super::{task_configuration_hex, test_task_configuration};
 use crate::{
@@ -185,6 +185,66 @@ fn collection_job_req_decode_is_lenient_about_extension_order() {
     let req = CollectionJobReq::<LeaderSelected>::get_decoded(&encoded)
         .expect("structurally valid collection job request must decode");
     assert_eq!(req.extensions().len(), 2);
+}
+
+#[test]
+fn collection_job_req_decode_encode_is_byte_identical() {
+    // The Helper stores the Collector's CollectionJobReq encoded and re-encodes it to rebuild the
+    // aggregate-share AAD on the poll path, so decode->encode must preserve bytes exactly.
+    let interval = Interval::new(
+        Time::from_seconds_since_epoch(54321, &TEST_TIME_PRECISION),
+        Duration::from_seconds(12345, &TEST_TIME_PRECISION),
+    )
+    .unwrap();
+    let extensions = Vec::from([
+        CollectionJobExtension::new(CollectionJobExtensionType::Reserved, Vec::new()),
+        CollectionJobExtension::new(
+            CollectionJobExtensionType::Unknown(0x0001),
+            Vec::from("ext"),
+        ),
+    ]);
+
+    for encoded in [
+        CollectionJobReq::<TimeInterval>::new(
+            Query::new_time_interval(interval),
+            Vec::from("012345"),
+        )
+        .get_encoded()
+        .unwrap(),
+        CollectionJobReq::<TimeInterval>::new(
+            Query::new_time_interval(interval),
+            Vec::from("012345"),
+        )
+        .with_extensions(extensions.clone())
+        .get_encoded()
+        .unwrap(),
+    ] {
+        assert_eq!(
+            CollectionJobReq::<TimeInterval>::get_decoded(&encoded)
+                .unwrap()
+                .get_encoded()
+                .unwrap(),
+            encoded,
+        );
+    }
+
+    for encoded in [
+        CollectionJobReq::<LeaderSelected>::new(Query::new_leader_selected(), Vec::from("012345"))
+            .get_encoded()
+            .unwrap(),
+        CollectionJobReq::<LeaderSelected>::new(Query::new_leader_selected(), Vec::from("012345"))
+            .with_extensions(extensions)
+            .get_encoded()
+            .unwrap(),
+    ] {
+        assert_eq!(
+            CollectionJobReq::<LeaderSelected>::get_decoded(&encoded)
+                .unwrap()
+                .get_encoded()
+                .unwrap(),
+            encoded,
+        );
+    }
 }
 
 #[test]

--- a/messages/src/tests/collection.rs
+++ b/messages/src/tests/collection.rs
@@ -185,66 +185,10 @@ fn collection_job_req_decode_is_lenient_about_extension_order() {
     let req = CollectionJobReq::<LeaderSelected>::get_decoded(&encoded)
         .expect("structurally valid collection job request must decode");
     assert_eq!(req.extensions().len(), 2);
-}
 
-#[test]
-fn collection_job_req_decode_encode_is_byte_identical() {
-    // The Helper stores the Collector's CollectionJobReq encoded and re-encodes it to rebuild the
-    // aggregate-share AAD on the poll path, so decode->encode must preserve bytes exactly.
-    let interval = Interval::new(
-        Time::from_seconds_since_epoch(54321, &TEST_TIME_PRECISION),
-        Duration::from_seconds(12345, &TEST_TIME_PRECISION),
-    )
-    .unwrap();
-    let extensions = Vec::from([
-        CollectionJobExtension::new(CollectionJobExtensionType::Reserved, Vec::new()),
-        CollectionJobExtension::new(
-            CollectionJobExtensionType::Unknown(0x0001),
-            Vec::from("ext"),
-        ),
-    ]);
-
-    for encoded in [
-        CollectionJobReq::<TimeInterval>::new(
-            Query::new_time_interval(interval),
-            Vec::from("012345"),
-        )
-        .get_encoded()
-        .unwrap(),
-        CollectionJobReq::<TimeInterval>::new(
-            Query::new_time_interval(interval),
-            Vec::from("012345"),
-        )
-        .with_extensions(extensions.clone())
-        .get_encoded()
-        .unwrap(),
-    ] {
-        assert_eq!(
-            CollectionJobReq::<TimeInterval>::get_decoded(&encoded)
-                .unwrap()
-                .get_encoded()
-                .unwrap(),
-            encoded,
-        );
-    }
-
-    for encoded in [
-        CollectionJobReq::<LeaderSelected>::new(Query::new_leader_selected(), Vec::from("012345"))
-            .get_encoded()
-            .unwrap(),
-        CollectionJobReq::<LeaderSelected>::new(Query::new_leader_selected(), Vec::from("012345"))
-            .with_extensions(extensions)
-            .get_encoded()
-            .unwrap(),
-    ] {
-        assert_eq!(
-            CollectionJobReq::<LeaderSelected>::get_decoded(&encoded)
-                .unwrap()
-                .get_encoded()
-                .unwrap(),
-            encoded,
-        );
-    }
+    // The Helper re-encodes the decoded request to rebuild the aggregate-share AAD, so even an
+    // unsorted extensions list must survive decode->encode byte-identically.
+    assert_eq!(req.get_encoded().unwrap(), encoded);
 }
 
 #[test]


### PR DESCRIPTION
This _enables_ collection extensions and batch selectors narrower than the query, but only does the work for the latter. Collection extensions are left to #4715 based on being unnecessary at this time.

Resolves #4743

> [!NOTE]
> I changed the existing `AggregateShareRequestRejected` to yield a problem document rather than a blank page, which affects several tests, but feels more right. That said, there's no DAP Problem Type for this (see my note on `http_handlers.rs:189`) and maybe there should be? But also, then I'd need to break `AggregateShareRequestRejected` apart a bit since we're using it for several purposes and now I distinguish them based on the `detail` field.

