### PR TITLE
[DAP-18] Replace PartialBatchSelector with aggregation job extensions

### DIFF
--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -2318,15 +2318,11 @@ impl VdafOps {
             }
         }
 
-        // Recover the partial batch identifier from the extensions. In leader-selected batch mode
-        // this requires the `leader_selected_batch_id` extension; its absence is `invalidMessage`.
+        // Recover the partial batch identifier from the extensions. Leader-selected batch mode
+        // requires the `leader_selected_batch_id` extension; time-interval mode forbids it.
         let partial_batch_identifier =
-            B::partial_batch_identifier_from_extensions(req.extensions()).ok_or_else(|| {
-                Error::InvalidMessage(
-                    Some(*task.id()),
-                    "aggregation job is missing a required batch identifier extension",
-                )
-            })?;
+            B::partial_batch_identifier_from_extensions(req.extensions())
+                .map_err(|detail| Error::InvalidMessage(Some(*task.id()), detail))?;
 
         // Build initial aggregation job & report aggregations.
         let client_timestamp_interval = req

--- a/aggregator/src/aggregator.rs
+++ b/aggregator/src/aggregator.rs
@@ -52,11 +52,12 @@ use janus_core::{
 };
 use janus_messages::{
     AggregateShare, AggregateShareAad, AggregateShareId, AggregateShareReq,
-    AggregationJobContinueReq, AggregationJobId, AggregationJobInitializeReq, AggregationJobResp,
-    AggregationJobStep, CollectionJobExtension, CollectionJobId, CollectionJobReq,
-    CollectionJobResp, Duration, ExtensionType, HpkeConfig, HpkeConfigList, InputShareAad,
-    Interval, PlaintextInputShare, Report, ReportError, ReportUploadStatus, Role,
-    TaskConfiguration, TaskExtension, TaskId, UploadErrors, Url as DapUrl, VerifyResp,
+    AggregationJobContinueReq, AggregationJobExtensionType, AggregationJobId,
+    AggregationJobInitializeReq, AggregationJobResp, AggregationJobStep, CollectionJobExtension,
+    CollectionJobId, CollectionJobReq, CollectionJobResp, Duration, ExtensionType, HpkeConfig,
+    HpkeConfigList, InputShareAad, Interval, PlaintextInputShare, Report, ReportError,
+    ReportUploadStatus, Role, TaskConfiguration, TaskExtension, TaskId, UploadErrors,
+    Url as DapUrl, VerifyResp,
     batch_mode::{LeaderSelected, TimeInterval},
     extensions_are_strictly_increasing,
 };
