### PR TITLE
Deduplicate VdafConfig and VDAF constructor arguments (#4711)

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -7,35 +7,29 @@
 //! # Examples
 //!
 //! ```no_run
-//! use prio::vdaf::prio3::Prio3Histogram;
-//! use janus_messages::{BatchConfig, TimePrecision, TaskId, Url, VdafConfig};
+//! use janus_core::vdaf::ConfiguredVdaf;
+//! use janus_messages::{BatchConfig, TimePrecision, TaskId, Url};
 //! use std::str::FromStr;
 //!
 //! #[tokio::main]
 //! async fn main() {
 //!     let leader_url = Url::try_from("https://leader.example.com/").unwrap();
 //!     let helper_url = Url::try_from("https://helper.example.com/").unwrap();
-//!     let vdaf = Prio3Histogram::new_histogram(
-//!         2,
-//!         12,
-//!         4
-//!     ).unwrap();
 //!     let taskid = "rc0jgm1MHH6Q7fcI4ZdNUxas9DAYLcJFK5CL7xUl-gU";
 //!     let task = TaskId::from_str(taskid).unwrap();
 //!
 //!     // The task parameters below are bound into HPKE AADs and MUST match those provisioned to the
 //!     // aggregators byte-for-byte.
-//!     let client = janus_client::Client::builder(
+//!     let client = janus_client::Client::builder_from_configured_vdaf(
 //!         task,
 //!         leader_url,
 //!         helper_url,
 //!         TimePrecision::from_seconds(300),
-//!         vdaf,
+//!         ConfiguredVdaf::prio3_histogram(12, 4).unwrap(),
 //!     )
 //!     .with_task_info(b"[task info]".to_vec())
 //!     .with_min_batch_size(1000)
 //!     .with_batch_config(BatchConfig::TimeInterval)
-//!     .with_vdaf_config(VdafConfig::Prio3Histogram { length: 12, chunk_length: 4 })
 //!     .build()
 //!     .await
 //!     .unwrap();
@@ -66,7 +60,7 @@ use janus_core::{
     task_config::build_task_configuration,
     time::{Clock, DateTimeExt, RealClock},
     url_for_join,
-    vdaf::vdaf_application_context,
+    vdaf::{ConfiguredVdaf, vdaf_application_context},
 };
 use janus_messages::{
     BatchConfig, HpkeConfig, HpkeConfigList, InputShareAad, Interval, MediaType,
@@ -483,7 +477,7 @@ impl<V: vdaf::Client<16>> ClientBuilder<V> {
     ///
     /// ```no_run
     /// # use url::Url;
-    /// # use prio::vdaf::prio3::Prio3Count;
+    /// # use janus_core::vdaf::ConfiguredVdaf;
     /// # use janus_messages::{TimePrecision, TaskId, Url as DapUrl};
     /// # use rand::random;
     /// # use std::str::FromStr;
@@ -492,12 +486,12 @@ impl<V: vdaf::Client<16>> ClientBuilder<V> {
     /// async fn main() {
     ///     let task_id = random();
     ///
-    ///     let client = janus_client::Client::builder(
+    ///     let client = janus_client::Client::builder_from_configured_vdaf(
     ///         task_id,
     ///         DapUrl::try_from("https://leader.example.com/").unwrap(),
     ///         DapUrl::try_from("https://helper.example.com/").unwrap(),
     ///         TimePrecision::from_seconds(1),
-    ///         Prio3Count::new_count(2).unwrap(),
+    ///         ConfiguredVdaf::prio3_count().unwrap(),
     ///     )
     ///     .with_ohttp_config(janus_client::OhttpConfig {
     ///         key_configs: Url::parse("https://ohttp-keys.example.com").unwrap(),
@@ -547,6 +541,26 @@ impl<V: vdaf::Client<16>> Client<V> {
             time_precision,
             vdaf,
         )
+    }
+
+    /// Creates a [`ClientBuilder`] from the required set of DAP task parameters and a
+    /// [`ConfiguredVdaf`], which supplies both the VDAF and its [`VdafConfig`].
+    pub fn builder_from_configured_vdaf(
+        task_id: TaskId,
+        leader_aggregator_endpoint: DapUrl,
+        helper_aggregator_endpoint: DapUrl,
+        time_precision: TimePrecision,
+        configured_vdaf: ConfiguredVdaf<V>,
+    ) -> ClientBuilder<V> {
+        let (vdaf, vdaf_config) = configured_vdaf.into_parts();
+        ClientBuilder::new(
+            task_id,
+            leader_aggregator_endpoint,
+            helper_aggregator_endpoint,
+            time_precision,
+            vdaf,
+        )
+        .with_vdaf_config(vdaf_config)
     }
 
     /// Shard a measurement, encrypt its shares, and construct a [`janus_messages::Report`] to be
@@ -631,27 +645,25 @@ impl<V: vdaf::Client<16>> Client<V> {
     ///
     /// ```no_run
     /// # use janus_client::{Client, Error};
-    /// # use janus_messages::{BatchConfig, TimePrecision, Time, VdafConfig};
-    /// # use prio::vdaf::prio3::Prio3;
+    /// # use janus_core::vdaf::ConfiguredVdaf;
+    /// # use janus_messages::{BatchConfig, TimePrecision, Time};
     /// # use rand::random;
     /// # use std::time::SystemTime;
     /// #
     /// # async fn test() -> Result<(), Error> {
     /// # let measurement1 = true;
     /// # let measurement2 = false;
-    /// # let vdaf = Prio3::new_count(2).unwrap();
     /// let time_precision = TimePrecision::from_seconds(3600);
-    /// let client = Client::builder(
+    /// let client = Client::builder_from_configured_vdaf(
     ///     random(),
     ///     "https://example.com/".parse().unwrap(),
     ///     "https://example.net/".parse().unwrap(),
     ///     time_precision,
-    ///     vdaf,
+    ///     ConfiguredVdaf::prio3_count().unwrap(),
     /// )
     /// .with_task_info(b"[task info]".to_vec())
     /// .with_min_batch_size(1000)
     /// .with_batch_config(BatchConfig::TimeInterval)
-    /// .with_vdaf_config(VdafConfig::Prio3Count)
     /// .build().await?;
     ///
     /// // Upload multiple measurements with explicit timestamps.
@@ -920,24 +932,23 @@ where
     ///
     /// ```no_run
     /// # use janus_client::{Client, UploadStats};
-    /// # use janus_messages::{BatchConfig, TimePrecision, Time, VdafConfig};
-    /// # use prio::vdaf::prio3::Prio3Count;
+    /// # use janus_core::vdaf::ConfiguredVdaf;
+    /// # use janus_messages::{BatchConfig, TimePrecision, Time};
     /// # use rand::random;
     /// #
     /// # #[tokio::main]
     /// # async fn main() {
     /// let time_precision = TimePrecision::from_seconds(300);
-    /// let client = Client::builder(
+    /// let client = Client::builder_from_configured_vdaf(
     ///     random(),
     ///     "https://leader.example.com/".parse().unwrap(),
     ///     "https://helper.example.com/".parse().unwrap(),
     ///     time_precision,
-    ///     Prio3Count::new_count(2).unwrap(),
+    ///     ConfiguredVdaf::prio3_count().unwrap(),
     /// )
     /// .with_task_info(b"[task info]".to_vec())
     /// .with_min_batch_size(1000)
     /// .with_batch_config(BatchConfig::TimeInterval)
-    /// .with_vdaf_config(VdafConfig::Prio3Count)
     /// .build().await.unwrap();
     ///
     /// let session = client.upload_session(100);

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -7,7 +7,7 @@
 //! # Examples
 //!
 //! ```no_run
-//! use janus_core::vdaf::ConfiguredVdaf;
+//! use janus_client::ConfiguredVdaf;
 //! use janus_messages::{BatchConfig, TimePrecision, TaskId, Url};
 //! use std::str::FromStr;
 //!
@@ -51,6 +51,7 @@ use educe::Educe;
 use http::{HeaderValue, header::ACCEPT};
 use http::{StatusCode, header::CONTENT_TYPE};
 use itertools::Itertools;
+pub use janus_core::vdaf::ConfiguredVdaf;
 use janus_core::{
     hpke::{self, HpkeApplicationInfo, Label, is_hpke_config_supported},
     http::{HttpErrorResponse, cached_resource::CachedResource},
@@ -60,7 +61,7 @@ use janus_core::{
     task_config::build_task_configuration,
     time::{Clock, DateTimeExt, RealClock},
     url_for_join,
-    vdaf::{ConfiguredVdaf, vdaf_application_context},
+    vdaf::vdaf_application_context,
 };
 use janus_messages::{
     BatchConfig, HpkeConfig, HpkeConfigList, InputShareAad, Interval, MediaType,
@@ -477,7 +478,7 @@ impl<V: vdaf::Client<16>> ClientBuilder<V> {
     ///
     /// ```no_run
     /// # use url::Url;
-    /// # use janus_core::vdaf::ConfiguredVdaf;
+    /// # use janus_client::ConfiguredVdaf;
     /// # use janus_messages::{TimePrecision, TaskId, Url as DapUrl};
     /// # use rand::random;
     /// # use std::str::FromStr;
@@ -645,7 +646,7 @@ impl<V: vdaf::Client<16>> Client<V> {
     ///
     /// ```no_run
     /// # use janus_client::{Client, Error};
-    /// # use janus_core::vdaf::ConfiguredVdaf;
+    /// # use janus_client::ConfiguredVdaf;
     /// # use janus_messages::{BatchConfig, TimePrecision, Time};
     /// # use rand::random;
     /// # use std::time::SystemTime;
@@ -932,7 +933,7 @@ where
     ///
     /// ```no_run
     /// # use janus_client::{Client, UploadStats};
-    /// # use janus_core::vdaf::ConfiguredVdaf;
+    /// # use janus_client::ConfiguredVdaf;
     /// # use janus_messages::{BatchConfig, TimePrecision, Time};
     /// # use rand::random;
     /// #

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //!     // The task parameters below are bound into HPKE AADs and MUST match those provisioned to the
 //!     // aggregators byte-for-byte.
-//!     let client = janus_client::Client::builder_from_configured_vdaf(
+//!     let client = janus_client::Client::builder(
 //!         task,
 //!         leader_url,
 //!         helper_url,
@@ -184,9 +184,8 @@ struct ClientParameters {
     /// Batch configuration bound into the task's `TaskConfiguration`. Required before uploading;
     /// set via [`ClientBuilder::with_batch_config`].
     batch_config: Option<BatchConfig>,
-    /// VDAF configuration bound into the task's `TaskConfiguration`. Required before uploading;
-    /// set via [`ClientBuilder::with_vdaf_config`].
-    vdaf_config: Option<VdafConfig>,
+    /// VDAF configuration bound into the task's `TaskConfiguration`.
+    vdaf_config: VdafConfig,
     /// Optional task validity interval bound into the task's `TaskConfiguration`.
     task_interval: Option<Interval>,
     /// Parameters to use when retrying HTTP requests.
@@ -200,6 +199,7 @@ impl ClientParameters {
         leader_aggregator_endpoint: DapUrl,
         helper_aggregator_endpoint: DapUrl,
         time_precision: TimePrecision,
+        vdaf_config: VdafConfig,
     ) -> Self {
         // Store the endpoints byte-for-byte; trailing-slash normalization happens at join time via
         // `url_for_join`, so the bytes bound into HPKE AADs stay exactly as provisioned (DAP §4.1).
@@ -211,15 +211,15 @@ impl ClientParameters {
             task_info: None,
             min_batch_size: None,
             batch_config: None,
-            vdaf_config: None,
+            vdaf_config,
             task_interval: None,
             http_request_retry_parameters: http_request_exponential_backoff(),
         }
     }
 
     /// Builds this task's canonical [`TaskConfiguration`] for binding into HPKE AADs. Errors if any
-    /// of the required parameters (`task_info`, `min_batch_size`, `batch_config`, `vdaf_config`)
-    /// were not supplied via the corresponding [`ClientBuilder`] setters.
+    /// of the required parameters (`task_info`, `min_batch_size`, `batch_config`) were not supplied
+    /// via the corresponding [`ClientBuilder`] setters.
     fn task_configuration(&self) -> Result<TaskConfiguration, Error> {
         Ok(build_task_configuration(
             self.task_info
@@ -233,9 +233,7 @@ impl ClientParameters {
             self.batch_config
                 .clone()
                 .ok_or(Error::InvalidParameter("batch_config not set"))?,
-            self.vdaf_config
-                .clone()
-                .ok_or(Error::InvalidParameter("vdaf_config not set"))?,
+            self.vdaf_config.clone(),
             self.task_interval,
         )?)
     }
@@ -303,13 +301,16 @@ pub struct ClientBuilder<V: vdaf::Client<16>> {
 }
 
 impl<V: vdaf::Client<16>> ClientBuilder<V> {
-    /// Construct a [`ClientBuilder`] from its required DAP task parameters.
+    /// Construct a [`ClientBuilder`] from its required DAP task parameters. The caller is
+    /// responsible for ensuring `vdaf_config` describes `vdaf`; prefer [`Client::builder`], which
+    /// cannot mismatch the two.
     pub fn new(
         task_id: TaskId,
         leader_aggregator_endpoint: DapUrl,
         helper_aggregator_endpoint: DapUrl,
         time_precision: TimePrecision,
         vdaf: V,
+        vdaf_config: VdafConfig,
     ) -> Self {
         Self {
             parameters: ClientParameters::new(
@@ -317,6 +318,7 @@ impl<V: vdaf::Client<16>> ClientBuilder<V> {
                 leader_aggregator_endpoint,
                 helper_aggregator_endpoint,
                 time_precision,
+                vdaf_config,
             ),
             vdaf,
             leader_hpke_config: None,
@@ -444,13 +446,6 @@ impl<V: vdaf::Client<16>> ClientBuilder<V> {
         self
     }
 
-    /// Set the VDAF configuration bound into the task's `TaskConfiguration`. Required before
-    /// [`Self::build`].
-    pub fn with_vdaf_config(mut self, vdaf_config: VdafConfig) -> Self {
-        self.parameters.vdaf_config = Some(vdaf_config);
-        self
-    }
-
     /// Set the optional task validity interval bound into the task's `TaskConfiguration`.
     pub fn with_task_interval(mut self, task_interval: Option<Interval>) -> Self {
         self.parameters.task_interval = task_interval;
@@ -487,7 +482,7 @@ impl<V: vdaf::Client<16>> ClientBuilder<V> {
     /// async fn main() {
     ///     let task_id = random();
     ///
-    ///     let client = janus_client::Client::builder_from_configured_vdaf(
+    ///     let client = janus_client::Client::builder(
     ///         task_id,
     ///         DapUrl::try_from("https://leader.example.com/").unwrap(),
     ///         DapUrl::try_from("https://helper.example.com/").unwrap(),
@@ -526,27 +521,9 @@ pub struct Client<V: vdaf::Client<16>> {
 }
 
 impl<V: vdaf::Client<16>> Client<V> {
-    /// Creates a [`ClientBuilder`] for further configuration from the required set of DAP task
-    /// parameters.
-    pub fn builder(
-        task_id: TaskId,
-        leader_aggregator_endpoint: DapUrl,
-        helper_aggregator_endpoint: DapUrl,
-        time_precision: TimePrecision,
-        vdaf: V,
-    ) -> ClientBuilder<V> {
-        ClientBuilder::new(
-            task_id,
-            leader_aggregator_endpoint,
-            helper_aggregator_endpoint,
-            time_precision,
-            vdaf,
-        )
-    }
-
     /// Creates a [`ClientBuilder`] from the required set of DAP task parameters and a
     /// [`ConfiguredVdaf`], which supplies both the VDAF and its [`VdafConfig`].
-    pub fn builder_from_configured_vdaf(
+    pub fn builder(
         task_id: TaskId,
         leader_aggregator_endpoint: DapUrl,
         helper_aggregator_endpoint: DapUrl,
@@ -560,8 +537,29 @@ impl<V: vdaf::Client<16>> Client<V> {
             helper_aggregator_endpoint,
             time_precision,
             vdaf,
+            vdaf_config,
         )
-        .with_vdaf_config(vdaf_config)
+    }
+
+    /// Creates a [`ClientBuilder`] when `vdaf` and `vdaf_config` are obtained separately, e.g. by
+    /// generic code deriving both from a `VdafInstance`. The caller is responsible for ensuring
+    /// they agree; a mismatch produces reports the aggregators cannot decrypt.
+    pub fn builder_with_custom_vdaf(
+        task_id: TaskId,
+        leader_aggregator_endpoint: DapUrl,
+        helper_aggregator_endpoint: DapUrl,
+        time_precision: TimePrecision,
+        vdaf: V,
+        vdaf_config: VdafConfig,
+    ) -> ClientBuilder<V> {
+        ClientBuilder::new(
+            task_id,
+            leader_aggregator_endpoint,
+            helper_aggregator_endpoint,
+            time_precision,
+            vdaf,
+            vdaf_config,
+        )
     }
 
     /// Shard a measurement, encrypt its shares, and construct a [`janus_messages::Report`] to be
@@ -655,7 +653,7 @@ impl<V: vdaf::Client<16>> Client<V> {
     /// # let measurement1 = true;
     /// # let measurement2 = false;
     /// let time_precision = TimePrecision::from_seconds(3600);
-    /// let client = Client::builder_from_configured_vdaf(
+    /// let client = Client::builder(
     ///     random(),
     ///     "https://example.com/".parse().unwrap(),
     ///     "https://example.net/".parse().unwrap(),
@@ -940,7 +938,7 @@ where
     /// # #[tokio::main]
     /// # async fn main() {
     /// let time_precision = TimePrecision::from_seconds(300);
-    /// let client = Client::builder_from_configured_vdaf(
+    /// let client = Client::builder(
     ///     random(),
     ///     "https://leader.example.com/".parse().unwrap(),
     ///     "https://helper.example.com/".parse().unwrap(),

--- a/client/src/tests/mod.rs
+++ b/client/src/tests/mod.rs
@@ -8,7 +8,7 @@ use janus_core::{
 };
 use janus_messages::{
     BatchConfig, HpkeConfigList, MediaType, ReportError, ReportUploadStatus, Role, Time,
-    TimePrecision, UploadErrors, UploadRequest, Url as DapUrl,
+    TimePrecision, UploadErrors, UploadRequest, Url as DapUrl, VdafConfig,
 };
 use prio::{
     codec::Encode,
@@ -26,7 +26,7 @@ async fn setup_client<V: vdaf::Client<16>>(
     configured_vdaf: ConfiguredVdaf<V>,
 ) -> Client<V> {
     let server_url = DapUrl::try_from(server.url().as_str()).unwrap();
-    Client::builder_from_configured_vdaf(
+    Client::builder(
         random(),
         server_url.clone(),
         server_url,
@@ -50,12 +50,13 @@ async fn build_fails_without_required_task_configuration() {
     // Omitting the required TaskConfiguration setters must fail fast at build(), before any network
     // access, rather than deferring to the first upload's AAD construction.
     let server_url = DapUrl::try_from("https://example.com/").unwrap();
-    let err = Client::builder(
+    let err = Client::builder_with_custom_vdaf(
         random(),
         server_url.clone(),
         server_url,
         TimePrecision::from_seconds(100),
         Prio3::new_count(2).unwrap(),
+        VdafConfig::Prio3Count,
     )
     .with_leader_hpke_config(HpkeKeypair::test().config().clone())
     .with_helper_hpke_config(HpkeKeypair::test().config().clone())
@@ -73,6 +74,7 @@ fn endpoints_preserved_and_joined() {
         "http://leader_endpoint/foo/bar".try_into().unwrap(),
         "http://helper_endpoint".try_into().unwrap(),
         TimePrecision::from_seconds(100),
+        VdafConfig::Prio3Count,
     );
 
     // Endpoints are stored verbatim (no trailing slash added), so the bytes bound into HPKE AADs
@@ -275,6 +277,7 @@ async fn unsupported_hpke_algorithms() {
         server_url.clone(),
         server_url,
         TimePrecision::from_seconds(100),
+        VdafConfig::Prio3Count,
     );
     client_parameters.http_request_retry_parameters = test_http_request_exponential_backoff();
 

--- a/client/src/tests/mod.rs
+++ b/client/src/tests/mod.rs
@@ -4,11 +4,11 @@ use http::{StatusCode, header::CONTENT_TYPE};
 use janus_core::{
     hpke::HpkeKeypair, initialize_rustls,
     retries::test_util::test_http_request_exponential_backoff,
-    test_util::install_test_trace_subscriber,
+    test_util::install_test_trace_subscriber, vdaf::ConfiguredVdaf,
 };
 use janus_messages::{
     BatchConfig, HpkeConfigList, MediaType, ReportError, ReportUploadStatus, Role, Time,
-    TimePrecision, UploadErrors, UploadRequest, Url as DapUrl, VdafConfig,
+    TimePrecision, UploadErrors, UploadRequest, Url as DapUrl,
 };
 use prio::{
     codec::Encode,
@@ -21,20 +21,22 @@ use crate::{Client, ClientParameters, Error, HpkeConfiguration, UploadStats, def
 #[cfg(feature = "ohttp")]
 mod ohttp;
 
-async fn setup_client<V: vdaf::Client<16>>(server: &mockito::Server, vdaf: V) -> Client<V> {
+async fn setup_client<V: vdaf::Client<16>>(
+    server: &mockito::Server,
+    configured_vdaf: ConfiguredVdaf<V>,
+) -> Client<V> {
     let server_url = DapUrl::try_from(server.url().as_str()).unwrap();
-    Client::builder(
+    Client::builder_from_configured_vdaf(
         random(),
         server_url.clone(),
         server_url,
         TimePrecision::from_seconds(100),
-        vdaf,
+        configured_vdaf,
     )
     .with_backoff(test_http_request_exponential_backoff())
     .with_task_info(b"test task".to_vec())
     .with_min_batch_size(1)
     .with_batch_config(BatchConfig::TimeInterval)
-    .with_vdaf_config(VdafConfig::Prio3Count)
     .with_leader_hpke_config(HpkeKeypair::test().config().clone())
     .with_helper_hpke_config(HpkeKeypair::test().config().clone())
     .build()
@@ -106,7 +108,7 @@ async fn upload_prio3_count() {
     install_test_trace_subscriber();
     initialize_rustls();
     let mut server = mockito::Server::new_async().await;
-    let client = setup_client(&server, Prio3::new_count(2).unwrap()).await;
+    let client = setup_client(&server, ConfiguredVdaf::prio3_count().unwrap()).await;
 
     let mocked_upload = server
         .mock(
@@ -129,7 +131,7 @@ async fn upload_prio3_invalid_measurement() {
     install_test_trace_subscriber();
     initialize_rustls();
     let server = mockito::Server::new_async().await;
-    let vdaf = Prio3::new_sum(2, 16).unwrap();
+    let vdaf = ConfiguredVdaf::prio3_sum(16).unwrap();
     let client = setup_client(&server, vdaf).await;
 
     // 65536 is too big for a 16 bit sum and will be rejected by the VDAF.
@@ -143,7 +145,7 @@ async fn upload_prio3_http_status_code() {
     install_test_trace_subscriber();
     initialize_rustls();
     let mut server = mockito::Server::new_async().await;
-    let client = setup_client(&server, Prio3::new_count(2).unwrap()).await;
+    let client = setup_client(&server, ConfiguredVdaf::prio3_count().unwrap()).await;
 
     let mocked_upload = server
         .mock(
@@ -171,7 +173,7 @@ async fn upload_problem_details() {
     install_test_trace_subscriber();
     initialize_rustls();
     let mut server = mockito::Server::new_async().await;
-    let client = setup_client(&server, Prio3::new_count(2).unwrap()).await;
+    let client = setup_client(&server, ConfiguredVdaf::prio3_count().unwrap()).await;
 
     let mocked_upload = server
         .mock(
@@ -213,7 +215,7 @@ async fn report_timestamp() {
     install_test_trace_subscriber();
     initialize_rustls();
     let server = mockito::Server::new_async().await;
-    let vdaf = Prio3::new_count(2).unwrap();
+    let vdaf = ConfiguredVdaf::prio3_count().unwrap();
     let mut client = setup_client(&server, vdaf).await;
 
     client.parameters.time_precision = TimePrecision::from_seconds(100);
@@ -320,7 +322,7 @@ async fn upload_with_per_report_errors() {
     install_test_trace_subscriber();
     initialize_rustls();
     let mut server = mockito::Server::new_async().await;
-    let client = setup_client(&server, Prio3::new_count(2).unwrap()).await;
+    let client = setup_client(&server, ConfiguredVdaf::prio3_count().unwrap()).await;
 
     // Create a report to determine its ID so we can create a matching error response
     let report = client
@@ -372,7 +374,7 @@ async fn upload_success_without_response_body() {
     install_test_trace_subscriber();
     initialize_rustls();
     let mut server = mockito::Server::new_async().await;
-    let client = setup_client(&server, Prio3::new_count(2).unwrap()).await;
+    let client = setup_client(&server, ConfiguredVdaf::prio3_count().unwrap()).await;
 
     let mocked_upload = server
         .mock(
@@ -396,7 +398,7 @@ async fn upload_success_with_empty_response() {
     install_test_trace_subscriber();
     initialize_rustls();
     let mut server = mockito::Server::new_async().await;
-    let client = setup_client(&server, Prio3::new_count(2).unwrap()).await;
+    let client = setup_client(&server, ConfiguredVdaf::prio3_count().unwrap()).await;
 
     // Empty UploadResponse (no errors)
     let upload_response = UploadErrors::new(&[]);
@@ -426,7 +428,7 @@ async fn upload_session_basic() {
     install_test_trace_subscriber();
     initialize_rustls();
     let mut server = mockito::Server::new_async().await;
-    let client = setup_client(&server, Prio3::new_count(2).unwrap()).await;
+    let client = setup_client(&server, ConfiguredVdaf::prio3_count().unwrap()).await;
 
     // Expect two batches: one full batch of 2 and one partial batch of 1.
     let mocked_upload = server
@@ -463,7 +465,7 @@ async fn upload_session_partial_batch() {
     install_test_trace_subscriber();
     initialize_rustls();
     let mut server = mockito::Server::new_async().await;
-    let client = setup_client(&server, Prio3::new_count(2).unwrap()).await;
+    let client = setup_client(&server, ConfiguredVdaf::prio3_count().unwrap()).await;
 
     let mocked_upload = server
         .mock(
@@ -497,7 +499,7 @@ async fn upload_session_error_propagation() {
     install_test_trace_subscriber();
     initialize_rustls();
     let mut server = mockito::Server::new_async().await;
-    let client = setup_client(&server, Prio3::new_count(2).unwrap()).await;
+    let client = setup_client(&server, ConfiguredVdaf::prio3_count().unwrap()).await;
 
     let mocked_upload = server
         .mock(

--- a/client/src/tests/ohttp.rs
+++ b/client/src/tests/ohttp.rs
@@ -31,7 +31,7 @@ async fn build_client(server: &mockito::ServerGuard) -> Result<Client<Prio3Count
     let keys_endpoint = Url::parse(format!("{}/ohttp-keys", server.url()).as_str()).unwrap();
     let relay = Url::parse(format!("{}/relay", server.url()).as_str()).unwrap();
 
-    Client::builder_from_configured_vdaf(
+    Client::builder(
         task_id,
         server_url.clone(),
         server_url.clone(),

--- a/client/src/tests/ohttp.rs
+++ b/client/src/tests/ohttp.rs
@@ -9,18 +9,14 @@ use janus_core::{
     initialize_rustls,
     retries::test_util::test_http_request_exponential_backoff,
     test_util::install_test_trace_subscriber,
+    vdaf::ConfiguredVdaf,
 };
-use janus_messages::{
-    BatchConfig, MediaType, Report, TimePrecision, UploadRequest, Url as DapUrl, VdafConfig,
-};
+use janus_messages::{BatchConfig, MediaType, Report, TimePrecision, UploadRequest, Url as DapUrl};
 use ohttp::{
     KeyConfig, SymmetricSuite,
     hpke::{Aead, Kdf},
 };
-use prio::{
-    codec::Decode,
-    vdaf::prio3::{Prio3, Prio3Count},
-};
+use prio::{codec::Decode, vdaf::prio3::Prio3Count};
 use rand::random;
 use url::Url;
 
@@ -35,18 +31,17 @@ async fn build_client(server: &mockito::ServerGuard) -> Result<Client<Prio3Count
     let keys_endpoint = Url::parse(format!("{}/ohttp-keys", server.url()).as_str()).unwrap();
     let relay = Url::parse(format!("{}/relay", server.url()).as_str()).unwrap();
 
-    Client::builder(
+    Client::builder_from_configured_vdaf(
         task_id,
         server_url.clone(),
         server_url.clone(),
         TimePrecision::from_seconds(100),
-        Prio3::new_count(2).unwrap(),
+        ConfiguredVdaf::prio3_count().unwrap(),
     )
     .with_backoff(test_http_request_exponential_backoff())
     .with_task_info(b"test task".to_vec())
     .with_min_batch_size(1)
     .with_batch_config(BatchConfig::TimeInterval)
-    .with_vdaf_config(VdafConfig::Prio3Count)
     .with_leader_hpke_config(HpkeKeypair::test().config().clone())
     .with_helper_hpke_config(HpkeKeypair::test().config().clone())
     .with_ohttp_config(OhttpConfig {

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -11,8 +11,7 @@
 //! ```no_run
 //! use std::{fs::File, str::FromStr};
 //!
-//! use janus_collector::{Collector, PrivateCollectorCredential};
-//! use janus_core::vdaf::ConfiguredVdaf;
+//! use janus_collector::{Collector, ConfiguredVdaf, PrivateCollectorCredential};
 //! use janus_messages::{BatchConfig, Duration, Interval, Query, TaskId, Time, TimePrecision, Url};
 //!
 //! # async fn run() {
@@ -82,9 +81,9 @@ pub use backon::{BackoffBuilder, ExponentialBackoff, ExponentialBuilder};
 use chrono::{DateTime, Duration, Utc};
 pub use credential::PrivateCollectorCredential;
 use educe::Educe;
-pub use janus_core::auth_tokens::AuthenticationToken;
+pub use janus_core::{auth_tokens::AuthenticationToken, hpke::HpkeKeypair, vdaf::ConfiguredVdaf};
 use janus_core::{
-    hpke::{self, HpkeApplicationInfo, HpkeKeypair},
+    hpke::{self, HpkeApplicationInfo},
     http::{HttpErrorResponse, ReqwestAuthenticationToken, check_content_type},
     retries::{
         ExponentialWithTotalDelayBuilder, http_request_exponential_backoff, retry_http_request,
@@ -92,7 +91,6 @@ use janus_core::{
     task_config::build_task_configuration,
     time::TimeExt,
     url_for_join,
-    vdaf::ConfiguredVdaf,
 };
 use janus_messages::{
     AggregateShareAad, BatchConfig, CollectionJobExtension, CollectionJobId, CollectionJobReq,

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -32,7 +32,7 @@
 //!
 //! // The task parameters below are bound into HPKE AADs and MUST match those provisioned to the
 //! // aggregators byte-for-byte.
-//! let collector = Collector::builder_from_configured_vdaf(
+//! let collector = Collector::builder(
 //!     task_id,
 //!     leader_url,
 //!     collector_credential.authentication_token(),
@@ -370,9 +370,8 @@ pub struct CollectorBuilder<V: vdaf::Collector> {
     /// Batch configuration bound into the task's `TaskConfiguration`. Required before
     /// [`Self::build`]; set via [`Self::with_batch_config`].
     batch_config: Option<BatchConfig>,
-    /// VDAF configuration bound into the task's `TaskConfiguration`. Required before
-    /// [`Self::build`]; set via [`Self::with_vdaf_config`].
-    vdaf_config: Option<VdafConfig>,
+    /// VDAF configuration bound into the task's `TaskConfiguration`.
+    vdaf_config: VdafConfig,
     /// Optional task validity interval bound into the task's `TaskConfiguration`.
     task_interval: Option<Interval>,
 
@@ -386,13 +385,15 @@ pub struct CollectorBuilder<V: vdaf::Collector> {
 
 impl<V: vdaf::Collector> CollectorBuilder<V> {
     /// Construct a [`CollectorBuilder`] from required DAP task parameters and an implementation of
-    /// the task's VDAF.
+    /// the task's VDAF. The caller is responsible for ensuring `vdaf_config` describes `vdaf`;
+    /// prefer [`Self::from_configured_vdaf`], which cannot mismatch the two.
     pub fn new(
         task_id: TaskId,
         leader_endpoint: DapUrl,
         authentication: AuthenticationToken,
         hpke_keypair: HpkeKeypair,
         vdaf: V,
+        vdaf_config: VdafConfig,
         time_precision: TimePrecision,
     ) -> Self {
         Self {
@@ -406,7 +407,7 @@ impl<V: vdaf::Collector> CollectorBuilder<V> {
             task_info: None,
             min_batch_size: None,
             batch_config: None,
-            vdaf_config: None,
+            vdaf_config,
             task_interval: None,
             http_client: None,
             http_request_retry_parameters: http_request_exponential_backoff(),
@@ -434,9 +435,9 @@ impl<V: vdaf::Collector> CollectorBuilder<V> {
             authentication,
             hpke_keypair,
             vdaf,
+            vdaf_config,
             time_precision,
         )
-        .with_vdaf_config(vdaf_config)
     }
 
     /// Finalize construction of a [`Collector`].
@@ -467,9 +468,7 @@ impl<V: vdaf::Collector> CollectorBuilder<V> {
             batch_config: self
                 .batch_config
                 .ok_or(Error::InvalidParameter("batch_config not set"))?,
-            vdaf_config: self
-                .vdaf_config
-                .ok_or(Error::InvalidParameter("vdaf_config not set"))?,
+            vdaf_config: self.vdaf_config,
             task_interval: self.task_interval,
             http_client,
             http_request_retry_parameters: self.http_request_retry_parameters,
@@ -527,13 +526,6 @@ impl<V: vdaf::Collector> CollectorBuilder<V> {
         self
     }
 
-    /// Set the VDAF configuration bound into the task's `TaskConfiguration`. Required before
-    /// [`Self::build`].
-    pub fn with_vdaf_config(mut self, vdaf_config: VdafConfig) -> Self {
-        self.vdaf_config = Some(vdaf_config);
-        self
-    }
-
     /// Set the optional task validity interval bound into the task's `TaskConfiguration`.
     pub fn with_task_interval(mut self, task_interval: Option<Interval>) -> Self {
         self.task_interval = task_interval;
@@ -584,14 +576,16 @@ pub struct Collector<V: vdaf::Collector> {
 }
 
 impl<V: vdaf::Collector> Collector<V> {
-    /// Construct a [`CollectorBuilder`] from required DAP task parameters and an implementation of
-    /// the task's VDAF.
-    pub fn builder(
+    /// Construct a [`CollectorBuilder`] when `vdaf` and `vdaf_config` are obtained separately, e.g.
+    /// by generic code deriving both from a `VdafInstance`. The caller is responsible for ensuring
+    /// they agree; a mismatch produces aggregate shares the collector cannot decrypt.
+    pub fn builder_with_custom_vdaf(
         task_id: TaskId,
         leader_endpoint: DapUrl,
         authentication: AuthenticationToken,
         hpke_keypair: HpkeKeypair,
         vdaf: V,
+        vdaf_config: VdafConfig,
         time_precision: TimePrecision,
     ) -> CollectorBuilder<V> {
         CollectorBuilder::new(
@@ -600,13 +594,14 @@ impl<V: vdaf::Collector> Collector<V> {
             authentication,
             hpke_keypair,
             vdaf,
+            vdaf_config,
             time_precision,
         )
     }
 
     /// Creates a [`CollectorBuilder`] from the required set of DAP task parameters and a
     /// [`ConfiguredVdaf`], which supplies both the VDAF and its [`VdafConfig`].
-    pub fn builder_from_configured_vdaf(
+    pub fn builder(
         task_id: TaskId,
         leader_endpoint: DapUrl,
         authentication: AuthenticationToken,
@@ -997,7 +992,7 @@ mod tests {
     ) -> Collector<V> {
         let server_url = DapUrl::try_from(server.url().as_str()).unwrap();
         let hpke_keypair = HpkeKeypair::test();
-        Collector::builder_from_configured_vdaf(
+        Collector::builder(
             random(),
             server_url.clone(),
             AuthenticationToken::new_bearer_token_from_string("Y29sbGVjdG9yIHRva2Vu").unwrap(),
@@ -1112,7 +1107,7 @@ mod tests {
             ("http://example.com/dap", "http://example.com/dap/"),
             ("http://example.com", "http://example.com/"),
         ] {
-            let collector = Collector::builder_from_configured_vdaf(
+            let collector = Collector::builder(
                 random(),
                 endpoint.try_into().unwrap(),
                 AuthenticationToken::new_bearer_token_from_string("Y29sbGVjdG9yIHRva2Vu").unwrap(),
@@ -1495,7 +1490,7 @@ mod tests {
         );
         let server_url = DapUrl::try_from(server.url().as_str()).unwrap();
         let hpke_keypair = HpkeKeypair::test();
-        let collector = Collector::builder_from_configured_vdaf(
+        let collector = Collector::builder(
             random(),
             server_url.clone(),
             AuthenticationToken::new_bearer_token_from_bytes(Vec::from([0x41u8; 16])).unwrap(),

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -12,10 +12,8 @@
 //! use std::{fs::File, str::FromStr};
 //!
 //! use janus_collector::{Collector, PrivateCollectorCredential};
-//! use janus_messages::{
-//!     BatchConfig, Duration, Interval, Query, TaskId, Time, TimePrecision, Url, VdafConfig,
-//! };
-//! use prio::vdaf::prio3::Prio3;
+//! use janus_core::vdaf::ConfiguredVdaf;
+//! use janus_messages::{BatchConfig, Duration, Interval, Query, TaskId, Time, TimePrecision, Url};
 //!
 //! # async fn run() {
 //! # const TIME_PRECISION: u64 = 3600;
@@ -33,24 +31,20 @@
 //!     Url::from_str("[absolute URI to the DAP helper, e.g. https://helper.dap.example.com/]")
 //!         .unwrap();
 //!
-//! // Supply a VDAF implementation, corresponding to this task.
-//! let vdaf = Prio3::new_count(2).unwrap();
-//!
 //! // The task parameters below are bound into HPKE AADs and MUST match those provisioned to the
 //! // aggregators byte-for-byte.
-//! let collector = Collector::builder(
+//! let collector = Collector::builder_from_configured_vdaf(
 //!     task_id,
 //!     leader_url,
 //!     collector_credential.authentication_token(),
 //!     collector_credential.hpke_keypair(),
-//!     vdaf,
+//!     ConfiguredVdaf::prio3_count().unwrap(),
 //!     time_precision,
 //! )
 //! .with_helper_endpoint(helper_url)
 //! .with_task_info(b"[task info]".to_vec())
 //! .with_min_batch_size(1000)
 //! .with_batch_config(BatchConfig::TimeInterval)
-//! .with_vdaf_config(VdafConfig::Prio3Count)
 //! .build()
 //! .unwrap();
 //!
@@ -98,6 +92,7 @@ use janus_core::{
     task_config::build_task_configuration,
     time::TimeExt,
     url_for_join,
+    vdaf::ConfiguredVdaf,
 };
 use janus_messages::{
     AggregateShareAad, BatchConfig, CollectionJobExtension, CollectionJobId, CollectionJobReq,
@@ -424,6 +419,28 @@ impl<V: vdaf::Collector> CollectorBuilder<V> {
         }
     }
 
+    /// Construct a [`CollectorBuilder`] from required DAP task parameters and a
+    /// [`ConfiguredVdaf`], which supplies both the VDAF and its [`VdafConfig`].
+    pub fn from_configured_vdaf(
+        task_id: TaskId,
+        leader_endpoint: DapUrl,
+        authentication: AuthenticationToken,
+        hpke_keypair: HpkeKeypair,
+        configured_vdaf: ConfiguredVdaf<V>,
+        time_precision: TimePrecision,
+    ) -> Self {
+        let (vdaf, vdaf_config) = configured_vdaf.into_parts();
+        Self::new(
+            task_id,
+            leader_endpoint,
+            authentication,
+            hpke_keypair,
+            vdaf,
+            time_precision,
+        )
+        .with_vdaf_config(vdaf_config)
+    }
+
     /// Finalize construction of a [`Collector`].
     pub fn build(self) -> Result<Collector<V>, Error> {
         let http_client = if let Some(http_client) = self.http_client {
@@ -585,6 +602,26 @@ impl<V: vdaf::Collector> Collector<V> {
             authentication,
             hpke_keypair,
             vdaf,
+            time_precision,
+        )
+    }
+
+    /// Creates a [`CollectorBuilder`] from the required set of DAP task parameters and a
+    /// [`ConfiguredVdaf`], which supplies both the VDAF and its [`VdafConfig`].
+    pub fn builder_from_configured_vdaf(
+        task_id: TaskId,
+        leader_endpoint: DapUrl,
+        authentication: AuthenticationToken,
+        hpke_keypair: HpkeKeypair,
+        configured_vdaf: ConfiguredVdaf<V>,
+        time_precision: TimePrecision,
+    ) -> CollectorBuilder<V> {
+        CollectorBuilder::from_configured_vdaf(
+            task_id,
+            leader_endpoint,
+            authentication,
+            hpke_keypair,
+            configured_vdaf,
             time_precision,
         )
     }
@@ -930,11 +967,12 @@ mod tests {
         initialize_rustls,
         retries::test_util::test_http_request_exponential_backoff,
         test_util::{VdafTranscript, install_test_trace_subscriber, run_vdaf},
+        vdaf::ConfiguredVdaf,
     };
     use janus_messages::{
         AggregateShareAad, BatchConfig, BatchId, CollectionJobId, CollectionJobReq,
         CollectionJobResp, Duration, HpkeCiphertext, Interval, MediaType, PartialBatchSelector,
-        Query, Role, TaskId, Time, TimePrecision, Url as DapUrl, VdafConfig,
+        Query, Role, TaskId, Time, TimePrecision, Url as DapUrl,
         batch_mode::{LeaderSelected, TimeInterval},
         problem_type::DapProblemType,
     };
@@ -942,7 +980,7 @@ mod tests {
     use prio::{
         codec::Encode,
         field::Field64,
-        vdaf::{self, AggregateShare, OutputShare, dummy, prio3::Prio3},
+        vdaf::{self, AggregateShare, OutputShare, dummy},
     };
     use rand::random;
     use reqwest::{
@@ -955,22 +993,24 @@ mod tests {
 
     const TEST_TIME_PRECISION: TimePrecision = TimePrecision::from_seconds(100);
 
-    fn setup_collector<V: vdaf::Collector>(server: &mut mockito::Server, vdaf: V) -> Collector<V> {
+    fn setup_collector<V: vdaf::Collector>(
+        server: &mut mockito::Server,
+        configured_vdaf: ConfiguredVdaf<V>,
+    ) -> Collector<V> {
         let server_url = DapUrl::try_from(server.url().as_str()).unwrap();
         let hpke_keypair = HpkeKeypair::test();
-        Collector::builder(
+        Collector::builder_from_configured_vdaf(
             random(),
             server_url.clone(),
             AuthenticationToken::new_bearer_token_from_string("Y29sbGVjdG9yIHRva2Vu").unwrap(),
             hpke_keypair,
-            vdaf,
+            configured_vdaf,
             TEST_TIME_PRECISION,
         )
         .with_helper_endpoint(server_url)
         .with_task_info(b"test task".to_vec())
         .with_min_batch_size(1)
         .with_batch_config(BatchConfig::TimeInterval)
-        .with_vdaf_config(VdafConfig::Prio3Count)
         .with_http_request_backoff(test_http_request_exponential_backoff())
         .with_collect_poll_backoff(test_http_request_exponential_backoff())
         .build()
@@ -1074,19 +1114,18 @@ mod tests {
             ("http://example.com/dap", "http://example.com/dap/"),
             ("http://example.com", "http://example.com/"),
         ] {
-            let collector = Collector::builder(
+            let collector = Collector::builder_from_configured_vdaf(
                 random(),
                 endpoint.try_into().unwrap(),
                 AuthenticationToken::new_bearer_token_from_string("Y29sbGVjdG9yIHRva2Vu").unwrap(),
                 hpke_keypair.clone(),
-                dummy::Vdaf::new(1),
+                ConfiguredVdaf::fake(1),
                 TEST_TIME_PRECISION,
             )
             .with_helper_endpoint("http://helper.example.com".try_into().unwrap())
             .with_task_info(b"test task".to_vec())
             .with_min_batch_size(1)
             .with_batch_config(BatchConfig::TimeInterval)
-            .with_vdaf_config(VdafConfig::Prio3Count)
             .build()
             .unwrap();
 
@@ -1111,9 +1150,16 @@ mod tests {
         install_test_trace_subscriber();
         initialize_rustls();
         let mut server = mockito::Server::new_async().await;
-        let vdaf = Prio3::new_count(2).unwrap();
-        let transcript = run_vdaf(&vdaf, &random(), &random(), &(), &random(), &true);
-        let collector = setup_collector(&mut server, vdaf);
+        let configured_vdaf = ConfiguredVdaf::prio3_count().unwrap();
+        let transcript = run_vdaf(
+            configured_vdaf.vdaf(),
+            &random(),
+            &random(),
+            &(),
+            &random(),
+            &true,
+        );
+        let collector = setup_collector(&mut server, configured_vdaf);
 
         let batch_interval = Interval::new(
             Time::from_seconds_since_epoch(1_000_000, &TEST_TIME_PRECISION),
@@ -1213,9 +1259,16 @@ mod tests {
         install_test_trace_subscriber();
         initialize_rustls();
         let mut server = mockito::Server::new_async().await;
-        let vdaf = Prio3::new_sum(2, 255).unwrap();
-        let transcript = run_vdaf(&vdaf, &random(), &random(), &(), &random(), &144);
-        let collector = setup_collector(&mut server, vdaf);
+        let configured_vdaf = ConfiguredVdaf::prio3_sum(255).unwrap();
+        let transcript = run_vdaf(
+            configured_vdaf.vdaf(),
+            &random(),
+            &random(),
+            &(),
+            &random(),
+            &144,
+        );
+        let collector = setup_collector(&mut server, configured_vdaf);
 
         let batch_interval = Interval::new(
             Time::from_seconds_since_epoch(1_000_000, &TEST_TIME_PRECISION),
@@ -1283,9 +1336,16 @@ mod tests {
         install_test_trace_subscriber();
         initialize_rustls();
         let mut server = mockito::Server::new_async().await;
-        let vdaf = Prio3::new_histogram(2, 4, 2).unwrap();
-        let transcript = run_vdaf(&vdaf, &random(), &random(), &(), &random(), &3);
-        let collector = setup_collector(&mut server, vdaf);
+        let configured_vdaf = ConfiguredVdaf::prio3_histogram(4, 2).unwrap();
+        let transcript = run_vdaf(
+            configured_vdaf.vdaf(),
+            &random(),
+            &random(),
+            &(),
+            &random(),
+            &3,
+        );
+        let collector = setup_collector(&mut server, configured_vdaf);
 
         let batch_interval = Interval::new(
             Time::from_seconds_since_epoch(1_000_000, &TEST_TIME_PRECISION),
@@ -1354,9 +1414,16 @@ mod tests {
         install_test_trace_subscriber();
         initialize_rustls();
         let mut server = mockito::Server::new_async().await;
-        let vdaf = Prio3::new_count(2).unwrap();
-        let transcript = run_vdaf(&vdaf, &random(), &random(), &(), &random(), &true);
-        let collector = setup_collector(&mut server, vdaf);
+        let configured_vdaf = ConfiguredVdaf::prio3_count().unwrap();
+        let transcript = run_vdaf(
+            configured_vdaf.vdaf(),
+            &random(),
+            &random(),
+            &(),
+            &random(),
+            &true,
+        );
+        let collector = setup_collector(&mut server, configured_vdaf);
 
         let batch_id = random();
         let collect_resp = build_collect_response_fixed(&transcript, &collector, &(), batch_id);
@@ -1419,23 +1486,29 @@ mod tests {
         install_test_trace_subscriber();
         initialize_rustls();
         let mut server = mockito::Server::new_async().await;
-        let vdaf = Prio3::new_count(2).unwrap();
-        let transcript = run_vdaf(&vdaf, &random(), &random(), &(), &random(), &true);
+        let configured_vdaf = ConfiguredVdaf::prio3_count().unwrap();
+        let transcript = run_vdaf(
+            configured_vdaf.vdaf(),
+            &random(),
+            &random(),
+            &(),
+            &random(),
+            &true,
+        );
         let server_url = DapUrl::try_from(server.url().as_str()).unwrap();
         let hpke_keypair = HpkeKeypair::test();
-        let collector = Collector::builder(
+        let collector = Collector::builder_from_configured_vdaf(
             random(),
             server_url.clone(),
             AuthenticationToken::new_bearer_token_from_bytes(Vec::from([0x41u8; 16])).unwrap(),
             hpke_keypair,
-            vdaf,
+            configured_vdaf,
             TEST_TIME_PRECISION,
         )
         .with_helper_endpoint(server_url)
         .with_task_info(b"test task".to_vec())
         .with_min_batch_size(1)
         .with_batch_config(BatchConfig::TimeInterval)
-        .with_vdaf_config(VdafConfig::Prio3Count)
         .with_http_request_backoff(test_http_request_exponential_backoff())
         .with_collect_poll_backoff(test_http_request_exponential_backoff())
         .build()
@@ -1510,8 +1583,8 @@ mod tests {
         install_test_trace_subscriber();
         initialize_rustls();
         let mut server = mockito::Server::new_async().await;
-        let vdaf = Prio3::new_count(2).unwrap();
-        let collector = setup_collector(&mut server, vdaf);
+        let configured_vdaf = ConfiguredVdaf::prio3_count().unwrap();
+        let collector = setup_collector(&mut server, configured_vdaf);
         let matcher = collection_uri_regex_matcher(&collector.task_id);
 
         let mock_server_error = server
@@ -1605,8 +1678,8 @@ mod tests {
         install_test_trace_subscriber();
         initialize_rustls();
         let mut server = mockito::Server::new_async().await;
-        let vdaf = Prio3::new_count(2).unwrap();
-        let collector = setup_collector(&mut server, vdaf);
+        let configured_vdaf = ConfiguredVdaf::prio3_count().unwrap();
+        let collector = setup_collector(&mut server, configured_vdaf);
         let matcher = collection_uri_regex_matcher(&collector.task_id);
 
         let mock_collect_start = server
@@ -1865,8 +1938,8 @@ mod tests {
         install_test_trace_subscriber();
         initialize_rustls();
         let mut server = mockito::Server::new_async().await;
-        let vdaf = Prio3::new_count(2).unwrap();
-        let collector = setup_collector(&mut server, vdaf);
+        let configured_vdaf = ConfiguredVdaf::prio3_count().unwrap();
+        let collector = setup_collector(&mut server, configured_vdaf);
         let matcher = collection_uri_regex_matcher(&collector.task_id);
 
         let mock_collect_start = server
@@ -1948,8 +2021,8 @@ mod tests {
         install_test_trace_subscriber();
         initialize_rustls();
         let mut server = mockito::Server::new_async().await;
-        let vdaf = Prio3::new_count(2).unwrap();
-        let mut collector = setup_collector(&mut server, vdaf);
+        let configured_vdaf = ConfiguredVdaf::prio3_count().unwrap();
+        let mut collector = setup_collector(&mut server, configured_vdaf);
         collector.collect_poll_wait_parameters = collector
             .collect_poll_wait_parameters
             .without_max_times()
@@ -2058,8 +2131,8 @@ mod tests {
         install_test_trace_subscriber();
         initialize_rustls();
         let mut server = mockito::Server::new_async().await;
-        let vdaf = dummy::Vdaf::new(1);
-        let collector = setup_collector(&mut server, vdaf);
+        let configured_vdaf = ConfiguredVdaf::fake(1);
+        let collector = setup_collector(&mut server, configured_vdaf);
 
         let collection_job_id = random();
         let collection_job = CollectionJob::new(
@@ -2096,8 +2169,8 @@ mod tests {
         install_test_trace_subscriber();
         initialize_rustls();
         let mut server = mockito::Server::new_async().await;
-        let vdaf = dummy::Vdaf::new(1);
-        let collector = setup_collector(&mut server, vdaf);
+        let configured_vdaf = ConfiguredVdaf::fake(1);
+        let collector = setup_collector(&mut server, configured_vdaf);
 
         let collection_job_id = random();
         let collection_job = CollectionJob::new(
@@ -2130,9 +2203,16 @@ mod tests {
         install_test_trace_subscriber();
         initialize_rustls();
         let mut server = mockito::Server::new_async().await;
-        let vdaf = Prio3::new_count(2).unwrap();
-        let transcript = run_vdaf(&vdaf, &random(), &random(), &(), &random(), &true);
-        let collector = setup_collector(&mut server, vdaf);
+        let configured_vdaf = ConfiguredVdaf::prio3_count().unwrap();
+        let transcript = run_vdaf(
+            configured_vdaf.vdaf(),
+            &random(),
+            &random(),
+            &(),
+            &random(),
+            &true,
+        );
+        let collector = setup_collector(&mut server, configured_vdaf);
 
         let batch_interval = Interval::new(
             Time::from_seconds_since_epoch(1_000_000, &TEST_TIME_PRECISION),

--- a/core/src/vdaf.rs
+++ b/core/src/vdaf.rs
@@ -1,13 +1,19 @@
 use std::str;
 
 use janus_messages::{TaskId, VdafConfig};
+#[cfg(feature = "test-util")]
+use prio::vdaf::dummy;
 use prio::{
     field::Field64,
     flp::{
-        gadgets::{Mul, ParallelSumGadget},
+        gadgets::{Mul, ParallelSum, ParallelSumGadget},
         types::SumVec,
     },
-    vdaf::{VdafError, prio3::Prio3, xof::XofHmacSha256Aes128},
+    vdaf::{
+        VdafError,
+        prio3::{Prio3, Prio3Count, Prio3Histogram, Prio3Sum, Prio3SumVec},
+        xof::XofHmacSha256Aes128,
+    },
 };
 use serde::{Deserialize, Serialize};
 
@@ -271,6 +277,118 @@ pub fn new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128<
         ALGORITHM_ID_PRIO3_SUM_VEC_FIELD64_MULTIPROOF_HMACSHA256_AES128,
         SumVec::new(max_measurement, length, chunk_length)?,
     )
+}
+
+/// A concrete VDAF paired with the [`VdafConfig`] describing it, both built from one set of
+/// parameters so that the values bound into HPKE AADs cannot drift from the VDAF in use.
+///
+/// Constructor arguments follow the wrapped `prio` constructor's order, not `VdafConfig`'s field
+/// order; the parameters are all integers, so a transposed call would compile.
+#[derive(Clone, Debug)]
+pub struct ConfiguredVdaf<V> {
+    vdaf: V,
+    config: VdafConfig,
+}
+
+impl<V> ConfiguredVdaf<V> {
+    pub fn vdaf(&self) -> &V {
+        &self.vdaf
+    }
+
+    pub fn config(&self) -> &VdafConfig {
+        &self.config
+    }
+
+    pub fn into_parts(self) -> (V, VdafConfig) {
+        (self.vdaf, self.config)
+    }
+}
+
+impl ConfiguredVdaf<Prio3Count> {
+    pub fn prio3_count() -> Result<Self, VdafError> {
+        Ok(Self {
+            vdaf: Prio3::new_count(2)?,
+            config: VdafConfig::Prio3Count,
+        })
+    }
+}
+
+impl ConfiguredVdaf<Prio3Sum> {
+    pub fn prio3_sum(max_measurement: u64) -> Result<Self, VdafError> {
+        Ok(Self {
+            vdaf: Prio3::new_sum(2, max_measurement)?,
+            config: VdafConfig::Prio3Sum { max_measurement },
+        })
+    }
+}
+
+impl ConfiguredVdaf<Prio3SumVec> {
+    pub fn prio3_sum_vec(
+        max_measurement: u64,
+        length: u32,
+        chunk_length: u32,
+    ) -> Result<Self, VdafError> {
+        Ok(Self {
+            vdaf: Prio3::new_sum_vec(
+                2,
+                u128::from(max_measurement),
+                length as usize,
+                chunk_length as usize,
+            )?,
+            config: VdafConfig::Prio3SumVec {
+                length,
+                max_measurement,
+                chunk_length,
+            },
+        })
+    }
+}
+
+impl ConfiguredVdaf<Prio3Histogram> {
+    pub fn prio3_histogram(length: u32, chunk_length: u32) -> Result<Self, VdafError> {
+        Ok(Self {
+            vdaf: Prio3::new_histogram(2, length as usize, chunk_length as usize)?,
+            config: VdafConfig::Prio3Histogram {
+                length,
+                chunk_length,
+            },
+        })
+    }
+}
+
+impl ConfiguredVdaf<Prio3SumVecField64MultiproofHmacSha256Aes128<ParallelSum<Field64, Mul>>> {
+    pub fn prio3_sum_vec_field64_multiproof_hmacsha256_aes128(
+        proofs: u8,
+        max_measurement: u64,
+        length: u32,
+        chunk_length: u32,
+    ) -> Result<Self, VdafError> {
+        Ok(Self {
+            vdaf: new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128(
+                proofs,
+                max_measurement,
+                length as usize,
+                chunk_length as usize,
+            )?,
+            config: VdafConfig::Prio3SumVecField64MultiproofHmacSha256Aes128 {
+                length,
+                max_measurement,
+                chunk_length,
+                proofs,
+            },
+        })
+    }
+}
+
+#[cfg(feature = "test-util")]
+#[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
+impl ConfiguredVdaf<dummy::Vdaf> {
+    pub fn fake(rounds: u32) -> Self {
+        Self {
+            vdaf: dummy::Vdaf::new(rounds),
+            config: VdafConfig::Fake { rounds },
+        }
+    }
 }
 
 /// Internal implementation details of [`vdaf_dispatch`](crate::vdaf_dispatch).
@@ -675,15 +793,100 @@ macro_rules! vdaf_dispatch {
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::Debug;
+
     use assert_matches::assert_matches;
     use janus_messages::VdafConfig;
-    use prio::dp::{
-        DifferentialPrivacyStrategy, PureDpBudget, Rational,
-        distributions::{DiscreteLaplaceDpStrategy, PureDpDiscreteLaplace},
+    use prio::{
+        dp::{
+            DifferentialPrivacyStrategy, PureDpBudget, Rational,
+            distributions::{DiscreteLaplaceDpStrategy, PureDpDiscreteLaplace},
+        },
+        field::Field64,
+        flp::gadgets::{Mul, ParallelSum},
+        vdaf::{dummy, prio3::Prio3},
     };
     use serde_test::{Token, assert_tokens};
 
-    use crate::vdaf::{VdafInstance, vdaf_dp_strategies};
+    use crate::vdaf::{
+        ConfiguredVdaf, VdafInstance, new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128,
+        vdaf_dp_strategies,
+    };
+
+    #[test]
+    fn configured_vdaf_pairing() {
+        // `Prio3`'s `Debug` carries the VDAF's parameters but it is not `PartialEq`.
+        fn assert_paired<V: Debug>(
+            configured: ConfiguredVdaf<V>,
+            expected_vdaf: V,
+            expected_config: VdafConfig,
+        ) {
+            assert_eq!(
+                format!("{:?}", configured.vdaf),
+                format!("{expected_vdaf:?}")
+            );
+            assert_eq!(configured.config, expected_config);
+            // The aggregators build their VDAF from `VdafInstance`, so the config must round-trip.
+            assert_eq!(
+                VdafInstance::try_from(&configured.config)
+                    .unwrap()
+                    .to_vdaf_config()
+                    .unwrap(),
+                configured.config
+            );
+        }
+
+        assert_paired(
+            ConfiguredVdaf::prio3_count().unwrap(),
+            Prio3::new_count(2).unwrap(),
+            VdafConfig::Prio3Count,
+        );
+        assert_paired(
+            ConfiguredVdaf::prio3_sum(4096).unwrap(),
+            Prio3::new_sum(2, 4096).unwrap(),
+            VdafConfig::Prio3Sum {
+                max_measurement: 4096,
+            },
+        );
+        assert_paired(
+            ConfiguredVdaf::prio3_sum_vec(4096, 8, 2).unwrap(),
+            Prio3::new_sum_vec(2, 4096, 8, 2).unwrap(),
+            VdafConfig::Prio3SumVec {
+                length: 8,
+                max_measurement: 4096,
+                chunk_length: 2,
+            },
+        );
+        assert_paired(
+            ConfiguredVdaf::prio3_histogram(12, 4).unwrap(),
+            Prio3::new_histogram(2, 12, 4).unwrap(),
+            VdafConfig::Prio3Histogram {
+                length: 12,
+                chunk_length: 4,
+            },
+        );
+        assert_paired(
+            ConfiguredVdaf::prio3_sum_vec_field64_multiproof_hmacsha256_aes128(3, 4096, 8, 2)
+                .unwrap(),
+            new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128::<ParallelSum<Field64, Mul>>(
+                3, 4096, 8, 2,
+            )
+            .unwrap(),
+            VdafConfig::Prio3SumVecField64MultiproofHmacSha256Aes128 {
+                length: 8,
+                max_measurement: 4096,
+                chunk_length: 2,
+                proofs: 3,
+            },
+        );
+        // `dummy::Vdaf` keeps `rounds` in a closure and redacts its `Debug`, so only the config
+        // half of this pairing is actually asserted.
+        assert_paired(
+            ConfiguredVdaf::fake(3),
+            dummy::Vdaf::new(3),
+            VdafConfig::Fake { rounds: 3 },
+        );
+    }
 
     #[test]
     fn vdaf_instance_to_vdaf_config() {

--- a/integration_tests/src/client.rs
+++ b/integration_tests/src/client.rs
@@ -275,22 +275,20 @@ where
         let (leader_aggregator_endpoint, helper_aggregator_endpoint, http_client) = task_parameters
             .endpoint_fragments
             .in_process_config(leader_port, helper_port);
-        let mut builder = Client::builder(
+        let mut builder = Client::builder_with_custom_vdaf(
             task_parameters.task_id,
             leader_aggregator_endpoint.as_str().try_into().unwrap(),
             helper_aggregator_endpoint.as_str().try_into().unwrap(),
             task_parameters.time_precision,
             vdaf,
-        )
-        .with_task_info(task_parameters.task_info.clone())
-        .with_min_batch_size(task_parameters.min_batch_size)
-        .with_batch_config(task_parameters.batch_mode.to_batch_config())
-        .with_vdaf_config(
             task_parameters
                 .vdaf
                 .to_vdaf_config()
                 .map_err(janus_client::Error::InvalidParameter)?,
         )
+        .with_task_info(task_parameters.task_info.clone())
+        .with_min_batch_size(task_parameters.min_batch_size)
+        .with_batch_config(task_parameters.batch_mode.to_batch_config())
         .with_task_interval(task_parameters.task_interval);
 
         if let Some(http_client) = http_client {

--- a/integration_tests/tests/integration/common.rs
+++ b/integration_tests/tests/integration/common.rs
@@ -261,19 +261,19 @@ where
     let (leader_endpoint, helper_endpoint, http_client) = task_parameters
         .endpoint_fragments
         .in_process_config(leader_port, helper_port);
-    let mut builder = Collector::builder(
+    let mut builder = Collector::builder_with_custom_vdaf(
         task_parameters.task_id,
         leader_endpoint.as_str().try_into().unwrap(),
         task_parameters.collector_auth_token.clone(),
         task_parameters.collector_hpke_keypair.clone(),
         vdaf,
+        task_parameters.vdaf.to_vdaf_config().unwrap(),
         task_parameters.time_precision,
     )
     .with_helper_endpoint(helper_endpoint.as_str().try_into().unwrap())
     .with_task_info(task_parameters.task_info.clone())
     .with_min_batch_size(task_parameters.min_batch_size)
     .with_batch_config(task_parameters.batch_mode.to_batch_config())
-    .with_vdaf_config(task_parameters.vdaf.to_vdaf_config().unwrap())
     .with_task_interval(task_parameters.task_interval)
     .with_http_request_backoff(test_http_request_exponential_backoff())
     .with_collect_poll_backoff(

--- a/integration_tests/tests/integration/simulation/setup.rs
+++ b/integration_tests/tests/integration/simulation/setup.rs
@@ -217,7 +217,7 @@ impl Components {
             .unwrap();
 
         let http_client = default_http_client().unwrap();
-        let client = Client::builder(
+        let client = Client::builder_with_custom_vdaf(
             *task.id(),
             task.leader_aggregator_endpoint()
                 .as_str()
@@ -229,12 +229,12 @@ impl Components {
                 .unwrap(),
             *task.time_precision(),
             state.vdaf.clone(),
+            leader_task.vdaf().to_vdaf_config().unwrap(),
         )
         .with_http_client(http_client.clone())
         .with_task_info(leader_task.task_info().to_vec())
         .with_min_batch_size(leader_task.min_batch_size())
         .with_batch_config(leader_task.batch_mode().to_batch_config())
-        .with_vdaf_config(leader_task.vdaf().to_vdaf_config().unwrap())
         .with_task_interval(leader_task.task_interval().copied())
         .build()
         .await
@@ -336,7 +336,7 @@ impl Components {
                 2,
             ));
 
-        let collector = Collector::builder(
+        let collector = Collector::builder_with_custom_vdaf(
             *task.id(),
             task.leader_aggregator_endpoint()
                 .as_str()
@@ -345,6 +345,7 @@ impl Components {
             task.collector_auth_token().clone(),
             task.collector_hpke_keypair().clone(),
             state.vdaf.clone(),
+            leader_task.vdaf().to_vdaf_config().unwrap(),
             *task.time_precision(),
         )
         .with_helper_endpoint(
@@ -356,7 +357,6 @@ impl Components {
         .with_task_info(leader_task.task_info().to_vec())
         .with_min_batch_size(leader_task.min_batch_size())
         .with_batch_config(leader_task.batch_mode().to_batch_config())
-        .with_vdaf_config(leader_task.vdaf().to_vdaf_config().unwrap())
         .with_task_interval(leader_task.task_interval().copied())
         .with_http_request_backoff(http_request_exponential_backoff())
         .with_collect_poll_backoff(

--- a/interop_binaries/src/commands/janus_interop_client.rs
+++ b/interop_binaries/src/commands/janus_interop_client.rs
@@ -97,18 +97,18 @@ async fn handle_upload_generic<V: prio::vdaf::Client<16>>(
         .to_vdaf_config()
         .map_err(|err| anyhow::anyhow!("unsupported VDAF for TaskConfiguration: {err}"))?;
 
-    let client = janus_client::Client::builder(
+    let client = janus_client::Client::builder_with_custom_vdaf(
         task_id,
         request.leader,
         request.helper,
         time_precision,
         vdaf,
+        vdaf_config,
     )
     .with_http_client(http_client.clone())
     .with_task_info(INTEROP_TASK_INFO.to_vec())
     .with_min_batch_size(request.min_batch_size)
     .with_batch_config(interop_batch_config(request.batch_mode)?)
-    .with_vdaf_config(vdaf_config)
     .build()
     .await
     .context("failed to construct client")?;

--- a/interop_binaries/src/commands/janus_interop_collector.rs
+++ b/interop_binaries/src/commands/janus_interop_collector.rs
@@ -222,19 +222,19 @@ where
     let vdaf_config = VdafInstance::from(task_state.vdaf.clone())
         .to_vdaf_config()
         .map_err(|err| anyhow::anyhow!("unsupported VDAF for TaskConfiguration: {err}"))?;
-    let collector = Collector::builder(
+    let collector = Collector::builder_with_custom_vdaf(
         task_state.task_id,
         task_state.leader_url.clone(),
         task_state.auth_token.clone(),
         task_state.keypair.clone(),
         vdaf,
+        vdaf_config,
         time_precision,
     )
     .with_helper_endpoint(task_state.helper_url.clone())
     .with_task_info(INTEROP_TASK_INFO.to_vec())
     .with_min_batch_size(task_state.min_batch_size)
     .with_batch_config(task_state.batch_config.clone())
-    .with_vdaf_config(vdaf_config)
     .with_http_client(http_client.clone())
     .with_http_request_backoff(
         ExponentialWithTotalDelayBuilder::new()

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -630,20 +630,21 @@ fn new_collector<V: vdaf::Collector>(
     let task_id = options.task_id;
     let leader_endpoint = options.leader;
     let time_precision = TimePrecision::from_seconds(options.time_precision);
-    let collector = Collector::builder(
+    let collector = Collector::builder_with_custom_vdaf(
         task_id,
         leader_endpoint,
         authentication,
         hpke_keypair,
         vdaf,
+        // Placeholder (#4713). Only `new-job` gets this far, and it never computes an AAD.
+        VdafConfig::Prio3Count,
         time_precision,
     )
-    // Placeholders (#4713). Only `new-job` gets this far, and it never computes an AAD.
+    // Placeholders (#4713), as above.
     .with_helper_endpoint("http://unused.helper.example/".try_into().unwrap())
     .with_task_info(Vec::new())
     .with_min_batch_size(0)
     .with_batch_config(BatchConfig::TimeInterval)
-    .with_vdaf_config(VdafConfig::Prio3Count)
     .with_http_client(http_client)
     .with_collect_poll_backoff(
         ExponentialWithTotalDelayBuilder::new()


### PR DESCRIPTION
As David pointed out (see #4711), building a client or collector required stating the VDAF's parameters twice: once to `Prio3::new_histogram(2, 12, 4)` and again as `VdafConfig::Prio3Histogram { length: 12, chunk_length: 4 }`. And a mismatch wasn't not a compile error, just a silent HPKE AAD byte-identity bug that surfaces as a decryption failure at the aggregator.

This adds `ConfiguredVdaf<V>` -- it holds a concrete VDAF alongside the `VdafConfig` describing it, with `prio3_*` constructors that build both from one set of parameters.

It also adds `Client::builder_from_configured_vdaf`, `Collector::builder_from_configured_vdaf`, and `CollectorBuilder::from_configured_vdaf`.

`with_vdaf_config` remains for the configs with no concrete VDAF to derive from.

Note this uncovered two existing mismatches: the client's `setup_client` and the collector's `setup_collector` test helpers both hardcoded `VdafConfig::Prio3Count` while callers passed Prio3Sum, Prio3Histogram, and `dummy::Vdaf`. Oops.