### PR TITLE
[DAP-17] Move TaskConfiguration Source of Truth (Part 1)

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -56,7 +56,7 @@ use janus_messages::{
     AggregationJobStep, CollectionJobExtension, CollectionJobId, CollectionJobReq,
     CollectionJobResp, Duration, ExtensionType, HpkeConfig, HpkeConfigList, InputShareAad,
     Interval, PartialBatchSelector, PlaintextInputShare, Report, ReportError, ReportUploadStatus,
-    Role, TaskConfiguration, TaskId, UploadErrors, Url as DapUrl, VerifyResp,
+    Role, TaskConfiguration, TaskExtension, TaskId, UploadErrors, Url as DapUrl, VerifyResp,
     batch_mode::{LeaderSelected, TimeInterval},
     extensions_are_strictly_increasing,
 };
@@ -858,6 +858,19 @@ impl<C: Clock> Aggregator<C> {
 
         // TODO(#1647): Check whether task config parameters are acceptable for privacy and
         // availability of the system.
+
+        // Supporting DAP task extensions is mandatory, so an extension we don't implement is a
+        // reason to opt out rather than aggregate under a task we only somewhat understand.
+        if let Some(extension) = task_config
+            .extensions()
+            .iter()
+            .find(|extension| matches!(extension, TaskExtension::Unknown { .. }))
+        {
+            return Err(Error::InvalidTask(
+                *task_id,
+                OptOutReason::UnsupportedExtension(extension.extension_type().into()),
+            ));
+        }
 
         let vdaf_instance = task_config.vdaf_config().try_into().map_err(|err: &str| {
             Error::InvalidTask(*task_id, OptOutReason::InvalidParameter(err.to_string()))

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -1958,8 +1958,7 @@ impl VdafOps {
 
         let input_share_aad = InputShareAad::new(
             *task.id(),
-            task.task_configuration()
-                .map_err(|e| UploadError::Internal(Arc::new(e.into())))?,
+            task.task_configuration(),
             report.metadata().clone(),
             report.public_share().to_vec(),
         )
@@ -3420,7 +3419,7 @@ impl VdafOps {
                         .map_err(Error::MessageEncode)?,
                     &AggregateShareAad::new(
                         *collection_job.task_id(),
-                        task.task_configuration()?,
+                        task.task_configuration(),
                         collection_job
                             .to_collection_job_req()
                             .map_err(Error::MessageEncode)?,
@@ -3648,7 +3647,7 @@ impl VdafOps {
                 .map_err(Error::MessageEncode)?,
             &AggregateShareAad::new(
                 *task.id(),
-                task.task_configuration()?,
+                task.task_configuration(),
                 aggregate_share_job.collection_job_req().clone(),
             )
             .get_encoded()
@@ -4043,7 +4042,7 @@ impl VdafOps {
                 .map_err(Error::MessageEncode)?,
             &AggregateShareAad::new(
                 *task.id(),
-                task.task_configuration()?,
+                task.task_configuration(),
                 aggregate_share_req.collection_job_req().clone(),
             )
             .get_encoded()

--- a/aggregator/src/aggregator/aggregation_job_creator.rs
+++ b/aggregator/src/aggregator/aggregation_job_creator.rs
@@ -970,7 +970,7 @@ mod tests {
         );
         let leader_report = Arc::new(LeaderStoredReport::generate(
             *leader_task.id(),
-            leader_task.task_configuration().unwrap(),
+            leader_task.task_configuration(),
             leader_report_metadata,
             helper_hpke_keypair.config(),
             Vec::new(),
@@ -1176,7 +1176,7 @@ mod tests {
                 );
                 LeaderStoredReport::generate(
                     *task.id(),
-                    task.task_configuration().unwrap(),
+                    task.task_configuration(),
                     report_metadata,
                     helper_hpke_keypair.config(),
                     Vec::new(),
@@ -1358,7 +1358,7 @@ mod tests {
         );
         let first_report = Arc::new(LeaderStoredReport::generate(
             *task.id(),
-            task.task_configuration().unwrap(),
+            task.task_configuration(),
             first_report_metadata,
             helper_hpke_keypair.config(),
             Vec::new(),
@@ -1376,7 +1376,7 @@ mod tests {
         );
         let second_report = Arc::new(LeaderStoredReport::generate(
             *task.id(),
-            task.task_configuration().unwrap(),
+            task.task_configuration(),
             second_report_metadata,
             helper_hpke_keypair.config(),
             Vec::new(),
@@ -1563,7 +1563,7 @@ mod tests {
         );
         let report = Arc::new(LeaderStoredReport::generate(
             *task.id(),
-            task.task_configuration().unwrap(),
+            task.task_configuration(),
             report_metadata,
             helper_hpke_keypair.config(),
             Vec::new(),
@@ -1729,7 +1729,7 @@ mod tests {
                 );
                 LeaderStoredReport::generate(
                     *task.id(),
-                    task.task_configuration().unwrap(),
+                    task.task_configuration(),
                     report_metadata,
                     helper_hpke_keypair.config(),
                     Vec::new(),
@@ -1918,7 +1918,7 @@ mod tests {
                 );
                 LeaderStoredReport::generate(
                     *task.id(),
-                    task.task_configuration().unwrap(),
+                    task.task_configuration(),
                     report_metadata,
                     helper_hpke_keypair.config(),
                     Vec::new(),
@@ -2119,7 +2119,7 @@ mod tests {
                 );
                 LeaderStoredReport::generate(
                     *task.id(),
-                    task.task_configuration().unwrap(),
+                    task.task_configuration(),
                     report_metadata,
                     helper_hpke_keypair.config(),
                     Vec::new(),
@@ -2285,7 +2285,7 @@ mod tests {
                 );
                 LeaderStoredReport::generate(
                     *task.id(),
-                    task.task_configuration().unwrap(),
+                    task.task_configuration(),
                     report_metadata,
                     helper_hpke_keypair.config(),
                     Vec::new(),
@@ -2401,7 +2401,7 @@ mod tests {
         );
         let last_report = Arc::new(LeaderStoredReport::generate(
             *task.id(),
-            task.task_configuration().unwrap(),
+            task.task_configuration(),
             last_report_metadata,
             helper_hpke_keypair.config(),
             Vec::new(),
@@ -2551,7 +2551,7 @@ mod tests {
                 );
                 LeaderStoredReport::generate(
                     *task.id(),
-                    task.task_configuration().unwrap(),
+                    task.task_configuration(),
                     report_metadata,
                     helper_hpke_keypair.config(),
                     Vec::new(),
@@ -2670,7 +2670,7 @@ mod tests {
                 );
                 LeaderStoredReport::generate(
                     *task.id(),
-                    task.task_configuration().unwrap(),
+                    task.task_configuration(),
                     report_metadata,
                     helper_hpke_keypair.config(),
                     Vec::new(),
@@ -2836,7 +2836,7 @@ mod tests {
                 );
                 LeaderStoredReport::generate(
                     *task.id(),
-                    task.task_configuration().unwrap(),
+                    task.task_configuration(),
                     report_metadata,
                     helper_hpke_keypair.config(),
                     Vec::new(),
@@ -2858,7 +2858,7 @@ mod tests {
                 );
                 LeaderStoredReport::generate(
                     *task.id(),
-                    task.task_configuration().unwrap(),
+                    task.task_configuration(),
                     report_metadata,
                     helper_hpke_keypair.config(),
                     Vec::new(),

--- a/aggregator/src/aggregator/aggregation_job_driver/tests.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver/tests.rs
@@ -6008,7 +6008,7 @@ async fn setup_cancel_aggregation_job_test() -> CancelAggregationJobTestCase {
     let helper_hpke_keypair = HpkeKeypair::test();
     let report = LeaderStoredReport::generate(
         *task.id(),
-        task.task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata,
         helper_hpke_keypair.config(),
         Vec::new(),

--- a/aggregator/src/aggregator/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/aggregation_job_init.rs
@@ -111,7 +111,7 @@ where
     C: Clock,
 {
     let verify_key = task.vdaf_verify_key()?;
-    let task_configuration = task.task_configuration()?;
+    let task_configuration = task.task_configuration();
     let report_aggregation_count = report_aggregations.len();
     let now = clock.now();
     let report_deadline = now
@@ -679,7 +679,7 @@ pub mod test_util {
             );
             let report_share = generate_helper_report_share::<V>(
                 *self.task.id(),
-                self.task.task_configuration().unwrap(),
+                self.task.task_configuration(),
                 report_metadata,
                 &self.hpke_config,
                 &transcript.public_share,

--- a/aggregator/src/aggregator/error.rs
+++ b/aggregator/src/aggregator/error.rs
@@ -303,6 +303,8 @@ pub enum OptOutReason {
     /// Catch-all error for generally invalid parameters.
     #[error("invalid parameter: {0}")]
     InvalidParameter(String),
+    #[error("unsupported task extension: {0:#06x}")]
+    UnsupportedExtension(u16),
 }
 
 impl Error {

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -4,7 +4,10 @@ use assert_matches::assert_matches;
 use axum::body::Body;
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use chrono::TimeDelta;
-use http::{Request, StatusCode};
+use http::{
+    Request, StatusCode,
+    header::{AUTHORIZATION, CONTENT_TYPE},
+};
 use janus_aggregator_core::{
     AsyncAggregator,
     datastore::{
@@ -326,9 +329,9 @@ async fn taskprov_aggregate_init() {
                             .unwrap()
                             .path(),
                     )
-                    .header(http::header::AUTHORIZATION, "Bearer invalid_token")
+                    .header(AUTHORIZATION, "Bearer invalid_token")
                     .header(
-                        http::header::CONTENT_TYPE,
+                        CONTENT_TYPE,
                         AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
                     )
                     .header(
@@ -356,7 +359,7 @@ async fn taskprov_aggregate_init() {
                     )
                     .with_authentication_token(test.peer_aggregator.primary_aggregator_auth_token())
                     .header(
-                        http::header::CONTENT_TYPE,
+                        CONTENT_TYPE,
                         AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
                     )
                     .header(
@@ -483,7 +486,7 @@ async fn taskprov_aggregate_init_without_task_interval() {
                 )
                 .with_authentication_token(test.peer_aggregator.primary_aggregator_auth_token())
                 .header(
-                    http::header::CONTENT_TYPE,
+                    CONTENT_TYPE,
                     AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
                 )
                 .header(
@@ -546,7 +549,7 @@ async fn taskprov_aggregate_init_missing_extension() {
                 )
                 .with_authentication_token(test.peer_aggregator.primary_aggregator_auth_token())
                 .header(
-                    http::header::CONTENT_TYPE,
+                    CONTENT_TYPE,
                     AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
                 )
                 .header(
@@ -647,7 +650,7 @@ async fn taskprov_aggregate_init_malformed_extension() {
                 )
                 .with_authentication_token(test.peer_aggregator.primary_aggregator_auth_token())
                 .header(
-                    http::header::CONTENT_TYPE,
+                    CONTENT_TYPE,
                     AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
                 )
                 .header(
@@ -753,7 +756,7 @@ async fn taskprov_opt_out_task_ended_regression() {
                 )
                 .with_authentication_token(test.peer_aggregator.primary_aggregator_auth_token())
                 .header(
-                    http::header::CONTENT_TYPE,
+                    CONTENT_TYPE,
                     AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
                 )
                 .header(
@@ -821,7 +824,7 @@ async fn taskprov_opt_out_mismatched_task_id() {
                 )
                 .with_authentication_token(test.peer_aggregator.primary_aggregator_auth_token())
                 .header(
-                    http::header::CONTENT_TYPE,
+                    CONTENT_TYPE,
                     AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
                 )
                 .header(
@@ -899,7 +902,7 @@ async fn taskprov_opt_out_peer_aggregator_wrong_role() {
                 ))
                 .with_authentication_token(test.peer_aggregator.primary_aggregator_auth_token())
                 .header(
-                    http::header::CONTENT_TYPE,
+                    CONTENT_TYPE,
                     AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
                 )
                 .header(
@@ -976,7 +979,7 @@ async fn taskprov_opt_out_peer_aggregator_does_not_exist() {
                 ))
                 .with_authentication_token(test.peer_aggregator.primary_aggregator_auth_token())
                 .header(
-                    http::header::CONTENT_TYPE,
+                    CONTENT_TYPE,
                     AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
                 )
                 .header(
@@ -1056,7 +1059,7 @@ async fn taskprov_opt_out_unsupported_extension() {
                 ))
                 .with_authentication_token(test.peer_aggregator.primary_aggregator_auth_token())
                 .header(
-                    http::header::CONTENT_TYPE,
+                    CONTENT_TYPE,
                     AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
                 )
                 .header(
@@ -1188,11 +1191,8 @@ async fn taskprov_aggregate_continue() {
                         .unwrap()
                         .path(),
                 )
-                .header(http::header::AUTHORIZATION, "Bearer invalid_token")
-                .header(
-                    http::header::CONTENT_TYPE,
-                    AggregationJobContinueReq::MEDIA_TYPE,
-                )
+                .header(AUTHORIZATION, "Bearer invalid_token")
+                .header(CONTENT_TYPE, AggregationJobContinueReq::MEDIA_TYPE)
                 .header(
                     TASKPROV_HEADER,
                     URL_SAFE_NO_PAD.encode(test.task_config.get_encoded().unwrap()),
@@ -1217,10 +1217,7 @@ async fn taskprov_aggregate_continue() {
                         .path(),
                 )
                 .with_authentication_token(test.peer_aggregator.primary_aggregator_auth_token())
-                .header(
-                    http::header::CONTENT_TYPE,
-                    AggregationJobContinueReq::MEDIA_TYPE,
-                )
+                .header(CONTENT_TYPE, AggregationJobContinueReq::MEDIA_TYPE)
                 .header(
                     TASKPROV_HEADER,
                     URL_SAFE_NO_PAD.encode(test.task_config.get_encoded().unwrap()),
@@ -1321,9 +1318,9 @@ async fn taskprov_aggregate_share() {
                         .unwrap()
                         .path(),
                 )
-                .header(http::header::AUTHORIZATION, "Bearer invalid_token")
+                .header(AUTHORIZATION, "Bearer invalid_token")
                 .header(
-                    http::header::CONTENT_TYPE,
+                    CONTENT_TYPE,
                     AggregateShareReq::<LeaderSelected>::MEDIA_TYPE,
                 )
                 .header(
@@ -1351,7 +1348,7 @@ async fn taskprov_aggregate_share() {
                 )
                 .with_authentication_token(test.peer_aggregator.primary_aggregator_auth_token())
                 .header(
-                    http::header::CONTENT_TYPE,
+                    CONTENT_TYPE,
                     AggregateShareReq::<LeaderSelected>::MEDIA_TYPE,
                 )
                 .header(
@@ -1424,7 +1421,7 @@ async fn end_to_end() {
                 )
                 .with_authentication_token(test.peer_aggregator.primary_aggregator_auth_token())
                 .header(
-                    http::header::CONTENT_TYPE,
+                    CONTENT_TYPE,
                     AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
                 )
                 .header(
@@ -1486,10 +1483,7 @@ async fn end_to_end() {
                         .path(),
                 )
                 .with_authentication_token(test.peer_aggregator.primary_aggregator_auth_token())
-                .header(
-                    http::header::CONTENT_TYPE,
-                    AggregationJobContinueReq::MEDIA_TYPE,
-                )
+                .header(CONTENT_TYPE, AggregationJobContinueReq::MEDIA_TYPE)
                 .header(
                     TASKPROV_HEADER,
                     URL_SAFE_NO_PAD.encode(test.task_config.get_encoded().unwrap()),
@@ -1543,7 +1537,7 @@ async fn end_to_end() {
                 )
                 .with_authentication_token(test.peer_aggregator.primary_aggregator_auth_token())
                 .header(
-                    http::header::CONTENT_TYPE,
+                    CONTENT_TYPE,
                     AggregateShareReq::<LeaderSelected>::MEDIA_TYPE,
                 )
                 .header(
@@ -1627,7 +1621,7 @@ async fn end_to_end_sumvec_hmac() {
                 )
                 .with_authentication_token(test.peer_aggregator.primary_aggregator_auth_token())
                 .header(
-                    http::header::CONTENT_TYPE,
+                    CONTENT_TYPE,
                     AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
                 )
                 .header(
@@ -1656,7 +1650,10 @@ async fn end_to_end_sumvec_hmac() {
     assert_eq!(verify_resps.len(), 1);
     let verify_resp = &verify_resps[0];
     assert_eq!(verify_resp.report_id(), report_share.metadata().id());
-    let message = assert_matches!(verify_resp.result(), VerifyStepResult::Continue { message } => message.clone());
+    let message = assert_matches!(
+        verify_resp.result(),
+        VerifyStepResult::Continue { message } => message.clone()
+    );
     assert_eq!(
         &message,
         transcript.helper_verify_transitions[0].message().unwrap()
@@ -1687,7 +1684,7 @@ async fn end_to_end_sumvec_hmac() {
                 )
                 .with_authentication_token(test.peer_aggregator.primary_aggregator_auth_token())
                 .header(
-                    http::header::CONTENT_TYPE,
+                    CONTENT_TYPE,
                     AggregateShareReq::<LeaderSelected>::MEDIA_TYPE,
                 )
                 .header(

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -36,8 +36,9 @@ use janus_messages::{
     AggregateShareReq, AggregationJobContinueReq, AggregationJobId, AggregationJobInitializeReq,
     AggregationJobResp, AggregationJobStep, BatchConfig, BatchSelector, CollectionJobReq, Duration,
     Extension, ExtensionType, Interval, MediaType, PartialBatchSelector, Query, ReportError,
-    ReportIdChecksum, ReportShare, Role, TaskConfiguration, TaskConfigurationBuilder, TaskId, Time,
-    TimePrecision, VdafConfig, VerifyContinue, VerifyInit, VerifyResp, VerifyStepResult,
+    ReportIdChecksum, ReportShare, Role, TaskConfiguration, TaskConfigurationBuilder,
+    TaskExtension, TaskExtensionType, TaskId, Time, TimePrecision, VdafConfig, VerifyContinue,
+    VerifyInit, VerifyResp, VerifyStepResult,
     batch_mode::LeaderSelected,
     codec::{Decode, Encode},
 };
@@ -998,6 +999,97 @@ async fn taskprov_opt_out_peer_aggregator_does_not_exist() {
             "detail": "this aggregator is not peered with the given leader aggregator",
         })
     );
+}
+
+#[tokio::test]
+async fn taskprov_opt_out_unsupported_extension() {
+    let test = TaskprovTestCase::new().await;
+
+    let (transcript, report_share, _) = test.next_report_share();
+    let batch_id = random();
+    let request = AggregationJobInitializeReq::new(
+        0,
+        ().get_encoded().unwrap(),
+        PartialBatchSelector::new_leader_selected(batch_id),
+        Vec::from([VerifyInit::new(
+            report_share.clone(),
+            transcript.leader_verify_transitions[0]
+                .message()
+                .unwrap()
+                .clone(),
+        )]),
+    );
+
+    let aggregation_job_id: AggregationJobId = random();
+
+    let another_task_config = TaskConfigurationBuilder::new(
+        Vec::from("foobar".as_bytes()),
+        "https://leader.example.com/".as_bytes().try_into().unwrap(),
+        "https://helper.example.com/".as_bytes().try_into().unwrap(),
+        *test.task.time_precision(),
+        100,
+        BatchConfig::LeaderSelected,
+        VdafConfig::Fake { rounds: 2 },
+    )
+    .with_extensions(Vec::from([TaskExtension::Unknown {
+        extension_type: TaskExtensionType::Unknown(0x1000),
+        extension_data: Vec::from("unsupported".as_bytes()),
+    }]))
+    .with_task_interval(
+        test.clock.now().to_time(test.task.time_precision()),
+        Duration::from_hours(24, test.task.time_precision()),
+    )
+    .unwrap()
+    .build()
+    .unwrap();
+    let another_task_config_encoded = another_task_config.get_encoded().unwrap();
+    let another_task_id = taskprov_task_id(&another_task_config_encoded);
+
+    let mut response = test
+        .router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri(format!(
+                    "/tasks/{another_task_id}/aggregation_jobs/{aggregation_job_id}"
+                ))
+                .with_authentication_token(test.peer_aggregator.primary_aggregator_auth_token())
+                .header(
+                    http::header::CONTENT_TYPE,
+                    AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
+                )
+                .header(
+                    TASKPROV_HEADER,
+                    URL_SAFE_NO_PAD.encode(another_task_config_encoded),
+                )
+                .body(Body::from(request.get_encoded().unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        take_problem_details(&mut response).await,
+        json!({
+            "status": StatusCode::BAD_REQUEST.as_u16(),
+            "type": "urn:ietf:params:ppm:dap:error:invalidTask",
+            "title": "Aggregator has opted out of the indicated task.",
+            "taskid": format!("{another_task_id}"),
+            "detail": "unsupported task extension: 0x1000",
+        })
+    );
+
+    // Make sure it didn't get provisioned
+    test.datastore
+        .run_unnamed_tx(|tx| {
+            Box::pin(async move {
+                assert!(tx.get_aggregator_task(&another_task_id).await?.is_none());
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
 }
 
 #[tokio::test]

--- a/aggregator/src/aggregator/test_util.rs
+++ b/aggregator/src/aggregator/test_util.rs
@@ -86,7 +86,7 @@ pub fn create_report_custom(
 
     let associated_data = InputShareAad::new(
         *task.id(),
-        task.task_configuration().unwrap(),
+        task.task_configuration(),
         report_metadata.clone(),
         public_share.get_encoded().unwrap(),
     );

--- a/aggregator/src/aggregator/upload_tests.rs
+++ b/aggregator/src/aggregator/upload_tests.rs
@@ -1016,7 +1016,7 @@ async fn upload_report_leader_input_share_decode_failure() {
                 .unwrap(),
             &InputShareAad::new(
                 *task.id(),
-                task.task_configuration().unwrap(),
+                task.task_configuration(),
                 report.metadata().clone(),
                 report.public_share().to_vec(),
             )

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -3656,7 +3656,7 @@ async fn get_collection_job(ephemeral_datastore: EphemeralDatastore) {
                 &[0, 1, 2, 3, 4, 5],
                 &AggregateShareAad::new(
                     *task.id(),
-                    task.task_configuration().unwrap(),
+                    task.task_configuration(),
                     first_collection_job.to_collection_job_req().unwrap(),
                 )
                 .get_encoded()

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -387,37 +387,42 @@ impl AggregatorTask {
     /// For taskprov tasks this is the wire configuration verbatim; for API-provisioned tasks it is
     /// synthesized from the stored parameters, pairing this aggregator's own and peer endpoints
     /// into leader/helper by role.
-    pub fn task_configuration(&self) -> Result<TaskConfiguration, Error> {
+    ///
+    /// # Panics
+    ///
+    /// Panics if a taskprov task is missing its configuration, or if the VDAF is not
+    /// representable on the wire. This is temporary until we store the TaskConf in the
+    /// DB in #4712.
+    pub fn task_configuration(&self) -> TaskConfiguration {
         if let Some(task_config) = &self.taskprov_task_config {
-            return Ok(task_config.clone());
+            return task_config.clone();
         }
 
         // A taskprov task must carry its wire configuration verbatim (set in `taskprov_opt_in` and
         // rehydrated on DB read); synthesizing one from the stored parameters is not byte-faithful.
         // Reaching here for a taskprov task means the config was lost, so fail loudly rather than
         // bind a wrong AAD.
-        if matches!(
-            self.aggregator_parameters,
-            AggregatorTaskParameters::TaskprovHelper { .. }
-        ) {
-            return Err(Error::InvalidParameter(
-                "taskprov task is missing its verbatim TaskConfiguration",
-            ));
-        }
+        assert!(
+            !matches!(
+                self.aggregator_parameters,
+                AggregatorTaskParameters::TaskprovHelper { .. }
+            ),
+            "taskprov task is missing its TaskConfiguration"
+        );
 
         let (leader_endpoint, helper_endpoint) = match self.role() {
             Role::Leader => (
                 &self.own_aggregator_endpoint,
                 &self.peer_aggregator_endpoint,
             ),
-            Role::Helper => (
+            // `role()` yields only Leader or Helper.
+            _ => (
                 &self.peer_aggregator_endpoint,
                 &self.own_aggregator_endpoint,
             ),
-            _ => return Err(Error::InvalidParameter("task role is not an aggregator")),
         };
 
-        Ok(build_task_configuration(
+        build_task_configuration(
             self.task_info().to_vec(),
             leader_endpoint.clone(),
             helper_endpoint.clone(),
@@ -426,9 +431,10 @@ impl AggregatorTask {
             self.batch_mode().to_batch_config(),
             self.vdaf()
                 .to_vdaf_config()
-                .map_err(Error::InvalidParameter)?,
+                .expect("VDAF is not representable as a VdafConfig"),
             self.task_interval().copied(),
-        )?)
+        )
+        .expect("task parameters are validated at construction")
     }
 
     /// Retrieves the batch mode associated with this task.
@@ -1257,9 +1263,9 @@ pub mod test_util {
 
         /// The task's [`TaskConfiguration`], as bound into HPKE AADs. Identical across aggregator
         /// views, so this collapses the frequent
-        /// `helper_view().unwrap().task_configuration().unwrap()` chain in tests.
+        /// `helper_view().unwrap().task_configuration()` chain in tests.
         pub fn task_configuration(&self) -> TaskConfiguration {
-            self.leader_view().unwrap().task_configuration().unwrap()
+            self.leader_view().unwrap().task_configuration()
         }
 
         /// Render a taskprov helper aggregator's view of this task.
@@ -1744,7 +1750,7 @@ mod tests {
         .with_helper_aggregator_endpoint("https://helper.example.com/".parse().unwrap())
         .build();
 
-        let leader_config = task.leader_view().unwrap().task_configuration().unwrap();
+        let leader_config = task.leader_view().unwrap().task_configuration();
         assert_eq!(
             leader_config.leader_aggregator_endpoint().as_str(),
             "https://leader.example.com/"
@@ -1755,7 +1761,7 @@ mod tests {
         );
         assert_eq!(
             leader_config,
-            task.helper_view().unwrap().task_configuration().unwrap()
+            task.helper_view().unwrap().task_configuration()
         );
     }
 
@@ -1786,16 +1792,17 @@ mod tests {
         .unwrap()
         .with_taskprov_task_config(wire.clone());
 
-        assert_eq!(task.task_configuration().unwrap(), wire);
+        assert_eq!(task.task_configuration(), wire);
         assert_eq!(
-            task.task_configuration().unwrap().task_info(),
+            task.task_configuration().task_info(),
             b"wire-specific-task-info"
         );
     }
 
     #[test]
-    fn task_configuration_taskprov_without_config_errors() {
-        // A taskprov task whose verbatim wire config is absent must fail loudly rather than
+    #[should_panic(expected = "taskprov task is missing its TaskConfiguration")]
+    fn task_configuration_taskprov_without_config_panics() {
+        // A taskprov task whose wire config is absent must fail loudly rather than
         // silently synthesize a (non-byte-faithful) config from its stored parameters.
         let task = TaskBuilder::new(
             BatchMode::TimeInterval,
@@ -1805,7 +1812,7 @@ mod tests {
         .build()
         .taskprov_helper_view()
         .unwrap();
-        assert_matches!(task.task_configuration(), Err(Error::InvalidParameter(_)));
+        let _ = task.task_configuration();
     }
 
     #[test]

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -415,11 +415,12 @@ impl AggregatorTask {
                 &self.own_aggregator_endpoint,
                 &self.peer_aggregator_endpoint,
             ),
-            // `role()` yields only Leader or Helper.
-            _ => (
+            Role::Helper => (
                 &self.peer_aggregator_endpoint,
                 &self.own_aggregator_endpoint,
             ),
+            // `role()` yields only Leader or Helper.
+            _ => panic!("We received a non-aggregator role from AggregatorTask::role()"),
         };
 
         build_task_configuration(


### PR DESCRIPTION
This is two independent commits, which independently result in green tests, albeit with a (temporary) production panic while I get the next pieces in place.

First, a small change to opt-out of TaskProv tasks with unsupported extensions. This is needed anyway, I just sorta stumbled on this while I was looking at the rest of the job.

Second, a big mechanical change to make `AggregatorTask::task_configuration()` infallible, because when it comes from the database, it will be. That said, at the conclusion of this it _isn't_, hence the prospect of panics. But the next part will do the database work.

### [DAP-17] Opt out of taskprov tasks with unsupported extensions

DAP task extensions are mandatory, so a TaskConfiguration
carrying an extension we don't implement is a reason to opt out rather
than aggregate under a task we only sort-of understand.

The check goes in taskprov_opt_in rather than taskprov_authorize_request.
Authorize_request runs on every taskprov request, which would reject
tasks already in the datastore, which seems to not be what we want.

Part of https://github.com/divviup/janus/issues/4712.

### [DAP-17] Make AggregatorTask::task_configuration() infallible

Returns TaskConfiguration by value rather than Result. This is part of
changing TaskConfiguration to be a value stored in the database rather
than one generated as needed.

This is not a change intended to stick around. I'm adding `expect()`s to
production code (OH NO!!!), which will get removed in the next PR.

But since this is kinda large and mechanical, let's keep it standalone
and stack the next PR on it.

So, two of the four error arms were already unreachable and are removed:
role() yields only Leader or Helper, and task_info length is validated at
construction, so build_task_configuration cannot fail for a task that
exists.

The remaining two become expect()s: a taskprov task missing its verbatim
config, and a VDAF that to_vdaf_config() rejects. These expects won't be
there when the TaskConfiguration is stored on the task, which is the next
PR.

Part of https://github.com/divviup/janus/issues/4712.