### PR TITLE
[DAP-17] Store and Recall TaskConfiguration from DB (Part 2)

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -887,7 +887,7 @@ impl<C: Clock> Aggregator<C> {
             .map(|a| Duration::from_chrono(a, task_config.time_precision()));
 
         let task = Arc::new(
-            AggregatorTask::new(
+            AggregatorTask::new_with_task_config(
                 *task_id,
                 leader_url,
                 helper_url,
@@ -910,11 +910,10 @@ impl<C: Clock> Aggregator<C> {
                         },
                     )?,
                 },
+                // Bind the received TaskConfiguration verbatim into HPKE AADs.
+                task_config.clone(),
             )
-            .map_err(|err| Error::InvalidTask(*task_id, OptOutReason::TaskParameters(err)))?
-            // Bind the received TaskConfiguration verbatim into HPKE AADs; it is not
-            // byte-reconstructible from the stored parameters.
-            .with_taskprov_task_config(task_config.clone()),
+            .map_err(|err| Error::InvalidTask(*task_id, OptOutReason::TaskParameters(err)))?,
         );
         self.datastore
             .run_tx("taskprov_put_task", |tx| {

--- a/aggregator/src/aggregator/http_handlers/tests/hpke_config.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/hpke_config.rs
@@ -208,7 +208,9 @@ async fn hpke_config_with_taskprov() {
         VdafInstance::Prio3Count,
     )
     .build();
-    let taskprov_helper_task = task.taskprov_helper_view().unwrap();
+    let taskprov_helper_task = task
+        .taskprov_helper_view_with_task_config(task.task_configuration())
+        .unwrap();
     datastore
         .put_aggregator_task(&taskprov_helper_task)
         .await

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -437,9 +437,8 @@ async fn taskprov_aggregate_init() {
     let got_task = got_task.unwrap();
     assert_eq!(
         test.task
-            .taskprov_helper_view()
-            .unwrap()
-            .with_taskprov_task_config(test.task_config.clone()),
+            .taskprov_helper_view_with_task_config(test.task_config.clone())
+            .unwrap(),
         got_task
     );
     assert_eq!(got_task.task_info(), b"foobar".as_slice());
@@ -608,9 +607,8 @@ async fn taskprov_aggregate_init_missing_extension() {
     );
     assert_eq!(
         test.task
-            .taskprov_helper_view()
-            .unwrap()
-            .with_taskprov_task_config(test.task_config.clone()),
+            .taskprov_helper_view_with_task_config(test.task_config.clone())
+            .unwrap(),
         got_task.unwrap()
     );
 }
@@ -709,9 +707,8 @@ async fn taskprov_aggregate_init_malformed_extension() {
     );
     assert_eq!(
         test.task
-            .taskprov_helper_view()
-            .unwrap()
-            .with_taskprov_task_config(test.task_config.clone()),
+            .taskprov_helper_view_with_task_config(test.task_config.clone())
+            .unwrap(),
         got_task.unwrap()
     );
 }
@@ -1107,13 +1104,18 @@ async fn taskprov_aggregate_continue() {
     test.datastore
         .run_unnamed_tx(|tx| {
             let task = test.task.clone();
+            let task_config = test.task_config.clone();
             let report_share = report_share.clone();
             let transcript = transcript.clone();
 
             Box::pin(async move {
                 // Aggregate continue is only possible if the task has already been inserted.
-                tx.put_aggregator_task(&task.taskprov_helper_view().unwrap())
-                    .await?;
+                tx.put_aggregator_task(
+                    &task
+                        .taskprov_helper_view_with_task_config(task_config)
+                        .unwrap(),
+                )
+                .await?;
 
                 tx.put_scrubbed_report(
                     task.id(),
@@ -1267,9 +1269,8 @@ async fn taskprov_aggregate_share() {
             Box::pin(async move {
                 tx.put_aggregator_task(
                     &task
-                        .taskprov_helper_view()
-                        .unwrap()
-                        .with_taskprov_task_config(task_config),
+                        .taskprov_helper_view_with_task_config(task_config)
+                        .unwrap(),
                 )
                 .await?;
 

--- a/aggregator_core/src/datastore.rs
+++ b/aggregator_core/src/datastore.rs
@@ -714,7 +714,7 @@ WHERE success = TRUE ORDER BY version DESC LIMIT(1)",
                 "-- put_aggregator_task()
 INSERT INTO tasks (
     task_id, aggregator_role, aggregation_mode, peer_aggregator_endpoint,
-    own_aggregator_endpoint, taskprov_task_config, batch_mode, vdaf, task_start,
+    own_aggregator_endpoint, task_config, batch_mode, vdaf, task_start,
     task_duration, report_expiry_age, min_batch_size,
     time_precision, tolerable_clock_skew, collector_hpke_config,
     vdaf_verify_key, task_info, deactivate_at, aggregator_auth_token_type,
@@ -739,11 +739,7 @@ ON CONFLICT DO NOTHING",
                     &task.peer_aggregator_endpoint().as_str(),
                     /* own_aggregator_endpoint */
                     &task.own_aggregator_endpoint().as_str(),
-                    /* taskprov_task_config */
-                    &task
-                        .taskprov_task_config()
-                        .map(|c| c.get_encoded())
-                        .transpose()?,
+                    /* task_config */ &task.task_configuration().get_encoded()?,
                     /* batch_mode */ &Json(task.batch_mode()),
                     /* vdaf */ &Json(task.vdaf()),
                     /* task_start */
@@ -899,7 +895,7 @@ UPDATE tasks SET
                 "-- get_aggregator_task()
 SELECT
     aggregator_role, aggregation_mode, peer_aggregator_endpoint,
-    own_aggregator_endpoint, taskprov_task_config, batch_mode,
+    own_aggregator_endpoint, task_config, batch_mode,
     vdaf, task_start, task_duration, report_expiry_age, min_batch_size,
     time_precision, tolerable_clock_skew, collector_hpke_config,
     vdaf_verify_key, task_info, deactivate_at, aggregator_auth_token_type,
@@ -923,7 +919,7 @@ FROM tasks WHERE task_id = $1",
                 "-- get_aggregator_tasks()
 SELECT
     task_id, aggregator_role, aggregation_mode, peer_aggregator_endpoint,
-    own_aggregator_endpoint, taskprov_task_config,
+    own_aggregator_endpoint, task_config,
     batch_mode, vdaf, task_start, task_duration, report_expiry_age, min_batch_size,
     time_precision, tolerable_clock_skew, collector_hpke_config,
     vdaf_verify_key, task_info, deactivate_at, aggregator_auth_token_type,
@@ -946,10 +942,7 @@ FROM tasks",
         let aggregator_role: AggregatorRole = row.get("aggregator_role");
         let peer_aggregator_endpoint = row.get::<_, String>("peer_aggregator_endpoint").parse()?;
         let own_aggregator_endpoint = row.get::<_, String>("own_aggregator_endpoint").parse()?;
-        let taskprov_task_config = row
-            .get::<_, Option<Vec<u8>>>("taskprov_task_config")
-            .map(|bytes| TaskConfiguration::get_decoded(&bytes))
-            .transpose()?;
+        let task_config = TaskConfiguration::get_decoded(row.try_get("task_config")?)?;
         let batch_mode = row.try_get::<_, Json<task::BatchMode>>("batch_mode")?.0;
         let aggregation_mode: Option<AggregationMode> = row.get("aggregation_mode");
         let vdaf = row.try_get::<_, Json<VdafInstance>>("vdaf")?.0;
@@ -1061,7 +1054,7 @@ FROM tasks",
             }
         };
 
-        let task = AggregatorTask::new(
+        Ok(AggregatorTask::new_with_task_config(
             *task_id,
             peer_aggregator_endpoint,
             own_aggregator_endpoint,
@@ -1075,13 +1068,9 @@ FROM tasks",
             tolerable_clock_skew,
             task_info,
             aggregator_parameters,
+            task_config,
         )?
-        .with_deactivate_at(deactivate_at);
-        let task = match taskprov_task_config {
-            Some(task_config) => task.with_taskprov_task_config(task_config),
-            None => task,
-        };
-        Ok(task)
+        .with_deactivate_at(deactivate_at))
     }
 
     /// Retrieves task IDs, optionally after some specified lower bound. This method returns tasks

--- a/aggregator_core/src/datastore/tests.rs
+++ b/aggregator_core/src/datastore/tests.rs
@@ -18,16 +18,17 @@ use chrono::{DateTime, TimeDelta, Utc};
 use futures::future::try_join_all;
 use janus_core::{
     hpke::{self, HpkeApplicationInfo, Label},
+    task_config::build_task_configuration,
     test_util::{install_test_trace_subscriber, run_vdaf},
     time::{Clock, DateTimeExt, IntervalExt, MockClock, TimeDeltaExt, TimeExt},
     vdaf::{VERIFY_KEY_LENGTH_PRIO3, VdafInstance, vdaf_dp_strategies},
 };
 use janus_messages::{
-    AggregateShareAad, AggregationJobId, AggregationJobStep, BatchId, CollectionJobExtension,
-    CollectionJobExtensionType, CollectionJobId, CollectionJobReq, Duration, Extension,
-    ExtensionType, HpkeCiphertext, HpkeConfigId, Interval, Query, ReportError, ReportId,
-    ReportIdChecksum, ReportMetadata, ReportShare, Role, TaskId, Time, TimePrecision,
-    VerifyContinue, VerifyInit, VerifyResp, VerifyStepResult,
+    AggregateShareAad, AggregationJobId, AggregationJobStep, BatchConfig, BatchId,
+    CollectionJobExtension, CollectionJobExtensionType, CollectionJobId, CollectionJobReq,
+    Duration, Extension, ExtensionType, HpkeCiphertext, HpkeConfigId, Interval, Query, ReportError,
+    ReportId, ReportIdChecksum, ReportMetadata, ReportShare, Role, TaskId, Time, TimePrecision,
+    VdafConfig, VerifyContinue, VerifyInit, VerifyResp, VerifyStepResult,
     batch_mode::{BatchMode, LeaderSelected, TimeInterval},
 };
 use postgres_types::Timestamp;
@@ -392,36 +393,66 @@ async fn roundtrip_task_own_endpoint_verbatim(ephemeral_datastore: EphemeralData
 
 #[rstest_reuse::apply(schema_versions_template)]
 #[tokio::test]
-async fn roundtrip_taskprov_task_config(ephemeral_datastore: EphemeralDatastore) {
-    // The verbatim taskprov TaskConfiguration must survive a DB round-trip: it is bound into HPKE
-    // AADs and is not byte-reconstructible from the task's other stored columns.
+async fn roundtrip_task_config(ephemeral_datastore: EphemeralDatastore) {
+    // The TaskConfiguration must survive a DB round-trip byte-for-byte: it is bound into
+    // HPKE AADs.
     install_test_trace_subscriber();
     let ds = ephemeral_datastore.datastore(MockClock::default()).await;
 
-    let base = TaskBuilder::new(
-        task::BatchMode::TimeInterval,
-        AggregationMode::Synchronous,
-        VdafInstance::Prio3Count,
+    // Each view needs its own task, since they would otherwise collide on task ID.
+    let new_base = || {
+        TaskBuilder::new(
+            task::BatchMode::TimeInterval,
+            AggregationMode::Synchronous,
+            VdafInstance::Prio3Count,
+        )
+        .build()
+    };
+    let taskprov_base = new_base();
+    // Give the taskprov view a wire config distinct from what synthesis would produce, so a
+    // synthesizing read path would be caught.
+    let taskprov_config = build_task_configuration(
+        b"wire-specific-task-info".to_vec(),
+        taskprov_base
+            .leader_aggregator_endpoint()
+            .as_str()
+            .parse()
+            .unwrap(),
+        taskprov_base
+            .helper_aggregator_endpoint()
+            .as_str()
+            .parse()
+            .unwrap(),
+        *taskprov_base.time_precision(),
+        taskprov_base.min_batch_size(),
+        BatchConfig::TimeInterval,
+        VdafConfig::Prio3Count,
+        None,
     )
-    .build();
-    // Source a TaskConfiguration to store from a non-taskprov view (synthesizing one for a taskprov
-    // task is now rejected); any valid config exercises the column's byte round-trip.
-    let task_config = base.task_configuration();
-    let task = base
-        .taskprov_helper_view()
-        .unwrap()
-        .with_taskprov_task_config(task_config.clone());
-    ds.put_aggregator_task(&task).await.unwrap();
+    .unwrap();
 
-    let retrieved = ds
-        .run_unnamed_tx(|tx| {
-            let task_id = *task.id();
-            Box::pin(async move { tx.get_aggregator_task(&task_id).await })
-        })
-        .await
-        .unwrap()
-        .unwrap();
-    assert_eq!(retrieved.taskprov_task_config(), Some(&task_config));
+    for task in [
+        new_base().leader_view().unwrap(),
+        new_base().helper_view().unwrap(),
+        taskprov_base
+            .taskprov_helper_view_with_task_config(taskprov_config)
+            .unwrap(),
+    ] {
+        ds.put_aggregator_task(&task).await.unwrap();
+
+        let retrieved = ds
+            .run_unnamed_tx(|tx| {
+                let task_id = *task.id();
+                Box::pin(async move { tx.get_aggregator_task(&task_id).await })
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            retrieved.task_configuration().get_encoded().unwrap(),
+            task.task_configuration().get_encoded().unwrap()
+        );
+    }
 }
 
 #[rstest_reuse::apply(schema_versions_template)]

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -268,11 +268,6 @@ pub struct AggregatorTask {
     /// The task's `TaskConfiguration`, bound verbatim into HPKE AADs. Adopted from the wire for
     /// taskprov tasks and synthesized once at provisioning time for API-provisioned tasks; either
     /// way it is frozen in the database and never re-synthesized on read.
-    ///
-    /// Persisted only via the datastore, not [`SerializedAggregatorTask`] (like `deactivate_at`);
-    /// deserializing that form re-synthesizes it via [`AggregatorTask::new`]. Safe because that
-    /// form accepts only the Leader and Helper roles, so a taskprov task — whose config must stay
-    /// verbatim — can never be provisioned through it.
     task_config: TaskConfiguration,
 }
 

--- a/aggregator_core/src/task.rs
+++ b/aggregator_core/src/task.rs
@@ -265,18 +265,21 @@ pub struct AggregatorTask {
     /// Deactivation instant. When set and reached (per the aggregator's clock), the
     /// aggregator stops accepting reports for this task. This is Janus-specific state.
     deactivate_at: Option<DateTime<Utc>>,
-    /// For taskprov tasks, the `TaskConfiguration` exactly as received on the wire, bound verbatim
-    /// into HPKE AADs. `None` for API-provisioned tasks, whose `TaskConfiguration` is synthesized
-    /// from the stored parameters. Reconstructing a taskprov config from those parameters is not
-    /// byte-safe (it would drop DP strategies and unknown extensions), so the wire bytes are kept.
+    /// The task's `TaskConfiguration`, bound verbatim into HPKE AADs. Adopted from the wire for
+    /// taskprov tasks and synthesized once at provisioning time for API-provisioned tasks; either
+    /// way it is frozen in the database and never re-synthesized on read.
     ///
     /// Persisted only via the datastore, not [`SerializedAggregatorTask`] (like `deactivate_at`);
-    /// taskprov tasks are never provisioned through that serde form.
-    taskprov_task_config: Option<TaskConfiguration>,
+    /// deserializing that form re-synthesizes it via [`AggregatorTask::new`]. Safe because that
+    /// form accepts only the Leader and Helper roles, so a taskprov task — whose config must stay
+    /// verbatim — can never be provisioned through it.
+    task_config: TaskConfiguration,
 }
 
 impl AggregatorTask {
-    /// Create a new [`AggregatorTask`] with the provided values.
+    /// Create a new [`AggregatorTask`] with the provided values, synthesizing its
+    /// [`TaskConfiguration`]. This is the provisioning constructor; a task adopting a
+    /// caller-supplied configuration uses [`AggregatorTask::new_with_task_config`] instead.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         task_id: TaskId,
@@ -313,16 +316,114 @@ impl AggregatorTask {
         )
     }
 
+    /// Create a new [`AggregatorTask`] from already-validated common parameters, synthesizing its
+    /// [`TaskConfiguration`].
     fn new_with_common_parameters(
         common_parameters: CommonTaskParameters,
         peer_aggregator_endpoint: DapUrl,
         own_aggregator_endpoint: DapUrl,
         aggregator_parameters: AggregatorTaskParameters,
     ) -> Result<Self, Error> {
+        Self::validate_parameters(
+            &common_parameters,
+            &peer_aggregator_endpoint,
+            &own_aggregator_endpoint,
+            &aggregator_parameters,
+        )?;
+
+        let (leader_endpoint, helper_endpoint) = match &aggregator_parameters {
+            AggregatorTaskParameters::Leader { .. } => {
+                (&own_aggregator_endpoint, &peer_aggregator_endpoint)
+            }
+            AggregatorTaskParameters::Helper { .. }
+            | AggregatorTaskParameters::TaskprovHelper { .. } => {
+                (&peer_aggregator_endpoint, &own_aggregator_endpoint)
+            }
+        };
+        let task_config = build_task_configuration(
+            common_parameters.task_info.clone(),
+            leader_endpoint.clone(),
+            helper_endpoint.clone(),
+            common_parameters.time_precision,
+            common_parameters.min_batch_size,
+            common_parameters.batch_mode.to_batch_config(),
+            common_parameters
+                .vdaf
+                .to_vdaf_config()
+                .map_err(Error::InvalidParameter)?,
+            common_parameters.task_interval,
+        )?;
+
+        Ok(Self {
+            common_parameters,
+            peer_aggregator_endpoint,
+            own_aggregator_endpoint,
+            aggregator_parameters,
+            deactivate_at: None,
+            task_config,
+        })
+    }
+
+    /// Create a new [`AggregatorTask`] adopting the provided [`TaskConfiguration`] verbatim rather
+    /// than synthesizing one. Used by the taskprov opt-in path, which must bind the configuration
+    /// exactly as received on the wire, and by the datastore, which must not re-synthesize a frozen
+    /// configuration on read.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_task_config(
+        task_id: TaskId,
+        peer_aggregator_endpoint: DapUrl,
+        own_aggregator_endpoint: DapUrl,
+        batch_mode: BatchMode,
+        vdaf: VdafInstance,
+        vdaf_verify_key: SecretBytes,
+        task_interval: Option<Interval>,
+        report_expiry_age: Option<Duration>,
+        min_batch_size: u64,
+        time_precision: TimePrecision,
+        tolerable_clock_skew: Duration,
+        task_info: Vec<u8>,
+        aggregator_parameters: AggregatorTaskParameters,
+        task_config: TaskConfiguration,
+    ) -> Result<Self, Error> {
+        let common_parameters = CommonTaskParameters::new(
+            task_id,
+            batch_mode,
+            vdaf,
+            vdaf_verify_key,
+            task_interval,
+            report_expiry_age,
+            min_batch_size,
+            time_precision,
+            tolerable_clock_skew,
+            task_info,
+        )?;
+        Self::validate_parameters(
+            &common_parameters,
+            &peer_aggregator_endpoint,
+            &own_aggregator_endpoint,
+            &aggregator_parameters,
+        )?;
+
+        Ok(Self {
+            common_parameters,
+            peer_aggregator_endpoint,
+            own_aggregator_endpoint,
+            aggregator_parameters,
+            deactivate_at: None,
+            task_config,
+        })
+    }
+
+    fn validate_parameters(
+        common_parameters: &CommonTaskParameters,
+        peer_aggregator_endpoint: &DapUrl,
+        own_aggregator_endpoint: &DapUrl,
+        aggregator_parameters: &AggregatorTaskParameters,
+    ) -> Result<(), Error> {
         // Reject an unparseable endpoint at construction. Without this check a
         // malformed endpoint would persist and never surface a user-visible error.
-        Url::try_from(&peer_aggregator_endpoint)?;
-        Url::try_from(&own_aggregator_endpoint)?;
+        Url::try_from(peer_aggregator_endpoint)?;
+        Url::try_from(own_aggregator_endpoint)?;
 
         if let BatchMode::LeaderSelected {
             batch_time_window_size: Some(batch_time_window_size),
@@ -341,14 +442,7 @@ impl AggregatorTask {
             }
         }
 
-        Ok(Self {
-            common_parameters,
-            peer_aggregator_endpoint,
-            own_aggregator_endpoint,
-            aggregator_parameters,
-            deactivate_at: None,
-            taskprov_task_config: None,
-        })
+        Ok(())
     }
 
     /// Retrieves the task ID associated with this task.
@@ -376,66 +470,10 @@ impl AggregatorTask {
         &self.own_aggregator_endpoint
     }
 
-    /// The received wire `TaskConfiguration` for a taskprov task, or `None` for an API-provisioned
-    /// task.
-    pub fn taskprov_task_config(&self) -> Option<&TaskConfiguration> {
-        self.taskprov_task_config.as_ref()
-    }
-
-    /// Returns the canonical [`TaskConfiguration`] for this task, as bound into HPKE AADs.
-    ///
-    /// For taskprov tasks this is the wire configuration verbatim; for API-provisioned tasks it is
-    /// synthesized from the stored parameters, pairing this aggregator's own and peer endpoints
-    /// into leader/helper by role.
-    ///
-    /// # Panics
-    ///
-    /// Panics if a taskprov task is missing its configuration, or if the VDAF is not
-    /// representable on the wire. This is temporary until we store the TaskConf in the
-    /// DB in #4712.
+    /// Returns the [`TaskConfiguration`] for this task, as bound into HPKE AADs. It was fixed at
+    /// provisioning time and is never re-synthesized.
     pub fn task_configuration(&self) -> TaskConfiguration {
-        if let Some(task_config) = &self.taskprov_task_config {
-            return task_config.clone();
-        }
-
-        // A taskprov task must carry its wire configuration verbatim (set in `taskprov_opt_in` and
-        // rehydrated on DB read); synthesizing one from the stored parameters is not byte-faithful.
-        // Reaching here for a taskprov task means the config was lost, so fail loudly rather than
-        // bind a wrong AAD.
-        assert!(
-            !matches!(
-                self.aggregator_parameters,
-                AggregatorTaskParameters::TaskprovHelper { .. }
-            ),
-            "taskprov task is missing its TaskConfiguration"
-        );
-
-        let (leader_endpoint, helper_endpoint) = match self.role() {
-            Role::Leader => (
-                &self.own_aggregator_endpoint,
-                &self.peer_aggregator_endpoint,
-            ),
-            Role::Helper => (
-                &self.peer_aggregator_endpoint,
-                &self.own_aggregator_endpoint,
-            ),
-            // `role()` yields only Leader or Helper.
-            _ => panic!("We received a non-aggregator role from AggregatorTask::role()"),
-        };
-
-        build_task_configuration(
-            self.task_info().to_vec(),
-            leader_endpoint.clone(),
-            helper_endpoint.clone(),
-            *self.time_precision(),
-            self.min_batch_size(),
-            self.batch_mode().to_batch_config(),
-            self.vdaf()
-                .to_vdaf_config()
-                .expect("VDAF is not representable as a VdafConfig"),
-            self.task_interval().copied(),
-        )
-        .expect("task parameters are validated at construction")
+        self.task_config.clone()
     }
 
     /// Retrieves the batch mode associated with this task.
@@ -476,12 +514,6 @@ impl AggregatorTask {
     /// Returns this task with its deactivation instant set. (Janus-specific)
     pub fn with_deactivate_at(mut self, deactivate_at: Option<DateTime<Utc>>) -> Self {
         self.deactivate_at = deactivate_at;
-        self
-    }
-
-    /// Returns this task with its verbatim taskprov [`TaskConfiguration`] set.
-    pub fn with_taskprov_task_config(mut self, task_config: TaskConfiguration) -> Self {
-        self.taskprov_task_config = Some(task_config);
         self
     }
 
@@ -1269,15 +1301,31 @@ pub mod test_util {
             self.leader_view().unwrap().task_configuration()
         }
 
-        /// Render a taskprov helper aggregator's view of this task.
-        pub fn taskprov_helper_view(&self) -> Result<AggregatorTask, Error> {
-            AggregatorTask::new_with_common_parameters(
-                self.common_parameters.clone(),
+        /// Render a taskprov helper aggregator's view of this task, binding `task_config` verbatim
+        /// as the opt-in path does. There is deliberately no synthesizing counterpart: a taskprov
+        /// task's configuration always comes from the wire.
+        pub fn taskprov_helper_view_with_task_config(
+            &self,
+            task_config: TaskConfiguration,
+        ) -> Result<AggregatorTask, Error> {
+            let common_parameters = self.common_parameters.clone();
+            AggregatorTask::new_with_task_config(
+                common_parameters.task_id,
                 to_dap_url(&self.leader_aggregator_endpoint),
                 to_dap_url(&self.helper_aggregator_endpoint),
+                common_parameters.batch_mode,
+                common_parameters.vdaf,
+                common_parameters.vdaf_verify_key,
+                common_parameters.task_interval,
+                common_parameters.report_expiry_age,
+                common_parameters.min_batch_size,
+                common_parameters.time_precision,
+                common_parameters.tolerable_clock_skew,
+                common_parameters.task_info,
                 AggregatorTaskParameters::TaskprovHelper {
                     aggregation_mode: self.helper_aggregation_mode,
                 },
+                task_config,
             )
         }
 
@@ -1576,6 +1624,7 @@ mod tests {
         BatchConfig, Duration, HpkeAeadId, HpkeConfig, HpkeConfigId, HpkeKdfId, HpkeKemId,
         HpkePublicKey, Interval, TaskId, Time, TimePrecision, Url as DapUrl, VdafConfig,
     };
+    use prio::codec::Encode as _;
     use rand::random;
     use serde_json::json;
     use serde_test::{Token, assert_de_tokens, assert_tokens};
@@ -1615,6 +1664,8 @@ mod tests {
         );
     }
 
+    // Note: `SerializedAggregatorTask` does not carry `task_config`, so these round trips are
+    // equal because deserialization re-synthesizes it identically via `AggregatorTask::new`.
     #[test]
     fn leader_task_serialization() {
         roundtrip_encoding(
@@ -1739,9 +1790,9 @@ mod tests {
 
     #[test]
     fn task_configuration_synthesized_for_api_task() {
-        // For an API-provisioned task, task_configuration() synthesizes from stored parameters,
-        // pairing own/peer endpoints into leader/helper by role. Both aggregators' views must
-        // produce byte-identical configurations, or their AADs would not match.
+        // For an API-provisioned task, the configuration is synthesized at construction from
+        // the task parameters. Each view synthesizes independently, so their configurations
+        // must come out identical or the two aggregators' AADs would not match.
         let task = TaskBuilder::new(
             BatchMode::TimeInterval,
             AggregationMode::Synchronous,
@@ -1761,8 +1812,12 @@ mod tests {
             "https://helper.example.com/"
         );
         assert_eq!(
-            leader_config,
-            task.helper_view().unwrap().task_configuration()
+            leader_config.get_encoded().unwrap(),
+            task.helper_view()
+                .unwrap()
+                .task_configuration()
+                .get_encoded()
+                .unwrap()
         );
     }
 
@@ -1789,31 +1844,14 @@ mod tests {
             VdafInstance::Prio3Count,
         )
         .build()
-        .taskprov_helper_view()
-        .unwrap()
-        .with_taskprov_task_config(wire.clone());
+        .taskprov_helper_view_with_task_config(wire.clone())
+        .unwrap();
 
         assert_eq!(task.task_configuration(), wire);
         assert_eq!(
             task.task_configuration().task_info(),
             b"wire-specific-task-info"
         );
-    }
-
-    #[test]
-    #[should_panic(expected = "taskprov task is missing its TaskConfiguration")]
-    fn task_configuration_taskprov_without_config_panics() {
-        // A taskprov task whose wire config is absent must fail loudly rather than
-        // silently synthesize a (non-byte-faithful) config from its stored parameters.
-        let task = TaskBuilder::new(
-            BatchMode::TimeInterval,
-            AggregationMode::Synchronous,
-            VdafInstance::Prio3Count,
-        )
-        .build()
-        .taskprov_helper_view()
-        .unwrap();
-        let _ = task.task_configuration();
     }
 
     #[test]

--- a/db/00000000000001_initial_schema.up.sql
+++ b/db/00000000000001_initial_schema.up.sql
@@ -105,7 +105,7 @@ CREATE TABLE tasks(
     aggregator_role             AGGREGATOR_ROLE NOT NULL,  -- the role of this aggregator for this task
     peer_aggregator_endpoint    TEXT NOT NULL,             -- peer aggregator's API endpoint
     own_aggregator_endpoint     TEXT NOT NULL,             -- this aggregator's own API endpoint
-    taskprov_task_config        BYTEA,                     -- verbatim wire TaskConfiguration for taskprov tasks (bound into HPKE AADs); NULL for API-provisioned tasks
+    task_config                 BYTEA NOT NULL,            -- the task's TaskConfiguration, verbatim wire bytes (bound into HPKE AADs)
     batch_mode                  JSONB NOT NULL,            -- the batch mode in use for this task, along with its parameters
     aggregation_mode            AGGREGATION_MODE,          -- the aggregation mode in use for this task (populated for Helper only)
     vdaf                        JSON NOT NULL,             -- the VDAF instance in use for this task, along with its parameters

--- a/messages/src/tests/task.rs
+++ b/messages/src/tests/task.rs
@@ -1018,3 +1018,57 @@ fn unknown_variants_with_known_codepoint_normalize_on_decode() {
     assert_eq!(decoded, VdafConfig::Prio3Count);
     assert_ne!(decoded, vdaf);
 }
+
+/// Decoding and re-encoding a `TaskConfiguration` must reproduce the original bytes exactly, even
+/// when it carries constructions this version does not understand. Janus stores each task's
+/// configuration as wire bytes and re-encodes them to build HPKE AADs, so any byte lost in that
+/// round trip would break decryption.
+#[test]
+fn task_configuration_decode_encode_is_byte_preserving() {
+    let bytes = hex::decode(concat!(
+        concat!(
+            // task_info
+            "04",       // length
+            "74657374", // "test"
+        ),
+        concat!(
+            // leader_aggregator_url
+            "0014",                                     // length
+            "68747470733A2F2F6578616D706C652E636F6D2F",  // "https://example.com/"
+        ),
+        concat!(
+            // helper_aggregator_url
+            "001C",                                                     // length
+            "68747470733A2F2F616E6F746865722E6578616D706C652E636F6D2F",  // "https://another.example.com/"
+        ),
+        "0000000000000E10", // time_precision
+        "0000000000002710", // min_batch_size
+        // Unknown batch mode with an opaque, non-empty batch_config.
+        "FE",     // batch_mode
+        "0003",   // batch_config length
+        "010203", // batch_config
+        // Unknown VDAF type with an opaque, non-empty vdaf_config.
+        "FFFFFFFF", // vdaf_type
+        "0004",     // vdaf_config length
+        "DEADBEEF", // vdaf_config
+        concat!(
+            // extensions: TaskInterval, then an unknown type (strictly increasing).
+            "0027", // length
+            concat!(
+                "0001",             // extension_type (TaskInterval)
+                "0010",             // extension_data length
+                "0000000000000115", // start
+                "000000000000001C", // duration
+            ),
+            concat!(
+                "1234",             // extension_type (unknown)
+                "000F",             // extension_data length
+                "BEEFCAFEDEADBEEFCAFEDEADBEEFCA", // extension_data (15 opaque bytes)
+            ),
+        ),
+    ))
+    .unwrap();
+
+    let decoded = TaskConfiguration::get_decoded(&bytes).unwrap();
+    assert_eq!(decoded.get_encoded().unwrap(), bytes);
+}


### PR DESCRIPTION
This is the transition from TaskProv TaskConfig to just plain **TaskConfig**. It becomes a not-NULL field in the Tasks table. Accordingly I rework how AggregatorTask construction works to provide a path for "TaskConfig is provided" and one for "TaskConfig is synthesized" -- and once set, it goes into the Tasks table and gets loaded upon future use.

In a lot of ways this is a very easy change at this point: When we're getting a task from the db, we load it. We already did all the hard work.

> [!NOTE]
> I tried to write some comments for us in the future about the different starting points for Task Configs at the relevant places, but I'm not sure if they're actually helpful enough to keep. I'm tempted to strip them back down. Your opinions are solicited! 

Closes #4712.