### PR TITLE
Update h2 to 0.4.16 for RUSTSEC-2026-0258 (release/0.7 backport)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2035,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
h2 <0.4.16 queues empty DATA frames without limit, which can drive unbounded memory growth or an overflow panic. Janus reaches h2 through hyper/axum.