@@ -2241,10 +2242,10 @@ impl VdafOps {
     {
         // Unwrap safety: SHA-256 computed by ring should always be 32 bytes.
         let request_hash = digest(&SHA256, req_bytes).as_ref().try_into().unwrap();
-        let req = AggregationJobInitializeReq::<B>::get_decoded(req_bytes)
-            .map_err(Error::MessageDecode)?;
+        let req =
+            AggregationJobInitializeReq::get_decoded(req_bytes).map_err(Error::MessageDecode)?;
 
-        Self::handle_aggregate_init_inner(
+        Self::handle_aggregate_init_inner::<SEED_SIZE, B, A, C>(
             datastore,
             hpke_keypairs,
             vdaf,
@@ -2263,10 +2264,7 @@ impl VdafOps {
 
     #[tracing::instrument(
         skip_all,
-        fields(
-            verification_key_id = req.verification_key_id(),
-            partial_batch_identifier = ?req.batch_selector().batch_identifier()
-        ),
+        fields(verification_key_id = req.verification_key_id()),
         err(level = Level::DEBUG)
     )]
     async fn handle_aggregate_init_inner<const SEED_SIZE: usize, B, A, C>(
@@ -2280,7 +2278,7 @@ impl VdafOps {
         aggregation_job_id: &AggregationJobId,
         require_taskbind_extension: bool,
         log_forbidden_mutations: Option<PathBuf>,
-        req: AggregationJobInitializeReq<B>,
+        req: AggregationJobInitializeReq,
         request_hash: [u8; 32],
     ) -> Result<Option<AggregationJobResp>, Error>
     where
@@ -2300,6 +2298,36 @@ impl VdafOps {
             }
         }
 
+        // Extensions are mandatory to support and strictly ordered; the helper aborts with
+        // `invalidMessage` (out of order) or `unsupportedExtension` (unrecognized) per §4.5.2.
+        if !req
+            .extensions()
+            .is_sorted_by(|a, b| a.extension_type() < b.extension_type())
+        {
+            return Err(Error::InvalidMessage(
+                Some(*task.id()),
+                "aggregation job extensions are not in strictly increasing order",
+            ));
+        }
+        for extension in req.extensions() {
+            if !extension.extension_type().is_supported() {
+                return Err(Error::UnsupportedExtension(
+                    Some(*task.id()),
+                    "unrecognized aggregation job extension type",
+                ));
+            }
+        }
+
+        // Recover the partial batch identifier from the extensions. In leader-selected batch mode
+        // this requires the `leader_selected_batch_id` extension; its absence is `invalidMessage`.
+        let partial_batch_identifier =
+            B::partial_batch_identifier_from_extensions(req.extensions()).ok_or_else(|| {
+                Error::InvalidMessage(
+                    Some(*task.id()),
+                    "aggregation job is missing a required batch identifier extension",
+                )
+            })?;
+
         // Build initial aggregation job & report aggregations.
         let client_timestamp_interval = req
             .verify_inits()
@@ -2313,7 +2341,7 @@ impl VdafOps {
             *aggregation_job_id,
             A::AggregationParam::get_decoded(req.aggregation_parameter())
                 .map_err(Error::MessageDecode)?,
-            req.batch_selector().batch_identifier().clone(),
+            partial_batch_identifier,
             client_timestamp_interval,
             AggregationJobState::AwaitingRequest,
             AggregationJobStep::from(0),
@@ -4276,6 +4304,17 @@ trait ExtensionTypeExt {
 impl ExtensionTypeExt for ExtensionType {
     fn is_supported(&self) -> bool {
         matches!(self, ExtensionType::Taskbind)
+    }
+}
+
+trait AggregationJobExtensionTypeExt {
+    /// Determines whether an aggregation job extension type is supported by this implementation.
+    fn is_supported(&self) -> bool;
+}
+
+impl AggregationJobExtensionTypeExt for AggregationJobExtensionType {
+    fn is_supported(&self) -> bool {
+        matches!(self, AggregationJobExtensionType::LeaderSelectedBatchId)
     }
 }
 

--- a/aggregator/src/aggregator/aggregation_job_continue.rs
+++ b/aggregator/src/aggregator/aggregation_job_continue.rs
@@ -381,8 +381,8 @@ mod tests {
     };
     use janus_messages::{
         AggregationJobContinueReq, AggregationJobId, AggregationJobInitializeReq,
-        AggregationJobResp, AggregationJobStep, Interval, PartialBatchSelector, Role,
-        VerifyContinue, VerifyResp, VerifyStepResult, batch_mode::TimeInterval,
+        AggregationJobResp, AggregationJobStep, Interval, Role, VerifyContinue, VerifyResp,
+        VerifyStepResult, batch_mode::TimeInterval,
     };
     use prio::{
         codec::Encode as _,
@@ -922,7 +922,7 @@ mod tests {
         let init_req = AggregationJobInitializeReq::new(
             0,
             test_case.aggregation_parameter.get_encoded().unwrap(),
-            PartialBatchSelector::new_time_interval(),
+            Vec::new(),
             Vec::from([verify_init_msg]),
         );
         let mut response = put_aggregation_job(

--- a/aggregator/src/aggregator/aggregation_job_driver.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver.rs
@@ -34,8 +34,8 @@ use janus_core::{
 };
 use janus_messages::{
     AggregationJobContinueReq, AggregationJobInitializeReq, AggregationJobResp, MediaType,
-    PartialBatchSelector, ReportError, ReportMetadata, ReportShare, Role, VerifyContinue,
-    VerifyInit, VerifyResp, VerifyStepResult,
+    ReportError, ReportMetadata, ReportShare, Role, VerifyContinue, VerifyInit, VerifyResp,
+    VerifyStepResult,
     batch_mode::{LeaderSelected, TimeInterval},
     extensions_are_strictly_increasing,
 };
@@ -646,14 +646,14 @@ where
 
         let (resp, retry_after) = if !verify_inits.is_empty() {
             // Construct request, send it to the helper, and process the response.
-            let request = AggregationJobInitializeReq::<B>::new(
+            let request = AggregationJobInitializeReq::new(
                 // Janus uses a single verification key per task.
                 0,
                 aggregation_job
                     .aggregation_parameter()
                     .get_encoded()
                     .map_err(Error::MessageEncode)?,
-                PartialBatchSelector::new(aggregation_job.partial_batch_identifier().clone()),
+                B::aggregation_job_extensions(aggregation_job.partial_batch_identifier()),
                 verify_inits,
             );
 
@@ -667,7 +667,7 @@ where
                     })?,
                 AGGREGATION_JOB_ROUTE,
                 Some(RequestBody {
-                    content_type: AggregationJobInitializeReq::<B>::MEDIA_TYPE,
+                    content_type: AggregationJobInitializeReq::MEDIA_TYPE,
                     body: Bytes::from(request.get_encoded().map_err(Error::MessageEncode)?),
                 }),
                 // The only way a task wouldn't have an aggregator auth token in it is in the

--- a/aggregator/src/aggregator/aggregation_job_driver/tests.rs
+++ b/aggregator/src/aggregator/aggregation_job_driver/tests.rs
@@ -34,10 +34,10 @@ use janus_core::{
     vdaf::{VERIFY_KEY_LENGTH_PRIO3, VdafInstance},
 };
 use janus_messages::{
-    AggregationJobContinueReq, AggregationJobInitializeReq, AggregationJobResp, AggregationJobStep,
-    Duration, Extension, ExtensionType, Interval, MediaType, PartialBatchSelector, ReportError,
-    ReportIdChecksum, ReportMetadata, ReportShare, Role, Time, TimePrecision, VerifyContinue,
-    VerifyInit, VerifyResp, VerifyStepResult,
+    AggregationJobContinueReq, AggregationJobExtension, AggregationJobInitializeReq,
+    AggregationJobResp, AggregationJobStep, Duration, Extension, ExtensionType, Interval,
+    MediaType, ReportError, ReportIdChecksum, ReportMetadata, ReportShare, Role, Time,
+    TimePrecision, VerifyContinue, VerifyInit, VerifyResp, VerifyStepResult,
     batch_mode::{LeaderSelected, TimeInterval},
     problem_type::DapProblemType,
 };
@@ -242,7 +242,7 @@ async fn aggregation_job_driver() {
     let helper_responses = Vec::from([
         (
             "PUT",
-            AggregationJobInitializeReq::<TimeInterval>::MEDIA_TYPE,
+            AggregationJobInitializeReq::MEDIA_TYPE,
             AggregationJobResp::MEDIA_TYPE,
             AggregationJobResp {
                 verify_resps: Vec::from([VerifyResp::new(
@@ -682,7 +682,7 @@ async fn leader_sync_time_interval_aggregation_job_init_single_step() {
     let leader_request = AggregationJobInitializeReq::new(
         0,
         ().get_encoded().unwrap(),
-        PartialBatchSelector::new_time_interval(),
+        Vec::new(),
         Vec::from([VerifyInit::new(
             ReportShare::new(
                 report.metadata().clone(),
@@ -728,7 +728,7 @@ async fn leader_sync_time_interval_aggregation_job_init_single_step() {
         .match_authentication_token(agg_auth_token)
         .match_header(
             CONTENT_TYPE.as_str(),
-            AggregationJobInitializeReq::<TimeInterval>::MEDIA_TYPE,
+            AggregationJobInitializeReq::MEDIA_TYPE,
         )
         .match_body(leader_request.get_encoded().unwrap())
         .with_status(201)
@@ -1077,7 +1077,7 @@ async fn leader_sync_time_interval_aggregation_job_init_two_steps() {
     let leader_request = AggregationJobInitializeReq::new(
         0,
         aggregation_param.get_encoded().unwrap(),
-        PartialBatchSelector::new_time_interval(),
+        Vec::new(),
         Vec::from([VerifyInit::new(
             ReportShare::new(
                 report.metadata().clone(),
@@ -1111,7 +1111,7 @@ async fn leader_sync_time_interval_aggregation_job_init_two_steps() {
         .match_authentication_token(agg_auth_token)
         .match_header(
             CONTENT_TYPE.as_str(),
-            AggregationJobInitializeReq::<TimeInterval>::MEDIA_TYPE,
+            AggregationJobInitializeReq::MEDIA_TYPE,
         )
         .match_body(leader_request.get_encoded().unwrap())
         .with_status(201)
@@ -1452,7 +1452,7 @@ async fn leader_sync_time_interval_aggregation_job_init_partially_garbage_collec
     let leader_request = AggregationJobInitializeReq::new(
         0,
         ().get_encoded().unwrap(),
-        PartialBatchSelector::new_time_interval(),
+        Vec::new(),
         Vec::from([
             VerifyInit::new(
                 ReportShare::new(
@@ -1510,7 +1510,7 @@ async fn leader_sync_time_interval_aggregation_job_init_partially_garbage_collec
         .match_authentication_token(agg_auth_token)
         .match_header(
             CONTENT_TYPE.as_str(),
-            AggregationJobInitializeReq::<TimeInterval>::MEDIA_TYPE,
+            AggregationJobInitializeReq::MEDIA_TYPE,
         )
         .match_body(leader_request.get_encoded().unwrap())
         .with_status(201)
@@ -1787,7 +1787,7 @@ async fn leader_sync_leader_selected_aggregation_job_init_single_step() {
     let leader_request = AggregationJobInitializeReq::new(
         0,
         ().get_encoded().unwrap(),
-        PartialBatchSelector::new_leader_selected(batch_id),
+        Vec::from([AggregationJobExtension::leader_selected_batch_id(&batch_id)]),
         Vec::from([VerifyInit::new(
             ReportShare::new(
                 report.metadata().clone(),
@@ -1833,7 +1833,7 @@ async fn leader_sync_leader_selected_aggregation_job_init_single_step() {
         .match_authentication_token(agg_auth_token)
         .match_header(
             CONTENT_TYPE.as_str(),
-            AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
+            AggregationJobInitializeReq::MEDIA_TYPE,
         )
         .match_body(leader_request.get_encoded().unwrap())
         .with_status(201)
@@ -2111,7 +2111,7 @@ async fn leader_sync_leader_selected_aggregation_job_init_two_steps() {
     let leader_request = AggregationJobInitializeReq::new(
         0,
         aggregation_param.get_encoded().unwrap(),
-        PartialBatchSelector::new_leader_selected(batch_id),
+        Vec::from([AggregationJobExtension::leader_selected_batch_id(&batch_id)]),
         Vec::from([VerifyInit::new(
             ReportShare::new(
                 report.metadata().clone(),
@@ -2145,7 +2145,7 @@ async fn leader_sync_leader_selected_aggregation_job_init_two_steps() {
         .match_authentication_token(agg_auth_token)
         .match_header(
             CONTENT_TYPE.as_str(),
-            AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
+            AggregationJobInitializeReq::MEDIA_TYPE,
         )
         .match_body(leader_request.get_encoded().unwrap())
         .with_status(201)
@@ -3037,7 +3037,7 @@ async fn leader_async_aggregation_job_init_to_pending() {
     let leader_request = AggregationJobInitializeReq::new(
         0,
         aggregation_param.get_encoded().unwrap(),
-        PartialBatchSelector::new_time_interval(),
+        Vec::new(),
         Vec::from([VerifyInit::new(
             ReportShare::new(
                 report.metadata().clone(),
@@ -3060,7 +3060,7 @@ async fn leader_async_aggregation_job_init_to_pending() {
         .match_authentication_token(agg_auth_token)
         .match_header(
             CONTENT_TYPE.as_str(),
-            AggregationJobInitializeReq::<TimeInterval>::MEDIA_TYPE,
+            AggregationJobInitializeReq::MEDIA_TYPE,
         )
         .match_body(leader_request.get_encoded().unwrap())
         .with_status(201)
@@ -3295,7 +3295,7 @@ async fn leader_async_aggregation_job_init_to_pending_two_step() {
     let leader_request = AggregationJobInitializeReq::new(
         0,
         aggregation_param.get_encoded().unwrap(),
-        PartialBatchSelector::new_time_interval(),
+        Vec::new(),
         Vec::from([VerifyInit::new(
             ReportShare::new(
                 report.metadata().clone(),
@@ -3318,7 +3318,7 @@ async fn leader_async_aggregation_job_init_to_pending_two_step() {
         .match_authentication_token(agg_auth_token)
         .match_header(
             CONTENT_TYPE.as_str(),
-            AggregationJobInitializeReq::<TimeInterval>::MEDIA_TYPE,
+            AggregationJobInitializeReq::MEDIA_TYPE,
         )
         .match_body(leader_request.get_encoded().unwrap())
         .with_status(201)
@@ -6399,7 +6399,7 @@ async fn abandon_failing_aggregation_job_with_retryable_error() {
         .match_authentication_token(agg_auth_token)
         .match_header(
             CONTENT_TYPE.as_str(),
-            AggregationJobInitializeReq::<TimeInterval>::MEDIA_TYPE,
+            AggregationJobInitializeReq::MEDIA_TYPE,
         )
         .with_status(500)
         .expect(3)
@@ -6418,7 +6418,7 @@ async fn abandon_failing_aggregation_job_with_retryable_error() {
         .match_authentication_token(agg_auth_token)
         .match_header(
             CONTENT_TYPE.as_str(),
-            AggregationJobInitializeReq::<TimeInterval>::MEDIA_TYPE,
+            AggregationJobInitializeReq::MEDIA_TYPE,
         )
         .with_status(500)
         .expect(1)
@@ -6651,7 +6651,7 @@ async fn abandon_failing_aggregation_job_with_fatal_error() {
         .match_authentication_token(agg_auth_token)
         .match_header(
             CONTENT_TYPE.as_str(),
-            AggregationJobInitializeReq::<TimeInterval>::MEDIA_TYPE,
+            AggregationJobInitializeReq::MEDIA_TYPE,
         )
         .with_status(404)
         .expect(1)
@@ -6670,7 +6670,7 @@ async fn abandon_failing_aggregation_job_with_fatal_error() {
         .match_authentication_token(agg_auth_token)
         .match_header(
             CONTENT_TYPE.as_str(),
-            AggregationJobInitializeReq::<TimeInterval>::MEDIA_TYPE,
+            AggregationJobInitializeReq::MEDIA_TYPE,
         )
         .with_status(500)
         .expect(1)

--- a/aggregator/src/aggregator/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/aggregation_job_init.rs
@@ -567,7 +567,6 @@ pub mod test_util {
     use janus_messages::{
         AggregationJobId, AggregationJobInitializeReq, Extension, HpkeConfig, MediaType,
         ReportMetadata, ReportShare, VerifyInit,
-        batch_mode::{self},
     };
     use prio::{
         codec::Encode,
@@ -690,10 +689,10 @@ pub mod test_util {
         }
     }
 
-    pub async fn put_aggregation_job<B: batch_mode::BatchMode>(
+    pub async fn put_aggregation_job(
         task: &Task,
         aggregation_job_id: &AggregationJobId,
-        aggregation_job: &AggregationJobInitializeReq<B>,
+        aggregation_job: &AggregationJobInitializeReq,
         router: &Router,
     ) -> http::Response<Body> {
         let request = Request::builder()
@@ -706,7 +705,7 @@ pub mod test_util {
             .with_authentication_token(task.aggregator_auth_token())
             .header(
                 header::CONTENT_TYPE,
-                AggregationJobInitializeReq::<B>::MEDIA_TYPE,
+                AggregationJobInitializeReq::MEDIA_TYPE,
             )
             .body(Body::from(aggregation_job.get_encoded().unwrap()))
             .unwrap();
@@ -737,9 +736,10 @@ mod tests {
         vdaf::VdafInstance,
     };
     use janus_messages::{
-        AggregationJobId, AggregationJobInitializeReq, AggregationJobResp, Duration, Extension,
-        ExtensionType, Interval, MediaType, PartialBatchSelector, ReportError, ReportMetadata,
-        TimePrecision, VerifyResp, VerifyStepResult, batch_mode::TimeInterval,
+        AggregationJobExtension, AggregationJobExtensionType, AggregationJobId,
+        AggregationJobInitializeReq, AggregationJobResp, Duration, Extension, ExtensionType,
+        Interval, MediaType, ReportError, ReportMetadata, TimePrecision, VerifyResp,
+        VerifyStepResult,
     };
     use prio::{
         codec::Encode,
@@ -766,7 +766,7 @@ mod tests {
         pub(super) task: Task,
         pub(super) verify_init_generator: VerifyInitGenerator<VERIFY_KEY_SIZE, V>,
         pub(super) aggregation_job_id: AggregationJobId,
-        pub(super) aggregation_job_init_req: AggregationJobInitializeReq<TimeInterval>,
+        pub(super) aggregation_job_init_req: AggregationJobInitializeReq,
         aggregation_job_init_resp: Option<AggregationJobResp>,
         pub(super) aggregation_param: V::AggregationParam,
         pub(super) router: Router,
@@ -894,7 +894,7 @@ mod tests {
         let aggregation_job_init_req = AggregationJobInitializeReq::new(
             0,
             aggregation_param.get_encoded().unwrap(),
-            PartialBatchSelector::new_time_interval(),
+            Vec::new(),
             verify_inits.clone(),
         );
 
@@ -934,7 +934,7 @@ mod tests {
             .with_authentication_token(test_case.task.aggregator_auth_token())
             .header(
                 header::CONTENT_TYPE,
-                AggregationJobInitializeReq::<TimeInterval>::MEDIA_TYPE,
+                AggregationJobInitializeReq::MEDIA_TYPE,
             )
             .body(Body::from(
                 test_case.aggregation_job_init_req.get_encoded().unwrap(),
@@ -984,7 +984,7 @@ mod tests {
                     )
                     .header(
                         header::CONTENT_TYPE,
-                        AggregationJobInitializeReq::<TimeInterval>::MEDIA_TYPE,
+                        AggregationJobInitializeReq::MEDIA_TYPE,
                     )
                     .body(Body::from(
                         test_case.aggregation_job_init_req.get_encoded().unwrap(),
@@ -1021,7 +1021,7 @@ mod tests {
         let aggregation_job_init_req = AggregationJobInitializeReq::new(
             0,
             dummy::AggregationParam(1).get_encoded().unwrap(),
-            PartialBatchSelector::new_time_interval(),
+            Vec::new(),
             Vec::from([verify_init]),
         );
 
@@ -1053,7 +1053,7 @@ mod tests {
         let mutated_aggregation_job_init_req = AggregationJobInitializeReq::new(
             0,
             dummy::AggregationParam(1).get_encoded().unwrap(),
-            PartialBatchSelector::new_time_interval(),
+            Vec::new(),
             test_case.aggregation_job_init_req.verify_inits().to_vec(),
         );
 
@@ -1092,7 +1092,7 @@ mod tests {
             let mutated_aggregation_job_init_req = AggregationJobInitializeReq::new(
                 0,
                 test_case.aggregation_param.get_encoded().unwrap(),
-                PartialBatchSelector::new_time_interval(),
+                Vec::new(),
                 mutated_verify_inits,
             );
             let response = put_aggregation_job(
@@ -1130,7 +1130,7 @@ mod tests {
         let mutated_aggregation_job_init_req = AggregationJobInitializeReq::new(
             0,
             test_case.aggregation_param.get_encoded().unwrap(),
-            PartialBatchSelector::new_time_interval(),
+            Vec::new(),
             mutated_verify_inits,
         );
 
@@ -1158,7 +1158,7 @@ mod tests {
         test_case.aggregation_job_init_req = AggregationJobInitializeReq::new(
             0,
             test_case.aggregation_param.get_encoded().unwrap(),
-            PartialBatchSelector::new_time_interval(),
+            Vec::new(),
             Vec::from([
                 // Barely tolerable.
                 test_case
@@ -1285,7 +1285,7 @@ mod tests {
         let aggregation_job_init_req = AggregationJobInitializeReq::new(
             0,
             aggregation_param.get_encoded().unwrap(),
-            PartialBatchSelector::new_time_interval(),
+            Vec::new(),
             Vec::from([
                 // Report with timestamp before task end should be accepted.
                 verify_init_generator
@@ -1433,7 +1433,7 @@ mod tests {
         let aggregation_job_init_req = AggregationJobInitializeReq::new(
             0,
             aggregation_param.get_encoded().unwrap(),
-            PartialBatchSelector::new_time_interval(),
+            Vec::new(),
             Vec::from([
                 // Report with timestamp after task start should be accepted.
                 verify_init_generator
@@ -1486,41 +1486,60 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn aggregation_job_init_wrong_query() {
+    async fn aggregation_job_init_out_of_order_extensions() {
         let test_case = setup_aggregate_init_test().await;
 
-        // setup_aggregate_init_test sets up a task with a time interval query. We send a
-        // leader-selected query which should yield an error.
-        let wrong_query = AggregationJobInitializeReq::new(
+        // Extensions must be in strictly increasing order of extension type; a decreasing pair is
+        // an `invalidMessage`.
+        let request = AggregationJobInitializeReq::new(
             0,
             test_case.aggregation_param.get_encoded().unwrap(),
-            PartialBatchSelector::new_leader_selected(random()),
+            Vec::from([
+                AggregationJobExtension::new(AggregationJobExtensionType::from(2), Vec::new()),
+                AggregationJobExtension::new(AggregationJobExtensionType::from(1), Vec::new()),
+            ]),
             test_case.aggregation_job_init_req.verify_inits().to_vec(),
         );
 
-        let req = Request::builder()
-            .method("PUT")
-            .uri(
-                test_case
-                    .task
-                    .aggregation_job_uri(&random(), None)
-                    .unwrap()
-                    .path(),
-            )
-            .with_authentication_token(test_case.task.aggregator_auth_token())
-            .header(
-                header::CONTENT_TYPE,
-                AggregationJobInitializeReq::<TimeInterval>::MEDIA_TYPE,
-            )
-            .body(Body::from(wrong_query.get_encoded().unwrap()))
-            .unwrap();
-        let mut response = test_case.router.clone().oneshot(req).await.unwrap();
+        let mut response =
+            put_aggregation_job(&test_case.task, &random(), &request, &test_case.router).await;
         assert_eq!(
             take_problem_details(&mut response).await,
             json!({
                 "status": StatusCode::BAD_REQUEST.as_u16(),
                 "type": "urn:ietf:params:ppm:dap:error:invalidMessage",
                 "title": "The message type for a response was incorrect or the payload was malformed.",
+                "taskid": format!("{}", test_case.task.id()),
+                "detail": "aggregation job extensions are not in strictly increasing order",
+            }),
+        );
+    }
+
+    #[tokio::test]
+    async fn aggregation_job_init_unsupported_extension() {
+        let test_case = setup_aggregate_init_test().await;
+
+        // An extension type the helper does not recognize is an `unsupportedExtension`.
+        let request = AggregationJobInitializeReq::new(
+            0,
+            test_case.aggregation_param.get_encoded().unwrap(),
+            Vec::from([AggregationJobExtension::new(
+                AggregationJobExtensionType::from(0xffff),
+                Vec::new(),
+            )]),
+            test_case.aggregation_job_init_req.verify_inits().to_vec(),
+        );
+
+        let mut response =
+            put_aggregation_job(&test_case.task, &random(), &request, &test_case.router).await;
+        assert_eq!(
+            take_problem_details(&mut response).await,
+            json!({
+                "status": StatusCode::BAD_REQUEST.as_u16(),
+                "type": "urn:ietf:params:ppm:dap:error:unsupportedExtension",
+                "title": "The message includes an unsupported extension.",
+                "taskid": format!("{}", test_case.task.id()),
+                "detail": "unrecognized aggregation job extension type",
             }),
         );
     }

--- a/aggregator/src/aggregator/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/aggregation_job_init.rs
@@ -1486,6 +1486,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn aggregation_job_init_unexpected_batch_id_extension() {
+        let test_case = setup_aggregate_init_test().await;
+
+        // A time-interval task has no use for a `leader_selected_batch_id` extension and rejects
+        // it as an `invalidMessage`.
+        let request = AggregationJobInitializeReq::new(
+            0,
+            test_case.aggregation_param.get_encoded().unwrap(),
+            Vec::from([AggregationJobExtension::leader_selected_batch_id(&random())]),
+            test_case.aggregation_job_init_req.verify_inits().to_vec(),
+        );
+
+        let mut response =
+            put_aggregation_job(&test_case.task, &random(), &request, &test_case.router).await;
+        assert_eq!(
+            take_problem_details(&mut response).await,
+            json!({
+                "status": StatusCode::BAD_REQUEST.as_u16(),
+                "type": "urn:ietf:params:ppm:dap:error:invalidMessage",
+                "title": "The message type for a response was incorrect or the payload was malformed.",
+                "taskid": format!("{}", test_case.task.id()),
+                "detail": "unexpected leader_selected_batch_id extension for time-interval batch mode",
+            }),
+        );
+    }
+
+    #[tokio::test]
     async fn aggregation_job_init_out_of_order_extensions() {
         let test_case = setup_aggregate_init_test().await;
 

--- a/aggregator/src/aggregator/http_handlers.rs
+++ b/aggregator/src/aggregator/http_handlers.rs
@@ -761,7 +761,7 @@ async fn aggregation_jobs_put<C: Clock>(
     AxumState(aggregator): AxumState<Arc<Aggregator<C>>>,
     body: Bytes,
 ) -> Result<Response, Error> {
-    validate_content_type_headers::<AggregationJobInitializeReq<TimeInterval>>(&headers)?;
+    validate_content_type_headers::<AggregationJobInitializeReq>(&headers)?;
 
     let task_id = path.task_id;
     let aggregation_job_id = path.aggregation_job_id;

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
@@ -1129,7 +1129,7 @@ async fn aggregate_init_leader_selected_missing_batch_id() {
             "type": "urn:ietf:params:ppm:dap:error:invalidMessage",
             "title": "The message type for a response was incorrect or the payload was malformed.",
             "taskid": format!("{}", task.id()),
-            "detail": "aggregation job is missing a required batch identifier extension",
+            "detail": "missing leader_selected_batch_id extension",
         }),
     );
 }
@@ -1202,7 +1202,7 @@ async fn aggregate_init_leader_selected_malformed_batch_id() {
             "type": "urn:ietf:params:ppm:dap:error:invalidMessage",
             "title": "The message type for a response was incorrect or the payload was malformed.",
             "taskid": format!("{}", task.id()),
-            "detail": "aggregation job is missing a required batch identifier extension",
+            "detail": "malformed leader_selected_batch_id extension",
         }),
     );
 }

--- a/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/aggregation_job_init.rs
@@ -23,10 +23,11 @@ use janus_core::{
     vdaf::VdafInstance,
 };
 use janus_messages::{
-    AggregateShareReq, AggregationJobId, AggregationJobInitializeReq, AggregationJobResp, BatchId,
-    BatchSelector, CollectionJobReq, Extension, ExtensionType, HpkeCiphertext, HpkeConfigId,
-    InputShareAad, Interval, MediaType, PartialBatchSelector, Query, ReportError, ReportIdChecksum,
-    ReportMetadata, ReportShare, Role, Time, VerifyInit, VerifyStepResult,
+    AggregateShareReq, AggregationJobExtension, AggregationJobExtensionType, AggregationJobId,
+    AggregationJobInitializeReq, AggregationJobResp, BatchId, BatchSelector, CollectionJobReq,
+    Extension, ExtensionType, HpkeCiphertext, HpkeConfigId, InputShareAad, Interval, MediaType,
+    Query, ReportError, ReportIdChecksum, ReportMetadata, ReportShare, Role, Time, VerifyInit,
+    VerifyStepResult,
     batch_mode::{LeaderSelected, TimeInterval},
 };
 use prio::{codec::Encode, vdaf::dummy};
@@ -69,12 +70,7 @@ async fn aggregate_leader() {
         .await
         .unwrap();
 
-    let request = AggregationJobInitializeReq::new(
-        0,
-        Vec::new(),
-        PartialBatchSelector::new_time_interval(),
-        Vec::new(),
-    );
+    let request = AggregationJobInitializeReq::new(0, Vec::new(), Vec::new(), Vec::new());
     let aggregation_job_id: AggregationJobId = random();
 
     let mut response = put_aggregation_job(&task, &aggregation_job_id, &request, &router).await;
@@ -163,12 +159,7 @@ async fn aggregate_wrong_agg_auth_token() {
         .await
         .unwrap();
 
-    let request = AggregationJobInitializeReq::new(
-        0,
-        Vec::new(),
-        PartialBatchSelector::new_time_interval(),
-        Vec::new(),
-    );
+    let request = AggregationJobInitializeReq::new(0, Vec::new(), Vec::new(), Vec::new());
     let aggregation_job_id: AggregationJobId = random();
 
     let wrong_token_value = AuthenticationToken::DapAuth(random());
@@ -191,10 +182,7 @@ async fn aggregate_wrong_agg_auth_token() {
                     .unwrap()
                     .path(),
             )
-            .header(
-                "content-type",
-                AggregationJobInitializeReq::<TimeInterval>::MEDIA_TYPE,
-            )
+            .header("content-type", AggregationJobInitializeReq::MEDIA_TYPE)
             .body(Body::from(request.get_encoded().unwrap()))
             .unwrap();
 
@@ -599,7 +587,7 @@ async fn aggregate_init_sync() {
     let request = AggregationJobInitializeReq::new(
         0,
         aggregation_param.get_encoded().unwrap(),
-        PartialBatchSelector::new_time_interval(),
+        Vec::new(),
         Vec::from([
             verify_init_0.clone(),
             verify_init_1.clone(),
@@ -866,7 +854,7 @@ async fn aggregate_init_async() {
     let request = AggregationJobInitializeReq::new(
         0,
         aggregation_param.get_encoded().unwrap(),
-        PartialBatchSelector::new_time_interval(),
+        Vec::new(),
         Vec::from([verify_init_0.clone(), verify_init_1.clone()]),
     );
 
@@ -999,7 +987,7 @@ async fn aggregate_init_batch_already_collected() {
     let request = AggregationJobInitializeReq::new(
         0,
         aggregation_param.get_encoded().unwrap(),
-        PartialBatchSelector::new_leader_selected(batch_id),
+        Vec::from([AggregationJobExtension::leader_selected_batch_id(&batch_id)]),
         Vec::from([verify_init.clone()]),
     );
 
@@ -1049,7 +1037,7 @@ async fn aggregate_init_batch_already_collected() {
         .with_authentication_token(task.aggregator_auth_token())
         .header(
             http::header::CONTENT_TYPE,
-            AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
+            AggregationJobInitializeReq::MEDIA_TYPE,
         )
         .body(Body::from(request.get_encoded().unwrap()))
         .unwrap();
@@ -1074,6 +1062,149 @@ async fn aggregate_init_batch_already_collected() {
 
     assert_task_aggregation_counter(&datastore, *task.id(), TaskAggregationCounter::default())
         .await;
+}
+
+#[tokio::test]
+async fn aggregate_init_leader_selected_missing_batch_id() {
+    let HttpHandlerTest {
+        clock,
+        ephemeral_datastore: _ephemeral_datastore,
+        datastore,
+        router,
+        hpke_keypair,
+        ..
+    } = HttpHandlerTest::new().await;
+
+    let task = TaskBuilder::new(
+        BatchMode::LeaderSelected {
+            batch_time_window_size: None,
+        },
+        AggregationMode::Synchronous,
+        VdafInstance::Fake { rounds: 1 },
+    )
+    .build();
+
+    let helper_task = task.helper_view().unwrap();
+    datastore.put_aggregator_task(&helper_task).await.unwrap();
+
+    let verify_init_generator = VerifyInitGenerator::new(
+        clock.clone(),
+        helper_task.clone(),
+        hpke_keypair.config().clone(),
+        dummy::Vdaf::new(1),
+        dummy::AggregationParam(0),
+    );
+    let (verify_init, _) = verify_init_generator.next(&0);
+
+    // A leader-selected aggregation job that omits the `leader_selected_batch_id` extension is an
+    // `invalidMessage`.
+    let request = AggregationJobInitializeReq::new(
+        0,
+        dummy::AggregationParam(0).get_encoded().unwrap(),
+        Vec::new(),
+        Vec::from([verify_init]),
+    );
+
+    let aggregation_job_id: AggregationJobId = random();
+    let req = Request::builder()
+        .method(Method::PUT)
+        .uri(
+            task.aggregation_job_uri(&aggregation_job_id, None)
+                .unwrap()
+                .path(),
+        )
+        .with_authentication_token(task.aggregator_auth_token())
+        .header(
+            http::header::CONTENT_TYPE,
+            AggregationJobInitializeReq::MEDIA_TYPE,
+        )
+        .body(Body::from(request.get_encoded().unwrap()))
+        .unwrap();
+    let mut response = router.clone().oneshot(req).await.unwrap();
+
+    assert_eq!(
+        take_problem_details(&mut response).await,
+        json!({
+            "status": StatusCode::BAD_REQUEST.as_u16(),
+            "type": "urn:ietf:params:ppm:dap:error:invalidMessage",
+            "title": "The message type for a response was incorrect or the payload was malformed.",
+            "taskid": format!("{}", task.id()),
+            "detail": "aggregation job is missing a required batch identifier extension",
+        }),
+    );
+}
+
+#[tokio::test]
+async fn aggregate_init_leader_selected_malformed_batch_id() {
+    let HttpHandlerTest {
+        clock,
+        ephemeral_datastore: _ephemeral_datastore,
+        datastore,
+        router,
+        hpke_keypair,
+        ..
+    } = HttpHandlerTest::new().await;
+
+    let task = TaskBuilder::new(
+        BatchMode::LeaderSelected {
+            batch_time_window_size: None,
+        },
+        AggregationMode::Synchronous,
+        VdafInstance::Fake { rounds: 1 },
+    )
+    .build();
+
+    let helper_task = task.helper_view().unwrap();
+    datastore.put_aggregator_task(&helper_task).await.unwrap();
+
+    let verify_init_generator = VerifyInitGenerator::new(
+        clock.clone(),
+        helper_task.clone(),
+        hpke_keypair.config().clone(),
+        dummy::Vdaf::new(1),
+        dummy::AggregationParam(0),
+    );
+    let (verify_init, _) = verify_init_generator.next(&0);
+
+    // A `leader_selected_batch_id` extension whose payload is not a valid (32-byte) batch ID is an
+    // `invalidMessage`.
+    let request = AggregationJobInitializeReq::new(
+        0,
+        dummy::AggregationParam(0).get_encoded().unwrap(),
+        Vec::from([AggregationJobExtension::new(
+            AggregationJobExtensionType::LeaderSelectedBatchId,
+            Vec::from([1, 2, 3]),
+        )]),
+        Vec::from([verify_init]),
+    );
+
+    let aggregation_job_id: AggregationJobId = random();
+    let req = Request::builder()
+        .method(Method::PUT)
+        .uri(
+            task.aggregation_job_uri(&aggregation_job_id, None)
+                .unwrap()
+                .path(),
+        )
+        .with_authentication_token(task.aggregator_auth_token())
+        .header(
+            http::header::CONTENT_TYPE,
+            AggregationJobInitializeReq::MEDIA_TYPE,
+        )
+        .body(Body::from(request.get_encoded().unwrap()))
+        .unwrap();
+    let mut response = router.clone().oneshot(req).await.unwrap();
+
+    assert_eq!(
+        take_problem_details(&mut response).await,
+        json!({
+            "status": StatusCode::BAD_REQUEST.as_u16(),
+            "type": "urn:ietf:params:ppm:dap:error:invalidMessage",
+            "title": "The message type for a response was incorrect or the payload was malformed.",
+            "taskid": format!("{}", task.id()),
+            "detail": "aggregation job is missing a required batch identifier extension",
+        }),
+    );
 }
 
 #[tokio::test]
@@ -1108,7 +1239,7 @@ async fn aggregate_init_verify_init_failed() {
     let request = AggregationJobInitializeReq::new(
         0,
         dummy::AggregationParam(0).get_encoded().unwrap(),
-        PartialBatchSelector::new_time_interval(),
+        Vec::new(),
         Vec::from([verify_init.clone()]),
     );
 
@@ -1175,7 +1306,7 @@ async fn aggregate_init_verify_step_failed() {
     let request = AggregationJobInitializeReq::new(
         0,
         dummy::AggregationParam(0).get_encoded().unwrap(),
-        PartialBatchSelector::new_time_interval(),
+        Vec::new(),
         Vec::from([verify_init.clone()]),
     );
 
@@ -1243,7 +1374,7 @@ async fn aggregate_init_duplicated_report_id() {
     let request = AggregationJobInitializeReq::new(
         0,
         dummy::AggregationParam(0).get_encoded().unwrap(),
-        PartialBatchSelector::new_time_interval(),
+        Vec::new(),
         Vec::from([verify_init.clone(), verify_init]),
     );
     let aggregation_job_id: AggregationJobId = random();
@@ -1297,7 +1428,7 @@ async fn aggregate_init_partially_replayed_aggregation_init() {
 
     let batch_id = BatchId::from([12; 32]);
     let agg_param = dummy::AggregationParam(0).get_encoded().unwrap();
-    let partial_batch_selector = PartialBatchSelector::new_leader_selected(batch_id);
+    let extensions = Vec::from([AggregationJobExtension::leader_selected_batch_id(&batch_id)]);
 
     let helper_task = task.helper_view().unwrap();
     let verify_init_generator = VerifyInitGenerator::new(
@@ -1329,7 +1460,7 @@ async fn aggregate_init_partially_replayed_aggregation_init() {
     let request = AggregationJobInitializeReq::new(
         0,
         agg_param.clone(),
-        partial_batch_selector.clone(),
+        extensions.clone(),
         Vec::from([verify_init_1.clone(), verify_init_2.clone()]),
     );
 
@@ -1354,7 +1485,7 @@ async fn aggregate_init_partially_replayed_aggregation_init() {
     let request = AggregationJobInitializeReq::new(
         0,
         agg_param.clone(),
-        partial_batch_selector,
+        extensions,
         Vec::from([
             verify_init_1.clone(),
             verify_init_2.clone(),

--- a/aggregator/src/aggregator/http_handlers/tests/helper_e2e.rs
+++ b/aggregator/src/aggregator/http_handlers/tests/helper_e2e.rs
@@ -3,8 +3,8 @@ use http::StatusCode;
 use janus_aggregator_core::task::{AggregationMode, BatchMode, test_util::TaskBuilder};
 use janus_core::{report_id::ReportIdChecksumExt, vdaf::VdafInstance};
 use janus_messages::{
-    AggregateShareId, AggregateShareReq, AggregationJobInitializeReq, AggregationJobResp,
-    BatchSelector, CollectionJobReq, PartialBatchSelector, Query, ReportError, ReportIdChecksum,
+    AggregateShareId, AggregateShareReq, AggregationJobExtension, AggregationJobInitializeReq,
+    AggregationJobResp, BatchSelector, CollectionJobReq, Query, ReportError, ReportIdChecksum,
     VerifyStepResult, batch_mode::LeaderSelected,
 };
 use prio::{
@@ -68,13 +68,17 @@ async fn helper_aggregation_report_share_replay() {
     let agg_init_req_1 = AggregationJobInitializeReq::new(
         0,
         agg_param.get_encoded().unwrap(),
-        PartialBatchSelector::new_leader_selected(batch_id_1),
+        Vec::from([AggregationJobExtension::leader_selected_batch_id(
+            &batch_id_1,
+        )]),
         Vec::from([replayed_report.clone(), other_report_1.clone()]),
     );
     let agg_init_req_2 = AggregationJobInitializeReq::new(
         0,
         agg_param.get_encoded().unwrap(),
-        PartialBatchSelector::new_leader_selected(batch_id_2),
+        Vec::from([AggregationJobExtension::leader_selected_batch_id(
+            &batch_id_2,
+        )]),
         Vec::from([replayed_report.clone(), other_report_2.clone()]),
     );
 

--- a/aggregator/src/aggregator/taskprov_tests.rs
+++ b/aggregator/src/aggregator/taskprov_tests.rs
@@ -36,12 +36,12 @@ use janus_core::{
 };
 use janus_messages::{
     AggregateShare as AggregateShareMessage, AggregateShareAad, AggregateShareId,
-    AggregateShareReq, AggregationJobContinueReq, AggregationJobId, AggregationJobInitializeReq,
-    AggregationJobResp, AggregationJobStep, BatchConfig, BatchSelector, CollectionJobReq, Duration,
-    Extension, ExtensionType, Interval, MediaType, PartialBatchSelector, Query, ReportError,
-    ReportIdChecksum, ReportShare, Role, TaskConfiguration, TaskConfigurationBuilder,
-    TaskExtension, TaskExtensionType, TaskId, Time, TimePrecision, VdafConfig, VerifyContinue,
-    VerifyInit, VerifyResp, VerifyStepResult,
+    AggregateShareReq, AggregationJobContinueReq, AggregationJobExtension, AggregationJobId,
+    AggregationJobInitializeReq, AggregationJobResp, AggregationJobStep, BatchConfig,
+    BatchSelector, CollectionJobReq, Duration, Extension, ExtensionType, Interval, MediaType,
+    Query, ReportError, ReportIdChecksum, ReportShare, Role, TaskConfiguration,
+    TaskConfigurationBuilder, TaskExtension, TaskExtensionType, TaskId, Time, TimePrecision,
+    VdafConfig, VerifyContinue, VerifyInit, VerifyResp, VerifyStepResult,
     batch_mode::LeaderSelected,
     codec::{Decode, Encode},
 };
@@ -286,7 +286,9 @@ async fn taskprov_aggregate_init() {
     let request_1 = AggregationJobInitializeReq::new(
         0,
         aggregation_param_1.get_encoded().unwrap(),
-        PartialBatchSelector::new_leader_selected(batch_id_1),
+        Vec::from([AggregationJobExtension::leader_selected_batch_id(
+            &batch_id_1,
+        )]),
         Vec::from([VerifyInit::new(
             report_share_1.clone(),
             transcript_1.leader_verify_transitions[0]
@@ -302,7 +304,9 @@ async fn taskprov_aggregate_init() {
     let request_2 = AggregationJobInitializeReq::new(
         0,
         aggregation_param_2.get_encoded().unwrap(),
-        PartialBatchSelector::new_leader_selected(batch_id_2),
+        Vec::from([AggregationJobExtension::leader_selected_batch_id(
+            &batch_id_2,
+        )]),
         Vec::from([VerifyInit::new(
             report_share_2.clone(),
             transcript_2.leader_verify_transitions[0]
@@ -330,10 +334,7 @@ async fn taskprov_aggregate_init() {
                             .path(),
                     )
                     .header(AUTHORIZATION, "Bearer invalid_token")
-                    .header(
-                        CONTENT_TYPE,
-                        AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
-                    )
+                    .header(CONTENT_TYPE, AggregationJobInitializeReq::MEDIA_TYPE)
                     .header(
                         TASKPROV_HEADER,
                         URL_SAFE_NO_PAD.encode(test.task_config.get_encoded().unwrap()),
@@ -358,10 +359,7 @@ async fn taskprov_aggregate_init() {
                             .path(),
                     )
                     .with_authentication_token(test.peer_aggregator.primary_aggregator_auth_token())
-                    .header(
-                        CONTENT_TYPE,
-                        AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
-                    )
+                    .header(CONTENT_TYPE, AggregationJobInitializeReq::MEDIA_TYPE)
                     .header(
                         TASKPROV_HEADER,
                         URL_SAFE_NO_PAD.encode(test.task_config.get_encoded().unwrap()),
@@ -460,7 +458,7 @@ async fn taskprov_aggregate_init_without_task_interval() {
     let request = AggregationJobInitializeReq::new(
         0,
         aggregation_param.get_encoded().unwrap(),
-        PartialBatchSelector::new_leader_selected(batch_id),
+        Vec::from([AggregationJobExtension::leader_selected_batch_id(&batch_id)]),
         Vec::from([VerifyInit::new(
             report_share.clone(),
             transcript.leader_verify_transitions[0]
@@ -484,10 +482,7 @@ async fn taskprov_aggregate_init_without_task_interval() {
                         .path(),
                 )
                 .with_authentication_token(test.peer_aggregator.primary_aggregator_auth_token())
-                .header(
-                    CONTENT_TYPE,
-                    AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
-                )
+                .header(CONTENT_TYPE, AggregationJobInitializeReq::MEDIA_TYPE)
                 .header(
                     TASKPROV_HEADER,
                     URL_SAFE_NO_PAD.encode(test.task_config.get_encoded().unwrap()),
@@ -523,7 +518,7 @@ async fn taskprov_aggregate_init_missing_extension() {
     let request = AggregationJobInitializeReq::new(
         0,
         aggregation_param.get_encoded().unwrap(),
-        PartialBatchSelector::new_leader_selected(batch_id),
+        Vec::from([AggregationJobExtension::leader_selected_batch_id(&batch_id)]),
         Vec::from([VerifyInit::new(
             report_share.clone(),
             transcript.leader_verify_transitions[0]
@@ -547,10 +542,7 @@ async fn taskprov_aggregate_init_missing_extension() {
                         .path(),
                 )
                 .with_authentication_token(test.peer_aggregator.primary_aggregator_auth_token())
-                .header(
-                    CONTENT_TYPE,
-                    AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
-                )
+                .header(CONTENT_TYPE, AggregationJobInitializeReq::MEDIA_TYPE)
                 .header(
                     TASKPROV_HEADER,
                     URL_SAFE_NO_PAD.encode(test.task_config.get_encoded().unwrap()),
@@ -623,7 +615,7 @@ async fn taskprov_aggregate_init_malformed_extension() {
     let request = AggregationJobInitializeReq::new(
         0,
         aggregation_param.get_encoded().unwrap(),
-        PartialBatchSelector::new_leader_selected(batch_id),
+        Vec::from([AggregationJobExtension::leader_selected_batch_id(&batch_id)]),
         Vec::from([VerifyInit::new(
             report_share.clone(),
             transcript.leader_verify_transitions[0]
@@ -647,10 +639,7 @@ async fn taskprov_aggregate_init_malformed_extension() {
                         .path(),
                 )
                 .with_authentication_token(test.peer_aggregator.primary_aggregator_auth_token())
-                .header(
-                    CONTENT_TYPE,
-                    AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
-                )
+                .header(CONTENT_TYPE, AggregationJobInitializeReq::MEDIA_TYPE)
                 .header(
                     TASKPROV_HEADER,
                     URL_SAFE_NO_PAD.encode(test.task_config.get_encoded().unwrap()),
@@ -724,7 +713,7 @@ async fn taskprov_opt_out_task_ended_regression() {
     let request = AggregationJobInitializeReq::new(
         0,
         aggregation_param.get_encoded().unwrap(),
-        PartialBatchSelector::new_leader_selected(batch_id),
+        Vec::from([AggregationJobExtension::leader_selected_batch_id(&batch_id)]),
         Vec::from([VerifyInit::new(
             report_share.clone(),
             transcript.leader_verify_transitions[0]
@@ -752,10 +741,7 @@ async fn taskprov_opt_out_task_ended_regression() {
                         .path(),
                 )
                 .with_authentication_token(test.peer_aggregator.primary_aggregator_auth_token())
-                .header(
-                    CONTENT_TYPE,
-                    AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
-                )
+                .header(CONTENT_TYPE, AggregationJobInitializeReq::MEDIA_TYPE)
                 .header(
                     TASKPROV_HEADER,
                     URL_SAFE_NO_PAD.encode(test.task_config.get_encoded().unwrap()),
@@ -777,7 +763,7 @@ async fn taskprov_opt_out_mismatched_task_id() {
     let request = AggregationJobInitializeReq::new(
         0,
         ().get_encoded().unwrap(),
-        PartialBatchSelector::new_leader_selected(batch_id),
+        Vec::from([AggregationJobExtension::leader_selected_batch_id(&batch_id)]),
         Vec::from([VerifyInit::new(
             report_share.clone(),
             transcript.leader_verify_transitions[0]
@@ -820,10 +806,7 @@ async fn taskprov_opt_out_mismatched_task_id() {
                         .path(),
                 )
                 .with_authentication_token(test.peer_aggregator.primary_aggregator_auth_token())
-                .header(
-                    CONTENT_TYPE,
-                    AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
-                )
+                .header(CONTENT_TYPE, AggregationJobInitializeReq::MEDIA_TYPE)
                 .header(
                     TASKPROV_HEADER,
                     // Use a different task than the URL's.
@@ -856,7 +839,7 @@ async fn taskprov_opt_out_peer_aggregator_wrong_role() {
     let request = AggregationJobInitializeReq::new(
         0,
         ().get_encoded().unwrap(),
-        PartialBatchSelector::new_leader_selected(batch_id),
+        Vec::from([AggregationJobExtension::leader_selected_batch_id(&batch_id)]),
         Vec::from([VerifyInit::new(
             report_share.clone(),
             transcript.leader_verify_transitions[0]
@@ -898,10 +881,7 @@ async fn taskprov_opt_out_peer_aggregator_wrong_role() {
                     "/tasks/{another_task_id}/aggregation_jobs/{aggregation_job_id}"
                 ))
                 .with_authentication_token(test.peer_aggregator.primary_aggregator_auth_token())
-                .header(
-                    CONTENT_TYPE,
-                    AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
-                )
+                .header(CONTENT_TYPE, AggregationJobInitializeReq::MEDIA_TYPE)
                 .header(
                     TASKPROV_HEADER,
                     URL_SAFE_NO_PAD.encode(another_task_config_encoded),
@@ -933,7 +913,7 @@ async fn taskprov_opt_out_peer_aggregator_does_not_exist() {
     let request = AggregationJobInitializeReq::new(
         0,
         ().get_encoded().unwrap(),
-        PartialBatchSelector::new_leader_selected(batch_id),
+        Vec::from([AggregationJobExtension::leader_selected_batch_id(&batch_id)]),
         Vec::from([VerifyInit::new(
             report_share.clone(),
             transcript.leader_verify_transitions[0]
@@ -975,10 +955,7 @@ async fn taskprov_opt_out_peer_aggregator_does_not_exist() {
                     "/tasks/{another_task_id}/aggregation_jobs/{aggregation_job_id}"
                 ))
                 .with_authentication_token(test.peer_aggregator.primary_aggregator_auth_token())
-                .header(
-                    CONTENT_TYPE,
-                    AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
-                )
+                .header(CONTENT_TYPE, AggregationJobInitializeReq::MEDIA_TYPE)
                 .header(
                     TASKPROV_HEADER,
                     URL_SAFE_NO_PAD.encode(another_task_config_encoded),
@@ -1010,7 +987,7 @@ async fn taskprov_opt_out_unsupported_extension() {
     let request = AggregationJobInitializeReq::new(
         0,
         ().get_encoded().unwrap(),
-        PartialBatchSelector::new_leader_selected(batch_id),
+        Vec::from([AggregationJobExtension::leader_selected_batch_id(&batch_id)]),
         Vec::from([VerifyInit::new(
             report_share.clone(),
             transcript.leader_verify_transitions[0]
@@ -1055,10 +1032,7 @@ async fn taskprov_opt_out_unsupported_extension() {
                     "/tasks/{another_task_id}/aggregation_jobs/{aggregation_job_id}"
                 ))
                 .with_authentication_token(test.peer_aggregator.primary_aggregator_auth_token())
-                .header(
-                    CONTENT_TYPE,
-                    AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
-                )
+                .header(CONTENT_TYPE, AggregationJobInitializeReq::MEDIA_TYPE)
                 .header(
                     TASKPROV_HEADER,
                     URL_SAFE_NO_PAD.encode(another_task_config_encoded),
@@ -1398,7 +1372,7 @@ async fn end_to_end() {
     let aggregation_job_init_request = AggregationJobInitializeReq::new(
         0,
         aggregation_param.get_encoded().unwrap(),
-        PartialBatchSelector::new_leader_selected(batch_id),
+        Vec::from([AggregationJobExtension::leader_selected_batch_id(&batch_id)]),
         Vec::from([VerifyInit::new(
             report_share.clone(),
             transcript.leader_verify_transitions[0]
@@ -1421,10 +1395,7 @@ async fn end_to_end() {
                         .path(),
                 )
                 .with_authentication_token(test.peer_aggregator.primary_aggregator_auth_token())
-                .header(
-                    CONTENT_TYPE,
-                    AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
-                )
+                .header(CONTENT_TYPE, AggregationJobInitializeReq::MEDIA_TYPE)
                 .header(
                     TASKPROV_HEADER,
                     URL_SAFE_NO_PAD.encode(test.task_config.get_encoded().unwrap()),
@@ -1598,7 +1569,7 @@ async fn end_to_end_sumvec_hmac() {
     let aggregation_job_init_request = AggregationJobInitializeReq::new(
         0,
         aggregation_param.get_encoded().unwrap(),
-        PartialBatchSelector::new_leader_selected(batch_id),
+        Vec::from([AggregationJobExtension::leader_selected_batch_id(&batch_id)]),
         Vec::from([VerifyInit::new(
             report_share.clone(),
             transcript.leader_verify_transitions[0]
@@ -1621,10 +1592,7 @@ async fn end_to_end_sumvec_hmac() {
                         .path(),
                 )
                 .with_authentication_token(test.peer_aggregator.primary_aggregator_auth_token())
-                .header(
-                    CONTENT_TYPE,
-                    AggregationJobInitializeReq::<LeaderSelected>::MEDIA_TYPE,
-                )
+                .header(CONTENT_TYPE, AggregationJobInitializeReq::MEDIA_TYPE)
                 .header(
                     TASKPROV_HEADER,
                     URL_SAFE_NO_PAD.encode(test.task_config.get_encoded().unwrap()),

--- a/messages/src/batch_mode.rs
+++ b/messages/src/batch_mode.rs
@@ -9,7 +9,7 @@ use num_enum::TryFromPrimitive;
 use prio::codec::{CodecError, Decode, Encode};
 use serde::{Deserialize, Serialize};
 
-use crate::{BatchId, Interval, Query};
+use crate::{AggregationJobExtension, AggregationJobExtensionType, BatchId, Interval, Query};
 
 /// BatchMode represents a DAP batch mode. This is a task-level configuration setting which
 /// determines how individual client reports are grouped together into batches for collection.
@@ -31,8 +31,8 @@ pub trait BatchMode: Clone + Debug + PartialEq + Eq + Send + Sync + 'static {
         + Send
         + Sync;
 
-    /// The type of a batch identifier as it appears in a `PartialBatchSelector`. Will be either
-    /// the same type as `BatchIdentifier`, or `()`.
+    /// The type of a batch identifier as conveyed by an aggregation job's extensions. Will be
+    /// either the same type as `BatchIdentifier`, or `()`.
     type PartialBatchIdentifier: Debug
         + Clone
         + Hash
@@ -59,6 +59,19 @@ pub trait BatchMode: Clone + Debug + PartialEq + Eq + Send + Sync + 'static {
         query: &Query<Self>,
         partial_batch_identifier: &Self::PartialBatchIdentifier,
     ) -> Self::BatchIdentifier;
+
+    /// Builds the aggregation job extensions that convey `partial_batch_identifier` to the helper
+    /// in an [`AggregationJobInitializeReq`](crate::AggregationJobInitializeReq).
+    fn aggregation_job_extensions(
+        partial_batch_identifier: &Self::PartialBatchIdentifier,
+    ) -> Vec<AggregationJobExtension>;
+
+    /// Recovers the partial batch identifier from an aggregation job's extensions. Returns `None`
+    /// if a required extension is absent or malformed; the helper reports this as the DAP
+    /// `invalidMessage` error.
+    fn partial_batch_identifier_from_extensions(
+        extensions: &[AggregationJobExtension],
+    ) -> Option<Self::PartialBatchIdentifier>;
 }
 
 /// Represents the `time-interval` DAP batch mode.
@@ -81,6 +94,14 @@ impl BatchMode for TimeInterval {
         _: &Self::PartialBatchIdentifier,
     ) -> Self::BatchIdentifier {
         *query.batch_interval()
+    }
+
+    fn aggregation_job_extensions(_: &()) -> Vec<AggregationJobExtension> {
+        Vec::new()
+    }
+
+    fn partial_batch_identifier_from_extensions(_: &[AggregationJobExtension]) -> Option<()> {
+        Some(())
     }
 }
 
@@ -106,6 +127,21 @@ impl BatchMode for LeaderSelected {
         partial_batch_identifier: &Self::PartialBatchIdentifier,
     ) -> Self::BatchIdentifier {
         *partial_batch_identifier
+    }
+
+    fn aggregation_job_extensions(batch_id: &BatchId) -> Vec<AggregationJobExtension> {
+        Vec::from([AggregationJobExtension::leader_selected_batch_id(batch_id)])
+    }
+
+    fn partial_batch_identifier_from_extensions(
+        extensions: &[AggregationJobExtension],
+    ) -> Option<BatchId> {
+        extensions
+            .iter()
+            .find(|extension| {
+                extension.extension_type() == AggregationJobExtensionType::LeaderSelectedBatchId
+            })
+            .and_then(|extension| BatchId::get_decoded(extension.extension_data()).ok())
     }
 }
 

--- a/messages/src/batch_mode.rs
+++ b/messages/src/batch_mode.rs
@@ -66,12 +66,12 @@ pub trait BatchMode: Clone + Debug + PartialEq + Eq + Send + Sync + 'static {
         partial_batch_identifier: &Self::PartialBatchIdentifier,
     ) -> Vec<AggregationJobExtension>;
 
-    /// Recovers the partial batch identifier from an aggregation job's extensions. Returns `None`
-    /// if a required extension is absent or malformed; the helper reports this as the DAP
-    /// `invalidMessage` error.
+    /// Recovers the partial batch identifier from an aggregation job's extensions. Returns `Err`
+    /// with a reason if a required extension is absent or malformed, or an extension inapplicable
+    /// to this batch mode is present; the helper reports this as the DAP `invalidMessage` error.
     fn partial_batch_identifier_from_extensions(
         extensions: &[AggregationJobExtension],
-    ) -> Option<Self::PartialBatchIdentifier>;
+    ) -> Result<Self::PartialBatchIdentifier, &'static str>;
 }
 
 /// Represents the `time-interval` DAP batch mode.
@@ -100,8 +100,17 @@ impl BatchMode for TimeInterval {
         Vec::new()
     }
 
-    fn partial_batch_identifier_from_extensions(_: &[AggregationJobExtension]) -> Option<()> {
-        Some(())
+    fn partial_batch_identifier_from_extensions(
+        extensions: &[AggregationJobExtension],
+    ) -> Result<(), &'static str> {
+        if extensions.iter().any(|extension| {
+            extension.extension_type() == AggregationJobExtensionType::LeaderSelectedBatchId
+        }) {
+            return Err(
+                "unexpected leader_selected_batch_id extension for time-interval batch mode",
+            );
+        }
+        Ok(())
     }
 }
 
@@ -135,13 +144,15 @@ impl BatchMode for LeaderSelected {
 
     fn partial_batch_identifier_from_extensions(
         extensions: &[AggregationJobExtension],
-    ) -> Option<BatchId> {
-        extensions
+    ) -> Result<BatchId, &'static str> {
+        let extension = extensions
             .iter()
             .find(|extension| {
                 extension.extension_type() == AggregationJobExtensionType::LeaderSelectedBatchId
             })
-            .and_then(|extension| BatchId::get_decoded(extension.extension_data()).ok())
+            .ok_or("missing leader_selected_batch_id extension")?;
+        BatchId::get_decoded(extension.extension_data())
+            .map_err(|_| "malformed leader_selected_batch_id extension")
     }
 }
 

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -1907,73 +1907,6 @@ impl<B: BatchMode> Decode for CollectionJobReq<B> {
     }
 }
 
-/// DAP protocol message representing a partial batch selector, identifying a batch of interest in
-/// cases where some batch modes can infer the selector.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct PartialBatchSelector<B: BatchMode> {
-    batch_identifier: B::PartialBatchIdentifier,
-}
-
-impl<B: BatchMode> PartialBatchSelector<B> {
-    /// Constructs a new partial batch selector.
-    ///
-    /// This method would typically be used for code which is generic over the batch mode. Batch
-    /// mode-specific code will typically call one of [`Self::new_time_interval`] or
-    /// [`Self::new_leader_selected`].
-    pub fn new(batch_identifier: B::PartialBatchIdentifier) -> Self {
-        Self { batch_identifier }
-    }
-
-    /// Gets the batch identifier associated with this collect response.
-    ///
-    /// This method would typically be used for code which is generic over the batch mode. Batch
-    /// mode-specific code will typically call [`Self::batch_id`].
-    pub fn batch_identifier(&self) -> &B::PartialBatchIdentifier {
-        &self.batch_identifier
-    }
-}
-
-impl PartialBatchSelector<TimeInterval> {
-    /// Constructs a new partial batch selector for a time-interval task.
-    pub fn new_time_interval() -> Self {
-        Self::new(())
-    }
-}
-
-impl PartialBatchSelector<LeaderSelected> {
-    /// Constructs a new partial batch selector for a leader-selected task.
-    pub fn new_leader_selected(batch_id: BatchId) -> Self {
-        Self::new(batch_id)
-    }
-
-    /// Gets the batch ID associated with this partial batch selector.
-    pub fn batch_id(&self) -> &BatchId {
-        self.batch_identifier()
-    }
-}
-
-impl<B: BatchMode> Encode for PartialBatchSelector<B> {
-    fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
-        B::CODE.encode(bytes)?;
-        encode_u16_items(bytes, &(), slice::from_ref(&self.batch_identifier))
-    }
-
-    fn encoded_len(&self) -> Option<usize> {
-        Some(1 + 2 + self.batch_identifier.encoded_len()?)
-    }
-}
-
-impl<B: BatchMode> Decode for PartialBatchSelector<B> {
-    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
-        batch_mode::Code::decode_expecting_value(bytes, B::CODE)?;
-
-        let buf = decode_u16_items(&(), bytes)?;
-        let batch_identifier = B::PartialBatchIdentifier::get_decoded(&buf)?;
-
-        Ok(Self { batch_identifier })
-    }
-}
-
 /// DAP protocol message representing an identifier for a collection.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CollectionJobId([u8; Self::LEN]);
@@ -2598,30 +2531,150 @@ impl Distribution<AggregationJobId> for StandardUniform {
     }
 }
 
+/// DAP protocol message representing an extension included in an aggregation job initialization
+/// request, conveying additional parameters for the aggregation job to the helper.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AggregationJobExtension {
+    extension_type: AggregationJobExtensionType,
+    extension_data: Vec<u8>,
+}
+
+impl AggregationJobExtension {
+    /// Construct an aggregation job extension from its type and payload.
+    pub fn new(
+        extension_type: AggregationJobExtensionType,
+        extension_data: Vec<u8>,
+    ) -> AggregationJobExtension {
+        AggregationJobExtension {
+            extension_type,
+            extension_data,
+        }
+    }
+
+    /// Constructs the `leader_selected_batch_id` extension, carrying the batch ID selected by the
+    /// leader for a leader-selected batch mode aggregation job.
+    pub fn leader_selected_batch_id(batch_id: &BatchId) -> AggregationJobExtension {
+        AggregationJobExtension::new(
+            AggregationJobExtensionType::LeaderSelectedBatchId,
+            batch_id.as_ref().to_vec(),
+        )
+    }
+
+    /// Returns the type of this extension.
+    pub fn extension_type(&self) -> AggregationJobExtensionType {
+        self.extension_type
+    }
+
+    /// Returns the unparsed data representing this extension.
+    pub fn extension_data(&self) -> &[u8] {
+        &self.extension_data
+    }
+}
+
+impl Encode for AggregationJobExtension {
+    fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
+        self.extension_type.encode(bytes)?;
+        encode_u16_items(bytes, &(), &self.extension_data)
+    }
+
+    fn encoded_len(&self) -> Option<usize> {
+        // Extra 2 bytes for the data length prefix.
+        Some(self.extension_type.encoded_len()? + 2 + self.extension_data.len())
+    }
+}
+
+impl Decode for AggregationJobExtension {
+    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        let extension_type = AggregationJobExtensionType::decode(bytes)?;
+        let extension_data = decode_u16_items(&(), bytes)?;
+
+        Ok(Self {
+            extension_type,
+            extension_data,
+        })
+    }
+}
+
+/// DAP protocol message representing the type of an aggregation job extension.
+///
+/// Equality, ordering, and hashing are all defined in terms of the underlying codepoint, so
+/// `Unknown(0x0000)` compares and hashes equal to `Reserved`.
+#[derive(Clone, Copy, Debug, FromPrimitive, IntoPrimitive)]
+#[repr(u16)]
+#[non_exhaustive]
+pub enum AggregationJobExtensionType {
+    Reserved = 0x0000,
+    LeaderSelectedBatchId = 0x0001,
+    #[num_enum(catch_all)]
+    Unknown(u16),
+}
+
+impl PartialEq for AggregationJobExtensionType {
+    fn eq(&self, other: &Self) -> bool {
+        u16::from(*self) == u16::from(*other)
+    }
+}
+
+impl Eq for AggregationJobExtensionType {}
+
+impl Hash for AggregationJobExtensionType {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        u16::from(*self).hash(state)
+    }
+}
+
+impl PartialOrd for AggregationJobExtensionType {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for AggregationJobExtensionType {
+    fn cmp(&self, other: &Self) -> Ordering {
+        u16::from(*self).cmp(&u16::from(*other))
+    }
+}
+
+impl Encode for AggregationJobExtensionType {
+    fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
+        u16::from(*self).encode(bytes)
+    }
+
+    fn encoded_len(&self) -> Option<usize> {
+        Some(2)
+    }
+}
+
+impl Decode for AggregationJobExtensionType {
+    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        Ok(Self::from(u16::decode(bytes)?))
+    }
+}
+
 /// DAP protocol message representing an aggregation job initialization request from leader to
 /// helper.
 #[derive(Clone, Educe, PartialEq, Eq)]
 #[educe(Debug)]
-pub struct AggregationJobInitializeReq<B: BatchMode> {
+pub struct AggregationJobInitializeReq {
     verification_key_id: u8,
     #[educe(Debug(ignore))]
     aggregation_parameter: Vec<u8>,
-    partial_batch_selector: PartialBatchSelector<B>,
+    extensions: Vec<AggregationJobExtension>,
     verify_inits: Vec<VerifyInit>,
 }
 
-impl<B: BatchMode> AggregationJobInitializeReq<B> {
+impl AggregationJobInitializeReq {
     /// Constructs an aggregate initialization request from its components.
     pub fn new(
         verification_key_id: u8,
         aggregation_parameter: Vec<u8>,
-        partial_batch_selector: PartialBatchSelector<B>,
+        extensions: Vec<AggregationJobExtension>,
         verify_inits: Vec<VerifyInit>,
     ) -> Self {
         Self {
             verification_key_id,
             aggregation_parameter,
-            partial_batch_selector,
+            extensions,
             verify_inits,
         }
     }
@@ -2636,9 +2689,9 @@ impl<B: BatchMode> AggregationJobInitializeReq<B> {
         &self.aggregation_parameter
     }
 
-    /// Gets the partial batch selector associated with this aggregate initialization request.
-    pub fn batch_selector(&self) -> &PartialBatchSelector<B> {
-        &self.partial_batch_selector
+    /// Gets the aggregation job extensions associated with this aggregate initialization request.
+    pub fn extensions(&self) -> &[AggregationJobExtension] {
+        &self.extensions
     }
 
     /// Gets the verification initialization messages associated with this aggregate initialization
@@ -2648,22 +2701,25 @@ impl<B: BatchMode> AggregationJobInitializeReq<B> {
     }
 }
 
-impl<B: BatchMode> MediaType for AggregationJobInitializeReq<B> {
+impl MediaType for AggregationJobInitializeReq {
     const MEDIA_TYPE: &'static str = "application/ppm-dap;message=aggregation-job-init-req";
 }
 
-impl<B: BatchMode> Encode for AggregationJobInitializeReq<B> {
+impl Encode for AggregationJobInitializeReq {
     fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
         self.verification_key_id.encode(bytes)?;
         encode_u32_items(bytes, &(), &self.aggregation_parameter)?;
-        self.partial_batch_selector.encode(bytes)?;
+        encode_u16_items(bytes, &(), &self.extensions)?;
         encode_u32_items(bytes, &(), &self.verify_inits)
     }
 
     fn encoded_len(&self) -> Option<usize> {
         let mut length = 1;
         length += 4 + self.aggregation_parameter.len();
-        length += self.partial_batch_selector.encoded_len()?;
+        length += 2;
+        for extension in &self.extensions {
+            length += extension.encoded_len()?;
+        }
         length += 4;
         for verify_init in &self.verify_inits {
             length += verify_init.encoded_len()?;
@@ -2672,17 +2728,20 @@ impl<B: BatchMode> Encode for AggregationJobInitializeReq<B> {
     }
 }
 
-impl<B: BatchMode> Decode for AggregationJobInitializeReq<B> {
+impl Decode for AggregationJobInitializeReq {
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        // Extension ordering and support are semantic checks the helper performs while handling the
+        // request (producing the DAP `unsupportedExtension`/`invalidMessage` errors), so decoding
+        // here is purely structural.
         let verification_key_id = u8::decode(bytes)?;
         let aggregation_parameter = decode_u32_items(&(), bytes)?;
-        let partial_batch_selector = PartialBatchSelector::decode(bytes)?;
+        let extensions = decode_u16_items(&(), bytes)?;
         let verify_inits = decode_u32_items(&(), bytes)?;
 
         Ok(Self {
             verification_key_id,
             aggregation_parameter,
-            partial_batch_selector,
+            extensions,
             verify_inits,
         })
     }

--- a/messages/src/tests/aggregation.rs
+++ b/messages/src/tests/aggregation.rs
@@ -2,9 +2,9 @@ use prio::topology::ping_pong::PingPongMessage;
 
 use crate::{
     AggregationJobContinueReq, AggregationJobInitializeReq, AggregationJobResp, AggregationJobStep,
-    BatchId, Extension, ExtensionType, HpkeCiphertext, HpkeConfigId, LeaderSelected,
-    PartialBatchSelector, ReportError, ReportId, ReportMetadata, ReportShare, Time, TimePrecision,
-    VerifyContinue, VerifyInit, VerifyResp, VerifyStepResult, roundtrip_encoding,
+    BatchId, Extension, ExtensionType, HpkeCiphertext, HpkeConfigId, LeaderSelected, ReportError,
+    ReportId, ReportMetadata, ReportShare, Time, TimePrecision, VerifyContinue, VerifyInit,
+    VerifyResp, VerifyStepResult, batch_mode::BatchMode, roundtrip_encoding,
 };
 
 const TEST_TIME_PRECISION: TimePrecision = TimePrecision::from_seconds(1);
@@ -327,11 +327,11 @@ fn roundtrip_report_share_error() {
 fn roundtrip_aggregation_job_initialize_req() {
     // TimeInterval.
     roundtrip_encoding(&[(
-        AggregationJobInitializeReq {
-            verification_key_id: 7,
-            aggregation_parameter: Vec::from("012345"),
-            partial_batch_selector: PartialBatchSelector::new_time_interval(),
-            verify_inits: Vec::from([
+        AggregationJobInitializeReq::new(
+            7,
+            Vec::from("012345"),
+            Vec::new(),
+            Vec::from([
                 VerifyInit {
                     report_share: ReportShare {
                         metadata: ReportMetadata::new(
@@ -369,7 +369,7 @@ fn roundtrip_aggregation_job_initialize_req() {
                     },
                 },
             ]),
-        },
+        ),
         concat!(
             "07", // verification_key_id
             concat!(
@@ -378,10 +378,8 @@ fn roundtrip_aggregation_job_initialize_req() {
                 "303132333435", // opaque data
             ),
             concat!(
-                // partial_batch_selector
-                "01",   // batch_mode
+                // extensions
                 "0000", // length
-                "",     // opaque data
             ),
             concat!(
                 // verify_inits
@@ -483,13 +481,11 @@ fn roundtrip_aggregation_job_initialize_req() {
 
     // LeaderSelected.
     roundtrip_encoding(&[(
-        AggregationJobInitializeReq::<LeaderSelected> {
-            verification_key_id: 255,
-            aggregation_parameter: Vec::from("012345"),
-            partial_batch_selector: PartialBatchSelector::new_leader_selected(BatchId::from(
-                [2u8; 32],
-            )),
-            verify_inits: Vec::from([
+        AggregationJobInitializeReq::new(
+            255,
+            Vec::from("012345"),
+            LeaderSelected::aggregation_job_extensions(&BatchId::from([2u8; 32])),
+            Vec::from([
                 VerifyInit {
                     report_share: ReportShare {
                         metadata: ReportMetadata::new(
@@ -527,7 +523,7 @@ fn roundtrip_aggregation_job_initialize_req() {
                     },
                 },
             ]),
-        },
+        ),
         concat!(
             "ff", // verification_key_id
             concat!(
@@ -536,10 +532,11 @@ fn roundtrip_aggregation_job_initialize_req() {
                 "303132333435", // opaque data
             ),
             concat!(
-                // partial_batch_selector
-                "02",                                                               // batch_mode
-                "0020",                                                             // length
-                "0202020202020202020202020202020202020202020202020202020202020202", // opaque data
+                // extensions
+                "0024",                                                             // length
+                "0001", // extension_type
+                "0020", // extension_data length
+                "0202020202020202020202020202020202020202020202020202020202020202", /* extension_data (BatchID) */
             ),
             concat!(
                 // verify_inits

--- a/messages/src/tests/collection.rs
+++ b/messages/src/tests/collection.rs
@@ -4,8 +4,8 @@ use super::{task_configuration_hex, test_task_configuration};
 use crate::{
     AggregateShare, AggregateShareAad, AggregateShareReq, BatchId, BatchSelector,
     CollectionJobExtension, CollectionJobExtensionType, CollectionJobReq, CollectionJobResp,
-    Duration, HpkeCiphertext, HpkeConfigId, Interval, LeaderSelected, PartialBatchSelector, Query,
-    ReportIdChecksum, TaskId, Time, TimeInterval, TimePrecision, roundtrip_encoding,
+    Duration, HpkeCiphertext, HpkeConfigId, Interval, LeaderSelected, Query, ReportIdChecksum,
+    TaskId, Time, TimeInterval, TimePrecision, roundtrip_encoding,
 };
 
 const TEST_TIME_PRECISION: TimePrecision = TimePrecision::from_seconds(1);
@@ -189,39 +189,6 @@ fn collection_job_req_decode_is_lenient_about_extension_order() {
     // The Helper re-encodes the decoded request to rebuild the aggregate-share AAD, so even an
     // unsorted extensions list must survive decode->encode byte-identically.
     assert_eq!(req.get_encoded().unwrap(), encoded);
-}
-
-#[test]
-fn roundtrip_partial_batch_selector() {
-    // TimeInterval.
-    roundtrip_encoding(&[(
-        PartialBatchSelector::new_time_interval(),
-        concat!(
-            "01",   // batch_mode
-            "0000", // length
-            "",     // opaque data
-        ),
-    )]);
-
-    // LeaderSelected.
-    roundtrip_encoding(&[
-        (
-            PartialBatchSelector::new_leader_selected(BatchId::from([3u8; 32])),
-            concat!(
-                "02",                                                               // batch_mode
-                "0020",                                                             // length
-                "0303030303030303030303030303030303030303030303030303030303030303", // opaque data
-            ),
-        ),
-        (
-            PartialBatchSelector::new_leader_selected(BatchId::from([4u8; 32])),
-            concat!(
-                "02",                                                               // batch_mode
-                "0020",                                                             // length
-                "0404040404040404040404040404040404040404040404040404040404040404", // opaque data
-            ),
-        ),
-    ])
 }
 
 #[test]

--- a/tools/src/bin/dap_decode.rs
+++ b/tools/src/bin/dap_decode.rs
@@ -48,16 +48,9 @@ fn decode_dap_message(message_file: &str, media_type: &MediaType) -> Result<Box<
             Box::new(message)
         }
         MediaType::AggregationJobInitializeReq => {
-            if let Ok(decoded) =
-                AggregationJobInitializeReq::<TimeInterval>::get_decoded(&message_buf)
-            {
-                let message: AggregationJobInitializeReq<TimeInterval> = decoded;
-                Box::new(message)
-            } else {
-                let message: AggregationJobInitializeReq<LeaderSelected> =
-                    AggregationJobInitializeReq::<LeaderSelected>::get_decoded(&message_buf)?;
-                Box::new(message)
-            }
+            let message: AggregationJobInitializeReq =
+                AggregationJobInitializeReq::get_decoded(&message_buf)?;
+            Box::new(message)
         }
         MediaType::AggregationJobContinueReq => {
             let message: AggregationJobContinueReq =


### PR DESCRIPTION
Fixes #4784

Per [DAP PR #762](https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/762), replaces the `PartialBatchSelector` in `AggregationJobInitializeReq` with an `AggregationJobExtension` list.

- New `AggregationJobExtension` + `AggregationJobExtensionType` registry (n.b. `leader_selected_batch_id` = 0x0001).
- Leader-selected batch ID now travels as an extension; the message is no longer generic over batch mode.
- Helper enforcement: unknown type becomes `unsupportedExtension`; out-of-order or missing/malformed batch-id becomes `invalidMessage`.