### PR TITLE
Prefer the Task::task_configuration accessor in tests

### DIFF
--- a/aggregator/src/aggregator/aggregation_job_driver/tests.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver/tests.rs
@@ -113,7 +113,7 @@ async fn aggregation_job_driver() {
     );
     let accepted_report = LeaderStoredReport::generate(
         *task.id(),
-        task.leader_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         accepted_report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -146,7 +146,7 @@ async fn aggregation_job_driver() {
             );
             let rejected_report = LeaderStoredReport::generate(
                 *task.id(),
-                task.leader_view().unwrap().task_configuration().unwrap(),
+                task.task_configuration(),
                 rejected_report_metadata,
                 helper_hpke_keypair.config(),
                 Vec::new(),
@@ -540,7 +540,7 @@ async fn leader_sync_time_interval_aggregation_job_init_single_step() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
-        task.leader_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -548,7 +548,7 @@ async fn leader_sync_time_interval_aggregation_job_init_single_step() {
     );
     let repeated_public_extension_report = LeaderStoredReport::generate(
         *task.id(),
-        task.leader_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         ReportMetadata::new(
             random(),
             time,
@@ -563,7 +563,7 @@ async fn leader_sync_time_interval_aggregation_job_init_single_step() {
     );
     let repeated_private_extension_report = LeaderStoredReport::generate(
         *task.id(),
-        task.leader_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         ReportMetadata::new(random(), time, Vec::new()),
         helper_hpke_keypair.config(),
         Vec::from([
@@ -574,7 +574,7 @@ async fn leader_sync_time_interval_aggregation_job_init_single_step() {
     );
     let repeated_public_private_extension_report = LeaderStoredReport::generate(
         *task.id(),
-        task.leader_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         ReportMetadata::new(
             random(),
             time,
@@ -1004,7 +1004,7 @@ async fn leader_sync_time_interval_aggregation_job_init_two_steps() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
-        task.leader_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -1315,7 +1315,7 @@ async fn leader_sync_time_interval_aggregation_job_init_partially_garbage_collec
     let helper_hpke_keypair = HpkeKeypair::test();
     let gc_eligible_report = LeaderStoredReport::generate(
         *task.id(),
-        task.leader_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         gc_eligible_report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -1323,7 +1323,7 @@ async fn leader_sync_time_interval_aggregation_job_init_partially_garbage_collec
     );
     let gc_ineligible_report = LeaderStoredReport::generate(
         *task.id(),
-        task.leader_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         gc_ineligible_report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -1706,7 +1706,7 @@ async fn leader_sync_leader_selected_aggregation_job_init_single_step() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
-        task.leader_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -2037,7 +2037,7 @@ async fn leader_sync_leader_selected_aggregation_job_init_two_steps() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
-        task.leader_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -2315,7 +2315,7 @@ async fn leader_sync_time_interval_aggregation_job_continue() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
-        task.leader_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -2670,7 +2670,7 @@ async fn leader_sync_leader_selected_aggregation_job_continue() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
-        task.leader_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -2965,7 +2965,7 @@ async fn leader_async_aggregation_job_init_to_pending() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
-        task.leader_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -3223,7 +3223,7 @@ async fn leader_async_aggregation_job_init_to_pending_two_step() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
-        task.leader_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -3482,7 +3482,7 @@ async fn leader_async_aggregation_job_continue_to_pending() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
-        task.leader_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -3744,7 +3744,7 @@ async fn leader_async_aggregation_job_init_poll_to_pending() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
-        task.leader_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -3989,7 +3989,7 @@ async fn leader_async_aggregation_job_init_poll_to_pending_two_step() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
-        task.leader_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -4234,7 +4234,7 @@ async fn leader_async_aggregation_job_init_poll_to_finished() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
-        task.leader_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -4496,7 +4496,7 @@ async fn leader_async_aggregation_job_init_poll_to_continue() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
-        task.leader_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -4758,7 +4758,7 @@ async fn leader_async_aggregation_job_continue_poll_to_pending() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
-        task.leader_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -5012,7 +5012,7 @@ async fn leader_async_aggregation_job_continue_poll_to_finished() {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
-        task.leader_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -5269,7 +5269,7 @@ async fn helper_async_init_processing_to_finished() {
 
     let report_share = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
-        task.helper_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata,
         hpke_keypair.config(),
         &transcript.public_share,
@@ -5513,7 +5513,7 @@ async fn helper_async_init_processing_to_continue() {
 
     let report_share = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
-        task.helper_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata,
         hpke_keypair.config(),
         &transcript.public_share,
@@ -5754,7 +5754,7 @@ async fn helper_async_continue_processing_to_finished() {
 
     let report_share = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
-        task.helper_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata,
         hpke_keypair.config(),
         &transcript.public_share,
@@ -6291,7 +6291,7 @@ async fn abandon_failing_aggregation_job_with_retryable_error() {
     );
     let report = LeaderStoredReport::generate(
         *task.id(),
-        task.leader_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),
@@ -6543,7 +6543,7 @@ async fn abandon_failing_aggregation_job_with_fatal_error() {
     );
     let report = LeaderStoredReport::generate(
         *task.id(),
-        task.leader_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_continue.rs
@@ -88,7 +88,7 @@ async fn aggregate_continue_sync() {
     let leader_verify_message_0 = transcript_0.leader_verify_transitions[1].message().unwrap();
     let report_share_0 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
-        task.helper_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata_0.clone(),
         hpke_key.config(),
         &transcript_0.public_share,
@@ -114,7 +114,7 @@ async fn aggregate_continue_sync() {
     let helper_verify_state_1 = transcript_1.helper_verify_transitions[0].verify_state();
     let report_share_1 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
-        task.helper_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata_1.clone(),
         hpke_key.config(),
         &transcript_1.public_share,
@@ -141,7 +141,7 @@ async fn aggregate_continue_sync() {
     let leader_verify_message_2 = transcript_2.leader_verify_transitions[1].message().unwrap();
     let report_share_2 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
-        task.helper_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata_2.clone(),
         hpke_key.config(),
         &transcript_2.public_share,
@@ -429,7 +429,7 @@ async fn aggregate_continue_async() {
     let leader_verify_message_0 = transcript_0.leader_verify_transitions[1].message().unwrap();
     let report_share_0 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
-        task.helper_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata_0.clone(),
         hpke_key.config(),
         &transcript_0.public_share,
@@ -455,7 +455,7 @@ async fn aggregate_continue_async() {
     let helper_verify_state_1 = transcript_1.helper_verify_transitions[0].verify_state();
     let report_share_1 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
-        task.helper_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata_1.clone(),
         hpke_key.config(),
         &transcript_1.public_share,
@@ -681,7 +681,7 @@ async fn aggregate_continue_accumulate_batch_aggregation() {
     let ping_pong_leader_message_0 = transcript_0.leader_verify_transitions[1].message().unwrap();
     let report_share_0 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
-        task.helper_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata_0.clone(),
         hpke_key.config(),
         &transcript_0.public_share,
@@ -707,7 +707,7 @@ async fn aggregate_continue_accumulate_batch_aggregation() {
     let ping_pong_leader_message_1 = transcript_1.leader_verify_transitions[1].message().unwrap();
     let report_share_1 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
-        task.helper_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata_1.clone(),
         hpke_key.config(),
         &transcript_1.public_share,
@@ -736,7 +736,7 @@ async fn aggregate_continue_accumulate_batch_aggregation() {
     let ping_pong_leader_message_2 = transcript_2.leader_verify_transitions[1].message().unwrap();
     let report_share_2 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
-        task.helper_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata_2.clone(),
         hpke_key.config(),
         &transcript_2.public_share,
@@ -1024,7 +1024,7 @@ async fn aggregate_continue_accumulate_batch_aggregation() {
     let ping_pong_leader_message_3 = transcript_3.leader_verify_transitions[1].message().unwrap();
     let report_share_3 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
-        task.helper_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata_3.clone(),
         hpke_key.config(),
         &transcript_3.public_share,
@@ -1053,7 +1053,7 @@ async fn aggregate_continue_accumulate_batch_aggregation() {
     let ping_pong_leader_message_4 = transcript_4.leader_verify_transitions[1].message().unwrap();
     let report_share_4 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
-        task.helper_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata_4.clone(),
         hpke_key.config(),
         &transcript_4.public_share,
@@ -1082,7 +1082,7 @@ async fn aggregate_continue_accumulate_batch_aggregation() {
     let ping_pong_leader_message_5 = transcript_5.leader_verify_transitions[1].message().unwrap();
     let report_share_5 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
-        task.helper_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata_5.clone(),
         hpke_key.config(),
         &transcript_5.public_share,
@@ -1452,7 +1452,7 @@ async fn aggregate_continue_verify_step_fails() {
     );
     let helper_report_share = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
-        task.helper_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata.clone(),
         hpke_key.config(),
         &transcript.public_share,

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_get.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_get.rs
@@ -186,7 +186,7 @@ async fn aggregation_job_get_unready() {
     let leader_message = transcript.leader_verify_transitions[0].message().unwrap();
     let report_share = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
-        task.helper_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata.clone(),
         hpke_keypair.config(),
         &transcript.public_share,

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
@@ -275,7 +275,7 @@ async fn aggregate_init_sync() {
         &input_share_bytes,
         &InputShareAad::new(
             *task.id(),
-            task.helper_view().unwrap().task_configuration().unwrap(),
+            task.task_configuration(),
             verify_init_2.report_share().metadata().clone(),
             transcript_2.public_share.get_encoded().unwrap(),
         )
@@ -296,7 +296,7 @@ async fn aggregate_init_sync() {
 
     let report_share_3 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
-        task.helper_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         verify_init_3.report_share().metadata().clone(),
         &wrong_hpke_config,
         &transcript_3.public_share,
@@ -327,7 +327,7 @@ async fn aggregate_init_sync() {
     );
     let report_share_5 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
-        task.helper_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata_5,
         hpke_keypair.config(),
         &transcript_5.public_share,
@@ -365,7 +365,7 @@ async fn aggregate_init_sync() {
         &transcript_6.helper_input_share.get_encoded().unwrap(),
         &InputShareAad::new(
             *task.id(),
-            task.helper_view().unwrap().task_configuration().unwrap(),
+            task.task_configuration(),
             report_metadata_6,
             public_share_6,
         )
@@ -400,7 +400,7 @@ async fn aggregate_init_sync() {
     );
     let report_share_7 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
-        task.helper_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata_7,
         hpke_keypair.config(),
         &transcript_7.public_share,
@@ -432,7 +432,7 @@ async fn aggregate_init_sync() {
     );
     let report_share_8 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
-        task.helper_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata_8,
         hpke_keypair.config(),
         &transcript_8.public_share,
@@ -468,7 +468,7 @@ async fn aggregate_init_sync() {
     );
     let report_share_9 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
-        task.helper_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata_9,
         hpke_keypair.config(),
         &transcript_9.public_share,
@@ -500,7 +500,7 @@ async fn aggregate_init_sync() {
     );
     let report_share_10 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
-        task.helper_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata_10,
         hpke_keypair.config(),
         &transcript_10.public_share,
@@ -532,7 +532,7 @@ async fn aggregate_init_sync() {
     );
     let report_share_11 = generate_helper_report_share::<dummy::Vdaf>(
         *task.id(),
-        task.helper_view().unwrap().task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata_11,
         hpke_keypair.config(),
         &transcript_11.public_share,

--- a/aggregator/src/aggregator/http_handlers/tests/report.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/report.rs
@@ -484,7 +484,7 @@ async fn upload_handler() {
                 .unwrap(),
             &InputShareAad::new(
                 *task.id(),
-                leader_task.task_configuration().unwrap(),
+                task.task_configuration(),
                 bad_leader_input_share_report.metadata().clone(),
                 bad_leader_input_share_report.public_share().to_vec(),
             )


### PR DESCRIPTION
Collapses the `helper_view()`/`leader_view()` unwrap chain at all other test call sites. Didn't do this in #4714 because I didn't want to pollute it.

Closes #4744