### PR TITLE
Ignore smartstring RUSTSEC advisory. (release/0.7 backport)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -29,8 +29,7 @@ ignore = [
     # See <https://github.com/fussybeaver/bollard/issues/612>.
     "RUSTSEC-2025-0134",
 
-    # 'smartstring' is part of Trillium. It goes away once divviup-client is migrated
-    # off Trillium.
+    # 'smartstring' is part of Trillium, and it's unmaintained.
     "RUSTSEC-2026-0249",
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -28,6 +28,10 @@ ignore = [
     # We have migrated from `rustls-pemfile` but not everything else has.
     # See <https://github.com/fussybeaver/bollard/issues/612>.
     "RUSTSEC-2025-0134",
+
+    # 'smartstring' is part of Trillium. It goes away once divviup-client is migrated
+    # off Trillium.
+    "RUSTSEC-2026-0249",
 ]
 
 [bans]


### PR DESCRIPTION
It's part of Trillium, which we'll soon be rid of.