### PR TITLE
Replace DAP task parameter flags with --task-config

### DIFF
--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -34,12 +34,12 @@
 //! // aggregators byte-for-byte.
 //! let collector = Collector::builder(
 //!     task_id,
-//!     leader_url,
 //!     collector_credential.authentication_token(),
 //!     collector_credential.hpke_keypair(),
 //!     ConfiguredVdaf::prio3_count().unwrap(),
-//!     time_precision,
 //! )
+//! .with_leader_endpoint(leader_url)
+//! .with_time_precision(time_precision)
 //! .with_helper_endpoint(helper_url)
 //! .with_task_info(b"[task info]".to_vec())
 //! .with_min_batch_size(1000)
@@ -348,16 +348,20 @@ where
 pub struct CollectorBuilder<V: vdaf::Collector> {
     /// Unique identifier for the task.
     task_id: TaskId,
-    /// The base URL of the leader's aggregator API endpoints.
-    leader_endpoint: DapUrl,
     /// The authentication information needed to communicate with the leader aggregator.
     authentication: AuthenticationToken,
     /// HPKE keypair used for decryption of aggregate shares.
     hpke_keypair: HpkeKeypair,
     /// An implementation of the task's VDAF.
     vdaf: V,
-    /// The task's time precision.
-    time_precision: TimePrecision,
+    /// The base URL of the leader's aggregator API endpoints, bound into the task's
+    /// `TaskConfiguration`. Required before [`Self::build`] unless
+    /// [`Self::with_task_configuration`] supplies it; set via [`Self::with_leader_endpoint`].
+    leader_endpoint: Option<DapUrl>,
+    /// The task's time precision, bound into the task's `TaskConfiguration`. Required before
+    /// [`Self::build`] unless [`Self::with_task_configuration`] supplies it; set via
+    /// [`Self::with_time_precision`].
+    time_precision: Option<TimePrecision>,
     /// The base URL of the helper's aggregator API endpoints. Required before [`Self::build`]; set
     /// via [`Self::with_helper_endpoint`].
     helper_endpoint: Option<DapUrl>,
@@ -387,25 +391,23 @@ pub struct CollectorBuilder<V: vdaf::Collector> {
 }
 
 impl<V: vdaf::Collector> CollectorBuilder<V> {
-    /// Construct a [`CollectorBuilder`] from required DAP task parameters and an implementation of
-    /// the task's VDAF. The caller is responsible for ensuring `vdaf_config` describes `vdaf`;
+    /// Construct a [`CollectorBuilder`] from an implementation of the task's VDAF and its
+    /// [`VdafConfig`]. The caller is responsible for ensuring `vdaf_config` describes `vdaf`;
     /// prefer [`Self::from_configured_vdaf`], which cannot mismatch the two.
     pub fn new(
         task_id: TaskId,
-        leader_endpoint: DapUrl,
         authentication: AuthenticationToken,
         hpke_keypair: HpkeKeypair,
         vdaf: V,
         vdaf_config: VdafConfig,
-        time_precision: TimePrecision,
     ) -> Self {
         Self {
             task_id,
-            leader_endpoint,
             authentication,
             hpke_keypair,
             vdaf,
-            time_precision,
+            leader_endpoint: None,
+            time_precision: None,
             helper_endpoint: None,
             task_info: None,
             min_batch_size: None,
@@ -422,26 +424,17 @@ impl<V: vdaf::Collector> CollectorBuilder<V> {
         }
     }
 
-    /// Construct a [`CollectorBuilder`] from required DAP task parameters and a
-    /// [`ConfiguredVdaf`], which supplies both the VDAF and its [`VdafConfig`].
+    /// Construct a [`CollectorBuilder`] from a [`ConfiguredVdaf`], which supplies both the VDAF and
+    /// its [`VdafConfig`]. The remaining task parameters come from either
+    /// [`Self::with_task_configuration`] or the individual setters.
     pub fn from_configured_vdaf(
         task_id: TaskId,
-        leader_endpoint: DapUrl,
         authentication: AuthenticationToken,
         hpke_keypair: HpkeKeypair,
         configured_vdaf: ConfiguredVdaf<V>,
-        time_precision: TimePrecision,
     ) -> Self {
         let (vdaf, vdaf_config) = configured_vdaf.into_parts();
-        Self::new(
-            task_id,
-            leader_endpoint,
-            authentication,
-            hpke_keypair,
-            vdaf,
-            vdaf_config,
-            time_precision,
-        )
+        Self::new(task_id, authentication, hpke_keypair, vdaf, vdaf_config)
     }
 
     /// Finalize construction of a [`Collector`].
@@ -455,13 +448,9 @@ impl<V: vdaf::Collector> CollectorBuilder<V> {
         Ok(Collector {
             task_id: self.task_id,
             task_configuration,
-            // Stored verbatim; the trailing slash is applied at join time via `url_for_join`, so
-            // the bytes bound into HPKE AADs stay exactly as provisioned (DAP §4.1).
-            leader_endpoint: self.leader_endpoint,
             authentication: self.authentication,
             hpke_keypair: self.hpke_keypair,
             vdaf: self.vdaf,
-            time_precision: self.time_precision,
             http_client,
             http_request_retry_parameters: self.http_request_retry_parameters,
             collect_poll_wait_parameters: self.collect_poll_wait_parameters,
@@ -472,16 +461,18 @@ impl<V: vdaf::Collector> CollectorBuilder<V> {
     /// [`Self::with_task_configuration`] or by composing one from the individual setters.
     fn resolve_task_configuration(&self) -> Result<TaskConfiguration, Error> {
         let Some(task_configuration) = &self.task_configuration else {
-            // fail fast if anything can't build.
             return Ok(build_task_configuration(
                 self.task_info
                     .clone()
                     .ok_or(Error::InvalidParameter("task_info not set"))?,
-                self.leader_endpoint.clone(),
+                self.leader_endpoint
+                    .clone()
+                    .ok_or(Error::InvalidParameter("leader_endpoint not set"))?,
                 self.helper_endpoint
                     .clone()
                     .ok_or(Error::InvalidParameter("helper_endpoint not set"))?,
-                self.time_precision,
+                self.time_precision
+                    .ok_or(Error::InvalidParameter("time_precision not set"))?,
                 self.min_batch_size
                     .ok_or(Error::InvalidParameter("min_batch_size not set"))?,
                 self.batch_config
@@ -508,21 +499,29 @@ impl<V: vdaf::Collector> CollectorBuilder<V> {
             ));
         }
 
-        // These three are also checked via the constructor (or, for the VDAF
-        // config, via `from_configured_vdaf`). It's deliberate, because a disagreement
-        // would be a silent AAD bug, and these checks are cheap.
+        // A disagreement with the task configuration would be a silent AAD bug, so cross-check
+        // whatever the caller supplied.
         if &self.vdaf_config != task_configuration.vdaf_config() {
             return Err(Error::InvalidParameter(
                 "vdaf_config disagrees with the task configuration's vdaf_config",
             ));
         }
-        if &self.leader_endpoint != task_configuration.leader_aggregator_endpoint() {
+        if self
+            .leader_endpoint
+            .as_ref()
+            .is_some_and(|leader_endpoint| {
+                leader_endpoint != task_configuration.leader_aggregator_endpoint()
+            })
+        {
             return Err(Error::InvalidParameter(
                 "leader_endpoint disagrees with the task configuration's \
                  leader_aggregator_endpoint",
             ));
         }
-        if &self.time_precision != task_configuration.time_precision() {
+        if self
+            .time_precision
+            .is_some_and(|time_precision| &time_precision != task_configuration.time_precision())
+        {
             return Err(Error::InvalidParameter(
                 "time_precision disagrees with the task configuration's time_precision",
             ));
@@ -546,6 +545,22 @@ impl<V: vdaf::Collector> CollectorBuilder<V> {
     /// Replace the exponential backoff settings used while polling for aggregate shares.
     pub fn with_collect_poll_backoff(mut self, backoff: ExponentialWithTotalDelayBuilder) -> Self {
         self.collect_poll_wait_parameters = backoff;
+        self
+    }
+
+    /// Set the base URL of the leader's aggregator API endpoints, bound into the task's
+    /// `TaskConfiguration`. Required before [`Self::build`] unless
+    /// [`Self::with_task_configuration`] supplies it, in which case the two must agree.
+    pub fn with_leader_endpoint(mut self, leader_endpoint: DapUrl) -> Self {
+        self.leader_endpoint = Some(leader_endpoint);
+        self
+    }
+
+    /// Set the task's time precision, bound into the task's `TaskConfiguration`. Required before
+    /// [`Self::build`] unless [`Self::with_task_configuration`] supplies it, in which case the two
+    /// must agree.
+    pub fn with_time_precision(mut self, time_precision: TimePrecision) -> Self {
+        self.time_precision = Some(time_precision);
         self
     }
 
@@ -599,9 +614,6 @@ impl<V: vdaf::Collector> CollectorBuilder<V> {
 pub struct Collector<V: vdaf::Collector> {
     /// Unique identifier for the task.
     task_id: TaskId,
-    /// The base URL of the leader's aggregator API endpoints.
-    #[educe(Debug(method(std::fmt::Display::fmt)))]
-    leader_endpoint: DapUrl,
     /// The authentication information needed to communicate with the leader aggregator.
     authentication: AuthenticationToken,
     /// HPKE keypair used for decryption of aggregate shares.
@@ -609,8 +621,6 @@ pub struct Collector<V: vdaf::Collector> {
     hpke_keypair: HpkeKeypair,
     /// An implementation of the task's VDAF.
     vdaf: V,
-    /// The task's time precision.
-    time_precision: TimePrecision,
     /// The task's configuration, bound into aggregate-share AADs.
     task_configuration: TaskConfiguration,
 
@@ -629,41 +639,28 @@ impl<V: vdaf::Collector> Collector<V> {
     /// they agree; a mismatch produces aggregate shares the collector cannot decrypt.
     pub fn builder_with_custom_vdaf(
         task_id: TaskId,
-        leader_endpoint: DapUrl,
         authentication: AuthenticationToken,
         hpke_keypair: HpkeKeypair,
         vdaf: V,
         vdaf_config: VdafConfig,
-        time_precision: TimePrecision,
     ) -> CollectorBuilder<V> {
-        CollectorBuilder::new(
-            task_id,
-            leader_endpoint,
-            authentication,
-            hpke_keypair,
-            vdaf,
-            vdaf_config,
-            time_precision,
-        )
+        CollectorBuilder::new(task_id, authentication, hpke_keypair, vdaf, vdaf_config)
     }
 
-    /// Creates a [`CollectorBuilder`] from the required set of DAP task parameters and a
-    /// [`ConfiguredVdaf`], which supplies both the VDAF and its [`VdafConfig`].
+    /// Creates a [`CollectorBuilder`] from a [`ConfiguredVdaf`], which supplies both the VDAF and
+    /// its [`VdafConfig`]. The remaining task parameters come from either
+    /// [`CollectorBuilder::with_task_configuration`] or the individual setters.
     pub fn builder(
         task_id: TaskId,
-        leader_endpoint: DapUrl,
         authentication: AuthenticationToken,
         hpke_keypair: HpkeKeypair,
         configured_vdaf: ConfiguredVdaf<V>,
-        time_precision: TimePrecision,
     ) -> CollectorBuilder<V> {
         CollectorBuilder::from_configured_vdaf(
             task_id,
-            leader_endpoint,
             authentication,
             hpke_keypair,
             configured_vdaf,
-            time_precision,
         )
     }
 
@@ -674,10 +671,14 @@ impl<V: vdaf::Collector> Collector<V> {
 
     /// Construct a URI for a collection.
     fn collection_job_uri(&self, collection_job_id: CollectionJobId) -> Result<Url, Error> {
-        Ok(url_for_join(&self.leader_endpoint)?.join(&format!(
-            "tasks/{}/collection_jobs/{collection_job_id}",
-            self.task_id
-        ))?)
+        // Joined at request time so the endpoint bytes bound into HPKE AADs stay verbatim
+        // (DAP §4.1).
+        Ok(
+            url_for_join(self.task_configuration.leader_aggregator_endpoint())?.join(&format!(
+                "tasks/{}/collection_jobs/{collection_job_id}",
+                self.task_id
+            ))?,
+        )
     }
 
     /// Construct a collection request to send to the leader aggregator.
@@ -847,11 +848,11 @@ impl<V: vdaf::Collector> Collector<V> {
                 collect_response
                     .interval
                     .start()
-                    .as_date_time(self.time_precision)?,
+                    .as_date_time(*self.task_configuration.time_precision())?,
                 collect_response
                     .interval
                     .duration()
-                    .to_chrono(&self.time_precision)?,
+                    .to_chrono(self.task_configuration.time_precision())?,
             ),
             aggregate_result,
         }))
@@ -1034,12 +1035,12 @@ mod tests {
         let hpke_keypair = HpkeKeypair::test();
         Collector::builder(
             random(),
-            server_url.clone(),
             AuthenticationToken::new_bearer_token_from_string("Y29sbGVjdG9yIHRva2Vu").unwrap(),
             hpke_keypair,
             configured_vdaf,
-            TEST_TIME_PRECISION,
         )
+        .with_leader_endpoint(server_url.clone())
+        .with_time_precision(TEST_TIME_PRECISION)
         .with_helper_endpoint(server_url)
         .with_task_info(b"test task".to_vec())
         .with_min_batch_size(1)
@@ -1160,11 +1161,9 @@ mod tests {
     ) -> CollectorBuilder<dummy::Vdaf> {
         Collector::builder(
             random(),
-            "http://leader.example.com".try_into().unwrap(),
             AuthenticationToken::new_bearer_token_from_string("Y29sbGVjdG9yIHRva2Vu").unwrap(),
             HpkeKeypair::test(),
             ConfiguredVdaf::fake(1),
-            TEST_TIME_PRECISION,
         )
         .with_task_configuration(task_configuration)
     }
@@ -1214,17 +1213,15 @@ mod tests {
 
     #[test]
     fn task_configuration_disagreement_rejected() {
-        // The VDAF config arrives from `from_configured_vdaf`, and the endpoint and time precision
-        // from the constructor. Each is also in the task configuration; a mismatch is an AAD
-        // byte-identity bug, so it must fail at build time.
+        // The VDAF config arrives from `from_configured_vdaf`; the endpoint and time precision are
+        // optional, but a caller may still supply them. Each is also in the task configuration; a
+        // mismatch is an AAD byte-identity bug, so it must fail at build time.
         assert_matches!(
             Collector::builder(
                 random(),
-                "http://leader.example.com".try_into().unwrap(),
                 AuthenticationToken::new_bearer_token_from_string("Y29sbGVjdG9yIHRva2Vu").unwrap(),
                 HpkeKeypair::test(),
                 ConfiguredVdaf::fake(2),
-                TEST_TIME_PRECISION,
             )
             .with_task_configuration(task_configuration_with_unknown_extension())
             .build(),
@@ -1232,31 +1229,44 @@ mod tests {
         );
 
         assert_matches!(
-            Collector::builder(
-                random(),
-                "http://leader.example.com/dap".try_into().unwrap(),
-                AuthenticationToken::new_bearer_token_from_string("Y29sbGVjdG9yIHRva2Vu").unwrap(),
-                HpkeKeypair::test(),
-                ConfiguredVdaf::fake(1),
-                TEST_TIME_PRECISION,
-            )
-            .with_task_configuration(task_configuration_with_unknown_extension())
-            .build(),
+            builder_with_task_configuration(task_configuration_with_unknown_extension())
+                .with_leader_endpoint("http://leader.example.com/dap".try_into().unwrap())
+                .build(),
             Err(Error::InvalidParameter(_))
         );
 
         assert_matches!(
+            builder_with_task_configuration(task_configuration_with_unknown_extension())
+                .with_time_precision(TimePrecision::from_seconds(3600))
+                .build(),
+            Err(Error::InvalidParameter(_))
+        );
+    }
+
+    #[test]
+    fn composed_task_configuration_requires_endpoint_and_time_precision() {
+        let builder = || {
             Collector::builder(
                 random(),
-                "http://leader.example.com".try_into().unwrap(),
                 AuthenticationToken::new_bearer_token_from_string("Y29sbGVjdG9yIHRva2Vu").unwrap(),
                 HpkeKeypair::test(),
                 ConfiguredVdaf::fake(1),
-                TimePrecision::from_seconds(3600),
             )
-            .with_task_configuration(task_configuration_with_unknown_extension())
-            .build(),
-            Err(Error::InvalidParameter(_))
+            .with_helper_endpoint("http://helper.example.com".try_into().unwrap())
+            .with_task_info(b"test task".to_vec())
+            .with_min_batch_size(1)
+            .with_batch_config(BatchConfig::TimeInterval)
+        };
+
+        assert_matches!(
+            builder().with_time_precision(TEST_TIME_PRECISION).build(),
+            Err(Error::InvalidParameter("leader_endpoint not set"))
+        );
+        assert_matches!(
+            builder()
+                .with_leader_endpoint("http://leader.example.com".try_into().unwrap())
+                .build(),
+            Err(Error::InvalidParameter("time_precision not set"))
         );
     }
 
@@ -1273,12 +1283,12 @@ mod tests {
         ] {
             let collector = Collector::builder(
                 random(),
-                endpoint.try_into().unwrap(),
                 AuthenticationToken::new_bearer_token_from_string("Y29sbGVjdG9yIHRva2Vu").unwrap(),
                 hpke_keypair.clone(),
                 ConfiguredVdaf::fake(1),
-                TEST_TIME_PRECISION,
             )
+            .with_leader_endpoint(endpoint.try_into().unwrap())
+            .with_time_precision(TEST_TIME_PRECISION)
             .with_helper_endpoint("http://helper.example.com".try_into().unwrap())
             .with_task_info(b"test task".to_vec())
             .with_min_batch_size(1)
@@ -1288,7 +1298,13 @@ mod tests {
 
             // Stored verbatim (no trailing slash added) for byte-identical HPKE AADs (DAP §4.1),
             // while the request URI is still joined against a slash-terminated base.
-            assert_eq!(collector.leader_endpoint.as_str(), endpoint);
+            assert_eq!(
+                collector
+                    .task_configuration
+                    .leader_aggregator_endpoint()
+                    .as_str(),
+                endpoint
+            );
             assert_eq!(
                 collector
                     .collection_job_uri(collection_job_id)
@@ -1656,12 +1672,12 @@ mod tests {
         let hpke_keypair = HpkeKeypair::test();
         let collector = Collector::builder(
             random(),
-            server_url.clone(),
             AuthenticationToken::new_bearer_token_from_bytes(Vec::from([0x41u8; 16])).unwrap(),
             hpke_keypair,
             configured_vdaf,
-            TEST_TIME_PRECISION,
         )
+        .with_leader_endpoint(server_url.clone())
+        .with_time_precision(TEST_TIME_PRECISION)
         .with_helper_endpoint(server_url)
         .with_task_info(b"test task".to_vec())
         .with_min_batch_size(1)

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -374,7 +374,7 @@ pub struct CollectorBuilder<V: vdaf::Collector> {
     vdaf_config: VdafConfig,
     /// Optional task validity interval bound into the task's `TaskConfiguration`.
     task_interval: Option<Interval>,
-    /// A pre-built `TaskConfiguration`, bound verbatim. Mutually exclusive with the setters above;
+    /// A pre-built `TaskConfiguration`. Mutually exclusive with the setters above;
     /// set via [`Self::with_task_configuration`].
     task_configuration: Option<TaskConfiguration>,
 
@@ -468,12 +468,11 @@ impl<V: vdaf::Collector> CollectorBuilder<V> {
         })
     }
 
-    /// Resolves the task's [`TaskConfiguration`], either from a verbatim message supplied to
+    /// Resolves the task's [`TaskConfiguration`], either from whatever was supplied to
     /// [`Self::with_task_configuration`] or by composing one from the individual setters.
     fn resolve_task_configuration(&self) -> Result<TaskConfiguration, Error> {
         let Some(task_configuration) = &self.task_configuration else {
-            // Composing fails fast here on parameters that cannot form a valid TaskConfiguration,
-            // rather than deferring to the first collection's AAD construction.
+            // fail fast if anything can't build.
             return Ok(build_task_configuration(
                 self.task_info
                     .clone()
@@ -493,9 +492,10 @@ impl<V: vdaf::Collector> CollectorBuilder<V> {
             )?);
         };
 
-        // A verbatim TaskConfiguration is the whole message, including extensions this
-        // implementation does not model, so composing from the setters cannot reproduce it.
-        // Reject rather than silently pick a winner.
+        // Since TaskConfiguration is the whole thing, including extensions this
+        // implementation does not model, composing from the setters can't reproduce it.
+        // If we got here, with_task_configuration was used, so enforce that the other
+        // setters _weren't_.
         if self.helper_endpoint.is_some()
             || self.task_info.is_some()
             || self.min_batch_size.is_some()
@@ -508,9 +508,9 @@ impl<V: vdaf::Collector> CollectorBuilder<V> {
             ));
         }
 
-        // These three are stated twice: once here and once via the constructor (or, for the VDAF
-        // config, via `from_configured_vdaf`). A disagreement would be a silent AAD byte-identity
-        // bug, so check rather than choose.
+        // These three are also checked via the constructor (or, for the VDAF
+        // config, via `from_configured_vdaf`). It's deliberate, because a disagreement
+        // would be a silent AAD bug, and these checks are cheap.
         if &self.vdaf_config != task_configuration.vdaf_config() {
             return Err(Error::InvalidParameter(
                 "vdaf_config disagrees with the task configuration's vdaf_config",
@@ -583,7 +583,7 @@ impl<V: vdaf::Collector> CollectorBuilder<V> {
         self
     }
 
-    /// Bind a pre-built [`TaskConfiguration`] verbatim, in place of composing one from the
+    /// Store a pre-built [`TaskConfiguration`], in place of composing one from the
     /// individual setters above (which this is mutually exclusive with). Use this when the
     /// configuration arrives already encoded, so that extensions this implementation does not
     /// model survive into the HPKE AAD.
@@ -1170,7 +1170,7 @@ mod tests {
     }
 
     #[test]
-    fn task_configuration_bound_verbatim() {
+    fn task_configuration_bound_identical() {
         // The bytes bound into the AAD must be the bytes we were handed, extensions included:
         // recomposing from the individual setters would silently drop the unknown extension and
         // every aggregate share would fail to decrypt.

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -374,6 +374,9 @@ pub struct CollectorBuilder<V: vdaf::Collector> {
     vdaf_config: VdafConfig,
     /// Optional task validity interval bound into the task's `TaskConfiguration`.
     task_interval: Option<Interval>,
+    /// A pre-built `TaskConfiguration`, bound verbatim. Mutually exclusive with the setters above;
+    /// set via [`Self::with_task_configuration`].
+    task_configuration: Option<TaskConfiguration>,
 
     /// HTTPS client.
     http_client: Option<reqwest::Client>,
@@ -409,6 +412,7 @@ impl<V: vdaf::Collector> CollectorBuilder<V> {
             batch_config: None,
             vdaf_config,
             task_interval: None,
+            task_configuration: None,
             http_client: None,
             http_request_retry_parameters: http_request_exponential_backoff(),
             collect_poll_wait_parameters: ExponentialWithTotalDelayBuilder::new()
@@ -442,42 +446,89 @@ impl<V: vdaf::Collector> CollectorBuilder<V> {
 
     /// Finalize construction of a [`Collector`].
     pub fn build(self) -> Result<Collector<V>, Error> {
+        let task_configuration = self.resolve_task_configuration()?;
         let http_client = if let Some(http_client) = self.http_client {
             http_client
         } else {
             default_http_client()?
         };
-        let collector = Collector {
+        Ok(Collector {
             task_id: self.task_id,
+            task_configuration,
             // Stored verbatim; the trailing slash is applied at join time via `url_for_join`, so
             // the bytes bound into HPKE AADs stay exactly as provisioned (DAP §4.1).
             leader_endpoint: self.leader_endpoint,
-            helper_endpoint: self
-                .helper_endpoint
-                .ok_or(Error::InvalidParameter("helper_endpoint not set"))?,
             authentication: self.authentication,
             hpke_keypair: self.hpke_keypair,
             vdaf: self.vdaf,
             time_precision: self.time_precision,
-            task_info: self
-                .task_info
-                .ok_or(Error::InvalidParameter("task_info not set"))?,
-            min_batch_size: self
-                .min_batch_size
-                .ok_or(Error::InvalidParameter("min_batch_size not set"))?,
-            batch_config: self
-                .batch_config
-                .ok_or(Error::InvalidParameter("batch_config not set"))?,
-            vdaf_config: self.vdaf_config,
-            task_interval: self.task_interval,
             http_client,
             http_request_retry_parameters: self.http_request_retry_parameters,
             collect_poll_wait_parameters: self.collect_poll_wait_parameters,
+        })
+    }
+
+    /// Resolves the task's [`TaskConfiguration`], either from a verbatim message supplied to
+    /// [`Self::with_task_configuration`] or by composing one from the individual setters.
+    fn resolve_task_configuration(&self) -> Result<TaskConfiguration, Error> {
+        let Some(task_configuration) = &self.task_configuration else {
+            // Composing fails fast here on parameters that cannot form a valid TaskConfiguration,
+            // rather than deferring to the first collection's AAD construction.
+            return Ok(build_task_configuration(
+                self.task_info
+                    .clone()
+                    .ok_or(Error::InvalidParameter("task_info not set"))?,
+                self.leader_endpoint.clone(),
+                self.helper_endpoint
+                    .clone()
+                    .ok_or(Error::InvalidParameter("helper_endpoint not set"))?,
+                self.time_precision,
+                self.min_batch_size
+                    .ok_or(Error::InvalidParameter("min_batch_size not set"))?,
+                self.batch_config
+                    .clone()
+                    .ok_or(Error::InvalidParameter("batch_config not set"))?,
+                self.vdaf_config.clone(),
+                self.task_interval,
+            )?);
         };
-        // Fail fast if the resolved parameters cannot form a valid TaskConfiguration (e.g. invalid
-        // endpoint bytes), rather than deferring to the first collection's AAD construction.
-        collector.task_configuration()?;
-        Ok(collector)
+
+        // A verbatim TaskConfiguration is the whole message, including extensions this
+        // implementation does not model, so composing from the setters cannot reproduce it.
+        // Reject rather than silently pick a winner.
+        if self.helper_endpoint.is_some()
+            || self.task_info.is_some()
+            || self.min_batch_size.is_some()
+            || self.batch_config.is_some()
+            || self.task_interval.is_some()
+        {
+            return Err(Error::InvalidParameter(
+                "with_task_configuration is mutually exclusive with the individual \
+                 TaskConfiguration setters",
+            ));
+        }
+
+        // These three are stated twice: once here and once via the constructor (or, for the VDAF
+        // config, via `from_configured_vdaf`). A disagreement would be a silent AAD byte-identity
+        // bug, so check rather than choose.
+        if &self.vdaf_config != task_configuration.vdaf_config() {
+            return Err(Error::InvalidParameter(
+                "vdaf_config disagrees with the task configuration's vdaf_config",
+            ));
+        }
+        if &self.leader_endpoint != task_configuration.leader_aggregator_endpoint() {
+            return Err(Error::InvalidParameter(
+                "leader_endpoint disagrees with the task configuration's \
+                 leader_aggregator_endpoint",
+            ));
+        }
+        if &self.time_precision != task_configuration.time_precision() {
+            return Err(Error::InvalidParameter(
+                "time_precision disagrees with the task configuration's time_precision",
+            ));
+        }
+
+        Ok(task_configuration.clone())
     }
 
     /// Provide an HTTPS client for the collector.
@@ -531,6 +582,15 @@ impl<V: vdaf::Collector> CollectorBuilder<V> {
         self.task_interval = task_interval;
         self
     }
+
+    /// Bind a pre-built [`TaskConfiguration`] verbatim, in place of composing one from the
+    /// individual setters above (which this is mutually exclusive with). Use this when the
+    /// configuration arrives already encoded, so that extensions this implementation does not
+    /// model survive into the HPKE AAD.
+    pub fn with_task_configuration(mut self, task_configuration: TaskConfiguration) -> Self {
+        self.task_configuration = Some(task_configuration);
+        self
+    }
 }
 
 /// A DAP collector.
@@ -542,9 +602,6 @@ pub struct Collector<V: vdaf::Collector> {
     /// The base URL of the leader's aggregator API endpoints.
     #[educe(Debug(method(std::fmt::Display::fmt)))]
     leader_endpoint: DapUrl,
-    /// The base URL of the helper's aggregator API endpoints.
-    #[educe(Debug(method(std::fmt::Display::fmt)))]
-    helper_endpoint: DapUrl,
     /// The authentication information needed to communicate with the leader aggregator.
     authentication: AuthenticationToken,
     /// HPKE keypair used for decryption of aggregate shares.
@@ -554,17 +611,8 @@ pub struct Collector<V: vdaf::Collector> {
     vdaf: V,
     /// The task's time precision.
     time_precision: TimePrecision,
-    /// Opaque task info bound into the task's `TaskConfiguration`.
-    #[educe(Debug(ignore))]
-    task_info: Vec<u8>,
-    /// Minimum batch size bound into the task's `TaskConfiguration`.
-    min_batch_size: u64,
-    /// Batch configuration bound into the task's `TaskConfiguration`.
-    batch_config: BatchConfig,
-    /// VDAF configuration bound into the task's `TaskConfiguration`.
-    vdaf_config: VdafConfig,
-    /// Optional task validity interval bound into the task's `TaskConfiguration`.
-    task_interval: Option<Interval>,
+    /// The task's configuration, bound into aggregate-share AADs.
+    task_configuration: TaskConfiguration,
 
     /// HTTPS client.
     #[educe(Debug(ignore))]
@@ -619,18 +667,9 @@ impl<V: vdaf::Collector> Collector<V> {
         )
     }
 
-    /// Builds this task's canonical [`TaskConfiguration`] for binding into aggregate-share AADs.
-    fn task_configuration(&self) -> Result<TaskConfiguration, Error> {
-        Ok(build_task_configuration(
-            self.task_info.clone(),
-            self.leader_endpoint.clone(),
-            self.helper_endpoint.clone(),
-            self.time_precision,
-            self.min_batch_size,
-            self.batch_config.clone(),
-            self.vdaf_config.clone(),
-            self.task_interval,
-        )?)
+    /// This task's [`TaskConfiguration`], as bound into aggregate-share AADs.
+    fn task_configuration(&self) -> &TaskConfiguration {
+        &self.task_configuration
     }
 
     /// Construct a URI for a collection.
@@ -769,7 +808,7 @@ impl<V: vdaf::Collector> Collector<V> {
 
         let aggregate_share_aad = AggregateShareAad::new(
             self.task_id,
-            self.task_configuration()?,
+            self.task_configuration().clone(),
             CollectionJobReq::new(job.query.clone(), job.aggregation_parameter.get_encoded()?),
         )
         .get_encoded()?;
@@ -965,13 +1004,14 @@ mod tests {
     use janus_messages::{
         AggregateShareAad, BatchConfig, BatchId, CollectionJobId, CollectionJobReq,
         CollectionJobResp, Duration, HpkeCiphertext, Interval, MediaType, PartialBatchSelector,
-        Query, Role, TaskId, Time, TimePrecision, Url as DapUrl,
+        Query, Role, TaskConfiguration, TaskExtension, TaskExtensionType, TaskId, Time,
+        TimePrecision, Url as DapUrl, VdafConfig,
         batch_mode::{LeaderSelected, TimeInterval},
         problem_type::DapProblemType,
     };
     use mockito::Matcher;
     use prio::{
-        codec::Encode,
+        codec::{Decode, Encode},
         field::Field64,
         vdaf::{self, AggregateShare, OutputShare, dummy},
     };
@@ -982,7 +1022,7 @@ mod tests {
     };
     use retry_after::RetryAfter;
 
-    use crate::{Collection, CollectionJob, Collector, Error, PollResult};
+    use crate::{Collection, CollectionJob, Collector, CollectorBuilder, Error, PollResult};
 
     const TEST_TIME_PRECISION: TimePrecision = TimePrecision::from_seconds(100);
 
@@ -1030,7 +1070,7 @@ mod tests {
     {
         let associated_data = AggregateShareAad::new(
             collector.task_id,
-            collector.task_configuration().unwrap(),
+            collector.task_configuration().clone(),
             CollectionJobReq::new(
                 Query::new_time_interval(batch_interval),
                 aggregation_parameter.get_encoded().unwrap(),
@@ -1069,7 +1109,7 @@ mod tests {
     {
         let associated_data = AggregateShareAad::new(
             collector.task_id,
-            collector.task_configuration().unwrap(),
+            collector.task_configuration().clone(),
             CollectionJobReq::new(
                 Query::new_leader_selected(),
                 aggregation_parameter.get_encoded().unwrap(),
@@ -1094,6 +1134,130 @@ mod tests {
             )
             .unwrap(),
         }
+    }
+
+    /// A `TaskConfiguration` carrying an extension this implementation does not model, which
+    /// composing from the individual setters cannot reproduce.
+    fn task_configuration_with_unknown_extension() -> TaskConfiguration {
+        TaskConfiguration::new(
+            b"test task".to_vec(),
+            "http://leader.example.com".try_into().unwrap(),
+            "http://helper.example.com".try_into().unwrap(),
+            TEST_TIME_PRECISION,
+            1,
+            BatchConfig::TimeInterval,
+            VdafConfig::Fake { rounds: 1 },
+            Vec::from([TaskExtension::Unknown {
+                extension_type: TaskExtensionType::from(0x1234),
+                extension_data: b"opaque".to_vec(),
+            }]),
+        )
+        .unwrap()
+    }
+
+    fn builder_with_task_configuration(
+        task_configuration: TaskConfiguration,
+    ) -> CollectorBuilder<dummy::Vdaf> {
+        Collector::builder(
+            random(),
+            "http://leader.example.com".try_into().unwrap(),
+            AuthenticationToken::new_bearer_token_from_string("Y29sbGVjdG9yIHRva2Vu").unwrap(),
+            HpkeKeypair::test(),
+            ConfiguredVdaf::fake(1),
+            TEST_TIME_PRECISION,
+        )
+        .with_task_configuration(task_configuration)
+    }
+
+    #[test]
+    fn task_configuration_bound_verbatim() {
+        // The bytes bound into the AAD must be the bytes we were handed, extensions included:
+        // recomposing from the individual setters would silently drop the unknown extension and
+        // every aggregate share would fail to decrypt.
+        let encoded = task_configuration_with_unknown_extension()
+            .get_encoded()
+            .unwrap();
+        let collector =
+            builder_with_task_configuration(TaskConfiguration::get_decoded(&encoded).unwrap())
+                .build()
+                .unwrap();
+
+        assert_eq!(
+            collector.task_configuration().get_encoded().unwrap(),
+            encoded
+        );
+    }
+
+    #[test]
+    fn task_configuration_conflicts_with_setters() {
+        for builder in [
+            builder_with_task_configuration(task_configuration_with_unknown_extension())
+                .with_min_batch_size(1),
+            builder_with_task_configuration(task_configuration_with_unknown_extension())
+                .with_task_info(b"test task".to_vec()),
+            builder_with_task_configuration(task_configuration_with_unknown_extension())
+                .with_helper_endpoint("http://helper.example.com".try_into().unwrap()),
+            builder_with_task_configuration(task_configuration_with_unknown_extension())
+                .with_batch_config(BatchConfig::TimeInterval),
+            builder_with_task_configuration(task_configuration_with_unknown_extension())
+                .with_task_interval(Some(
+                    Interval::new(
+                        Time::from_time_precision_units(0),
+                        Duration::from_time_precision_units(1),
+                    )
+                    .unwrap(),
+                )),
+        ] {
+            assert_matches!(builder.build(), Err(Error::InvalidParameter(_)));
+        }
+    }
+
+    #[test]
+    fn task_configuration_disagreement_rejected() {
+        // The VDAF config arrives from `from_configured_vdaf`, and the endpoint and time precision
+        // from the constructor. Each is also in the task configuration; a mismatch is an AAD
+        // byte-identity bug, so it must fail at build time.
+        assert_matches!(
+            Collector::builder(
+                random(),
+                "http://leader.example.com".try_into().unwrap(),
+                AuthenticationToken::new_bearer_token_from_string("Y29sbGVjdG9yIHRva2Vu").unwrap(),
+                HpkeKeypair::test(),
+                ConfiguredVdaf::fake(2),
+                TEST_TIME_PRECISION,
+            )
+            .with_task_configuration(task_configuration_with_unknown_extension())
+            .build(),
+            Err(Error::InvalidParameter(_))
+        );
+
+        assert_matches!(
+            Collector::builder(
+                random(),
+                "http://leader.example.com/dap".try_into().unwrap(),
+                AuthenticationToken::new_bearer_token_from_string("Y29sbGVjdG9yIHRva2Vu").unwrap(),
+                HpkeKeypair::test(),
+                ConfiguredVdaf::fake(1),
+                TEST_TIME_PRECISION,
+            )
+            .with_task_configuration(task_configuration_with_unknown_extension())
+            .build(),
+            Err(Error::InvalidParameter(_))
+        );
+
+        assert_matches!(
+            Collector::builder(
+                random(),
+                "http://leader.example.com".try_into().unwrap(),
+                AuthenticationToken::new_bearer_token_from_string("Y29sbGVjdG9yIHRva2Vu").unwrap(),
+                HpkeKeypair::test(),
+                ConfiguredVdaf::fake(1),
+                TimePrecision::from_seconds(3600),
+            )
+            .with_task_configuration(task_configuration_with_unknown_extension())
+            .build(),
+            Err(Error::InvalidParameter(_))
+        );
     }
 
     #[test]
@@ -1827,7 +1991,7 @@ mod tests {
 
         let associated_data = AggregateShareAad::new(
             collector.task_id,
-            collector.task_configuration().unwrap(),
+            collector.task_configuration().clone(),
             CollectionJobReq::new(
                 Query::new_time_interval(batch_interval),
                 ().get_encoded().unwrap(),

--- a/integration_tests/tests/integration/common.rs
+++ b/integration_tests/tests/integration/common.rs
@@ -263,13 +263,13 @@ where
         .in_process_config(leader_port, helper_port);
     let mut builder = Collector::builder_with_custom_vdaf(
         task_parameters.task_id,
-        leader_endpoint.as_str().try_into().unwrap(),
         task_parameters.collector_auth_token.clone(),
         task_parameters.collector_hpke_keypair.clone(),
         vdaf,
         task_parameters.vdaf.to_vdaf_config().unwrap(),
-        task_parameters.time_precision,
     )
+    .with_leader_endpoint(leader_endpoint.as_str().try_into().unwrap())
+    .with_time_precision(task_parameters.time_precision)
     .with_helper_endpoint(helper_endpoint.as_str().try_into().unwrap())
     .with_task_info(task_parameters.task_info.clone())
     .with_min_batch_size(task_parameters.min_batch_size)

--- a/integration_tests/tests/integration/simulation/setup.rs
+++ b/integration_tests/tests/integration/simulation/setup.rs
@@ -338,16 +338,18 @@ impl Components {
 
         let collector = Collector::builder_with_custom_vdaf(
             *task.id(),
-            task.leader_aggregator_endpoint()
-                .as_str()
-                .try_into()
-                .unwrap(),
             task.collector_auth_token().clone(),
             task.collector_hpke_keypair().clone(),
             state.vdaf.clone(),
             leader_task.vdaf().to_vdaf_config().unwrap(),
-            *task.time_precision(),
         )
+        .with_leader_endpoint(
+            task.leader_aggregator_endpoint()
+                .as_str()
+                .try_into()
+                .unwrap(),
+        )
+        .with_time_precision(*task.time_precision())
         .with_helper_endpoint(
             task.helper_aggregator_endpoint()
                 .as_str()

--- a/interop_binaries/src/commands/janus_interop_collector.rs
+++ b/interop_binaries/src/commands/janus_interop_collector.rs
@@ -133,8 +133,6 @@ struct TaskState {
     task_id: TaskId,
     keypair: HpkeKeypair,
     leader_url: DapUrl,
-    /// Retained for dispatching to a concrete VDAF; the `VdafConfig` bound into AADs lives in
-    /// `task_configuration`.
     vdaf: VdafObject,
     auth_token: AuthenticationToken,
     time_precision: TimePrecision,

--- a/interop_binaries/src/commands/janus_interop_collector.rs
+++ b/interop_binaries/src/commands/janus_interop_collector.rs
@@ -132,10 +132,8 @@ struct CollectPollResponse {
 struct TaskState {
     task_id: TaskId,
     keypair: HpkeKeypair,
-    leader_url: DapUrl,
     vdaf: VdafObject,
     auth_token: AuthenticationToken,
-    time_precision: TimePrecision,
     task_configuration: TaskConfiguration,
 }
 
@@ -194,7 +192,7 @@ async fn handle_add_task(
 
     let task_configuration = build_task_configuration(
         INTEROP_TASK_INFO.to_vec(),
-        request.leader.clone(),
+        request.leader,
         request.helper,
         time_precision,
         request.min_batch_size,
@@ -206,10 +204,8 @@ async fn handle_add_task(
     entry.or_insert(TaskState {
         task_id,
         keypair,
-        leader_url: request.leader,
         vdaf: request.vdaf,
         auth_token,
-        time_precision,
         task_configuration,
     });
 
@@ -232,12 +228,10 @@ where
 {
     let collector = Collector::builder_with_custom_vdaf(
         task_state.task_id,
-        task_state.leader_url.clone(),
         task_state.auth_token.clone(),
         task_state.keypair.clone(),
         vdaf,
         task_state.task_configuration.vdaf_config().clone(),
-        task_state.time_precision,
     )
     .with_task_configuration(task_state.task_configuration.clone())
     .with_http_client(http_client.clone())
@@ -298,7 +292,7 @@ async fn handle_collection_start(
 
     let query = match request.query.batch_mode {
         1 => {
-            let time_precision = task_state.time_precision;
+            let time_precision = *task_state.task_configuration.time_precision();
             let start = Time::from_seconds_since_epoch(
                 request
                     .query

--- a/interop_binaries/src/commands/janus_interop_collector.rs
+++ b/interop_binaries/src/commands/janus_interop_collector.rs
@@ -20,10 +20,11 @@ use janus_core::{
     auth_tokens::AuthenticationToken,
     hpke::HpkeKeypair,
     retries::ExponentialWithTotalDelayBuilder,
+    task_config::build_task_configuration,
     vdaf::{VdafInstance, new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128},
 };
 use janus_messages::{
-    BatchConfig, BatchId, Duration, HpkeConfig, Interval, PartialBatchSelector, Query, TaskId,
+    BatchId, Duration, HpkeConfig, Interval, PartialBatchSelector, Query, TaskConfiguration, TaskId,
     Time, TimePrecision, Url as DapUrl, batch_mode::BatchMode,
 };
 use prio::{
@@ -132,12 +133,12 @@ struct TaskState {
     task_id: TaskId,
     keypair: HpkeKeypair,
     leader_url: DapUrl,
-    helper_url: DapUrl,
+    /// Retained for dispatching to a concrete VDAF; the `VdafConfig` bound into AADs lives in
+    /// `task_configuration`.
     vdaf: VdafObject,
     auth_token: AuthenticationToken,
     time_precision: TimePrecision,
-    min_batch_size: u64,
-    batch_config: BatchConfig,
+    task_configuration: TaskConfiguration,
 }
 
 /// A collection job handle.
@@ -188,17 +189,30 @@ async fn handle_add_task(
             .context("invalid header value in \"collector_authentication_token\"")?;
 
     let batch_config = interop_batch_config(request.batch_mode)?;
+    let vdaf_config = VdafInstance::from(request.vdaf.clone())
+        .to_vdaf_config()
+        .map_err(|err| anyhow::anyhow!("unsupported VDAF for TaskConfiguration: {err}"))?;
+    let time_precision = TimePrecision::from_seconds(request.time_precision);
+
+    let task_configuration = build_task_configuration(
+        INTEROP_TASK_INFO.to_vec(),
+        request.leader.clone(),
+        request.helper,
+        time_precision,
+        request.min_batch_size,
+        batch_config,
+        vdaf_config,
+        None,
+    )?;
 
     entry.or_insert(TaskState {
         task_id,
         keypair,
         leader_url: request.leader,
-        helper_url: request.helper,
         vdaf: request.vdaf,
         auth_token,
-        time_precision: TimePrecision::from_seconds(request.time_precision),
-        min_batch_size: request.min_batch_size,
-        batch_config,
+        time_precision,
+        task_configuration,
     });
 
     Ok(hpke_config)
@@ -218,23 +232,16 @@ where
     V::AggregationParam: Send + Sync + 'static,
     B: BatchMode,
 {
-    let time_precision = task_state.time_precision;
-    let vdaf_config = VdafInstance::from(task_state.vdaf.clone())
-        .to_vdaf_config()
-        .map_err(|err| anyhow::anyhow!("unsupported VDAF for TaskConfiguration: {err}"))?;
     let collector = Collector::builder_with_custom_vdaf(
         task_state.task_id,
         task_state.leader_url.clone(),
         task_state.auth_token.clone(),
         task_state.keypair.clone(),
         vdaf,
-        vdaf_config,
-        time_precision,
+        task_state.task_configuration.vdaf_config().clone(),
+        task_state.time_precision,
     )
-    .with_helper_endpoint(task_state.helper_url.clone())
-    .with_task_info(INTEROP_TASK_INFO.to_vec())
-    .with_min_batch_size(task_state.min_batch_size)
-    .with_batch_config(task_state.batch_config.clone())
+    .with_task_configuration(task_state.task_configuration.clone())
     .with_http_client(http_client.clone())
     .with_http_request_backoff(
         ExponentialWithTotalDelayBuilder::new()

--- a/interop_binaries/src/commands/janus_interop_collector.rs
+++ b/interop_binaries/src/commands/janus_interop_collector.rs
@@ -24,8 +24,8 @@ use janus_core::{
     vdaf::{VdafInstance, new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128},
 };
 use janus_messages::{
-    BatchId, Duration, HpkeConfig, Interval, PartialBatchSelector, Query, TaskConfiguration, TaskId,
-    Time, TimePrecision, Url as DapUrl, batch_mode::BatchMode,
+    BatchId, Duration, HpkeConfig, Interval, PartialBatchSelector, Query, TaskConfiguration,
+    TaskId, Time, TimePrecision, Url as DapUrl, batch_mode::BatchMode,
 };
 use prio::{
     codec::{Decode, Encode},

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -1,9 +1,9 @@
 use std::{fmt::Debug, fs::File, path::PathBuf, process::exit, time::Duration as StdDuration};
 
-use anyhow::{Context, anyhow};
+use anyhow::Context;
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use clap::{
-    Args, CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum,
+    Args, CommandFactory, FromArgMatches, Parser, Subcommand,
     builder::{NonEmptyStringValueParser, StringValueParser, TypedValueParser},
     error::ErrorKind,
 };
@@ -14,20 +14,21 @@ use janus_collector::{
 use janus_core::{
     hpke::{HpkeKeypair, HpkePrivateKey},
     retries::ExponentialWithTotalDelayBuilder,
+    vdaf::VdafInstance,
+    vdaf_dispatch,
 };
 use janus_messages::{
     BatchConfig, CollectionJobId, Duration, HpkeConfig, Interval, PartialBatchSelector, Query,
-    TaskId, Time, TimePrecision, Url as DapUrl, VdafConfig,
+    TaskConfiguration, TaskId, Time,
     batch_mode::{BatchMode, LeaderSelected, TimeInterval},
 };
 use prio::{
     codec::Decode,
-    vdaf::{self, Vdaf, prio3::Prio3},
+    vdaf::{self, Vdaf, VdafError},
 };
 use rand::random;
 use tracing_log::LogTracer;
 use tracing_subscriber::{EnvFilter, Registry, prelude::*};
-use url::Url;
 
 /// Enum to propagate errors through this program. Clap errors are handled separately from all
 /// others because [`clap::Error::exit`] takes care of its own error formatting, command-line help,
@@ -56,33 +57,14 @@ impl From<clap::Error> for Error {
     }
 }
 
-/// Decrypting an aggregate share requires binding the task's `TaskConfiguration` into the AAD, but
-/// this tool does not yet accept the parameters needed to reconstruct it, so [`new_collector`]
-/// supplies placeholders. Refuse up front rather than decrypt against an AAD we know is wrong and
-/// fail with an opaque HPKE error.
-fn ensure_aggregate_share_decryption_supported() -> Result<(), Error> {
-    Err(Error::Anyhow(anyhow!(
-        "collecting an aggregate share is not yet supported: the helper endpoint, task info, \
-         minimum batch size, batch config, and VDAF config are needed to reconstruct the task's \
-         TaskConfiguration, and this tool does not yet accept them. The `new-job` subcommand still \
-         works. See https://github.com/divviup/janus/issues/4713."
-    )))
+// `vdaf_dispatch!` applies `?` to the VDAF constructors it expands to.
+impl From<VdafError> for Error {
+    fn from(error: VdafError) -> Self {
+        Error::Anyhow(error.into())
+    }
 }
 
 // Parsers for command-line arguments:
-
-#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
-#[clap(rename_all = "lower")]
-enum VdafType {
-    /// Prio3Count
-    Count,
-    /// Prio3Sum
-    Sum,
-    /// Prio3SumVec
-    SumVec,
-    /// Prio3Histogram
-    Histogram,
-}
 
 #[derive(Clone)]
 struct HpkeConfigValueParser {
@@ -151,12 +133,35 @@ fn private_collector_credential_parser(
     serde_json::from_str(s)
 }
 
-/// Parses an endpoint into a byte-preserving [`DapUrl`], rejecting a value that is not a parseable
-/// URL. The exact bytes are kept for later HPKE AAD binding (`DapUrl` alone only checks ASCII); the
-/// `url::Url` parse is a discarded validity gate.
-fn leader_endpoint_parser(s: &str) -> Result<DapUrl, anyhow::Error> {
-    Url::parse(s)?;
-    Ok(DapUrl::try_from(s)?)
+#[derive(Clone)]
+struct TaskConfigurationValueParser {
+    inner: NonEmptyStringValueParser,
+}
+
+impl TaskConfigurationValueParser {
+    fn new() -> TaskConfigurationValueParser {
+        TaskConfigurationValueParser {
+            inner: NonEmptyStringValueParser::new(),
+        }
+    }
+}
+
+impl TypedValueParser for TaskConfigurationValueParser {
+    type Value = TaskConfiguration;
+
+    fn parse_ref(
+        &self,
+        cmd: &clap::Command,
+        arg: Option<&clap::Arg>,
+        value: &std::ffi::OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        let input = self.inner.parse_ref(cmd, arg, value)?;
+        let bytes = URL_SAFE_NO_PAD
+            .decode(input)
+            .map_err(|err| clap::Error::raw(ErrorKind::ValueValidation, err))?;
+        TaskConfiguration::get_decoded(&bytes)
+            .map_err(|err| clap::Error::raw(ErrorKind::ValueValidation, err))
+    }
 }
 
 #[derive(Debug, Args, PartialEq, Eq)]
@@ -307,39 +312,24 @@ struct Options {
     /// DAP task identifier, encoded with unpadded base64url
     #[clap(long, help_heading = "DAP Task Parameters", display_order = 0)]
     task_id: TaskId,
-    /// The leader aggregator's endpoint URL
+    /// The task's DAP TaskConfiguration message, encoded with unpadded base64url
+    ///
+    /// This supplies the aggregator endpoints, time precision, batch configuration, and VDAF
+    /// configuration. Its bytes are bound into the HPKE additional authenticated data, so it must
+    /// be exactly the message the aggregators were provisioned with.
     #[clap(
         long,
-        value_parser = leader_endpoint_parser,
+        value_parser = TaskConfigurationValueParser::new(),
         help_heading = "DAP Task Parameters",
         display_order = 1
     )]
-    leader: DapUrl,
-    /// The task's time precision, in seconds
-    #[clap(long, help_heading = "DAP Task Parameters", display_order = 2)]
-    time_precision: u64,
+    task_config: TaskConfiguration,
 
     #[clap(flatten)]
     authentication: AuthenticationOptions,
 
     #[clap(flatten)]
     hpke_config: HpkeConfigOptions,
-
-    /// VDAF algorithm
-    #[clap(
-        long,
-        value_enum,
-        help_heading = "VDAF Algorithm and Parameters",
-        display_order = 0
-    )]
-    vdaf: VdafType,
-    /// Number of vector elements, when used with --vdaf=sumvec or number of histogram buckets,
-    /// when used with --vdaf=histogram
-    #[clap(long, help_heading = "VDAF Algorithm and Parameters")]
-    length: Option<usize>,
-    /// Maximum measurement value, for use with --vdaf=sum or --vdaf=sumvec
-    #[clap(long, help_heading = "VDAF Algorithm and Parameters")]
-    max_measurement: Option<u64>,
 
     #[clap(flatten)]
     query: QueryOptions,
@@ -446,77 +436,88 @@ async fn main() -> anyhow::Result<()> {
     }
 }
 
+/// The batch to collect, resolved against the task's batch configuration.
+enum ResolvedQuery {
+    TimeInterval(Interval),
+    LeaderSelected,
+}
+
+/// Resolves the query arguments against the batch configuration in `--task-config`. The batch mode
+/// comes from the task configuration and the batch interval from the command line, so clap cannot
+/// rule out a disagreement between them.
+fn resolve_query(options: &Options) -> Result<ResolvedQuery, Error> {
+    let batch_config = options.task_config.batch_config();
+    match (
+        batch_config,
+        options.query.batch_interval_start,
+        options.query.batch_interval_duration,
+    ) {
+        (BatchConfig::TimeInterval, Some(start), Some(duration)) => {
+            let time_precision = options.task_config.time_precision();
+            Ok(ResolvedQuery::TimeInterval(
+                Interval::new(
+                    Time::from_seconds_since_epoch(start, time_precision),
+                    Duration::from_seconds(duration, time_precision),
+                )
+                .map_err(|err| Error::Anyhow(err.into()))?,
+            ))
+        }
+        (BatchConfig::TimeInterval, None, None) => Err(clap::Error::raw(
+            ErrorKind::MissingRequiredArgument,
+            "the task is a time-interval task, so --batch-interval-start and \
+             --batch-interval-duration are required\n",
+        )
+        .into()),
+        (BatchConfig::LeaderSelected, None, None) => Ok(ResolvedQuery::LeaderSelected),
+        (BatchConfig::LeaderSelected, _, _) => Err(clap::Error::raw(
+            ErrorKind::ArgumentConflict,
+            "the task is a leader-selected task, so --batch-interval-start and \
+             --batch-interval-duration must not be provided\n",
+        )
+        .into()),
+        (batch_config, _, _) => Err(clap::Error::raw(
+            ErrorKind::ValueValidation,
+            format!(
+                "unsupported batch mode in --task-config: {}\n",
+                batch_config.batch_mode()
+            ),
+        )
+        .into()),
+        // Clap requires the two batch interval arguments together, so a lone one cannot reach here.
+    }
+}
+
 macro_rules! options_query_dispatch {
     ($options:expr, ($query:ident) => $body:tt) => {
-        match (
-            &$options.query.batch_interval_start,
-            &$options.query.batch_interval_duration,
-        ) {
-            (Some(batch_interval_start), Some(batch_interval_duration)) => {
-                let time_precision = &TimePrecision::from_seconds($options.time_precision);
-                let $query = Query::new_time_interval(
-                    Interval::new(
-                        Time::from_seconds_since_epoch(*batch_interval_start, time_precision),
-                        Duration::from_seconds(*batch_interval_duration, time_precision),
-                    )
-                    .map_err(|err| Error::Anyhow(err.into()))?,
-                );
+        match resolve_query(&$options)? {
+            ResolvedQuery::TimeInterval(batch_interval) => {
+                let $query = Query::new_time_interval(batch_interval);
                 $body
             }
-            (None, None) => {
+            ResolvedQuery::LeaderSelected => {
                 let $query = Query::new_leader_selected();
                 $body
             }
-            _ => unreachable!("clap argument parsing shouldn't allow this to be possible"),
         }
     };
 }
 
 macro_rules! options_vdaf_dispatch {
-    ($options:expr, ($vdaf:ident) => $body:tt) => {
-        match ($options.vdaf, $options.length, $options.max_measurement) {
-            (VdafType::Count, None, None) => {
-                let $vdaf = Prio3::new_count(2).map_err(|err| Error::Anyhow(err.into()))?;
-                let body = $body;
-                body
-            }
-            (VdafType::Sum, None, Some(max_measurement)) => {
-                let $vdaf = Prio3::new_sum(2, u64::from(max_measurement))
-                    .map_err(|err| Error::Anyhow(err.into()))?;
-                let body = $body;
-                body
-            }
-            (VdafType::SumVec, Some(length), Some(max_measurement)) => {
-                // We can take advantage of the fact that Prio3SumVec unsharding does not use the
-                // chunk_length parameter and avoid asking the user for it.
-                let $vdaf = Prio3::new_sum_vec(2, max_measurement as u128, length, 1)
-                    .map_err(|err| Error::Anyhow(err.into()))?;
-                let body = $body;
-                body
-            }
-            (VdafType::Histogram, Some(length), None) => {
-                // We can take advantage of the fact that Prio3Histogram unsharding does not use the
-                // chunk_length parameter and avoid asking the user for it.
-                let $vdaf =
-                    Prio3::new_histogram(2, length, 1).map_err(|err| Error::Anyhow(err.into()))?;
-                let body = $body;
-                body
-            }
-            _ => Err(clap::Error::raw(
-                ErrorKind::ArgumentConflict,
-                format!(
-                    "incorrect VDAF parameter arguments were supplied for {}",
-                    $options
-                        .vdaf
-                        .to_possible_value()
-                        .unwrap()
-                        .get_help()
-                        .unwrap(),
-                ),
-            )
-            .into()),
-        }
-    };
+    ($options:expr, ($vdaf:ident) => $body:tt) => {{
+        let vdaf_instance = VdafInstance::try_from($options.task_config.vdaf_config())
+            .map_err(|err| {
+                clap::Error::raw(
+                    ErrorKind::ValueValidation,
+                    format!("unsupported VDAF in --task-config: {err}\n"),
+                )
+            })?;
+        vdaf_dispatch!(&vdaf_instance, ($vdaf, VdafType, _VERIFY_KEY_LEN) => {
+            // The multiproof VDAF's constructor is generic over its gadget, so pin the arm's
+            // concrete type rather than leaving it to inference at the call sites.
+            let $vdaf: VdafType = $vdaf;
+            $body
+        })
+    }};
 }
 
 macro_rules! options_dispatch {
@@ -533,15 +534,17 @@ macro_rules! options_dispatch {
 async fn run(options: Options) -> Result<(), Error> {
     let http_client = default_http_client().map_err(|err| Error::Anyhow(err.into()))?;
     options_dispatch!(options, (query, vdaf) => {
+        // Every VDAF this tool dispatches to has a trivial aggregation parameter.
+        let agg_param: &<VdafType as Vdaf>::AggregationParam = &Default::default();
         match options.subcommand {
             Some(Subcommands::NewJob { collection_job_id }) => {
                 let collection_job_id = collection_job_id.unwrap_or_else(random);
-                run_new_job(options, vdaf, http_client, query, &(), collection_job_id).await
+                run_new_job(options, vdaf, http_client, query, agg_param, collection_job_id).await
             }
             Some(Subcommands::PollJob { collection_job_id }) => {
-                run_poll_job(options, vdaf, http_client, query, &(), collection_job_id).await
+                run_poll_job(options, vdaf, http_client, query, agg_param, collection_job_id).await
             }
-            _ => run_collection(options, vdaf, http_client, query, &()).await,
+            _ => run_collection(options, vdaf, http_client, query, agg_param).await,
         }
     })
 }
@@ -556,7 +559,6 @@ async fn run_collection<V: vdaf::Collector, B: BatchModeExt>(
 where
     V::AggregateResult: Debug,
 {
-    ensure_aggregate_share_decryption_supported()?;
     let collection = new_collector(options, vdaf, http_client)?
         .collection(query, agg_param)
         .collect()
@@ -598,7 +600,6 @@ async fn run_poll_job<V: vdaf::Collector, B: BatchModeExt>(
 where
     V::AggregateResult: Debug,
 {
-    ensure_aggregate_share_decryption_supported()?;
     let collection_job = CollectionJob::new(collection_job_id, query, agg_param.clone());
     let poll_result = new_collector(options, vdaf, http_client)?
         .poll_once(&collection_job)
@@ -627,24 +628,18 @@ fn new_collector<V: vdaf::Collector>(
     http_client: reqwest::Client,
 ) -> Result<Collector<V>, Error> {
     let (authentication, hpke_keypair) = options.credential()?;
-    let task_id = options.task_id;
-    let leader_endpoint = options.leader;
-    let time_precision = TimePrecision::from_seconds(options.time_precision);
+    let task_config = options.task_config;
     let collector = Collector::builder_with_custom_vdaf(
-        task_id,
-        leader_endpoint,
+        options.task_id,
+        task_config.leader_aggregator_endpoint().clone(),
         authentication,
         hpke_keypair,
         vdaf,
-        // Placeholder (#4713). Only `new-job` gets this far, and it never computes an AAD.
-        VdafConfig::Prio3Count,
-        time_precision,
+        task_config.vdaf_config().clone(),
+        *task_config.time_precision(),
     )
-    // Placeholders (#4713), as above.
-    .with_helper_endpoint("http://unused.helper.example/".try_into().unwrap())
-    .with_task_info(Vec::new())
-    .with_min_batch_size(0)
-    .with_batch_config(BatchConfig::TimeInterval)
+    // Bound verbatim, so extensions this tool does not model still reach the HPKE AAD.
+    .with_task_configuration(task_config)
     .with_http_client(http_client)
     .with_collect_poll_backoff(
         ExponentialWithTotalDelayBuilder::new()
@@ -735,14 +730,14 @@ mod tests {
         initialize_rustls,
         test_util::install_test_trace_subscriber,
     };
-    use janus_messages::{CollectionJobId, TaskId, Url as DapUrl};
+    use janus_messages::{BatchConfig, TaskConfiguration, TaskId, TimePrecision, VdafConfig};
     use prio::codec::Encode;
     use rand::random;
     use tempfile::NamedTempFile;
 
     use crate::{
         AuthenticationOptions, AuthenticationToken, Error, HpkeConfigOptions, Options,
-        QueryOptions, Subcommands, VdafType, run,
+        QueryOptions, Subcommands, run,
     };
 
     const SAMPLE_COLLECTOR_CREDENTIAL: &str = r#"{
@@ -756,64 +751,32 @@ mod tests {
 }
 "#;
 
+    const LEADER_ENDPOINT: &str = "https://example.com/dap/";
+
+    fn task_config(batch_config: BatchConfig) -> TaskConfiguration {
+        TaskConfiguration::new(
+            b"test task".to_vec(),
+            LEADER_ENDPOINT.try_into().unwrap(),
+            "https://helper.example.com/dap/".try_into().unwrap(),
+            TimePrecision::from_seconds(300),
+            100,
+            batch_config,
+            VdafConfig::Prio3Count,
+            Vec::new(),
+        )
+        .unwrap()
+    }
+
+    fn task_config_argument(batch_config: BatchConfig) -> String {
+        format!(
+            "--task-config={}",
+            URL_SAFE_NO_PAD.encode(task_config(batch_config).get_encoded().unwrap())
+        )
+    }
+
     #[test]
     fn verify_app() {
         Options::command().debug_assert();
-    }
-
-    /// The paths that decrypt an aggregate share must refuse before contacting the leader, rather
-    /// than build an AAD from the placeholders in `new_collector` and fail to decrypt. See #4713.
-    #[tokio::test]
-    async fn aggregate_share_decryption_refused() {
-        install_test_trace_subscriber();
-        initialize_rustls();
-
-        let hpke_keypair = HpkeKeypair::test();
-        let task_id: TaskId = random();
-        let auth_token = AuthenticationToken::DapAuth(random());
-        let arguments = [
-            "collect".to_string(),
-            format!(
-                "--task-id={}",
-                URL_SAFE_NO_PAD.encode(task_id.get_encoded().unwrap())
-            ),
-            "--leader=https://example.com/dap/".to_string(),
-            format!("--dap-auth-token={}", auth_token.as_str()),
-            format!(
-                "--hpke-config={}",
-                URL_SAFE_NO_PAD.encode(hpke_keypair.config().get_encoded().unwrap())
-            ),
-            format!(
-                "--hpke-private-key={}",
-                URL_SAFE_NO_PAD.encode(hpke_keypair.private_key().as_ref())
-            ),
-            "--vdaf=count".to_string(),
-            "--batch-interval-start=1000000".to_string(),
-            "--batch-interval-duration=1000".to_string(),
-            "--time-precision=300".to_string(),
-        ];
-
-        let collection_job_id: CollectionJobId = random();
-
-        // The default (collect-and-wait) path, and the poll path.
-        for subcommand in [
-            Vec::new(),
-            Vec::from([
-                "poll-job".to_string(),
-                "--".to_string(),
-                collection_job_id.to_string(),
-            ]),
-        ] {
-            let options =
-                Options::try_parse_from(arguments.iter().cloned().chain(subcommand)).unwrap();
-            assert_matches!(
-                run(options).await.unwrap_err(),
-                Error::Anyhow(err) => assert!(
-                    err.to_string().contains("issues/4713"),
-                    "unexpected error: {err}"
-                )
-            );
-        }
     }
 
     #[tokio::test]
@@ -827,14 +790,12 @@ mod tests {
         let encoded_private_key = URL_SAFE_NO_PAD.encode(hpke_keypair.private_key().as_ref());
 
         let task_id = random();
-        let leader = DapUrl::try_from("https://example.com/dap/").unwrap();
         let auth_token = AuthenticationToken::DapAuth(random());
 
         let expected = Options {
             subcommand: None,
             task_id,
-            leader: leader.clone(),
-            time_precision: 300,
+            task_config: task_config(BatchConfig::TimeInterval),
             authentication: AuthenticationOptions {
                 dap_auth_token: Some(auth_token.clone()),
                 authorization_bearer_token: None,
@@ -845,30 +806,24 @@ mod tests {
                 collector_credential_file: None,
                 collector_credential: None,
             },
-            vdaf: VdafType::Count,
-            length: None,
-            max_measurement: None,
             query: QueryOptions {
                 batch_interval_start: Some(1_000_000),
                 batch_interval_duration: Some(1_000),
             },
         };
         let task_id_encoded = URL_SAFE_NO_PAD.encode(task_id.get_encoded().unwrap());
+        let task_config_argument = task_config_argument(BatchConfig::TimeInterval);
         let correct_arguments = [
             "collect",
             &format!("--task-id={task_id_encoded}"),
-            "--leader",
-            leader.as_str(),
+            &task_config_argument,
             &format!("--dap-auth-token={}", auth_token.as_str()),
             &format!("--hpke-config={encoded_hpke_config}"),
             &format!("--hpke-private-key={encoded_private_key}"),
-            "--vdaf",
-            "count",
             "--batch-interval-start",
             "1000000",
             "--batch-interval-duration",
             "1000",
-            "--time-precision=300",
         ];
         match Options::try_parse_from(correct_arguments) {
             Ok(got) => assert_eq!(got, expected),
@@ -885,16 +840,26 @@ mod tests {
             Options::try_parse_from([
                 "collect",
                 &format!("--task-id={task_id_encoded}"),
-                "--leader",
-                leader.as_str(),
+                &task_config_argument,
                 &format!("--dap-auth-token={}", auth_token.as_str()),
-                "--vdaf",
-                "count",
                 "--batch-interval-start",
                 "1000000",
                 "--batch-interval-duration",
                 "1000",
-                "--time-precision=300",
+            ])
+            .unwrap_err()
+            .kind(),
+            ErrorKind::MissingRequiredArgument,
+        );
+
+        // Missing the task configuration entirely.
+        assert_eq!(
+            Options::try_parse_from([
+                "collect",
+                &format!("--task-id={task_id_encoded}"),
+                &format!("--dap-auth-token={}", auth_token.as_str()),
+                &format!("--hpke-config={encoded_hpke_config}"),
+                &format!("--hpke-private-key={encoded_private_key}"),
             ])
             .unwrap_err()
             .kind(),
@@ -918,79 +883,90 @@ mod tests {
         );
 
         let mut bad_arguments = correct_arguments;
-        bad_arguments[3] = "http:bad:url:///dap@";
+        bad_arguments[2] = "--task-config=not valid base64";
+        assert_eq!(
+            Options::try_parse_from(bad_arguments).unwrap_err().kind(),
+            ErrorKind::ValueValidation,
+        );
+
+        // A truncated task configuration: valid base64url, but not a decodable message.
+        let mut bad_arguments = correct_arguments;
+        let truncated = task_config(BatchConfig::TimeInterval)
+            .get_encoded()
+            .unwrap();
+        let bad_argument = format!(
+            "--task-config={}",
+            URL_SAFE_NO_PAD.encode(&truncated[..truncated.len() / 2])
+        );
+        bad_arguments[2] = &bad_argument;
         assert_eq!(
             Options::try_parse_from(bad_arguments).unwrap_err().kind(),
             ErrorKind::ValueValidation,
         );
 
         let mut bad_arguments = correct_arguments;
-        bad_arguments[5] = "--hpke-config=not valid base64";
+        bad_arguments[4] = "--hpke-config=not valid base64";
         assert_eq!(
             Options::try_parse_from(bad_arguments).unwrap_err().kind(),
             ErrorKind::ValueValidation,
         );
 
         let mut bad_arguments = correct_arguments;
-        bad_arguments[6] = "--hpke-private-key=not valid base64";
+        bad_arguments[5] = "--hpke-private-key=not valid base64";
         assert_eq!(
             Options::try_parse_from(bad_arguments).unwrap_err().kind(),
             ErrorKind::ValueValidation,
         );
+    }
 
+    /// The task configuration states the batch mode and the command line selects the batch, so
+    /// clap cannot rule out a disagreement between them.
+    #[tokio::test]
+    async fn query_must_match_batch_config() {
+        install_test_trace_subscriber();
+        initialize_rustls();
+
+        let hpke_keypair = HpkeKeypair::test();
+        let task_id: TaskId = random();
+        let auth_token = AuthenticationToken::DapAuth(random());
         let base_arguments = Vec::from([
             "collect".to_string(),
-            format!("--task-id={task_id_encoded}"),
-            "--leader".to_string(),
-            leader.to_string(),
+            format!(
+                "--task-id={}",
+                URL_SAFE_NO_PAD.encode(task_id.get_encoded().unwrap())
+            ),
             format!("--dap-auth-token={}", auth_token.as_str()),
-            format!("--hpke-config={encoded_hpke_config}"),
-            format!("--hpke-private-key={encoded_private_key}"),
-            "--batch-interval-start".to_string(),
-            "1000000".to_string(),
-            "--batch-interval-duration".to_string(),
-            "1000".to_string(),
-            "--time-precision=300".to_string(),
+            format!(
+                "--hpke-config={}",
+                URL_SAFE_NO_PAD.encode(hpke_keypair.config().get_encoded().unwrap())
+            ),
+            format!(
+                "--hpke-private-key={}",
+                URL_SAFE_NO_PAD.encode(hpke_keypair.private_key().as_ref())
+            ),
         ]);
 
-        let mut bad_arguments = base_arguments.clone();
-        bad_arguments.extend(["--vdaf=histogram".to_string(), "--length=apple".to_string()]);
-        assert_eq!(
-            Options::try_parse_from(bad_arguments).unwrap_err().kind(),
-            ErrorKind::ValueValidation
-        );
-
-        let mut bad_arguments = base_arguments.clone();
-        bad_arguments.extend(["--vdaf=histogram".to_string()]);
-        let bad_options = Options::try_parse_from(bad_arguments).unwrap();
+        // A time-interval task with no batch interval.
+        let mut arguments = base_arguments.clone();
+        arguments.push(task_config_argument(BatchConfig::TimeInterval));
+        let options = Options::try_parse_from(arguments).unwrap();
         assert_matches!(
-            run(bad_options).await.unwrap_err(),
-            Error::Clap(err) => assert_eq!(err.kind(), ErrorKind::ArgumentConflict)
+            run(options).await.unwrap_err(),
+            Error::Clap(err) => assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument)
         );
 
-        let mut bad_arguments = base_arguments.clone();
-        bad_arguments.extend(["--vdaf=sum".to_string()]);
-        let bad_options = Options::try_parse_from(bad_arguments).unwrap();
-        assert_matches!(
-            run(bad_options).await.unwrap_err(),
-            Error::Clap(err) => assert_eq!(err.kind(), ErrorKind::ArgumentConflict)
-        );
-
-        let mut good_arguments = base_arguments.clone();
-        good_arguments.extend(["--vdaf=sum".to_string(), "--max-measurement=8".to_string()]);
-        Options::try_parse_from(good_arguments).unwrap();
-
-        let mut good_arguments = base_arguments.clone();
-        good_arguments.extend([
-            "--vdaf=sumvec".to_string(),
-            "--max-measurement=8".to_string(),
-            "--length=10".to_string(),
+        // A leader-selected task with a batch interval.
+        let mut arguments = base_arguments;
+        arguments.extend([
+            task_config_argument(BatchConfig::LeaderSelected),
+            "--batch-interval-start=1000000".to_string(),
+            "--batch-interval-duration=1000".to_string(),
         ]);
-        Options::try_parse_from(good_arguments).unwrap();
-
-        let mut good_arguments = base_arguments.clone();
-        good_arguments.extend(["--vdaf=histogram".to_string(), "--length=4".to_string()]);
-        Options::try_parse_from(good_arguments).unwrap();
+        let options = Options::try_parse_from(arguments).unwrap();
+        assert_matches!(
+            run(options).await.unwrap_err(),
+            Error::Clap(err) => assert_eq!(err.kind(), ErrorKind::ArgumentConflict)
+        );
     }
 
     #[test]
@@ -998,20 +974,18 @@ mod tests {
         let task_id: TaskId = random();
         let task_id_encoded = URL_SAFE_NO_PAD.encode(task_id.get_encoded().unwrap());
 
-        let leader = DapUrl::try_from("https://example.com/dap/").unwrap();
-
         let hpke_keypair = HpkeKeypair::test();
         let encoded_hpke_config =
             URL_SAFE_NO_PAD.encode(hpke_keypair.config().get_encoded().unwrap());
         let encoded_private_key = URL_SAFE_NO_PAD.encode(hpke_keypair.private_key().as_ref());
         let auth_token = AuthenticationToken::DapAuth(random());
+        let task_config_argument = task_config_argument(BatchConfig::LeaderSelected);
 
         // Check parsing arguments for a leader-selected query.
         let expected = Options {
             subcommand: None,
             task_id,
-            leader: leader.clone(),
-            time_precision: 300,
+            task_config: task_config(BatchConfig::LeaderSelected),
             authentication: AuthenticationOptions {
                 dap_auth_token: Some(auth_token.clone()),
                 authorization_bearer_token: None,
@@ -1022,9 +996,6 @@ mod tests {
                 collector_credential_file: None,
                 collector_credential: None,
             },
-            vdaf: VdafType::Count,
-            length: None,
-            max_measurement: None,
             query: QueryOptions {
                 batch_interval_start: None,
                 batch_interval_duration: None,
@@ -1033,33 +1004,25 @@ mod tests {
         let correct_arguments = [
             "collect",
             &format!("--task-id={task_id_encoded}"),
-            "--leader",
-            leader.as_str(),
+            &task_config_argument,
             &format!("--dap-auth-token={}", auth_token.as_str()),
             &format!("--hpke-config={encoded_hpke_config}"),
             &format!("--hpke-private-key={encoded_private_key}"),
-            "--vdaf",
-            "count",
-            "--time-precision=300",
         ];
         match Options::try_parse_from(correct_arguments) {
             Ok(got) => assert_eq!(got, expected),
             Err(e) => panic!("{e}\narguments were {correct_arguments:?}"),
         }
 
-        // Check that clap enforces all the constraints we need on combinations of query arguments.
-        // This allows us to treat a default match branch as `unreachable!()` when unpacking the
-        // argument matches.
+        // Clap requires the two batch interval arguments together, which is what lets
+        // `resolve_query` treat a lone one as unreachable.
         let base_arguments = Vec::from([
             "collect".to_string(),
             format!("--task-id={task_id_encoded}"),
-            "--leader".to_string(),
-            "https://example.com/dap/".to_string(),
+            task_config_argument,
             format!("--dap-auth-token={}", auth_token.as_str()),
             format!("--hpke-config={encoded_hpke_config}"),
             format!("--hpke-private-key={encoded_private_key}"),
-            "--vdaf=count".to_string(),
-            "--time-precision=300".to_string(),
         ]);
 
         Options::try_parse_from(base_arguments.clone()).unwrap();
@@ -1092,16 +1055,13 @@ mod tests {
         let base_arguments = Vec::from([
             "collect".to_string(),
             format!("--task-id={task_id_encoded}"),
-            "--leader".to_string(),
-            "https://example.com/dap/".to_string(),
+            task_config_argument(BatchConfig::TimeInterval),
             format!("--hpke-config={encoded_hpke_config}"),
             format!("--hpke-private-key={encoded_private_key}"),
             "--batch-interval-start".to_string(),
             "1000000".to_string(),
             "--batch-interval-duration".to_string(),
             "1000".to_string(),
-            "--vdaf=count".to_string(),
-            "--time-precision=300".to_string(),
         ]);
 
         let dap_auth_token: DapAuthToken = random();
@@ -1171,14 +1131,11 @@ mod tests {
         let base_arguments = Vec::from([
             "collect".to_string(),
             format!("--task-id={task_id_encoded}"),
-            "--leader".to_string(),
-            "https://example.com/dap/".to_string(),
+            task_config_argument(BatchConfig::TimeInterval),
             "--batch-interval-start".to_string(),
             "1000000".to_string(),
             "--batch-interval-duration".to_string(),
             "1000".to_string(),
-            "--vdaf=count".to_string(),
-            "--time-precision=300".to_string(),
         ]);
 
         // Missing all credential args entirely.
@@ -1250,14 +1207,11 @@ mod tests {
         let base_arguments = Vec::from([
             "collect".to_string(),
             format!("--task-id={task_id_encoded}"),
-            "--leader".to_string(),
-            "https://example.com/dap/".to_string(),
+            task_config_argument(BatchConfig::TimeInterval),
             "--batch-interval-start".to_string(),
             "1000000".to_string(),
             "--batch-interval-duration".to_string(),
             "1000".to_string(),
-            "--vdaf=count".to_string(),
-            "--time-precision=300".to_string(),
             format!("--authorization-bearer-token={}", bearer_token.as_str()),
             format!("--collector-credential={SAMPLE_COLLECTOR_CREDENTIAL}"),
         ]);
@@ -1276,7 +1230,6 @@ mod tests {
     fn hpke_config() {
         let task_id: TaskId = random();
         let task_id_encoded = URL_SAFE_NO_PAD.encode(task_id.get_encoded().unwrap());
-        let leader = DapUrl::try_from("https://example.com/dap/").unwrap();
         let hpke_keypair = HpkeKeypair::test();
         let encoded_hpke_config =
             URL_SAFE_NO_PAD.encode(hpke_keypair.config().get_encoded().unwrap());
@@ -1286,12 +1239,8 @@ mod tests {
         let base_arguments = Vec::from([
             "collect".to_string(),
             format!("--task-id={task_id_encoded}"),
-            "--leader".to_string(),
-            leader.to_string(),
+            task_config_argument(BatchConfig::TimeInterval),
             format!("--dap-auth-token={}", auth_token.as_str()),
-            "--vdaf".to_string(),
-            "count".to_string(),
-            "--time-precision=300".to_string(),
         ]);
 
         let mut correct_arguments = base_arguments.clone();
@@ -1349,16 +1298,15 @@ mod tests {
         let encoded_private_key = URL_SAFE_NO_PAD.encode(hpke_keypair.private_key().as_ref());
 
         let task_id = random();
-        let leader = DapUrl::try_from("https://example.com/dap/").unwrap();
         let auth_token = AuthenticationToken::DapAuth(random());
+        let task_config_argument = task_config_argument(BatchConfig::TimeInterval);
 
         let mut expected = Options {
             subcommand: Some(Subcommands::NewJob {
                 collection_job_id: None,
             }),
             task_id,
-            leader: leader.clone(),
-            time_precision: 300,
+            task_config: task_config(BatchConfig::TimeInterval),
             authentication: AuthenticationOptions {
                 dap_auth_token: Some(auth_token.clone()),
                 authorization_bearer_token: None,
@@ -1369,9 +1317,6 @@ mod tests {
                 collector_credential_file: None,
                 collector_credential: None,
             },
-            vdaf: VdafType::Count,
-            length: None,
-            max_measurement: None,
             query: QueryOptions {
                 batch_interval_start: Some(1_000_000),
                 batch_interval_duration: Some(1_000),
@@ -1381,18 +1326,14 @@ mod tests {
         let correct_arguments = [
             "collect",
             &format!("--task-id={task_id_encoded}"),
-            "--leader",
-            leader.as_str(),
+            &task_config_argument,
             &format!("--dap-auth-token={}", auth_token.as_str()),
             &format!("--hpke-config={encoded_hpke_config}"),
             &format!("--hpke-private-key={encoded_private_key}"),
-            "--vdaf",
-            "count",
             "--batch-interval-start",
             "1000000",
             "--batch-interval-duration",
             "1000",
-            "--time-precision=300",
             "new-job",
         ];
         match Options::try_parse_from(correct_arguments) {
@@ -1407,18 +1348,14 @@ mod tests {
         let correct_arguments = [
             "collect",
             &format!("--task-id={task_id_encoded}"),
-            "--leader",
-            leader.as_str(),
+            &task_config_argument,
             &format!("--dap-auth-token={}", auth_token.as_str()),
             &format!("--hpke-config={encoded_hpke_config}"),
             &format!("--hpke-private-key={encoded_private_key}"),
-            "--vdaf",
-            "count",
             "--batch-interval-start",
             "1000000",
             "--batch-interval-duration",
             "1000",
-            "--time-precision=300",
             "new-job",
             "--", // prevent ID from being interpreted as a flag, in case it starts with a hyphen.
             &format!("{collection_job_id}"),
@@ -1437,14 +1374,13 @@ mod tests {
         let encoded_private_key = URL_SAFE_NO_PAD.encode(hpke_keypair.private_key().as_ref());
 
         let task_id = random();
-        let leader = DapUrl::try_from("https://example.com/dap/").unwrap();
         let auth_token = AuthenticationToken::DapAuth(random());
+        let task_config_argument = task_config_argument(BatchConfig::TimeInterval);
         let collection_job_id = random();
         let expected = Options {
             subcommand: Some(Subcommands::PollJob { collection_job_id }),
             task_id,
-            leader: leader.clone(),
-            time_precision: 300,
+            task_config: task_config(BatchConfig::TimeInterval),
             authentication: AuthenticationOptions {
                 dap_auth_token: Some(auth_token.clone()),
                 authorization_bearer_token: None,
@@ -1455,9 +1391,6 @@ mod tests {
                 collector_credential_file: None,
                 collector_credential: None,
             },
-            vdaf: VdafType::Count,
-            length: None,
-            max_measurement: None,
             query: QueryOptions {
                 batch_interval_start: Some(1_000_000),
                 batch_interval_duration: Some(1_000),
@@ -1467,18 +1400,14 @@ mod tests {
         let correct_arguments = [
             "collect",
             &format!("--task-id={task_id_encoded}"),
-            "--leader",
-            leader.as_str(),
+            &task_config_argument,
             &format!("--dap-auth-token={}", auth_token.as_str()),
             &format!("--hpke-config={encoded_hpke_config}"),
             &format!("--hpke-private-key={encoded_private_key}"),
-            "--vdaf",
-            "count",
             "--batch-interval-start",
             "1000000",
             "--batch-interval-duration",
             "1000",
-            "--time-precision=300",
             "poll-job",
             "--", // prevent ID from being interpreted as a flag, in case it starts with a hyphen.
             &collection_job_id.to_string(),

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -468,7 +468,6 @@ fn resolve_query(options: &Options) -> Result<ResolvedQuery, Error> {
              --batch-interval-duration are required\n",
         )
         .into()),
-        // Clap requires the two batch interval arguments together.
         (BatchConfig::TimeInterval, _, _) => {
             unreachable!("clap requires both batch interval arguments together")
         }
@@ -634,12 +633,10 @@ fn new_collector<V: vdaf::Collector>(
     let task_config = options.task_config;
     let collector = Collector::builder_with_custom_vdaf(
         options.task_id,
-        task_config.leader_aggregator_endpoint().clone(),
         authentication,
         hpke_keypair,
         vdaf,
         task_config.vdaf_config().clone(),
-        *task_config.time_precision(),
     )
     .with_task_configuration(task_config)
     .with_http_client(http_client)
@@ -921,9 +918,9 @@ mod tests {
         );
     }
 
-    /// The collector cross-checks the leader endpoint and time precision it is constructed with
-    /// against the ones in the task configuration, so a wiring mistake in `new_collector` would
-    /// fail every real invocation at build time while leaving the argument-parsing tests green.
+    /// The collector's task parameters are all resolved from the task configuration at build time,
+    /// so a wiring mistake in `new_collector` would fail every real invocation while leaving the
+    /// argument-parsing tests green.
     #[test]
     fn new_collector_accepts_task_config() {
         install_test_trace_subscriber();

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -468,6 +468,10 @@ fn resolve_query(options: &Options) -> Result<ResolvedQuery, Error> {
              --batch-interval-duration are required\n",
         )
         .into()),
+        // Clap requires the two batch interval arguments together.
+        (BatchConfig::TimeInterval, _, _) => {
+            unreachable!("clap requires both batch interval arguments together")
+        }
         (BatchConfig::LeaderSelected, None, None) => Ok(ResolvedQuery::LeaderSelected),
         (BatchConfig::LeaderSelected, _, _) => Err(clap::Error::raw(
             ErrorKind::ArgumentConflict,
@@ -483,7 +487,6 @@ fn resolve_query(options: &Options) -> Result<ResolvedQuery, Error> {
             ),
         )
         .into()),
-        // Clap requires the two batch interval arguments together, so a lone one cannot reach here.
     }
 }
 
@@ -638,7 +641,6 @@ fn new_collector<V: vdaf::Collector>(
         task_config.vdaf_config().clone(),
         *task_config.time_precision(),
     )
-    // Bound verbatim, so extensions this tool does not model still reach the HPKE AAD.
     .with_task_configuration(task_config)
     .with_http_client(http_client)
     .with_collect_poll_backoff(
@@ -731,13 +733,13 @@ mod tests {
         test_util::install_test_trace_subscriber,
     };
     use janus_messages::{BatchConfig, TaskConfiguration, TaskId, TimePrecision, VdafConfig};
-    use prio::codec::Encode;
+    use prio::{codec::Encode, vdaf::prio3::Prio3};
     use rand::random;
     use tempfile::NamedTempFile;
 
     use crate::{
         AuthenticationOptions, AuthenticationToken, Error, HpkeConfigOptions, Options,
-        QueryOptions, Subcommands, run,
+        QueryOptions, Subcommands, default_http_client, new_collector, run,
     };
 
     const SAMPLE_COLLECTOR_CREDENTIAL: &str = r#"{
@@ -917,6 +919,46 @@ mod tests {
             Options::try_parse_from(bad_arguments).unwrap_err().kind(),
             ErrorKind::ValueValidation,
         );
+    }
+
+    /// The collector cross-checks the leader endpoint and time precision it is constructed with
+    /// against the ones in the task configuration, so a wiring mistake in `new_collector` would
+    /// fail every real invocation at build time while leaving the argument-parsing tests green.
+    #[test]
+    fn new_collector_accepts_task_config() {
+        install_test_trace_subscriber();
+        initialize_rustls();
+
+        let hpke_keypair = HpkeKeypair::test();
+        let task_id: TaskId = random();
+        let auth_token = AuthenticationToken::DapAuth(random());
+        let options = Options::try_parse_from([
+            "collect".to_string(),
+            format!(
+                "--task-id={}",
+                URL_SAFE_NO_PAD.encode(task_id.get_encoded().unwrap())
+            ),
+            task_config_argument(BatchConfig::TimeInterval),
+            format!("--dap-auth-token={}", auth_token.as_str()),
+            format!(
+                "--hpke-config={}",
+                URL_SAFE_NO_PAD.encode(hpke_keypair.config().get_encoded().unwrap())
+            ),
+            format!(
+                "--hpke-private-key={}",
+                URL_SAFE_NO_PAD.encode(hpke_keypair.private_key().as_ref())
+            ),
+            "--batch-interval-start=1000000".to_string(),
+            "--batch-interval-duration=1000".to_string(),
+        ])
+        .unwrap();
+
+        new_collector(
+            options,
+            Prio3::new_count(2).unwrap(),
+            default_http_client().unwrap(),
+        )
+        .unwrap();
     }
 
     /// The task configuration states the batch mode and the command line selects the batch, so

--- a/tools/tests/cmd/collect.trycmd
+++ b/tools/tests/cmd/collect.trycmd
@@ -4,7 +4,7 @@ Command-line DAP-PPM collector from ISRG's Divvi Up
 
 The default subcommand is "run", which will create a collection job and poll it to completion
 
-Usage: collect [OPTIONS] --task-id <TASK_ID> --leader <LEADER> --time-precision <TIME_PRECISION> --vdaf <VDAF> <--hpke-config <HPKE_CONFIG>|--hpke-private-key <HPKE_PRIVATE_KEY>|--collector-credential-file <COLLECTOR_CREDENTIAL_FILE>|--collector-credential <COLLECTOR_CREDENTIAL>> [COMMAND]
+Usage: collect [OPTIONS] --task-id <TASK_ID> --task-config <TASK_CONFIG> <--hpke-config <HPKE_CONFIG>|--hpke-private-key <HPKE_PRIVATE_KEY>|--collector-credential-file <COLLECTOR_CREDENTIAL_FILE>|--collector-credential <COLLECTOR_CREDENTIAL>> [COMMAND]
 
 Commands:
   run       Create a new collection job and poll it to completion
@@ -23,11 +23,10 @@ DAP Task Parameters:
       --task-id <TASK_ID>
           DAP task identifier, encoded with unpadded base64url
 
-      --leader <LEADER>
-          The leader aggregator's endpoint URL
-
-      --time-precision <TIME_PRECISION>
-          The task's time precision, in seconds
+      --task-config <TASK_CONFIG>
+          The task's DAP TaskConfiguration message, encoded with unpadded base64url
+          
+          This supplies the aggregator endpoints, time precision, batch configuration, and VDAF configuration. Its bytes are bound into the HPKE additional authenticated data, so it must be exactly the message the aggregators were provisioned with.
 
 Authorization:
       --dap-auth-token <DAP_AUTH_TOKEN>
@@ -62,22 +61,6 @@ HPKE Configuration:
           This can be obtained with the command `divviup collector-credential generate`.
           
           [env: COLLECTOR_CREDENTIAL]
-
-VDAF Algorithm and Parameters:
-      --vdaf <VDAF>
-          VDAF algorithm
-
-          Possible values:
-          - count:     Prio3Count
-          - sum:       Prio3Sum
-          - sumvec:    Prio3SumVec
-          - histogram: Prio3Histogram
-
-      --length <LENGTH>
-          Number of vector elements, when used with --vdaf=sumvec or number of histogram buckets, when used with --vdaf=histogram
-
-      --max-measurement <MAX_MEASUREMENT>
-          Maximum measurement value, for use with --vdaf=sum or --vdaf=sumvec
 
 Collect Request Parameters (Time Interval):
       --batch-interval-start <BATCH_INTERVAL_START>


### PR DESCRIPTION
`--task-config` takes the task's base64url TaskConfiguration and supplies the aggregator endpoints, time precision, batch configuration, and VDAF configuration, so the tool can reconstruct the AAD the aggregators bind.

This gets the collector, both CLI and the interop version.

Closes https://github.com/divviup/janus/issues/4713.