### PR TITLE
[DAP-18] Remove PartialBatchSelector from CollectionJobResp

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -4,6 +4,7 @@ use std::{
     borrow::Cow,
     collections::{HashMap, HashSet},
     fmt::Debug,
+    marker::PhantomData,
     panic,
     path::PathBuf,
     sync::{Arc, Mutex},
@@ -55,8 +56,8 @@ use janus_messages::{
     AggregationJobContinueReq, AggregationJobId, AggregationJobInitializeReq, AggregationJobResp,
     AggregationJobStep, CollectionJobExtension, CollectionJobId, CollectionJobReq,
     CollectionJobResp, Duration, ExtensionType, HpkeConfig, HpkeConfigList, InputShareAad,
-    Interval, PartialBatchSelector, PlaintextInputShare, Report, ReportError, ReportUploadStatus,
-    Role, TaskConfiguration, TaskExtension, TaskId, UploadErrors, Url as DapUrl, VerifyResp,
+    Interval, PlaintextInputShare, Report, ReportError, ReportUploadStatus, Role,
+    TaskConfiguration, TaskExtension, TaskId, UploadErrors, Url as DapUrl, VerifyResp,
     batch_mode::{LeaderSelected, TimeInterval},
     extensions_are_strictly_increasing,
 };
@@ -3428,13 +3429,11 @@ impl VdafOps {
                 )?;
 
                 CollectionJobResp::<B> {
-                    partial_batch_selector: PartialBatchSelector::new(
-                        B::partial_batch_identifier(collection_job.batch_identifier()).clone(),
-                    ),
                     report_count: *report_count,
                     interval: *client_timestamp_interval,
                     leader_encrypted_agg_share: encrypted_leader_aggregate_share,
                     helper_encrypted_agg_share: encrypted_helper_aggregate_share.clone(),
+                    phantom: PhantomData,
                 }
                 .get_encoded()
                 .map_err(Error::MessageEncode)

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -74,6 +74,7 @@ mod credential;
 
 use std::{
     convert::TryFrom,
+    marker::PhantomData,
     time::{Duration as StdDuration, SystemTime},
 };
 
@@ -94,8 +95,8 @@ use janus_core::{
 };
 use janus_messages::{
     AggregateShareAad, BatchConfig, CollectionJobExtension, CollectionJobId, CollectionJobReq,
-    CollectionJobResp, Interval, MediaType, PartialBatchSelector, Query, Role, TaskConfiguration,
-    TaskId, TimePrecision, Url as DapUrl, VdafConfig,
+    CollectionJobResp, Interval, MediaType, Query, Role, TaskConfiguration, TaskId, TimePrecision,
+    Url as DapUrl, VdafConfig,
     batch_mode::{BatchMode, TimeInterval},
 };
 use prio::{
@@ -291,21 +292,16 @@ pub struct Collection<T, B>
 where
     B: BatchMode,
 {
-    partial_batch_selector: PartialBatchSelector<B>,
     report_count: u64,
     interval: (DateTime<Utc>, Duration),
     aggregate_result: T,
+    phantom: PhantomData<B>,
 }
 
 impl<T, B> Collection<T, B>
 where
     B: BatchMode,
 {
-    /// Retrieves the partial batch selector of this collection.
-    pub fn partial_batch_selector(&self) -> &PartialBatchSelector<B> {
-        &self.partial_batch_selector
-    }
-
     /// Retrieves the number of client reports included in this collection.
     pub fn report_count(&self) -> u64 {
         self.report_count
@@ -330,16 +326,15 @@ where
 {
     /// Creates a new [`Collection`].
     pub fn new(
-        partial_batch_selector: PartialBatchSelector<B>,
         report_count: u64,
         interval: (DateTime<Utc>, Duration),
         aggregate_result: T,
     ) -> Self {
         Self {
-            partial_batch_selector,
             report_count,
             interval,
             aggregate_result,
+            phantom: PhantomData,
         }
     }
 }
@@ -842,7 +837,6 @@ impl<V: vdaf::Collector> Collector<V> {
         )?;
 
         Ok(PollResult::CollectionResult(Collection {
-            partial_batch_selector: collect_response.partial_batch_selector.clone(),
             report_count: collect_response.report_count,
             interval: (
                 collect_response
@@ -855,6 +849,7 @@ impl<V: vdaf::Collector> Collector<V> {
                     .to_chrono(self.task_configuration.time_precision())?,
             ),
             aggregate_result,
+            phantom: PhantomData,
         }))
     }
 
@@ -990,7 +985,7 @@ impl<V: vdaf::Collector> Collector<V> {
 
 #[cfg(test)]
 mod tests {
-    use std::time::SystemTime;
+    use std::{marker::PhantomData, time::SystemTime};
 
     use assert_matches::assert_matches;
     use chrono::{DateTime, TimeZone, Utc};
@@ -1003,10 +998,9 @@ mod tests {
         vdaf::ConfiguredVdaf,
     };
     use janus_messages::{
-        AggregateShareAad, BatchConfig, BatchId, CollectionJobId, CollectionJobReq,
-        CollectionJobResp, Duration, HpkeCiphertext, Interval, MediaType, PartialBatchSelector,
-        Query, Role, TaskConfiguration, TaskExtension, TaskExtensionType, TaskId, Time,
-        TimePrecision, Url as DapUrl, VdafConfig,
+        AggregateShareAad, BatchConfig, CollectionJobId, CollectionJobReq, CollectionJobResp,
+        Duration, HpkeCiphertext, Interval, MediaType, Query, Role, TaskConfiguration,
+        TaskExtension, TaskExtensionType, TaskId, Time, TimePrecision, Url as DapUrl, VdafConfig,
         batch_mode::{LeaderSelected, TimeInterval},
         problem_type::DapProblemType,
     };
@@ -1078,7 +1072,6 @@ mod tests {
             ),
         );
         CollectionJobResp {
-            partial_batch_selector: PartialBatchSelector::new_time_interval(),
             report_count: 1,
             interval: batch_interval,
             leader_encrypted_agg_share: hpke::seal(
@@ -1095,6 +1088,7 @@ mod tests {
                 &associated_data.get_encoded().unwrap(),
             )
             .unwrap(),
+            phantom: PhantomData,
         }
     }
 
@@ -1102,7 +1096,6 @@ mod tests {
         transcript: &VdafTranscript<SEED_SIZE, V>,
         collector: &Collector<V>,
         aggregation_parameter: &V::AggregationParam,
-        batch_id: BatchId,
     ) -> CollectionJobResp<LeaderSelected>
     where
         V: vdaf::Aggregator<SEED_SIZE, 16> + vdaf::Collector,
@@ -1117,7 +1110,6 @@ mod tests {
             ),
         );
         CollectionJobResp {
-            partial_batch_selector: PartialBatchSelector::new_leader_selected(batch_id),
             report_count: 1,
             interval: Interval::minimal(Time::from_time_precision_units(0)).unwrap(),
             leader_encrypted_agg_share: hpke::seal(
@@ -1134,6 +1126,7 @@ mod tests {
                 &associated_data.get_encoded().unwrap(),
             )
             .unwrap(),
+            phantom: PhantomData,
         }
     }
 
@@ -1412,7 +1405,6 @@ mod tests {
         assert_eq!(
             collection,
             Collection::new(
-                PartialBatchSelector::new_time_interval(),
                 1,
                 (
                     DateTime::<Utc>::from_timestamp(1_000_000, 0).unwrap(),
@@ -1491,7 +1483,6 @@ mod tests {
         assert_eq!(
             collection,
             Collection::new(
-                PartialBatchSelector::new_time_interval(),
                 1,
                 (
                     DateTime::<Utc>::from_timestamp(1_000_000, 0).unwrap(),
@@ -1569,7 +1560,6 @@ mod tests {
         assert_eq!(
             collection,
             Collection::new(
-                PartialBatchSelector::new_time_interval(),
                 1,
                 (
                     DateTime::<Utc>::from_timestamp(1_000_000, 0).unwrap(),
@@ -1598,8 +1588,7 @@ mod tests {
         );
         let collector = setup_collector(&mut server, configured_vdaf);
 
-        let batch_id = random();
-        let collect_resp = build_collect_response_fixed(&transcript, &collector, &(), batch_id);
+        let collect_resp = build_collect_response_fixed(&transcript, &collector, &());
         let matcher = collection_uri_regex_matcher(&collector.task_id);
 
         let mocked_collect_start_success = server
@@ -1641,7 +1630,6 @@ mod tests {
         assert_eq!(
             collection,
             Collection::new(
-                PartialBatchSelector::new_leader_selected(batch_id),
                 1,
                 (
                     DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
@@ -1738,7 +1726,6 @@ mod tests {
         assert_eq!(
             agg_result,
             Collection::new(
-                PartialBatchSelector::new_time_interval(),
                 1,
                 (
                     DateTime::<Utc>::from_timestamp(1_000_000, 0).unwrap(),
@@ -1978,8 +1965,7 @@ mod tests {
                 CollectionJobResp::<TimeInterval>::MEDIA_TYPE,
             )
             .with_body(
-                CollectionJobResp {
-                    partial_batch_selector: PartialBatchSelector::new_time_interval(),
+                CollectionJobResp::<TimeInterval> {
                     report_count: 1,
                     interval: batch_interval,
                     leader_encrypted_agg_share: HpkeCiphertext::new(
@@ -1992,6 +1978,7 @@ mod tests {
                         Vec::new(),
                         Vec::new(),
                     ),
+                    phantom: PhantomData,
                 }
                 .get_encoded()
                 .unwrap(),
@@ -2013,8 +2000,7 @@ mod tests {
                 ().get_encoded().unwrap(),
             ),
         );
-        let collect_resp = CollectionJobResp {
-            partial_batch_selector: PartialBatchSelector::new_time_interval(),
+        let collect_resp = CollectionJobResp::<TimeInterval> {
             report_count: 1,
             interval: batch_interval,
             leader_encrypted_agg_share: hpke::seal(
@@ -2031,6 +2017,7 @@ mod tests {
                 &associated_data.get_encoded().unwrap(),
             )
             .unwrap(),
+            phantom: PhantomData,
         };
         let mock_collection_job_bad_shares = server
             .mock("GET", collection_job_path.as_str())
@@ -2049,8 +2036,7 @@ mod tests {
 
         mock_collection_job_bad_shares.assert_async().await;
 
-        let collect_resp = CollectionJobResp {
-            partial_batch_selector: PartialBatchSelector::new_time_interval(),
+        let collect_resp = CollectionJobResp::<TimeInterval> {
             report_count: 1,
             interval: batch_interval,
             leader_encrypted_agg_share: hpke::seal(
@@ -2074,6 +2060,7 @@ mod tests {
                 &associated_data.get_encoded().unwrap(),
             )
             .unwrap(),
+            phantom: PhantomData,
         };
         let mock_collection_job_wrong_length = server
             .mock("GET", collection_job_path.as_str())

--- a/integration_tests/tests/integration/simulation/run.rs
+++ b/integration_tests/tests/integration/simulation/run.rs
@@ -516,7 +516,6 @@ impl Simulation {
             let result = self.components.collector.poll_once(collection_job).await;
             match result {
                 Ok(PollResult::CollectionResult(collection)) => {
-                    let partial_batch_selector = collection.partial_batch_selector().clone();
                     let report_count = collection.report_count();
                     let interval = *collection.interval();
                     let aggregate_result = collection.aggregate_result().clone();
@@ -525,8 +524,7 @@ impl Simulation {
                         .aggregate_results_leader_selected
                         .insert(*collection_job_id, collection);
                     if let Some(old_collection) = old_opt {
-                        if &partial_batch_selector != old_collection.partial_batch_selector()
-                            || report_count != old_collection.report_count()
+                        if report_count != old_collection.report_count()
                             || &interval != old_collection.interval()
                             || &aggregate_result != old_collection.aggregate_result()
                         {

--- a/interop_binaries/src/commands/janus_interop_collector.rs
+++ b/interop_binaries/src/commands/janus_interop_collector.rs
@@ -24,8 +24,8 @@ use janus_core::{
     vdaf::{VdafInstance, new_prio3_sum_vec_field64_multiproof_hmacsha256_aes128},
 };
 use janus_messages::{
-    BatchId, Duration, HpkeConfig, Interval, PartialBatchSelector, Query, TaskConfiguration,
-    TaskId, Time, TimePrecision, Url as DapUrl, batch_mode::BatchMode,
+    Duration, HpkeConfig, Interval, Query, TaskConfiguration, TaskId, Time, TimePrecision,
+    Url as DapUrl, batch_mode::BatchMode,
 };
 use prio::{
     codec::{Decode, Encode},
@@ -98,7 +98,6 @@ struct CollectPollRequest {
 
 #[derive(Debug, Clone)]
 struct CollectResult {
-    partial_batch_selector: Option<BatchId>,
     report_count: u64,
     interval_start: i64,
     interval_duration: i64,
@@ -218,7 +217,6 @@ async fn handle_collect_generic<V, B>(
     query: Query<B>,
     vdaf: V,
     agg_param_encoded: &[u8],
-    batch_convert_fn: impl Fn(&PartialBatchSelector<B>) -> Option<BatchId> + Send + 'static,
     result_convert_fn: impl Fn(&V::AggregateResult) -> AggregationResult + Send + 'static,
 ) -> anyhow::Result<JoinHandle<anyhow::Result<CollectResult>>>
 where
@@ -256,7 +254,6 @@ where
         let collect_result = collector.collection(query, &agg_param).collect().await?;
         let (interval_start, interval_duration) = collect_result.interval();
         Ok(CollectResult {
-            partial_batch_selector: batch_convert_fn(collect_result.partial_batch_selector()),
             report_count: collect_result.report_count(),
             interval_start: interval_start.timestamp(),
             interval_duration: interval_duration.num_seconds(),
@@ -331,7 +328,6 @@ async fn handle_collection_start(
                     Query::new_time_interval(batch_interval),
                     vdaf,
                     &agg_param,
-                    |_| None,
                     |result| AggregationResult::Number(NumberAsString((*result).into())),
                 )
                 .await?
@@ -349,7 +345,6 @@ async fn handle_collection_start(
                     Query::new_time_interval(batch_interval),
                     vdaf,
                     &agg_param,
-                    |_| None,
                     |result| AggregationResult::Number(NumberAsString(u128::from(*result))),
                 )
                 .await?
@@ -372,7 +367,6 @@ async fn handle_collection_start(
                     Query::new_time_interval(batch_interval),
                     vdaf,
                     &agg_param,
-                    |_| None,
                     |result| {
                         let converted = result.iter().cloned().map(NumberAsString).collect();
                         AggregationResult::NumberVec(converted)
@@ -401,7 +395,6 @@ async fn handle_collection_start(
                     Query::new_time_interval(batch_interval),
                     vdaf,
                     &agg_param,
-                    |_| None,
                     |result: &Vec<u64>| {
                         let converted = result
                             .iter()
@@ -431,7 +424,6 @@ async fn handle_collection_start(
                     Query::new_time_interval(batch_interval),
                     vdaf,
                     &agg_param,
-                    |_| None,
                     |result| {
                         let converted = result.iter().cloned().map(NumberAsString).collect();
                         AggregationResult::NumberVec(converted)
@@ -448,7 +440,6 @@ async fn handle_collection_start(
                     Query::new_leader_selected(),
                     vdaf,
                     &agg_param,
-                    |selector| Some(*selector.batch_id()),
                     |result| AggregationResult::Number(NumberAsString((*result).into())),
                 )
                 .await?
@@ -463,7 +454,6 @@ async fn handle_collection_start(
                     Query::new_leader_selected(),
                     vdaf,
                     &agg_param,
-                    |selector| Some(*selector.batch_id()),
                     |result| AggregationResult::Number(NumberAsString(u128::from(*result))),
                 )
                 .await?
@@ -486,7 +476,6 @@ async fn handle_collection_start(
                     Query::new_leader_selected(),
                     vdaf,
                     &agg_param,
-                    |selector| Some(*selector.batch_id()),
                     |result| {
                         let converted = result.iter().cloned().map(NumberAsString).collect();
                         AggregationResult::NumberVec(converted)
@@ -515,7 +504,6 @@ async fn handle_collection_start(
                     Query::new_leader_selected(),
                     vdaf,
                     &agg_param,
-                    |selector| Some(*selector.batch_id()),
                     |result: &Vec<u64>| {
                         let converted = result
                             .iter()
@@ -545,7 +533,6 @@ async fn handle_collection_start(
                     Query::new_leader_selected(),
                     vdaf,
                     &agg_param,
-                    |selector| Some(*selector.batch_id()),
                     |result| {
                         let converted = result.iter().cloned().map(NumberAsString).collect();
                         AggregationResult::NumberVec(converted)
@@ -726,9 +713,7 @@ async fn collection_poll_handler(
         Ok(Some(collect_result)) => Json(CollectPollResponse {
             status: COMPLETE,
             error: None,
-            batch_id: collect_result
-                .partial_batch_selector
-                .map(|batch_id| URL_SAFE_NO_PAD.encode(batch_id.as_ref())),
+            batch_id: None,
             report_count: Some(collect_result.report_count),
             interval_start: Some(collect_result.interval_start),
             interval_duration: Some(collect_result.interval_duration),

--- a/interop_binaries/tests/end_to_end.rs
+++ b/interop_binaries/tests/end_to_end.rs
@@ -553,14 +553,6 @@ async fn run(
             "error: {:?}",
             collection_poll_response_object.get("error"),
         );
-        if let QueryKind::LeaderSelected = query_kind {
-            let batch_id_encoded = collection_poll_response_object
-                .get("batch_id")
-                .expect("completed collection_poll response is missing \"batch_id\"")
-                .as_str()
-                .expect("\"batch_id\" value is not a string");
-            URL_SAFE_NO_PAD.decode(batch_id_encoded).unwrap();
-        }
         collection_poll_response_object
             .get("report_count")
             .expect("completed collection_poll response is missing \"report_count\"")

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -11,6 +11,7 @@ use std::{
     fmt::{self, Debug, Display, Formatter},
     hash::{Hash, Hasher},
     io::{Cursor, Read},
+    marker::PhantomData,
     num::TryFromIntError,
     str::{self, FromStr},
 };
@@ -2033,11 +2034,11 @@ impl Distribution<CollectionJobId> for StandardUniform {
 /// aggregate shares for a given query.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CollectionJobResp<B: BatchMode> {
-    pub partial_batch_selector: PartialBatchSelector<B>,
     pub report_count: u64,
     pub interval: Interval,
     pub leader_encrypted_agg_share: HpkeCiphertext,
     pub helper_encrypted_agg_share: HpkeCiphertext,
+    pub phantom: PhantomData<B>,
 }
 
 impl<B: BatchMode> MediaType for CollectionJobResp<B> {
@@ -2048,7 +2049,6 @@ impl<B: BatchMode> Encode for CollectionJobResp<B> {
     fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
         // The encoding includes an implicit discriminator byte called CollectionJobStatus in the
         // DAP specification.
-        self.partial_batch_selector.encode(bytes)?;
         self.report_count.encode(bytes)?;
         self.interval.encode(bytes)?;
         self.leader_encrypted_agg_share.encode(bytes)?;
@@ -2057,8 +2057,7 @@ impl<B: BatchMode> Encode for CollectionJobResp<B> {
 
     fn encoded_len(&self) -> Option<usize> {
         Some(
-            self.partial_batch_selector.encoded_len()?
-                + self.report_count.encoded_len()?
+            self.report_count.encoded_len()?
                 + self.interval.encoded_len()?
                 + self.leader_encrypted_agg_share.encoded_len()?
                 + self.helper_encrypted_agg_share.encoded_len()?,
@@ -2069,18 +2068,17 @@ impl<B: BatchMode> Encode for CollectionJobResp<B> {
 impl<B: BatchMode> Decode for CollectionJobResp<B> {
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
         Ok({
-            let partial_batch_selector = PartialBatchSelector::decode(bytes)?;
             let report_count = u64::decode(bytes)?;
             let interval = Interval::decode(bytes)?;
             let leader_encrypted_agg_share = HpkeCiphertext::decode(bytes)?;
             let helper_encrypted_agg_share = HpkeCiphertext::decode(bytes)?;
 
             Self {
-                partial_batch_selector,
                 report_count,
                 interval,
                 leader_encrypted_agg_share,
                 helper_encrypted_agg_share,
+                phantom: PhantomData,
             }
         })
     }

--- a/messages/src/tests/collection.rs
+++ b/messages/src/tests/collection.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use prio::codec::{Decode, Encode};
 
 use super::{task_configuration_hex, test_task_configuration};
@@ -234,8 +236,7 @@ fn roundtrip_collection_job_resp() {
     // TimeInterval.
     roundtrip_encoding(&[
         (
-            CollectionJobResp {
-                partial_batch_selector: PartialBatchSelector::new_time_interval(),
+            CollectionJobResp::<TimeInterval> {
                 report_count: 0,
                 interval,
                 leader_encrypted_agg_share: HpkeCiphertext::new(
@@ -248,14 +249,9 @@ fn roundtrip_collection_job_resp() {
                     Vec::from("01234"),
                     Vec::from("567"),
                 ),
+                phantom: PhantomData,
             },
             concat!(
-                concat!(
-                    // partial_batch_selector
-                    "01",   // batch_mode
-                    "0000", // length
-                    "",     // opaque data
-                ),
                 "0000000000000000", // report_count
                 concat!(
                     // interval
@@ -293,8 +289,7 @@ fn roundtrip_collection_job_resp() {
             ),
         ),
         (
-            CollectionJobResp {
-                partial_batch_selector: PartialBatchSelector::new_time_interval(),
+            CollectionJobResp::<TimeInterval> {
                 report_count: 23,
                 interval,
                 leader_encrypted_agg_share: HpkeCiphertext::new(
@@ -307,14 +302,9 @@ fn roundtrip_collection_job_resp() {
                     Vec::from("01234"),
                     Vec::from("567"),
                 ),
+                phantom: PhantomData,
             },
             concat!(
-                concat!(
-                    // partial_batch_selector
-                    "01",   // batch_mode
-                    "0000", // length
-                    "",     // opaque data
-                ),
                 "0000000000000017", // report_count
                 concat!(
                     // interval
@@ -356,10 +346,7 @@ fn roundtrip_collection_job_resp() {
     // LeaderSelected.
     roundtrip_encoding(&[
         (
-            CollectionJobResp {
-                partial_batch_selector: PartialBatchSelector::new_leader_selected(BatchId::from(
-                    [3u8; 32],
-                )),
+            CollectionJobResp::<LeaderSelected> {
                 report_count: 0,
                 interval,
                 leader_encrypted_agg_share: HpkeCiphertext::new(
@@ -372,15 +359,9 @@ fn roundtrip_collection_job_resp() {
                     Vec::from("01234"),
                     Vec::from("567"),
                 ),
+                phantom: PhantomData,
             },
             concat!(
-                concat!(
-                    // partial_batch_selector
-                    "02",   // batch_mode
-                    "0020", // length
-                    // opaque data
-                    "0303030303030303030303030303030303030303030303030303030303030303",
-                ),
                 "0000000000000000", // report_count
                 concat!(
                     // interval
@@ -418,10 +399,7 @@ fn roundtrip_collection_job_resp() {
             ),
         ),
         (
-            CollectionJobResp {
-                partial_batch_selector: PartialBatchSelector::new_leader_selected(BatchId::from(
-                    [4u8; 32],
-                )),
+            CollectionJobResp::<LeaderSelected> {
                 report_count: 23,
                 interval,
                 leader_encrypted_agg_share: HpkeCiphertext::new(
@@ -434,15 +412,9 @@ fn roundtrip_collection_job_resp() {
                     Vec::from("01234"),
                     Vec::from("567"),
                 ),
+                phantom: PhantomData,
             },
             concat!(
-                concat!(
-                    // partial_batch_selector
-                    "02",   // batch_mode
-                    "0020", // length
-                    // opaque data
-                    "0404040404040404040404040404040404040404040404040404040404040404",
-                ),
                 "0000000000000017", // report_count
                 concat!(
                     // interval

--- a/tools/src/bin/collect.rs
+++ b/tools/src/bin/collect.rs
@@ -18,9 +18,8 @@ use janus_core::{
     vdaf_dispatch,
 };
 use janus_messages::{
-    BatchConfig, CollectionJobId, Duration, HpkeConfig, Interval, PartialBatchSelector, Query,
-    TaskConfiguration, TaskId, Time,
-    batch_mode::{BatchMode, LeaderSelected, TimeInterval},
+    BatchConfig, CollectionJobId, Duration, HpkeConfig, Interval, Query, TaskConfiguration, TaskId,
+    Time, batch_mode::BatchMode,
 };
 use prio::{
     codec::Decode,
@@ -551,7 +550,7 @@ async fn run(options: Options) -> Result<(), Error> {
     })
 }
 
-async fn run_collection<V: vdaf::Collector, B: BatchModeExt>(
+async fn run_collection<V: vdaf::Collector, B: BatchMode>(
     options: Options,
     vdaf: V,
     http_client: reqwest::Client,
@@ -570,7 +569,7 @@ where
     Ok(())
 }
 
-async fn run_new_job<V: vdaf::Collector, B: BatchModeExt>(
+async fn run_new_job<V: vdaf::Collector, B: BatchMode>(
     options: Options,
     vdaf: V,
     http_client: reqwest::Client,
@@ -591,7 +590,7 @@ where
     Ok(())
 }
 
-async fn run_poll_job<V: vdaf::Collector, B: BatchModeExt>(
+async fn run_poll_job<V: vdaf::Collector, B: BatchMode>(
     options: Options,
     vdaf: V,
     http_client: reqwest::Client,
@@ -653,15 +652,9 @@ fn new_collector<V: vdaf::Collector>(
     Ok(collector)
 }
 
-fn print_collection<V: vdaf::Collector, B: BatchModeExt>(
+fn print_collection<V: vdaf::Collector, B: BatchMode>(
     collection: Collection<<V as Vdaf>::AggregateResult, B>,
 ) -> Result<(), Error> {
-    if !B::IS_PARTIAL_BATCH_SELECTOR_TRIVIAL {
-        println!(
-            "Batch: {}",
-            B::format_partial_batch_selector(collection.partial_batch_selector())
-        );
-    }
     let (start, duration) = collection.interval();
 
     println!("Number of reports: {}", collection.report_count());
@@ -688,31 +681,6 @@ fn install_tracing_subscriber() -> anyhow::Result<()> {
     LogTracer::init()?;
 
     Ok(())
-}
-
-trait BatchModeExt: BatchMode {
-    const IS_PARTIAL_BATCH_SELECTOR_TRIVIAL: bool;
-
-    fn format_partial_batch_selector(partial_batch_selector: &PartialBatchSelector<Self>)
-    -> String;
-}
-
-impl BatchModeExt for TimeInterval {
-    const IS_PARTIAL_BATCH_SELECTOR_TRIVIAL: bool = true;
-
-    fn format_partial_batch_selector(_: &PartialBatchSelector<Self>) -> String {
-        "()".to_string()
-    }
-}
-
-impl BatchModeExt for LeaderSelected {
-    const IS_PARTIAL_BATCH_SELECTOR_TRIVIAL: bool = false;
-
-    fn format_partial_batch_selector(
-        partial_batch_selector: &PartialBatchSelector<Self>,
-    ) -> String {
-        URL_SAFE_NO_PAD.encode(partial_batch_selector.batch_id().as_ref())
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The DAP spec dropped the field (https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/778); the response is now `{report_count, interval, leader_encrypted_agg_share, helper_encrypted_agg_share}`. Cascades into the collector's public Collection type, the collect CLI's batch-id output, and the interop collector, which can no longer observe a leader-selected batch ID from the response.

Fixes #4783